### PR TITLE
fix(desktop): prove focused Repos bottom-action reachability

### DIFF
--- a/apps/neondiff-desktop/Package.swift
+++ b/apps/neondiff-desktop/Package.swift
@@ -53,7 +53,11 @@ let package = Package(
         ),
         .executableTarget(
             name: "NeonDiffDesktopCapture",
-            dependencies: ["NeonDiffDesktopCore"]
+            dependencies: ["NeonDiffDesktopCore", "NeonDiffDesktopEvaluationSupport"]
+        ),
+        .executableTarget(
+            name: "NeonDiffDesktopReachabilityChecks",
+            dependencies: ["NeonDiffDesktopEvaluationSupport"]
         ),
         .executableTarget(
             name: "NeonDiffDesktopFixtureResolve",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -10,6 +10,7 @@ struct ReposView: View {
             pageContent
         }
         .scrollContentBackground(.hidden)
+        .scrollIndicators(.visible, axes: .vertical)
     }
 
     private var pageContent: some View {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -10,7 +10,6 @@ struct ReposView: View {
             pageContent
         }
         .scrollContentBackground(.hidden)
-        .scrollIndicators(.visible, axes: .vertical)
     }
 
     private var pageContent: some View {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -6,6 +6,14 @@ struct ReposView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
+        ScrollView(.vertical) {
+            pageContent
+        }
+        .scrollContentBackground(.hidden)
+        .scrollIndicators(.visible, axes: .vertical)
+    }
+
+    private var pageContent: some View {
         VStack(alignment: .leading, spacing: 14) {
             OperatorSection("GitHub Connection") {
                 VStack(alignment: .leading, spacing: 10) {
@@ -196,7 +204,7 @@ struct ReposView: View {
                     }
                 }
                 .scrollContentBackground(.hidden)
-                .frame(minHeight: 360)
+                .frame(height: 360)
 
                 HStack(spacing: 10) {
                     TextField("owner/repo", text: $model.pendingRepoName)
@@ -259,6 +267,7 @@ struct ReposView: View {
             OperatorSection("Boundary") {
                 Text("Repo changes are written through `config patch` only; the desktop does not post reviews or bypass daemon gates.")
                     .operatorBodyText()
+                    .accessibilityIdentifier("neondiff-repos-boundary")
             }
         }
         .padding(24)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -402,20 +402,23 @@ private struct DesktopReposReachabilityAXTracer {
 
         var pre = PhaseAcquisition.empty
         var post = PhaseAcquisition.empty
-        var outerScroll: DesktopReposOuterScrollObservation?
+        var scrollInteraction: DesktopReposScrollInteraction?
         var failure: DesktopReposReachabilityAcquisitionFailureReason?
         if timeoutInstalled {
-            pre = acquireStableSamples()
-            failure = pre.failure
-            if failure == nil {
-                switch scrollBoundaryAncestorToMaximum() {
-                case .success(let observation):
-                    outerScroll = observation
-                case .failure(let reason):
-                    failure = reason
+            do {
+                let binding = try incrementPagePressBinding()
+                pre = acquireStableSamples(binding: binding.semantic)
+                failure = pre.failure
+                if failure == nil {
+                    scrollInteraction = try performIncrementPagePress(binding)
                 }
+            } catch let reason as Failure {
+                failure = reason
+            } catch {
+                failure = .invalidType
             }
-            if failure == nil {
+            if failure == nil,
+               scrollInteraction?.incrementPagePress?.performResult == .success {
                 post = acquireStableSamples()
                 failure = post.failure
             }
@@ -431,7 +434,7 @@ private struct DesktopReposReachabilityAXTracer {
             failureReason: failure
         )
         return DesktopReposReachabilityTrace(
-            schemaVersion: 1,
+            schemaVersion: 2,
             fixture: .tabRepos,
             ready: readinessGatePassed,
             quiescent: readinessGatePassed && pre.stable && post.stable,
@@ -442,7 +445,7 @@ private struct DesktopReposReachabilityAXTracer {
             tolerancePoints: Self.tolerance,
             acquisition: acquisition,
             preScrollSamples: pre.samples,
-            outerScroll: outerScroll,
+            scrollInteraction: scrollInteraction,
             postScrollSamples: post.samples
         )
     }
@@ -507,12 +510,16 @@ private struct DesktopReposReachabilityAXTracer {
         }
     }
 
-    private func acquireStableSamples() -> PhaseAcquisition {
+    private func acquireStableSamples(binding providedBinding: SemanticBinding? = nil) -> PhaseAcquisition {
         let phaseStarted = DispatchTime.now().uptimeNanoseconds
         let binding: SemanticBinding
         do {
-            let window = try verifiedWindow()
-            binding = SemanticBinding(window: window, elements: try semanticElements(in: window))
+            if let providedBinding {
+                binding = providedBinding
+            } else {
+                let window = try verifiedWindow()
+                binding = SemanticBinding(window: window, elements: try semanticElements(in: window))
+            }
         } catch let reason as DesktopReposReachabilityAcquisitionFailureReason {
             return PhaseAcquisition(
                 samples: [],
@@ -595,6 +602,91 @@ private struct DesktopReposReachabilityAXTracer {
         }
     }
 
+    private func incrementPagePressBinding() throws -> ScrollBehaviorBinding {
+        let window = try verifiedWindow()
+        let elements = try semanticElements(in: window)
+        guard let scrollArea = try outermostScrollArea(from: elements.boundaryBody, to: window),
+              let scrollBar = try verticalScrollBar(in: scrollArea),
+              let incrementPage = try incrementPageButton(in: scrollBar) else {
+            throw Failure.semanticMissing
+        }
+        let advertised = try actionNames(incrementPage).contains(NSAccessibility.Action.press.rawValue)
+        return ScrollBehaviorBinding(
+            semantic: .init(window: window, elements: elements),
+            incrementPage: incrementPage,
+            actionAdvertised: advertised,
+            outerClipBefore: try elementFrame(scrollArea)
+        )
+    }
+
+    private func performIncrementPagePress(
+        _ binding: ScrollBehaviorBinding
+    ) throws -> DesktopReposScrollInteraction {
+        guard binding.actionAdvertised else {
+            return DesktopReposScrollInteraction(
+                mechanism: .incrementPagePress,
+                incrementPagePress: .init(
+                    actionAdvertised: false,
+                    attemptCount: 0,
+                    performResult: nil,
+                    outerClipBefore: binding.outerClipBefore,
+                    outerClipAfter: nil
+                ),
+                valueMutation: nil
+            )
+        }
+        try requireTargetPID(binding.incrementPage)
+        guard try actionNames(binding.incrementPage).contains(NSAccessibility.Action.press.rawValue) else {
+            return DesktopReposScrollInteraction(
+                mechanism: .incrementPagePress,
+                incrementPagePress: .init(
+                    actionAdvertised: false,
+                    attemptCount: 0,
+                    performResult: nil,
+                    outerClipBefore: binding.outerClipBefore,
+                    outerClipAfter: nil
+                ),
+                valueMutation: nil
+            )
+        }
+        let result = AXUIElementPerformAction(
+            binding.incrementPage,
+            NSAccessibility.Action.press.rawValue as CFString
+        )
+        let performResult = scrollActionResult(result)
+        var clipAfter: DesktopReposReachabilityFrame?
+        if result == .success {
+            let window = try verifiedWindow()
+            let elements = try semanticElements(in: window)
+            guard let scrollArea = try outermostScrollArea(from: elements.boundaryBody, to: window) else {
+                throw Failure.ancestryUnavailable
+            }
+            clipAfter = try elementFrame(scrollArea)
+        }
+        return DesktopReposScrollInteraction(
+            mechanism: .incrementPagePress,
+            incrementPagePress: .init(
+                actionAdvertised: true,
+                attemptCount: 1,
+                performResult: performResult,
+                outerClipBefore: binding.outerClipBefore,
+                outerClipAfter: clipAfter
+            ),
+            valueMutation: nil
+        )
+    }
+
+    private func scrollActionResult(_ error: AXError) -> DesktopReposScrollActionResult {
+        switch error {
+        case .success: return .success
+        case .cannotComplete: return .cannotComplete
+        case .actionUnsupported: return .actionUnsupported
+        case .invalidUIElement, .invalidUIElementObserver: return .invalidElement
+        case .apiDisabled: return .permissionDenied
+        default: return .otherError
+        }
+    }
+
     private func milliseconds(from start: UInt64, to end: UInt64) -> Int {
         Int((end - start) / 1_000_000)
     }
@@ -646,64 +738,6 @@ private struct DesktopReposReachabilityAXTracer {
             && abs(lhs.y - rhs.y) <= Self.tolerance
             && abs(lhs.width - rhs.width) <= Self.tolerance
             && abs(lhs.height - rhs.height) <= Self.tolerance
-    }
-
-    private func scrollBoundaryAncestorToMaximum() -> Result<DesktopReposOuterScrollObservation?, DesktopReposReachabilityAcquisitionFailureReason> {
-        do {
-            let window = try verifiedWindow()
-            let boundary = try semanticElements(in: window).boundaryBody
-            guard let scrollArea = try outermostScrollArea(from: boundary, to: window) else {
-                return .success(nil)
-            }
-            guard let scrollBar = try verticalScrollBar(in: scrollArea) else {
-                return .success(unsupportedScroll())
-            }
-
-            var settable = DarwinBoolean(false)
-            let settableResult = AXUIElementIsAttributeSettable(
-                scrollBar,
-                kAXValueAttribute as CFString,
-                &settable
-            )
-            if settableResult != .success {
-                if settableResult == .attributeUnsupported { return .success(unsupportedScroll()) }
-                throw mapAXError(settableResult)
-            }
-            guard settable.boolValue else { return .success(unsupportedScroll()) }
-            let rawMinimum: CFTypeRef
-            let rawMaximum: CFTypeRef
-            let rawBefore: CFTypeRef
-            do {
-                rawMinimum = try requiredAttribute(scrollBar, kAXMinValueAttribute as CFString)
-                rawMaximum = try requiredAttribute(scrollBar, kAXMaxValueAttribute as CFString)
-                rawBefore = try requiredAttribute(scrollBar, kAXValueAttribute as CFString)
-            } catch Failure.attributeUnavailable {
-                return .success(unsupportedScroll())
-            }
-            let minimum = try numericValue(rawMinimum)
-            let maximum = try numericValue(rawMaximum)
-            let before = try numericValue(rawBefore)
-            let setResult = AXUIElementSetAttributeValue(scrollBar, kAXValueAttribute as CFString, rawMaximum)
-            if setResult != .success {
-                if setResult == .attributeUnsupported || setResult == .actionUnsupported {
-                    return .success(unsupportedScroll())
-                }
-                throw mapAXError(setResult)
-            }
-            let readback = try numericValue(try requiredAttribute(scrollBar, kAXValueAttribute as CFString))
-            return .success(DesktopReposOuterScrollObservation(
-                verticalScrollBarSupported: true,
-                minimumValue: minimum,
-                maximumValue: maximum,
-                valueBeforeScroll: before,
-                valueAfterScroll: readback,
-                setToMaximumSucceeded: abs(maximum - readback) <= 0.001
-            ))
-        } catch let reason as Failure {
-            return .failure(reason)
-        } catch {
-            return .failure(.invalidType)
-        }
     }
 
     private func verticalScrollBar(in scrollArea: AXUIElement) throws -> AXUIElement? {
@@ -834,17 +868,6 @@ private struct DesktopReposReachabilityAXTracer {
         case .unsupported:
             return nil
         }
-    }
-
-    private func unsupportedScroll() -> DesktopReposOuterScrollObservation {
-        DesktopReposOuterScrollObservation(
-            verticalScrollBarSupported: false,
-            minimumValue: nil,
-            maximumValue: nil,
-            valueBeforeScroll: nil,
-            valueAfterScroll: nil,
-            setToMaximumSucceeded: false
-        )
     }
 
     private func verifiedWindow() throws -> AXUIElement {
@@ -1106,6 +1129,13 @@ private struct DesktopReposReachabilityAXTracer {
     private struct SemanticBinding {
         let window: AXUIElement
         let elements: SemanticElements
+    }
+
+    private struct ScrollBehaviorBinding {
+        let semantic: SemanticBinding
+        let incrementPage: AXUIElement
+        let actionAdvertised: Bool
+        let outerClipBefore: DesktopReposReachabilityFrame
     }
 
     private struct SemanticElements {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -409,8 +409,11 @@ private struct DesktopReposReachabilityAXTracer {
                 let binding = try incrementPagePressBinding()
                 pre = acquireStableSamples(binding: binding.semantic)
                 failure = pre.failure
-                if failure == nil {
-                    scrollInteraction = try performIncrementPagePress(binding)
+                if failure == nil, let settledBefore = pre.samples.last?.outerClip {
+                    scrollInteraction = try performIncrementPagePress(
+                        binding,
+                        settledOuterClipBefore: settledBefore
+                    )
                 }
             } catch let reason as Failure {
                 failure = reason
@@ -421,6 +424,14 @@ private struct DesktopReposReachabilityAXTracer {
                scrollInteraction?.incrementPagePress?.performResult == .success {
                 post = acquireStableSamples()
                 failure = post.failure
+                if failure == nil,
+                   let interaction = scrollInteraction,
+                   let settledAfter = post.samples.last?.outerClip {
+                    scrollInteraction = interactionWithSettledOuterClipAfter(
+                        interaction,
+                        settledOuterClipAfter: settledAfter
+                    )
+                }
             }
         } else {
             failure = .messagingTimeoutUnavailable
@@ -517,8 +528,7 @@ private struct DesktopReposReachabilityAXTracer {
             if let providedBinding {
                 binding = providedBinding
             } else {
-                let window = try verifiedWindow()
-                binding = SemanticBinding(window: window, elements: try semanticElements(in: window))
+                binding = try semanticBinding()
             }
         } catch let reason as DesktopReposReachabilityAcquisitionFailureReason {
             return PhaseAcquisition(
@@ -603,76 +613,89 @@ private struct DesktopReposReachabilityAXTracer {
     }
 
     private func incrementPagePressBinding() throws -> ScrollBehaviorBinding {
-        let window = try verifiedWindow()
-        let elements = try semanticElements(in: window)
-        guard let scrollArea = try outermostScrollArea(from: elements.boundaryBody, to: window),
-              let scrollBar = try verticalScrollBar(in: scrollArea),
+        let semantic = try semanticBinding()
+        guard let scrollBar = try verticalScrollBar(in: semantic.outerScrollArea),
               let incrementPage = try incrementPageButton(in: scrollBar) else {
             throw Failure.semanticMissing
         }
         let advertised = try actionNames(incrementPage).contains(NSAccessibility.Action.press.rawValue)
         return ScrollBehaviorBinding(
-            semantic: .init(window: window, elements: elements),
+            semantic: semantic,
+            verticalScrollBar: scrollBar,
             incrementPage: incrementPage,
-            actionAdvertised: advertised,
-            outerClipBefore: try elementFrame(scrollArea)
+            actionAdvertised: advertised
         )
     }
 
     private func performIncrementPagePress(
-        _ binding: ScrollBehaviorBinding
+        _ binding: ScrollBehaviorBinding,
+        settledOuterClipBefore: DesktopReposReachabilityFrame
     ) throws -> DesktopReposScrollInteraction {
-        guard binding.actionAdvertised else {
+        let current = try revalidatedIncrementPagePressBinding(binding)
+        guard current.actionAdvertised else {
             return DesktopReposScrollInteraction(
                 mechanism: .incrementPagePress,
                 incrementPagePress: .init(
                     actionAdvertised: false,
                     attemptCount: 0,
                     performResult: nil,
-                    outerClipBefore: binding.outerClipBefore,
-                    outerClipAfter: nil
-                ),
-                valueMutation: nil
-            )
-        }
-        try requireTargetPID(binding.incrementPage)
-        guard try actionNames(binding.incrementPage).contains(NSAccessibility.Action.press.rawValue) else {
-            return DesktopReposScrollInteraction(
-                mechanism: .incrementPagePress,
-                incrementPagePress: .init(
-                    actionAdvertised: false,
-                    attemptCount: 0,
-                    performResult: nil,
-                    outerClipBefore: binding.outerClipBefore,
+                    outerClipBefore: settledOuterClipBefore,
                     outerClipAfter: nil
                 ),
                 valueMutation: nil
             )
         }
         let result = AXUIElementPerformAction(
-            binding.incrementPage,
+            current.incrementPage,
             NSAccessibility.Action.press.rawValue as CFString
         )
         let performResult = scrollActionResult(result)
-        var clipAfter: DesktopReposReachabilityFrame?
-        if result == .success {
-            let window = try verifiedWindow()
-            let elements = try semanticElements(in: window)
-            guard let scrollArea = try outermostScrollArea(from: elements.boundaryBody, to: window) else {
-                throw Failure.ancestryUnavailable
-            }
-            clipAfter = try elementFrame(scrollArea)
-        }
         return DesktopReposScrollInteraction(
             mechanism: .incrementPagePress,
             incrementPagePress: .init(
                 actionAdvertised: true,
                 attemptCount: 1,
                 performResult: performResult,
-                outerClipBefore: binding.outerClipBefore,
-                outerClipAfter: clipAfter
+                outerClipBefore: settledOuterClipBefore,
+                outerClipAfter: nil
             ),
             valueMutation: nil
+        )
+    }
+
+    private func revalidatedIncrementPagePressBinding(
+        _ original: ScrollBehaviorBinding
+    ) throws -> ScrollBehaviorBinding {
+        let current = try incrementPagePressBinding()
+        guard CFEqual(original.semantic.window, current.semantic.window),
+              CFEqual(original.semantic.elements.table, current.semantic.elements.table),
+              CFEqual(original.semantic.elements.applyAllowlist, current.semantic.elements.applyAllowlist),
+              CFEqual(original.semantic.elements.boundaryBody, current.semantic.elements.boundaryBody),
+              CFEqual(original.semantic.outerScrollArea, current.semantic.outerScrollArea),
+              original.semantic.boundaryScrollAncestorCount == current.semantic.boundaryScrollAncestorCount,
+              CFEqual(original.verticalScrollBar, current.verticalScrollBar),
+              CFEqual(original.incrementPage, current.incrementPage),
+              original.actionAdvertised == current.actionAdvertised else {
+            throw Failure.semanticChanged
+        }
+        return current
+    }
+
+    private func interactionWithSettledOuterClipAfter(
+        _ interaction: DesktopReposScrollInteraction,
+        settledOuterClipAfter: DesktopReposReachabilityFrame
+    ) -> DesktopReposScrollInteraction {
+        guard let press = interaction.incrementPagePress else { return interaction }
+        return DesktopReposScrollInteraction(
+            mechanism: interaction.mechanism,
+            incrementPagePress: .init(
+                actionAdvertised: press.actionAdvertised,
+                attemptCount: press.attemptCount,
+                performResult: press.performResult,
+                outerClipBefore: press.outerClipBefore,
+                outerClipAfter: settledOuterClipAfter
+            ),
+            valueMutation: interaction.valueMutation
         )
     }
 
@@ -697,6 +720,7 @@ private struct DesktopReposReachabilityAXTracer {
     ) -> Result<DesktopReposReachabilitySample, DesktopReposReachabilityAcquisitionFailureReason> {
         do {
             let viewport = try elementFrame(binding.window)
+            let outerClip = try elementFrame(binding.outerScrollArea)
             let pairs: [(DesktopReposReachabilityRegion, AXUIElement)] = [
                 (.table, binding.elements.table),
                 (.applyAllowlist, binding.elements.applyAllowlist),
@@ -708,6 +732,8 @@ private struct DesktopReposReachabilityAXTracer {
             return .success(DesktopReposReachabilitySample(
                 elapsedMilliseconds: elapsedMilliseconds,
                 viewport: viewport,
+                outerClip: outerClip,
+                boundaryScrollAncestorCount: binding.boundaryScrollAncestorCount,
                 regions: regions
             ))
         } catch let reason as DesktopReposReachabilityAcquisitionFailureReason {
@@ -717,11 +743,28 @@ private struct DesktopReposReachabilityAXTracer {
         }
     }
 
+    private func semanticBinding() throws -> SemanticBinding {
+        let window = try verifiedWindow()
+        let elements = try semanticElements(in: window)
+        guard let ancestry = try scrollAreaAncestry(from: elements.boundaryBody, to: window) else {
+            throw Failure.ancestryUnavailable
+        }
+        return SemanticBinding(
+            window: window,
+            elements: elements,
+            outerScrollArea: ancestry.outermost,
+            boundaryScrollAncestorCount: ancestry.count
+        )
+    }
+
     private func samplesMatch(
         _ lhs: DesktopReposReachabilitySample,
         _ rhs: DesktopReposReachabilitySample
     ) -> Bool {
-        guard framesMatch(lhs.viewport, rhs.viewport), lhs.regions.count == rhs.regions.count else {
+        guard framesMatch(lhs.viewport, rhs.viewport),
+              framesMatch(lhs.outerClip, rhs.outerClip),
+              lhs.boundaryScrollAncestorCount == rhs.boundaryScrollAncestorCount,
+              lhs.regions.count == rhs.regions.count else {
             return false
         }
         let right = Dictionary(uniqueKeysWithValues: rhs.regions.map { ($0.id, $0.frame) })
@@ -972,8 +1015,16 @@ private struct DesktopReposReachabilityAXTracer {
         from boundary: AXUIElement,
         to window: AXUIElement
     ) throws -> AXUIElement? {
+        try scrollAreaAncestry(from: boundary, to: window)?.outermost
+    }
+
+    private func scrollAreaAncestry(
+        from boundary: AXUIElement,
+        to window: AXUIElement
+    ) throws -> ScrollAncestry? {
         var current = boundary
         var outermost: AXUIElement?
+        var count = 0
         var visited = Set<CFHashCode>()
         for _ in 0..<64 {
             guard visited.insert(CFHash(current)).inserted else { throw Failure.ancestryCycle }
@@ -984,10 +1035,11 @@ private struct DesktopReposReachabilityAXTracer {
             let parent = rawParent as! AXUIElement
             try requireTargetPID(parent)
             if CFEqual(parent, window) {
-                return outermost
+                return outermost.map { ScrollAncestry(outermost: $0, count: count) }
             }
             if try optionalString(parent, kAXRoleAttribute as CFString) == (kAXScrollAreaRole as String) {
                 outermost = parent
+                count += 1
             }
             current = parent
         }
@@ -1129,13 +1181,20 @@ private struct DesktopReposReachabilityAXTracer {
     private struct SemanticBinding {
         let window: AXUIElement
         let elements: SemanticElements
+        let outerScrollArea: AXUIElement
+        let boundaryScrollAncestorCount: Int
     }
 
     private struct ScrollBehaviorBinding {
         let semantic: SemanticBinding
+        let verticalScrollBar: AXUIElement
         let incrementPage: AXUIElement
         let actionAdvertised: Bool
-        let outerClipBefore: DesktopReposReachabilityFrame
+    }
+
+    private struct ScrollAncestry {
+        let outermost: AXUIElement
+        let count: Int
     }
 
     private struct SemanticElements {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -482,13 +482,23 @@ private struct DesktopReposReachabilityAXTracer {
 
             let verticalScrollBar = try verticalScrollBar(in: outerScrollArea)
             let scrollBarActionNames = try verticalScrollBar.map(actionNames)
+            let incrementPage: AXUIElement?
+            if let verticalScrollBar {
+                incrementPage = try incrementPageButton(in: verticalScrollBar)
+            } else {
+                incrementPage = nil
+            }
+            let incrementPageActionNames = try incrementPage.map(actionNames)
             return try DesktopReposScrollCapabilityContract.evaluate(
                 osMajorVersion: osMajorVersion,
                 boundaryActionNames: boundaryActionNames,
                 verticalScrollBarResolved: verticalScrollBar != nil,
                 scrollBarActionNames: scrollBarActionNames,
+                incrementPageResolved: incrementPage != nil,
+                incrementPageActionNames: incrementPageActionNames,
                 scrollToVisibleActionName: scrollToVisibleActionName,
-                incrementActionName: NSAccessibility.Action.increment.rawValue
+                incrementActionName: NSAccessibility.Action.increment.rawValue,
+                pressActionName: NSAccessibility.Action.press.rawValue
             )
         } catch let reason as Failure {
             return .failed(osMajorVersion: osMajorVersion, reason: reason)
@@ -776,6 +786,53 @@ private struct DesktopReposReachabilityAXTracer {
             return .invalidType
         case .ambiguousVerticalChildren:
             return .semanticDuplicate
+        }
+    }
+
+    private func incrementPageButton(in scrollBar: AXUIElement) throws -> AXUIElement? {
+        guard let rawChildren = try optionalAttribute(
+            scrollBar,
+            kAXChildrenAttribute as CFString
+        ) else {
+            throw Failure.attributeUnavailable
+        }
+        guard CFGetTypeID(rawChildren) == CFArrayGetTypeID(),
+              let children = rawChildren as? [AXUIElement] else {
+            throw Failure.invalidType
+        }
+
+        var candidates: [DesktopReposIncrementPageCandidate] = []
+        candidates.reserveCapacity(children.count)
+        for child in children {
+            try requireTargetPID(child)
+            candidates.append(.init(
+                role: try optionalString(child, kAXRoleAttribute as CFString),
+                subrole: try optionalString(child, kAXSubroleAttribute as CFString)
+            ))
+        }
+
+        let selection: DesktopReposIncrementPageSelection
+        do {
+            selection = try DesktopReposIncrementPageSelectionContract.select(
+                directChildren: candidates
+            )
+        } catch let error as DesktopReposIncrementPageSelectionError {
+            switch error {
+            case .missingRole, .missingSubrole:
+                throw Failure.attributeUnavailable
+            case .invalidIncrementPageRole:
+                throw Failure.invalidType
+            case .duplicateIncrementPage:
+                throw Failure.semanticDuplicate
+            }
+        }
+
+        switch selection {
+        case .directChild(let index):
+            guard children.indices.contains(index) else { throw Failure.invalidType }
+            return children[index]
+        case .unsupported:
+            return nil
         }
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -81,6 +81,11 @@ private struct Options {
     }
 }
 
+private struct ReposFocusedEvidence {
+    let reachability: [String: String]
+    let scrollCapabilities: [String: String]
+}
+
 private struct CaptureRunner {
     let options: Options
 
@@ -129,7 +134,7 @@ private struct CaptureRunner {
         ]
         let geometryData = try JSONSerialization.data(withJSONObject: geometry, options: [.prettyPrinted, .sortedKeys])
         try geometryData.write(to: geometryURL, options: [.atomic])
-        let reachability = try writeReachabilityIfRequired(ready: ready)
+        let reposFocusedEvidence = try writeReposFocusedEvidenceIfRequired(ready: ready)
 
         var result: [String: Any] = [
             "ok": true,
@@ -139,8 +144,9 @@ private struct CaptureRunner {
             "accessibility": try evidence(accessibilityURL),
             "geometry": try evidence(geometryURL)
         ]
-        if let reachability {
-            result["reachability"] = reachability
+        if let reposFocusedEvidence {
+            result["reachability"] = reposFocusedEvidence.reachability
+            result["scrollCapabilities"] = reposFocusedEvidence.scrollCapabilities
         }
         return result
     }
@@ -162,14 +168,19 @@ private struct CaptureRunner {
         return ready
     }
 
-    private func writeReachabilityIfRequired(ready: ReadyDocument) throws -> [String: String]? {
+    private func writeReposFocusedEvidenceIfRequired(ready: ReadyDocument) throws -> ReposFocusedEvidence? {
         guard options.capturesReposReachability else { return nil }
-        let trace = DesktopReposReachabilityAXTracer(pid: options.pid, ready: ready).capture()
+        let tracer = DesktopReposReachabilityAXTracer(pid: options.pid, ready: ready)
+        let trace = tracer.capture()
+        let scrollCapabilities = tracer.captureScrollCapabilities()
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(trace)
-        let url = options.outputDirectory.appendingPathComponent("reachability.json")
-        try data.write(to: url, options: [.atomic])
+        let reachabilityData = try encoder.encode(trace)
+        let reachabilityURL = options.outputDirectory.appendingPathComponent("reachability.json")
+        try reachabilityData.write(to: reachabilityURL, options: [.atomic])
+        let capabilitiesData = try encoder.encode(scrollCapabilities.validated())
+        let capabilitiesURL = options.outputDirectory.appendingPathComponent("scroll-capabilities.json")
+        try capabilitiesData.write(to: capabilitiesURL, options: [.atomic])
         let status: String
         do {
             _ = try DesktopReposReachabilityValidator.validate(trace)
@@ -179,7 +190,17 @@ private struct CaptureRunner {
         } catch {
             status = "unreachable"
         }
-        return ["path": url.lastPathComponent, "sha256": try sha256(url), "status": status]
+        return ReposFocusedEvidence(
+            reachability: [
+                "path": reachabilityURL.lastPathComponent,
+                "sha256": try sha256(reachabilityURL),
+                "status": status
+            ],
+            scrollCapabilities: [
+                "path": capabilitiesURL.lastPathComponent,
+                "sha256": try sha256(capabilitiesURL)
+            ]
+        )
     }
 
     private func requireRegularFile(_ url: URL, label: String) throws {
@@ -426,6 +447,56 @@ private struct DesktopReposReachabilityAXTracer {
         )
     }
 
+    func captureScrollCapabilities() -> DesktopReposScrollCapabilities {
+        let osMajorVersion = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        let systemWide = AXUIElementCreateSystemWide()
+        let timeoutInstalled = AXUIElementSetMessagingTimeout(systemWide, 1.0) == .success
+        guard timeoutInstalled else {
+            return .failed(osMajorVersion: osMajorVersion, reason: .messagingTimeoutUnavailable)
+        }
+        defer { _ = AXUIElementSetMessagingTimeout(systemWide, 0) }
+
+        do {
+            let window = try verifiedWindow()
+            let elements = try semanticElements(in: window)
+            guard let outerScrollArea = try outermostScrollArea(
+                from: elements.boundaryBody,
+                to: window
+            ) else {
+                throw Failure.ancestryUnavailable
+            }
+
+            let boundaryActionNames: [String]?
+            let scrollToVisibleActionName: String?
+            if osMajorVersion >= 26 {
+                if #available(macOS 26.0, *) {
+                    boundaryActionNames = try actionNames(elements.boundaryBody)
+                    scrollToVisibleActionName = NSAccessibility.Action.scrollToVisibleAction.rawValue
+                } else {
+                    throw Failure.invalidType
+                }
+            } else {
+                boundaryActionNames = nil
+                scrollToVisibleActionName = nil
+            }
+
+            let verticalScrollBar = try verticalScrollBar(in: outerScrollArea)
+            let scrollBarActionNames = try verticalScrollBar.map(actionNames)
+            return try DesktopReposScrollCapabilityContract.evaluate(
+                osMajorVersion: osMajorVersion,
+                boundaryActionNames: boundaryActionNames,
+                verticalScrollBarResolved: verticalScrollBar != nil,
+                scrollBarActionNames: scrollBarActionNames,
+                scrollToVisibleActionName: scrollToVisibleActionName,
+                incrementActionName: NSAccessibility.Action.increment.rawValue
+            )
+        } catch let reason as Failure {
+            return .failed(osMajorVersion: osMajorVersion, reason: reason)
+        } catch {
+            return .failed(osMajorVersion: osMajorVersion, reason: .invalidType)
+        }
+    }
+
     private func acquireStableSamples() -> PhaseAcquisition {
         let phaseStarted = DispatchTime.now().uptimeNanoseconds
         let binding: SemanticBinding
@@ -635,6 +706,20 @@ private struct DesktopReposReachabilityAXTracer {
             }
             let scrollBar = rawScrollBar as! AXUIElement
             try requireTargetPID(scrollBar)
+            let candidate = DesktopReposVerticalScrollBarCandidate(
+                role: try optionalString(scrollBar, kAXRoleAttribute as CFString),
+                orientation: try optionalString(scrollBar, kAXOrientationAttribute as CFString)
+            )
+            do {
+                guard try DesktopReposVerticalScrollBarSelectionContract.select(
+                    convenienceCandidate: candidate,
+                    directChildren: []
+                ) == .convenienceAttribute else {
+                    throw Failure.invalidType
+                }
+            } catch let error as DesktopReposVerticalScrollBarSelectionError {
+                throw selectionFailure(error)
+            }
             return scrollBar
         }
 
@@ -663,18 +748,11 @@ private struct DesktopReposReachabilityAXTracer {
         let selection: DesktopReposVerticalScrollBarSelection
         do {
             selection = try DesktopReposVerticalScrollBarSelectionContract.select(
-                convenienceAvailable: false,
+                convenienceCandidate: nil,
                 directChildren: candidates
             )
         } catch let error as DesktopReposVerticalScrollBarSelectionError {
-            switch error {
-            case .missingRole, .missingOrientation:
-                throw Failure.attributeUnavailable
-            case .invalidOrientation:
-                throw Failure.invalidType
-            case .ambiguousVerticalChildren:
-                throw Failure.semanticDuplicate
-            }
+            throw selectionFailure(error)
         }
 
         switch selection {
@@ -685,6 +763,19 @@ private struct DesktopReposReachabilityAXTracer {
             return children[index]
         case .unsupported:
             return nil
+        }
+    }
+
+    private func selectionFailure(
+        _ error: DesktopReposVerticalScrollBarSelectionError
+    ) -> Failure {
+        switch error {
+        case .missingRole, .missingOrientation:
+            return .attributeUnavailable
+        case .invalidRole, .invalidOrientation:
+            return .invalidType
+        case .ambiguousVerticalChildren:
+            return .semanticDuplicate
         }
     }
 
@@ -856,6 +947,20 @@ private struct DesktopReposReachabilityAXTracer {
         guard let raw = try optionalAttribute(element, attribute) else { return nil }
         guard CFGetTypeID(raw) == CFStringGetTypeID() else { throw Failure.invalidType }
         return raw as? String
+    }
+
+    private func actionNames(_ element: AXUIElement) throws -> [String] {
+        try requireTargetPID(element)
+        var rawActionNames: CFArray?
+        let result = AXUIElementCopyActionNames(element, &rawActionNames)
+        guard result == .success else { throw mapAXError(result) }
+        guard let rawActionNames else { throw Failure.attributeUnavailable }
+        guard CFGetTypeID(rawActionNames) == CFArrayGetTypeID(),
+              let names = rawActionNames as? [String],
+              names.allSatisfy({ !$0.isEmpty }) else {
+            throw Failure.invalidType
+        }
+        return names
     }
 
     private func optionalTextValue(_ element: AXUIElement, _ attribute: CFString) throws -> String? {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -427,29 +427,77 @@ private struct DesktopReposReachabilityAXTracer {
     }
 
     private func acquireStableSamples() -> PhaseAcquisition {
-        let started = DispatchTime.now().uptimeNanoseconds
-        var nextDeadline = started
+        let phaseStarted = DispatchTime.now().uptimeNanoseconds
+        let binding: SemanticBinding
+        do {
+            let window = try verifiedWindow()
+            binding = SemanticBinding(window: window, elements: try semanticElements(in: window))
+        } catch let reason as DesktopReposReachabilityAcquisitionFailureReason {
+            return PhaseAcquisition(
+                samples: [],
+                durationMilliseconds: milliseconds(
+                    from: phaseStarted,
+                    to: DispatchTime.now().uptimeNanoseconds
+                ),
+                stable: false,
+                failure: reason
+            )
+        } catch {
+            return PhaseAcquisition(
+                samples: [],
+                durationMilliseconds: milliseconds(
+                    from: phaseStarted,
+                    to: DispatchTime.now().uptimeNanoseconds
+                ),
+                stable: false,
+                failure: .invalidType
+            )
+        }
+
+        let samplingStarted = DispatchTime.now().uptimeNanoseconds
+        guard milliseconds(from: phaseStarted, to: samplingStarted) <= Self.maximumAcquisitionMilliseconds else {
+            return PhaseAcquisition(
+                samples: [],
+                durationMilliseconds: milliseconds(from: phaseStarted, to: samplingStarted),
+                stable: false,
+                failure: .timeout
+            )
+        }
         var rolling: [DesktopReposReachabilitySample] = []
         while true {
             let beforeSample = DispatchTime.now().uptimeNanoseconds
-            let elapsed = milliseconds(from: started, to: beforeSample)
-            guard elapsed <= Self.maximumAcquisitionMilliseconds else {
-                return PhaseAcquisition(samples: rolling, durationMilliseconds: elapsed, stable: false, failure: .timeout)
+            let elapsedBeforeSample = milliseconds(from: phaseStarted, to: beforeSample)
+            guard elapsedBeforeSample <= Self.maximumAcquisitionMilliseconds else {
+                return PhaseAcquisition(
+                    samples: rolling,
+                    durationMilliseconds: elapsedBeforeSample,
+                    stable: false,
+                    failure: .timeout
+                )
             }
-            switch sample(elapsedMilliseconds: elapsed) {
+            let elapsed = milliseconds(from: samplingStarted, to: beforeSample)
+            switch sample(binding: binding, elapsedMilliseconds: elapsed) {
             case .success(let value):
                 rolling.append(value)
             case .failure(let reason):
                 return PhaseAcquisition(
                     samples: rolling,
-                    durationMilliseconds: milliseconds(from: started, to: DispatchTime.now().uptimeNanoseconds),
+                    durationMilliseconds: milliseconds(
+                        from: phaseStarted,
+                        to: DispatchTime.now().uptimeNanoseconds
+                    ),
                     stable: false,
                     failure: reason
                 )
             }
-            if rolling.count > 3 { rolling.removeFirst() }
-            let duration = milliseconds(from: started, to: DispatchTime.now().uptimeNanoseconds)
-            if rolling.count == 3,
+            if rolling.count > DesktopReposReachabilitySamplingContract.minimumStableSampleCount {
+                rolling.removeFirst()
+            }
+            let duration = milliseconds(from: phaseStarted, to: DispatchTime.now().uptimeNanoseconds)
+            if rolling.count == DesktopReposReachabilitySamplingContract.minimumStableSampleCount,
+               DesktopReposReachabilitySamplingContract.hasStableCadence(
+                   rolling.map(\.elapsedMilliseconds)
+               ),
                samplesMatch(rolling[0], rolling[1]),
                samplesMatch(rolling[0], rolling[2]),
                duration <= Self.maximumAcquisitionMilliseconds {
@@ -458,8 +506,8 @@ private struct DesktopReposReachabilityAXTracer {
             guard duration <= Self.maximumAcquisitionMilliseconds else {
                 return PhaseAcquisition(samples: rolling, durationMilliseconds: duration, stable: false, failure: .timeout)
             }
-            nextDeadline += Self.intervalNanoseconds
             let now = DispatchTime.now().uptimeNanoseconds
+            let nextDeadline = max(beforeSample + Self.intervalNanoseconds, now)
             if nextDeadline > now {
                 usleep(useconds_t((nextDeadline - now) / 1_000))
             }
@@ -471,16 +519,15 @@ private struct DesktopReposReachabilityAXTracer {
     }
 
     private func sample(
+        binding: SemanticBinding,
         elapsedMilliseconds: Int
     ) -> Result<DesktopReposReachabilitySample, DesktopReposReachabilityAcquisitionFailureReason> {
         do {
-            let window = try verifiedWindow()
-            let viewport = try elementFrame(window)
-            let elements = try semanticElements(in: window)
+            let viewport = try elementFrame(binding.window)
             let pairs: [(DesktopReposReachabilityRegion, AXUIElement)] = [
-                (.table, elements.table),
-                (.applyAllowlist, elements.applyAllowlist),
-                (.boundaryBody, elements.boundaryBody)
+                (.table, binding.elements.table),
+                (.applyAllowlist, binding.elements.applyAllowlist),
+                (.boundaryBody, binding.elements.boundaryBody)
             ]
             let regions = try pairs.map { id, element in
                 DesktopReposReachabilityRegionFrame(id: id, frame: try elementFrame(element))
@@ -835,6 +882,11 @@ private struct DesktopReposReachabilityAXTracer {
         let failure: Failure?
 
         static let empty = PhaseAcquisition(samples: [], durationMilliseconds: 0, stable: false, failure: nil)
+    }
+
+    private struct SemanticBinding {
+        let window: AXUIElement
+        let elements: SemanticElements
     }
 
     private struct SemanticElements {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -658,7 +658,7 @@ private struct DesktopReposReachabilityAXTracer {
         let description = try optionalString(element, kAXDescriptionAttribute as CFString)
         let value = try optionalTextValue(element, kAXValueAttribute as CFString)
         let identifier = try optionalString(element, kAXIdentifierAttribute as CFString)
-        if role == (kAXTableRole as String) {
+        if DesktopReposReachabilitySemanticContract.matchesTable(role: role) {
             candidates.table.append(element)
         }
         if DesktopReposReachabilitySemanticContract.matchesApplyAllowlist(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -11,6 +11,7 @@ private enum CaptureError: LocalizedError {
     case usage
     case unsafePath(String)
     case invalidReadyFile
+    case unsupportedReachabilityTarget
     case permission(String)
     case window(String)
     case screenshot(String)
@@ -21,6 +22,8 @@ private enum CaptureError: LocalizedError {
             "usage: NeonDiffDesktopCapture --pid <pid> --ready <ready.json> --output-dir <directory> [--repos-reachability]"
         case .unsafePath(let detail): "Unsafe capture path: \(detail)"
         case .invalidReadyFile: "Evaluation readiness file is invalid or does not match the target process."
+        case .unsupportedReachabilityTarget:
+            "Repositories reachability capture requires tab-repos at 1040x680."
         case .permission(let detail): "Capture permission is unavailable: \(detail)"
         case .window(let detail): "Target window is unavailable: \(detail)"
         case .screenshot(let detail): "Window screenshot failed: \(detail)"
@@ -83,6 +86,17 @@ private struct CaptureRunner {
 
     func run() throws -> [String: Any] {
         let ready = try loadReady()
+        if options.capturesReposReachability {
+            do {
+                _ = try DesktopReposReachabilityTarget.requireSupported(
+                    fixtureId: ready.fixtureId,
+                    contentWidth: ready.contentFrame.width,
+                    contentHeight: ready.contentFrame.height
+                )
+            } catch {
+                throw CaptureError.unsupportedReachabilityTarget
+            }
+        }
         guard CGPreflightScreenCaptureAccess() else {
             throw CaptureError.permission("Screen Recording")
         }
@@ -115,9 +129,9 @@ private struct CaptureRunner {
         ]
         let geometryData = try JSONSerialization.data(withJSONObject: geometry, options: [.prettyPrinted, .sortedKeys])
         try geometryData.write(to: geometryURL, options: [.atomic])
-        try writeReachabilityIfRequired(ready: ready)
+        let reachability = try writeReachabilityIfRequired(ready: ready)
 
-        return [
+        var result: [String: Any] = [
             "ok": true,
             "fixtureId": ready.fixtureId,
             "windowNumber": ready.windowNumber,
@@ -125,6 +139,10 @@ private struct CaptureRunner {
             "accessibility": try evidence(accessibilityURL),
             "geometry": try evidence(geometryURL)
         ]
+        if let reachability {
+            result["reachability"] = reachability
+        }
+        return result
     }
 
     private func loadReady() throws -> ReadyDocument {
@@ -144,21 +162,24 @@ private struct CaptureRunner {
         return ready
     }
 
-    private func writeReachabilityIfRequired(ready: ReadyDocument) throws {
-        guard options.capturesReposReachability,
-              ready.fixtureId == DesktopReposReachabilityFixture.tabRepos.rawValue,
-              abs(ready.contentFrame.width - 1040) <= 1,
-              abs(ready.contentFrame.height - 680) <= 1 else {
-            return
-        }
+    private func writeReachabilityIfRequired(ready: ReadyDocument) throws -> [String: String]? {
+        guard options.capturesReposReachability else { return nil }
         let trace = DesktopReposReachabilityAXTracer(pid: options.pid, ready: ready).capture()
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(trace)
-        try data.write(
-            to: options.outputDirectory.appendingPathComponent("reachability.json"),
-            options: [.atomic]
-        )
+        let url = options.outputDirectory.appendingPathComponent("reachability.json")
+        try data.write(to: url, options: [.atomic])
+        let status: String
+        do {
+            _ = try DesktopReposReachabilityValidator.validate(trace)
+            status = "reachable"
+        } catch DesktopReposReachabilityValidationError.acquisitionFailed {
+            status = "acquisition-failed"
+        } catch {
+            status = "unreachable"
+        }
+        return ["path": url.lastPathComponent, "sha256": try sha256(url), "status": status]
     }
 
     private func requireRegularFile(_ url: URL, label: String) throws {
@@ -358,36 +379,54 @@ private struct DesktopReposReachabilityAXTracer {
             }
         }
 
-        let pre: (samples: [DesktopReposReachabilitySample], durationMilliseconds: Int, stable: Bool) = timeoutInstalled
-            ? acquireStableSamples()
-            : (samples: [], durationMilliseconds: 0, stable: false)
-        let scroll = timeoutInstalled ? scrollBoundaryAncestorToMaximum() : nil
-        let post = timeoutInstalled ? acquireStableSamples() : (samples: [], durationMilliseconds: 0, stable: false)
+        var pre = PhaseAcquisition.empty
+        var post = PhaseAcquisition.empty
+        var outerScroll: DesktopReposOuterScrollObservation?
+        var failure: DesktopReposReachabilityAcquisitionFailureReason?
+        if timeoutInstalled {
+            pre = acquireStableSamples()
+            failure = pre.failure
+            if failure == nil {
+                switch scrollBoundaryAncestorToMaximum() {
+                case .success(let observation):
+                    outerScroll = observation
+                case .failure(let reason):
+                    failure = reason
+                }
+            }
+            if failure == nil {
+                post = acquireStableSamples()
+                failure = post.failure
+            }
+        } else {
+            failure = .messagingTimeoutUnavailable
+        }
 
         // The ready document is emitted only after the DEBUG fixture render
         // latch and three stable 100 ms readiness samples have completed.
         let readinessGatePassed = ready.ready
+        let acquisition = DesktopReposReachabilityAcquisition(
+            status: failure == nil ? .complete : .failed,
+            failureReason: failure
+        )
         return DesktopReposReachabilityTrace(
             schemaVersion: 1,
             fixture: .tabRepos,
             ready: readinessGatePassed,
-            quiescent: readinessGatePassed && pre.stable,
+            quiescent: readinessGatePassed && pre.stable && post.stable,
             requestedContentSize: DesktopEvaluationContentSize(width: 1040, height: 680),
             sampleIntervalMilliseconds: 100,
             preScrollAcquisitionMilliseconds: pre.durationMilliseconds,
             postScrollAcquisitionMilliseconds: post.durationMilliseconds,
             tolerancePoints: Self.tolerance,
+            acquisition: acquisition,
             preScrollSamples: pre.samples,
-            outerScroll: scroll,
+            outerScroll: outerScroll,
             postScrollSamples: post.samples
         )
     }
 
-    private func acquireStableSamples() -> (
-        samples: [DesktopReposReachabilitySample],
-        durationMilliseconds: Int,
-        stable: Bool
-    ) {
+    private func acquireStableSamples() -> PhaseAcquisition {
         let started = DispatchTime.now().uptimeNanoseconds
         var nextDeadline = started
         var rolling: [DesktopReposReachabilitySample] = []
@@ -395,19 +434,29 @@ private struct DesktopReposReachabilityAXTracer {
             let beforeSample = DispatchTime.now().uptimeNanoseconds
             let elapsed = milliseconds(from: started, to: beforeSample)
             guard elapsed <= Self.maximumAcquisitionMilliseconds else {
-                return (rolling, elapsed, false)
+                return PhaseAcquisition(samples: rolling, durationMilliseconds: elapsed, stable: false, failure: .timeout)
             }
-            rolling.append(sample(elapsedMilliseconds: elapsed))
+            switch sample(elapsedMilliseconds: elapsed) {
+            case .success(let value):
+                rolling.append(value)
+            case .failure(let reason):
+                return PhaseAcquisition(
+                    samples: rolling,
+                    durationMilliseconds: milliseconds(from: started, to: DispatchTime.now().uptimeNanoseconds),
+                    stable: false,
+                    failure: reason
+                )
+            }
             if rolling.count > 3 { rolling.removeFirst() }
             let duration = milliseconds(from: started, to: DispatchTime.now().uptimeNanoseconds)
             if rolling.count == 3,
                samplesMatch(rolling[0], rolling[1]),
                samplesMatch(rolling[0], rolling[2]),
                duration <= Self.maximumAcquisitionMilliseconds {
-                return (rolling, duration, true)
+                return PhaseAcquisition(samples: rolling, durationMilliseconds: duration, stable: true, failure: nil)
             }
             guard duration <= Self.maximumAcquisitionMilliseconds else {
-                return (rolling, duration, false)
+                return PhaseAcquisition(samples: rolling, durationMilliseconds: duration, stable: false, failure: .timeout)
             }
             nextDeadline += Self.intervalNanoseconds
             let now = DispatchTime.now().uptimeNanoseconds
@@ -421,30 +470,31 @@ private struct DesktopReposReachabilityAXTracer {
         Int((end - start) / 1_000_000)
     }
 
-    private func sample(elapsedMilliseconds: Int) -> DesktopReposReachabilitySample {
-        guard let window = verifiedWindow(),
-              let viewport = elementFrame(window),
-              let elements = semanticElements(in: window) else {
-            return DesktopReposReachabilitySample(
+    private func sample(
+        elapsedMilliseconds: Int
+    ) -> Result<DesktopReposReachabilitySample, DesktopReposReachabilityAcquisitionFailureReason> {
+        do {
+            let window = try verifiedWindow()
+            let viewport = try elementFrame(window)
+            let elements = try semanticElements(in: window)
+            let pairs: [(DesktopReposReachabilityRegion, AXUIElement)] = [
+                (.table, elements.table),
+                (.applyAllowlist, elements.applyAllowlist),
+                (.boundaryBody, elements.boundaryBody)
+            ]
+            let regions = try pairs.map { id, element in
+                DesktopReposReachabilityRegionFrame(id: id, frame: try elementFrame(element))
+            }
+            return .success(DesktopReposReachabilitySample(
                 elapsedMilliseconds: elapsedMilliseconds,
-                viewport: DesktopReposReachabilityFrame(x: 0, y: 0, width: 0, height: 0),
-                regions: []
-            )
+                viewport: viewport,
+                regions: regions
+            ))
+        } catch let reason as DesktopReposReachabilityAcquisitionFailureReason {
+            return .failure(reason)
+        } catch {
+            return .failure(.invalidType)
         }
-        let pairs: [(DesktopReposReachabilityRegion, AXUIElement?)] = [
-            (.table, elements.table),
-            (.applyAllowlist, elements.applyAllowlist),
-            (.boundaryBody, elements.boundaryBody)
-        ]
-        let regions = pairs.compactMap { id, element -> DesktopReposReachabilityRegionFrame? in
-            guard let element, let frame = elementFrame(element) else { return nil }
-            return DesktopReposReachabilityRegionFrame(id: id, frame: frame)
-        }
-        return DesktopReposReachabilitySample(
-            elapsedMilliseconds: elapsedMilliseconds,
-            viewport: viewport,
-            regions: regions
-        )
     }
 
     private func samplesMatch(
@@ -470,60 +520,68 @@ private struct DesktopReposReachabilityAXTracer {
             && abs(lhs.height - rhs.height) <= Self.tolerance
     }
 
-    private func scrollBoundaryAncestorToMaximum() -> DesktopReposOuterScrollObservation? {
-        guard let window = verifiedWindow(),
-              let boundary = semanticElements(in: window)?.boundaryBody,
-              let scrollArea = outermostScrollArea(from: boundary, to: window) else {
-            return nil
-        }
-        guard case .value(let rawScrollBar) = copyAttribute(scrollArea, kAXVerticalScrollBarAttribute as CFString),
-              CFGetTypeID(rawScrollBar) == AXUIElementGetTypeID() else {
-            return unsupportedScroll()
-        }
-        let scrollBar = rawScrollBar as! AXUIElement
-        guard elementBelongsToTarget(scrollBar) else { return unsupportedScroll() }
+    private func scrollBoundaryAncestorToMaximum() -> Result<DesktopReposOuterScrollObservation?, DesktopReposReachabilityAcquisitionFailureReason> {
+        do {
+            let window = try verifiedWindow()
+            let boundary = try semanticElements(in: window).boundaryBody
+            guard let scrollArea = try outermostScrollArea(from: boundary, to: window) else {
+                return .success(nil)
+            }
+            guard let rawScrollBar = try optionalAttribute(
+                scrollArea,
+                kAXVerticalScrollBarAttribute as CFString
+            ) else {
+                return .success(unsupportedScroll())
+            }
+            guard CFGetTypeID(rawScrollBar) == AXUIElementGetTypeID() else { throw Failure.invalidType }
+            let scrollBar = rawScrollBar as! AXUIElement
+            try requireTargetPID(scrollBar)
 
-        var settable = DarwinBoolean(false)
-        guard AXUIElementIsAttributeSettable(
-            scrollBar,
-            kAXValueAttribute as CFString,
-            &settable
-        ) == .success, settable.boolValue else {
-            return unsupportedScroll()
-        }
-        guard case .value(let rawMinimum) = copyAttribute(scrollBar, kAXMinValueAttribute as CFString),
-              case .value(let rawMaximum) = copyAttribute(scrollBar, kAXMaxValueAttribute as CFString),
-              case .value(let rawBefore) = copyAttribute(scrollBar, kAXValueAttribute as CFString),
-              let minimum = numericValue(rawMinimum),
-              let maximum = numericValue(rawMaximum),
-              let before = numericValue(rawBefore) else {
-            return unsupportedScroll()
-        }
-        let setResult = AXUIElementSetAttributeValue(
-            scrollBar,
-            kAXValueAttribute as CFString,
-            rawMaximum
-        )
-        guard setResult == .success,
-              case .value(let rawReadback) = copyAttribute(scrollBar, kAXValueAttribute as CFString),
-              let readback = numericValue(rawReadback) else {
-            return DesktopReposOuterScrollObservation(
+            var settable = DarwinBoolean(false)
+            let settableResult = AXUIElementIsAttributeSettable(
+                scrollBar,
+                kAXValueAttribute as CFString,
+                &settable
+            )
+            if settableResult != .success {
+                if settableResult == .attributeUnsupported { return .success(unsupportedScroll()) }
+                throw mapAXError(settableResult)
+            }
+            guard settable.boolValue else { return .success(unsupportedScroll()) }
+            let rawMinimum: CFTypeRef
+            let rawMaximum: CFTypeRef
+            let rawBefore: CFTypeRef
+            do {
+                rawMinimum = try requiredAttribute(scrollBar, kAXMinValueAttribute as CFString)
+                rawMaximum = try requiredAttribute(scrollBar, kAXMaxValueAttribute as CFString)
+                rawBefore = try requiredAttribute(scrollBar, kAXValueAttribute as CFString)
+            } catch Failure.attributeUnavailable {
+                return .success(unsupportedScroll())
+            }
+            let minimum = try numericValue(rawMinimum)
+            let maximum = try numericValue(rawMaximum)
+            let before = try numericValue(rawBefore)
+            let setResult = AXUIElementSetAttributeValue(scrollBar, kAXValueAttribute as CFString, rawMaximum)
+            if setResult != .success {
+                if setResult == .attributeUnsupported || setResult == .actionUnsupported {
+                    return .success(unsupportedScroll())
+                }
+                throw mapAXError(setResult)
+            }
+            let readback = try numericValue(try requiredAttribute(scrollBar, kAXValueAttribute as CFString))
+            return .success(DesktopReposOuterScrollObservation(
                 verticalScrollBarSupported: true,
                 minimumValue: minimum,
                 maximumValue: maximum,
                 valueBeforeScroll: before,
-                valueAfterScroll: nil,
-                setToMaximumSucceeded: false
-            )
+                valueAfterScroll: readback,
+                setToMaximumSucceeded: abs(maximum - readback) <= 0.001
+            ))
+        } catch let reason as Failure {
+            return .failure(reason)
+        } catch {
+            return .failure(.invalidType)
         }
-        return DesktopReposOuterScrollObservation(
-            verticalScrollBarSupported: true,
-            minimumValue: minimum,
-            maximumValue: maximum,
-            valueBeforeScroll: before,
-            valueAfterScroll: readback,
-            setToMaximumSucceeded: abs(maximum - readback) <= 0.001
-        )
     }
 
     private func unsupportedScroll() -> DesktopReposOuterScrollObservation {
@@ -537,37 +595,49 @@ private struct DesktopReposReachabilityAXTracer {
         )
     }
 
-    private func verifiedWindow() -> AXUIElement? {
+    private func verifiedWindow() throws -> AXUIElement {
         let application = AXUIElementCreateApplication(pid)
-        guard elementBelongsToTarget(application),
-              case .value(let rawWindows) = copyAttribute(application, kAXWindowsAttribute as CFString),
-              CFGetTypeID(rawWindows) == CFArrayGetTypeID() else {
-            return nil
-        }
+        try requireTargetPID(application)
+        let rawWindows = try requiredAttribute(application, kAXWindowsAttribute as CFString)
+        guard CFGetTypeID(rawWindows) == CFArrayGetTypeID() else { throw Failure.invalidType }
         let windows = rawWindows as! [AXUIElement]
         guard windows.count == 1, let window = windows.first,
-              elementBelongsToTarget(window),
-              stringValue(window, kAXRoleAttribute as CFString) == (kAXWindowRole as String),
-              let frame = elementFrame(window),
+              try optionalString(window, kAXRoleAttribute as CFString) == (kAXWindowRole as String) else {
+            throw Failure.windowMismatch
+        }
+        try requireTargetPID(window)
+        let frame = try elementFrame(window)
+        guard
               abs(frame.width - ready.windowFrame.width) <= Self.tolerance,
               abs(frame.height - ready.windowFrame.height) <= Self.tolerance else {
-            return nil
+            throw Failure.windowMismatch
         }
         return window
     }
 
-    private func semanticElements(in window: AXUIElement) -> SemanticElements? {
-        var result = SemanticElements()
+    private func semanticElements(in window: AXUIElement) throws -> SemanticElements {
+        var candidates = SemanticCandidates()
         var remaining = 10_000
         var visited = Set<CFHashCode>()
-        visit(
+        try visit(
             window,
             depth: 0,
             remaining: &remaining,
             visited: &visited,
-            result: &result
+            candidates: &candidates
         )
-        return result
+        if let reason = DesktopReposReachabilitySemanticContract.failureReason(
+            tableCount: candidates.table.count,
+            applyAllowlistCount: candidates.applyAllowlist.count,
+            boundaryBodyCount: candidates.boundaryBody.count
+        ) {
+            throw reason
+        }
+        return SemanticElements(
+            table: candidates.table[0],
+            applyAllowlist: candidates.applyAllowlist[0],
+            boundaryBody: candidates.boundaryBody[0]
+        )
     }
 
     private func visit(
@@ -575,42 +645,50 @@ private struct DesktopReposReachabilityAXTracer {
         depth: Int,
         remaining: inout Int,
         visited: inout Set<CFHashCode>,
-        result: inout SemanticElements
-    ) {
-        guard depth <= 32, remaining > 0, elementBelongsToTarget(element) else { return }
+        candidates: inout SemanticCandidates
+    ) throws {
+        guard depth <= 32, remaining > 0 else { throw Failure.ancestryLimit }
+        try requireTargetPID(element)
         let hash = CFHash(element)
-        guard visited.insert(hash).inserted else { return }
+        guard visited.insert(hash).inserted else { throw Failure.ancestryCycle }
         remaining -= 1
 
-        let role = stringValue(element, kAXRoleAttribute as CFString)
-        let description = stringValue(element, kAXDescriptionAttribute as CFString)
-        let value = stringValue(element, kAXValueAttribute as CFString)
-        if result.table == nil, role == (kAXTableRole as String) {
-            result.table = element
+        let role = try optionalString(element, kAXRoleAttribute as CFString)
+        let title = try optionalString(element, kAXTitleAttribute as CFString)
+        let description = try optionalString(element, kAXDescriptionAttribute as CFString)
+        let value = try optionalTextValue(element, kAXValueAttribute as CFString)
+        let identifier = try optionalString(element, kAXIdentifierAttribute as CFString)
+        if role == (kAXTableRole as String) {
+            candidates.table.append(element)
         }
-        if result.applyAllowlist == nil,
-           role == (kAXButtonRole as String),
-           [description, value].compactMap({ $0 }).contains("Apply Allowlist") {
-            result.applyAllowlist = element
+        if DesktopReposReachabilitySemanticContract.matchesApplyAllowlist(
+            isButton: role == (kAXButtonRole as String),
+            identifier: identifier,
+            title: title,
+            description: description,
+            value: value
+        ) {
+            candidates.applyAllowlist.append(element)
         }
-        if result.boundaryBody == nil,
-           role == (kAXStaticTextRole as String),
-           [description, value].compactMap({ $0 }).contains(where: {
-               $0.contains("Repo changes are written through")
-           }) {
-            result.boundaryBody = element
+        if DesktopReposReachabilitySemanticContract.matchesBoundaryBody(
+            isStaticText: role == (kAXStaticTextRole as String),
+            identifier: identifier,
+            description: description,
+            value: value
+        ) {
+            candidates.boundaryBody.append(element)
         }
 
-        guard case .value(let rawChildren) = copyAttribute(element, kAXChildrenAttribute as CFString),
-              CFGetTypeID(rawChildren) == CFArrayGetTypeID() else { return }
+        guard let rawChildren = try optionalAttribute(element, kAXChildrenAttribute as CFString) else { return }
+        guard CFGetTypeID(rawChildren) == CFArrayGetTypeID() else { throw Failure.invalidType }
         let children = rawChildren as! [AXUIElement]
         for child in children {
-            visit(
+            try visit(
                 child,
                 depth: depth + 1,
                 remaining: &remaining,
                 visited: &visited,
-                result: &result
+                candidates: &candidates
             )
         }
     }
@@ -618,46 +696,49 @@ private struct DesktopReposReachabilityAXTracer {
     private func outermostScrollArea(
         from boundary: AXUIElement,
         to window: AXUIElement
-    ) -> AXUIElement? {
+    ) throws -> AXUIElement? {
         var current = boundary
         var outermost: AXUIElement?
         var visited = Set<CFHashCode>()
         for _ in 0..<64 {
-            guard visited.insert(CFHash(current)).inserted,
-                  case .value(let rawParent) = copyAttribute(current, kAXParentAttribute as CFString),
-                  CFGetTypeID(rawParent) == AXUIElementGetTypeID() else {
-                return nil
+            guard visited.insert(CFHash(current)).inserted else { throw Failure.ancestryCycle }
+            guard let rawParent = try optionalAttribute(current, kAXParentAttribute as CFString) else {
+                throw Failure.ancestryUnavailable
             }
+            guard CFGetTypeID(rawParent) == AXUIElementGetTypeID() else { throw Failure.invalidType }
             let parent = rawParent as! AXUIElement
-            guard elementBelongsToTarget(parent) else { return nil }
+            try requireTargetPID(parent)
             if CFEqual(parent, window) {
                 return outermost
             }
-            if stringValue(parent, kAXRoleAttribute as CFString) == (kAXScrollAreaRole as String) {
+            if try optionalString(parent, kAXRoleAttribute as CFString) == (kAXScrollAreaRole as String) {
                 outermost = parent
             }
             current = parent
         }
-        return nil
+        throw Failure.ancestryLimit
     }
 
-    private func elementBelongsToTarget(_ element: AXUIElement) -> Bool {
+    private func requireTargetPID(_ element: AXUIElement) throws {
         var elementPID: pid_t = 0
-        return AXUIElementGetPid(element, &elementPID) == .success && elementPID == pid
+        let result = AXUIElementGetPid(element, &elementPID)
+        guard result == .success else { throw mapAXError(result) }
+        guard elementPID == pid else { throw Failure.pidMismatch }
     }
 
-    private func elementFrame(_ element: AXUIElement) -> DesktopReposReachabilityFrame? {
-        guard case .value(let rawPosition) = copyAttribute(element, kAXPositionAttribute as CFString),
-              case .value(let rawSize) = copyAttribute(element, kAXSizeAttribute as CFString),
-              let position = pointValue(rawPosition),
-              let size = sizeValue(rawSize),
+    private func elementFrame(_ element: AXUIElement) throws -> DesktopReposReachabilityFrame {
+        let rawPosition = try requiredAttribute(element, kAXPositionAttribute as CFString)
+        let rawSize = try requiredAttribute(element, kAXSizeAttribute as CFString)
+        let position = try pointValue(rawPosition)
+        let size = try sizeValue(rawSize)
+        guard
               position.x.isFinite,
               position.y.isFinite,
               size.width.isFinite,
               size.height.isFinite,
               size.width > 0,
               size.height > 0 else {
-            return nil
+            throw Failure.invalidType
         }
         return DesktopReposReachabilityFrame(
             x: position.x,
@@ -667,28 +748,53 @@ private struct DesktopReposReachabilityAXTracer {
         )
     }
 
-    private func stringValue(_ element: AXUIElement, _ attribute: CFString) -> String? {
-        guard case .value(let raw) = copyAttribute(element, attribute),
+    private func optionalString(_ element: AXUIElement, _ attribute: CFString) throws -> String? {
+        guard let raw = try optionalAttribute(element, attribute) else { return nil }
+        guard CFGetTypeID(raw) == CFStringGetTypeID() else { throw Failure.invalidType }
+        return raw as? String
+    }
+
+    private func optionalTextValue(_ element: AXUIElement, _ attribute: CFString) throws -> String? {
+        guard let raw = try optionalAttribute(element, attribute),
               CFGetTypeID(raw) == CFStringGetTypeID() else { return nil }
         return raw as? String
     }
 
-    private func numericValue(_ raw: CFTypeRef) -> Double? {
-        guard CFGetTypeID(raw) == CFNumberGetTypeID() else { return nil }
-        guard let value = (raw as? NSNumber)?.doubleValue, value.isFinite else { return nil }
+    private func numericValue(_ raw: CFTypeRef) throws -> Double {
+        guard CFGetTypeID(raw) == CFNumberGetTypeID(),
+              let value = (raw as? NSNumber)?.doubleValue,
+              value.isFinite else { throw Failure.invalidType }
         return value
     }
 
-    private func pointValue(_ raw: CFTypeRef) -> CGPoint? {
-        guard CFGetTypeID(raw) == AXValueGetTypeID() else { return nil }
+    private func pointValue(_ raw: CFTypeRef) throws -> CGPoint {
+        guard CFGetTypeID(raw) == AXValueGetTypeID() else { throw Failure.invalidType }
         var point = CGPoint.zero
-        return AXValueGetValue(raw as! AXValue, .cgPoint, &point) ? point : nil
+        guard AXValueGetValue(raw as! AXValue, .cgPoint, &point) else { throw Failure.invalidType }
+        return point
     }
 
-    private func sizeValue(_ raw: CFTypeRef) -> CGSize? {
-        guard CFGetTypeID(raw) == AXValueGetTypeID() else { return nil }
+    private func sizeValue(_ raw: CFTypeRef) throws -> CGSize {
+        guard CFGetTypeID(raw) == AXValueGetTypeID() else { throw Failure.invalidType }
         var size = CGSize.zero
-        return AXValueGetValue(raw as! AXValue, .cgSize, &size) ? size : nil
+        guard AXValueGetValue(raw as! AXValue, .cgSize, &size) else { throw Failure.invalidType }
+        return size
+    }
+
+    private func requiredAttribute(_ element: AXUIElement, _ attribute: CFString) throws -> CFTypeRef {
+        guard let value = try optionalAttribute(element, attribute) else { throw Failure.attributeUnavailable }
+        return value
+    }
+
+    private func optionalAttribute(_ element: AXUIElement, _ attribute: CFString) throws -> CFTypeRef? {
+        switch copyAttribute(element, attribute) {
+        case .value(let value):
+            return value
+        case .failure(let error) where error == .noValue || error == .attributeUnsupported:
+            return nil
+        case .failure(let error):
+            throw mapAXError(error)
+        }
     }
 
     private func copyAttribute(_ element: AXUIElement, _ attribute: CFString) -> AXReadResult {
@@ -705,10 +811,42 @@ private struct DesktopReposReachabilityAXTracer {
         return .failure(.cannotComplete)
     }
 
+    private func mapAXError(_ error: AXError) -> Failure {
+        switch error {
+        case .cannotComplete:
+            return .cannotComplete
+        case .invalidUIElement, .invalidUIElementObserver:
+            return .invalidElement
+        case .apiDisabled:
+            return .permissionDenied
+        case .attributeUnsupported, .noValue:
+            return .attributeUnavailable
+        default:
+            return .invalidType
+        }
+    }
+
+    private typealias Failure = DesktopReposReachabilityAcquisitionFailureReason
+
+    private struct PhaseAcquisition {
+        let samples: [DesktopReposReachabilitySample]
+        let durationMilliseconds: Int
+        let stable: Bool
+        let failure: Failure?
+
+        static let empty = PhaseAcquisition(samples: [], durationMilliseconds: 0, stable: false, failure: nil)
+    }
+
     private struct SemanticElements {
-        var table: AXUIElement?
-        var applyAllowlist: AXUIElement?
-        var boundaryBody: AXUIElement?
+        let table: AXUIElement
+        let applyAllowlist: AXUIElement
+        let boundaryBody: AXUIElement
+    }
+
+    private struct SemanticCandidates {
+        var table: [AXUIElement] = []
+        var applyAllowlist: [AXUIElement] = []
+        var boundaryBody: [AXUIElement] = []
     }
 
     private enum AXReadResult {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -574,15 +574,9 @@ private struct DesktopReposReachabilityAXTracer {
             guard let scrollArea = try outermostScrollArea(from: boundary, to: window) else {
                 return .success(nil)
             }
-            guard let rawScrollBar = try optionalAttribute(
-                scrollArea,
-                kAXVerticalScrollBarAttribute as CFString
-            ) else {
+            guard let scrollBar = try verticalScrollBar(in: scrollArea) else {
                 return .success(unsupportedScroll())
             }
-            guard CFGetTypeID(rawScrollBar) == AXUIElementGetTypeID() else { throw Failure.invalidType }
-            let scrollBar = rawScrollBar as! AXUIElement
-            try requireTargetPID(scrollBar)
 
             var settable = DarwinBoolean(false)
             let settableResult = AXUIElementIsAttributeSettable(
@@ -628,6 +622,69 @@ private struct DesktopReposReachabilityAXTracer {
             return .failure(reason)
         } catch {
             return .failure(.invalidType)
+        }
+    }
+
+    private func verticalScrollBar(in scrollArea: AXUIElement) throws -> AXUIElement? {
+        if let rawScrollBar = try optionalAttribute(
+            scrollArea,
+            kAXVerticalScrollBarAttribute as CFString
+        ) {
+            guard CFGetTypeID(rawScrollBar) == AXUIElementGetTypeID() else {
+                throw Failure.invalidType
+            }
+            let scrollBar = rawScrollBar as! AXUIElement
+            try requireTargetPID(scrollBar)
+            return scrollBar
+        }
+
+        guard let rawChildren = try optionalAttribute(
+            scrollArea,
+            kAXChildrenAttribute as CFString
+        ) else {
+            return nil
+        }
+        guard CFGetTypeID(rawChildren) == CFArrayGetTypeID(),
+              let children = rawChildren as? [AXUIElement] else {
+            throw Failure.invalidType
+        }
+
+        var candidates: [DesktopReposVerticalScrollBarCandidate] = []
+        candidates.reserveCapacity(children.count)
+        for child in children {
+            try requireTargetPID(child)
+            let role = try optionalString(child, kAXRoleAttribute as CFString)
+            let orientation = role == (kAXScrollBarRole as String)
+                ? try optionalString(child, kAXOrientationAttribute as CFString)
+                : nil
+            candidates.append(.init(role: role, orientation: orientation))
+        }
+
+        let selection: DesktopReposVerticalScrollBarSelection
+        do {
+            selection = try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceAvailable: false,
+                directChildren: candidates
+            )
+        } catch let error as DesktopReposVerticalScrollBarSelectionError {
+            switch error {
+            case .missingRole, .missingOrientation:
+                throw Failure.attributeUnavailable
+            case .invalidOrientation:
+                throw Failure.invalidType
+            case .ambiguousVerticalChildren:
+                throw Failure.semanticDuplicate
+            }
+        }
+
+        switch selection {
+        case .convenienceAttribute:
+            throw Failure.invalidType
+        case .directChild(let index):
+            guard children.indices.contains(index) else { throw Failure.invalidType }
+            return children[index]
+        case .unsupported:
+            return nil
         }
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -483,12 +483,9 @@ private struct DesktopReposReachabilityAXTracer {
             let boundaryActionNames: [String]?
             let scrollToVisibleActionName: String?
             if osMajorVersion >= 26 {
-                if #available(macOS 26.0, *) {
-                    boundaryActionNames = try actionNames(elements.boundaryBody)
-                    scrollToVisibleActionName = NSAccessibility.Action.scrollToVisibleAction.rawValue
-                } else {
-                    throw Failure.invalidType
-                }
+                boundaryActionNames = try actionNames(elements.boundaryBody)
+                scrollToVisibleActionName = DesktopReposScrollCapabilityContract
+                    .scrollToVisibleActionName
             } else {
                 boundaryActionNames = nil
                 scrollToVisibleActionName = nil

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift
@@ -5,6 +5,7 @@ import CryptoKit
 import Darwin
 import Foundation
 import NeonDiffDesktopCore
+import NeonDiffDesktopEvaluationSupport
 
 private enum CaptureError: LocalizedError {
     case usage
@@ -17,7 +18,7 @@ private enum CaptureError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .usage:
-            "usage: NeonDiffDesktopCapture --pid <pid> --ready <ready.json> --output-dir <directory>"
+            "usage: NeonDiffDesktopCapture --pid <pid> --ready <ready.json> --output-dir <directory> [--repos-reachability]"
         case .unsafePath(let detail): "Unsafe capture path: \(detail)"
         case .invalidReadyFile: "Evaluation readiness file is invalid or does not match the target process."
         case .permission(let detail): "Capture permission is unavailable: \(detail)"
@@ -49,6 +50,7 @@ private struct Options {
     let pid: Int32
     let readyURL: URL
     let outputDirectory: URL
+    let capturesReposReachability: Bool
 
     static func parse(_ arguments: [String]) throws -> Options {
         func value(_ flag: String) throws -> String {
@@ -60,7 +62,9 @@ private struct Options {
             }
             return arguments[index + 1]
         }
-        guard arguments.count == 7,
+        let capturesReposReachability = arguments.contains("--repos-reachability")
+        guard arguments.filter({ $0 == "--repos-reachability" }).count <= 1,
+              arguments.count == (capturesReposReachability ? 8 : 7),
               let pid = Int32(try value("--pid")),
               pid > 0 else {
             throw CaptureError.usage
@@ -68,7 +72,8 @@ private struct Options {
         return Options(
             pid: pid,
             readyURL: URL(fileURLWithPath: try value("--ready")).standardizedFileURL,
-            outputDirectory: URL(fileURLWithPath: try value("--output-dir"), isDirectory: true).standardizedFileURL
+            outputDirectory: URL(fileURLWithPath: try value("--output-dir"), isDirectory: true).standardizedFileURL,
+            capturesReposReachability: capturesReposReachability
         )
     }
 }
@@ -110,6 +115,7 @@ private struct CaptureRunner {
         ]
         let geometryData = try JSONSerialization.data(withJSONObject: geometry, options: [.prettyPrinted, .sortedKeys])
         try geometryData.write(to: geometryURL, options: [.atomic])
+        try writeReachabilityIfRequired(ready: ready)
 
         return [
             "ok": true,
@@ -136,6 +142,23 @@ private struct CaptureRunner {
             throw CaptureError.invalidReadyFile
         }
         return ready
+    }
+
+    private func writeReachabilityIfRequired(ready: ReadyDocument) throws {
+        guard options.capturesReposReachability,
+              ready.fixtureId == DesktopReposReachabilityFixture.tabRepos.rawValue,
+              abs(ready.contentFrame.width - 1040) <= 1,
+              abs(ready.contentFrame.height - 680) <= 1 else {
+            return
+        }
+        let trace = DesktopReposReachabilityAXTracer(pid: options.pid, ready: ready).capture()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(trace)
+        try data.write(
+            to: options.outputDirectory.appendingPathComponent("reachability.json"),
+            options: [.atomic]
+        )
     }
 
     private func requireRegularFile(_ url: URL, label: String) throws {
@@ -315,6 +338,382 @@ private struct CaptureRunner {
 
     private func frameDictionary(_ frame: Frame) -> [String: Double] {
         ["x": frame.x, "y": frame.y, "width": frame.width, "height": frame.height]
+    }
+}
+
+private struct DesktopReposReachabilityAXTracer {
+    private static let intervalNanoseconds: UInt64 = 100_000_000
+    private static let maximumAcquisitionMilliseconds = 5_000
+    private static let tolerance = 1.0
+
+    let pid: Int32
+    let ready: ReadyDocument
+
+    func capture() -> DesktopReposReachabilityTrace {
+        let systemWide = AXUIElementCreateSystemWide()
+        let timeoutInstalled = AXUIElementSetMessagingTimeout(systemWide, 1.0) == .success
+        defer {
+            if timeoutInstalled {
+                _ = AXUIElementSetMessagingTimeout(systemWide, 0)
+            }
+        }
+
+        let pre: (samples: [DesktopReposReachabilitySample], durationMilliseconds: Int, stable: Bool) = timeoutInstalled
+            ? acquireStableSamples()
+            : (samples: [], durationMilliseconds: 0, stable: false)
+        let scroll = timeoutInstalled ? scrollBoundaryAncestorToMaximum() : nil
+        let post = timeoutInstalled ? acquireStableSamples() : (samples: [], durationMilliseconds: 0, stable: false)
+
+        // The ready document is emitted only after the DEBUG fixture render
+        // latch and three stable 100 ms readiness samples have completed.
+        let readinessGatePassed = ready.ready
+        return DesktopReposReachabilityTrace(
+            schemaVersion: 1,
+            fixture: .tabRepos,
+            ready: readinessGatePassed,
+            quiescent: readinessGatePassed && pre.stable,
+            requestedContentSize: DesktopEvaluationContentSize(width: 1040, height: 680),
+            sampleIntervalMilliseconds: 100,
+            preScrollAcquisitionMilliseconds: pre.durationMilliseconds,
+            postScrollAcquisitionMilliseconds: post.durationMilliseconds,
+            tolerancePoints: Self.tolerance,
+            preScrollSamples: pre.samples,
+            outerScroll: scroll,
+            postScrollSamples: post.samples
+        )
+    }
+
+    private func acquireStableSamples() -> (
+        samples: [DesktopReposReachabilitySample],
+        durationMilliseconds: Int,
+        stable: Bool
+    ) {
+        let started = DispatchTime.now().uptimeNanoseconds
+        var nextDeadline = started
+        var rolling: [DesktopReposReachabilitySample] = []
+        while true {
+            let beforeSample = DispatchTime.now().uptimeNanoseconds
+            let elapsed = milliseconds(from: started, to: beforeSample)
+            guard elapsed <= Self.maximumAcquisitionMilliseconds else {
+                return (rolling, elapsed, false)
+            }
+            rolling.append(sample(elapsedMilliseconds: elapsed))
+            if rolling.count > 3 { rolling.removeFirst() }
+            let duration = milliseconds(from: started, to: DispatchTime.now().uptimeNanoseconds)
+            if rolling.count == 3,
+               samplesMatch(rolling[0], rolling[1]),
+               samplesMatch(rolling[0], rolling[2]),
+               duration <= Self.maximumAcquisitionMilliseconds {
+                return (rolling, duration, true)
+            }
+            guard duration <= Self.maximumAcquisitionMilliseconds else {
+                return (rolling, duration, false)
+            }
+            nextDeadline += Self.intervalNanoseconds
+            let now = DispatchTime.now().uptimeNanoseconds
+            if nextDeadline > now {
+                usleep(useconds_t((nextDeadline - now) / 1_000))
+            }
+        }
+    }
+
+    private func milliseconds(from start: UInt64, to end: UInt64) -> Int {
+        Int((end - start) / 1_000_000)
+    }
+
+    private func sample(elapsedMilliseconds: Int) -> DesktopReposReachabilitySample {
+        guard let window = verifiedWindow(),
+              let viewport = elementFrame(window),
+              let elements = semanticElements(in: window) else {
+            return DesktopReposReachabilitySample(
+                elapsedMilliseconds: elapsedMilliseconds,
+                viewport: DesktopReposReachabilityFrame(x: 0, y: 0, width: 0, height: 0),
+                regions: []
+            )
+        }
+        let pairs: [(DesktopReposReachabilityRegion, AXUIElement?)] = [
+            (.table, elements.table),
+            (.applyAllowlist, elements.applyAllowlist),
+            (.boundaryBody, elements.boundaryBody)
+        ]
+        let regions = pairs.compactMap { id, element -> DesktopReposReachabilityRegionFrame? in
+            guard let element, let frame = elementFrame(element) else { return nil }
+            return DesktopReposReachabilityRegionFrame(id: id, frame: frame)
+        }
+        return DesktopReposReachabilitySample(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: viewport,
+            regions: regions
+        )
+    }
+
+    private func samplesMatch(
+        _ lhs: DesktopReposReachabilitySample,
+        _ rhs: DesktopReposReachabilitySample
+    ) -> Bool {
+        guard framesMatch(lhs.viewport, rhs.viewport), lhs.regions.count == rhs.regions.count else {
+            return false
+        }
+        let right = Dictionary(uniqueKeysWithValues: rhs.regions.map { ($0.id, $0.frame) })
+        return lhs.regions.allSatisfy { region in
+            right[region.id].map { framesMatch(region.frame, $0) } == true
+        }
+    }
+
+    private func framesMatch(
+        _ lhs: DesktopReposReachabilityFrame,
+        _ rhs: DesktopReposReachabilityFrame
+    ) -> Bool {
+        abs(lhs.x - rhs.x) <= Self.tolerance
+            && abs(lhs.y - rhs.y) <= Self.tolerance
+            && abs(lhs.width - rhs.width) <= Self.tolerance
+            && abs(lhs.height - rhs.height) <= Self.tolerance
+    }
+
+    private func scrollBoundaryAncestorToMaximum() -> DesktopReposOuterScrollObservation? {
+        guard let window = verifiedWindow(),
+              let boundary = semanticElements(in: window)?.boundaryBody,
+              let scrollArea = outermostScrollArea(from: boundary, to: window) else {
+            return nil
+        }
+        guard case .value(let rawScrollBar) = copyAttribute(scrollArea, kAXVerticalScrollBarAttribute as CFString),
+              CFGetTypeID(rawScrollBar) == AXUIElementGetTypeID() else {
+            return unsupportedScroll()
+        }
+        let scrollBar = rawScrollBar as! AXUIElement
+        guard elementBelongsToTarget(scrollBar) else { return unsupportedScroll() }
+
+        var settable = DarwinBoolean(false)
+        guard AXUIElementIsAttributeSettable(
+            scrollBar,
+            kAXValueAttribute as CFString,
+            &settable
+        ) == .success, settable.boolValue else {
+            return unsupportedScroll()
+        }
+        guard case .value(let rawMinimum) = copyAttribute(scrollBar, kAXMinValueAttribute as CFString),
+              case .value(let rawMaximum) = copyAttribute(scrollBar, kAXMaxValueAttribute as CFString),
+              case .value(let rawBefore) = copyAttribute(scrollBar, kAXValueAttribute as CFString),
+              let minimum = numericValue(rawMinimum),
+              let maximum = numericValue(rawMaximum),
+              let before = numericValue(rawBefore) else {
+            return unsupportedScroll()
+        }
+        let setResult = AXUIElementSetAttributeValue(
+            scrollBar,
+            kAXValueAttribute as CFString,
+            rawMaximum
+        )
+        guard setResult == .success,
+              case .value(let rawReadback) = copyAttribute(scrollBar, kAXValueAttribute as CFString),
+              let readback = numericValue(rawReadback) else {
+            return DesktopReposOuterScrollObservation(
+                verticalScrollBarSupported: true,
+                minimumValue: minimum,
+                maximumValue: maximum,
+                valueBeforeScroll: before,
+                valueAfterScroll: nil,
+                setToMaximumSucceeded: false
+            )
+        }
+        return DesktopReposOuterScrollObservation(
+            verticalScrollBarSupported: true,
+            minimumValue: minimum,
+            maximumValue: maximum,
+            valueBeforeScroll: before,
+            valueAfterScroll: readback,
+            setToMaximumSucceeded: abs(maximum - readback) <= 0.001
+        )
+    }
+
+    private func unsupportedScroll() -> DesktopReposOuterScrollObservation {
+        DesktopReposOuterScrollObservation(
+            verticalScrollBarSupported: false,
+            minimumValue: nil,
+            maximumValue: nil,
+            valueBeforeScroll: nil,
+            valueAfterScroll: nil,
+            setToMaximumSucceeded: false
+        )
+    }
+
+    private func verifiedWindow() -> AXUIElement? {
+        let application = AXUIElementCreateApplication(pid)
+        guard elementBelongsToTarget(application),
+              case .value(let rawWindows) = copyAttribute(application, kAXWindowsAttribute as CFString),
+              CFGetTypeID(rawWindows) == CFArrayGetTypeID() else {
+            return nil
+        }
+        let windows = rawWindows as! [AXUIElement]
+        guard windows.count == 1, let window = windows.first,
+              elementBelongsToTarget(window),
+              stringValue(window, kAXRoleAttribute as CFString) == (kAXWindowRole as String),
+              let frame = elementFrame(window),
+              abs(frame.width - ready.windowFrame.width) <= Self.tolerance,
+              abs(frame.height - ready.windowFrame.height) <= Self.tolerance else {
+            return nil
+        }
+        return window
+    }
+
+    private func semanticElements(in window: AXUIElement) -> SemanticElements? {
+        var result = SemanticElements()
+        var remaining = 10_000
+        var visited = Set<CFHashCode>()
+        visit(
+            window,
+            depth: 0,
+            remaining: &remaining,
+            visited: &visited,
+            result: &result
+        )
+        return result
+    }
+
+    private func visit(
+        _ element: AXUIElement,
+        depth: Int,
+        remaining: inout Int,
+        visited: inout Set<CFHashCode>,
+        result: inout SemanticElements
+    ) {
+        guard depth <= 32, remaining > 0, elementBelongsToTarget(element) else { return }
+        let hash = CFHash(element)
+        guard visited.insert(hash).inserted else { return }
+        remaining -= 1
+
+        let role = stringValue(element, kAXRoleAttribute as CFString)
+        let description = stringValue(element, kAXDescriptionAttribute as CFString)
+        let value = stringValue(element, kAXValueAttribute as CFString)
+        if result.table == nil, role == (kAXTableRole as String) {
+            result.table = element
+        }
+        if result.applyAllowlist == nil,
+           role == (kAXButtonRole as String),
+           [description, value].compactMap({ $0 }).contains("Apply Allowlist") {
+            result.applyAllowlist = element
+        }
+        if result.boundaryBody == nil,
+           role == (kAXStaticTextRole as String),
+           [description, value].compactMap({ $0 }).contains(where: {
+               $0.contains("Repo changes are written through")
+           }) {
+            result.boundaryBody = element
+        }
+
+        guard case .value(let rawChildren) = copyAttribute(element, kAXChildrenAttribute as CFString),
+              CFGetTypeID(rawChildren) == CFArrayGetTypeID() else { return }
+        let children = rawChildren as! [AXUIElement]
+        for child in children {
+            visit(
+                child,
+                depth: depth + 1,
+                remaining: &remaining,
+                visited: &visited,
+                result: &result
+            )
+        }
+    }
+
+    private func outermostScrollArea(
+        from boundary: AXUIElement,
+        to window: AXUIElement
+    ) -> AXUIElement? {
+        var current = boundary
+        var outermost: AXUIElement?
+        var visited = Set<CFHashCode>()
+        for _ in 0..<64 {
+            guard visited.insert(CFHash(current)).inserted,
+                  case .value(let rawParent) = copyAttribute(current, kAXParentAttribute as CFString),
+                  CFGetTypeID(rawParent) == AXUIElementGetTypeID() else {
+                return nil
+            }
+            let parent = rawParent as! AXUIElement
+            guard elementBelongsToTarget(parent) else { return nil }
+            if CFEqual(parent, window) {
+                return outermost
+            }
+            if stringValue(parent, kAXRoleAttribute as CFString) == (kAXScrollAreaRole as String) {
+                outermost = parent
+            }
+            current = parent
+        }
+        return nil
+    }
+
+    private func elementBelongsToTarget(_ element: AXUIElement) -> Bool {
+        var elementPID: pid_t = 0
+        return AXUIElementGetPid(element, &elementPID) == .success && elementPID == pid
+    }
+
+    private func elementFrame(_ element: AXUIElement) -> DesktopReposReachabilityFrame? {
+        guard case .value(let rawPosition) = copyAttribute(element, kAXPositionAttribute as CFString),
+              case .value(let rawSize) = copyAttribute(element, kAXSizeAttribute as CFString),
+              let position = pointValue(rawPosition),
+              let size = sizeValue(rawSize),
+              position.x.isFinite,
+              position.y.isFinite,
+              size.width.isFinite,
+              size.height.isFinite,
+              size.width > 0,
+              size.height > 0 else {
+            return nil
+        }
+        return DesktopReposReachabilityFrame(
+            x: position.x,
+            y: position.y,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    private func stringValue(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        guard case .value(let raw) = copyAttribute(element, attribute),
+              CFGetTypeID(raw) == CFStringGetTypeID() else { return nil }
+        return raw as? String
+    }
+
+    private func numericValue(_ raw: CFTypeRef) -> Double? {
+        guard CFGetTypeID(raw) == CFNumberGetTypeID() else { return nil }
+        guard let value = (raw as? NSNumber)?.doubleValue, value.isFinite else { return nil }
+        return value
+    }
+
+    private func pointValue(_ raw: CFTypeRef) -> CGPoint? {
+        guard CFGetTypeID(raw) == AXValueGetTypeID() else { return nil }
+        var point = CGPoint.zero
+        return AXValueGetValue(raw as! AXValue, .cgPoint, &point) ? point : nil
+    }
+
+    private func sizeValue(_ raw: CFTypeRef) -> CGSize? {
+        guard CFGetTypeID(raw) == AXValueGetTypeID() else { return nil }
+        var size = CGSize.zero
+        return AXValueGetValue(raw as! AXValue, .cgSize, &size) ? size : nil
+    }
+
+    private func copyAttribute(_ element: AXUIElement, _ attribute: CFString) -> AXReadResult {
+        for attempt in 0..<3 {
+            var raw: CFTypeRef?
+            let result = AXUIElementCopyAttributeValue(element, attribute, &raw)
+            if result == .success, let raw { return .value(raw) }
+            if result == .cannotComplete, attempt < 2 {
+                usleep(20_000)
+                continue
+            }
+            return .failure(result)
+        }
+        return .failure(.cannotComplete)
+    }
+
+    private struct SemanticElements {
+        var table: AXUIElement?
+        var applyAllowlist: AXUIElement?
+        var boundaryBody: AXUIElement?
+    }
+
+    private enum AXReadResult {
+        case value(CFTypeRef)
+        case failure(AXError)
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -44,6 +44,7 @@ public enum DesktopReposReachabilityAcquisitionFailureReason: String, Codable, E
     case windowMismatch = "window-mismatch"
     case semanticMissing = "semantic-missing"
     case semanticDuplicate = "semantic-duplicate"
+    case semanticChanged = "semantic-changed"
     case timeout
     case ancestryUnavailable = "ancestry-unavailable"
     case ancestryCycle = "ancestry-cycle"
@@ -294,15 +295,23 @@ public struct DesktopReposReachabilitySample: Codable, Equatable, Sendable {
     public let elapsedMilliseconds: Int
     /// The verified Accessibility window frame, in AX screen coordinates.
     public let viewport: DesktopReposReachabilityFrame
+    /// The outermost Boundary ancestor scroll area's settled AX frame.
+    public let outerClip: DesktopReposReachabilityFrame
+    /// Number of Boundary ancestor scroll areas from Boundary to the window.
+    public let boundaryScrollAncestorCount: Int
     public let regions: [DesktopReposReachabilityRegionFrame]
 
     public init(
         elapsedMilliseconds: Int,
         viewport: DesktopReposReachabilityFrame,
+        outerClip: DesktopReposReachabilityFrame,
+        boundaryScrollAncestorCount: Int,
         regions: [DesktopReposReachabilityRegionFrame]
     ) {
         self.elapsedMilliseconds = elapsedMilliseconds
         self.viewport = viewport
+        self.outerClip = outerClip
+        self.boundaryScrollAncestorCount = boundaryScrollAncestorCount
         self.regions = regions
     }
 }
@@ -595,8 +604,11 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
 
     private static func validateSample(_ object: Any) -> Bool {
         guard let sample = object as? [String: Any],
-              hasOnly(sample, ["elapsedMilliseconds", "viewport", "regions"]),
+              hasOnly(sample, [
+                  "elapsedMilliseconds", "viewport", "outerClip", "boundaryScrollAncestorCount", "regions"
+              ]),
               validateFrame(sample["viewport"]),
+              validateFrame(sample["outerClip"]),
               let regions = sample["regions"] as? [Any] else {
             return false
         }
@@ -651,6 +663,7 @@ public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, 
     case actionPerformFailed(DesktopReposScrollActionResult)
     case unstableWindow
     case unstableOuterClip
+    case unstableScrollAncestry
     case outerClipOutsideWindow
     case boundaryInitiallyInsideOuterClip
     case noUpwardMovement
@@ -685,6 +698,8 @@ public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, 
             return "Reachability trace window changed across the scroll interaction."
         case .unstableOuterClip:
             return "Reachability trace outer clip changed across the scroll interaction."
+        case .unstableScrollAncestry:
+            return "Reachability trace Boundary scroll ancestry changed across the scroll interaction."
         case .outerClipOutsideWindow:
             return "Reachability trace outer clip is outside the verified window."
         case .boundaryInitiallyInsideOuterClip:
@@ -698,6 +713,103 @@ public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, 
         case .regionOutsideViewport(let phase, let index, let region):
             return "Reachability trace \(region.rawValue) is outside the viewport in \(phase.rawValue) sample \(index)."
         }
+    }
+}
+
+public enum DesktopReposReachabilityCheckStatus: String, Codable, Equatable, Sendable {
+    case reachable
+    case failed
+}
+
+public enum DesktopReposReachabilityCheckCategory: String, Codable, Equatable, Sendable {
+    case none
+    case input
+    case contract
+    case acquisition
+    case action
+    case geometry
+}
+
+public struct DesktopReposReachabilityCheckResult: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let ok: Bool
+    public let status: DesktopReposReachabilityCheckStatus
+    public let category: DesktopReposReachabilityCheckCategory
+    public let reasonCode: String
+
+    public init(
+        schemaVersion: Int = 1,
+        ok: Bool,
+        status: DesktopReposReachabilityCheckStatus,
+        category: DesktopReposReachabilityCheckCategory,
+        reasonCode: String
+    ) {
+        self.schemaVersion = schemaVersion
+        self.ok = ok
+        self.status = status
+        self.category = category
+        self.reasonCode = reasonCode
+    }
+
+    public static let reachable = Self(
+        ok: true,
+        status: .reachable,
+        category: .none,
+        reasonCode: "none"
+    )
+
+    public static func inputFailure(_ reasonCode: String) -> Self {
+        Self(ok: false, status: .failed, category: .input, reasonCode: reasonCode)
+    }
+
+    public static func failure(_ error: DesktopReposReachabilityValidationError) -> Self {
+        switch error {
+        case .invalidContract:
+            return failed(.contract, "invalid-contract")
+        case .acquisitionFailed(let reason):
+            return failed(.acquisition, "acquisition-\(reason.rawValue)")
+        case .insufficientSamples(let phase):
+            return failed(.geometry, "insufficient-\(phase.rawValue)-samples")
+        case .nonfiniteFrame:
+            return failed(.contract, "nonfinite-frame")
+        case .duplicateRegion:
+            return failed(.contract, "duplicate-region")
+        case .missingRegion:
+            return failed(.contract, "missing-region")
+        case .excessiveDrift:
+            return failed(.geometry, "excessive-drift")
+        case .missingScrollInteraction:
+            return failed(.contract, "missing-scroll-interaction")
+        case .actionNotAdvertised:
+            return failed(.action, "action-not-advertised")
+        case .actionPerformFailed(let result):
+            return failed(.action, "action-perform-\(result.rawValue)")
+        case .unstableWindow:
+            return failed(.geometry, "unstable-window")
+        case .unstableOuterClip:
+            return failed(.geometry, "unstable-outer-clip")
+        case .unstableScrollAncestry:
+            return failed(.geometry, "unstable-scroll-ancestry")
+        case .outerClipOutsideWindow:
+            return failed(.geometry, "outer-clip-outside-window")
+        case .boundaryInitiallyInsideOuterClip:
+            return failed(.geometry, "boundary-initially-inside-outer-clip")
+        case .noUpwardMovement:
+            return failed(.geometry, "no-upward-movement")
+        case .nonRigidMovement:
+            return failed(.geometry, "non-rigid-movement")
+        case .pressInsufficient(let region):
+            return failed(.geometry, "press-insufficient-\(region.rawValue)")
+        case .regionOutsideViewport:
+            return failed(.geometry, "region-outside-viewport")
+        }
+    }
+
+    private static func failed(
+        _ category: DesktopReposReachabilityCheckCategory,
+        _ reasonCode: String
+    ) -> Self {
+        Self(ok: false, status: .failed, category: category, reasonCode: reasonCode)
     }
 }
 
@@ -777,8 +889,13 @@ public enum DesktopReposReachabilityValidator {
         }
         let baseline = samples[0]
         for (index, sample) in samples.enumerated() {
-            guard sample.viewport.isFiniteAndNonempty else {
+            guard sample.viewport.isFiniteAndNonempty,
+                  sample.outerClip.isFiniteAndNonempty,
+                  sample.boundaryScrollAncestorCount > 0 else {
                 throw DesktopReposReachabilityValidationError.nonfiniteFrame(phase, index)
+            }
+            guard sample.viewport.contains(sample.outerClip) else {
+                throw DesktopReposReachabilityValidationError.outerClipOutsideWindow
             }
             var byID: [DesktopReposReachabilityRegion: DesktopReposReachabilityFrame] = [:]
             for region in sample.regions {
@@ -795,6 +912,12 @@ public enum DesktopReposReachabilityValidator {
             guard index > 0 else { continue }
             if sample.viewport.differs(from: baseline.viewport, byMoreThan: tolerance) {
                 throw DesktopReposReachabilityValidationError.excessiveDrift(phase, index, nil)
+            }
+            if sample.outerClip.differs(from: baseline.outerClip, byMoreThan: tolerance) {
+                throw DesktopReposReachabilityValidationError.unstableOuterClip
+            }
+            if sample.boundaryScrollAncestorCount != baseline.boundaryScrollAncestorCount {
+                throw DesktopReposReachabilityValidationError.unstableScrollAncestry
             }
             let baselineByID = Dictionary(uniqueKeysWithValues: baseline.regions.map { ($0.id, $0.frame) })
             for id in DesktopReposReachabilityRegion.allCases {
@@ -856,15 +979,19 @@ public enum DesktopReposReachabilityValidator {
         if exceedsEnvelopeTolerance((pre + post).map(\.viewport), tolerance: tolerance) {
             throw DesktopReposReachabilityValidationError.unstableWindow
         }
-        if press.outerClipBefore.differs(from: clipAfter, byMoreThan: tolerance) {
+        let allClips = [press.outerClipBefore, clipAfter] + (pre + post).map(\.outerClip)
+        if exceedsEnvelopeTolerance(allClips, tolerance: tolerance) {
             throw DesktopReposReachabilityValidationError.unstableOuterClip
+        }
+        if Set((pre + post).map(\.boundaryScrollAncestorCount)).count != 1 {
+            throw DesktopReposReachabilityValidationError.unstableScrollAncestry
         }
         guard beforeSample.viewport.contains(press.outerClipBefore),
               afterSample.viewport.contains(clipAfter) else {
             throw DesktopReposReachabilityValidationError.outerClipOutsideWindow
         }
         guard let beforeBoundary = frame(.boundaryBody, in: beforeSample),
-              !press.outerClipBefore.contains(beforeBoundary) else {
+              !beforeSample.outerClip.contains(beforeBoundary) else {
             throw DesktopReposReachabilityValidationError.boundaryInitiallyInsideOuterClip
         }
         let beforeByID = Dictionary(uniqueKeysWithValues: beforeSample.regions.map { ($0.id, $0.frame) })
@@ -887,7 +1014,7 @@ public enum DesktopReposReachabilityValidator {
         }
         for id in [DesktopReposReachabilityRegion.applyAllowlist, .boundaryBody] {
             for sample in post {
-                guard let region = frame(id, in: sample), clipAfter.contains(region) else {
+                guard let region = frame(id, in: sample), sample.outerClip.contains(region) else {
                     throw DesktopReposReachabilityValidationError.pressInsufficient(id)
                 }
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -332,6 +332,102 @@ public struct DesktopReposOuterScrollObservation: Codable, Equatable, Sendable {
     }
 }
 
+public enum DesktopReposScrollMechanism: String, Codable, Equatable, Sendable {
+    case incrementPagePress = "increment-page-press"
+}
+
+public enum DesktopReposScrollActionResult: String, Codable, Equatable, Sendable {
+    case success
+    case cannotComplete = "cannot-complete"
+    case actionUnsupported = "action-unsupported"
+    case invalidElement = "invalid-element"
+    case permissionDenied = "permission-denied"
+    case otherError = "other-error"
+}
+
+public struct DesktopReposIncrementPagePressObservation: Codable, Equatable, Sendable {
+    public let actionAdvertised: Bool
+    public let attemptCount: Int
+    public let performResult: DesktopReposScrollActionResult?
+    public let outerClipBefore: DesktopReposReachabilityFrame
+    public let outerClipAfter: DesktopReposReachabilityFrame?
+
+    public init(
+        actionAdvertised: Bool,
+        attemptCount: Int,
+        performResult: DesktopReposScrollActionResult?,
+        outerClipBefore: DesktopReposReachabilityFrame,
+        outerClipAfter: DesktopReposReachabilityFrame?
+    ) {
+        self.actionAdvertised = actionAdvertised
+        self.attemptCount = attemptCount
+        self.performResult = performResult
+        self.outerClipBefore = outerClipBefore
+        self.outerClipAfter = outerClipAfter
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case actionAdvertised, attemptCount, performResult, outerClipBefore, outerClipAfter
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        actionAdvertised = try container.decode(Bool.self, forKey: .actionAdvertised)
+        attemptCount = try container.decode(Int.self, forKey: .attemptCount)
+        performResult = try container.decodeIfPresent(DesktopReposScrollActionResult.self, forKey: .performResult)
+        outerClipBefore = try container.decode(DesktopReposReachabilityFrame.self, forKey: .outerClipBefore)
+        outerClipAfter = try container.decodeIfPresent(DesktopReposReachabilityFrame.self, forKey: .outerClipAfter)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(actionAdvertised, forKey: .actionAdvertised)
+        try container.encode(attemptCount, forKey: .attemptCount)
+        if let performResult { try container.encode(performResult, forKey: .performResult) }
+        else { try container.encodeNil(forKey: .performResult) }
+        try container.encode(outerClipBefore, forKey: .outerClipBefore)
+        if let outerClipAfter { try container.encode(outerClipAfter, forKey: .outerClipAfter) }
+        else { try container.encodeNil(forKey: .outerClipAfter) }
+    }
+}
+
+public struct DesktopReposScrollInteraction: Codable, Equatable, Sendable {
+    public let mechanism: DesktopReposScrollMechanism
+    public let incrementPagePress: DesktopReposIncrementPagePressObservation?
+    public let valueMutation: DesktopReposOuterScrollObservation?
+
+    public init(
+        mechanism: DesktopReposScrollMechanism,
+        incrementPagePress: DesktopReposIncrementPagePressObservation?,
+        valueMutation: DesktopReposOuterScrollObservation?
+    ) {
+        self.mechanism = mechanism
+        self.incrementPagePress = incrementPagePress
+        self.valueMutation = valueMutation
+    }
+
+    private enum CodingKeys: String, CodingKey { case mechanism, incrementPagePress, valueMutation }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        mechanism = try container.decode(DesktopReposScrollMechanism.self, forKey: .mechanism)
+        incrementPagePress = try container.decodeIfPresent(
+            DesktopReposIncrementPagePressObservation.self,
+            forKey: .incrementPagePress
+        )
+        valueMutation = try container.decodeIfPresent(DesktopReposOuterScrollObservation.self, forKey: .valueMutation)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(mechanism, forKey: .mechanism)
+        if let incrementPagePress { try container.encode(incrementPagePress, forKey: .incrementPagePress) }
+        else { try container.encodeNil(forKey: .incrementPagePress) }
+        if let valueMutation { try container.encode(valueMutation, forKey: .valueMutation) }
+        else { try container.encodeNil(forKey: .valueMutation) }
+    }
+}
+
 public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
     public let schemaVersion: Int
     public let fixture: DesktopReposReachabilityFixture
@@ -344,7 +440,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
     public let tolerancePoints: Double
     public let acquisition: DesktopReposReachabilityAcquisition
     public let preScrollSamples: [DesktopReposReachabilitySample]
-    public let outerScroll: DesktopReposOuterScrollObservation?
+    public let scrollInteraction: DesktopReposScrollInteraction?
     public let postScrollSamples: [DesktopReposReachabilitySample]
 
     public init(
@@ -359,7 +455,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         tolerancePoints: Double,
         acquisition: DesktopReposReachabilityAcquisition,
         preScrollSamples: [DesktopReposReachabilitySample],
-        outerScroll: DesktopReposOuterScrollObservation?,
+        scrollInteraction: DesktopReposScrollInteraction?,
         postScrollSamples: [DesktopReposReachabilitySample]
     ) {
         self.schemaVersion = schemaVersion
@@ -373,7 +469,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         self.tolerancePoints = tolerancePoints
         self.acquisition = acquisition
         self.preScrollSamples = preScrollSamples
-        self.outerScroll = outerScroll
+        self.scrollInteraction = scrollInteraction
         self.postScrollSamples = postScrollSamples
     }
 
@@ -389,7 +485,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         case tolerancePoints
         case acquisition
         case preScrollSamples
-        case outerScroll
+        case scrollInteraction
         case postScrollSamples
     }
 
@@ -406,7 +502,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         tolerancePoints = try container.decode(Double.self, forKey: .tolerancePoints)
         acquisition = try container.decode(DesktopReposReachabilityAcquisition.self, forKey: .acquisition)
         preScrollSamples = try container.decode([DesktopReposReachabilitySample].self, forKey: .preScrollSamples)
-        outerScroll = try container.decodeIfPresent(DesktopReposOuterScrollObservation.self, forKey: .outerScroll)
+        scrollInteraction = try container.decodeIfPresent(DesktopReposScrollInteraction.self, forKey: .scrollInteraction)
         postScrollSamples = try container.decode([DesktopReposReachabilitySample].self, forKey: .postScrollSamples)
     }
 
@@ -423,10 +519,10 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         try container.encode(tolerancePoints, forKey: .tolerancePoints)
         try container.encode(acquisition, forKey: .acquisition)
         try container.encode(preScrollSamples, forKey: .preScrollSamples)
-        if let outerScroll {
-            try container.encode(outerScroll, forKey: .outerScroll)
+        if let scrollInteraction {
+            try container.encode(scrollInteraction, forKey: .scrollInteraction)
         } else {
-            try container.encodeNil(forKey: .outerScroll)
+            try container.encodeNil(forKey: .scrollInteraction)
         }
         try container.encode(postScrollSamples, forKey: .postScrollSamples)
     }
@@ -459,12 +555,12 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
               hasAllowedAndRequired(root, allowed: [
                   "schemaVersion", "fixture", "ready", "quiescent", "requestedContentSize",
                   "sampleIntervalMilliseconds", "preScrollAcquisitionMilliseconds", "tolerancePoints",
-                  "postScrollAcquisitionMilliseconds", "acquisition", "preScrollSamples", "outerScroll",
+                  "postScrollAcquisitionMilliseconds", "acquisition", "preScrollSamples", "scrollInteraction",
                   "postScrollSamples"
               ], required: [
                   "schemaVersion", "fixture", "ready", "quiescent", "requestedContentSize",
                   "sampleIntervalMilliseconds", "preScrollAcquisitionMilliseconds", "tolerancePoints",
-                  "postScrollAcquisitionMilliseconds", "acquisition", "preScrollSamples", "outerScroll",
+                  "postScrollAcquisitionMilliseconds", "acquisition", "preScrollSamples", "scrollInteraction",
                   "postScrollSamples"
               ]),
               let acquisition = root["acquisition"] as? [String: Any],
@@ -481,12 +577,16 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
               post.allSatisfy(validateSample) else {
             return false
         }
-        if let scroll = root["outerScroll"], !(scroll is NSNull) {
-            guard let dictionary = scroll as? [String: Any],
-                  hasAllowedAndRequired(dictionary, allowed: [
-                      "verticalScrollBarSupported", "minimumValue", "maximumValue", "valueBeforeScroll",
-                      "valueAfterScroll", "setToMaximumSucceeded"
-                  ], required: ["verticalScrollBarSupported", "setToMaximumSucceeded"]) else {
+        if let interaction = root["scrollInteraction"], !(interaction is NSNull) {
+            guard let dictionary = interaction as? [String: Any],
+                  hasOnly(dictionary, ["mechanism", "incrementPagePress", "valueMutation"]),
+                  dictionary["valueMutation"] is NSNull,
+                  let press = dictionary["incrementPagePress"] as? [String: Any],
+                  hasOnly(press, [
+                      "actionAdvertised", "attemptCount", "performResult", "outerClipBefore", "outerClipAfter"
+                  ]),
+                  validateFrame(press["outerClipBefore"]),
+                  (press["outerClipAfter"] is NSNull || validateFrame(press["outerClipAfter"])) else {
                 return false
             }
         }
@@ -546,8 +646,16 @@ public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, 
     case duplicateRegion(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
     case missingRegion(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
     case excessiveDrift(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion?)
-    case missingOuterScroll
-    case unsupportedOuterScroll
+    case missingScrollInteraction
+    case actionNotAdvertised
+    case actionPerformFailed(DesktopReposScrollActionResult)
+    case unstableWindow
+    case unstableOuterClip
+    case outerClipOutsideWindow
+    case boundaryInitiallyInsideOuterClip
+    case noUpwardMovement
+    case nonRigidMovement
+    case pressInsufficient(DesktopReposReachabilityRegion)
     case regionOutsideViewport(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
 
     public var errorDescription: String? {
@@ -567,10 +675,26 @@ public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, 
         case .excessiveDrift(let phase, let index, let region):
             let name = region?.rawValue ?? "viewport"
             return "Reachability trace \(name) drift exceeds tolerance in \(phase.rawValue) sample \(index)."
-        case .missingOuterScroll:
-            return "Reachability trace has no outer scroll area."
-        case .unsupportedOuterScroll:
-            return "Reachability trace outer scroll area cannot be set to its maximum."
+        case .missingScrollInteraction:
+            return "Reachability trace has no scroll interaction."
+        case .actionNotAdvertised:
+            return "Reachability trace increment-page press was not advertised."
+        case .actionPerformFailed(let result):
+            return "Reachability trace increment-page press failed: \(result.rawValue)."
+        case .unstableWindow:
+            return "Reachability trace window changed across the scroll interaction."
+        case .unstableOuterClip:
+            return "Reachability trace outer clip changed across the scroll interaction."
+        case .outerClipOutsideWindow:
+            return "Reachability trace outer clip is outside the verified window."
+        case .boundaryInitiallyInsideOuterClip:
+            return "Reachability trace Boundary did not begin below the outer clip."
+        case .noUpwardMovement:
+            return "Reachability trace increment-page press produced no upward movement."
+        case .nonRigidMovement:
+            return "Reachability trace regions did not move as one rigid page."
+        case .pressInsufficient(let region):
+            return "Reachability trace press-insufficient: \(region.rawValue) remains outside the outer clip."
         case .regionOutsideViewport(let phase, let index, let region):
             return "Reachability trace \(region.rawValue) is outside the viewport in \(phase.rawValue) sample \(index)."
         }
@@ -581,7 +705,7 @@ public enum DesktopReposReachabilityValidator {
     public static func validate(
         _ trace: DesktopReposReachabilityTrace
     ) throws -> DesktopReposReachabilityValidationStatus {
-        guard trace.schemaVersion == 1,
+        guard trace.schemaVersion == 2,
               trace.fixture == .tabRepos,
               trace.requestedContentSize == DesktopEvaluationContentSize(width: 1040, height: 680),
               trace.sampleIntervalMilliseconds == 100,
@@ -600,6 +724,7 @@ public enum DesktopReposReachabilityValidator {
         case (.complete, .some), (.failed, nil):
             throw DesktopReposReachabilityValidationError.invalidContract
         }
+        let press = try validateInteraction(trace.scrollInteraction)
         guard trace.ready,
               trace.quiescent,
               trace.preScrollAcquisitionMilliseconds <= 5_000,
@@ -616,7 +741,6 @@ public enum DesktopReposReachabilityValidator {
               trace.preScrollAcquisitionMilliseconds >= lastPreScrollSample.elapsedMilliseconds else {
             throw DesktopReposReachabilityValidationError.invalidContract
         }
-        try validateScroll(trace.outerScroll)
         try validateSamples(
             trace.postScrollSamples,
             phase: .postScroll,
@@ -626,8 +750,12 @@ public enum DesktopReposReachabilityValidator {
               trace.postScrollAcquisitionMilliseconds >= lastPostScrollSample.elapsedMilliseconds else {
             throw DesktopReposReachabilityValidationError.invalidContract
         }
-        try requireVisible(.applyAllowlist, in: trace.postScrollSamples, phase: .postScroll)
-        try requireVisible(.boundaryBody, in: trace.postScrollSamples, phase: .postScroll)
+        try validateBehaviorGeometry(
+            pre: trace.preScrollSamples,
+            post: trace.postScrollSamples,
+            press: press,
+            tolerance: trace.tolerancePoints
+        )
         return .reachable
     }
 
@@ -680,25 +808,112 @@ public enum DesktopReposReachabilityValidator {
         }
     }
 
-    private static func validateScroll(_ scroll: DesktopReposOuterScrollObservation?) throws {
-        let scalarEpsilon = 0.001
-        guard let scroll else {
-            throw DesktopReposReachabilityValidationError.missingOuterScroll
+    private static func validateInteraction(
+        _ interaction: DesktopReposScrollInteraction?
+    ) throws -> DesktopReposIncrementPagePressObservation {
+        guard let interaction else {
+            throw DesktopReposReachabilityValidationError.missingScrollInteraction
         }
-        guard scroll.verticalScrollBarSupported,
-              scroll.setToMaximumSucceeded,
-              let minimum = scroll.minimumValue,
-              let maximum = scroll.maximumValue,
-              let before = scroll.valueBeforeScroll,
-              let after = scroll.valueAfterScroll,
-              minimum.isFinite,
-              maximum.isFinite,
-              before.isFinite,
-              after.isFinite,
-              maximum > minimum,
-              abs(before - minimum) <= scalarEpsilon,
-              abs(maximum - after) <= scalarEpsilon else {
-            throw DesktopReposReachabilityValidationError.unsupportedOuterScroll
+        guard interaction.mechanism == .incrementPagePress,
+              interaction.valueMutation == nil,
+              let press = interaction.incrementPagePress,
+              press.outerClipBefore.isFiniteAndNonempty else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        if !press.actionAdvertised {
+            guard press.attemptCount == 0,
+                  press.performResult == nil,
+                  press.outerClipAfter == nil else {
+                throw DesktopReposReachabilityValidationError.invalidContract
+            }
+            throw DesktopReposReachabilityValidationError.actionNotAdvertised
+        }
+        guard press.attemptCount == 1 else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        guard let result = press.performResult else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        guard result == .success else {
+            throw DesktopReposReachabilityValidationError.actionPerformFailed(result)
+        }
+        guard let after = press.outerClipAfter, after.isFiniteAndNonempty else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        return press
+    }
+
+    private static func validateBehaviorGeometry(
+        pre: [DesktopReposReachabilitySample],
+        post: [DesktopReposReachabilitySample],
+        press: DesktopReposIncrementPagePressObservation,
+        tolerance: Double
+    ) throws {
+        guard let beforeSample = pre.last, let afterSample = post.first,
+              let clipAfter = press.outerClipAfter else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        if exceedsEnvelopeTolerance((pre + post).map(\.viewport), tolerance: tolerance) {
+            throw DesktopReposReachabilityValidationError.unstableWindow
+        }
+        if press.outerClipBefore.differs(from: clipAfter, byMoreThan: tolerance) {
+            throw DesktopReposReachabilityValidationError.unstableOuterClip
+        }
+        guard beforeSample.viewport.contains(press.outerClipBefore),
+              afterSample.viewport.contains(clipAfter) else {
+            throw DesktopReposReachabilityValidationError.outerClipOutsideWindow
+        }
+        guard let beforeBoundary = frame(.boundaryBody, in: beforeSample),
+              !press.outerClipBefore.contains(beforeBoundary) else {
+            throw DesktopReposReachabilityValidationError.boundaryInitiallyInsideOuterClip
+        }
+        let beforeByID = Dictionary(uniqueKeysWithValues: beforeSample.regions.map { ($0.id, $0.frame) })
+        let afterByID = Dictionary(uniqueKeysWithValues: afterSample.regions.map { ($0.id, $0.frame) })
+        guard let referenceBefore = beforeByID[.table], let referenceAfter = afterByID[.table] else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        let delta = referenceAfter.y - referenceBefore.y
+        guard delta < -1 else {
+            throw DesktopReposReachabilityValidationError.noUpwardMovement
+        }
+        for id in DesktopReposReachabilityRegion.allCases {
+            guard let lhs = beforeByID[id], let rhs = afterByID[id],
+                  abs(rhs.x - lhs.x) <= tolerance,
+                  abs(rhs.width - lhs.width) <= tolerance,
+                  abs(rhs.height - lhs.height) <= tolerance,
+                  abs((rhs.y - lhs.y) - delta) <= tolerance else {
+                throw DesktopReposReachabilityValidationError.nonRigidMovement
+            }
+        }
+        for id in [DesktopReposReachabilityRegion.applyAllowlist, .boundaryBody] {
+            for sample in post {
+                guard let region = frame(id, in: sample), clipAfter.contains(region) else {
+                    throw DesktopReposReachabilityValidationError.pressInsufficient(id)
+                }
+            }
+        }
+    }
+
+    private static func frame(
+        _ id: DesktopReposReachabilityRegion,
+        in sample: DesktopReposReachabilitySample
+    ) -> DesktopReposReachabilityFrame? {
+        sample.regions.first(where: { $0.id == id })?.frame
+    }
+
+    private static func exceedsEnvelopeTolerance(
+        _ frames: [DesktopReposReachabilityFrame],
+        tolerance: Double
+    ) -> Bool {
+        let components = [
+            frames.map(\.x),
+            frames.map(\.y),
+            frames.map(\.width),
+            frames.map(\.height)
+        ]
+        return components.contains { values in
+            guard let minimum = values.min(), let maximum = values.max() else { return true }
+            return maximum - minimum > tolerance
         }
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -123,6 +123,69 @@ public enum DesktopReposReachabilitySamplingContract {
     }
 }
 
+public struct DesktopReposVerticalScrollBarCandidate: Equatable, Sendable {
+    public let role: String?
+    public let orientation: String?
+
+    public init(role: String?, orientation: String?) {
+        self.role = role
+        self.orientation = orientation
+    }
+}
+
+public enum DesktopReposVerticalScrollBarSelection: Equatable, Sendable {
+    case convenienceAttribute
+    case directChild(index: Int)
+    case unsupported
+}
+
+public enum DesktopReposVerticalScrollBarSelectionError: Error, Equatable, Sendable {
+    case missingRole
+    case missingOrientation
+    case invalidOrientation
+    case ambiguousVerticalChildren
+}
+
+public enum DesktopReposVerticalScrollBarSelectionContract {
+    public static let scrollBarRole = "AXScrollBar"
+    public static let verticalOrientation = "AXVerticalOrientation"
+    public static let horizontalOrientation = "AXHorizontalOrientation"
+
+    public static func select(
+        convenienceAvailable: Bool,
+        directChildren: [DesktopReposVerticalScrollBarCandidate]
+    ) throws -> DesktopReposVerticalScrollBarSelection {
+        if convenienceAvailable {
+            return .convenienceAttribute
+        }
+
+        var verticalIndices: [Int] = []
+        for (index, child) in directChildren.enumerated() {
+            guard let role = child.role else {
+                throw DesktopReposVerticalScrollBarSelectionError.missingRole
+            }
+            guard role == scrollBarRole else { continue }
+            guard let orientation = child.orientation else {
+                throw DesktopReposVerticalScrollBarSelectionError.missingOrientation
+            }
+            switch orientation {
+            case verticalOrientation:
+                verticalIndices.append(index)
+            case horizontalOrientation:
+                continue
+            default:
+                throw DesktopReposVerticalScrollBarSelectionError.invalidOrientation
+            }
+        }
+
+        guard verticalIndices.count <= 1 else {
+            throw DesktopReposVerticalScrollBarSelectionError.ambiguousVerticalChildren
+        }
+        guard let index = verticalIndices.first else { return .unsupported }
+        return .directChild(index: index)
+    }
+}
+
 public enum DesktopReposReachabilitySemanticContract {
     public static let tableRole = "AXOutline"
     public static let boundaryIdentifier = "neondiff-repos-boundary"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -103,6 +103,26 @@ public enum DesktopReposReachabilityRegion: String, Codable, CaseIterable, Equat
     case boundaryBody = "boundary-body"
 }
 
+public enum DesktopReposReachabilitySamplingContract {
+    public static let minimumStableSampleCount = 3
+    public static let minimumCadenceMilliseconds = 50
+    public static let maximumCadenceMilliseconds = 150
+
+    public static func hasStableCadence(_ elapsedMilliseconds: [Int]) -> Bool {
+        guard elapsedMilliseconds.count >= minimumStableSampleCount,
+              let first = elapsedMilliseconds.first,
+              first >= 0 else {
+            return false
+        }
+        return zip(elapsedMilliseconds, elapsedMilliseconds.dropFirst()).allSatisfy { prior, current in
+            guard current > prior else { return false }
+            let cadence = current - prior
+            return cadence >= minimumCadenceMilliseconds
+                && cadence <= maximumCadenceMilliseconds
+        }
+    }
+}
+
 public enum DesktopReposReachabilitySemanticContract {
     public static let tableRole = "AXOutline"
     public static let boundaryIdentifier = "neondiff-repos-boundary"
@@ -540,25 +560,19 @@ public enum DesktopReposReachabilityValidator {
         phase: DesktopReposReachabilityValidationPhase,
         tolerance: Double
     ) throws {
-        guard samples.count >= 3 else {
+        guard samples.count >= DesktopReposReachabilitySamplingContract.minimumStableSampleCount else {
             throw DesktopReposReachabilityValidationError.insufficientSamples(phase)
+        }
+        guard DesktopReposReachabilitySamplingContract.hasStableCadence(
+            samples.map(\.elapsedMilliseconds)
+        ) else {
+            throw DesktopReposReachabilityValidationError.invalidContract
         }
         guard let finalSample = samples.last, finalSample.elapsedMilliseconds <= 5_000 else {
             throw DesktopReposReachabilityValidationError.invalidContract
         }
         let baseline = samples[0]
-        var priorElapsed = -1
         for (index, sample) in samples.enumerated() {
-            guard sample.elapsedMilliseconds >= 0, sample.elapsedMilliseconds > priorElapsed else {
-                throw DesktopReposReachabilityValidationError.invalidContract
-            }
-            if index > 0 {
-                let cadence = sample.elapsedMilliseconds - priorElapsed
-                guard cadence >= 50, cadence <= 150 else {
-                    throw DesktopReposReachabilityValidationError.invalidContract
-                }
-            }
-            priorElapsed = sample.elapsedMilliseconds
             guard sample.viewport.isFiniteAndNonempty else {
                 throw DesktopReposReachabilityValidationError.nonfiniteFrame(phase, index)
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -104,10 +104,15 @@ public enum DesktopReposReachabilityRegion: String, Codable, CaseIterable, Equat
 }
 
 public enum DesktopReposReachabilitySemanticContract {
+    public static let tableRole = "AXOutline"
     public static let boundaryIdentifier = "neondiff-repos-boundary"
     public static let boundaryValue = "Repo changes are written through config patch only; the desktop does not post reviews or bypass daemon gates."
     public static let applyAllowlistIdentifier = "neondiff-repo-apply-patch"
     public static let applyAllowlistValue = "Apply Allowlist"
+
+    public static func matchesTable(role: String?) -> Bool {
+        role == tableRole
+    }
 
     public static func matchesApplyAllowlist(
         isButton: Bool,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -141,6 +141,7 @@ public enum DesktopReposVerticalScrollBarSelection: Equatable, Sendable {
 
 public enum DesktopReposVerticalScrollBarSelectionError: Error, Equatable, Sendable {
     case missingRole
+    case invalidRole
     case missingOrientation
     case invalidOrientation
     case ambiguousVerticalChildren
@@ -152,10 +153,22 @@ public enum DesktopReposVerticalScrollBarSelectionContract {
     public static let horizontalOrientation = "AXHorizontalOrientation"
 
     public static func select(
-        convenienceAvailable: Bool,
+        convenienceCandidate: DesktopReposVerticalScrollBarCandidate?,
         directChildren: [DesktopReposVerticalScrollBarCandidate]
     ) throws -> DesktopReposVerticalScrollBarSelection {
-        if convenienceAvailable {
+        if let convenienceCandidate {
+            guard let role = convenienceCandidate.role else {
+                throw DesktopReposVerticalScrollBarSelectionError.missingRole
+            }
+            guard role == scrollBarRole else {
+                throw DesktopReposVerticalScrollBarSelectionError.invalidRole
+            }
+            guard let orientation = convenienceCandidate.orientation else {
+                throw DesktopReposVerticalScrollBarSelectionError.missingOrientation
+            }
+            guard orientation == verticalOrientation else {
+                throw DesktopReposVerticalScrollBarSelectionError.invalidOrientation
+            }
             return .convenienceAttribute
         }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -1,0 +1,412 @@
+import Foundation
+
+public enum DesktopReposReachabilityFixture: String, Codable, Equatable, Sendable {
+    case tabRepos = "tab-repos"
+}
+
+public enum DesktopReposReachabilityRegion: String, Codable, CaseIterable, Equatable, Sendable {
+    case table
+    case applyAllowlist = "apply-allowlist"
+    case boundaryBody = "boundary-body"
+}
+
+public struct DesktopReposReachabilityFrame: Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    fileprivate var isFiniteAndNonempty: Bool {
+        [x, y, width, height, x + width, y + height].allSatisfy(\.isFinite)
+            && width > 0
+            && height > 0
+    }
+
+    fileprivate func contains(_ other: Self) -> Bool {
+        other.x >= x
+            && other.y >= y
+            && other.x + other.width <= x + width
+            && other.y + other.height <= y + height
+    }
+
+    fileprivate func differs(from other: Self, byMoreThan tolerance: Double) -> Bool {
+        zip(values, other.values).contains { abs($0 - $1) > tolerance }
+    }
+
+    private var values: [Double] { [x, y, width, height] }
+}
+
+public struct DesktopReposReachabilityRegionFrame: Codable, Equatable, Sendable {
+    public let id: DesktopReposReachabilityRegion
+    public let frame: DesktopReposReachabilityFrame
+
+    public init(id: DesktopReposReachabilityRegion, frame: DesktopReposReachabilityFrame) {
+        self.id = id
+        self.frame = frame
+    }
+}
+
+public struct DesktopReposReachabilitySample: Codable, Equatable, Sendable {
+    /// Milliseconds from the beginning of this sampling phase. Frames and the
+    /// viewport use the Accessibility screen-coordinate space.
+    public let elapsedMilliseconds: Int
+    /// The verified Accessibility window frame, in AX screen coordinates.
+    public let viewport: DesktopReposReachabilityFrame
+    public let regions: [DesktopReposReachabilityRegionFrame]
+
+    public init(
+        elapsedMilliseconds: Int,
+        viewport: DesktopReposReachabilityFrame,
+        regions: [DesktopReposReachabilityRegionFrame]
+    ) {
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.viewport = viewport
+        self.regions = regions
+    }
+}
+
+public struct DesktopReposOuterScrollObservation: Codable, Equatable, Sendable {
+    public let verticalScrollBarSupported: Bool
+    public let minimumValue: Double?
+    public let maximumValue: Double?
+    public let valueBeforeScroll: Double?
+    public let valueAfterScroll: Double?
+    public let setToMaximumSucceeded: Bool
+
+    public init(
+        verticalScrollBarSupported: Bool,
+        minimumValue: Double?,
+        maximumValue: Double?,
+        valueBeforeScroll: Double?,
+        valueAfterScroll: Double?,
+        setToMaximumSucceeded: Bool
+    ) {
+        self.verticalScrollBarSupported = verticalScrollBarSupported
+        self.minimumValue = minimumValue
+        self.maximumValue = maximumValue
+        self.valueBeforeScroll = valueBeforeScroll
+        self.valueAfterScroll = valueAfterScroll
+        self.setToMaximumSucceeded = setToMaximumSucceeded
+    }
+}
+
+public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let fixture: DesktopReposReachabilityFixture
+    public let ready: Bool
+    public let quiescent: Bool
+    public let requestedContentSize: DesktopEvaluationContentSize
+    public let sampleIntervalMilliseconds: Int
+    public let preScrollAcquisitionMilliseconds: Int
+    public let postScrollAcquisitionMilliseconds: Int
+    public let tolerancePoints: Double
+    public let preScrollSamples: [DesktopReposReachabilitySample]
+    public let outerScroll: DesktopReposOuterScrollObservation?
+    public let postScrollSamples: [DesktopReposReachabilitySample]
+
+    public init(
+        schemaVersion: Int,
+        fixture: DesktopReposReachabilityFixture,
+        ready: Bool,
+        quiescent: Bool,
+        requestedContentSize: DesktopEvaluationContentSize,
+        sampleIntervalMilliseconds: Int,
+        preScrollAcquisitionMilliseconds: Int,
+        postScrollAcquisitionMilliseconds: Int,
+        tolerancePoints: Double,
+        preScrollSamples: [DesktopReposReachabilitySample],
+        outerScroll: DesktopReposOuterScrollObservation?,
+        postScrollSamples: [DesktopReposReachabilitySample]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.fixture = fixture
+        self.ready = ready
+        self.quiescent = quiescent
+        self.requestedContentSize = requestedContentSize
+        self.sampleIntervalMilliseconds = sampleIntervalMilliseconds
+        self.preScrollAcquisitionMilliseconds = preScrollAcquisitionMilliseconds
+        self.postScrollAcquisitionMilliseconds = postScrollAcquisitionMilliseconds
+        self.tolerancePoints = tolerancePoints
+        self.preScrollSamples = preScrollSamples
+        self.outerScroll = outerScroll
+        self.postScrollSamples = postScrollSamples
+    }
+
+    public static func decode(data: Data) throws -> Self {
+        guard data.count <= 256 * 1024 else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        guard validateShape(object) else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        let trace: Self
+        do {
+            trace = try JSONDecoder().decode(Self.self, from: data)
+        } catch {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        _ = try DesktopReposReachabilityValidator.validate(trace)
+        return trace
+    }
+
+    private static func validateShape(_ object: Any) -> Bool {
+        guard let root = object as? [String: Any],
+              hasAllowedAndRequired(root, allowed: [
+                  "schemaVersion", "fixture", "ready", "quiescent", "requestedContentSize",
+                  "sampleIntervalMilliseconds", "preScrollAcquisitionMilliseconds", "tolerancePoints",
+                  "postScrollAcquisitionMilliseconds", "preScrollSamples", "outerScroll", "postScrollSamples"
+              ], required: [
+                  "schemaVersion", "fixture", "ready", "quiescent", "requestedContentSize",
+                  "sampleIntervalMilliseconds", "preScrollAcquisitionMilliseconds", "tolerancePoints",
+                  "postScrollAcquisitionMilliseconds", "preScrollSamples", "postScrollSamples"
+              ]),
+              let size = root["requestedContentSize"] as? [String: Any],
+              hasOnly(size, ["width", "height"]),
+              let pre = root["preScrollSamples"] as? [Any],
+              let post = root["postScrollSamples"] as? [Any],
+              pre.allSatisfy(validateSample),
+              post.allSatisfy(validateSample) else {
+            return false
+        }
+        if let scroll = root["outerScroll"], !(scroll is NSNull) {
+            guard let dictionary = scroll as? [String: Any],
+                  hasAllowedAndRequired(dictionary, allowed: [
+                      "verticalScrollBarSupported", "minimumValue", "maximumValue", "valueBeforeScroll",
+                      "valueAfterScroll", "setToMaximumSucceeded"
+                  ], required: ["verticalScrollBarSupported", "setToMaximumSucceeded"]) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func validateSample(_ object: Any) -> Bool {
+        guard let sample = object as? [String: Any],
+              hasOnly(sample, ["elapsedMilliseconds", "viewport", "regions"]),
+              validateFrame(sample["viewport"]),
+              let regions = sample["regions"] as? [Any] else {
+            return false
+        }
+        return regions.allSatisfy { object in
+            guard let region = object as? [String: Any],
+                  hasOnly(region, ["id", "frame"]),
+                  validateFrame(region["frame"]) else {
+                return false
+            }
+            return true
+        }
+    }
+
+    private static func validateFrame(_ object: Any?) -> Bool {
+        guard let frame = object as? [String: Any] else { return false }
+        return hasOnly(frame, ["x", "y", "width", "height"])
+    }
+
+    private static func hasOnly(_ object: [String: Any], _ keys: Set<String>) -> Bool {
+        Set(object.keys) == keys
+    }
+
+    private static func hasAllowedAndRequired(
+        _ object: [String: Any],
+        allowed: Set<String>,
+        required: Set<String>
+    ) -> Bool {
+        let keys = Set(object.keys)
+        return keys.isSubset(of: allowed) && required.isSubset(of: keys)
+    }
+}
+
+public enum DesktopReposReachabilityValidationStatus: String, Codable, Equatable, Sendable {
+    case reachable
+}
+
+public enum DesktopReposReachabilityValidationPhase: String, Codable, Equatable, Sendable {
+    case preScroll = "pre-scroll"
+    case postScroll = "post-scroll"
+}
+
+public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, Sendable {
+    case invalidContract
+    case insufficientSamples(DesktopReposReachabilityValidationPhase)
+    case nonfiniteFrame(DesktopReposReachabilityValidationPhase, Int)
+    case duplicateRegion(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
+    case missingRegion(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
+    case excessiveDrift(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion?)
+    case missingOuterScroll
+    case unsupportedOuterScroll
+    case regionOutsideViewport(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidContract:
+            return "Reachability trace contract is invalid."
+        case .insufficientSamples(let phase):
+            return "Reachability trace has fewer than three \(phase.rawValue) samples."
+        case .nonfiniteFrame(let phase, let index):
+            return "Reachability trace has invalid geometry in \(phase.rawValue) sample \(index)."
+        case .duplicateRegion(let phase, let index, let region):
+            return "Reachability trace repeats \(region.rawValue) in \(phase.rawValue) sample \(index)."
+        case .missingRegion(let phase, let index, let region):
+            return "Reachability trace is missing \(region.rawValue) in \(phase.rawValue) sample \(index)."
+        case .excessiveDrift(let phase, let index, let region):
+            let name = region?.rawValue ?? "viewport"
+            return "Reachability trace \(name) drift exceeds tolerance in \(phase.rawValue) sample \(index)."
+        case .missingOuterScroll:
+            return "Reachability trace has no outer scroll area."
+        case .unsupportedOuterScroll:
+            return "Reachability trace outer scroll area cannot be set to its maximum."
+        case .regionOutsideViewport(let phase, let index, let region):
+            return "Reachability trace \(region.rawValue) is outside the viewport in \(phase.rawValue) sample \(index)."
+        }
+    }
+}
+
+public enum DesktopReposReachabilityValidator {
+    public static func validate(
+        _ trace: DesktopReposReachabilityTrace
+    ) throws -> DesktopReposReachabilityValidationStatus {
+        guard trace.schemaVersion == 1,
+              trace.fixture == .tabRepos,
+              trace.ready,
+              trace.quiescent,
+              trace.requestedContentSize == DesktopEvaluationContentSize(width: 1040, height: 680),
+              trace.sampleIntervalMilliseconds == 100,
+              trace.preScrollAcquisitionMilliseconds >= 0,
+              trace.preScrollAcquisitionMilliseconds <= 5_000,
+              trace.postScrollAcquisitionMilliseconds >= 0,
+              trace.postScrollAcquisitionMilliseconds <= 5_000,
+              trace.tolerancePoints.isFinite,
+              trace.tolerancePoints > 0,
+              trace.tolerancePoints <= 1 else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+
+        try validateSamples(
+            trace.preScrollSamples,
+            phase: .preScroll,
+            tolerance: trace.tolerancePoints
+        )
+        guard let lastPreScrollSample = trace.preScrollSamples.last,
+              trace.preScrollAcquisitionMilliseconds >= lastPreScrollSample.elapsedMilliseconds else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        try validateScroll(trace.outerScroll)
+        try validateSamples(
+            trace.postScrollSamples,
+            phase: .postScroll,
+            tolerance: trace.tolerancePoints
+        )
+        guard let lastPostScrollSample = trace.postScrollSamples.last,
+              trace.postScrollAcquisitionMilliseconds >= lastPostScrollSample.elapsedMilliseconds else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        try requireVisible(.applyAllowlist, in: trace.postScrollSamples, phase: .postScroll)
+        try requireVisible(.boundaryBody, in: trace.postScrollSamples, phase: .postScroll)
+        return .reachable
+    }
+
+    private static func validateSamples(
+        _ samples: [DesktopReposReachabilitySample],
+        phase: DesktopReposReachabilityValidationPhase,
+        tolerance: Double
+    ) throws {
+        guard samples.count >= 3 else {
+            throw DesktopReposReachabilityValidationError.insufficientSamples(phase)
+        }
+        guard let finalSample = samples.last, finalSample.elapsedMilliseconds <= 5_000 else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        let baseline = samples[0]
+        var priorElapsed = -1
+        for (index, sample) in samples.enumerated() {
+            guard sample.elapsedMilliseconds >= 0, sample.elapsedMilliseconds > priorElapsed else {
+                throw DesktopReposReachabilityValidationError.invalidContract
+            }
+            if index > 0 {
+                let cadence = sample.elapsedMilliseconds - priorElapsed
+                guard cadence >= 50, cadence <= 150 else {
+                    throw DesktopReposReachabilityValidationError.invalidContract
+                }
+            }
+            priorElapsed = sample.elapsedMilliseconds
+            guard sample.viewport.isFiniteAndNonempty else {
+                throw DesktopReposReachabilityValidationError.nonfiniteFrame(phase, index)
+            }
+            var byID: [DesktopReposReachabilityRegion: DesktopReposReachabilityFrame] = [:]
+            for region in sample.regions {
+                guard region.frame.isFiniteAndNonempty else {
+                    throw DesktopReposReachabilityValidationError.nonfiniteFrame(phase, index)
+                }
+                guard byID.updateValue(region.frame, forKey: region.id) == nil else {
+                    throw DesktopReposReachabilityValidationError.duplicateRegion(phase, index, region.id)
+                }
+            }
+            for id in DesktopReposReachabilityRegion.allCases where byID[id] == nil {
+                throw DesktopReposReachabilityValidationError.missingRegion(phase, index, id)
+            }
+            guard index > 0 else { continue }
+            if sample.viewport.differs(from: baseline.viewport, byMoreThan: tolerance) {
+                throw DesktopReposReachabilityValidationError.excessiveDrift(phase, index, nil)
+            }
+            let baselineByID = Dictionary(uniqueKeysWithValues: baseline.regions.map { ($0.id, $0.frame) })
+            for id in DesktopReposReachabilityRegion.allCases {
+                guard let frame = byID[id], let baselineFrame = baselineByID[id] else {
+                    throw DesktopReposReachabilityValidationError.missingRegion(phase, index, id)
+                }
+                if frame.differs(from: baselineFrame, byMoreThan: tolerance) {
+                    throw DesktopReposReachabilityValidationError.excessiveDrift(phase, index, id)
+                }
+            }
+        }
+    }
+
+    private static func validateScroll(_ scroll: DesktopReposOuterScrollObservation?) throws {
+        let scalarEpsilon = 0.001
+        guard let scroll else {
+            throw DesktopReposReachabilityValidationError.missingOuterScroll
+        }
+        guard scroll.verticalScrollBarSupported,
+              scroll.setToMaximumSucceeded,
+              let minimum = scroll.minimumValue,
+              let maximum = scroll.maximumValue,
+              let before = scroll.valueBeforeScroll,
+              let after = scroll.valueAfterScroll,
+              minimum.isFinite,
+              maximum.isFinite,
+              before.isFinite,
+              after.isFinite,
+              maximum > minimum,
+              abs(before - minimum) <= scalarEpsilon,
+              abs(maximum - after) <= scalarEpsilon else {
+            throw DesktopReposReachabilityValidationError.unsupportedOuterScroll
+        }
+    }
+
+    private static func requireVisible(
+        _ id: DesktopReposReachabilityRegion,
+        in samples: [DesktopReposReachabilitySample],
+        phase: DesktopReposReachabilityValidationPhase
+    ) throws {
+        for (index, sample) in samples.enumerated() {
+            guard let region = sample.regions.first(where: { $0.id == id }) else {
+                throw DesktopReposReachabilityValidationError.missingRegion(phase, index, id)
+            }
+            guard sample.viewport.contains(region.frame) else {
+                throw DesktopReposReachabilityValidationError.regionOutsideViewport(phase, index, id)
+            }
+        }
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposReachabilityTrace.swift
@@ -4,10 +4,144 @@ public enum DesktopReposReachabilityFixture: String, Codable, Equatable, Sendabl
     case tabRepos = "tab-repos"
 }
 
+public enum DesktopReposReachabilityTarget: String, Codable, Equatable, Sendable {
+    case tabRepos1040x680 = "tab-repos-1040x680"
+
+    public static func requireSupported(
+        fixtureId: String,
+        contentWidth: Double,
+        contentHeight: Double
+    ) throws -> Self {
+        guard fixtureId == DesktopReposReachabilityFixture.tabRepos.rawValue,
+              contentWidth == 1040,
+              contentHeight == 680 else {
+            throw DesktopReposReachabilityTargetError.unsupportedTarget
+        }
+        return .tabRepos1040x680
+    }
+}
+
+public enum DesktopReposReachabilityTargetError: LocalizedError, Equatable, Sendable {
+    case unsupportedTarget
+
+    public var errorDescription: String? {
+        "Repositories reachability capture requires tab-repos at 1040x680."
+    }
+}
+
+public enum DesktopReposReachabilityAcquisitionStatus: String, Codable, Equatable, Sendable {
+    case complete
+    case failed
+}
+
+public enum DesktopReposReachabilityAcquisitionFailureReason: String, Codable, Error, Equatable, Sendable {
+    case cannotComplete = "cannot-complete"
+    case invalidElement = "invalid-element"
+    case permissionDenied = "permission-denied"
+    case invalidType = "invalid-type"
+    case attributeUnavailable = "attribute-unavailable"
+    case pidMismatch = "pid-mismatch"
+    case windowMismatch = "window-mismatch"
+    case semanticMissing = "semantic-missing"
+    case semanticDuplicate = "semantic-duplicate"
+    case timeout
+    case ancestryUnavailable = "ancestry-unavailable"
+    case ancestryCycle = "ancestry-cycle"
+    case ancestryLimit = "ancestry-limit"
+    case messagingTimeoutUnavailable = "messaging-timeout-unavailable"
+}
+
+public struct DesktopReposReachabilityAcquisition: Codable, Equatable, Sendable {
+    public let status: DesktopReposReachabilityAcquisitionStatus
+    public let failureReason: DesktopReposReachabilityAcquisitionFailureReason?
+
+    public init(
+        status: DesktopReposReachabilityAcquisitionStatus,
+        failureReason: DesktopReposReachabilityAcquisitionFailureReason?
+    ) {
+        self.status = status
+        self.failureReason = failureReason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case failureReason
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard container.contains(.failureReason) else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.failureReason,
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Acquisition failureReason must be explicit."
+                )
+            )
+        }
+        status = try container.decode(DesktopReposReachabilityAcquisitionStatus.self, forKey: .status)
+        failureReason = try container.decodeIfPresent(
+            DesktopReposReachabilityAcquisitionFailureReason.self,
+            forKey: .failureReason
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(status, forKey: .status)
+        if let failureReason {
+            try container.encode(failureReason, forKey: .failureReason)
+        } else {
+            try container.encodeNil(forKey: .failureReason)
+        }
+    }
+}
+
 public enum DesktopReposReachabilityRegion: String, Codable, CaseIterable, Equatable, Sendable {
     case table
     case applyAllowlist = "apply-allowlist"
     case boundaryBody = "boundary-body"
+}
+
+public enum DesktopReposReachabilitySemanticContract {
+    public static let boundaryIdentifier = "neondiff-repos-boundary"
+    public static let boundaryValue = "Repo changes are written through config patch only; the desktop does not post reviews or bypass daemon gates."
+    public static let applyAllowlistIdentifier = "neondiff-repo-apply-patch"
+    public static let applyAllowlistValue = "Apply Allowlist"
+
+    public static func matchesApplyAllowlist(
+        isButton: Bool,
+        identifier: String?,
+        title: String?,
+        description: String?,
+        value: String?
+    ) -> Bool {
+        isButton
+            && (identifier == applyAllowlistIdentifier
+                || [title, description, value].compactMap({ $0 }).contains(applyAllowlistValue))
+    }
+
+    public static func matchesBoundaryBody(
+        isStaticText: Bool,
+        identifier: String?,
+        description: String?,
+        value: String?
+    ) -> Bool {
+        isStaticText
+            && (identifier == boundaryIdentifier
+                || [description, value].compactMap({ $0 }).contains(boundaryValue))
+    }
+
+    public static func failureReason(
+        tableCount: Int,
+        applyAllowlistCount: Int,
+        boundaryBodyCount: Int
+    ) -> DesktopReposReachabilityAcquisitionFailureReason? {
+        let counts = [tableCount, applyAllowlistCount, boundaryBodyCount]
+        if counts.contains(where: { $0 > 1 }) { return .semanticDuplicate }
+        if counts.contains(where: { $0 != 1 }) { return .semanticMissing }
+        return nil
+    }
 }
 
 public struct DesktopReposReachabilityFrame: Codable, Equatable, Sendable {
@@ -107,6 +241,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
     public let preScrollAcquisitionMilliseconds: Int
     public let postScrollAcquisitionMilliseconds: Int
     public let tolerancePoints: Double
+    public let acquisition: DesktopReposReachabilityAcquisition
     public let preScrollSamples: [DesktopReposReachabilitySample]
     public let outerScroll: DesktopReposOuterScrollObservation?
     public let postScrollSamples: [DesktopReposReachabilitySample]
@@ -121,6 +256,7 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         preScrollAcquisitionMilliseconds: Int,
         postScrollAcquisitionMilliseconds: Int,
         tolerancePoints: Double,
+        acquisition: DesktopReposReachabilityAcquisition,
         preScrollSamples: [DesktopReposReachabilitySample],
         outerScroll: DesktopReposOuterScrollObservation?,
         postScrollSamples: [DesktopReposReachabilitySample]
@@ -134,9 +270,64 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
         self.preScrollAcquisitionMilliseconds = preScrollAcquisitionMilliseconds
         self.postScrollAcquisitionMilliseconds = postScrollAcquisitionMilliseconds
         self.tolerancePoints = tolerancePoints
+        self.acquisition = acquisition
         self.preScrollSamples = preScrollSamples
         self.outerScroll = outerScroll
         self.postScrollSamples = postScrollSamples
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case fixture
+        case ready
+        case quiescent
+        case requestedContentSize
+        case sampleIntervalMilliseconds
+        case preScrollAcquisitionMilliseconds
+        case postScrollAcquisitionMilliseconds
+        case tolerancePoints
+        case acquisition
+        case preScrollSamples
+        case outerScroll
+        case postScrollSamples
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        fixture = try container.decode(DesktopReposReachabilityFixture.self, forKey: .fixture)
+        ready = try container.decode(Bool.self, forKey: .ready)
+        quiescent = try container.decode(Bool.self, forKey: .quiescent)
+        requestedContentSize = try container.decode(DesktopEvaluationContentSize.self, forKey: .requestedContentSize)
+        sampleIntervalMilliseconds = try container.decode(Int.self, forKey: .sampleIntervalMilliseconds)
+        preScrollAcquisitionMilliseconds = try container.decode(Int.self, forKey: .preScrollAcquisitionMilliseconds)
+        postScrollAcquisitionMilliseconds = try container.decode(Int.self, forKey: .postScrollAcquisitionMilliseconds)
+        tolerancePoints = try container.decode(Double.self, forKey: .tolerancePoints)
+        acquisition = try container.decode(DesktopReposReachabilityAcquisition.self, forKey: .acquisition)
+        preScrollSamples = try container.decode([DesktopReposReachabilitySample].self, forKey: .preScrollSamples)
+        outerScroll = try container.decodeIfPresent(DesktopReposOuterScrollObservation.self, forKey: .outerScroll)
+        postScrollSamples = try container.decode([DesktopReposReachabilitySample].self, forKey: .postScrollSamples)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(fixture, forKey: .fixture)
+        try container.encode(ready, forKey: .ready)
+        try container.encode(quiescent, forKey: .quiescent)
+        try container.encode(requestedContentSize, forKey: .requestedContentSize)
+        try container.encode(sampleIntervalMilliseconds, forKey: .sampleIntervalMilliseconds)
+        try container.encode(preScrollAcquisitionMilliseconds, forKey: .preScrollAcquisitionMilliseconds)
+        try container.encode(postScrollAcquisitionMilliseconds, forKey: .postScrollAcquisitionMilliseconds)
+        try container.encode(tolerancePoints, forKey: .tolerancePoints)
+        try container.encode(acquisition, forKey: .acquisition)
+        try container.encode(preScrollSamples, forKey: .preScrollSamples)
+        if let outerScroll {
+            try container.encode(outerScroll, forKey: .outerScroll)
+        } else {
+            try container.encodeNil(forKey: .outerScroll)
+        }
+        try container.encode(postScrollSamples, forKey: .postScrollSamples)
     }
 
     public static func decode(data: Data) throws -> Self {
@@ -167,12 +358,20 @@ public struct DesktopReposReachabilityTrace: Codable, Equatable, Sendable {
               hasAllowedAndRequired(root, allowed: [
                   "schemaVersion", "fixture", "ready", "quiescent", "requestedContentSize",
                   "sampleIntervalMilliseconds", "preScrollAcquisitionMilliseconds", "tolerancePoints",
-                  "postScrollAcquisitionMilliseconds", "preScrollSamples", "outerScroll", "postScrollSamples"
+                  "postScrollAcquisitionMilliseconds", "acquisition", "preScrollSamples", "outerScroll",
+                  "postScrollSamples"
               ], required: [
                   "schemaVersion", "fixture", "ready", "quiescent", "requestedContentSize",
                   "sampleIntervalMilliseconds", "preScrollAcquisitionMilliseconds", "tolerancePoints",
-                  "postScrollAcquisitionMilliseconds", "preScrollSamples", "postScrollSamples"
+                  "postScrollAcquisitionMilliseconds", "acquisition", "preScrollSamples", "outerScroll",
+                  "postScrollSamples"
               ]),
+              let acquisition = root["acquisition"] as? [String: Any],
+              hasAllowedAndRequired(
+                  acquisition,
+                  allowed: ["status", "failureReason"],
+                  required: ["status", "failureReason"]
+              ),
               let size = root["requestedContentSize"] as? [String: Any],
               hasOnly(size, ["width", "height"]),
               let pre = root["preScrollSamples"] as? [Any],
@@ -240,6 +439,7 @@ public enum DesktopReposReachabilityValidationPhase: String, Codable, Equatable,
 
 public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, Sendable {
     case invalidContract
+    case acquisitionFailed(DesktopReposReachabilityAcquisitionFailureReason)
     case insufficientSamples(DesktopReposReachabilityValidationPhase)
     case nonfiniteFrame(DesktopReposReachabilityValidationPhase, Int)
     case duplicateRegion(DesktopReposReachabilityValidationPhase, Int, DesktopReposReachabilityRegion)
@@ -253,6 +453,8 @@ public enum DesktopReposReachabilityValidationError: LocalizedError, Equatable, 
         switch self {
         case .invalidContract:
             return "Reachability trace contract is invalid."
+        case .acquisitionFailed(let reason):
+            return "Reachability trace acquisition failed: \(reason.rawValue)."
         case .insufficientSamples(let phase):
             return "Reachability trace has fewer than three \(phase.rawValue) samples."
         case .nonfiniteFrame(let phase, let index):
@@ -280,17 +482,27 @@ public enum DesktopReposReachabilityValidator {
     ) throws -> DesktopReposReachabilityValidationStatus {
         guard trace.schemaVersion == 1,
               trace.fixture == .tabRepos,
-              trace.ready,
-              trace.quiescent,
               trace.requestedContentSize == DesktopEvaluationContentSize(width: 1040, height: 680),
               trace.sampleIntervalMilliseconds == 100,
               trace.preScrollAcquisitionMilliseconds >= 0,
-              trace.preScrollAcquisitionMilliseconds <= 5_000,
               trace.postScrollAcquisitionMilliseconds >= 0,
-              trace.postScrollAcquisitionMilliseconds <= 5_000,
               trace.tolerancePoints.isFinite,
               trace.tolerancePoints > 0,
               trace.tolerancePoints <= 1 else {
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        switch (trace.acquisition.status, trace.acquisition.failureReason) {
+        case (.complete, nil):
+            break
+        case (.failed, .some(let reason)):
+            throw DesktopReposReachabilityValidationError.acquisitionFailed(reason)
+        case (.complete, .some), (.failed, nil):
+            throw DesktopReposReachabilityValidationError.invalidContract
+        }
+        guard trace.ready,
+              trace.quiescent,
+              trace.preScrollAcquisitionMilliseconds <= 5_000,
+              trace.postScrollAcquisitionMilliseconds <= 5_000 else {
             throw DesktopReposReachabilityValidationError.invalidContract
         }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+public enum DesktopReposScrollCapabilityContractError: Error, Equatable, Sendable {
+    case invalidOperatingSystemVersion
+    case missingBoundaryActionNames
+    case unexpectedBoundaryActionNames
+    case missingScrollBarActionNames
+    case unexpectedScrollBarActionNames
+    case missingActionName
+}
+
+public enum DesktopReposScrollCapabilitiesValidationError: Error, Equatable, Sendable {
+    case invalidContract
+}
+
+public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let fixture: DesktopReposReachabilityFixture
+    public let requestedContentSize: DesktopEvaluationContentSize
+    public let osMajorVersion: Int
+    public let acquisition: DesktopReposReachabilityAcquisition
+    public let scrollToVisibleActionAvailable: Bool
+    public let boundaryAdvertisesScrollToVisible: Bool?
+    public let outerVerticalScrollBarResolved: Bool?
+    public let outerVerticalScrollBarAdvertisesIncrement: Bool?
+
+    public init(
+        schemaVersion: Int = 1,
+        fixture: DesktopReposReachabilityFixture = .tabRepos,
+        requestedContentSize: DesktopEvaluationContentSize = .init(width: 1040, height: 680),
+        osMajorVersion: Int,
+        acquisition: DesktopReposReachabilityAcquisition,
+        scrollToVisibleActionAvailable: Bool,
+        boundaryAdvertisesScrollToVisible: Bool?,
+        outerVerticalScrollBarResolved: Bool?,
+        outerVerticalScrollBarAdvertisesIncrement: Bool?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.fixture = fixture
+        self.requestedContentSize = requestedContentSize
+        self.osMajorVersion = osMajorVersion
+        self.acquisition = acquisition
+        self.scrollToVisibleActionAvailable = scrollToVisibleActionAvailable
+        self.boundaryAdvertisesScrollToVisible = boundaryAdvertisesScrollToVisible
+        self.outerVerticalScrollBarResolved = outerVerticalScrollBarResolved
+        self.outerVerticalScrollBarAdvertisesIncrement = outerVerticalScrollBarAdvertisesIncrement
+    }
+
+    public static func failed(
+        osMajorVersion: Int,
+        reason: DesktopReposReachabilityAcquisitionFailureReason
+    ) -> Self {
+        Self(
+            fixture: .tabRepos,
+            requestedContentSize: .init(width: 1040, height: 680),
+            osMajorVersion: osMajorVersion,
+            acquisition: .init(status: .failed, failureReason: reason),
+            scrollToVisibleActionAvailable: osMajorVersion >= 26,
+            boundaryAdvertisesScrollToVisible: nil,
+            outerVerticalScrollBarResolved: nil,
+            outerVerticalScrollBarAdvertisesIncrement: nil
+        )
+    }
+
+    public func validated() throws -> Self {
+        guard schemaVersion == 1,
+              fixture == .tabRepos,
+              requestedContentSize == .init(width: 1040, height: 680),
+              (1...100).contains(osMajorVersion),
+              scrollToVisibleActionAvailable == (osMajorVersion >= 26) else {
+            throw DesktopReposScrollCapabilitiesValidationError.invalidContract
+        }
+
+        switch acquisition.status {
+        case .complete:
+            guard acquisition.failureReason == nil,
+                  let boundaryAdvertisesScrollToVisible,
+                  let outerVerticalScrollBarResolved,
+                  let outerVerticalScrollBarAdvertisesIncrement,
+                  scrollToVisibleActionAvailable || !boundaryAdvertisesScrollToVisible,
+                  outerVerticalScrollBarResolved || !outerVerticalScrollBarAdvertisesIncrement else {
+                throw DesktopReposScrollCapabilitiesValidationError.invalidContract
+            }
+        case .failed:
+            guard acquisition.failureReason != nil,
+                  boundaryAdvertisesScrollToVisible == nil,
+                  outerVerticalScrollBarResolved == nil,
+                  outerVerticalScrollBarAdvertisesIncrement == nil else {
+                throw DesktopReposScrollCapabilitiesValidationError.invalidContract
+            }
+        }
+        return self
+    }
+
+    public static func decode(data: Data) throws -> Self {
+        do {
+            guard data.count <= 4_096,
+                  let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  Set(object.keys) == Set(CodingKeys.allCases.map(\.rawValue)),
+                  let acquisition = object[CodingKeys.acquisition.rawValue] as? [String: Any],
+                  Set(acquisition.keys) == Set(["status", "failureReason"]) else {
+                throw DesktopReposScrollCapabilitiesValidationError.invalidContract
+            }
+            return try JSONDecoder().decode(Self.self, from: data).validated()
+        } catch let error as DesktopReposScrollCapabilitiesValidationError {
+            throw error
+        } catch {
+            throw DesktopReposScrollCapabilitiesValidationError.invalidContract
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion
+        case fixture
+        case requestedContentSize
+        case osMajorVersion
+        case acquisition
+        case scrollToVisibleActionAvailable
+        case boundaryAdvertisesScrollToVisible
+        case outerVerticalScrollBarResolved
+        case outerVerticalScrollBarAdvertisesIncrement
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard container.allKeys.count == CodingKeys.allCases.count,
+              CodingKeys.allCases.allSatisfy(container.contains) else {
+            throw DesktopReposScrollCapabilitiesValidationError.invalidContract
+        }
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        fixture = try container.decode(DesktopReposReachabilityFixture.self, forKey: .fixture)
+        requestedContentSize = try container.decode(
+            DesktopEvaluationContentSize.self,
+            forKey: .requestedContentSize
+        )
+        osMajorVersion = try container.decode(Int.self, forKey: .osMajorVersion)
+        acquisition = try container.decode(DesktopReposReachabilityAcquisition.self, forKey: .acquisition)
+        scrollToVisibleActionAvailable = try container.decode(Bool.self, forKey: .scrollToVisibleActionAvailable)
+        boundaryAdvertisesScrollToVisible = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .boundaryAdvertisesScrollToVisible
+        )
+        outerVerticalScrollBarResolved = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .outerVerticalScrollBarResolved
+        )
+        outerVerticalScrollBarAdvertisesIncrement = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .outerVerticalScrollBarAdvertisesIncrement
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(fixture, forKey: .fixture)
+        try container.encode(requestedContentSize, forKey: .requestedContentSize)
+        try container.encode(osMajorVersion, forKey: .osMajorVersion)
+        try container.encode(acquisition, forKey: .acquisition)
+        try container.encode(scrollToVisibleActionAvailable, forKey: .scrollToVisibleActionAvailable)
+        if let boundaryAdvertisesScrollToVisible {
+            try container.encode(boundaryAdvertisesScrollToVisible, forKey: .boundaryAdvertisesScrollToVisible)
+        } else {
+            try container.encodeNil(forKey: .boundaryAdvertisesScrollToVisible)
+        }
+        if let outerVerticalScrollBarResolved {
+            try container.encode(outerVerticalScrollBarResolved, forKey: .outerVerticalScrollBarResolved)
+        } else {
+            try container.encodeNil(forKey: .outerVerticalScrollBarResolved)
+        }
+        if let outerVerticalScrollBarAdvertisesIncrement {
+            try container.encode(
+                outerVerticalScrollBarAdvertisesIncrement,
+                forKey: .outerVerticalScrollBarAdvertisesIncrement
+            )
+        } else {
+            try container.encodeNil(forKey: .outerVerticalScrollBarAdvertisesIncrement)
+        }
+    }
+}
+
+public enum DesktopReposScrollCapabilityContract {
+    public static func evaluate(
+        osMajorVersion: Int,
+        boundaryActionNames: [String]?,
+        verticalScrollBarResolved: Bool,
+        scrollBarActionNames: [String]?,
+        scrollToVisibleActionName: String?,
+        incrementActionName: String
+    ) throws -> DesktopReposScrollCapabilities {
+        guard (1...100).contains(osMajorVersion) else {
+            throw DesktopReposScrollCapabilityContractError.invalidOperatingSystemVersion
+        }
+        guard !incrementActionName.isEmpty else {
+            throw DesktopReposScrollCapabilityContractError.missingActionName
+        }
+
+        let scrollToVisibleAvailable = osMajorVersion >= 26
+        let boundaryAdvertisesScrollToVisible: Bool
+        if scrollToVisibleAvailable {
+            guard let boundaryActionNames else {
+                throw DesktopReposScrollCapabilityContractError.missingBoundaryActionNames
+            }
+            guard let scrollToVisibleActionName, !scrollToVisibleActionName.isEmpty else {
+                throw DesktopReposScrollCapabilityContractError.missingActionName
+            }
+            boundaryAdvertisesScrollToVisible = boundaryActionNames.contains(scrollToVisibleActionName)
+        } else {
+            guard boundaryActionNames == nil else {
+                throw DesktopReposScrollCapabilityContractError.unexpectedBoundaryActionNames
+            }
+            boundaryAdvertisesScrollToVisible = false
+        }
+
+        let advertisesIncrement: Bool
+        if verticalScrollBarResolved {
+            guard let scrollBarActionNames else {
+                throw DesktopReposScrollCapabilityContractError.missingScrollBarActionNames
+            }
+            advertisesIncrement = scrollBarActionNames.contains(incrementActionName)
+        } else {
+            guard scrollBarActionNames == nil else {
+                throw DesktopReposScrollCapabilityContractError.unexpectedScrollBarActionNames
+            }
+            advertisesIncrement = false
+        }
+
+        return try DesktopReposScrollCapabilities(
+            fixture: .tabRepos,
+            requestedContentSize: .init(width: 1040, height: 680),
+            osMajorVersion: osMajorVersion,
+            acquisition: .init(status: .complete, failureReason: nil),
+            scrollToVisibleActionAvailable: scrollToVisibleAvailable,
+            boundaryAdvertisesScrollToVisible: boundaryAdvertisesScrollToVisible,
+            outerVerticalScrollBarResolved: verticalScrollBarResolved,
+            outerVerticalScrollBarAdvertisesIncrement: advertisesIncrement
+        ).validated()
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
@@ -49,14 +49,17 @@ public enum DesktopReposIncrementPageSelectionContract {
             guard let role = child.role else {
                 throw DesktopReposIncrementPageSelectionError.missingRole
             }
-            guard let subrole = child.subrole else {
-                throw DesktopReposIncrementPageSelectionError.missingSubrole
+            if role == buttonRole {
+                guard let subrole = child.subrole else {
+                    throw DesktopReposIncrementPageSelectionError.missingSubrole
+                }
+                guard subrole == incrementPageSubrole else { continue }
+                incrementPageIndices.append(index)
+                continue
             }
-            guard subrole == incrementPageSubrole else { continue }
-            guard role == buttonRole else {
+            if child.subrole == incrementPageSubrole {
                 throw DesktopReposIncrementPageSelectionError.invalidIncrementPageRole
             }
-            incrementPageIndices.append(index)
         }
         switch incrementPageIndices.count {
         case 0:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
@@ -281,6 +281,8 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
 }
 
 public enum DesktopReposScrollCapabilityContract {
+    public static let scrollToVisibleActionName = "AXScrollToVisible"
+
     public static func evaluate(
         osMajorVersion: Int,
         boundaryActionNames: [String]?,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
@@ -98,7 +98,9 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
                   let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   Set(object.keys) == Set(CodingKeys.allCases.map(\.rawValue)),
                   let acquisition = object[CodingKeys.acquisition.rawValue] as? [String: Any],
-                  Set(acquisition.keys) == Set(["status", "failureReason"]) else {
+                  Set(acquisition.keys) == Set(["status", "failureReason"]),
+                  let requestedContentSize = object[CodingKeys.requestedContentSize.rawValue] as? [String: Any],
+                  Set(requestedContentSize.keys) == Set(["width", "height"]) else {
                 throw DesktopReposScrollCapabilitiesValidationError.invalidContract
             }
             return try JSONDecoder().decode(Self.self, from: data).validated()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopReposScrollCapabilities.swift
@@ -6,11 +6,67 @@ public enum DesktopReposScrollCapabilityContractError: Error, Equatable, Sendabl
     case unexpectedBoundaryActionNames
     case missingScrollBarActionNames
     case unexpectedScrollBarActionNames
+    case missingIncrementPageActionNames
+    case unexpectedIncrementPageActionNames
     case missingActionName
 }
 
 public enum DesktopReposScrollCapabilitiesValidationError: Error, Equatable, Sendable {
     case invalidContract
+}
+
+public struct DesktopReposIncrementPageCandidate: Equatable, Sendable {
+    public let role: String?
+    public let subrole: String?
+
+    public init(role: String?, subrole: String?) {
+        self.role = role
+        self.subrole = subrole
+    }
+}
+
+public enum DesktopReposIncrementPageSelection: Equatable, Sendable {
+    case directChild(index: Int)
+    case unsupported
+}
+
+public enum DesktopReposIncrementPageSelectionError: Error, Equatable, Sendable {
+    case missingRole
+    case missingSubrole
+    case invalidIncrementPageRole
+    case duplicateIncrementPage
+}
+
+public enum DesktopReposIncrementPageSelectionContract {
+    public static let buttonRole = "AXButton"
+    public static let incrementPageSubrole = "AXIncrementPage"
+
+    public static func select(
+        directChildren: [DesktopReposIncrementPageCandidate]
+    ) throws -> DesktopReposIncrementPageSelection {
+        var incrementPageIndices: [Int] = []
+        for (index, child) in directChildren.enumerated() {
+            guard let role = child.role else {
+                throw DesktopReposIncrementPageSelectionError.missingRole
+            }
+            guard let subrole = child.subrole else {
+                throw DesktopReposIncrementPageSelectionError.missingSubrole
+            }
+            guard subrole == incrementPageSubrole else { continue }
+            guard role == buttonRole else {
+                throw DesktopReposIncrementPageSelectionError.invalidIncrementPageRole
+            }
+            incrementPageIndices.append(index)
+        }
+        switch incrementPageIndices.count {
+        case 0:
+            return .unsupported
+        case 1:
+            return .directChild(index: incrementPageIndices[0])
+        default:
+            throw DesktopReposIncrementPageSelectionError.duplicateIncrementPage
+        }
+    }
 }
 
 public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
@@ -23,6 +79,8 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
     public let boundaryAdvertisesScrollToVisible: Bool?
     public let outerVerticalScrollBarResolved: Bool?
     public let outerVerticalScrollBarAdvertisesIncrement: Bool?
+    public let outerVerticalIncrementPageResolved: Bool?
+    public let outerVerticalIncrementPageAdvertisesPress: Bool?
 
     public init(
         schemaVersion: Int = 1,
@@ -33,7 +91,9 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
         scrollToVisibleActionAvailable: Bool,
         boundaryAdvertisesScrollToVisible: Bool?,
         outerVerticalScrollBarResolved: Bool?,
-        outerVerticalScrollBarAdvertisesIncrement: Bool?
+        outerVerticalScrollBarAdvertisesIncrement: Bool?,
+        outerVerticalIncrementPageResolved: Bool?,
+        outerVerticalIncrementPageAdvertisesPress: Bool?
     ) {
         self.schemaVersion = schemaVersion
         self.fixture = fixture
@@ -44,6 +104,8 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
         self.boundaryAdvertisesScrollToVisible = boundaryAdvertisesScrollToVisible
         self.outerVerticalScrollBarResolved = outerVerticalScrollBarResolved
         self.outerVerticalScrollBarAdvertisesIncrement = outerVerticalScrollBarAdvertisesIncrement
+        self.outerVerticalIncrementPageResolved = outerVerticalIncrementPageResolved
+        self.outerVerticalIncrementPageAdvertisesPress = outerVerticalIncrementPageAdvertisesPress
     }
 
     public static func failed(
@@ -58,7 +120,9 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
             scrollToVisibleActionAvailable: osMajorVersion >= 26,
             boundaryAdvertisesScrollToVisible: nil,
             outerVerticalScrollBarResolved: nil,
-            outerVerticalScrollBarAdvertisesIncrement: nil
+            outerVerticalScrollBarAdvertisesIncrement: nil,
+            outerVerticalIncrementPageResolved: nil,
+            outerVerticalIncrementPageAdvertisesPress: nil
         )
     }
 
@@ -77,15 +141,21 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
                   let boundaryAdvertisesScrollToVisible,
                   let outerVerticalScrollBarResolved,
                   let outerVerticalScrollBarAdvertisesIncrement,
+                  let outerVerticalIncrementPageResolved,
+                  let outerVerticalIncrementPageAdvertisesPress,
                   scrollToVisibleActionAvailable || !boundaryAdvertisesScrollToVisible,
-                  outerVerticalScrollBarResolved || !outerVerticalScrollBarAdvertisesIncrement else {
+                  outerVerticalScrollBarResolved || !outerVerticalScrollBarAdvertisesIncrement,
+                  outerVerticalScrollBarResolved || !outerVerticalIncrementPageResolved,
+                  outerVerticalIncrementPageResolved || !outerVerticalIncrementPageAdvertisesPress else {
                 throw DesktopReposScrollCapabilitiesValidationError.invalidContract
             }
         case .failed:
             guard acquisition.failureReason != nil,
                   boundaryAdvertisesScrollToVisible == nil,
                   outerVerticalScrollBarResolved == nil,
-                  outerVerticalScrollBarAdvertisesIncrement == nil else {
+                  outerVerticalScrollBarAdvertisesIncrement == nil,
+                  outerVerticalIncrementPageResolved == nil,
+                  outerVerticalIncrementPageAdvertisesPress == nil else {
                 throw DesktopReposScrollCapabilitiesValidationError.invalidContract
             }
         }
@@ -121,6 +191,8 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
         case boundaryAdvertisesScrollToVisible
         case outerVerticalScrollBarResolved
         case outerVerticalScrollBarAdvertisesIncrement
+        case outerVerticalIncrementPageResolved
+        case outerVerticalIncrementPageAdvertisesPress
     }
 
     public init(from decoder: Decoder) throws {
@@ -150,6 +222,14 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
             Bool.self,
             forKey: .outerVerticalScrollBarAdvertisesIncrement
         )
+        outerVerticalIncrementPageResolved = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .outerVerticalIncrementPageResolved
+        )
+        outerVerticalIncrementPageAdvertisesPress = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .outerVerticalIncrementPageAdvertisesPress
+        )
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -178,6 +258,22 @@ public struct DesktopReposScrollCapabilities: Codable, Equatable, Sendable {
         } else {
             try container.encodeNil(forKey: .outerVerticalScrollBarAdvertisesIncrement)
         }
+        if let outerVerticalIncrementPageResolved {
+            try container.encode(
+                outerVerticalIncrementPageResolved,
+                forKey: .outerVerticalIncrementPageResolved
+            )
+        } else {
+            try container.encodeNil(forKey: .outerVerticalIncrementPageResolved)
+        }
+        if let outerVerticalIncrementPageAdvertisesPress {
+            try container.encode(
+                outerVerticalIncrementPageAdvertisesPress,
+                forKey: .outerVerticalIncrementPageAdvertisesPress
+            )
+        } else {
+            try container.encodeNil(forKey: .outerVerticalIncrementPageAdvertisesPress)
+        }
     }
 }
 
@@ -187,14 +283,30 @@ public enum DesktopReposScrollCapabilityContract {
         boundaryActionNames: [String]?,
         verticalScrollBarResolved: Bool,
         scrollBarActionNames: [String]?,
+        incrementPageResolved: Bool,
+        incrementPageActionNames: [String]?,
         scrollToVisibleActionName: String?,
-        incrementActionName: String
+        incrementActionName: String,
+        pressActionName: String
     ) throws -> DesktopReposScrollCapabilities {
         guard (1...100).contains(osMajorVersion) else {
             throw DesktopReposScrollCapabilityContractError.invalidOperatingSystemVersion
         }
-        guard !incrementActionName.isEmpty else {
+        guard !incrementActionName.isEmpty, !pressActionName.isEmpty else {
             throw DesktopReposScrollCapabilityContractError.missingActionName
+        }
+
+        let incrementPageAdvertisesPress: Bool
+        if incrementPageResolved {
+            guard let incrementPageActionNames else {
+                throw DesktopReposScrollCapabilityContractError.missingIncrementPageActionNames
+            }
+            incrementPageAdvertisesPress = incrementPageActionNames.contains(pressActionName)
+        } else {
+            guard incrementPageActionNames == nil else {
+                throw DesktopReposScrollCapabilityContractError.unexpectedIncrementPageActionNames
+            }
+            incrementPageAdvertisesPress = false
         }
 
         let scrollToVisibleAvailable = osMajorVersion >= 26
@@ -235,7 +347,9 @@ public enum DesktopReposScrollCapabilityContract {
             scrollToVisibleActionAvailable: scrollToVisibleAvailable,
             boundaryAdvertisesScrollToVisible: boundaryAdvertisesScrollToVisible,
             outerVerticalScrollBarResolved: verticalScrollBarResolved,
-            outerVerticalScrollBarAdvertisesIncrement: advertisesIncrement
+            outerVerticalScrollBarAdvertisesIncrement: advertisesIncrement,
+            outerVerticalIncrementPageResolved: incrementPageResolved,
+            outerVerticalIncrementPageAdvertisesPress: incrementPageAdvertisesPress
         ).validated()
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopReachabilityChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopReachabilityChecks/main.swift
@@ -1,0 +1,37 @@
+import Darwin
+import Foundation
+import NeonDiffDesktopEvaluationSupport
+
+private enum CheckerError: LocalizedError {
+    case usage
+    case unsafeInput
+
+    var errorDescription: String? {
+        switch self {
+        case .usage:
+            return "usage: NeonDiffDesktopReachabilityChecks <absolute-reachability-json>"
+        case .unsafeInput:
+            return "reachability trace must be an absolute regular non-symlink file"
+        }
+    }
+}
+
+do {
+    guard CommandLine.arguments.count == 2 else { throw CheckerError.usage }
+    let input = URL(fileURLWithPath: CommandLine.arguments[1]).standardizedFileURL
+    guard input.isFileURL,
+          input.path.hasPrefix("/"),
+          input.lastPathComponent == "reachability.json" else {
+        throw CheckerError.unsafeInput
+    }
+    let values = try input.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+    guard values.isRegularFile == true, values.isSymbolicLink != true else {
+        throw CheckerError.unsafeInput
+    }
+    let trace = try DesktopReposReachabilityTrace.decode(data: Data(contentsOf: input, options: [.mappedIfSafe]))
+    _ = try DesktopReposReachabilityValidator.validate(trace)
+    FileHandle.standardOutput.write(Data("{\"ok\":true,\"status\":\"reachable\"}\n".utf8))
+} catch {
+    FileHandle.standardError.write(Data("\(error.localizedDescription)\n".utf8))
+    exit(65)
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopReachabilityChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopReachabilityChecks/main.swift
@@ -2,18 +2,22 @@ import Darwin
 import Foundation
 import NeonDiffDesktopEvaluationSupport
 
-private enum CheckerError: LocalizedError {
+private enum CheckerError: Error {
     case usage
     case unsafeInput
+}
 
-    var errorDescription: String? {
-        switch self {
-        case .usage:
-            return "usage: NeonDiffDesktopReachabilityChecks <absolute-reachability-json>"
-        case .unsafeInput:
-            return "reachability trace must be an absolute regular non-symlink file"
-        }
+private func emit(_ result: DesktopReposReachabilityCheckResult) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(result) else {
+        FileHandle.standardOutput.write(Data(
+            "{\"category\":\"contract\",\"ok\":false,\"reasonCode\":\"checker-encoding-failed\",\"schemaVersion\":1,\"status\":\"failed\"}\n".utf8
+        ))
+        exit(70)
     }
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
 }
 
 do {
@@ -30,8 +34,17 @@ do {
     }
     let trace = try DesktopReposReachabilityTrace.decode(data: Data(contentsOf: input, options: [.mappedIfSafe]))
     _ = try DesktopReposReachabilityValidator.validate(trace)
-    FileHandle.standardOutput.write(Data("{\"ok\":true,\"status\":\"reachable\"}\n".utf8))
+    emit(.reachable)
+} catch CheckerError.usage {
+    emit(.inputFailure("usage"))
+    exit(64)
+} catch CheckerError.unsafeInput {
+    emit(.inputFailure("unsafe-input"))
+    exit(65)
+} catch let error as DesktopReposReachabilityValidationError {
+    emit(.failure(error))
+    exit(65)
 } catch {
-    FileHandle.standardError.write(Data("\(error.localizedDescription)\n".utf8))
+    emit(.inputFailure("input-read-failed"))
     exit(65)
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@Suite struct ReposReachabilityLayoutContractTests {
+    @Test func reposPageKeepsApplyAndBoundaryReachableAtCompactHeights() throws {
+        let reposView = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views/ReposView.swift")
+        let source = try sourceBoundaryText(at: reposView)
+
+        let outerScroll = try #require(source.range(of: "ScrollView(.vertical) {"))
+        let outerBackground = try #require(
+            source.range(
+                of: ".scrollContentBackground(.hidden)",
+                range: outerScroll.upperBound..<source.endIndex
+            )
+        )
+        let outerIndicators = try #require(
+            source.range(
+                of: ".scrollIndicators(.visible, axes: .vertical)",
+                range: outerBackground.upperBound..<source.endIndex
+            )
+        )
+        let pageContent = try #require(source.range(of: "private var pageContent: some View"))
+        let pageStack = try #require(
+            source.range(
+                of: "VStack(alignment: .leading, spacing: 14) {",
+                range: pageContent.upperBound..<source.endIndex
+            )
+        )
+        let readOnlyBoundary = try #require(source.range(of: ".disabled(!model.canEditProviderConfiguration)"))
+
+        #expect(outerScroll.lowerBound < outerBackground.lowerBound)
+        #expect(outerBackground.lowerBound < outerIndicators.lowerBound)
+        #expect(outerIndicators.lowerBound < pageContent.lowerBound)
+        #expect(pageContent.lowerBound < pageStack.lowerBound)
+        #expect(pageStack.lowerBound < readOnlyBoundary.lowerBound)
+        #expect(source.contains(".frame(height: 360)"))
+        #expect(!source.contains(".frame(minHeight: 360)"))
+        #expect(source.contains(".accessibilityIdentifier(\"neondiff-repos-boundary\")"))
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
@@ -14,6 +14,12 @@ import Testing
                 range: outerScroll.upperBound..<source.endIndex
             )
         )
+        let outerIndicators = try #require(
+            source.range(
+                of: ".scrollIndicators(.visible, axes: .vertical)",
+                range: outerBackground.upperBound..<source.endIndex
+            )
+        )
         let pageContent = try #require(source.range(of: "private var pageContent: some View"))
         let pageStack = try #require(
             source.range(
@@ -24,7 +30,8 @@ import Testing
         let readOnlyBoundary = try #require(source.range(of: ".disabled(!model.canEditProviderConfiguration)"))
 
         #expect(outerScroll.lowerBound < outerBackground.lowerBound)
-        #expect(outerBackground.lowerBound < pageContent.lowerBound)
+        #expect(outerBackground.lowerBound < outerIndicators.lowerBound)
+        #expect(outerIndicators.lowerBound < pageContent.lowerBound)
         #expect(pageContent.lowerBound < pageStack.lowerBound)
         #expect(pageStack.lowerBound < readOnlyBoundary.lowerBound)
         #expect(source.contains(".frame(height: 360)"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
@@ -14,12 +14,6 @@ import Testing
                 range: outerScroll.upperBound..<source.endIndex
             )
         )
-        let outerIndicators = try #require(
-            source.range(
-                of: ".scrollIndicators(.visible, axes: .vertical)",
-                range: outerBackground.upperBound..<source.endIndex
-            )
-        )
         let pageContent = try #require(source.range(of: "private var pageContent: some View"))
         let pageStack = try #require(
             source.range(
@@ -30,8 +24,7 @@ import Testing
         let readOnlyBoundary = try #require(source.range(of: ".disabled(!model.canEditProviderConfiguration)"))
 
         #expect(outerScroll.lowerBound < outerBackground.lowerBound)
-        #expect(outerBackground.lowerBound < outerIndicators.lowerBound)
-        #expect(outerIndicators.lowerBound < pageContent.lowerBound)
+        #expect(outerBackground.lowerBound < pageContent.lowerBound)
         #expect(pageContent.lowerBound < pageStack.lowerBound)
         #expect(pageStack.lowerBound < readOnlyBoundary.lowerBound)
         #expect(source.contains(".frame(height: 360)"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -1,0 +1,264 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopEvaluationSupport
+
+@Suite("Desktop Repositories reachability trace")
+struct DesktopReposReachabilityTraceTests {
+    @Test func acceptsStableReachableTrace() throws {
+        let trace = makeTrace()
+
+        #expect(try DesktopReposReachabilityValidator.validate(trace) == .reachable)
+        #expect(try DesktopReposReachabilityTrace.decode(data: JSONEncoder().encode(trace)) == trace)
+    }
+
+    @Test(arguments: [
+        DesktopReposReachabilityRegion.table,
+        .applyAllowlist,
+        .boundaryBody
+    ])
+    func rejectsMissingSemanticRegion(region: DesktopReposReachabilityRegion) {
+        let trace = makeTrace(preSamples: stableSamples().map { sample in
+            sample.removing(region)
+        })
+
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(trace)
+        }
+    }
+
+    @Test func rejectsNonfiniteAndDuplicateRegions() {
+        var samples = stableSamples()
+        samples[0] = DesktopReposReachabilitySample(
+            elapsedMilliseconds: 0,
+            viewport: .init(x: 0, y: 0, width: .infinity, height: 680),
+            regions: samples[0].regions + [samples[0].regions[0]]
+        )
+        let trace = makeTrace(preSamples: samples)
+
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(trace)
+        }
+    }
+
+    @Test func rejectsFewerThanThreeSamplesAndDriftAboveOnePoint() {
+        let tooFew = makeTrace(preSamples: Array(stableSamples().prefix(2)))
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(tooFew)
+        }
+
+        var drifting = stableSamples()
+        drifting[2] = drifting[2].replacing(
+            .table,
+            frame: .init(x: 24, y: 24, width: 901.01, height: 360)
+        )
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(preSamples: drifting))
+        }
+    }
+
+    @Test func rejectsWrongFixtureSizeReadinessCadenceWindowOrTolerance() {
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(ready: false))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(quiescent: false))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                requestedContentSize: .init(width: 1280, height: 800)
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                preScrollAcquisitionMilliseconds: 5_001
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                postScrollAcquisitionMilliseconds: 5_001
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(tolerancePoints: 1.01))
+        }
+
+        var wrongCadence = stableSamples()
+        wrongCadence[2] = DesktopReposReachabilitySample(
+            elapsedMilliseconds: 301,
+            viewport: wrongCadence[2].viewport,
+            regions: wrongCadence[2].regions
+        )
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(preSamples: wrongCadence))
+        }
+
+        let latePost = stableSamples().enumerated().map { index, sample in
+            DesktopReposReachabilitySample(
+                elapsedMilliseconds: 4_900 + index * 100,
+                viewport: sample.viewport,
+                regions: sample.regions
+            )
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: latePost))
+        }
+    }
+
+    @Test func rejectsMissingOrUnsupportedOuterScroll() {
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: nil))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.missingOuterScroll) {
+            try DesktopReposReachabilityTrace.decode(data: JSONEncoder().encode(makeTrace(outerScroll: nil)))
+        }
+
+        let unsupported = DesktopReposOuterScrollObservation(
+            verticalScrollBarSupported: false,
+            minimumValue: nil,
+            maximumValue: nil,
+            valueBeforeScroll: nil,
+            valueAfterScroll: nil,
+            setToMaximumSucceeded: false
+        )
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: unsupported))
+        }
+
+        let noMovement = DesktopReposOuterScrollObservation(
+            verticalScrollBarSupported: true,
+            minimumValue: 0,
+            maximumValue: 1,
+            valueBeforeScroll: 0,
+            valueAfterScroll: 0,
+            setToMaximumSucceeded: true
+        )
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: noMovement))
+        }
+
+        let noRange = DesktopReposOuterScrollObservation(
+            verticalScrollBarSupported: true,
+            minimumValue: 1,
+            maximumValue: 1,
+            valueBeforeScroll: 1,
+            valueAfterScroll: 1,
+            setToMaximumSucceeded: true
+        )
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: noRange))
+        }
+    }
+
+    @Test func rejectsApplyOrBoundaryOutsideViewport() {
+        let outsideApply = stableSamples().map {
+            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 665, width: 180, height: 30))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: outsideApply))
+        }
+
+        let outsideBoundary = stableSamples().map {
+            $0.replacing(.boundaryBody, frame: .init(x: 24, y: -20, width: 760, height: 40))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.self) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: outsideBoundary))
+        }
+    }
+
+    @Test func allowsApplyOutsideTheInitialViewportWhenPostScrollSampleIsReachable() throws {
+        let preScroll = stableSamples().map {
+            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 700, width: 180, height: 30))
+        }
+
+        #expect(try DesktopReposReachabilityValidator.validate(makeTrace(preSamples: preScroll)) == .reachable)
+    }
+
+    @Test func encodedTraceContainsNoSemanticTextOrPaths() throws {
+        let data = try JSONEncoder().encode(makeTrace())
+        let text = String(decoding: data, as: UTF8.self)
+
+        #expect(!text.contains("Apply Allowlist"))
+        #expect(!text.contains("Repo changes"))
+        #expect(!text.contains("/"))
+        #expect(!text.contains("identifier"))
+    }
+
+    @Test func decodingFailsClosedOnUnknownFields() throws {
+        let encoded = try JSONEncoder().encode(makeTrace())
+        var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object["visibleText"] = "must not survive typed decoding"
+        let data = try JSONSerialization.data(withJSONObject: object)
+
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: data)
+        }
+    }
+}
+
+private func makeTrace(
+    ready: Bool = true,
+    quiescent: Bool = true,
+    requestedContentSize: DesktopEvaluationContentSize = .init(width: 1040, height: 680),
+    preScrollAcquisitionMilliseconds: Int = 200,
+    postScrollAcquisitionMilliseconds: Int = 200,
+    tolerancePoints: Double = 1,
+    preSamples: [DesktopReposReachabilitySample] = stableSamples(),
+    outerScroll: DesktopReposOuterScrollObservation? = .init(
+        verticalScrollBarSupported: true,
+        minimumValue: 0,
+        maximumValue: 1,
+        valueBeforeScroll: 0,
+        valueAfterScroll: 1,
+        setToMaximumSucceeded: true
+    ),
+    postSamples: [DesktopReposReachabilitySample] = stableSamples()
+) -> DesktopReposReachabilityTrace {
+    DesktopReposReachabilityTrace(
+        schemaVersion: 1,
+        fixture: .tabRepos,
+        ready: ready,
+        quiescent: quiescent,
+        requestedContentSize: requestedContentSize,
+        sampleIntervalMilliseconds: 100,
+        preScrollAcquisitionMilliseconds: preScrollAcquisitionMilliseconds,
+        postScrollAcquisitionMilliseconds: postScrollAcquisitionMilliseconds,
+        tolerancePoints: tolerancePoints,
+        preScrollSamples: preSamples,
+        outerScroll: outerScroll,
+        postScrollSamples: postSamples
+    )
+}
+
+private func stableSamples() -> [DesktopReposReachabilitySample] {
+    (0..<3).map { index in
+        DesktopReposReachabilitySample(
+            elapsedMilliseconds: index * 100,
+            viewport: .init(x: 0, y: 0, width: 1040, height: 680),
+            regions: [
+                .init(id: .table, frame: .init(x: 24, y: 100, width: 900, height: 360)),
+                .init(id: .applyAllowlist, frame: .init(x: 24, y: 500, width: 180, height: 30)),
+                .init(id: .boundaryBody, frame: .init(x: 24, y: 600, width: 760, height: 40))
+            ]
+        )
+    }
+}
+
+private extension DesktopReposReachabilitySample {
+    func removing(_ id: DesktopReposReachabilityRegion) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: viewport,
+            regions: regions.filter { $0.id != id }
+        )
+    }
+
+    func replacing(_ id: DesktopReposReachabilityRegion, frame: DesktopReposReachabilityFrame) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: viewport,
+            regions: regions.map { region in
+                region.id == id ? .init(id: id, frame: frame) : region
+            }
+        )
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -357,6 +357,78 @@ struct DesktopReposReachabilityTraceTests {
             try DesktopReposReachabilityValidator.validate(makeTrace(preSamples: delayed))
         }
     }
+
+    @Test func verticalScrollBarSelectionPrefersTheConvenienceAttribute() throws {
+        let selection = try DesktopReposVerticalScrollBarSelectionContract.select(
+            convenienceAvailable: true,
+            directChildren: [
+                .init(role: nil, orientation: nil),
+                .init(role: "AXScrollBar", orientation: "AXVerticalOrientation")
+            ]
+        )
+
+        #expect(selection == .convenienceAttribute)
+    }
+
+    @Test func verticalScrollBarSelectionAcceptsOneExactDirectChild() throws {
+        let selection = try DesktopReposVerticalScrollBarSelectionContract.select(
+            convenienceAvailable: false,
+            directChildren: [
+                .init(role: "AXGroup", orientation: nil),
+                .init(role: "AXScrollBar", orientation: "AXHorizontalOrientation"),
+                .init(role: "AXScrollBar", orientation: "AXVerticalOrientation")
+            ]
+        )
+
+        #expect(selection == .directChild(index: 2))
+    }
+
+    @Test func verticalScrollBarSelectionRejectsHorizontalAndCannotSeeNestedDescendants() throws {
+        #expect(try DesktopReposVerticalScrollBarSelectionContract.select(
+            convenienceAvailable: false,
+            directChildren: [.init(role: "AXScrollBar", orientation: "AXHorizontalOrientation")]
+        ) == .unsupported)
+
+        // A group may contain a nested scrollbar in the real AX tree, but the
+        // strict contract deliberately receives direct children only.
+        #expect(try DesktopReposVerticalScrollBarSelectionContract.select(
+            convenienceAvailable: false,
+            directChildren: [.init(role: "AXGroup", orientation: nil)]
+        ) == .unsupported)
+    }
+
+    @Test func verticalScrollBarSelectionFailsClosedOnAmbiguousDirectChildren() {
+        #expect(throws: DesktopReposVerticalScrollBarSelectionError.ambiguousVerticalChildren) {
+            try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceAvailable: false,
+                directChildren: [
+                    .init(role: "AXScrollBar", orientation: "AXVerticalOrientation"),
+                    .init(role: "AXScrollBar", orientation: "AXVerticalOrientation")
+                ]
+            )
+        }
+    }
+
+    @Test func verticalScrollBarSelectionFailsClosedOnMalformedRoleOrOrientation() {
+        #expect(throws: DesktopReposVerticalScrollBarSelectionError.missingRole) {
+            try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceAvailable: false,
+                directChildren: [.init(role: nil, orientation: nil)]
+            )
+        }
+        #expect(throws: DesktopReposVerticalScrollBarSelectionError.missingOrientation) {
+            try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceAvailable: false,
+                directChildren: [.init(role: "AXScrollBar", orientation: nil)]
+            )
+        }
+        #expect(throws: DesktopReposVerticalScrollBarSelectionError.invalidOrientation) {
+            try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceAvailable: false,
+                directChildren: [.init(role: "AXScrollBar", orientation: "AXDiagonalOrientation")]
+            )
+        }
+    }
 }
 
 private func makeTrace(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -320,6 +320,10 @@ struct DesktopReposReachabilityTraceTests {
     }
 
     @Test func semanticCandidateCardinalityFailsClosed() {
+        #expect(DesktopReposReachabilitySemanticContract.tableRole == "AXOutline")
+        #expect(DesktopReposReachabilitySemanticContract.matchesTable(role: "AXOutline"))
+        #expect(!DesktopReposReachabilitySemanticContract.matchesTable(role: "AXTable"))
+        #expect(!DesktopReposReachabilitySemanticContract.matchesTable(role: "AXScrollArea"))
         #expect(DesktopReposReachabilitySemanticContract.failureReason(
             tableCount: 1,
             applyAllowlistCount: 1,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -340,6 +340,23 @@ struct DesktopReposReachabilityTraceTests {
             boundaryBodyCount: 1
         ) == .semanticMissing)
     }
+
+    @Test func stableCadenceRequiresThreeScheduledSamplesWithinBounds() {
+        #expect(DesktopReposReachabilitySamplingContract.hasStableCadence([0, 100, 200]))
+        #expect(!DesktopReposReachabilitySamplingContract.hasStableCadence([0, 100, 423]))
+        #expect(!DesktopReposReachabilitySamplingContract.hasStableCadence([0, 100]))
+
+        let delayed = zip(stableSamples(), [0, 100, 423]).map { sample, elapsed in
+            DesktopReposReachabilitySample(
+                elapsedMilliseconds: elapsed,
+                viewport: sample.viewport,
+                regions: sample.regions
+            )
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(preSamples: delayed))
+        }
+    }
 }
 
 private func makeTrace(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -112,6 +112,24 @@ struct DesktopReposReachabilityTraceTests {
             try DesktopReposReachabilityTrace.decode(data: JSONEncoder().encode(makeTrace(outerScroll: nil)))
         }
 
+        let incomplete = makeTrace(
+            quiescent: false,
+            preScrollAcquisitionMilliseconds: 5_001,
+            postScrollAcquisitionMilliseconds: 5_001,
+            acquisition: .init(status: .failed, failureReason: .cannotComplete),
+            preSamples: [],
+            outerScroll: nil,
+            postSamples: []
+        )
+        #expect(throws: DesktopReposReachabilityValidationError.acquisitionFailed(.cannotComplete)) {
+            try DesktopReposReachabilityValidator.validate(incomplete)
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.acquisitionFailed(.semanticDuplicate)) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                acquisition: .init(status: .failed, failureReason: .semanticDuplicate)
+            ))
+        }
+
         let unsupported = DesktopReposOuterScrollObservation(
             verticalScrollBarSupported: false,
             minimumValue: nil,
@@ -193,15 +211,142 @@ struct DesktopReposReachabilityTraceTests {
             try DesktopReposReachabilityTrace.decode(data: data)
         }
     }
+
+    @Test func nilOuterScrollHasAnExplicitUnambiguousWireKey() throws {
+        let data = try JSONEncoder().encode(makeTrace(outerScroll: nil))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let acquisition = try #require(object["acquisition"] as? [String: Any])
+
+        #expect(object.keys.contains("outerScroll"))
+        #expect(object["outerScroll"] is NSNull)
+        #expect(acquisition.keys.contains("failureReason"))
+        #expect(acquisition["failureReason"] is NSNull)
+
+        let failedData = try JSONEncoder().encode(makeTrace(
+            acquisition: .init(status: .failed, failureReason: .cannotComplete),
+            outerScroll: nil
+        ))
+        let failedObject = try #require(JSONSerialization.jsonObject(with: failedData) as? [String: Any])
+        let failedAcquisition = try #require(failedObject["acquisition"] as? [String: Any])
+        #expect(failedAcquisition["failureReason"] as? String == "cannot-complete")
+
+        var ambiguous = object
+        var ambiguousAcquisition = acquisition
+        ambiguousAcquisition.removeValue(forKey: "failureReason")
+        ambiguous["acquisition"] = ambiguousAcquisition
+        let ambiguousData = try JSONSerialization.data(withJSONObject: ambiguous)
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: ambiguousData)
+        }
+    }
+
+    @Test func focusedCaptureTargetRejectsUnsupportedFixtureOrSize() throws {
+        #expect(throws: DesktopReposReachabilityTargetError.unsupportedTarget) {
+            try DesktopReposReachabilityTarget.requireSupported(
+                fixtureId: "tab-providers",
+                contentWidth: 1040,
+                contentHeight: 680
+            )
+        }
+        #expect(throws: DesktopReposReachabilityTargetError.unsupportedTarget) {
+            try DesktopReposReachabilityTarget.requireSupported(
+                fixtureId: "tab-repos",
+                contentWidth: 1280,
+                contentHeight: 800
+            )
+        }
+        #expect(try DesktopReposReachabilityTarget.requireSupported(
+            fixtureId: "tab-repos",
+            contentWidth: 1040,
+            contentHeight: 680
+        ) == .tabRepos1040x680)
+    }
+
+    @Test func malformedMetadataIsNotMaskedByAcquisitionFailure() {
+        let trace = makeTrace(
+            schemaVersion: 999,
+            acquisition: .init(status: .failed, failureReason: .cannotComplete),
+            preSamples: [],
+            outerScroll: nil,
+            postSamples: []
+        )
+
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityValidator.validate(trace)
+        }
+    }
+
+    @Test func semanticFallbackMatchesRenderedAccessibilityValueExactly() {
+        #expect(DesktopReposReachabilitySemanticContract.boundaryIdentifier == "neondiff-repos-boundary")
+        #expect(DesktopReposReachabilitySemanticContract.applyAllowlistIdentifier == "neondiff-repo-apply-patch")
+        #expect(
+            DesktopReposReachabilitySemanticContract.boundaryValue
+                == "Repo changes are written through config patch only; the desktop does not post reviews or bypass daemon gates."
+        )
+        #expect(DesktopReposReachabilitySemanticContract.applyAllowlistValue == "Apply Allowlist")
+        #expect(DesktopReposReachabilitySemanticContract.matchesApplyAllowlist(
+            isButton: true,
+            identifier: "neondiff-repo-apply-patch",
+            title: nil,
+            description: nil,
+            value: nil
+        ))
+        #expect(DesktopReposReachabilitySemanticContract.matchesApplyAllowlist(
+            isButton: true,
+            identifier: nil,
+            title: "Apply Allowlist",
+            description: nil,
+            value: nil
+        ))
+        #expect(!DesktopReposReachabilitySemanticContract.matchesApplyAllowlist(
+            isButton: false,
+            identifier: "neondiff-repo-apply-patch",
+            title: "Apply Allowlist",
+            description: nil,
+            value: nil
+        ))
+        #expect(DesktopReposReachabilitySemanticContract.matchesBoundaryBody(
+            isStaticText: true,
+            identifier: "neondiff-repos-boundary",
+            description: nil,
+            value: nil
+        ))
+        #expect(!DesktopReposReachabilitySemanticContract.matchesBoundaryBody(
+            isStaticText: false,
+            identifier: "neondiff-repos-boundary",
+            description: nil,
+            value: nil
+        ))
+    }
+
+    @Test func semanticCandidateCardinalityFailsClosed() {
+        #expect(DesktopReposReachabilitySemanticContract.failureReason(
+            tableCount: 1,
+            applyAllowlistCount: 1,
+            boundaryBodyCount: 1
+        ) == nil)
+        #expect(DesktopReposReachabilitySemanticContract.failureReason(
+            tableCount: 2,
+            applyAllowlistCount: 1,
+            boundaryBodyCount: 1
+        ) == .semanticDuplicate)
+        #expect(DesktopReposReachabilitySemanticContract.failureReason(
+            tableCount: 1,
+            applyAllowlistCount: 0,
+            boundaryBodyCount: 1
+        ) == .semanticMissing)
+    }
 }
 
 private func makeTrace(
+    schemaVersion: Int = 1,
     ready: Bool = true,
     quiescent: Bool = true,
     requestedContentSize: DesktopEvaluationContentSize = .init(width: 1040, height: 680),
     preScrollAcquisitionMilliseconds: Int = 200,
     postScrollAcquisitionMilliseconds: Int = 200,
     tolerancePoints: Double = 1,
+    acquisition: DesktopReposReachabilityAcquisition = .init(status: .complete, failureReason: nil),
     preSamples: [DesktopReposReachabilitySample] = stableSamples(),
     outerScroll: DesktopReposOuterScrollObservation? = .init(
         verticalScrollBarSupported: true,
@@ -214,7 +359,7 @@ private func makeTrace(
     postSamples: [DesktopReposReachabilitySample] = stableSamples()
 ) -> DesktopReposReachabilityTrace {
     DesktopReposReachabilityTrace(
-        schemaVersion: 1,
+        schemaVersion: schemaVersion,
         fixture: .tabRepos,
         ready: ready,
         quiescent: quiescent,
@@ -223,6 +368,7 @@ private func makeTrace(
         preScrollAcquisitionMilliseconds: preScrollAcquisitionMilliseconds,
         postScrollAcquisitionMilliseconds: postScrollAcquisitionMilliseconds,
         tolerancePoints: tolerancePoints,
+        acquisition: acquisition,
         preScrollSamples: preSamples,
         outerScroll: outerScroll,
         postScrollSamples: postSamples

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -17,7 +17,7 @@ struct DesktopReposReachabilityTraceTests {
         .boundaryBody
     ])
     func rejectsMissingSemanticRegion(region: DesktopReposReachabilityRegion) {
-        let trace = makeTrace(preSamples: stableSamples().map { sample in
+        let trace = makeTrace(preSamples: preScrollSamples().map { sample in
             sample.removing(region)
         })
 
@@ -27,7 +27,7 @@ struct DesktopReposReachabilityTraceTests {
     }
 
     @Test func rejectsNonfiniteAndDuplicateRegions() {
-        var samples = stableSamples()
+        var samples = preScrollSamples()
         samples[0] = DesktopReposReachabilitySample(
             elapsedMilliseconds: 0,
             viewport: .init(x: 0, y: 0, width: .infinity, height: 680),
@@ -41,12 +41,12 @@ struct DesktopReposReachabilityTraceTests {
     }
 
     @Test func rejectsFewerThanThreeSamplesAndDriftAboveOnePoint() {
-        let tooFew = makeTrace(preSamples: Array(stableSamples().prefix(2)))
+        let tooFew = makeTrace(preSamples: Array(preScrollSamples().prefix(2)))
         #expect(throws: DesktopReposReachabilityValidationError.self) {
             try DesktopReposReachabilityValidator.validate(tooFew)
         }
 
-        var drifting = stableSamples()
+        var drifting = preScrollSamples()
         drifting[2] = drifting[2].replacing(
             .table,
             frame: .init(x: 24, y: 24, width: 901.01, height: 360)
@@ -82,7 +82,7 @@ struct DesktopReposReachabilityTraceTests {
             try DesktopReposReachabilityValidator.validate(makeTrace(tolerancePoints: 1.01))
         }
 
-        var wrongCadence = stableSamples()
+        var wrongCadence = preScrollSamples()
         wrongCadence[2] = DesktopReposReachabilitySample(
             elapsedMilliseconds: 301,
             viewport: wrongCadence[2].viewport,
@@ -104,21 +104,14 @@ struct DesktopReposReachabilityTraceTests {
         }
     }
 
-    @Test func rejectsMissingOrUnsupportedOuterScroll() {
-        #expect(throws: DesktopReposReachabilityValidationError.self) {
-            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: nil))
-        }
-        #expect(throws: DesktopReposReachabilityValidationError.missingOuterScroll) {
-            try DesktopReposReachabilityTrace.decode(data: JSONEncoder().encode(makeTrace(outerScroll: nil)))
-        }
-
+    @Test func rejectsFailedAcquisitionOrInvalidPressContract() {
         let incomplete = makeTrace(
             quiescent: false,
             preScrollAcquisitionMilliseconds: 5_001,
             postScrollAcquisitionMilliseconds: 5_001,
             acquisition: .init(status: .failed, failureReason: .cannotComplete),
             preSamples: [],
-            outerScroll: nil,
+            scrollInteraction: nil,
             postSamples: []
         )
         #expect(throws: DesktopReposReachabilityValidationError.acquisitionFailed(.cannotComplete)) {
@@ -130,40 +123,174 @@ struct DesktopReposReachabilityTraceTests {
             ))
         }
 
-        let unsupported = DesktopReposOuterScrollObservation(
-            verticalScrollBarSupported: false,
-            minimumValue: nil,
-            maximumValue: nil,
-            valueBeforeScroll: nil,
-            valueAfterScroll: nil,
-            setToMaximumSucceeded: false
-        )
-        #expect(throws: DesktopReposReachabilityValidationError.self) {
-            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: unsupported))
+        #expect(throws: DesktopReposReachabilityValidationError.actionNotAdvertised) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(
+                    actionAdvertised: false,
+                    attemptCount: 0,
+                    performResult: nil,
+                    clipAfter: nil
+                )
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(
+                    actionAdvertised: false,
+                    attemptCount: 2,
+                    performResult: .success
+                )
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.actionPerformFailed(.cannotComplete)) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(performResult: .cannotComplete)
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.actionPerformFailed(.actionUnsupported)) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(performResult: .actionUnsupported)
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(attemptCount: 0)
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(attemptCount: -1)
+            ))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(attemptCount: 2)
+            ))
+        }
+    }
+
+    @Test func rejectsNoWrongOrNonrigidMovement() {
+        #expect(throws: DesktopReposReachabilityValidationError.noUpwardMovement) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: preScrollSamples()))
+        }
+        let downward = preScrollSamples().map { $0.translated(y: 20) }
+        #expect(throws: DesktopReposReachabilityValidationError.noUpwardMovement) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: downward))
+        }
+        let onlyTable = preScrollSamples().map {
+            $0.replacing(.table, frame: .init(x: 24, y: 0, width: 900, height: 360))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.nonRigidMovement) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: onlyTable))
+        }
+        for frame in [
+            DesktopReposReachabilityFrame(x: 26, y: 500, width: 180, height: 30),
+            .init(x: 24, y: 500, width: 182, height: 30),
+            .init(x: 24, y: 500, width: 180, height: 32)
+        ] {
+            let nonRigid = stableSamples().map { $0.replacing(.applyAllowlist, frame: frame) }
+            #expect(throws: DesktopReposReachabilityValidationError.nonRigidMovement) {
+                try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: nonRigid))
+            }
+        }
+    }
+
+    @Test func requiresRigidUpwardMovementStrictlyGreaterThanOnePoint() throws {
+        let clip = DesktopReposReachabilityFrame(x: 20, y: 50, width: 1000, height: 580)
+        let pre = preScrollSamples().map {
+            $0
+                .replacing(.applyAllowlist, frame: .init(x: 24, y: 600, width: 180, height: 30))
+                .replacing(.boundaryBody, frame: .init(x: 24, y: 590.5, width: 760, height: 40))
         }
 
-        let noMovement = DesktopReposOuterScrollObservation(
-            verticalScrollBarSupported: true,
-            minimumValue: 0,
-            maximumValue: 1,
-            valueBeforeScroll: 0,
-            valueAfterScroll: 0,
-            setToMaximumSucceeded: true
-        )
-        #expect(throws: DesktopReposReachabilityValidationError.self) {
-            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: noMovement))
+        #expect(throws: DesktopReposReachabilityValidationError.noUpwardMovement) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                tolerancePoints: 0.1,
+                preSamples: pre,
+                scrollInteraction: makeInteraction(clipBefore: clip, clipAfter: clip),
+                postSamples: pre.map { $0.translated(y: -0.5) }
+            ))
         }
 
-        let noRange = DesktopReposOuterScrollObservation(
-            verticalScrollBarSupported: true,
-            minimumValue: 1,
-            maximumValue: 1,
-            valueBeforeScroll: 1,
-            valueAfterScroll: 1,
-            setToMaximumSucceeded: true
-        )
-        #expect(throws: DesktopReposReachabilityValidationError.self) {
-            try DesktopReposReachabilityValidator.validate(makeTrace(outerScroll: noRange))
+        let exactlyOne = pre.map {
+            $0.replacing(.boundaryBody, frame: .init(x: 24, y: 591, width: 760, height: 40))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.noUpwardMovement) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                tolerancePoints: 0.1,
+                preSamples: exactlyOne,
+                scrollInteraction: makeInteraction(clipBefore: clip, clipAfter: clip),
+                postSamples: exactlyOne.map { $0.translated(y: -1) }
+            ))
+        }
+
+        let beyondOne = pre.map {
+            $0.replacing(.boundaryBody, frame: .init(x: 24, y: 591.1, width: 760, height: 40))
+        }
+        #expect(try DesktopReposReachabilityValidator.validate(makeTrace(
+            tolerancePoints: 0.1,
+            preSamples: beyondOne,
+            scrollInteraction: makeInteraction(clipBefore: clip, clipAfter: clip),
+            postSamples: beyondOne.map { $0.translated(y: -1.1) }
+        )) == .reachable)
+    }
+
+    @Test func rejectsUnstableWindowClipAndWindowOnlyContainment() throws {
+        let movedWindow = stableSamples().map { $0.replacingViewport(.init(x: 2, y: 0, width: 1040, height: 680)) }
+        #expect(throws: DesktopReposReachabilityValidationError.unstableWindow) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: movedWindow))
+        }
+        let cumulativeWindowDrift = zip(stableSamples(), [1.0, 2.0, 2.0]).map { sample, x in
+            sample.replacingViewport(.init(x: x, y: 0, width: 1040, height: 680))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.unstableWindow) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: cumulativeWindowDrift))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.unstableOuterClip) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(clipAfter: .init(x: 22, y: 50, width: 1000, height: 580))
+            ))
+        }
+        let onePointWindow = stableSamples().map {
+            $0.replacingViewport(.init(x: 1, y: 0, width: 1040, height: 680))
+        }
+        #expect(try DesktopReposReachabilityValidator.validate(makeTrace(
+            scrollInteraction: makeInteraction(
+                clipAfter: .init(x: 21, y: 50, width: 1000, height: 580)
+            ),
+            postSamples: onePointWindow
+        )) == .reachable)
+        #expect(throws: DesktopReposReachabilityValidationError.outerClipOutsideWindow) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(
+                    clipBefore: .init(x: -1, y: 50, width: 1000, height: 580),
+                    clipAfter: .init(x: -1, y: 50, width: 1000, height: 580)
+                )
+            ))
+        }
+        let outsideClip = stableSamples().map {
+            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 640, width: 180, height: 30))
+        }
+        let beforeOutsideClip = preScrollSamples().map {
+            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 740, width: 180, height: 30))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.pressInsufficient(.applyAllowlist)) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                preSamples: beforeOutsideClip,
+                postSamples: outsideClip
+            ))
+        }
+        let boundaryStillOutside = stableSamples().map {
+            $0.replacing(.boundaryBody, frame: .init(x: 24, y: 610, width: 760, height: 40))
+        }
+        let boundaryBefore = preScrollSamples().map {
+            $0.replacing(.boundaryBody, frame: .init(x: 24, y: 710, width: 760, height: 40))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.pressInsufficient(.boundaryBody)) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                preSamples: boundaryBefore,
+                postSamples: boundaryStillOutside
+            ))
         }
     }
 
@@ -184,11 +311,17 @@ struct DesktopReposReachabilityTraceTests {
     }
 
     @Test func allowsApplyOutsideTheInitialViewportWhenPostScrollSampleIsReachable() throws {
-        let preScroll = stableSamples().map {
-            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 700, width: 180, height: 30))
+        let preScroll = preScrollSamples().map {
+            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 640, width: 180, height: 30))
+        }
+        let postScroll = stableSamples().map {
+            $0.replacing(.applyAllowlist, frame: .init(x: 24, y: 540, width: 180, height: 30))
         }
 
-        #expect(try DesktopReposReachabilityValidator.validate(makeTrace(preSamples: preScroll)) == .reachable)
+        #expect(try DesktopReposReachabilityValidator.validate(makeTrace(
+            preSamples: preScroll,
+            postSamples: postScroll
+        )) == .reachable)
     }
 
     @Test func encodedTraceContainsNoSemanticTextOrPaths() throws {
@@ -212,19 +345,96 @@ struct DesktopReposReachabilityTraceTests {
         }
     }
 
-    @Test func nilOuterScrollHasAnExplicitUnambiguousWireKey() throws {
-        let data = try JSONEncoder().encode(makeTrace(outerScroll: nil))
+    @Test func decodingFailsClosedOnNestedUnknownsAndMissingInactiveNull() throws {
+        let encoded = try JSONEncoder().encode(makeTrace())
+        let base = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        var unknownAcquisition = base
+        var acquisition = try #require(unknownAcquisition["acquisition"] as? [String: Any])
+        acquisition["unexpected"] = true
+        unknownAcquisition["acquisition"] = acquisition
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(
+                data: JSONSerialization.data(withJSONObject: unknownAcquisition)
+            )
+        }
+
+        var unknownInteraction = base
+        var interaction = try #require(unknownInteraction["scrollInteraction"] as? [String: Any])
+        interaction["unexpected"] = true
+        unknownInteraction["scrollInteraction"] = interaction
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(
+                data: JSONSerialization.data(withJSONObject: unknownInteraction)
+            )
+        }
+
+        var unknownPress = base
+        interaction = try #require(unknownPress["scrollInteraction"] as? [String: Any])
+        var press = try #require(interaction["incrementPagePress"] as? [String: Any])
+        press["unexpected"] = true
+        interaction["incrementPagePress"] = press
+        unknownPress["scrollInteraction"] = interaction
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: JSONSerialization.data(withJSONObject: unknownPress))
+        }
+
+        var missingInactiveNull = base
+        interaction = try #require(missingInactiveNull["scrollInteraction"] as? [String: Any])
+        interaction.removeValue(forKey: "valueMutation")
+        missingInactiveNull["scrollInteraction"] = interaction
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(
+                data: JSONSerialization.data(withJSONObject: missingInactiveNull)
+            )
+        }
+
+        var unknownSample = base
+        var samples = try #require(unknownSample["preScrollSamples"] as? [[String: Any]])
+        samples[0]["unexpected"] = true
+        unknownSample["preScrollSamples"] = samples
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: JSONSerialization.data(withJSONObject: unknownSample))
+        }
+
+        var unknownRegion = base
+        samples = try #require(unknownRegion["preScrollSamples"] as? [[String: Any]])
+        var regions = try #require(samples[0]["regions"] as? [[String: Any]])
+        regions[0]["unexpected"] = true
+        samples[0]["regions"] = regions
+        unknownRegion["preScrollSamples"] = samples
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: JSONSerialization.data(withJSONObject: unknownRegion))
+        }
+
+        var unknownFrame = base
+        samples = try #require(unknownFrame["preScrollSamples"] as? [[String: Any]])
+        regions = try #require(samples[0]["regions"] as? [[String: Any]])
+        var frame = try #require(regions[0]["frame"] as? [String: Any])
+        frame["unexpected"] = true
+        regions[0]["frame"] = frame
+        samples[0]["regions"] = regions
+        unknownFrame["preScrollSamples"] = samples
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: JSONSerialization.data(withJSONObject: unknownFrame))
+        }
+    }
+
+    @Test func interactionHasExplicitInactiveValueMutationAndUnambiguousPressBranch() throws {
+        let data = try JSONEncoder().encode(makeTrace())
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         let acquisition = try #require(object["acquisition"] as? [String: Any])
+        let interaction = try #require(object["scrollInteraction"] as? [String: Any])
 
-        #expect(object.keys.contains("outerScroll"))
-        #expect(object["outerScroll"] is NSNull)
+        #expect(interaction["mechanism"] as? String == "increment-page-press")
+        #expect(interaction["valueMutation"] is NSNull)
+        #expect(interaction["incrementPagePress"] is [String: Any])
         #expect(acquisition.keys.contains("failureReason"))
         #expect(acquisition["failureReason"] is NSNull)
 
         let failedData = try JSONEncoder().encode(makeTrace(
             acquisition: .init(status: .failed, failureReason: .cannotComplete),
-            outerScroll: nil
+            scrollInteraction: nil
         ))
         let failedObject = try #require(JSONSerialization.jsonObject(with: failedData) as? [String: Any])
         let failedAcquisition = try #require(failedObject["acquisition"] as? [String: Any])
@@ -237,6 +447,16 @@ struct DesktopReposReachabilityTraceTests {
         let ambiguousData = try JSONSerialization.data(withJSONObject: ambiguous)
         #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
             try DesktopReposReachabilityTrace.decode(data: ambiguousData)
+        }
+
+        var inactiveBranch = object
+        var invalidInteraction = interaction
+        invalidInteraction["valueMutation"] = ["forbidden": true]
+        inactiveBranch["scrollInteraction"] = invalidInteraction
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(
+                data: JSONSerialization.data(withJSONObject: inactiveBranch)
+            )
         }
     }
 
@@ -267,7 +487,7 @@ struct DesktopReposReachabilityTraceTests {
             schemaVersion: 999,
             acquisition: .init(status: .failed, failureReason: .cannotComplete),
             preSamples: [],
-            outerScroll: nil,
+            scrollInteraction: nil,
             postSamples: []
         )
 
@@ -444,7 +664,7 @@ struct DesktopReposReachabilityTraceTests {
 }
 
 private func makeTrace(
-    schemaVersion: Int = 1,
+    schemaVersion: Int = 2,
     ready: Bool = true,
     quiescent: Bool = true,
     requestedContentSize: DesktopEvaluationContentSize = .init(width: 1040, height: 680),
@@ -452,15 +672,8 @@ private func makeTrace(
     postScrollAcquisitionMilliseconds: Int = 200,
     tolerancePoints: Double = 1,
     acquisition: DesktopReposReachabilityAcquisition = .init(status: .complete, failureReason: nil),
-    preSamples: [DesktopReposReachabilitySample] = stableSamples(),
-    outerScroll: DesktopReposOuterScrollObservation? = .init(
-        verticalScrollBarSupported: true,
-        minimumValue: 0,
-        maximumValue: 1,
-        valueBeforeScroll: 0,
-        valueAfterScroll: 1,
-        setToMaximumSucceeded: true
-    ),
+    preSamples: [DesktopReposReachabilitySample] = preScrollSamples(),
+    scrollInteraction: DesktopReposScrollInteraction? = makeInteraction(),
     postSamples: [DesktopReposReachabilitySample] = stableSamples()
 ) -> DesktopReposReachabilityTrace {
     DesktopReposReachabilityTrace(
@@ -475,9 +688,43 @@ private func makeTrace(
         tolerancePoints: tolerancePoints,
         acquisition: acquisition,
         preScrollSamples: preSamples,
-        outerScroll: outerScroll,
+        scrollInteraction: scrollInteraction,
         postScrollSamples: postSamples
     )
+}
+
+private func makeInteraction(
+    actionAdvertised: Bool = true,
+    attemptCount: Int = 1,
+    performResult: DesktopReposScrollActionResult? = .success,
+    clipBefore: DesktopReposReachabilityFrame = .init(x: 20, y: 50, width: 1000, height: 580),
+    clipAfter: DesktopReposReachabilityFrame? = .init(x: 20, y: 50, width: 1000, height: 580)
+) -> DesktopReposScrollInteraction {
+    .init(
+        mechanism: .incrementPagePress,
+        incrementPagePress: .init(
+            actionAdvertised: actionAdvertised,
+            attemptCount: attemptCount,
+            performResult: performResult,
+            outerClipBefore: clipBefore,
+            outerClipAfter: clipAfter
+        ),
+        valueMutation: nil
+    )
+}
+
+private func preScrollSamples() -> [DesktopReposReachabilitySample] {
+    (0..<3).map { index in
+        DesktopReposReachabilitySample(
+            elapsedMilliseconds: index * 100,
+            viewport: .init(x: 0, y: 0, width: 1040, height: 680),
+            regions: [
+                .init(id: .table, frame: .init(x: 24, y: 100, width: 900, height: 360)),
+                .init(id: .applyAllowlist, frame: .init(x: 24, y: 600, width: 180, height: 30)),
+                .init(id: .boundaryBody, frame: .init(x: 24, y: 650, width: 760, height: 40))
+            ]
+        )
+    }
 }
 
 private func stableSamples() -> [DesktopReposReachabilitySample] {
@@ -486,15 +733,34 @@ private func stableSamples() -> [DesktopReposReachabilitySample] {
             elapsedMilliseconds: index * 100,
             viewport: .init(x: 0, y: 0, width: 1040, height: 680),
             regions: [
-                .init(id: .table, frame: .init(x: 24, y: 100, width: 900, height: 360)),
+                .init(id: .table, frame: .init(x: 24, y: 0, width: 900, height: 360)),
                 .init(id: .applyAllowlist, frame: .init(x: 24, y: 500, width: 180, height: 30)),
-                .init(id: .boundaryBody, frame: .init(x: 24, y: 600, width: 760, height: 40))
+                .init(id: .boundaryBody, frame: .init(x: 24, y: 550, width: 760, height: 40))
             ]
         )
     }
 }
 
 private extension DesktopReposReachabilitySample {
+    func translated(y delta: Double) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: viewport,
+            regions: regions.map { region in
+                .init(id: region.id, frame: .init(
+                    x: region.frame.x,
+                    y: region.frame.y + delta,
+                    width: region.frame.width,
+                    height: region.frame.height
+                ))
+            }
+        )
+    }
+
+    func replacingViewport(_ frame: DesktopReposReachabilityFrame) -> Self {
+        .init(elapsedMilliseconds: elapsedMilliseconds, viewport: frame, regions: regions)
+    }
+
     func removing(_ id: DesktopReposReachabilityRegion) -> Self {
         .init(
             elapsedMilliseconds: elapsedMilliseconds,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -11,6 +11,27 @@ struct DesktopReposReachabilityTraceTests {
         #expect(try DesktopReposReachabilityTrace.decode(data: JSONEncoder().encode(trace)) == trace)
     }
 
+    @Test func schemaRequiresSettledOuterClipAndBoundaryAncestryInEverySample() throws {
+        let encoded = try JSONEncoder().encode(makeTrace())
+        var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        for key in ["preScrollSamples", "postScrollSamples"] {
+            var samples = try #require(object[key] as? [[String: Any]])
+            for index in samples.indices {
+                samples[index].removeValue(forKey: "outerClip")
+                samples[index].removeValue(forKey: "boundaryScrollAncestorCount")
+            }
+            object[key] = samples
+        }
+        let legacy = try JSONSerialization.data(withJSONObject: object)
+
+        #expect(throws: Never.self) {
+            try DesktopReposReachabilityTrace.decode(data: encoded)
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.invalidContract) {
+            try DesktopReposReachabilityTrace.decode(data: legacy)
+        }
+    }
+
     @Test(arguments: [
         DesktopReposReachabilityRegion.table,
         .applyAllowlist,
@@ -31,6 +52,8 @@ struct DesktopReposReachabilityTraceTests {
         samples[0] = DesktopReposReachabilitySample(
             elapsedMilliseconds: 0,
             viewport: .init(x: 0, y: 0, width: .infinity, height: 680),
+            outerClip: samples[0].outerClip,
+            boundaryScrollAncestorCount: samples[0].boundaryScrollAncestorCount,
             regions: samples[0].regions + [samples[0].regions[0]]
         )
         let trace = makeTrace(preSamples: samples)
@@ -86,6 +109,8 @@ struct DesktopReposReachabilityTraceTests {
         wrongCadence[2] = DesktopReposReachabilitySample(
             elapsedMilliseconds: 301,
             viewport: wrongCadence[2].viewport,
+            outerClip: wrongCadence[2].outerClip,
+            boundaryScrollAncestorCount: wrongCadence[2].boundaryScrollAncestorCount,
             regions: wrongCadence[2].regions
         )
         #expect(throws: DesktopReposReachabilityValidationError.self) {
@@ -96,6 +121,8 @@ struct DesktopReposReachabilityTraceTests {
             DesktopReposReachabilitySample(
                 elapsedMilliseconds: 4_900 + index * 100,
                 viewport: sample.viewport,
+                outerClip: sample.outerClip,
+                boundaryScrollAncestorCount: sample.boundaryScrollAncestorCount,
                 regions: sample.regions
             )
         }
@@ -167,6 +194,68 @@ struct DesktopReposReachabilityTraceTests {
                 scrollInteraction: makeInteraction(attemptCount: 2)
             ))
         }
+    }
+
+    @Test func successfulPressLedgerSurvivesPostActionAcquisitionFailures() throws {
+        for reason in [
+            DesktopReposReachabilityAcquisitionFailureReason.cannotComplete,
+            .invalidElement,
+            .permissionDenied,
+            .invalidType,
+            .ancestryUnavailable,
+            .semanticChanged
+        ] {
+            let trace = makeTrace(
+                quiescent: false,
+                acquisition: .init(status: .failed, failureReason: reason),
+                scrollInteraction: makeInteraction(clipAfter: nil),
+                postSamples: []
+            )
+            let data = try JSONEncoder().encode(trace)
+            let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let interaction = try #require(object["scrollInteraction"] as? [String: Any])
+            let press = try #require(interaction["incrementPagePress"] as? [String: Any])
+
+            #expect(press["attemptCount"] as? Int == 1)
+            #expect(press["performResult"] as? String == "success")
+            #expect(press["outerClipAfter"] is NSNull)
+            #expect(throws: DesktopReposReachabilityValidationError.acquisitionFailed(reason)) {
+                try DesktopReposReachabilityValidator.validate(trace)
+            }
+        }
+    }
+
+    @Test func checkerResultsClassifyActionGeometryAcquisitionAndContractFailures() throws {
+        let cases: [(DesktopReposReachabilityValidationError, DesktopReposReachabilityCheckCategory, String)] = [
+            (.actionNotAdvertised, .action, "action-not-advertised"),
+            (.actionPerformFailed(.cannotComplete), .action, "action-perform-cannot-complete"),
+            (.noUpwardMovement, .geometry, "no-upward-movement"),
+            (.nonRigidMovement, .geometry, "non-rigid-movement"),
+            (.pressInsufficient(.applyAllowlist), .geometry, "press-insufficient-apply-allowlist"),
+            (.unstableOuterClip, .geometry, "unstable-outer-clip"),
+            (.unstableScrollAncestry, .geometry, "unstable-scroll-ancestry"),
+            (.acquisitionFailed(.semanticChanged), .acquisition, "acquisition-semantic-changed"),
+            (.invalidContract, .contract, "invalid-contract")
+        ]
+
+        for (error, category, reasonCode) in cases {
+            let result = DesktopReposReachabilityCheckResult.failure(error)
+            #expect(result.schemaVersion == 1)
+            #expect(!result.ok)
+            #expect(result.status == .failed)
+            #expect(result.category == category)
+            #expect(result.reasonCode == reasonCode)
+            let object = try #require(
+                JSONSerialization.jsonObject(with: JSONEncoder().encode(result)) as? [String: Any]
+            )
+            #expect(Set(object.keys) == ["schemaVersion", "ok", "status", "category", "reasonCode"])
+        }
+
+        let success = DesktopReposReachabilityCheckResult.reachable
+        #expect(success.ok)
+        #expect(success.status == .reachable)
+        #expect(success.category == .none)
+        #expect(success.reasonCode == "none")
     }
 
     @Test func rejectsNoWrongOrNonrigidMovement() {
@@ -251,6 +340,28 @@ struct DesktopReposReachabilityTraceTests {
                 scrollInteraction: makeInteraction(clipAfter: .init(x: 22, y: 50, width: 1000, height: 580))
             ))
         }
+        let cumulativeClipDrift = zip(stableSamples(), [21.0, 22.0, 22.0]).map { sample, x in
+            sample.replacingOuterClip(.init(x: x, y: 50, width: 1000, height: 580))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.unstableOuterClip) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(
+                scrollInteraction: makeInteraction(
+                    clipAfter: .init(x: 22, y: 50, width: 1000, height: 580)
+                ),
+                postSamples: cumulativeClipDrift
+            ))
+        }
+        let staleImmediateClip = stableSamples().map {
+            $0.replacingOuterClip(.init(x: 20, y: 50, width: 1000, height: 500))
+        }
+        #expect(throws: DesktopReposReachabilityValidationError.unstableOuterClip) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: staleImmediateClip))
+        }
+        var changedAncestry = stableSamples()
+        changedAncestry[2] = changedAncestry[2].replacingBoundaryScrollAncestorCount(2)
+        #expect(throws: DesktopReposReachabilityValidationError.unstableScrollAncestry) {
+            try DesktopReposReachabilityValidator.validate(makeTrace(postSamples: changedAncestry))
+        }
         let onePointWindow = stableSamples().map {
             $0.replacingViewport(.init(x: 1, y: 0, width: 1040, height: 680))
         }
@@ -261,11 +372,14 @@ struct DesktopReposReachabilityTraceTests {
             postSamples: onePointWindow
         )) == .reachable)
         #expect(throws: DesktopReposReachabilityValidationError.outerClipOutsideWindow) {
-            try DesktopReposReachabilityValidator.validate(makeTrace(
+            let outsideWindowClip = DesktopReposReachabilityFrame(x: -1, y: 50, width: 1000, height: 580)
+            _ = try DesktopReposReachabilityValidator.validate(makeTrace(
+                preSamples: preScrollSamples().map { $0.replacingOuterClip(outsideWindowClip) },
                 scrollInteraction: makeInteraction(
-                    clipBefore: .init(x: -1, y: 50, width: 1000, height: 580),
-                    clipAfter: .init(x: -1, y: 50, width: 1000, height: 580)
-                )
+                    clipBefore: outsideWindowClip,
+                    clipAfter: outsideWindowClip
+                ),
+                postSamples: stableSamples().map { $0.replacingOuterClip(outsideWindowClip) }
             ))
         }
         let outsideClip = stableSamples().map {
@@ -570,6 +684,8 @@ struct DesktopReposReachabilityTraceTests {
             DesktopReposReachabilitySample(
                 elapsedMilliseconds: elapsed,
                 viewport: sample.viewport,
+                outerClip: sample.outerClip,
+                boundaryScrollAncestorCount: sample.boundaryScrollAncestorCount,
                 regions: sample.regions
             )
         }
@@ -718,6 +834,8 @@ private func preScrollSamples() -> [DesktopReposReachabilitySample] {
         DesktopReposReachabilitySample(
             elapsedMilliseconds: index * 100,
             viewport: .init(x: 0, y: 0, width: 1040, height: 680),
+            outerClip: .init(x: 20, y: 50, width: 1000, height: 580),
+            boundaryScrollAncestorCount: 1,
             regions: [
                 .init(id: .table, frame: .init(x: 24, y: 100, width: 900, height: 360)),
                 .init(id: .applyAllowlist, frame: .init(x: 24, y: 600, width: 180, height: 30)),
@@ -732,6 +850,8 @@ private func stableSamples() -> [DesktopReposReachabilitySample] {
         DesktopReposReachabilitySample(
             elapsedMilliseconds: index * 100,
             viewport: .init(x: 0, y: 0, width: 1040, height: 680),
+            outerClip: .init(x: 20, y: 50, width: 1000, height: 580),
+            boundaryScrollAncestorCount: 1,
             regions: [
                 .init(id: .table, frame: .init(x: 24, y: 0, width: 900, height: 360)),
                 .init(id: .applyAllowlist, frame: .init(x: 24, y: 500, width: 180, height: 30)),
@@ -746,6 +866,8 @@ private extension DesktopReposReachabilitySample {
         .init(
             elapsedMilliseconds: elapsedMilliseconds,
             viewport: viewport,
+            outerClip: outerClip,
+            boundaryScrollAncestorCount: boundaryScrollAncestorCount,
             regions: regions.map { region in
                 .init(id: region.id, frame: .init(
                     x: region.frame.x,
@@ -758,13 +880,41 @@ private extension DesktopReposReachabilitySample {
     }
 
     func replacingViewport(_ frame: DesktopReposReachabilityFrame) -> Self {
-        .init(elapsedMilliseconds: elapsedMilliseconds, viewport: frame, regions: regions)
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: frame,
+            outerClip: outerClip,
+            boundaryScrollAncestorCount: boundaryScrollAncestorCount,
+            regions: regions
+        )
+    }
+
+    func replacingOuterClip(_ frame: DesktopReposReachabilityFrame) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: viewport,
+            outerClip: frame,
+            boundaryScrollAncestorCount: boundaryScrollAncestorCount,
+            regions: regions
+        )
+    }
+
+    func replacingBoundaryScrollAncestorCount(_ count: Int) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            viewport: viewport,
+            outerClip: outerClip,
+            boundaryScrollAncestorCount: count,
+            regions: regions
+        )
     }
 
     func removing(_ id: DesktopReposReachabilityRegion) -> Self {
         .init(
             elapsedMilliseconds: elapsedMilliseconds,
             viewport: viewport,
+            outerClip: outerClip,
+            boundaryScrollAncestorCount: boundaryScrollAncestorCount,
             regions: regions.filter { $0.id != id }
         )
     }
@@ -773,6 +923,8 @@ private extension DesktopReposReachabilitySample {
         .init(
             elapsedMilliseconds: elapsedMilliseconds,
             viewport: viewport,
+            outerClip: outerClip,
+            boundaryScrollAncestorCount: boundaryScrollAncestorCount,
             regions: regions.map { region in
                 region.id == id ? .init(id: id, frame: frame) : region
             }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposReachabilityTraceTests.swift
@@ -360,7 +360,7 @@ struct DesktopReposReachabilityTraceTests {
 
     @Test func verticalScrollBarSelectionPrefersTheConvenienceAttribute() throws {
         let selection = try DesktopReposVerticalScrollBarSelectionContract.select(
-            convenienceAvailable: true,
+            convenienceCandidate: .init(role: "AXScrollBar", orientation: "AXVerticalOrientation"),
             directChildren: [
                 .init(role: nil, orientation: nil),
                 .init(role: "AXScrollBar", orientation: "AXVerticalOrientation")
@@ -372,7 +372,7 @@ struct DesktopReposReachabilityTraceTests {
 
     @Test func verticalScrollBarSelectionAcceptsOneExactDirectChild() throws {
         let selection = try DesktopReposVerticalScrollBarSelectionContract.select(
-            convenienceAvailable: false,
+            convenienceCandidate: nil,
             directChildren: [
                 .init(role: "AXGroup", orientation: nil),
                 .init(role: "AXScrollBar", orientation: "AXHorizontalOrientation"),
@@ -385,14 +385,14 @@ struct DesktopReposReachabilityTraceTests {
 
     @Test func verticalScrollBarSelectionRejectsHorizontalAndCannotSeeNestedDescendants() throws {
         #expect(try DesktopReposVerticalScrollBarSelectionContract.select(
-            convenienceAvailable: false,
+            convenienceCandidate: nil,
             directChildren: [.init(role: "AXScrollBar", orientation: "AXHorizontalOrientation")]
         ) == .unsupported)
 
         // A group may contain a nested scrollbar in the real AX tree, but the
         // strict contract deliberately receives direct children only.
         #expect(try DesktopReposVerticalScrollBarSelectionContract.select(
-            convenienceAvailable: false,
+            convenienceCandidate: nil,
             directChildren: [.init(role: "AXGroup", orientation: nil)]
         ) == .unsupported)
     }
@@ -400,7 +400,7 @@ struct DesktopReposReachabilityTraceTests {
     @Test func verticalScrollBarSelectionFailsClosedOnAmbiguousDirectChildren() {
         #expect(throws: DesktopReposVerticalScrollBarSelectionError.ambiguousVerticalChildren) {
             try DesktopReposVerticalScrollBarSelectionContract.select(
-                convenienceAvailable: false,
+                convenienceCandidate: nil,
                 directChildren: [
                     .init(role: "AXScrollBar", orientation: "AXVerticalOrientation"),
                     .init(role: "AXScrollBar", orientation: "AXVerticalOrientation")
@@ -412,20 +412,32 @@ struct DesktopReposReachabilityTraceTests {
     @Test func verticalScrollBarSelectionFailsClosedOnMalformedRoleOrOrientation() {
         #expect(throws: DesktopReposVerticalScrollBarSelectionError.missingRole) {
             try DesktopReposVerticalScrollBarSelectionContract.select(
-                convenienceAvailable: false,
+                convenienceCandidate: nil,
                 directChildren: [.init(role: nil, orientation: nil)]
             )
         }
         #expect(throws: DesktopReposVerticalScrollBarSelectionError.missingOrientation) {
             try DesktopReposVerticalScrollBarSelectionContract.select(
-                convenienceAvailable: false,
+                convenienceCandidate: nil,
                 directChildren: [.init(role: "AXScrollBar", orientation: nil)]
             )
         }
         #expect(throws: DesktopReposVerticalScrollBarSelectionError.invalidOrientation) {
             try DesktopReposVerticalScrollBarSelectionContract.select(
-                convenienceAvailable: false,
+                convenienceCandidate: nil,
                 directChildren: [.init(role: "AXScrollBar", orientation: "AXDiagonalOrientation")]
+            )
+        }
+        #expect(throws: DesktopReposVerticalScrollBarSelectionError.invalidRole) {
+            try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceCandidate: .init(role: "AXGroup", orientation: "AXVerticalOrientation"),
+                directChildren: []
+            )
+        }
+        #expect(throws: DesktopReposVerticalScrollBarSelectionError.invalidOrientation) {
+            try DesktopReposVerticalScrollBarSelectionContract.select(
+                convenienceCandidate: .init(role: "AXScrollBar", orientation: "AXHorizontalOrientation"),
+                directChildren: []
             )
         }
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
@@ -4,6 +4,13 @@ import Testing
 
 @Suite("Desktop Repositories scroll capabilities")
 struct DesktopReposScrollCapabilitiesTests {
+    @Test func exposesSDKIndependentPublicScrollToVisibleActionName() {
+        #expect(
+            DesktopReposScrollCapabilityContract.scrollToVisibleActionName
+                == "AXScrollToVisible"
+        )
+    }
+
     @Test func reducesMacOS26ActionNamesToSanitizedBooleans() throws {
         let capabilities = try DesktopReposScrollCapabilityContract.evaluate(
             osMajorVersion: 26,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
@@ -120,6 +120,15 @@ struct DesktopReposScrollCapabilitiesTests {
             try DesktopReposScrollCapabilities.decode(data: wrongTargetData)
         }
 
+        var unknownSize = object
+        var size = try #require(unknownSize["requestedContentSize"] as? [String: Any])
+        size["scale"] = 2
+        unknownSize["requestedContentSize"] = size
+        let unknownSizeData = try JSONSerialization.data(withJSONObject: unknownSize)
+        #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
+            try DesktopReposScrollCapabilities.decode(data: unknownSizeData)
+        }
+
         let oversized = Data(repeating: 0x20, count: 4_097)
         #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
             try DesktopReposScrollCapabilities.decode(data: oversized)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
@@ -10,8 +10,11 @@ struct DesktopReposScrollCapabilitiesTests {
             boundaryActionNames: ["AXScrollToVisible", "AXShowMenu"],
             verticalScrollBarResolved: true,
             scrollBarActionNames: ["AXIncrement"],
+            incrementPageResolved: true,
+            incrementPageActionNames: ["AXPress"],
             scrollToVisibleActionName: "AXScrollToVisible",
-            incrementActionName: "AXIncrement"
+            incrementActionName: "AXIncrement",
+            pressActionName: "AXPress"
         )
 
         #expect(capabilities.acquisition == .init(status: .complete, failureReason: nil))
@@ -21,6 +24,8 @@ struct DesktopReposScrollCapabilitiesTests {
         #expect(capabilities.boundaryAdvertisesScrollToVisible == true)
         #expect(capabilities.outerVerticalScrollBarResolved == true)
         #expect(capabilities.outerVerticalScrollBarAdvertisesIncrement == true)
+        #expect(capabilities.outerVerticalIncrementPageResolved == true)
+        #expect(capabilities.outerVerticalIncrementPageAdvertisesPress == true)
     }
 
     @Test func recordsScrollToVisibleAsUnavailableBelowMacOS26WithoutInspectingBoundaryActions() throws {
@@ -29,14 +34,19 @@ struct DesktopReposScrollCapabilitiesTests {
             boundaryActionNames: nil,
             verticalScrollBarResolved: false,
             scrollBarActionNames: nil,
+            incrementPageResolved: false,
+            incrementPageActionNames: nil,
             scrollToVisibleActionName: nil,
-            incrementActionName: "AXIncrement"
+            incrementActionName: "AXIncrement",
+            pressActionName: "AXPress"
         )
 
         #expect(!capabilities.scrollToVisibleActionAvailable)
         #expect(capabilities.boundaryAdvertisesScrollToVisible == false)
         #expect(capabilities.outerVerticalScrollBarResolved == false)
         #expect(capabilities.outerVerticalScrollBarAdvertisesIncrement == false)
+        #expect(capabilities.outerVerticalIncrementPageResolved == false)
+        #expect(capabilities.outerVerticalIncrementPageAdvertisesPress == false)
     }
 
     @Test func requiresActionNamesOnlyForCapabilitiesThatWereAvailableAndResolved() {
@@ -46,8 +56,11 @@ struct DesktopReposScrollCapabilitiesTests {
                 boundaryActionNames: nil,
                 verticalScrollBarResolved: false,
                 scrollBarActionNames: nil,
+                incrementPageResolved: false,
+                incrementPageActionNames: nil,
                 scrollToVisibleActionName: "AXScrollToVisible",
-                incrementActionName: "AXIncrement"
+                incrementActionName: "AXIncrement",
+                pressActionName: "AXPress"
             )
         }
         #expect(throws: DesktopReposScrollCapabilityContractError.missingScrollBarActionNames) {
@@ -56,8 +69,24 @@ struct DesktopReposScrollCapabilitiesTests {
                 boundaryActionNames: [],
                 verticalScrollBarResolved: true,
                 scrollBarActionNames: nil,
+                incrementPageResolved: false,
+                incrementPageActionNames: nil,
                 scrollToVisibleActionName: "AXScrollToVisible",
-                incrementActionName: "AXIncrement"
+                incrementActionName: "AXIncrement",
+                pressActionName: "AXPress"
+            )
+        }
+        #expect(throws: DesktopReposScrollCapabilityContractError.missingIncrementPageActionNames) {
+            try DesktopReposScrollCapabilityContract.evaluate(
+                osMajorVersion: 26,
+                boundaryActionNames: [],
+                verticalScrollBarResolved: true,
+                scrollBarActionNames: [],
+                incrementPageResolved: true,
+                incrementPageActionNames: nil,
+                scrollToVisibleActionName: "AXScrollToVisible",
+                incrementActionName: "AXIncrement",
+                pressActionName: "AXPress"
             )
         }
     }
@@ -73,6 +102,8 @@ struct DesktopReposScrollCapabilitiesTests {
         #expect(object["boundaryAdvertisesScrollToVisible"] is NSNull)
         #expect(object["outerVerticalScrollBarResolved"] is NSNull)
         #expect(object["outerVerticalScrollBarAdvertisesIncrement"] is NSNull)
+        #expect(object["outerVerticalIncrementPageResolved"] is NSNull)
+        #expect(object["outerVerticalIncrementPageAdvertisesPress"] is NSNull)
         #expect(try DesktopReposScrollCapabilities.decode(data: data) == capabilities)
     }
 
@@ -82,8 +113,11 @@ struct DesktopReposScrollCapabilitiesTests {
             boundaryActionNames: ["AXScrollToVisible"],
             verticalScrollBarResolved: true,
             scrollBarActionNames: [],
+            incrementPageResolved: true,
+            incrementPageActionNames: [],
             scrollToVisibleActionName: "AXScrollToVisible",
-            incrementActionName: "AXIncrement"
+            incrementActionName: "AXIncrement",
+            pressActionName: "AXPress"
         )
         let data = try JSONEncoder().encode(capabilities)
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -97,11 +131,14 @@ struct DesktopReposScrollCapabilitiesTests {
             "scrollToVisibleActionAvailable",
             "boundaryAdvertisesScrollToVisible",
             "outerVerticalScrollBarResolved",
-            "outerVerticalScrollBarAdvertisesIncrement"
+            "outerVerticalScrollBarAdvertisesIncrement",
+            "outerVerticalIncrementPageResolved",
+            "outerVerticalIncrementPageAdvertisesPress"
         ]))
         let text = String(decoding: data, as: UTF8.self)
         #expect(!text.contains("AXScrollToVisible"))
         #expect(!text.contains("AXIncrement"))
+        #expect(!text.contains("AXPress"))
         #expect(!text.contains("actionNames"))
         #expect(!text.contains("path"))
         #expect(!text.contains("identifier"))
@@ -132,6 +169,78 @@ struct DesktopReposScrollCapabilitiesTests {
         let oversized = Data(repeating: 0x20, count: 4_097)
         #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
             try DesktopReposScrollCapabilities.decode(data: oversized)
+        }
+    }
+
+    @Test func selectsOnlyOneExactDirectIncrementPageChild() throws {
+        let selection = try DesktopReposIncrementPageSelectionContract.select(
+            directChildren: [
+                .init(role: "AXButton", subrole: "AXDecrementPage"),
+                .init(role: "AXButton", subrole: "AXIncrementPage"),
+                .init(role: "AXButton", subrole: "AXIncrementArrow")
+            ]
+        )
+        #expect(selection == .directChild(index: 1))
+    }
+
+    @Test func arrowsSubstitutionsAndUnknownSubrolesDoNotResolveIncrementPage() throws {
+        #expect(try DesktopReposIncrementPageSelectionContract.select(directChildren: [
+            .init(role: "AXButton", subrole: "AXIncrementArrow"),
+            .init(role: "AXButton", subrole: "AXUnknown")
+        ]) == .unsupported)
+        #expect(try DesktopReposIncrementPageSelectionContract.select(directChildren: []) == .unsupported)
+    }
+
+    @Test func incrementPageSelectionFailsClosedOnMalformedOrDuplicateChildren() {
+        #expect(throws: DesktopReposIncrementPageSelectionError.missingRole) {
+            try DesktopReposIncrementPageSelectionContract.select(directChildren: [
+                .init(role: nil, subrole: "AXIncrementPage")
+            ])
+        }
+        #expect(throws: DesktopReposIncrementPageSelectionError.missingSubrole) {
+            try DesktopReposIncrementPageSelectionContract.select(directChildren: [
+                .init(role: "AXButton", subrole: nil)
+            ])
+        }
+        #expect(throws: DesktopReposIncrementPageSelectionError.invalidIncrementPageRole) {
+            try DesktopReposIncrementPageSelectionContract.select(directChildren: [
+                .init(role: "AXCheckBox", subrole: "AXIncrementPage")
+            ])
+        }
+        #expect(throws: DesktopReposIncrementPageSelectionError.duplicateIncrementPage) {
+            try DesktopReposIncrementPageSelectionContract.select(directChildren: [
+                .init(role: "AXButton", subrole: "AXIncrementPage"),
+                .init(role: "AXButton", subrole: "AXIncrementPage")
+            ])
+        }
+    }
+
+    @Test func capabilityCrossFieldsRejectPageWithoutScrollbarAndPressWithoutPage() {
+        let base = DesktopReposScrollCapabilities(
+            osMajorVersion: 26,
+            acquisition: .init(status: .complete, failureReason: nil),
+            scrollToVisibleActionAvailable: true,
+            boundaryAdvertisesScrollToVisible: false,
+            outerVerticalScrollBarResolved: false,
+            outerVerticalScrollBarAdvertisesIncrement: false,
+            outerVerticalIncrementPageResolved: true,
+            outerVerticalIncrementPageAdvertisesPress: false
+        )
+        #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
+            try base.validated()
+        }
+        let pressWithoutPage = DesktopReposScrollCapabilities(
+            osMajorVersion: 26,
+            acquisition: .init(status: .complete, failureReason: nil),
+            scrollToVisibleActionAvailable: true,
+            boundaryAdvertisesScrollToVisible: false,
+            outerVerticalScrollBarResolved: true,
+            outerVerticalScrollBarAdvertisesIncrement: false,
+            outerVerticalIncrementPageResolved: false,
+            outerVerticalIncrementPageAdvertisesPress: true
+        )
+        #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
+            try pressWithoutPage.validated()
         }
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopEvaluationSupport
+
+@Suite("Desktop Repositories scroll capabilities")
+struct DesktopReposScrollCapabilitiesTests {
+    @Test func reducesMacOS26ActionNamesToSanitizedBooleans() throws {
+        let capabilities = try DesktopReposScrollCapabilityContract.evaluate(
+            osMajorVersion: 26,
+            boundaryActionNames: ["AXScrollToVisible", "AXShowMenu"],
+            verticalScrollBarResolved: true,
+            scrollBarActionNames: ["AXIncrement"],
+            scrollToVisibleActionName: "AXScrollToVisible",
+            incrementActionName: "AXIncrement"
+        )
+
+        #expect(capabilities.acquisition == .init(status: .complete, failureReason: nil))
+        #expect(capabilities.fixture == .tabRepos)
+        #expect(capabilities.requestedContentSize == .init(width: 1040, height: 680))
+        #expect(capabilities.scrollToVisibleActionAvailable)
+        #expect(capabilities.boundaryAdvertisesScrollToVisible == true)
+        #expect(capabilities.outerVerticalScrollBarResolved == true)
+        #expect(capabilities.outerVerticalScrollBarAdvertisesIncrement == true)
+    }
+
+    @Test func recordsScrollToVisibleAsUnavailableBelowMacOS26WithoutInspectingBoundaryActions() throws {
+        let capabilities = try DesktopReposScrollCapabilityContract.evaluate(
+            osMajorVersion: 15,
+            boundaryActionNames: nil,
+            verticalScrollBarResolved: false,
+            scrollBarActionNames: nil,
+            scrollToVisibleActionName: nil,
+            incrementActionName: "AXIncrement"
+        )
+
+        #expect(!capabilities.scrollToVisibleActionAvailable)
+        #expect(capabilities.boundaryAdvertisesScrollToVisible == false)
+        #expect(capabilities.outerVerticalScrollBarResolved == false)
+        #expect(capabilities.outerVerticalScrollBarAdvertisesIncrement == false)
+    }
+
+    @Test func requiresActionNamesOnlyForCapabilitiesThatWereAvailableAndResolved() {
+        #expect(throws: DesktopReposScrollCapabilityContractError.missingBoundaryActionNames) {
+            try DesktopReposScrollCapabilityContract.evaluate(
+                osMajorVersion: 26,
+                boundaryActionNames: nil,
+                verticalScrollBarResolved: false,
+                scrollBarActionNames: nil,
+                scrollToVisibleActionName: "AXScrollToVisible",
+                incrementActionName: "AXIncrement"
+            )
+        }
+        #expect(throws: DesktopReposScrollCapabilityContractError.missingScrollBarActionNames) {
+            try DesktopReposScrollCapabilityContract.evaluate(
+                osMajorVersion: 26,
+                boundaryActionNames: [],
+                verticalScrollBarResolved: true,
+                scrollBarActionNames: nil,
+                scrollToVisibleActionName: "AXScrollToVisible",
+                incrementActionName: "AXIncrement"
+            )
+        }
+    }
+
+    @Test func failedAcquisitionUsesExplicitNullCapabilitiesRatherThanFalse() throws {
+        let capabilities = DesktopReposScrollCapabilities.failed(
+            osMajorVersion: 26,
+            reason: .attributeUnavailable
+        )
+        let data = try JSONEncoder().encode(capabilities)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(object["boundaryAdvertisesScrollToVisible"] is NSNull)
+        #expect(object["outerVerticalScrollBarResolved"] is NSNull)
+        #expect(object["outerVerticalScrollBarAdvertisesIncrement"] is NSNull)
+        #expect(try DesktopReposScrollCapabilities.decode(data: data) == capabilities)
+    }
+
+    @Test func wireContractContainsOnlySanitizedCapabilityFacts() throws {
+        let capabilities = try DesktopReposScrollCapabilityContract.evaluate(
+            osMajorVersion: 26,
+            boundaryActionNames: ["AXScrollToVisible"],
+            verticalScrollBarResolved: true,
+            scrollBarActionNames: [],
+            scrollToVisibleActionName: "AXScrollToVisible",
+            incrementActionName: "AXIncrement"
+        )
+        let data = try JSONEncoder().encode(capabilities)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(Set(object.keys) == Set([
+            "schemaVersion",
+            "fixture",
+            "requestedContentSize",
+            "osMajorVersion",
+            "acquisition",
+            "scrollToVisibleActionAvailable",
+            "boundaryAdvertisesScrollToVisible",
+            "outerVerticalScrollBarResolved",
+            "outerVerticalScrollBarAdvertisesIncrement"
+        ]))
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(!text.contains("AXScrollToVisible"))
+        #expect(!text.contains("AXIncrement"))
+        #expect(!text.contains("actionNames"))
+        #expect(!text.contains("path"))
+        #expect(!text.contains("identifier"))
+
+        var unknown = object
+        unknown["rawActions"] = ["must-not-decode"]
+        let unknownData = try JSONSerialization.data(withJSONObject: unknown)
+        #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
+            try DesktopReposScrollCapabilities.decode(data: unknownData)
+        }
+
+        var wrongTarget = object
+        wrongTarget["fixture"] = "tab-providers"
+        let wrongTargetData = try JSONSerialization.data(withJSONObject: wrongTarget)
+        #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
+            try DesktopReposScrollCapabilities.decode(data: wrongTargetData)
+        }
+
+        let oversized = Data(repeating: 0x20, count: 4_097)
+        #expect(throws: DesktopReposScrollCapabilitiesValidationError.invalidContract) {
+            try DesktopReposScrollCapabilities.decode(data: oversized)
+        }
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopReposScrollCapabilitiesTests.swift
@@ -175,12 +175,13 @@ struct DesktopReposScrollCapabilitiesTests {
     @Test func selectsOnlyOneExactDirectIncrementPageChild() throws {
         let selection = try DesktopReposIncrementPageSelectionContract.select(
             directChildren: [
+                .init(role: "AXValueIndicator", subrole: nil),
                 .init(role: "AXButton", subrole: "AXDecrementPage"),
                 .init(role: "AXButton", subrole: "AXIncrementPage"),
                 .init(role: "AXButton", subrole: "AXIncrementArrow")
             ]
         )
-        #expect(selection == .directChild(index: 1))
+        #expect(selection == .directChild(index: 2))
     }
 
     @Test func arrowsSubstitutionsAndUnknownSubrolesDoNotResolveIncrementPage() throws {

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -178,12 +178,24 @@ customer state.
 The separate schema-v2 reachability behavior is enabled only by this focused
 DEBUG runner. After binding the freshly launched fixture PID, unique Table,
 Apply, Boundary, Boundary's outermost scroll ancestor, and the exact direct
-Increment Page child, it rechecks advertised `AXPress` and performs that public
-action exactly once. It does not retry, substitute arrows, use a private action,
-or target an installed/live app. API acceptance is recorded but is not treated
-as reachability: the checker requires stable window and outer-clip geometry,
-one rigid upward translation of Table, Apply, and Boundary, and post-action
-Apply/Boundary containment in the outer clip.
+Increment Page child, it collects settled pre-action samples. Every settled
+pre/post sample records the current window frame, outer scroll clip, Boundary
+scroll-ancestor count, and semantic-region frames. Immediately before the sole
+press, the helper re-resolves the full Boundary -> outer scroll -> vertical
+scrollbar -> direct Increment Page chain and requires every cached semantic and
+action element plus the ancestry count to match. A replaced or stale chain is a
+typed `semantic-changed` acquisition failure and no action is performed.
+
+Only after that revalidation does the helper recheck advertised `AXPress`; the
+helper performs that public action exactly once. It does not retry, substitute
+arrows, use a private action, or target an installed/live app. The successful action
+ledger is persisted before any post-action read, so a later acquisition failure
+retains `attemptCount: 1` and `performResult: success` without inventing a
+settled post clip. API acceptance is recorded but is not treated as
+reachability: the checker requires a one-point all-phase envelope for the
+window, every settled outer clip, and the Boundary ancestry count; one rigid
+upward translation of Table, Apply, and Boundary; and Apply/Boundary containment
+against every settled post-action outer clip.
 
 Capture output remains in the private workspace until the helper exits
 successfully and every required file is present. A fixture exit before
@@ -195,13 +207,18 @@ marker are published only after the packet scan passes and a final clean
 exact-HEAD check succeeds.
 
 All checker failures are ordinary typed failures; there is no legacy
-"expected pre-fix" exception. Boundary is a sibling of Table, so nested Table
-scrolling cannot satisfy the rigid page-translation contract. The DEBUG fixture
-may mutate only its deterministic test UI to exercise scroll reachability; it
-does not authorize live product or runtime mutation. A checker failure preserves `reachability.json`
-and `scroll-capabilities.json`.
-The normalized checker status and public-safety result are written before the
-runner returns the nonzero checker exit.
+"expected pre-fix" exception. The checker emits one strict public-safe JSON
+result with `input`, `contract`, `acquisition`, `action`, or `geometry`
+classification and an allowlisted reason code. The runner validates that
+result and its exit-status relationship; malformed output fails closed as
+`checker-result-invalid` and the runner does not infer a result from the raw
+trace. Boundary is a sibling of Table, so nested Table scrolling cannot satisfy
+the rigid page-translation contract. The DEBUG fixture may mutate only its
+deterministic test UI to exercise scroll reachability; it does not authorize
+live product or runtime mutation. A checker failure preserves
+`reachability.json` and `scroll-capabilities.json`. The normalized checker
+status and public-safety result are written before the runner returns the
+nonzero checker exit.
 
 This focused packet does not prove:
 

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -185,7 +185,7 @@ Boundary is a sibling of Table, so a Table scroll does not satisfy the checker.
 The DEBUG fixture may
 mutate only its deterministic test UI to exercise scroll reachability; it does
 not authorize live product or runtime mutation. A checker failure preserves
-both `reachability.json` and `scroll-capabilities.json`.
+`reachability.json` and `scroll-capabilities.json`.
 The normalized checker status and public-safety result are written before the
 runner returns the nonzero checker exit.
 

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -161,12 +161,13 @@ text. It never reads live configuration, Keychain, GitHub, provider, daemon,
 network, or customer state.
 
 Capture output remains in the private workspace until the helper exits
-successfully and every required file is present. A timeout, TCC denial, partial
+successfully and every required file is present. A fixture exit before
+readiness, bounded readiness timeout, capture timeout, TCC denial, partial
 capture, or source-HEAD drift leaves `focused-capture-status.json` marked
 `incomplete`, does not publish a focused proof or safety `ok` marker, and does
-not expose raw capture stderr. The final proof, safety result, and `ok` marker
-are published only after the packet scan passes and a final clean exact-HEAD
-check succeeds.
+not expose raw launch or capture logs. The final proof, safety result, and `ok`
+marker are published only after the packet scan passes and a final clean
+exact-HEAD check succeeds.
 
 The current pre-fix result is the missing outer `AXScrollArea` ancestor. It is
 classified as that expected RED only when the typed reachability acquisition is

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -164,8 +164,10 @@ sanitized capability booleans. It uses `AXUIElementCopyActionNames` only to
 check the verified Boundary, outer vertical scrollbar, and one exact direct
 child with role `AXButton` and subrole `AXIncrementPage`; it does not perform accessibility actions.
 The probe requires every direct scrollbar child to retain the fixture PID and
-well-typed role/subrole attributes, never recurses into descendants, and never
-substitutes increment/decrement arrows or geometry. It records only whether the
+a well-typed role, and every button child to provide a well-typed subrole. A
+non-button such as `AXValueIndicator` may omit its subrole, but cannot claim
+`AXIncrementPage`. The probe never recurses into descendants or substitutes
+increment/decrement arrows or geometry. It records only whether the
 Increment Page child resolved and whether that child advertises the exact public
 `AXPress` action.
 Missing, malformed, or failed action-name acquisition is

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -160,7 +160,19 @@ absolute reachability path, and scans the focused evidence for secret-shaped
 text. It never reads live configuration, Keychain, GitHub, provider, daemon,
 network, or customer state.
 
-The current pre-fix result is the missing outer `AXScrollArea` ancestor.
+Capture output remains in the private workspace until the helper exits
+successfully and every required file is present. A timeout, TCC denial, partial
+capture, or source-HEAD drift leaves `focused-capture-status.json` marked
+`incomplete`, does not publish a focused proof or safety `ok` marker, and does
+not expose raw capture stderr. The final proof, safety result, and `ok` marker
+are published only after the packet scan passes and a final clean exact-HEAD
+check succeeds.
+
+The current pre-fix result is the missing outer `AXScrollArea` ancestor. It is
+classified as that expected RED only when the typed reachability acquisition is
+`complete`, its failure reason is explicitly null, `outerScroll` is explicitly
+null, and the checker reports the exact missing-scroll error. Acquisition
+failures and unrelated checker failures remain ordinary checker failures.
 Boundary is a sibling of Table, so a Table scroll does not satisfy the checker.
 The DEBUG fixture may
 mutate only its deterministic test UI to exercise scroll reachability; it does

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -161,7 +161,13 @@ the focused evidence for secret-shaped text. The capability packet is bound to
 the `tab-repos` fixture and requested `1040x680` content size, is capped at 4096
 bytes, and contains only schema/OS metadata, typed acquisition state, and
 sanitized capability booleans. It uses `AXUIElementCopyActionNames` only to
-check the verified Boundary and outer vertical scrollbar; it does not perform accessibility actions.
+check the verified Boundary, outer vertical scrollbar, and one exact direct
+child with role `AXButton` and subrole `AXIncrementPage`; it does not perform accessibility actions.
+The probe requires every direct scrollbar child to retain the fixture PID and
+well-typed role/subrole attributes, never recurses into descendants, and never
+substitutes increment/decrement arrows or geometry. It records only whether the
+Increment Page child resolved and whether that child advertises the exact public
+`AXPress` action.
 Missing, malformed, or failed action-name acquisition is
 a typed acquisition failure rather than a false capability result. It never
 reads live configuration, Keychain, GitHub, provider, daemon, network, or

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -155,10 +155,17 @@ checker products, and launches only the public-safe `tab-repos` fixture at
 `--repos-reachability` opt-in to the capture helper, so canonical #515 captures
 keep their existing byte and artifact shape. The runner waits boundedly for
 app-authored readiness, captures the window, AX tree, geometry, and
-`reachability.json`, terminates its children, runs the checker against the
-absolute reachability path, and scans the focused evidence for secret-shaped
-text. It never reads live configuration, Keychain, GitHub, provider, daemon,
-network, or customer state.
+`reachability.json`, plus a separate `scroll-capabilities.json`, terminates its
+children, runs the checker against the absolute reachability path, and scans
+the focused evidence for secret-shaped text. The capability packet is bound to
+the `tab-repos` fixture and requested `1040x680` content size, is capped at 4096
+bytes, and contains only schema/OS metadata, typed acquisition state, and
+sanitized capability booleans. It uses `AXUIElementCopyActionNames` only to
+check the verified Boundary and outer vertical scrollbar; it does not perform
+accessibility actions. Missing, malformed, or failed action-name acquisition is
+a typed acquisition failure rather than a false capability result. It never
+reads live configuration, Keychain, GitHub, provider, daemon, network, or
+customer state.
 
 Capture output remains in the private workspace until the helper exits
 successfully and every required file is present. A fixture exit before
@@ -177,7 +184,8 @@ failures and unrelated checker failures remain ordinary checker failures.
 Boundary is a sibling of Table, so a Table scroll does not satisfy the checker.
 The DEBUG fixture may
 mutate only its deterministic test UI to exercise scroll reachability; it does
-not authorize live product or runtime mutation. A checker failure preserves `reachability.json`.
+not authorize live product or runtime mutation. A checker failure preserves
+both `reachability.json` and `scroll-capabilities.json`.
 The normalized checker status and public-safety result are written before the
 runner returns the nonzero checker exit.
 

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -175,6 +175,16 @@ a typed acquisition failure rather than a false capability result. It never
 reads live configuration, Keychain, GitHub, provider, daemon, network, or
 customer state.
 
+The separate schema-v2 reachability behavior is enabled only by this focused
+DEBUG runner. After binding the freshly launched fixture PID, unique Table,
+Apply, Boundary, Boundary's outermost scroll ancestor, and the exact direct
+Increment Page child, it rechecks advertised `AXPress` and performs that public
+action exactly once. It does not retry, substitute arrows, use a private action,
+or target an installed/live app. API acceptance is recorded but is not treated
+as reachability: the checker requires stable window and outer-clip geometry,
+one rigid upward translation of Table, Apply, and Boundary, and post-action
+Apply/Boundary containment in the outer clip.
+
 Capture output remains in the private workspace until the helper exits
 successfully and every required file is present. A fixture exit before
 readiness, bounded readiness timeout, capture timeout, TCC denial, partial
@@ -184,15 +194,11 @@ not expose raw launch or capture logs. The final proof, safety result, and `ok`
 marker are published only after the packet scan passes and a final clean
 exact-HEAD check succeeds.
 
-The current pre-fix result is the missing outer `AXScrollArea` ancestor. It is
-classified as that expected RED only when the typed reachability acquisition is
-`complete`, its failure reason is explicitly null, `outerScroll` is explicitly
-null, and the checker reports the exact missing-scroll error. Acquisition
-failures and unrelated checker failures remain ordinary checker failures.
-Boundary is a sibling of Table, so a Table scroll does not satisfy the checker.
-The DEBUG fixture may
-mutate only its deterministic test UI to exercise scroll reachability; it does
-not authorize live product or runtime mutation. A checker failure preserves `reachability.json`
+All checker failures are ordinary typed failures; there is no legacy
+"expected pre-fix" exception. Boundary is a sibling of Table, so nested Table
+scrolling cannot satisfy the rigid page-translation contract. The DEBUG fixture
+may mutate only its deterministic test UI to exercise scroll reachability; it
+does not authorize live product or runtime mutation. A checker failure preserves `reachability.json`
 and `scroll-capabilities.json`.
 The normalized checker status and public-safety result are written before the
 runner returns the nonzero checker exit.

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -161,8 +161,8 @@ the focused evidence for secret-shaped text. The capability packet is bound to
 the `tab-repos` fixture and requested `1040x680` content size, is capped at 4096
 bytes, and contains only schema/OS metadata, typed acquisition state, and
 sanitized capability booleans. It uses `AXUIElementCopyActionNames` only to
-check the verified Boundary and outer vertical scrollbar; it does not perform
-accessibility actions. Missing, malformed, or failed action-name acquisition is
+check the verified Boundary and outer vertical scrollbar; it does not perform accessibility actions.
+Missing, malformed, or failed action-name acquisition is
 a typed acquisition failure rather than a false capability result. It never
 reads live configuration, Keychain, GitHub, provider, daemon, network, or
 customer state.
@@ -184,8 +184,8 @@ failures and unrelated checker failures remain ordinary checker failures.
 Boundary is a sibling of Table, so a Table scroll does not satisfy the checker.
 The DEBUG fixture may
 mutate only its deterministic test UI to exercise scroll reachability; it does
-not authorize live product or runtime mutation. A checker failure preserves
-`reachability.json` and `scroll-capabilities.json`.
+not authorize live product or runtime mutation. A checker failure preserves `reachability.json`
+and `scroll-capabilities.json`.
 The normalized checker status and public-safety result are written before the
 runner returns the nonzero checker exit.
 

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -138,6 +138,52 @@ Those two sizes cover the main-window minimum and baseline only. The onboarding
 760x560, Settings 560x700, and wide 1440x900 captures, plus click-to-click
 geometry traces, remain #515/#517 work and are not implied by this packet.
 
+## Focused #517 Repos Reachability Proof
+
+The Repos-only runner is a focused partial #517 proof outside the canonical #515 packet.
+From a clean exact HEAD, give it a fresh absolute output path:
+
+```bash
+apps/neondiff-desktop/scripts/capture-repos-reachability.sh \
+  --output /absolute/fresh/evidence/path
+```
+
+The runner creates a private `/tmp` workspace, keeps SwiftPM DEBUG products and
+the launched app there, builds one app bundle plus the capture and reachability
+checker products, and launches only the public-safe `tab-repos` fixture at
+`1040x680`. Only this focused runner passes the explicit
+`--repos-reachability` opt-in to the capture helper, so canonical #515 captures
+keep their existing byte and artifact shape. The runner waits boundedly for
+app-authored readiness, captures the window, AX tree, geometry, and
+`reachability.json`, terminates its children, runs the checker against the
+absolute reachability path, and scans the focused evidence for secret-shaped
+text. It never reads live configuration, Keychain, GitHub, provider, daemon,
+network, or customer state.
+
+The current pre-fix result is the missing outer `AXScrollArea` ancestor.
+Boundary is a sibling of Table, so a Table scroll does not satisfy the checker.
+The DEBUG fixture may
+mutate only its deterministic test UI to exercise scroll reachability; it does
+not authorize live product or runtime mutation. A checker failure preserves `reachability.json`.
+The normalized checker status and public-safety result are written before the
+runner returns the nonzero checker exit.
+
+This focused packet does not prove:
+
+- the rest of the fixture catalog, the second baseline size, wide, onboarding,
+  Settings, or the remaining state matrix;
+- successful clicks, scripted outcomes, keyboard focus order, tooltips,
+  before/after geometry, or full issue #517 layout-stability and accessibility
+  conformance;
+- the canonical #515 schema-2 manifest, reference comparison, or full baseline;
+- release-bundle isolation, signing, notarization, appcast, installed-app, live
+  runtime, customer, browser/native parity, GA, or customer readiness.
+
+Rebuilding the DEBUG app or capture helper can change its code requirement and
+invalidate an existing macOS TCC Screen Recording or Accessibility grant. A TCC
+failure limits this local dev proof; it is not a Repos reachability result and
+must not be bypassed by touching privacy settings from the runner.
+
 The Swift desktop gate runs the fixture checks whenever evaluation sources or
 catalog files change. It keeps the normal debug bundle separate, stages an
 explicit release bundle under `dist-release`, and scans only the release

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -258,7 +258,22 @@ done
         and (.scrollToVisibleActionAvailable or (.boundaryAdvertisesScrollToVisible | not))
         and (.outerVerticalScrollBarResolved or (.outerVerticalScrollBarAdvertisesIncrement | not))
       elif .acquisition.status == "failed" then
-        (.acquisition.failureReason | type == "string" and length > 0)
+        (.acquisition.failureReason as $reason | [
+          "cannot-complete",
+          "invalid-element",
+          "permission-denied",
+          "invalid-type",
+          "attribute-unavailable",
+          "pid-mismatch",
+          "window-mismatch",
+          "semantic-missing",
+          "semantic-duplicate",
+          "timeout",
+          "ancestry-unavailable",
+          "ancestry-cycle",
+          "ancestry-limit",
+          "messaging-timeout-unavailable"
+        ] | index($reason) != null)
         and .boundaryAdvertisesScrollToVisible == null
         and .outerVerticalScrollBarResolved == null
         and .outerVerticalScrollBarAdvertisesIncrement == null

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -251,7 +251,7 @@ done
     and (.osMajorVersion | type == "number" and . >= 1 and . <= 100 and floor == .)
     and .scrollToVisibleActionAvailable == (.osMajorVersion >= 26)
     and (.acquisition | type == "object" and keys == ["failureReason", "status"])
-    and (
+    and (.reasonCode as $reason |
       if .acquisition.status == "complete" then
         .acquisition.failureReason == null
         and (.boundaryAdvertisesScrollToVisible | type == "boolean")
@@ -338,18 +338,59 @@ else
   checker_status=$?
   checker_result="failed"
 fi
-checker_failed=false
-checker_reason_code="none"
-if [ "$checker_status" -ne 0 ]; then
-  checker_failed=true
-  checker_reason_code="checker_nonzero"
+checker_output_valid=false
+if jq -e '
+    type == "object"
+    and keys == ["category", "ok", "reasonCode", "schemaVersion", "status"]
+    and .schemaVersion == 1
+    and (.reasonCode as $reason |
+      if .ok == true then
+        .status == "reachable" and .category == "none" and .reasonCode == "none"
+      elif .ok == false and .status == "failed" then
+        (
+          (.category == "input" and (["usage", "unsafe-input", "input-read-failed"] | index($reason)) != null)
+          or (.category == "contract" and ([
+            "invalid-contract", "nonfinite-frame", "duplicate-region", "missing-region",
+            "missing-scroll-interaction", "checker-encoding-failed"
+          ] | index($reason)) != null)
+          or (.category == "acquisition" and (.reasonCode | test("^acquisition-(cannot-complete|invalid-element|permission-denied|invalid-type|attribute-unavailable|pid-mismatch|window-mismatch|semantic-missing|semantic-duplicate|semantic-changed|timeout|ancestry-unavailable|ancestry-cycle|ancestry-limit|messaging-timeout-unavailable)$")))
+          or (.category == "action" and (.reasonCode | test("^action-(not-advertised|perform-(cannot-complete|action-unsupported|invalid-element|permission-denied|other-error))$")))
+          or (.category == "geometry" and ([
+            "insufficient-pre-scroll-samples", "insufficient-post-scroll-samples", "excessive-drift",
+            "unstable-window", "unstable-outer-clip", "unstable-scroll-ancestry",
+            "outer-clip-outside-window", "boundary-initially-inside-outer-clip",
+            "no-upward-movement", "non-rigid-movement", "press-insufficient-apply-allowlist",
+            "press-insufficient-boundary-body", "region-outside-viewport"
+          ] | index($reason)) != null)
+        )
+      else false end
+    )' "$output/validation/reachability-check.json" >/dev/null 2>&1; then
+  if { [ "$checker_status" -eq 0 ] && jq -e '.ok == true' "$output/validation/reachability-check.json" >/dev/null; } \
+    || { [ "$checker_status" -ne 0 ] && jq -e '.ok == false' "$output/validation/reachability-check.json" >/dev/null; }; then
+    checker_output_valid=true
+  fi
+fi
+checker_failed=true
+checker_category="checker"
+checker_reason_code="checker-result-invalid"
+if [ "$checker_output_valid" = true ]; then
+  checker_category=$(jq -r '.category' "$output/validation/reachability-check.json")
+  checker_reason_code=$(jq -r '.reasonCode' "$output/validation/reachability-check.json")
+  if [ "$checker_status" -eq 0 ]; then
+    checker_failed=false
+    checker_result="passed"
+  fi
+elif [ "$checker_status" -eq 0 ]; then
+  checker_status=65
+  checker_result="failed"
 fi
 jq -n \
   --arg status "$checker_result" \
+  --arg category "$checker_category" \
   --arg reasonCode "$checker_reason_code" \
   --argjson checkerFailed "$checker_failed" \
   --argjson exitCode "$checker_status" \
-  '{schemaVersion:1,status:$status,checkerFailed:$checkerFailed,exitCode:$exitCode,reasonCode:$reasonCode}' \
+  '{schemaVersion:2,status:$status,checkerFailed:$checkerFailed,exitCode:$exitCode,category:$category,reasonCode:$reasonCode}' \
   >"$output/validation/reachability-check-status.json"
 
 reachability_sha=$(shasum -a 256 "$reachability" | awk '{print $1}')

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+set -eu
+umask 077
+
+usage() {
+  echo "usage: $0 --output <fresh-absolute-evidence-directory>" >&2
+  exit 64
+}
+
+[ "$#" -eq 2 ] && [ "$1" = "--output" ] || usage
+output=$2
+case "$output" in /*) ;; *) usage ;; esac
+[ ! -e "$output" ] && [ ! -L "$output" ] \
+  || { echo "focused capture output must not already exist" >&2; exit 65; }
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+package_dir=$(dirname -- "$script_dir")
+repo_dir=$(CDPATH='' cd -- "$package_dir/../.." && pwd)
+cd "$repo_dir"
+
+[ -z "$(git status --porcelain --untracked-files=all)" ] \
+  || { echo "canonical focused capture requires a clean worktree" >&2; exit 65; }
+head_sha=$(git rev-parse HEAD)
+printf '%s\n' "$head_sha" | grep -Eq '^[0-9a-f]{40}$' \
+  || { echo "could not bind focused capture to an exact HEAD" >&2; exit 65; }
+
+assert_clean_head() {
+  [ "$(git rev-parse HEAD)" = "$head_sha" ] \
+    && [ -z "$(git status --porcelain --untracked-files=all)" ] \
+    || { echo "source changed during focused capture" >&2; exit 65; }
+}
+
+mkdir -m 700 "$output" \
+  || { echo "could not create fresh focused capture output" >&2; exit 65; }
+mkdir -p "$output/cases/tab-repos/1040x680" "$output/validation"
+case_dir="$output/cases/tab-repos/1040x680"
+
+tmp_root=$(/usr/bin/mktemp -d "/tmp/neondiff-desktop-repos-reachability.XXXXXXXX") \
+  || { echo "could not create private focused capture workspace" >&2; exit 65; }
+[ -d "$tmp_root" ] && [ ! -L "$tmp_root" ] \
+  || { echo "focused capture workspace is not a private directory" >&2; exit 65; }
+/bin/chmod 700 "$tmp_root"
+tmp_mode=$(/usr/bin/stat -f '%Lp' "$tmp_root" 2>/dev/null || /usr/bin/stat -c '%a' "$tmp_root")
+[ "$tmp_mode" = 700 ] \
+  || { echo "focused capture workspace permissions are not private" >&2; exit 65; }
+
+app_pid=
+capture_pid=
+terminate_process() {
+  target_pid=$1
+  case "$target_pid" in ''|*[!0-9]*) return ;; esac
+  [ "$target_pid" -ne "$$" ] || return
+  kill -TERM "$target_pid" >/dev/null 2>&1 || true
+  terminate_attempts=0
+  while kill -0 "$target_pid" 2>/dev/null && [ "$terminate_attempts" -lt 10 ]; do
+    /bin/sleep 0.1
+    terminate_attempts=$((terminate_attempts + 1))
+  done
+  if kill -0 "$target_pid" 2>/dev/null; then
+    kill -KILL "$target_pid" >/dev/null 2>&1 || true
+  fi
+  wait "$target_pid" >/dev/null 2>&1 || true
+}
+cleanup() {
+  if [ -n "$capture_pid" ]; then terminate_process "$capture_pid"; fi
+  if [ -n "$app_pid" ]; then terminate_process "$app_pid"; fi
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+fixture_id="tab-repos"
+content_size="1040x680"
+source_fixture="$package_dir/fixtures/ui/tab-repos.json"
+[ -f "$source_fixture" ] && [ ! -L "$source_fixture" ] \
+  || { echo "tab-repos fixture must be a regular non-symlink file" >&2; exit 65; }
+fixture="$tmp_root/tab-repos.json"
+cp "$source_fixture" "$fixture"
+
+# Keep every DEBUG build product and launched bundle inside the private workspace.
+export SWIFTPM_BUILD_DIR="$tmp_root/swift-build"
+dist_dir="$tmp_root/dist"
+NEONDIFF_DESKTOP_DIST_DIR="$dist_dir" \
+  "$package_dir/script/build_and_run.sh" build \
+  >"$output/validation/debug-app-build.log" 2>&1
+swift build --package-path "$package_dir" --product NeonDiffDesktopCapture \
+  >"$output/validation/capture-helper-build.log" 2>&1
+swift build --package-path "$package_dir" --product NeonDiffDesktopReachabilityChecks \
+  >"$output/validation/reachability-checker-build.log" 2>&1
+swift_bin=$(swift build --package-path "$package_dir" --show-bin-path)
+app_bin="$dist_dir/NeonDiffDesktop.app/Contents/MacOS/NeonDiffDesktop"
+capture_bin="$swift_bin/NeonDiffDesktopCapture"
+[ -x "$app_bin" ] && [ -x "$capture_bin" ] \
+  || { echo "focused DEBUG capture products are missing" >&2; exit 65; }
+assert_clean_head
+
+npm run check:secrets >"$output/validation/repository-secret-scan.log" 2>&1
+
+ready_dir="$tmp_root/ready"
+mkdir -m 700 "$ready_dir"
+ready="$ready_dir/ready.json"
+NEONDIFF_DESKTOP_EVALUATION_READY_PATH="$ready" \
+  "$app_bin" \
+  --ui-testing \
+  --ui-fixture "$fixture" \
+  --content-size "$content_size" \
+  --disable-animations \
+  >"$case_dir/launch.log" 2>&1 &
+app_pid=$!
+
+ready_attempts=0
+while [ ! -f "$ready" ] && kill -0 "$app_pid" 2>/dev/null && [ "$ready_attempts" -lt 100 ]; do
+  /bin/sleep 0.1
+  ready_attempts=$((ready_attempts + 1))
+done
+[ -f "$ready" ] && [ ! -L "$ready" ] \
+  || { echo "tab-repos fixture did not become ready at 1040x680" >&2; exit 1; }
+jq -e --arg fixture "$fixture_id" --argjson pid "$app_pid" \
+  '.schemaVersion == 1 and .ready == true and .fixtureId == $fixture and .pid == $pid' \
+  "$ready" >/dev/null \
+  || { echo "tab-repos readiness did not match the launched process" >&2; exit 1; }
+cp "$ready" "$case_dir/readiness.json"
+
+"$capture_bin" \
+  --pid "$app_pid" \
+  --ready "$ready" \
+  --output-dir "$case_dir" \
+  --repos-reachability \
+  >"$case_dir/capture.json.tmp" \
+  2>"$tmp_root/capture.stderr" &
+capture_pid=$!
+capture_attempts=0
+while kill -0 "$capture_pid" 2>/dev/null && [ "$capture_attempts" -lt 150 ]; do
+  /bin/sleep 0.1
+  capture_attempts=$((capture_attempts + 1))
+done
+if kill -0 "$capture_pid" 2>/dev/null; then
+  terminate_process "$capture_pid"
+  capture_pid=
+  echo "capture helper timed out: tab-repos 1040x680" >&2
+  exit 1
+fi
+capture_status=0
+wait "$capture_pid" || capture_status=$?
+capture_pid=
+mv "$case_dir/capture.json.tmp" "$case_dir/capture.json"
+if [ "$capture_status" -ne 0 ]; then
+  echo "capture helper failed: tab-repos 1040x680" >&2
+  exit "$capture_status"
+fi
+
+reachability="$case_dir/reachability.json"
+[ -f "$reachability" ] && [ ! -L "$reachability" ] \
+  || { echo "capture helper did not write reachability.json" >&2; exit 1; }
+terminate_process "$app_pid"
+app_pid=
+assert_clean_head
+
+# The pre-fix Repos tree is expected to fail this checker. Keep the capture and
+# finish the public-safety scan before returning the checker's nonzero status.
+checker_status=0
+if swift run --skip-build --package-path "$package_dir" \
+  NeonDiffDesktopReachabilityChecks "$reachability" \
+  >"$output/validation/reachability-check.json" \
+  2>"$tmp_root/reachability-check.stderr"; then
+  checker_result="passed"
+else
+  checker_status=$?
+  checker_result="failed"
+fi
+checker_failed=false
+expected_pre_fix_failure=false
+checker_reason_code="none"
+if [ "$checker_status" -ne 0 ]; then
+  checker_failed=true
+  checker_reason_code="checker_nonzero"
+  if jq -e \
+      '.schemaVersion == 1 and .fixture == "tab-repos" and .requestedContentSize.width == 1040 and .requestedContentSize.height == 680 and has("outerScroll") and .outerScroll == null' \
+      "$reachability" >/dev/null \
+    && [ "$(cat "$tmp_root/reachability-check.stderr")" = "Reachability trace has no outer scroll area." ]; then
+    expected_pre_fix_failure=true
+    checker_reason_code="missing_outer_scroll"
+  fi
+fi
+jq -n \
+  --arg status "$checker_result" \
+  --arg reasonCode "$checker_reason_code" \
+  --argjson checkerFailed "$checker_failed" \
+  --argjson exitCode "$checker_status" \
+  --argjson expectedPreFixFailure "$expected_pre_fix_failure" \
+  '{schemaVersion:1,status:$status,checkerFailed:$checkerFailed,exitCode:$exitCode,expectedPreFixFailure:$expectedPreFixFailure,reasonCode:$reasonCode}' \
+  >"$output/validation/reachability-check-status.json"
+
+reachability_sha=$(shasum -a 256 "$reachability" | awk '{print $1}')
+jq -n \
+  --arg headSHA "$head_sha" \
+  --arg fixtureId "$fixture_id" \
+  --arg contentSize "$content_size" \
+  --arg reachabilitySHA256 "$reachability_sha" \
+  --arg checkerStatus "$checker_result" \
+  '{
+    schemaVersion: 1,
+    issue: 517,
+    headSHA: $headSHA,
+    fixtureId: $fixtureId,
+    contentSize: $contentSize,
+    buildConfiguration: "debug",
+    reachabilitySHA256: $reachabilitySHA256,
+    checkerStatus: $checkerStatus,
+    proofBoundary: "Focused deterministic Repos reachability dev proof outside the canonical issue 515 packet.",
+    exclusions: [
+      "Not a full fixture or viewport matrix.",
+      "Not full issue 517 interaction, layout-stability, or accessibility-conformance proof.",
+      "Not signed, notarized, installed-app, release, runtime, or customer proof."
+    ]
+  }' >"$output/focused-proof.json"
+
+node scripts/check-desktop-evaluation-packet-secrets.mjs --packet "$output" \
+  >"$tmp_root/packet-safety-scan.json"
+jq -e \
+  '.ok == true and (.findings | length) == 0 and (.sensitiveFiles | length) == 0 and (.skippedImages | index("cases/tab-repos/1040x680/screenshot.png") != null)' \
+  "$tmp_root/packet-safety-scan.json" >/dev/null
+cp "$tmp_root/packet-safety-scan.json" "$output/validation/packet-safety-scan.json"
+printf 'ok\n' >"$output/validation/packet-safety-scan.ok"
+assert_clean_head
+
+if [ "$checker_status" -ne 0 ]; then
+  echo "reachability checker failed with exit $checker_status; reachability.json was preserved" >&2
+  exit "$checker_status"
+fi
+printf '%s\n' "$output"

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -237,6 +237,8 @@ done
       "boundaryAdvertisesScrollToVisible",
       "fixture",
       "osMajorVersion",
+      "outerVerticalIncrementPageAdvertisesPress",
+      "outerVerticalIncrementPageResolved",
       "outerVerticalScrollBarAdvertisesIncrement",
       "outerVerticalScrollBarResolved",
       "requestedContentSize",
@@ -253,10 +255,14 @@ done
       if .acquisition.status == "complete" then
         .acquisition.failureReason == null
         and (.boundaryAdvertisesScrollToVisible | type == "boolean")
+        and (.outerVerticalIncrementPageAdvertisesPress | type == "boolean")
+        and (.outerVerticalIncrementPageResolved | type == "boolean")
         and (.outerVerticalScrollBarResolved | type == "boolean")
         and (.outerVerticalScrollBarAdvertisesIncrement | type == "boolean")
         and (.scrollToVisibleActionAvailable or (.boundaryAdvertisesScrollToVisible | not))
         and (.outerVerticalScrollBarResolved or (.outerVerticalScrollBarAdvertisesIncrement | not))
+        and (.outerVerticalScrollBarResolved or (.outerVerticalIncrementPageResolved | not))
+        and (.outerVerticalIncrementPageResolved or (.outerVerticalIncrementPageAdvertisesPress | not))
       elif .acquisition.status == "failed" then
         (.acquisition.failureReason as $reason | [
           "cannot-complete",
@@ -275,6 +281,8 @@ done
           "messaging-timeout-unavailable"
         ] | index($reason) != null)
         and .boundaryAdvertisesScrollToVisible == null
+        and .outerVerticalIncrementPageAdvertisesPress == null
+        and .outerVerticalIncrementPageResolved == null
         and .outerVerticalScrollBarResolved == null
         and .outerVerticalScrollBarAdvertisesIncrement == null
       else false end

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -73,7 +73,7 @@ write_focused_status() {
 
 write_focused_status incomplete setup capture_in_progress incomplete not_emitted ""
 
-tmp_root=$(/usr/bin/mktemp -d "/tmp/neondiff-desktop-repos-reachability.XXXXXXXX") \
+tmp_root=$(/usr/bin/mktemp -d "/tmp/neondiff-desktop-evaluation.XXXXXXXX") \
   || { echo "could not create private focused capture workspace" >&2; exit 65; }
 [ -d "$tmp_root" ] && [ ! -L "$tmp_root" ] \
   || { echo "focused capture workspace is not a private directory" >&2; exit 65; }
@@ -157,12 +157,34 @@ while [ ! -f "$ready" ] && kill -0 "$app_pid" 2>/dev/null && [ "$ready_attempts"
   /bin/sleep 0.1
   ready_attempts=$((ready_attempts + 1))
 done
-[ -f "$ready" ] && [ ! -L "$ready" ] \
-  || { echo "tab-repos fixture did not become ready at 1040x680" >&2; exit 1; }
+if [ ! -f "$ready" ]; then
+  if kill -0 "$app_pid" 2>/dev/null; then
+    terminate_process "$app_pid"
+    app_pid=
+    write_focused_status incomplete readiness readiness_timeout incomplete not_emitted ""
+    echo "tab-repos readiness timed out at 1040x680" >&2
+  else
+    wait "$app_pid" >/dev/null 2>&1 || true
+    app_pid=
+    write_focused_status incomplete launch fixture_launch_failed incomplete not_emitted ""
+    echo "tab-repos fixture exited before readiness at 1040x680" >&2
+  fi
+  exit 1
+fi
+[ ! -L "$ready" ] \
+  || {
+    write_focused_status incomplete readiness readiness_invalid incomplete not_emitted ""
+    echo "tab-repos readiness was not a regular private file" >&2
+    exit 1
+  }
 jq -e --arg fixture "$fixture_id" --argjson pid "$app_pid" \
   '.schemaVersion == 1 and .ready == true and .fixtureId == $fixture and .pid == $pid' \
   "$ready" >/dev/null \
-  || { echo "tab-repos readiness did not match the launched process" >&2; exit 1; }
+  || {
+    write_focused_status incomplete readiness readiness_invalid incomplete not_emitted ""
+    echo "tab-repos readiness did not match the launched process" >&2
+    exit 1
+  }
 cp "$ready" "$capture_stage/readiness.json"
 
 "$capture_bin" \

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -24,6 +24,21 @@ head_sha=$(git rev-parse HEAD)
 printf '%s\n' "$head_sha" | grep -Eq '^[0-9a-f]{40}$' \
   || { echo "could not bind focused capture to an exact HEAD" >&2; exit 65; }
 
+capture_attempt_limit=150
+if [ "${NEONDIFF_DESKTOP_TEST_MODE:-}" = 1 ]; then
+  capture_attempt_limit=${NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS:-150}
+  case "$capture_attempt_limit" in ''|*[!0-9]*)
+    echo "test capture attempt limit must be an integer from 1 through 150" >&2
+    exit 65
+  esac
+  [ "$capture_attempt_limit" -ge 1 ] && [ "$capture_attempt_limit" -le 150 ] \
+    || { echo "test capture attempt limit must be an integer from 1 through 150" >&2; exit 65; }
+elif [ -n "${NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS:-}" ]; then
+  echo "test capture attempt limit requires explicit test mode" >&2
+  exit 65
+fi
+unset NEONDIFF_DESKTOP_TEST_MODE NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS
+
 assert_clean_head() {
   current_head=$(git rev-parse HEAD 2>/dev/null || true)
   current_status=$(git status --porcelain --untracked-files=all 2>/dev/null || printf 'git-status-failed\n')
@@ -196,7 +211,7 @@ cp "$ready" "$capture_stage/readiness.json"
   2>"$tmp_root/capture.stderr" &
 capture_pid=$!
 capture_attempts=0
-while kill -0 "$capture_pid" 2>/dev/null && [ "$capture_attempts" -lt 150 ]; do
+while kill -0 "$capture_pid" 2>/dev/null && [ "$capture_attempts" -lt "$capture_attempt_limit" ]; do
   /bin/sleep 0.1
   capture_attempts=$((capture_attempts + 1))
 done

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -25,15 +25,53 @@ printf '%s\n' "$head_sha" | grep -Eq '^[0-9a-f]{40}$' \
   || { echo "could not bind focused capture to an exact HEAD" >&2; exit 65; }
 
 assert_clean_head() {
-  [ "$(git rev-parse HEAD)" = "$head_sha" ] \
-    && [ -z "$(git status --porcelain --untracked-files=all)" ] \
-    || { echo "source changed during focused capture" >&2; exit 65; }
+  current_head=$(git rev-parse HEAD 2>/dev/null || true)
+  current_status=$(git status --porcelain --untracked-files=all 2>/dev/null || printf 'git-status-failed\n')
+  if [ "$current_head" != "$head_sha" ] || [ -n "$current_status" ]; then
+    write_focused_status incomplete source source_changed incomplete not_emitted ""
+    echo "source changed during focused capture" >&2
+    exit 65
+  fi
 }
 
 mkdir -m 700 "$output" \
   || { echo "could not create fresh focused capture output" >&2; exit 65; }
-mkdir -p "$output/cases/tab-repos/1040x680" "$output/validation"
+mkdir -p "$output/cases" "$output/validation"
 case_dir="$output/cases/tab-repos/1040x680"
+status_path="$output/validation/focused-capture-status.json"
+
+render_focused_status() {
+  status_target=$1
+  status_value=$2
+  phase_value=$3
+  reason_value=$4
+  public_safety_value=$5
+  focused_proof_value=$6
+  capture_exit_value=$7
+  jq -n \
+    --arg status "$status_value" \
+    --arg phase "$phase_value" \
+    --arg reasonCode "$reason_value" \
+    --arg publicSafety "$public_safety_value" \
+    --arg focusedProof "$focused_proof_value" \
+    --arg captureExitCode "$capture_exit_value" \
+    '{
+      schemaVersion: 1,
+      status: $status,
+      phase: $phase,
+      reasonCode: $reasonCode,
+      publicSafety: $publicSafety,
+      focusedProof: $focusedProof
+    } + (if $captureExitCode == "" then {} else {captureExitCode: ($captureExitCode | tonumber)} end)' \
+    >"$status_target.tmp"
+  mv "$status_target.tmp" "$status_target"
+}
+
+write_focused_status() {
+  render_focused_status "$status_path" "$@"
+}
+
+write_focused_status incomplete setup capture_in_progress incomplete not_emitted ""
 
 tmp_root=$(/usr/bin/mktemp -d "/tmp/neondiff-desktop-repos-reachability.XXXXXXXX") \
   || { echo "could not create private focused capture workspace" >&2; exit 65; }
@@ -64,6 +102,11 @@ terminate_process() {
 cleanup() {
   if [ -n "$capture_pid" ]; then terminate_process "$capture_pid"; fi
   if [ -n "$app_pid" ]; then terminate_process "$app_pid"; fi
+  rm -f \
+    "$output/.focused-proof.json.pending" \
+    "$output/validation/.focused-capture-status.json.pending" \
+    "$output/validation/.packet-safety-scan.json.pending" \
+    "$output/validation/.packet-safety-scan.ok.pending"
   rm -rf "$tmp_root"
 }
 trap cleanup EXIT HUP INT TERM
@@ -98,13 +141,15 @@ npm run check:secrets >"$output/validation/repository-secret-scan.log" 2>&1
 ready_dir="$tmp_root/ready"
 mkdir -m 700 "$ready_dir"
 ready="$ready_dir/ready.json"
+capture_stage="$tmp_root/capture-output"
+mkdir -m 700 "$capture_stage"
 NEONDIFF_DESKTOP_EVALUATION_READY_PATH="$ready" \
   "$app_bin" \
   --ui-testing \
   --ui-fixture "$fixture" \
   --content-size "$content_size" \
   --disable-animations \
-  >"$case_dir/launch.log" 2>&1 &
+  >"$tmp_root/launch.log" 2>&1 &
 app_pid=$!
 
 ready_attempts=0
@@ -118,14 +163,14 @@ jq -e --arg fixture "$fixture_id" --argjson pid "$app_pid" \
   '.schemaVersion == 1 and .ready == true and .fixtureId == $fixture and .pid == $pid' \
   "$ready" >/dev/null \
   || { echo "tab-repos readiness did not match the launched process" >&2; exit 1; }
-cp "$ready" "$case_dir/readiness.json"
+cp "$ready" "$capture_stage/readiness.json"
 
 "$capture_bin" \
   --pid "$app_pid" \
   --ready "$ready" \
-  --output-dir "$case_dir" \
+  --output-dir "$capture_stage" \
   --repos-reachability \
-  >"$case_dir/capture.json.tmp" \
+  >"$tmp_root/capture.json" \
   2>"$tmp_root/capture.stderr" &
 capture_pid=$!
 capture_attempts=0
@@ -136,24 +181,63 @@ done
 if kill -0 "$capture_pid" 2>/dev/null; then
   terminate_process "$capture_pid"
   capture_pid=
+  write_focused_status incomplete capture capture_timeout incomplete not_emitted 124
   echo "capture helper timed out: tab-repos 1040x680" >&2
-  exit 1
+  exit 124
 fi
 capture_status=0
 wait "$capture_pid" || capture_status=$?
 capture_pid=
-mv "$case_dir/capture.json.tmp" "$case_dir/capture.json"
 if [ "$capture_status" -ne 0 ]; then
+  capture_reason="capture_failed"
+  capture_error=$(cat "$tmp_root/capture.stderr")
+  case "$capture_error" in
+    "Capture permission is unavailable: Screen Recording") capture_reason="screen_recording_unavailable" ;;
+    "Capture permission is unavailable: Accessibility") capture_reason="accessibility_unavailable" ;;
+  esac
+  write_focused_status incomplete capture "$capture_reason" incomplete not_emitted "$capture_status"
   echo "capture helper failed: tab-repos 1040x680" >&2
   exit "$capture_status"
 fi
 
-reachability="$case_dir/reachability.json"
-[ -f "$reachability" ] && [ ! -L "$reachability" ] \
-  || { echo "capture helper did not write reachability.json" >&2; exit 1; }
+for capture_file in screenshot.png accessibility.json geometry.json reachability.json readiness.json; do
+  [ -f "$capture_stage/$capture_file" ] && [ ! -L "$capture_stage/$capture_file" ] \
+    || {
+      write_focused_status incomplete capture capture_output_incomplete incomplete not_emitted 1
+      echo "capture helper did not write complete focused evidence" >&2
+      exit 1
+    }
+done
+[ -s "$tmp_root/capture.json" ] \
+  || {
+    write_focused_status incomplete capture capture_output_incomplete incomplete not_emitted 1
+    echo "capture helper did not write complete focused evidence" >&2
+    exit 1
+  }
 terminate_process "$app_pid"
 app_pid=
 assert_clean_head
+
+case_parent="$output/cases/tab-repos"
+pending_case="$case_parent/.1040x680.pending"
+mkdir -p "$case_parent"
+mkdir -m 700 "$pending_case"
+if cp "$tmp_root/launch.log" "$pending_case/launch.log" \
+  && cp "$tmp_root/capture.json" "$pending_case/capture.json" \
+  && cp "$capture_stage/readiness.json" "$pending_case/readiness.json" \
+  && cp "$capture_stage/screenshot.png" "$pending_case/screenshot.png" \
+  && cp "$capture_stage/accessibility.json" "$pending_case/accessibility.json" \
+  && cp "$capture_stage/geometry.json" "$pending_case/geometry.json" \
+  && cp "$capture_stage/reachability.json" "$pending_case/reachability.json" \
+  && mv "$pending_case" "$case_dir"; then
+  :
+else
+  rm -rf "$pending_case"
+  write_focused_status incomplete evidence evidence_publish_failed incomplete not_emitted ""
+  echo "could not publish complete focused evidence" >&2
+  exit 1
+fi
+reachability="$case_dir/reachability.json"
 
 # The pre-fix Repos tree is expected to fail this checker. Keep the capture and
 # finish the public-safety scan before returning the checker's nonzero status.
@@ -174,7 +258,7 @@ if [ "$checker_status" -ne 0 ]; then
   checker_failed=true
   checker_reason_code="checker_nonzero"
   if jq -e \
-      '.schemaVersion == 1 and .fixture == "tab-repos" and .requestedContentSize.width == 1040 and .requestedContentSize.height == 680 and has("outerScroll") and .outerScroll == null' \
+      '.schemaVersion == 1 and .fixture == "tab-repos" and .requestedContentSize.width == 1040 and .requestedContentSize.height == 680 and (.acquisition | type == "object" and .status == "complete" and has("failureReason") and .failureReason == null) and has("outerScroll") and .outerScroll == null' \
       "$reachability" >/dev/null \
     && [ "$(cat "$tmp_root/reachability-check.stderr")" = "Reachability trace has no outer scroll area." ]; then
     expected_pre_fix_failure=true
@@ -212,16 +296,56 @@ jq -n \
       "Not full issue 517 interaction, layout-stability, or accessibility-conformance proof.",
       "Not signed, notarized, installed-app, release, runtime, or customer proof."
     ]
-  }' >"$output/focused-proof.json"
+  }' >"$tmp_root/focused-proof.json"
+render_focused_status \
+  "$tmp_root/final-focused-capture-status.json" \
+  complete complete none passed emitted ""
 
-node scripts/check-desktop-evaluation-packet-secrets.mjs --packet "$output" \
-  >"$tmp_root/packet-safety-scan.json"
-jq -e \
-  '.ok == true and (.findings | length) == 0 and (.sensitiveFiles | length) == 0 and (.skippedImages | index("cases/tab-repos/1040x680/screenshot.png") != null)' \
-  "$tmp_root/packet-safety-scan.json" >/dev/null
-cp "$tmp_root/packet-safety-scan.json" "$output/validation/packet-safety-scan.json"
-printf 'ok\n' >"$output/validation/packet-safety-scan.ok"
+safety_packet="$tmp_root/safety-packet"
+mkdir -m 700 "$safety_packet"
+cp -R "$output/." "$safety_packet/"
+cp "$tmp_root/focused-proof.json" "$safety_packet/focused-proof.json"
+cp "$tmp_root/final-focused-capture-status.json" \
+  "$safety_packet/validation/focused-capture-status.json"
+safety_status=0
+if node scripts/check-desktop-evaluation-packet-secrets.mjs --packet "$safety_packet" \
+  >"$tmp_root/packet-safety-scan.json"; then
+  :
+else
+  safety_status=$?
+fi
+if [ "$safety_status" -ne 0 ] \
+  || ! jq -e \
+    '.ok == true and (.findings | length) == 0 and (.sensitiveFiles | length) == 0 and (.skippedImages | index("cases/tab-repos/1040x680/screenshot.png") != null)' \
+    "$tmp_root/packet-safety-scan.json" >/dev/null; then
+  write_focused_status incomplete public_safety public_safety_failed failed not_emitted ""
+  echo "focused evidence failed the public-safety scan" >&2
+  if [ "$safety_status" -ne 0 ]; then exit "$safety_status"; else exit 1; fi
+fi
+
 assert_clean_head
+if cp "$tmp_root/focused-proof.json" "$output/.focused-proof.json.pending" \
+  && cp "$tmp_root/final-focused-capture-status.json" \
+    "$output/validation/.focused-capture-status.json.pending" \
+  && cp "$tmp_root/packet-safety-scan.json" \
+    "$output/validation/.packet-safety-scan.json.pending" \
+  && printf 'ok\n' >"$output/validation/.packet-safety-scan.ok.pending" \
+  && mv "$output/.focused-proof.json.pending" "$output/focused-proof.json" \
+  && mv "$output/validation/.packet-safety-scan.json.pending" \
+    "$output/validation/packet-safety-scan.json" \
+  && mv "$output/validation/.packet-safety-scan.ok.pending" \
+    "$output/validation/packet-safety-scan.ok" \
+  && mv "$output/validation/.focused-capture-status.json.pending" "$status_path"; then
+  :
+else
+  rm -f \
+    "$output/focused-proof.json" \
+    "$output/validation/packet-safety-scan.json" \
+    "$output/validation/packet-safety-scan.ok"
+  write_focused_status incomplete evidence evidence_publish_failed passed not_emitted ""
+  echo "could not publish focused proof atomically" >&2
+  exit 1
+fi
 
 if [ "$checker_status" -ne 0 ]; then
   echo "reachability checker failed with exit $checker_status; reachability.json was preserved" >&2

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -326,8 +326,8 @@ fi
 reachability="$case_dir/reachability.json"
 scroll_capabilities="$case_dir/scroll-capabilities.json"
 
-# The pre-fix Repos tree is expected to fail this checker. Keep the capture and
-# finish the public-safety scan before returning the checker's nonzero status.
+# Preserve the behavior trace for diagnosis and finish the public-safety scan
+# before returning any ordinary checker failure.
 checker_status=0
 if swift run --skip-build --package-path "$package_dir" \
   NeonDiffDesktopReachabilityChecks "$reachability" \
@@ -339,26 +339,17 @@ else
   checker_result="failed"
 fi
 checker_failed=false
-expected_pre_fix_failure=false
 checker_reason_code="none"
 if [ "$checker_status" -ne 0 ]; then
   checker_failed=true
   checker_reason_code="checker_nonzero"
-  if jq -e \
-      '.schemaVersion == 1 and .fixture == "tab-repos" and .requestedContentSize.width == 1040 and .requestedContentSize.height == 680 and (.acquisition | type == "object" and .status == "complete" and has("failureReason") and .failureReason == null) and has("outerScroll") and .outerScroll == null' \
-      "$reachability" >/dev/null \
-    && [ "$(cat "$tmp_root/reachability-check.stderr")" = "Reachability trace has no outer scroll area." ]; then
-    expected_pre_fix_failure=true
-    checker_reason_code="missing_outer_scroll"
-  fi
 fi
 jq -n \
   --arg status "$checker_result" \
   --arg reasonCode "$checker_reason_code" \
   --argjson checkerFailed "$checker_failed" \
   --argjson exitCode "$checker_status" \
-  --argjson expectedPreFixFailure "$expected_pre_fix_failure" \
-  '{schemaVersion:1,status:$status,checkerFailed:$checkerFailed,exitCode:$exitCode,expectedPreFixFailure:$expectedPreFixFailure,reasonCode:$reasonCode}' \
+  '{schemaVersion:1,status:$status,checkerFailed:$checkerFailed,exitCode:$exitCode,reasonCode:$reasonCode}' \
   >"$output/validation/reachability-check-status.json"
 
 reachability_sha=$(shasum -a 256 "$reachability" | awk '{print $1}')

--- a/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
+++ b/apps/neondiff-desktop/scripts/capture-repos-reachability.sh
@@ -222,7 +222,7 @@ if [ "$capture_status" -ne 0 ]; then
   exit "$capture_status"
 fi
 
-for capture_file in screenshot.png accessibility.json geometry.json reachability.json readiness.json; do
+for capture_file in screenshot.png accessibility.json geometry.json reachability.json scroll-capabilities.json readiness.json; do
   [ -f "$capture_stage/$capture_file" ] && [ ! -L "$capture_stage/$capture_file" ] \
     || {
       write_focused_status incomplete capture capture_output_incomplete incomplete not_emitted 1
@@ -230,6 +230,46 @@ for capture_file in screenshot.png accessibility.json geometry.json reachability
       exit 1
     }
 done
+[ "$(wc -c <"$capture_stage/scroll-capabilities.json")" -le 4096 ] \
+  && jq -e '
+    keys == [
+      "acquisition",
+      "boundaryAdvertisesScrollToVisible",
+      "fixture",
+      "osMajorVersion",
+      "outerVerticalScrollBarAdvertisesIncrement",
+      "outerVerticalScrollBarResolved",
+      "requestedContentSize",
+      "schemaVersion",
+      "scrollToVisibleActionAvailable"
+    ]
+    and .schemaVersion == 1
+    and .fixture == "tab-repos"
+    and .requestedContentSize == {"width":1040,"height":680}
+    and (.osMajorVersion | type == "number" and . >= 1 and . <= 100 and floor == .)
+    and .scrollToVisibleActionAvailable == (.osMajorVersion >= 26)
+    and (.acquisition | type == "object" and keys == ["failureReason", "status"])
+    and (
+      if .acquisition.status == "complete" then
+        .acquisition.failureReason == null
+        and (.boundaryAdvertisesScrollToVisible | type == "boolean")
+        and (.outerVerticalScrollBarResolved | type == "boolean")
+        and (.outerVerticalScrollBarAdvertisesIncrement | type == "boolean")
+        and (.scrollToVisibleActionAvailable or (.boundaryAdvertisesScrollToVisible | not))
+        and (.outerVerticalScrollBarResolved or (.outerVerticalScrollBarAdvertisesIncrement | not))
+      elif .acquisition.status == "failed" then
+        (.acquisition.failureReason | type == "string" and length > 0)
+        and .boundaryAdvertisesScrollToVisible == null
+        and .outerVerticalScrollBarResolved == null
+        and .outerVerticalScrollBarAdvertisesIncrement == null
+      else false end
+    )
+  ' "$capture_stage/scroll-capabilities.json" >/dev/null \
+  || {
+    write_focused_status incomplete capture capture_output_incomplete incomplete not_emitted 1
+    echo "capture helper wrote invalid sanitized scroll capabilities" >&2
+    exit 1
+  }
 [ -s "$tmp_root/capture.json" ] \
   || {
     write_focused_status incomplete capture capture_output_incomplete incomplete not_emitted 1
@@ -251,6 +291,7 @@ if cp "$tmp_root/launch.log" "$pending_case/launch.log" \
   && cp "$capture_stage/accessibility.json" "$pending_case/accessibility.json" \
   && cp "$capture_stage/geometry.json" "$pending_case/geometry.json" \
   && cp "$capture_stage/reachability.json" "$pending_case/reachability.json" \
+  && cp "$capture_stage/scroll-capabilities.json" "$pending_case/scroll-capabilities.json" \
   && mv "$pending_case" "$case_dir"; then
   :
 else
@@ -260,6 +301,7 @@ else
   exit 1
 fi
 reachability="$case_dir/reachability.json"
+scroll_capabilities="$case_dir/scroll-capabilities.json"
 
 # The pre-fix Repos tree is expected to fail this checker. Keep the capture and
 # finish the public-safety scan before returning the checker's nonzero status.
@@ -297,11 +339,13 @@ jq -n \
   >"$output/validation/reachability-check-status.json"
 
 reachability_sha=$(shasum -a 256 "$reachability" | awk '{print $1}')
+scroll_capabilities_sha=$(shasum -a 256 "$scroll_capabilities" | awk '{print $1}')
 jq -n \
   --arg headSHA "$head_sha" \
   --arg fixtureId "$fixture_id" \
   --arg contentSize "$content_size" \
   --arg reachabilitySHA256 "$reachability_sha" \
+  --arg scrollCapabilitiesSHA256 "$scroll_capabilities_sha" \
   --arg checkerStatus "$checker_result" \
   '{
     schemaVersion: 1,
@@ -311,6 +355,7 @@ jq -n \
     contentSize: $contentSize,
     buildConfiguration: "debug",
     reachabilitySHA256: $reachabilitySHA256,
+    scrollCapabilitiesSHA256: $scrollCapabilitiesSHA256,
     checkerStatus: $checkerStatus,
     proofBoundary: "Focused deterministic Repos reachability dev proof outside the canonical issue 515 packet.",
     exclusions: [

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -25,6 +25,7 @@ const SWIFT_ROOT_FILES = new Set([
   "scripts/shared/swift-corpus-boundary.mjs",
   "scripts/check-desktop-fixture-boundary.mjs",
   "tests/desktop-evaluation-boundary.test.ts",
+  "tests/desktop-repos-reachability-capture.test.ts",
   "scripts/secret-rule-foundation-runner.swift"
 ]);
 

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -45,12 +45,14 @@ function createFakeHarnessRepository(): {
   const output = join(root, "evidence");
   const commandLog = join(root, "commands.log");
   const appTemplate = join(root, "fake-app");
+  const gitState = join(root, "git-state");
   mkdirSync(fakeBin, { recursive: true });
   mkdirSync(swiftBin, { recursive: true });
   mkdirSync(join(root, "apps/neondiff-desktop/scripts"), { recursive: true });
   mkdirSync(join(root, "apps/neondiff-desktop/script"), { recursive: true });
   mkdirSync(join(root, "apps/neondiff-desktop/fixtures/ui"), { recursive: true });
   mkdirSync(join(root, "scripts"), { recursive: true });
+  mkdirSync(gitState, { recursive: true });
 
   writeFileSync(join(root, scriptPath), readFileSync(scriptPath));
   chmodSync(join(root, scriptPath), 0o755);
@@ -59,6 +61,7 @@ function createFakeHarnessRepository(): {
   writeExecutable(appTemplate, `#!/bin/sh
 set -eu
 printf 'app %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+printf 'app-pid %s\\n' "$$" >>"$FAKE_COMMAND_LOG"
 ready=\${NEONDIFF_DESKTOP_EVALUATION_READY_PATH:?}
 printf '{"schemaVersion":1,"fixtureId":"tab-repos","pid":%s,"windowNumber":41,"windowFrame":{"x":0,"y":0,"width":1040,"height":702},"contentFrame":{"x":0,"y":22,"width":1040,"height":680},"backingScale":2,"ready":true}\\n' "$$" >"$ready"
 trap 'exit 0' HUP INT TERM
@@ -78,8 +81,26 @@ chmod +x "$app"
 set -eu
 printf 'git %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
 case "$*" in
-  'status --porcelain --untracked-files=all') exit 0 ;;
-  'rev-parse HEAD') printf '%040d\\n' 0; exit 0 ;;
+  'status --porcelain --untracked-files=all')
+    count=0
+    [ ! -f "$FAKE_GIT_STATE/status-count" ] || count=$(cat "$FAKE_GIT_STATE/status-count")
+    count=$((count + 1))
+    printf '%s\\n' "$count" >"$FAKE_GIT_STATE/status-count"
+    if [ "\${FAKE_GIT_DIRTY_STATUS_CALL:-0}" -eq "$count" ]; then printf ' M drifted-file\\n'; fi
+    exit 0
+    ;;
+  'rev-parse HEAD')
+    count=0
+    [ ! -f "$FAKE_GIT_STATE/head-count" ] || count=$(cat "$FAKE_GIT_STATE/head-count")
+    count=$((count + 1))
+    printf '%s\\n' "$count" >"$FAKE_GIT_STATE/head-count"
+    if [ "\${FAKE_GIT_HEAD_DRIFT_CALL:-0}" -eq "$count" ]; then
+      printf '%039d1\\n' 0
+    else
+      printf '%040d\\n' 0
+    fi
+    exit 0
+    ;;
 esac
 exit 2
 `);
@@ -93,7 +114,12 @@ printf 'repository secret scan passed\\n'
   writeExecutable(join(fakeBin, "node"), `#!/bin/sh
 set -eu
 printf 'node %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
-printf '%s\\n' '{"ok":true,"skippedImages":["cases/tab-repos/1040x680/screenshot.png"],"findings":[],"sensitiveFiles":[]}'
+if [ "\${FAKE_SAFETY_SCAN_OK:-true}" = true ]; then
+  printf '%s\\n' '{"ok":true,"skippedImages":["cases/tab-repos/1040x680/screenshot.png"],"findings":[],"sensitiveFiles":[]}'
+  exit 0
+fi
+printf '%s\\n' '{"ok":false,"skippedImages":["cases/tab-repos/1040x680/screenshot.png"],"findings":[{"rule":"redacted"}],"sensitiveFiles":[]}'
+exit 9
 `);
 
   writeExecutable(join(fakeBin, "swift"), `#!/bin/sh
@@ -104,8 +130,12 @@ case " $* " in
 esac
 if [ "$1" = build ]; then exit 0; fi
 if [ "$1" = run ]; then
-  printf '%s\\n' '{"ok":false,"failure":"missing outer AXScrollArea ancestor"}'
-  printf '%s\\n' "\${FAKE_CHECKER_MESSAGE:-Reachability trace has no outer scroll area.}" >&2
+  if [ "\${FAKE_CHECKER_STATUS:-0}" -eq 0 ]; then
+    printf '%s\\n' '{"ok":true}'
+  else
+    printf '%s\\n' '{"ok":false,"failure":"missing outer AXScrollArea ancestor"}'
+  fi
+  if [ -n "\${FAKE_CHECKER_MESSAGE:-}" ]; then printf '%s\\n' "$FAKE_CHECKER_MESSAGE" >&2; fi
   exit "\${FAKE_CHECKER_STATUS:-0}"
 fi
 exit 2
@@ -122,11 +152,22 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ "\${repos_reachability:-false}" = true ] || exit 64
+printf 'capture-pid %s\\n' "$$" >>"$FAKE_COMMAND_LOG"
+if [ "\${FAKE_CAPTURE_HANG:-false}" = true ]; then
+  trap 'exit 0' HUP INT TERM
+  while :; do /bin/sleep 0.1; done
+fi
 printf 'png' >"$output_dir/screenshot.png"
 printf '%s\\n' '{"role":"AXWindow","children":[]}' >"$output_dir/accessibility.json"
 printf '%s\\n' '{"schemaVersion":1,"fixtureId":"tab-repos"}' >"$output_dir/geometry.json"
-printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"outerScroll":null}' >"$output_dir/reachability.json"
+printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"acquisition":{"status":"%s","failureReason":%s},"outerScroll":null}\\n' \\
+  "\${FAKE_ACQUISITION_STATUS:-complete}" "\${FAKE_ACQUISITION_FAILURE_REASON:-null}" \\
+  >"$output_dir/reachability.json"
 printf '%s\\n' '{"ok":true,"fixtureId":"tab-repos"}'
+if [ "\${FAKE_CAPTURE_STATUS:-0}" -ne 0 ]; then
+  if [ -n "\${FAKE_CAPTURE_MESSAGE:-}" ]; then printf '%s\\n' "$FAKE_CAPTURE_MESSAGE" >&2; fi
+  exit "$FAKE_CAPTURE_STATUS"
+fi
 `);
 
   return {
@@ -140,9 +181,50 @@ printf '%s\\n' '{"ok":true,"fixtureId":"tab-repos"}'
       FAKE_COMMAND_LOG: commandLog,
       FAKE_SWIFT_BIN: swiftBin,
       FAKE_CHECKER_STATUS: "7",
-      FAKE_CHECKER_MESSAGE: "Reachability trace has no outer scroll area."
+      FAKE_CHECKER_MESSAGE: "Reachability trace has no outer scroll area.",
+      FAKE_CAPTURE_STATUS: "0",
+      FAKE_CAPTURE_MESSAGE: "",
+      FAKE_CAPTURE_HANG: "false",
+      FAKE_ACQUISITION_STATUS: "complete",
+      FAKE_ACQUISITION_FAILURE_REASON: "null",
+      FAKE_SAFETY_SCAN_OK: "true",
+      FAKE_GIT_STATE: gitState,
+      FAKE_GIT_DIRTY_STATUS_CALL: "0",
+      FAKE_GIT_HEAD_DRIFT_CALL: "0"
     }
   };
+}
+
+function runHarness(harness: ReturnType<typeof createFakeHarnessRepository>, overrides: NodeJS.ProcessEnv = {}) {
+  return spawnSync(join(harness.root, scriptPath), ["--output", harness.output], {
+    cwd: harness.root,
+    encoding: "utf8",
+    env: { ...harness.env, ...overrides },
+    timeout: 25_000
+  });
+}
+
+function focusedStatus(harness: ReturnType<typeof createFakeHarnessRepository>): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(harness.output, "validation/focused-capture-status.json"), "utf8"));
+}
+
+function expectNoFinalProof(harness: ReturnType<typeof createFakeHarnessRepository>): void {
+  expect(existsSync(join(harness.output, "focused-proof.json"))).toBe(false);
+  expect(existsSync(join(harness.output, "validation/packet-safety-scan.ok"))).toBe(false);
+}
+
+function launchedPID(harness: ReturnType<typeof createFakeHarnessRepository>): number {
+  const commands = readFileSync(harness.commandLog, "utf8");
+  const match = commands.match(/^app-pid (\d+)$/m);
+  expect(match).not.toBeNull();
+  return Number(match?.[1]);
+}
+
+function capturePID(harness: ReturnType<typeof createFakeHarnessRepository>): number {
+  const commands = readFileSync(harness.commandLog, "utf8");
+  const match = commands.match(/^capture-pid (\d+)$/m);
+  expect(match).not.toBeNull();
+  return Number(match?.[1]);
 }
 
 describe("focused Repos reachability capture", () => {
@@ -179,6 +261,7 @@ describe("focused Repos reachability capture", () => {
 
   it("builds one DEBUG app, capture helper, and checker and launches only the Repos fixture", () => {
     const script = readFileSync(scriptPath, "utf8");
+    const canonical = readFileSync("apps/neondiff-desktop/scripts/capture-evaluation-baseline.sh", "utf8");
     expect(script.match(/build_and_run\.sh" build/g)).toHaveLength(1);
     expect(script.match(/--product NeonDiffDesktopCapture/g)).toHaveLength(1);
     expect(script.match(/--product NeonDiffDesktopReachabilityChecks/g)).toHaveLength(1);
@@ -187,6 +270,7 @@ describe("focused Repos reachability capture", () => {
     expect(appLaunch).toMatch(/--ui-fixture "\$fixture"[\s\S]*--content-size "\$content_size"[\s\S]*--disable-animations/);
     expect(appLaunch).not.toContain("--repos-reachability");
     expect(captureLaunch).toContain("--repos-reachability");
+    expect(canonical).not.toContain("--repos-reachability");
     expect(script).not.toMatch(/for\s+size\s+in/);
     expect(script).not.toContain("1280x800");
     expect(script).not.toContain("1440x900");
@@ -197,12 +281,7 @@ describe("focused Repos reachability capture", () => {
     { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
-      const result = spawnSync(join(harness.root, scriptPath), ["--output", harness.output], {
-        cwd: harness.root,
-        encoding: "utf8",
-        env: harness.env,
-        timeout: 25_000
-      });
+      const result = runHarness(harness);
 
       expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
       const commandTrace = existsSync(harness.commandLog) ? readFileSync(harness.commandLog, "utf8") : "";
@@ -244,12 +323,7 @@ describe("focused Repos reachability capture", () => {
     { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
-      const result = spawnSync(join(harness.root, scriptPath), ["--output", harness.output], {
-        cwd: harness.root,
-        encoding: "utf8",
-        env: { ...harness.env, FAKE_CHECKER_MESSAGE: "Reachability trace schema is invalid." },
-        timeout: 25_000
-      });
+      const result = runHarness(harness, { FAKE_CHECKER_MESSAGE: "Reachability trace schema is invalid." });
 
       expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
@@ -260,6 +334,193 @@ describe("focused Repos reachability capture", () => {
           expectedPreFixFailure: false,
           reasonCode: "checker_nonzero"
         });
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "does not classify failed acquisition as the expected missing-scroll result",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, {
+        FAKE_ACQUISITION_STATUS: "failed",
+        FAKE_ACQUISITION_FAILURE_REASON: '"semantic-missing"'
+      });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
+      expect(JSON.parse(readFileSync(
+        join(harness.output, "cases/tab-repos/1040x680/reachability.json"),
+        "utf8"
+      ))).toMatchObject({ acquisition: { status: "failed", failureReason: "semantic-missing" }, outerScroll: null });
+      expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
+        .toMatchObject({
+          checkerFailed: true,
+          exitCode: 7,
+          expectedPreFixFailure: false,
+          reasonCode: "checker_nonzero"
+        });
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "rejects capture partials and normalizes a Screen Recording failure without raw stderr",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, {
+        FAKE_CAPTURE_STATUS: "13",
+        FAKE_CAPTURE_MESSAGE: "Capture permission is unavailable: Screen Recording"
+      });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(13);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "capture",
+        reasonCode: "screen_recording_unavailable",
+        captureExitCode: 13,
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expect(existsSync(join(harness.output, "validation/capture.stderr"))).toBe(false);
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "terminates timed-out capture and app processes without publishing partials",
+    { timeout: 25_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_CAPTURE_HANG: "true" });
+
+      expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(124);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "capture",
+        reasonCode: "capture_timeout",
+        captureExitCode: 124,
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expect(() => process.kill(capturePID(harness), 0)).toThrow();
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "keeps proof incomplete when the public-safety scan fails",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, {
+        FAKE_CHECKER_STATUS: "0",
+        FAKE_CHECKER_MESSAGE: "",
+        FAKE_SAFETY_SCAN_OK: "false"
+      });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(9);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "public_safety",
+        reasonCode: "public_safety_failed",
+        publicSafety: "failed",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "validation/packet-safety-scan.json"))).toBe(false);
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "records source drift as incomplete before launching the fixture",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_GIT_DIRTY_STATUS_CALL: "2" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(65);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "source",
+        reasonCode: "source_changed",
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(readFileSync(harness.commandLog, "utf8")).not.toMatch(/^app /m);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "records exact-HEAD drift as incomplete before launching the fixture",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_GIT_HEAD_DRIFT_CALL: "2" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(65);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "source",
+        reasonCode: "source_changed",
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(readFileSync(harness.commandLog, "utf8")).not.toMatch(/^app /m);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "does not publish proof when source drift is detected after the safety gate",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, {
+        FAKE_CHECKER_STATUS: "0",
+        FAKE_CHECKER_MESSAGE: "",
+        FAKE_GIT_DIRTY_STATUS_CALL: "4"
+      });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(65);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "source",
+        reasonCode: "source_changed",
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "validation/packet-safety-scan.json"))).toBe(false);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "emits final proof only after a green checker and passing safety scan",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_CHECKER_STATUS: "0", FAKE_CHECKER_MESSAGE: "" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "complete",
+        phase: "complete",
+        reasonCode: "none",
+        publicSafety: "passed",
+        focusedProof: "emitted"
+      });
+      expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
+        .toMatchObject({ checkerFailed: false, exitCode: 0, expectedPreFixFailure: false, reasonCode: "none" });
+      expect(existsSync(join(harness.output, "focused-proof.json"))).toBe(true);
+      expect(existsSync(join(harness.output, "validation/packet-safety-scan.ok"))).toBe(true);
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
     }
   );
 

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -1,0 +1,280 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const scriptPath = "apps/neondiff-desktop/scripts/capture-repos-reachability.sh";
+const testPath = "tests/desktop-repos-reachability-capture.test.ts";
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function writeExecutable(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+function swiftAffected(files: string[]): { affected: boolean; matched: string[] } {
+  return JSON.parse(
+    execFileSync("node", ["scripts/swift-affected.mjs", "--files", ...files], { encoding: "utf8" })
+  );
+}
+
+function createFakeHarnessRepository(): {
+  root: string;
+  output: string;
+  env: NodeJS.ProcessEnv;
+  commandLog: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-repos-capture-test-"));
+  roots.push(root);
+  const fakeBin = join(root, "fake-bin");
+  const swiftBin = join(root, "swift-bin");
+  const output = join(root, "evidence");
+  const commandLog = join(root, "commands.log");
+  const appTemplate = join(root, "fake-app");
+  mkdirSync(fakeBin, { recursive: true });
+  mkdirSync(swiftBin, { recursive: true });
+  mkdirSync(join(root, "apps/neondiff-desktop/scripts"), { recursive: true });
+  mkdirSync(join(root, "apps/neondiff-desktop/script"), { recursive: true });
+  mkdirSync(join(root, "apps/neondiff-desktop/fixtures/ui"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+
+  writeFileSync(join(root, scriptPath), readFileSync(scriptPath));
+  chmodSync(join(root, scriptPath), 0o755);
+  writeFileSync(join(root, "apps/neondiff-desktop/fixtures/ui/tab-repos.json"), '{"id":"tab-repos"}\n');
+
+  writeExecutable(appTemplate, `#!/bin/sh
+set -eu
+printf 'app %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+ready=\${NEONDIFF_DESKTOP_EVALUATION_READY_PATH:?}
+printf '{"schemaVersion":1,"fixtureId":"tab-repos","pid":%s,"windowNumber":41,"windowFrame":{"x":0,"y":0,"width":1040,"height":702},"contentFrame":{"x":0,"y":22,"width":1040,"height":680},"backingScale":2,"ready":true}\\n' "$$" >"$ready"
+trap 'exit 0' HUP INT TERM
+while :; do /bin/sleep 0.1; done
+`);
+
+  writeExecutable(join(root, "apps/neondiff-desktop/script/build_and_run.sh"), `#!/bin/sh
+set -eu
+printf 'build-app %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+app="$NEONDIFF_DESKTOP_DIST_DIR/NeonDiffDesktop.app/Contents/MacOS/NeonDiffDesktop"
+mkdir -p "$(dirname "$app")"
+cp "$FAKE_APP_TEMPLATE" "$app"
+chmod +x "$app"
+`);
+
+  writeExecutable(join(fakeBin, "git"), `#!/bin/sh
+set -eu
+printf 'git %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+case "$*" in
+  'status --porcelain --untracked-files=all') exit 0 ;;
+  'rev-parse HEAD') printf '%040d\\n' 0; exit 0 ;;
+esac
+exit 2
+`);
+
+  writeExecutable(join(fakeBin, "npm"), `#!/bin/sh
+set -eu
+printf 'npm %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+printf 'repository secret scan passed\\n'
+`);
+
+  writeExecutable(join(fakeBin, "node"), `#!/bin/sh
+set -eu
+printf 'node %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+printf '%s\\n' '{"ok":true,"skippedImages":["cases/tab-repos/1040x680/screenshot.png"],"findings":[],"sensitiveFiles":[]}'
+`);
+
+  writeExecutable(join(fakeBin, "swift"), `#!/bin/sh
+set -eu
+printf 'swift %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+case " $* " in
+  *' --show-bin-path '*) printf '%s\\n' "$FAKE_SWIFT_BIN"; exit 0 ;;
+esac
+if [ "$1" = build ]; then exit 0; fi
+if [ "$1" = run ]; then
+  printf '%s\\n' '{"ok":false,"failure":"missing outer AXScrollArea ancestor"}'
+  printf '%s\\n' "\${FAKE_CHECKER_MESSAGE:-Reachability trace has no outer scroll area.}" >&2
+  exit "\${FAKE_CHECKER_STATUS:-0}"
+fi
+exit 2
+`);
+
+  writeExecutable(join(swiftBin, "NeonDiffDesktopCapture"), `#!/bin/sh
+set -eu
+printf 'capture %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-dir) output_dir=$2; shift 2 ;;
+    --repos-reachability) repos_reachability=true; shift ;;
+    *) shift ;;
+  esac
+done
+[ "\${repos_reachability:-false}" = true ] || exit 64
+printf 'png' >"$output_dir/screenshot.png"
+printf '%s\\n' '{"role":"AXWindow","children":[]}' >"$output_dir/accessibility.json"
+printf '%s\\n' '{"schemaVersion":1,"fixtureId":"tab-repos"}' >"$output_dir/geometry.json"
+printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"outerScroll":null}' >"$output_dir/reachability.json"
+printf '%s\\n' '{"ok":true,"fixtureId":"tab-repos"}'
+`);
+
+  return {
+    root,
+    output,
+    commandLog,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      FAKE_APP_TEMPLATE: appTemplate,
+      FAKE_COMMAND_LOG: commandLog,
+      FAKE_SWIFT_BIN: swiftBin,
+      FAKE_CHECKER_STATUS: "7",
+      FAKE_CHECKER_MESSAGE: "Reachability trace has no outer scroll area."
+    }
+  };
+}
+
+describe("focused Repos reachability capture", () => {
+  it("rejects relative or pre-existing output before capture", () => {
+    const relative = spawnSync(scriptPath, ["--output", "relative-evidence"], { encoding: "utf8" });
+    expect(relative.status).toBe(64);
+    expect(relative.stderr).toMatch(/usage:/);
+
+    const existing = mkdtempSync(join(tmpdir(), "neondiff-existing-repos-capture-"));
+    roots.push(existing);
+    const collision = spawnSync(scriptPath, ["--output", existing], { encoding: "utf8" });
+    expect(collision.status).toBe(65);
+    expect(collision.stderr).toContain("focused capture output must not already exist");
+  });
+
+  it("defines a syntactically valid, exact-HEAD, private focused harness", () => {
+    const syntax = spawnSync("sh", ["-n", scriptPath], { encoding: "utf8" });
+    expect(syntax.status, syntax.stderr).toBe(0);
+
+    const script = readFileSync(scriptPath, "utf8");
+    expect(script).toContain("umask 077");
+    expect(script).toMatch(/mktemp -d [^\n]*\/tmp\/neondiff-desktop-repos-reachability/);
+    expect(script).toContain("canonical focused capture requires a clean worktree");
+    expect(script).toContain("assert_clean_head");
+    expect(script).toContain('fixture_id="tab-repos"');
+    expect(script).toContain('content_size="1040x680"');
+    expect(script).toContain("NEONDIFF_DESKTOP_EVALUATION_READY_PATH");
+    expect(script).toContain("capture helper timed out");
+    expect(script).toContain("kill -KILL");
+    expect(script).toContain("npm run check:secrets");
+    expect(script).toContain("check-desktop-evaluation-packet-secrets.mjs");
+    expect(script).not.toMatch(/\bsecurity\s+find-|\blaunchctl\b|\bdefaults\s+(?:read|write)\b/);
+  });
+
+  it("builds one DEBUG app, capture helper, and checker and launches only the Repos fixture", () => {
+    const script = readFileSync(scriptPath, "utf8");
+    expect(script.match(/build_and_run\.sh" build/g)).toHaveLength(1);
+    expect(script.match(/--product NeonDiffDesktopCapture/g)).toHaveLength(1);
+    expect(script.match(/--product NeonDiffDesktopReachabilityChecks/g)).toHaveLength(1);
+    const appLaunch = script.match(/NEONDIFF_DESKTOP_EVALUATION_READY_PATH[\s\S]*?app_pid=\$!/)?.[0];
+    const captureLaunch = script.match(/"\$capture_bin"[\s\S]*?capture_pid=\$!/)?.[0];
+    expect(appLaunch).toMatch(/--ui-fixture "\$fixture"[\s\S]*--content-size "\$content_size"[\s\S]*--disable-animations/);
+    expect(appLaunch).not.toContain("--repos-reachability");
+    expect(captureLaunch).toContain("--repos-reachability");
+    expect(script).not.toMatch(/for\s+size\s+in/);
+    expect(script).not.toContain("1280x800");
+    expect(script).not.toContain("1440x900");
+  });
+
+  it.runIf(process.platform === "darwin")(
+    "preserves reachability and public-safe status evidence when the checker reports the expected pre-fix failure",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = spawnSync(join(harness.root, scriptPath), ["--output", harness.output], {
+        cwd: harness.root,
+        encoding: "utf8",
+        env: harness.env,
+        timeout: 25_000
+      });
+
+      expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
+      const commandTrace = existsSync(harness.commandLog) ? readFileSync(harness.commandLog, "utf8") : "";
+      expect(result.status, `${result.stderr}\n${result.stdout}\n${commandTrace}`).toBe(7);
+      const caseRoot = join(harness.output, "cases/tab-repos/1040x680");
+      expect(JSON.parse(readFileSync(join(caseRoot, "reachability.json"), "utf8"))).toMatchObject({
+        fixture: "tab-repos",
+        requestedContentSize: { width: 1040, height: 680 },
+        outerScroll: null
+      });
+      expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
+        .toMatchObject({
+          status: "failed",
+          checkerFailed: true,
+          exitCode: 7,
+          expectedPreFixFailure: true,
+          reasonCode: "missing_outer_scroll"
+        });
+      expect(JSON.parse(readFileSync(join(harness.output, "validation/packet-safety-scan.json"), "utf8")))
+        .toMatchObject({ ok: true, findings: [], sensitiveFiles: [] });
+      expect(existsSync(join(harness.output, "validation/reachability-check.stderr"))).toBe(false);
+
+      const ready = JSON.parse(readFileSync(join(caseRoot, "readiness.json"), "utf8"));
+      expect(() => process.kill(ready.pid, 0)).toThrow();
+
+      const commands = commandTrace;
+      expect(commands.match(/build-app build/g)).toHaveLength(1);
+      expect(commands.match(/swift build .*--product NeonDiffDesktopCapture/g)).toHaveLength(1);
+      expect(commands.match(/swift build .*--product NeonDiffDesktopReachabilityChecks/g)).toHaveLength(1);
+      expect(commands).toMatch(/app --ui-testing --ui-fixture .*tab-repos\.json --content-size 1040x680 --disable-animations/);
+      expect(commands).not.toMatch(/app .*--repos-reachability/);
+      expect(commands).toMatch(/capture .*--output-dir .* --repos-reachability/);
+      expect(commands).toMatch(/swift run --skip-build --package-path .* NeonDiffDesktopReachabilityChecks .*reachability\.json/);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "does not classify an unrelated checker failure as the expected pre-fix result",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = spawnSync(join(harness.root, scriptPath), ["--output", harness.output], {
+        cwd: harness.root,
+        encoding: "utf8",
+        env: { ...harness.env, FAKE_CHECKER_MESSAGE: "Reachability trace schema is invalid." },
+        timeout: 25_000
+      });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
+      expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
+        .toMatchObject({
+          status: "failed",
+          checkerFailed: true,
+          exitCode: 7,
+          expectedPreFixFailure: false,
+          reasonCode: "checker_nonzero"
+        });
+    }
+  );
+
+  it("routes the focused harness contract through the Swift desktop gate", () => {
+    expect(swiftAffected([testPath])).toMatchObject({ affected: true, matched: [testPath] });
+  });
+
+  it("documents a partial #517 dev proof outside the canonical #515 packet", () => {
+    const docs = readFileSync("apps/neondiff-desktop/docs/ui-evaluation.md", "utf8");
+    expect(docs).toMatch(/focused partial #517 proof/i);
+    expect(docs).toMatch(/outside the canonical #515 packet/i);
+    expect(docs).toMatch(/missing outer `AXScrollArea` ancestor/i);
+    expect(docs).toMatch(/Table scroll/i);
+    expect(docs).toMatch(/checker failure preserves `reachability\.json`/i);
+    expect(docs).toMatch(/TCC/i);
+    expect(docs).toMatch(/does not prove/i);
+  });
+});

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -173,7 +173,15 @@ printf '%s\\n' '{"schemaVersion":1,"fixtureId":"tab-repos"}' >"$output_dir/geome
 printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"acquisition":{"status":"%s","failureReason":%s},"outerScroll":null}\\n' \\
   "\${FAKE_ACQUISITION_STATUS:-complete}" "\${FAKE_ACQUISITION_FAILURE_REASON:-null}" \\
   >"$output_dir/reachability.json"
-printf '%s\\n' '{"ok":true,"fixtureId":"tab-repos"}'
+case "\${FAKE_CAPABILITIES_MODE:-valid}" in
+  valid)
+    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false}' \\
+      >"$output_dir/scroll-capabilities.json"
+    ;;
+  invalid) printf '%s\\n' '{}' >"$output_dir/scroll-capabilities.json" ;;
+  missing) ;;
+esac
+printf '%s\\n' '{"ok":true,"fixtureId":"tab-repos","scrollCapabilities":{"path":"scroll-capabilities.json","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}'
 if [ "\${FAKE_CAPTURE_STATUS:-0}" -ne 0 ]; then
   if [ -n "\${FAKE_CAPTURE_MESSAGE:-}" ]; then printf '%s\\n' "$FAKE_CAPTURE_MESSAGE" >&2; fi
   exit "$FAKE_CAPTURE_STATUS"
@@ -198,6 +206,7 @@ fi
       FAKE_CAPTURE_HANG: "false",
       FAKE_ACQUISITION_STATUS: "complete",
       FAKE_ACQUISITION_FAILURE_REASON: "null",
+      FAKE_CAPABILITIES_MODE: "valid",
       FAKE_SAFETY_SCAN_OK: "true",
       FAKE_GIT_STATE: gitState,
       FAKE_GIT_DIRTY_STATUS_CALL: "0",
@@ -304,6 +313,19 @@ describe("focused Repos reachability capture", () => {
         requestedContentSize: { width: 1040, height: 680 },
         outerScroll: null
       });
+      expect(JSON.parse(readFileSync(join(caseRoot, "scroll-capabilities.json"), "utf8"))).toEqual({
+        schemaVersion: 1,
+        fixture: "tab-repos",
+        requestedContentSize: { width: 1040, height: 680 },
+        osMajorVersion: 26,
+        acquisition: { status: "complete", failureReason: null },
+        scrollToVisibleActionAvailable: true,
+        boundaryAdvertisesScrollToVisible: false,
+        outerVerticalScrollBarResolved: true,
+        outerVerticalScrollBarAdvertisesIncrement: false
+      });
+      expect(JSON.parse(readFileSync(join(caseRoot, "capture.json"), "utf8")))
+        .toMatchObject({ scrollCapabilities: { path: "scroll-capabilities.json", sha256: expect.any(String) } });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
         .toMatchObject({
           status: "failed",
@@ -314,6 +336,8 @@ describe("focused Repos reachability capture", () => {
         });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/packet-safety-scan.json"), "utf8")))
         .toMatchObject({ ok: true, findings: [], sensitiveFiles: [] });
+      expect(JSON.parse(readFileSync(join(harness.output, "focused-proof.json"), "utf8"))
+        .scrollCapabilitiesSHA256).toMatch(/^[a-f0-9]{64}$/);
       expect(existsSync(join(harness.output, "validation/reachability-check.stderr"))).toBe(false);
 
       const ready = JSON.parse(readFileSync(join(caseRoot, "readiness.json"), "utf8"));
@@ -327,6 +351,44 @@ describe("focused Repos reachability capture", () => {
       expect(commands).not.toMatch(/app .*--repos-reachability/);
       expect(commands).toMatch(/capture .*--output-dir .* --repos-reachability/);
       expect(commands).toMatch(/swift run --skip-build --package-path .* NeonDiffDesktopReachabilityChecks .*reachability\.json/);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "rejects a capture that omits the sanitized scroll capability artifact",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_CAPABILITIES_MODE: "missing" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "capture",
+        reasonCode: "capture_output_incomplete",
+        focusedProof: "not_emitted"
+      });
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expectNoFinalProof(harness);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "rejects a malformed sanitized scroll capability artifact",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_CAPABILITIES_MODE: "invalid" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "capture",
+        reasonCode: "capture_output_incomplete",
+        focusedProof: "not_emitted"
+      });
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expectNoFinalProof(harness);
     }
   );
 
@@ -593,6 +655,8 @@ describe("focused Repos reachability capture", () => {
     expect(docs).toMatch(/missing outer `AXScrollArea` ancestor/i);
     expect(docs).toMatch(/Table scroll/i);
     expect(docs).toMatch(/checker failure preserves `reachability\.json`/i);
+    expect(docs).toMatch(/`scroll-capabilities\.json`/i);
+    expect(docs).toMatch(/does not perform accessibility actions/i);
     expect(docs).toMatch(/TCC/i);
     expect(docs).toMatch(/does not prove/i);
   });

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -143,7 +143,7 @@ if [ "$1" = run ]; then
   if [ "\${FAKE_CHECKER_STATUS:-0}" -eq 0 ]; then
     printf '%s\\n' '{"ok":true}'
   else
-    printf '%s\\n' '{"ok":false,"failure":"missing outer AXScrollArea ancestor"}'
+    printf '%s\\n' '{"ok":false,"failure":"behavior trace rejected"}'
   fi
   if [ -n "\${FAKE_CHECKER_MESSAGE:-}" ]; then printf '%s\\n' "$FAKE_CHECKER_MESSAGE" >&2; fi
   exit "\${FAKE_CHECKER_STATUS:-0}"
@@ -170,12 +170,20 @@ fi
 printf 'png' >"$output_dir/screenshot.png"
 printf '%s\\n' '{"role":"AXWindow","children":[]}' >"$output_dir/accessibility.json"
 printf '%s\\n' '{"schemaVersion":1,"fixtureId":"tab-repos"}' >"$output_dir/geometry.json"
-printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"acquisition":{"status":"%s","failureReason":%s},"outerScroll":null}\\n' \\
-  "\${FAKE_ACQUISITION_STATUS:-complete}" "\${FAKE_ACQUISITION_FAILURE_REASON:-null}" \\
-  >"$output_dir/reachability.json"
+printf '%s\\n' '{"schemaVersion":2,"fixture":"tab-repos","ready":true,"quiescent":true,"requestedContentSize":{"width":1040,"height":680},"sampleIntervalMilliseconds":100,"preScrollAcquisitionMilliseconds":200,"postScrollAcquisitionMilliseconds":200,"tolerancePoints":1,"acquisition":{"status":"complete","failureReason":null},"preScrollSamples":[{"elapsedMilliseconds":0,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":100,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":600,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":650,"width":760,"height":40}}]},{"elapsedMilliseconds":100,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":100,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":600,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":650,"width":760,"height":40}}]},{"elapsedMilliseconds":200,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":100,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":600,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":650,"width":760,"height":40}}]}],"scrollInteraction":{"mechanism":"increment-page-press","incrementPagePress":{"actionAdvertised":true,"attemptCount":1,"performResult":"success","outerClipBefore":{"x":20,"y":50,"width":1000,"height":580},"outerClipAfter":{"x":20,"y":50,"width":1000,"height":580}},"valueMutation":null},"postScrollSamples":[{"elapsedMilliseconds":0,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":0,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":500,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":550,"width":760,"height":40}}]},{"elapsedMilliseconds":100,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":0,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":500,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":550,"width":760,"height":40}}]},{"elapsedMilliseconds":200,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":0,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":500,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":550,"width":760,"height":40}}]}]}' >"$output_dir/reachability.json"
+if [ "\${FAKE_ACQUISITION_STATUS:-complete}" != complete ]; then
+  jq --arg status "$FAKE_ACQUISITION_STATUS" --argjson reason "$FAKE_ACQUISITION_FAILURE_REASON" \
+    '.acquisition = {status:$status,failureReason:$reason}
+      | .ready = false
+      | .quiescent = false
+      | .scrollInteraction = null
+      | .postScrollSamples = []' "$output_dir/reachability.json" \
+    >"$output_dir/reachability.tmp"
+  mv "$output_dir/reachability.tmp" "$output_dir/reachability.json"
+fi
 case "\${FAKE_CAPABILITIES_MODE:-valid}" in
   valid)
-    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false,"outerVerticalIncrementPageResolved":true,"outerVerticalIncrementPageAdvertisesPress":false}' \\
+    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false,"outerVerticalIncrementPageResolved":true,"outerVerticalIncrementPageAdvertisesPress":true}' \\
       >"$output_dir/scroll-capabilities.json"
     ;;
   failed)
@@ -214,7 +222,7 @@ fi
       FAKE_COMMAND_LOG: commandLog,
       FAKE_SWIFT_BIN: swiftBin,
       FAKE_CHECKER_STATUS: "7",
-      FAKE_CHECKER_MESSAGE: "Reachability trace has no outer scroll area.",
+      FAKE_CHECKER_MESSAGE: "Reachability behavior trace was rejected.",
       FAKE_CAPTURE_STATUS: "0",
       FAKE_CAPTURE_MESSAGE: "",
       FAKE_CAPTURE_HANG: "false",
@@ -318,7 +326,7 @@ describe("focused Repos reachability capture", () => {
       "utf8"
     );
     const incrementPageProbe = captureSource.match(
-      /private func incrementPageButton[\s\S]*?private func unsupportedScroll/
+      /private func incrementPageButton[\s\S]*?private func verifiedWindow/
     )?.[0];
     expect(incrementPageProbe).toBeDefined();
     expect(incrementPageProbe).toContain("kAXChildrenAttribute");
@@ -328,11 +336,20 @@ describe("focused Repos reachability capture", () => {
     expect(incrementPageProbe).not.toContain("visit(");
     expect(captureSource).toContain("NSAccessibility.Action.press.rawValue");
     expect(captureSource).toContain("AXUIElementCopyActionNames");
-    expect(captureSource).not.toContain("AXUIElementPerformAction");
+    const capabilityProbe = captureSource.match(
+      /func captureScrollCapabilities[\s\S]*?private func acquireStableSamples/
+    )?.[0];
+    expect(capabilityProbe).not.toContain("AXUIElementPerformAction");
+    const behaviorPress = captureSource.match(
+      /private func performIncrementPagePress[\s\S]*?private func scrollActionResult/
+    )?.[0];
+    expect(behaviorPress?.match(/AXUIElementPerformAction/g)).toHaveLength(1);
+    expect(behaviorPress).toContain("NSAccessibility.Action.press.rawValue");
+    expect(behaviorPress).not.toMatch(/for |while |repeat /);
   });
 
   it.runIf(process.platform === "darwin")(
-    "preserves reachability and public-safe status evidence when the checker reports the expected pre-fix failure",
+    "preserves reachability and public-safe status evidence when the checker rejects the behavior trace",
     { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
@@ -345,7 +362,7 @@ describe("focused Repos reachability capture", () => {
       expect(JSON.parse(readFileSync(join(caseRoot, "reachability.json"), "utf8"))).toMatchObject({
         fixture: "tab-repos",
         requestedContentSize: { width: 1040, height: 680 },
-        outerScroll: null
+        scrollInteraction: { mechanism: "increment-page-press", valueMutation: null }
       });
       expect(JSON.parse(readFileSync(join(caseRoot, "scroll-capabilities.json"), "utf8"))).toEqual({
         schemaVersion: 1,
@@ -358,17 +375,17 @@ describe("focused Repos reachability capture", () => {
         outerVerticalScrollBarResolved: true,
         outerVerticalScrollBarAdvertisesIncrement: false,
         outerVerticalIncrementPageResolved: true,
-        outerVerticalIncrementPageAdvertisesPress: false
+        outerVerticalIncrementPageAdvertisesPress: true
       });
       expect(JSON.parse(readFileSync(join(caseRoot, "capture.json"), "utf8")))
         .toMatchObject({ scrollCapabilities: { path: "scroll-capabilities.json", sha256: expect.any(String) } });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
-        .toMatchObject({
+        .toEqual({
+          schemaVersion: 1,
           status: "failed",
           checkerFailed: true,
           exitCode: 7,
-          expectedPreFixFailure: true,
-          reasonCode: "missing_outer_scroll"
+          reasonCode: "checker_nonzero"
         });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/packet-safety-scan.json"), "utf8")))
         .toMatchObject({ ok: true, findings: [], sensitiveFiles: [] });
@@ -480,7 +497,7 @@ describe("focused Repos reachability capture", () => {
   );
 
   it.runIf(process.platform === "darwin")(
-    "does not classify an unrelated checker failure as the expected pre-fix result",
+    "classifies every checker rejection as an ordinary checker failure",
     { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
@@ -492,14 +509,13 @@ describe("focused Repos reachability capture", () => {
           status: "failed",
           checkerFailed: true,
           exitCode: 7,
-          expectedPreFixFailure: false,
           reasonCode: "checker_nonzero"
         });
     }
   );
 
   it.runIf(process.platform === "darwin")(
-    "does not classify failed acquisition as the expected missing-scroll result",
+    "preserves a typed failed acquisition without a behavior interaction",
     { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
@@ -512,12 +528,17 @@ describe("focused Repos reachability capture", () => {
       expect(JSON.parse(readFileSync(
         join(harness.output, "cases/tab-repos/1040x680/reachability.json"),
         "utf8"
-      ))).toMatchObject({ acquisition: { status: "failed", failureReason: "semantic-missing" }, outerScroll: null });
+      ))).toMatchObject({
+        ready: false,
+        quiescent: false,
+        acquisition: { status: "failed", failureReason: "semantic-missing" },
+        scrollInteraction: null,
+        postScrollSamples: []
+      });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
         .toMatchObject({
           checkerFailed: true,
           exitCode: 7,
-          expectedPreFixFailure: false,
           reasonCode: "checker_nonzero"
         });
     }
@@ -724,7 +745,7 @@ describe("focused Repos reachability capture", () => {
         focusedProof: "emitted"
       });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
-        .toMatchObject({ checkerFailed: false, exitCode: 0, expectedPreFixFailure: false, reasonCode: "none" });
+        .toMatchObject({ checkerFailed: false, exitCode: 0, reasonCode: "none" });
       expect(existsSync(join(harness.output, "focused-proof.json"))).toBe(true);
       expect(existsSync(join(harness.output, "validation/packet-safety-scan.ok"))).toBe(true);
       expect(() => process.kill(launchedPID(harness), 0)).toThrow();
@@ -739,8 +760,9 @@ describe("focused Repos reachability capture", () => {
     const docs = readFileSync("apps/neondiff-desktop/docs/ui-evaluation.md", "utf8");
     expect(docs).toMatch(/focused partial #517 proof/i);
     expect(docs).toMatch(/outside the canonical #515 packet/i);
-    expect(docs).toMatch(/missing outer `AXScrollArea` ancestor/i);
-    expect(docs).toMatch(/Table scroll/i);
+    expect(docs).toMatch(/performs that public\s+action exactly once/i);
+    expect(docs).toMatch(/rigid upward translation/i);
+    expect(docs).toMatch(/nested Table/i);
     expect(docs).toMatch(/checker failure preserves `reachability\.json`/i);
     expect(docs).toMatch(/`scroll-capabilities\.json`/i);
     expect(docs).toMatch(/does not perform accessibility actions/i);

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -237,6 +237,8 @@ fi
       FAKE_CAPTURE_STATUS: "0",
       FAKE_CAPTURE_MESSAGE: "",
       FAKE_CAPTURE_HANG: "false",
+      NEONDIFF_DESKTOP_TEST_MODE: "1",
+      NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS: "30",
       FAKE_ACQUISITION_STATUS: "complete",
       FAKE_ACQUISITION_FAILURE_REASON: "null",
       FAKE_CAPABILITIES_MODE: "valid",
@@ -308,11 +310,25 @@ describe("focused Repos reachability capture", () => {
     expect(script).toContain('content_size="1040x680"');
     expect(script).toContain("NEONDIFF_DESKTOP_EVALUATION_READY_PATH");
     expect(script).toContain("capture helper timed out");
+    expect(script).toContain("NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS");
+    expect(script).toContain("unset NEONDIFF_DESKTOP_TEST_MODE NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS");
     expect(script).toContain("kill -KILL");
     expect(script).toContain("npm run check:secrets");
     expect(script).toContain("check-desktop-evaluation-packet-secrets.mjs");
     expect(script).not.toMatch(/\bsecurity\s+find-|\blaunchctl\b|\bdefaults\s+(?:read|write)\b/);
   });
+
+  it.runIf(process.platform === "darwin")(
+    "rejects an unsafe test-only capture timeout override before launching",
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { NEONDIFF_DESKTOP_TEST_CAPTURE_ATTEMPTS: "151" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(65);
+      expect(result.stderr).toContain("test capture attempt limit must be an integer from 1 through 150");
+      expect(readFileSync(harness.commandLog, "utf8")).not.toContain("build-app");
+    }
+  );
 
   it("builds one DEBUG app, capture helper, and checker and launches only the Repos fixture", () => {
     const script = readFileSync(scriptPath, "utf8");
@@ -679,8 +695,34 @@ describe("focused Repos reachability capture", () => {
   );
 
   it.runIf(process.platform === "darwin")(
+    "normalizes an Accessibility failure without raw stderr",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, {
+        FAKE_CAPTURE_STATUS: "13",
+        FAKE_CAPTURE_MESSAGE: "Capture permission is unavailable: Accessibility"
+      });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(13);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "capture",
+        reasonCode: "accessibility_unavailable",
+        captureExitCode: 13,
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expect(existsSync(join(harness.output, "validation/capture.stderr"))).toBe(false);
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
     "terminates timed-out capture and app processes without publishing partials",
-    { timeout: 25_000 },
+    { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
       const result = runHarness(harness, { FAKE_CAPTURE_HANG: "true" });

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -140,10 +140,13 @@ case " $* " in
 esac
 if [ "$1" = build ]; then exit 0; fi
 if [ "$1" = run ]; then
-  if [ "\${FAKE_CHECKER_STATUS:-0}" -eq 0 ]; then
-    printf '%s\\n' '{"ok":true}'
+  if [ -n "\${FAKE_CHECKER_OUTPUT:-}" ]; then
+    printf '%s\\n' "$FAKE_CHECKER_OUTPUT"
+  elif [ "\${FAKE_CHECKER_STATUS:-0}" -eq 0 ]; then
+    printf '%s\\n' '{"category":"none","ok":true,"reasonCode":"none","schemaVersion":1,"status":"reachable"}'
   else
-    printf '%s\\n' '{"ok":false,"failure":"behavior trace rejected"}'
+    printf '{"category":"%s","ok":false,"reasonCode":"%s","schemaVersion":1,"status":"failed"}\\n' \\
+      "\${FAKE_CHECKER_CATEGORY:-geometry}" "\${FAKE_CHECKER_REASON:-no-upward-movement}"
   fi
   if [ -n "\${FAKE_CHECKER_MESSAGE:-}" ]; then printf '%s\\n' "$FAKE_CHECKER_MESSAGE" >&2; fi
   exit "\${FAKE_CHECKER_STATUS:-0}"
@@ -171,6 +174,11 @@ printf 'png' >"$output_dir/screenshot.png"
 printf '%s\\n' '{"role":"AXWindow","children":[]}' >"$output_dir/accessibility.json"
 printf '%s\\n' '{"schemaVersion":1,"fixtureId":"tab-repos"}' >"$output_dir/geometry.json"
 printf '%s\\n' '{"schemaVersion":2,"fixture":"tab-repos","ready":true,"quiescent":true,"requestedContentSize":{"width":1040,"height":680},"sampleIntervalMilliseconds":100,"preScrollAcquisitionMilliseconds":200,"postScrollAcquisitionMilliseconds":200,"tolerancePoints":1,"acquisition":{"status":"complete","failureReason":null},"preScrollSamples":[{"elapsedMilliseconds":0,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":100,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":600,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":650,"width":760,"height":40}}]},{"elapsedMilliseconds":100,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":100,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":600,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":650,"width":760,"height":40}}]},{"elapsedMilliseconds":200,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":100,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":600,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":650,"width":760,"height":40}}]}],"scrollInteraction":{"mechanism":"increment-page-press","incrementPagePress":{"actionAdvertised":true,"attemptCount":1,"performResult":"success","outerClipBefore":{"x":20,"y":50,"width":1000,"height":580},"outerClipAfter":{"x":20,"y":50,"width":1000,"height":580}},"valueMutation":null},"postScrollSamples":[{"elapsedMilliseconds":0,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":0,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":500,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":550,"width":760,"height":40}}]},{"elapsedMilliseconds":100,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":0,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":500,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":550,"width":760,"height":40}}]},{"elapsedMilliseconds":200,"viewport":{"x":0,"y":0,"width":1040,"height":680},"regions":[{"id":"table","frame":{"x":24,"y":0,"width":900,"height":360}},{"id":"apply-allowlist","frame":{"x":24,"y":500,"width":180,"height":30}},{"id":"boundary-body","frame":{"x":24,"y":550,"width":760,"height":40}}]}]}' >"$output_dir/reachability.json"
+jq '(.preScrollSamples[]?, .postScrollSamples[]?) |= . + {
+      outerClip:{x:20,y:50,width:1000,height:580},
+      boundaryScrollAncestorCount:1
+    }' "$output_dir/reachability.json" >"$output_dir/reachability.tmp"
+mv "$output_dir/reachability.tmp" "$output_dir/reachability.json"
 if [ "\${FAKE_ACQUISITION_STATUS:-complete}" != complete ]; then
   jq --arg status "$FAKE_ACQUISITION_STATUS" --argjson reason "$FAKE_ACQUISITION_FAILURE_REASON" \
     '.acquisition = {status:$status,failureReason:$reason}
@@ -223,6 +231,9 @@ fi
       FAKE_SWIFT_BIN: swiftBin,
       FAKE_CHECKER_STATUS: "7",
       FAKE_CHECKER_MESSAGE: "Reachability behavior trace was rejected.",
+      FAKE_CHECKER_OUTPUT: "",
+      FAKE_CHECKER_CATEGORY: "geometry",
+      FAKE_CHECKER_REASON: "no-upward-movement",
       FAKE_CAPTURE_STATUS: "0",
       FAKE_CAPTURE_MESSAGE: "",
       FAKE_CAPTURE_HANG: "false",
@@ -320,7 +331,7 @@ describe("focused Repos reachability capture", () => {
     expect(script).not.toContain("1440x900");
   });
 
-  it("keeps the Increment Page probe direct-child, PID-bound, and action-free", () => {
+  it("keeps the Increment Page action full-chain rebound, single-shot, and ledger-first", () => {
     const captureSource = readFileSync(
       "apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift",
       "utf8"
@@ -341,11 +352,33 @@ describe("focused Repos reachability capture", () => {
     )?.[0];
     expect(capabilityProbe).not.toContain("AXUIElementPerformAction");
     const behaviorPress = captureSource.match(
-      /private func performIncrementPagePress[\s\S]*?private func scrollActionResult/
+      /private func performIncrementPagePress[\s\S]*?private func revalidatedIncrementPagePressBinding/
     )?.[0];
     expect(behaviorPress?.match(/AXUIElementPerformAction/g)).toHaveLength(1);
     expect(behaviorPress).toContain("NSAccessibility.Action.press.rawValue");
     expect(behaviorPress).not.toMatch(/for |while |repeat /);
+    expect(behaviorPress).not.toMatch(/verifiedWindow\(|semanticElements\(|outermostScrollArea\(/);
+    const revalidation = captureSource.match(
+      /private func revalidatedIncrementPagePressBinding[\s\S]*?private func interactionWithSettledOuterClipAfter/
+    )?.[0];
+    expect(revalidation).toContain("let current = try incrementPagePressBinding()");
+    expect(revalidation?.match(/CFEqual\(/g)).toHaveLength(7);
+    expect(revalidation).toContain("boundaryScrollAncestorCount == current.semantic.boundaryScrollAncestorCount");
+    expect(revalidation).toContain("original.actionAdvertised == current.actionAdvertised");
+    expect(revalidation).toContain("throw Failure.semanticChanged");
+    const captureFlow = captureSource.match(
+      /func capture\(\)[\s\S]*?func captureScrollCapabilities/
+    )?.[0];
+    expect(captureFlow).toMatch(
+      /scrollInteraction = try performIncrementPagePress[\s\S]*?post = acquireStableSamples\(\)[\s\S]*?interactionWithSettledOuterClipAfter/
+    );
+    expect(captureSource).toMatch(
+      /outerClip: outerClip,[\s\S]*?boundaryScrollAncestorCount: binding\.boundaryScrollAncestorCount/
+    );
+    const checkerSection = readFileSync(scriptPath, "utf8").match(
+      /checker_status=0[\s\S]*?reachability_sha=/
+    )?.[0];
+    expect(checkerSection).not.toMatch(/jq[\s\S]*?"\$reachability"/);
   });
 
   it.runIf(process.platform === "darwin")(
@@ -381,11 +414,12 @@ describe("focused Repos reachability capture", () => {
         .toMatchObject({ scrollCapabilities: { path: "scroll-capabilities.json", sha256: expect.any(String) } });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
         .toEqual({
-          schemaVersion: 1,
+          schemaVersion: 2,
           status: "failed",
           checkerFailed: true,
           exitCode: 7,
-          reasonCode: "checker_nonzero"
+          category: "geometry",
+          reasonCode: "no-upward-movement"
         });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/packet-safety-scan.json"), "utf8")))
         .toMatchObject({ ok: true, findings: [], sensitiveFiles: [] });
@@ -501,7 +535,11 @@ describe("focused Repos reachability capture", () => {
     { timeout: 30_000 },
     () => {
       const harness = createFakeHarnessRepository();
-      const result = runHarness(harness, { FAKE_CHECKER_MESSAGE: "Reachability trace schema is invalid." });
+      const result = runHarness(harness, {
+        FAKE_CHECKER_MESSAGE: "Reachability trace action was unavailable.",
+        FAKE_CHECKER_CATEGORY: "action",
+        FAKE_CHECKER_REASON: "action-not-advertised"
+      });
 
       expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
@@ -509,7 +547,28 @@ describe("focused Repos reachability capture", () => {
           status: "failed",
           checkerFailed: true,
           exitCode: 7,
-          reasonCode: "checker_nonzero"
+          category: "action",
+          reasonCode: "action-not-advertised"
+        });
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "fails closed on malformed checker output without inferring from the raw trace",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_CHECKER_OUTPUT: "{}" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
+      expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
+        .toEqual({
+          schemaVersion: 2,
+          status: "failed",
+          checkerFailed: true,
+          exitCode: 7,
+          category: "checker",
+          reasonCode: "checker-result-invalid"
         });
     }
   );
@@ -521,7 +580,9 @@ describe("focused Repos reachability capture", () => {
       const harness = createFakeHarnessRepository();
       const result = runHarness(harness, {
         FAKE_ACQUISITION_STATUS: "failed",
-        FAKE_ACQUISITION_FAILURE_REASON: '"semantic-missing"'
+        FAKE_ACQUISITION_FAILURE_REASON: '"semantic-missing"',
+        FAKE_CHECKER_CATEGORY: "acquisition",
+        FAKE_CHECKER_REASON: "acquisition-semantic-missing"
       });
 
       expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
@@ -539,7 +600,8 @@ describe("focused Repos reachability capture", () => {
         .toMatchObject({
           checkerFailed: true,
           exitCode: 7,
-          reasonCode: "checker_nonzero"
+          category: "acquisition",
+          reasonCode: "acquisition-semantic-missing"
         });
     }
   );
@@ -745,7 +807,13 @@ describe("focused Repos reachability capture", () => {
         focusedProof: "emitted"
       });
       expect(JSON.parse(readFileSync(join(harness.output, "validation/reachability-check-status.json"), "utf8")))
-        .toMatchObject({ checkerFailed: false, exitCode: 0, reasonCode: "none" });
+        .toMatchObject({
+          schemaVersion: 2,
+          checkerFailed: false,
+          exitCode: 0,
+          category: "none",
+          reasonCode: "none"
+        });
       expect(existsSync(join(harness.output, "focused-proof.json"))).toBe(true);
       expect(existsSync(join(harness.output, "validation/packet-safety-scan.ok"))).toBe(true);
       expect(() => process.kill(launchedPID(harness), 0)).toThrow();
@@ -761,9 +829,13 @@ describe("focused Repos reachability capture", () => {
     expect(docs).toMatch(/focused partial #517 proof/i);
     expect(docs).toMatch(/outside the canonical #515 packet/i);
     expect(docs).toMatch(/performs that public\s+action exactly once/i);
-    expect(docs).toMatch(/rigid upward translation/i);
+    expect(docs).toMatch(/re-resolves the full Boundary -> outer scroll -> vertical\s+scrollbar -> direct Increment Page chain/i);
+    expect(docs).toMatch(/successful action\s+ledger is persisted before any post-action read/i);
+    expect(docs).toMatch(/every settled post-action outer clip/i);
+    expect(docs).toMatch(/rigid\s+upward translation/i);
     expect(docs).toMatch(/nested Table/i);
-    expect(docs).toMatch(/checker failure preserves `reachability\.json`/i);
+    expect(docs).toMatch(/checker failure preserves\s+`reachability\.json`/i);
+    expect(docs).toMatch(/runner does not infer a result from the raw\s+trace/i);
     expect(docs).toMatch(/`scroll-capabilities\.json`/i);
     expect(docs).toMatch(/does not perform accessibility actions/i);
     expect(docs).toMatch(/TCC/i);

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -178,6 +178,11 @@ case "\${FAKE_CAPABILITIES_MODE:-valid}" in
     printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false}' \\
       >"$output_dir/scroll-capabilities.json"
     ;;
+  failed)
+    printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"failed","failureReason":"%s"},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":null,"outerVerticalScrollBarResolved":null,"outerVerticalScrollBarAdvertisesIncrement":null}\n' \
+      "\${FAKE_CAPABILITY_FAILURE_REASON:-semantic-missing}" \
+      >"$output_dir/scroll-capabilities.json"
+    ;;
   invalid) printf '%s\\n' '{}' >"$output_dir/scroll-capabilities.json" ;;
   missing) ;;
 esac
@@ -207,6 +212,7 @@ fi
       FAKE_ACQUISITION_STATUS: "complete",
       FAKE_ACQUISITION_FAILURE_REASON: "null",
       FAKE_CAPABILITIES_MODE: "valid",
+      FAKE_CAPABILITY_FAILURE_REASON: "semantic-missing",
       FAKE_SAFETY_SCAN_OK: "true",
       FAKE_GIT_STATE: gitState,
       FAKE_GIT_DIRTY_STATUS_CALL: "0",
@@ -379,6 +385,48 @@ describe("focused Repos reachability capture", () => {
     () => {
       const harness = createFakeHarnessRepository();
       const result = runHarness(harness, { FAKE_CAPABILITIES_MODE: "invalid" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "capture",
+        reasonCode: "capture_output_incomplete",
+        focusedProof: "not_emitted"
+      });
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expectNoFinalProof(harness);
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "accepts an exact typed capability acquisition failure",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_CAPABILITIES_MODE: "failed" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(7);
+      expect(JSON.parse(readFileSync(
+        join(harness.output, "cases/tab-repos/1040x680/scroll-capabilities.json"),
+        "utf8"
+      ))).toMatchObject({
+        acquisition: { status: "failed", failureReason: "semantic-missing" },
+        boundaryAdvertisesScrollToVisible: null,
+        outerVerticalScrollBarResolved: null,
+        outerVerticalScrollBarAdvertisesIncrement: null
+      });
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "rejects an unknown capability acquisition failure reason",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, {
+        FAKE_CAPABILITIES_MODE: "failed",
+        FAKE_CAPABILITY_FAILURE_REASON: "unknown-reason"
+      });
 
       expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
       expect(focusedStatus(harness)).toMatchObject({

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -63,6 +63,16 @@ set -eu
 printf 'app %s\\n' "$*" >>"$FAKE_COMMAND_LOG"
 printf 'app-pid %s\\n' "$$" >>"$FAKE_COMMAND_LOG"
 ready=\${NEONDIFF_DESKTOP_EVALUATION_READY_PATH:?}
+case "\${FAKE_APP_READINESS_MODE:-ready}" in
+  exit)
+    printf 'private launch failure detail\\n'
+    exit 73
+    ;;
+  timeout)
+    trap 'exit 0' HUP INT TERM
+    while :; do /bin/sleep 0.1; done
+    ;;
+esac
 printf '{"schemaVersion":1,"fixtureId":"tab-repos","pid":%s,"windowNumber":41,"windowFrame":{"x":0,"y":0,"width":1040,"height":702},"contentFrame":{"x":0,"y":22,"width":1040,"height":680},"backingScale":2,"ready":true}\\n' "$$" >"$ready"
 trap 'exit 0' HUP INT TERM
 while :; do /bin/sleep 0.1; done
@@ -178,6 +188,7 @@ fi
       ...process.env,
       PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       FAKE_APP_TEMPLATE: appTemplate,
+      FAKE_APP_READINESS_MODE: "ready",
       FAKE_COMMAND_LOG: commandLog,
       FAKE_SWIFT_BIN: swiftBin,
       FAKE_CHECKER_STATUS: "7",
@@ -246,7 +257,8 @@ describe("focused Repos reachability capture", () => {
 
     const script = readFileSync(scriptPath, "utf8");
     expect(script).toContain("umask 077");
-    expect(script).toMatch(/mktemp -d [^\n]*\/tmp\/neondiff-desktop-repos-reachability/);
+    expect(script).toContain('"/tmp/neondiff-desktop-evaluation.XXXXXXXX"');
+    expect(script).not.toContain("neondiff-desktop-repos-reachability.XXXXXXXX");
     expect(script).toContain("canonical focused capture requires a clean worktree");
     expect(script).toContain("assert_clean_head");
     expect(script).toContain('fixture_id="tab-repos"');
@@ -359,6 +371,52 @@ describe("focused Repos reachability capture", () => {
           expectedPreFixFailure: false,
           reasonCode: "checker_nonzero"
         });
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "normalizes an app exit before readiness without exposing the private launch log",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_APP_READINESS_MODE: "exit" });
+
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "launch",
+        reasonCode: "fixture_launch_failed",
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expect(existsSync(join(harness.output, "validation/launch.log"))).toBe(false);
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain("private launch failure detail");
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
+    }
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "terminates an app that times out before readiness and records a public-safe status",
+    { timeout: 30_000 },
+    () => {
+      const harness = createFakeHarnessRepository();
+      const result = runHarness(harness, { FAKE_APP_READINESS_MODE: "timeout" });
+
+      expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
+      expect(focusedStatus(harness)).toMatchObject({
+        status: "incomplete",
+        phase: "readiness",
+        reasonCode: "readiness_timeout",
+        publicSafety: "incomplete",
+        focusedProof: "not_emitted"
+      });
+      expectNoFinalProof(harness);
+      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+      expect(existsSync(join(harness.output, "validation/launch.log"))).toBe(false);
+      expect(() => process.kill(launchedPID(harness), 0)).toThrow();
     }
   );
 

--- a/tests/desktop-repos-reachability-capture.test.ts
+++ b/tests/desktop-repos-reachability-capture.test.ts
@@ -175,13 +175,22 @@ printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width"
   >"$output_dir/reachability.json"
 case "\${FAKE_CAPABILITIES_MODE:-valid}" in
   valid)
-    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false}' \\
+    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false,"outerVerticalIncrementPageResolved":true,"outerVerticalIncrementPageAdvertisesPress":false}' \\
       >"$output_dir/scroll-capabilities.json"
     ;;
   failed)
-    printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"failed","failureReason":"%s"},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":null,"outerVerticalScrollBarResolved":null,"outerVerticalScrollBarAdvertisesIncrement":null}\n' \
+    printf '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"failed","failureReason":"%s"},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":null,"outerVerticalScrollBarResolved":null,"outerVerticalScrollBarAdvertisesIncrement":null,"outerVerticalIncrementPageResolved":null,"outerVerticalIncrementPageAdvertisesPress":null}\n' \
       "\${FAKE_CAPABILITY_FAILURE_REASON:-semantic-missing}" \
       >"$output_dir/scroll-capabilities.json"
+    ;;
+  missing-page-field)
+    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false,"outerVerticalIncrementPageResolved":true}' >"$output_dir/scroll-capabilities.json"
+    ;;
+  unknown-page-field)
+    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false,"outerVerticalIncrementPageResolved":true,"outerVerticalIncrementPageAdvertisesPress":false,"rawIncrementPage":"forbidden"}' >"$output_dir/scroll-capabilities.json"
+    ;;
+  invalid-page-cross-field)
+    printf '%s\\n' '{"schemaVersion":1,"fixture":"tab-repos","requestedContentSize":{"width":1040,"height":680},"osMajorVersion":26,"acquisition":{"status":"complete","failureReason":null},"scrollToVisibleActionAvailable":true,"boundaryAdvertisesScrollToVisible":false,"outerVerticalScrollBarResolved":true,"outerVerticalScrollBarAdvertisesIncrement":false,"outerVerticalIncrementPageResolved":false,"outerVerticalIncrementPageAdvertisesPress":true}' >"$output_dir/scroll-capabilities.json"
     ;;
   invalid) printf '%s\\n' '{}' >"$output_dir/scroll-capabilities.json" ;;
   missing) ;;
@@ -303,6 +312,25 @@ describe("focused Repos reachability capture", () => {
     expect(script).not.toContain("1440x900");
   });
 
+  it("keeps the Increment Page probe direct-child, PID-bound, and action-free", () => {
+    const captureSource = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktopCapture/main.swift",
+      "utf8"
+    );
+    const incrementPageProbe = captureSource.match(
+      /private func incrementPageButton[\s\S]*?private func unsupportedScroll/
+    )?.[0];
+    expect(incrementPageProbe).toBeDefined();
+    expect(incrementPageProbe).toContain("kAXChildrenAttribute");
+    expect(incrementPageProbe).toMatch(/for child in children[\s\S]*try requireTargetPID\(child\)/);
+    expect(incrementPageProbe).toContain("kAXRoleAttribute");
+    expect(incrementPageProbe).toContain("kAXSubroleAttribute");
+    expect(incrementPageProbe).not.toContain("visit(");
+    expect(captureSource).toContain("NSAccessibility.Action.press.rawValue");
+    expect(captureSource).toContain("AXUIElementCopyActionNames");
+    expect(captureSource).not.toContain("AXUIElementPerformAction");
+  });
+
   it.runIf(process.platform === "darwin")(
     "preserves reachability and public-safe status evidence when the checker reports the expected pre-fix failure",
     { timeout: 30_000 },
@@ -328,7 +356,9 @@ describe("focused Repos reachability capture", () => {
         scrollToVisibleActionAvailable: true,
         boundaryAdvertisesScrollToVisible: false,
         outerVerticalScrollBarResolved: true,
-        outerVerticalScrollBarAdvertisesIncrement: false
+        outerVerticalScrollBarAdvertisesIncrement: false,
+        outerVerticalIncrementPageResolved: true,
+        outerVerticalIncrementPageAdvertisesPress: false
       });
       expect(JSON.parse(readFileSync(join(caseRoot, "capture.json"), "utf8")))
         .toMatchObject({ scrollCapabilities: { path: "scroll-capabilities.json", sha256: expect.any(String) } });
@@ -383,18 +413,25 @@ describe("focused Repos reachability capture", () => {
     "rejects a malformed sanitized scroll capability artifact",
     { timeout: 30_000 },
     () => {
-      const harness = createFakeHarnessRepository();
-      const result = runHarness(harness, { FAKE_CAPABILITIES_MODE: "invalid" });
+      for (const mode of [
+        "invalid",
+        "missing-page-field",
+        "unknown-page-field",
+        "invalid-page-cross-field"
+      ]) {
+        const harness = createFakeHarnessRepository();
+        const result = runHarness(harness, { FAKE_CAPABILITIES_MODE: mode });
 
-      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
-      expect(focusedStatus(harness)).toMatchObject({
-        status: "incomplete",
-        phase: "capture",
-        reasonCode: "capture_output_incomplete",
-        focusedProof: "not_emitted"
-      });
-      expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
-      expectNoFinalProof(harness);
+        expect(result.status, `${mode}: ${result.stderr}\n${result.stdout}`).toBe(1);
+        expect(focusedStatus(harness)).toMatchObject({
+          status: "incomplete",
+          phase: "capture",
+          reasonCode: "capture_output_incomplete",
+          focusedProof: "not_emitted"
+        });
+        expect(existsSync(join(harness.output, "cases/tab-repos/1040x680"))).toBe(false);
+        expectNoFinalProof(harness);
+      }
     }
   );
 
@@ -413,7 +450,9 @@ describe("focused Repos reachability capture", () => {
         acquisition: { status: "failed", failureReason: "semantic-missing" },
         boundaryAdvertisesScrollToVisible: null,
         outerVerticalScrollBarResolved: null,
-        outerVerticalScrollBarAdvertisesIncrement: null
+        outerVerticalScrollBarAdvertisesIncrement: null,
+        outerVerticalIncrementPageResolved: null,
+        outerVerticalIncrementPageAdvertisesPress: null
       });
     }
   );


### PR DESCRIPTION
## Summary

- add an outer vertical Repos page scroll while preserving the native inner Table scroll;
- fix the native Table at 360 points so page-level actions and the Boundary section can move as one rigid surface;
- add a concrete Boundary accessibility identifier;
- add a DEBUG-only, PID-bound Repos reachability trace, strict checker, typed runner status, and public-safety gates;
- prove one nominal dark `tab-repos` fixture at 1040x680 reaches the bottom action region through exactly one verified public Increment Page press.

Related: #517

This PR advances only the bounded nominal Repos wedge. #517 remains open for
its broader acceptance matrix.

## Exact source

- base: `f658fceefd68a70c4261c0f3162ff7d53602312d`
- PR head: `0a0c1c1a80575650aec17abf45b2d35e27d391c4`
- real DEBUG evidence head: `f844660a3b23b8bb4f78fbf0004a751b412b9003`
- branch: `fix/517-repos-reachability`

The post-evidence commits are limited to SDK compatibility and review-driven
test hardening: the public raw action name `AXScrollToVisible` now lives in
evaluation support so the helper builds on pre-macOS-26 SDKs; the fake runner
also covers Accessibility-denial normalization and uses a bounded test-mode-only
timeout control with the canonical 150-attempt default unchanged. Neither
commit alters the product layout, performed `AXPress`, trace schema, checker,
or evidence packet.

## Failing-first evidence

At pre-fix head `5ea0df7915e23a9d0e3a8a091becb6fab95acd79`, the same fixture produced a complete, safety-passed typed RED result: `missing_outer_scroll`.

## Validation

- Swift layout/reachability/capability suites: 39/39 passed across three suites.
- Focused runner Vitest contract: 25/25 passed with exit 0.
- Adjacent evaluation-boundary and Swift-routing Vitest contracts: 16/16
  passed.
- `NeonDiffDesktopCapture` and `NeonDiffDesktopReachabilityChecks` build.
- Exact recorded reachability input re-checks as `ok=true`, `status=reachable`, `category=none`, `reasonCode=none`.
- `sh -n`, `git diff --check`, and repository secret scan pass; the current secret scan covered 717 tracked files.
- Static action surface: exactly one `AXUIElementPerformAction`; zero `AXUIElementSetAttributeValue` calls.
- Two independent adversarial reviews at `a68cea3` (spec/product-design and
  security/AX) returned READY with no actionable P0-P3 finding. evaOS then
  found two P3 test-contract gaps at that head; both are fixed at the current
  head and their threads are resolved. At exact current head, CodeRabbit
  approved and evaOS completed with no validated inline finding.

## Exact evidence-head DEBUG fixture result

The following real fixture result remains immutably bound to `f844660`.

- focused capture: `complete`; public safety: `passed`; proof: `emitted`;
- checker exit: `0`; result: `reachable`;
- capability acquisition: complete; direct vertical scrollbar and Increment Page resolved; Increment Page advertises public `AXPress`;
- action ledger: advertised `true`, attempt count `1`, perform result `success`, value mutation `null`;
- settled outer clip remained `x=311 y=333 width=809 height=490` with one Boundary scroll ancestor;
- pre cadence: `0/100/205ms`; post cadence: `210/312/417ms`;
- Table, Apply, and Boundary each translated upward exactly 480 points with unchanged x/width/height;
- Apply and Boundary are contained by every settled post-action outer clip;
- safety scan: zero findings, zero sensitive files, zero invalid or unsupported entries.

Public-safe hashes:

- reachability trace: `d828040ad216a6ab553cac404daf84967d83cb58e5df837b58e5c34e0b6fdbc0`
- focused proof: `4ddda3a0eaa8826087c2e3b8628835d0a005e2b2ef468029f2a754d9947cea9c`
- scroll capabilities: `570e26c4791ae27d24499453016b4590b7580450492eb7bd9e18949c2396c141`

## Safety and proof boundary

The action path is bound to the freshly launched fixture PID, re-resolves and identity-checks the complete Boundary -> outer scroll -> vertical scrollbar -> Increment Page chain immediately before acting, performs one public `AXPress`, and has no retry, private/global/fallback action, or AX value mutation.

This proves only one deterministic dark `tab-repos` DEBUG fixture at 1040x680. It does not prove the rest of #517: every transition/action/result/error state, overflow rows, all tabs or canonical sizes, large text, trackpad/keyboard/VoiceOver behavior, hosted XCUITest/`.xcresult`, signing/notarization, installed-app behavior, browser/native parity, release readiness, GA, customer readiness, or v1.1 completion.

No live daemon, configuration, launchd, product runtime, release, TCC, provider, npm, website, or customer state was changed.
