### PR TITLE
test(desktop): define cross-tab settled geometry contract

### DIFF
--- a/apps/neondiff-desktop/Package.swift
+++ b/apps/neondiff-desktop/Package.swift
@@ -60,6 +60,10 @@ let package = Package(
             dependencies: ["NeonDiffDesktopEvaluationSupport"]
         ),
         .executableTarget(
+            name: "NeonDiffDesktopGeometryChecks",
+            dependencies: ["NeonDiffDesktopEvaluationSupport"]
+        ),
+        .executableTarget(
             name: "NeonDiffDesktopFixtureResolve",
             dependencies: ["NeonDiffDesktopEvaluationSupport"]
         ),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -60,6 +60,7 @@ struct NeonDiffDesktopApp: App {
                 updateController: updateController,
                 preferredColorScheme: preferredColorScheme,
                 rootAccessibilityIdentifier: rootAccessibilityIdentifier,
+                enablesEvaluationRegionBindings: evaluationRegionBindingsEnabled,
                 onSurfaceReady: evaluationSurfaceReadyAction
             )
                 .frame(
@@ -187,6 +188,14 @@ struct NeonDiffDesktopApp: App {
             ?? "neondiff.desktop.root"
 #else
         "neondiff.desktop.root"
+#endif
+    }
+
+    private var evaluationRegionBindingsEnabled: Bool {
+#if DEBUG
+        evaluationContext != nil
+#else
+        false
 #endif
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -35,10 +35,14 @@ struct ContentView: View {
 
             VStack(spacing: 0) {
                 NeonChromeStrip(model: model, updateController: updateController)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("neondiff-chrome")
                     .ignoresSafeArea(.container, edges: .top)
 
                 HStack(spacing: 0) {
                     SidebarView(selection: $model.selectedSection)
+                        .accessibilityElement(children: .contain)
+                        .accessibilityIdentifier("neondiff-sidebar")
                         .frame(width: 230)
 
                     Rectangle()
@@ -50,6 +54,8 @@ struct ContentView: View {
                         updateController: updateController,
                         onSurfaceReady: model.isOnboardingPresented ? nil : onSurfaceReady
                     )
+                        .accessibilityElement(children: .contain)
+                        .accessibilityIdentifier("neondiff-detail")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @ObservedObject var updateController: NeonUpdateController
     let preferredColorScheme: ColorScheme?
     let rootAccessibilityIdentifier: String
+    let enablesEvaluationRegionBindings: Bool
     let onSurfaceReady: (() -> Void)?
 
     init(
@@ -14,12 +15,14 @@ struct ContentView: View {
         updateController: NeonUpdateController,
         preferredColorScheme: ColorScheme? = .dark,
         rootAccessibilityIdentifier: String = "neondiff.desktop.root",
+        enablesEvaluationRegionBindings: Bool = false,
         onSurfaceReady: (() -> Void)? = nil
     ) {
         self.model = model
         self.updateController = updateController
         self.preferredColorScheme = preferredColorScheme
         self.rootAccessibilityIdentifier = rootAccessibilityIdentifier
+        self.enablesEvaluationRegionBindings = enablesEvaluationRegionBindings
         self.onSurfaceReady = onSurfaceReady
     }
 
@@ -35,15 +38,19 @@ struct ContentView: View {
 
             VStack(spacing: 0) {
                 NeonChromeStrip(model: model, updateController: updateController)
-                    .accessibilityElement(children: .contain)
-                    .accessibilityIdentifier("neondiff-chrome")
                     .ignoresSafeArea(.container, edges: .top)
+                    .evaluationAccessibilityRegion(
+                        "neondiff-chrome",
+                        enabled: enablesEvaluationRegionBindings
+                    )
 
                 HStack(spacing: 0) {
                     SidebarView(selection: $model.selectedSection)
-                        .accessibilityElement(children: .contain)
-                        .accessibilityIdentifier("neondiff-sidebar")
                         .frame(width: 230)
+                        .evaluationAccessibilityRegion(
+                            "neondiff-sidebar",
+                            enabled: enablesEvaluationRegionBindings
+                        )
 
                     Rectangle()
                         .fill(NeonDiffTheme.stroke.opacity(0.55))
@@ -54,9 +61,11 @@ struct ContentView: View {
                         updateController: updateController,
                         onSurfaceReady: model.isOnboardingPresented ? nil : onSurfaceReady
                     )
-                        .accessibilityElement(children: .contain)
-                        .accessibilityIdentifier("neondiff-detail")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .evaluationAccessibilityRegion(
+                            "neondiff-detail",
+                            enabled: enablesEvaluationRegionBindings
+                        )
                 }
             }
         }
@@ -71,6 +80,18 @@ struct ContentView: View {
                 .preferredColorScheme(preferredColorScheme)
                 .interactiveDismissDisabled(model.onboardingFlow.currentStep != .done)
                 .onAppear { onSurfaceReady?() }
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func evaluationAccessibilityRegion(_ identifier: String, enabled: Bool) -> some View {
+        if enabled {
+            accessibilityElement(children: .contain)
+                .accessibilityIdentifier(identifier)
+        } else {
+            self
         }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -9,6 +9,7 @@ struct ReposView: View {
         ScrollView(.vertical) {
             pageContent
         }
+        .accessibilityIdentifier("neondiff-repos-outer-scroll")
         .scrollContentBackground(.hidden)
         .scrollIndicators(.visible, axes: .vertical)
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopSettledGeometryTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopSettledGeometryTrace.swift
@@ -11,6 +11,10 @@ public enum DesktopSettledGeometryScenario: String, Codable, Equatable, Sendable
     }
 }
 
+public enum DesktopSettledGeometryCoordinateSpace: String, Codable, Equatable, Sendable {
+    case globalTopLeft = "global-top-left"
+}
+
 public enum DesktopSettledGeometryRegion: String, Codable, CaseIterable, Equatable, Sendable {
     case chrome
     case sidebar
@@ -132,6 +136,7 @@ public struct DesktopSettledGeometryTrace: Codable, Equatable, Sendable {
     public let fixtureId: String
     public let pid: Int32
     public let windowNumber: Int
+    public let coordinateSpace: DesktopSettledGeometryCoordinateSpace
     public let requestedContentSize: DesktopEvaluationContentSize
     public let tolerancePoints: Double
     public let sampleIntervalMilliseconds: Int
@@ -143,6 +148,7 @@ public struct DesktopSettledGeometryTrace: Codable, Equatable, Sendable {
         fixtureId: String,
         pid: Int32,
         windowNumber: Int,
+        coordinateSpace: DesktopSettledGeometryCoordinateSpace,
         requestedContentSize: DesktopEvaluationContentSize,
         tolerancePoints: Double,
         sampleIntervalMilliseconds: Int,
@@ -153,6 +159,7 @@ public struct DesktopSettledGeometryTrace: Codable, Equatable, Sendable {
         self.fixtureId = fixtureId
         self.pid = pid
         self.windowNumber = windowNumber
+        self.coordinateSpace = coordinateSpace
         self.requestedContentSize = requestedContentSize
         self.tolerancePoints = tolerancePoints
         self.sampleIntervalMilliseconds = sampleIntervalMilliseconds
@@ -186,7 +193,8 @@ public struct DesktopSettledGeometryTrace: Codable, Equatable, Sendable {
         guard let root = object as? [String: Any],
               hasOnly(root, [
                   "schemaVersion", "scenario", "fixtureId", "pid", "windowNumber",
-                  "requestedContentSize", "tolerancePoints", "sampleIntervalMilliseconds", "checkpoints"
+                  "coordinateSpace", "requestedContentSize", "tolerancePoints",
+                  "sampleIntervalMilliseconds", "checkpoints"
               ]),
               let size = root["requestedContentSize"] as? [String: Any],
               hasOnly(size, ["width", "height"]),
@@ -231,6 +239,25 @@ public struct DesktopSettledGeometryTrace: Codable, Equatable, Sendable {
     }
 }
 
+public enum DesktopSettledGeometryInputPathError: Error, Equatable, Sendable {
+    case unsafeInput
+}
+
+public enum DesktopSettledGeometryInputPath {
+    public static func validate(rawArgument: String) throws -> URL {
+        guard NSString(string: rawArgument).isAbsolutePath else {
+            throw DesktopSettledGeometryInputPathError.unsafeInput
+        }
+        let input = URL(fileURLWithPath: rawArgument).standardizedFileURL
+        guard input.isFileURL,
+              input.path.hasPrefix("/"),
+              input.lastPathComponent == "settled-geometry.json" else {
+            throw DesktopSettledGeometryInputPathError.unsafeInput
+        }
+        return input
+    }
+}
+
 public enum DesktopSettledGeometryValidationStatus: String, Codable, Equatable, Sendable {
     case stable
 }
@@ -268,6 +295,7 @@ public enum DesktopSettledGeometryValidator {
               trace.fixtureId.range(of: #"^[a-z0-9][a-z0-9-]{0,63}$"#, options: .regularExpression) != nil,
               trace.pid > 0,
               trace.windowNumber > 0,
+              trace.coordinateSpace == .globalTopLeft,
               trace.requestedContentSize == .init(width: 1040, height: 680),
               trace.tolerancePoints.isFinite,
               trace.tolerancePoints > 0,
@@ -333,9 +361,19 @@ public enum DesktopSettledGeometryValidator {
               last.elapsedMilliseconds <= acquisitionMilliseconds else {
             throw DesktopSettledGeometryValidationError.invalidCadence(index: checkpoint)
         }
+        guard samples.allSatisfy({
+            $0.elapsedMilliseconds >= 0
+                && $0.elapsedMilliseconds <= acquisitionMilliseconds
+        }) else {
+            throw DesktopSettledGeometryValidationError.invalidCadence(index: checkpoint)
+        }
         for pair in zip(samples, samples.dropFirst()) {
-            let delta = pair.1.elapsedMilliseconds - pair.0.elapsedMilliseconds
-            guard delta >= interval - 10, delta <= interval + 25 else {
+            let subtraction = pair.1.elapsedMilliseconds.subtractingReportingOverflow(
+                pair.0.elapsedMilliseconds
+            )
+            guard !subtraction.overflow,
+                  subtraction.partialValue >= interval - 10,
+                  subtraction.partialValue <= interval + 25 else {
                 throw DesktopSettledGeometryValidationError.invalidCadence(index: checkpoint)
             }
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopSettledGeometryTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopSettledGeometryTrace.swift
@@ -1,0 +1,628 @@
+import Foundation
+import NeonDiffDesktopCore
+
+public enum DesktopSettledGeometryScenario: String, Codable, Equatable, Sendable {
+    case overviewReposOverview = "overview-repos-overview"
+
+    public var sections: [DesktopSection] {
+        switch self {
+        case .overviewReposOverview: [.overview, .repos, .overview]
+        }
+    }
+}
+
+public enum DesktopSettledGeometryRegion: String, Codable, CaseIterable, Equatable, Sendable {
+    case chrome
+    case sidebar
+    case detail
+    case reposOuterScroll = "repos-outer-scroll"
+    case reposBottomSentinel = "repos-bottom-sentinel"
+
+    public var accessibilityIdentifier: String {
+        switch self {
+        case .chrome: "neondiff-chrome"
+        case .sidebar: "neondiff-sidebar"
+        case .detail: "neondiff-detail"
+        case .reposOuterScroll: "neondiff-repos-outer-scroll"
+        case .reposBottomSentinel: "neondiff-repos-boundary"
+        }
+    }
+}
+
+public struct DesktopSettledGeometryFrame: Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    fileprivate var isFiniteAndNonempty: Bool {
+        [x, y, width, height].allSatisfy(\.isFinite) && width > 0 && height > 0
+    }
+
+    fileprivate func contains(_ other: Self, tolerance: Double) -> Bool {
+        other.x >= x - tolerance
+            && other.y >= y - tolerance
+            && other.x + other.width <= x + width + tolerance
+            && other.y + other.height <= y + height + tolerance
+    }
+
+    fileprivate func containsHorizontally(_ other: Self, tolerance: Double) -> Bool {
+        other.x >= x - tolerance
+            && other.x + other.width <= x + width + tolerance
+    }
+
+    fileprivate func differs(from other: Self, byMoreThan tolerance: Double) -> Bool {
+        abs(x - other.x) > tolerance
+            || abs(y - other.y) > tolerance
+            || abs(width - other.width) > tolerance
+            || abs(height - other.height) > tolerance
+    }
+
+    fileprivate func overlaps(_ other: Self, byMoreThan tolerance: Double) -> Bool {
+        let overlapWidth = min(x + width, other.x + other.width) - max(x, other.x)
+        let overlapHeight = min(y + height, other.y + other.height) - max(y, other.y)
+        return overlapWidth > tolerance && overlapHeight > tolerance
+    }
+}
+
+public struct DesktopSettledGeometryRegionFrame: Codable, Equatable, Sendable {
+    public let id: DesktopSettledGeometryRegion
+    public let frame: DesktopSettledGeometryFrame
+
+    public init(id: DesktopSettledGeometryRegion, frame: DesktopSettledGeometryFrame) {
+        self.id = id
+        self.frame = frame
+    }
+}
+
+public struct DesktopSettledGeometrySample: Codable, Equatable, Sendable {
+    public let elapsedMilliseconds: Int
+    public let windowFrame: DesktopSettledGeometryFrame
+    public let contentFrame: DesktopSettledGeometryFrame
+    public let regions: [DesktopSettledGeometryRegionFrame]
+
+    public init(
+        elapsedMilliseconds: Int,
+        windowFrame: DesktopSettledGeometryFrame,
+        contentFrame: DesktopSettledGeometryFrame,
+        regions: [DesktopSettledGeometryRegionFrame]
+    ) {
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.windowFrame = windowFrame
+        self.contentFrame = contentFrame
+        self.regions = regions
+    }
+}
+
+public struct DesktopSettledGeometryCheckpoint: Codable, Equatable, Sendable {
+    public let index: Int
+    public let section: DesktopSection
+    public let ready: Bool
+    public let quiescent: Bool
+    public let acquisitionMilliseconds: Int
+    public let samples: [DesktopSettledGeometrySample]
+
+    public init(
+        index: Int,
+        section: DesktopSection,
+        ready: Bool,
+        quiescent: Bool,
+        acquisitionMilliseconds: Int,
+        samples: [DesktopSettledGeometrySample]
+    ) {
+        self.index = index
+        self.section = section
+        self.ready = ready
+        self.quiescent = quiescent
+        self.acquisitionMilliseconds = acquisitionMilliseconds
+        self.samples = samples
+    }
+}
+
+public struct DesktopSettledGeometryTrace: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let scenario: DesktopSettledGeometryScenario
+    public let fixtureId: String
+    public let pid: Int32
+    public let windowNumber: Int
+    public let requestedContentSize: DesktopEvaluationContentSize
+    public let tolerancePoints: Double
+    public let sampleIntervalMilliseconds: Int
+    public let checkpoints: [DesktopSettledGeometryCheckpoint]
+
+    public init(
+        schemaVersion: Int,
+        scenario: DesktopSettledGeometryScenario,
+        fixtureId: String,
+        pid: Int32,
+        windowNumber: Int,
+        requestedContentSize: DesktopEvaluationContentSize,
+        tolerancePoints: Double,
+        sampleIntervalMilliseconds: Int,
+        checkpoints: [DesktopSettledGeometryCheckpoint]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.scenario = scenario
+        self.fixtureId = fixtureId
+        self.pid = pid
+        self.windowNumber = windowNumber
+        self.requestedContentSize = requestedContentSize
+        self.tolerancePoints = tolerancePoints
+        self.sampleIntervalMilliseconds = sampleIntervalMilliseconds
+        self.checkpoints = checkpoints
+    }
+
+    public static func decode(data: Data) throws -> Self {
+        guard data.count <= 256 * 1024 else {
+            throw DesktopSettledGeometryValidationError.invalidContract
+        }
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw DesktopSettledGeometryValidationError.invalidContract
+        }
+        guard validateShape(object) else {
+            throw DesktopSettledGeometryValidationError.invalidContract
+        }
+        let trace: Self
+        do {
+            trace = try JSONDecoder().decode(Self.self, from: data)
+        } catch {
+            throw DesktopSettledGeometryValidationError.invalidContract
+        }
+        _ = try DesktopSettledGeometryValidator.validate(trace)
+        return trace
+    }
+
+    private static func validateShape(_ object: Any) -> Bool {
+        guard let root = object as? [String: Any],
+              hasOnly(root, [
+                  "schemaVersion", "scenario", "fixtureId", "pid", "windowNumber",
+                  "requestedContentSize", "tolerancePoints", "sampleIntervalMilliseconds", "checkpoints"
+              ]),
+              let size = root["requestedContentSize"] as? [String: Any],
+              hasOnly(size, ["width", "height"]),
+              let checkpoints = root["checkpoints"] as? [Any] else {
+            return false
+        }
+        return checkpoints.allSatisfy { value in
+            guard let checkpoint = value as? [String: Any],
+                  hasOnly(checkpoint, [
+                      "index", "section", "ready", "quiescent", "acquisitionMilliseconds", "samples"
+                  ]),
+                  let samples = checkpoint["samples"] as? [Any] else {
+                return false
+            }
+            return samples.allSatisfy { value in
+                guard let sample = value as? [String: Any],
+                      hasOnly(sample, ["elapsedMilliseconds", "windowFrame", "contentFrame", "regions"]),
+                      validateFrame(sample["windowFrame"]),
+                      validateFrame(sample["contentFrame"]),
+                      let regions = sample["regions"] as? [Any] else {
+                    return false
+                }
+                return regions.allSatisfy { value in
+                    guard let region = value as? [String: Any],
+                          hasOnly(region, ["id", "frame"]),
+                          validateFrame(region["frame"]) else {
+                        return false
+                    }
+                    return true
+                }
+            }
+        }
+    }
+
+    private static func validateFrame(_ value: Any?) -> Bool {
+        guard let frame = value as? [String: Any] else { return false }
+        return hasOnly(frame, ["x", "y", "width", "height"])
+    }
+
+    private static func hasOnly(_ object: [String: Any], _ keys: Set<String>) -> Bool {
+        Set(object.keys) == keys
+    }
+}
+
+public enum DesktopSettledGeometryValidationStatus: String, Codable, Equatable, Sendable {
+    case stable
+}
+
+public enum DesktopSettledGeometryValidationError: Error, Equatable, Sendable {
+    case invalidContract
+    case invalidSequence(index: Int)
+    case notQuiescent(index: Int)
+    case insufficientSamples(index: Int)
+    case invalidCadence(index: Int)
+    case nonfiniteFrame(checkpoint: Int, sample: Int)
+    case contentSizeMismatch(checkpoint: Int, sample: Int)
+    case duplicateRegion(checkpoint: Int, sample: Int, region: DesktopSettledGeometryRegion)
+    case missingRegion(checkpoint: Int, sample: Int, region: DesktopSettledGeometryRegion)
+    case unexpectedRegion(checkpoint: Int, sample: Int, region: DesktopSettledGeometryRegion)
+    case regionOutsideWindow(checkpoint: Int, sample: Int, region: DesktopSettledGeometryRegion)
+    case sidebarDetailOverlap(checkpoint: Int, sample: Int)
+    case reposScrollOutsideDetail(checkpoint: Int, sample: Int)
+    case reposSentinelOutsideScrollWidth(checkpoint: Int, sample: Int)
+    case unstableCheckpoint(checkpoint: Int, region: DesktopSettledGeometryRegion?)
+    case unstableTransition(checkpoint: Int, region: DesktopSettledGeometryRegion?)
+}
+
+public enum DesktopSettledGeometryValidator {
+    private static let genericRegions: Set<DesktopSettledGeometryRegion> = [.chrome, .sidebar, .detail]
+    private static let reposRegions: Set<DesktopSettledGeometryRegion> = [
+        .chrome, .sidebar, .detail, .reposOuterScroll, .reposBottomSentinel
+    ]
+
+    public static func validate(
+        _ trace: DesktopSettledGeometryTrace
+    ) throws -> DesktopSettledGeometryValidationStatus {
+        guard trace.schemaVersion == 1,
+              trace.fixtureId == "tab-overview",
+              trace.fixtureId.range(of: #"^[a-z0-9][a-z0-9-]{0,63}$"#, options: .regularExpression) != nil,
+              trace.pid > 0,
+              trace.windowNumber > 0,
+              trace.requestedContentSize == .init(width: 1040, height: 680),
+              trace.tolerancePoints.isFinite,
+              trace.tolerancePoints > 0,
+              trace.tolerancePoints <= 1,
+              trace.sampleIntervalMilliseconds == 100,
+              trace.checkpoints.count == trace.scenario.sections.count else {
+            throw DesktopSettledGeometryValidationError.invalidContract
+        }
+
+        var settledCheckpoints: [[DesktopSettledGeometrySample]] = []
+        for (checkpointIndex, checkpoint) in trace.checkpoints.enumerated() {
+            guard checkpoint.index == checkpointIndex,
+                  checkpoint.section == trace.scenario.sections[checkpointIndex] else {
+                throw DesktopSettledGeometryValidationError.invalidSequence(index: checkpointIndex)
+            }
+            guard checkpoint.ready else {
+                throw DesktopSettledGeometryValidationError.invalidContract
+            }
+            guard checkpoint.quiescent else {
+                throw DesktopSettledGeometryValidationError.notQuiescent(index: checkpointIndex)
+            }
+            guard checkpoint.acquisitionMilliseconds >= 0,
+                  checkpoint.acquisitionMilliseconds <= 5_000 else {
+                throw DesktopSettledGeometryValidationError.invalidContract
+            }
+            guard checkpoint.samples.count >= 3 else {
+                throw DesktopSettledGeometryValidationError.insufficientSamples(index: checkpointIndex)
+            }
+            try validateCadence(
+                checkpoint.samples,
+                checkpoint: checkpointIndex,
+                interval: trace.sampleIntervalMilliseconds,
+                acquisitionMilliseconds: checkpoint.acquisitionMilliseconds
+            )
+            try validateSamples(
+                checkpoint.samples,
+                section: checkpoint.section,
+                checkpoint: checkpointIndex,
+                requestedContentSize: trace.requestedContentSize,
+                tolerance: trace.tolerancePoints
+            )
+            try validateCheckpointStability(
+                checkpoint.samples,
+                checkpoint: checkpointIndex,
+                tolerance: trace.tolerancePoints
+            )
+            settledCheckpoints.append(checkpoint.samples)
+        }
+        try validateTransitionStability(settledCheckpoints, tolerance: trace.tolerancePoints)
+        return .stable
+    }
+
+    private static func validateCadence(
+        _ samples: [DesktopSettledGeometrySample],
+        checkpoint: Int,
+        interval: Int,
+        acquisitionMilliseconds: Int
+    ) throws {
+        guard let first = samples.first,
+              let last = samples.last,
+              first.elapsedMilliseconds >= 0,
+              first.elapsedMilliseconds <= 25,
+              last.elapsedMilliseconds <= acquisitionMilliseconds else {
+            throw DesktopSettledGeometryValidationError.invalidCadence(index: checkpoint)
+        }
+        for pair in zip(samples, samples.dropFirst()) {
+            let delta = pair.1.elapsedMilliseconds - pair.0.elapsedMilliseconds
+            guard delta >= interval - 10, delta <= interval + 25 else {
+                throw DesktopSettledGeometryValidationError.invalidCadence(index: checkpoint)
+            }
+        }
+    }
+
+    private static func validateSamples(
+        _ samples: [DesktopSettledGeometrySample],
+        section: DesktopSection,
+        checkpoint: Int,
+        requestedContentSize: DesktopEvaluationContentSize,
+        tolerance: Double
+    ) throws {
+        let required = section == .repos ? reposRegions : genericRegions
+        for (sampleIndex, sample) in samples.enumerated() {
+            guard sample.windowFrame.isFiniteAndNonempty,
+                  sample.contentFrame.isFiniteAndNonempty else {
+                throw DesktopSettledGeometryValidationError.nonfiniteFrame(
+                    checkpoint: checkpoint,
+                    sample: sampleIndex
+                )
+            }
+            guard sample.windowFrame.contains(sample.contentFrame, tolerance: tolerance) else {
+                throw DesktopSettledGeometryValidationError.invalidContract
+            }
+            guard abs(sample.contentFrame.width - Double(requestedContentSize.width)) <= tolerance,
+                  abs(sample.contentFrame.height - Double(requestedContentSize.height)) <= tolerance else {
+                throw DesktopSettledGeometryValidationError.contentSizeMismatch(
+                    checkpoint: checkpoint,
+                    sample: sampleIndex
+                )
+            }
+            var byID: [DesktopSettledGeometryRegion: DesktopSettledGeometryFrame] = [:]
+            for region in sample.regions {
+                guard region.frame.isFiniteAndNonempty else {
+                    throw DesktopSettledGeometryValidationError.nonfiniteFrame(
+                        checkpoint: checkpoint,
+                        sample: sampleIndex
+                    )
+                }
+                guard byID.updateValue(region.frame, forKey: region.id) == nil else {
+                    throw DesktopSettledGeometryValidationError.duplicateRegion(
+                        checkpoint: checkpoint,
+                        sample: sampleIndex,
+                        region: region.id
+                    )
+                }
+            }
+            for region in required where byID[region] == nil {
+                throw DesktopSettledGeometryValidationError.missingRegion(
+                    checkpoint: checkpoint,
+                    sample: sampleIndex,
+                    region: region
+                )
+            }
+            if let unexpected = Set(byID.keys).subtracting(required).first {
+                throw DesktopSettledGeometryValidationError.unexpectedRegion(
+                    checkpoint: checkpoint,
+                    sample: sampleIndex,
+                    region: unexpected
+                )
+            }
+            for region in genericRegions.union([.reposOuterScroll]) {
+                guard let frame = byID[region] else { continue }
+                guard sample.windowFrame.contains(frame, tolerance: tolerance) else {
+                    throw DesktopSettledGeometryValidationError.regionOutsideWindow(
+                        checkpoint: checkpoint,
+                        sample: sampleIndex,
+                        region: region
+                    )
+                }
+            }
+            guard let sidebar = byID[.sidebar], let detail = byID[.detail] else {
+                throw DesktopSettledGeometryValidationError.invalidContract
+            }
+            guard !sidebar.overlaps(detail, byMoreThan: tolerance) else {
+                throw DesktopSettledGeometryValidationError.sidebarDetailOverlap(
+                    checkpoint: checkpoint,
+                    sample: sampleIndex
+                )
+            }
+            if section == .repos {
+                guard let scroll = byID[.reposOuterScroll],
+                      let sentinel = byID[.reposBottomSentinel] else {
+                    throw DesktopSettledGeometryValidationError.invalidContract
+                }
+                guard detail.contains(scroll, tolerance: tolerance) else {
+                    throw DesktopSettledGeometryValidationError.reposScrollOutsideDetail(
+                        checkpoint: checkpoint,
+                        sample: sampleIndex
+                    )
+                }
+                guard scroll.containsHorizontally(sentinel, tolerance: tolerance) else {
+                    throw DesktopSettledGeometryValidationError.reposSentinelOutsideScrollWidth(
+                        checkpoint: checkpoint,
+                        sample: sampleIndex
+                    )
+                }
+            }
+        }
+    }
+
+    private static func validateCheckpointStability(
+        _ samples: [DesktopSettledGeometrySample],
+        checkpoint: Int,
+        tolerance: Double
+    ) throws {
+        let baseline = samples[0]
+        let baselineByID = Dictionary(uniqueKeysWithValues: baseline.regions.map { ($0.id, $0.frame) })
+        for sample in samples.dropFirst() {
+            if sample.windowFrame.differs(from: baseline.windowFrame, byMoreThan: tolerance)
+                || sample.contentFrame.differs(from: baseline.contentFrame, byMoreThan: tolerance) {
+                throw DesktopSettledGeometryValidationError.unstableCheckpoint(
+                    checkpoint: checkpoint,
+                    region: nil
+                )
+            }
+            let byID = Dictionary(uniqueKeysWithValues: sample.regions.map { ($0.id, $0.frame) })
+            for (region, frame) in baselineByID {
+                guard let current = byID[region],
+                      !current.differs(from: frame, byMoreThan: tolerance) else {
+                    throw DesktopSettledGeometryValidationError.unstableCheckpoint(
+                        checkpoint: checkpoint,
+                        region: region
+                    )
+                }
+            }
+        }
+    }
+
+    private static func validateTransitionStability(
+        _ checkpoints: [[DesktopSettledGeometrySample]],
+        tolerance: Double
+    ) throws {
+        guard let baseline = checkpoints.first?.first else {
+            throw DesktopSettledGeometryValidationError.invalidContract
+        }
+        let baselineByID = Dictionary(uniqueKeysWithValues: baseline.regions.map { ($0.id, $0.frame) })
+        for (checkpoint, samples) in checkpoints.enumerated().dropFirst() {
+            for sample in samples {
+                if sample.windowFrame.differs(from: baseline.windowFrame, byMoreThan: tolerance)
+                    || sample.contentFrame.differs(from: baseline.contentFrame, byMoreThan: tolerance) {
+                    throw DesktopSettledGeometryValidationError.unstableTransition(
+                        checkpoint: checkpoint,
+                        region: nil
+                    )
+                }
+                let byID = Dictionary(uniqueKeysWithValues: sample.regions.map { ($0.id, $0.frame) })
+                for region in genericRegions {
+                    guard let original = baselineByID[region],
+                          let current = byID[region],
+                          !current.differs(from: original, byMoreThan: tolerance) else {
+                        throw DesktopSettledGeometryValidationError.unstableTransition(
+                            checkpoint: checkpoint,
+                            region: region
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+public enum DesktopSettledGeometryCheckStatus: String, Codable, Equatable, Sendable {
+    case stable
+    case failed
+}
+
+public enum DesktopSettledGeometryCheckCategory: String, Codable, Equatable, Sendable {
+    case none
+    case input
+    case contract
+    case sequence
+    case geometry
+}
+
+public struct DesktopSettledGeometryCheckResult: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let ok: Bool
+    public let status: DesktopSettledGeometryCheckStatus
+    public let category: DesktopSettledGeometryCheckCategory
+    public let reasonCode: String
+
+    public init(
+        schemaVersion: Int = 1,
+        ok: Bool,
+        status: DesktopSettledGeometryCheckStatus,
+        category: DesktopSettledGeometryCheckCategory,
+        reasonCode: String
+    ) {
+        self.schemaVersion = schemaVersion
+        self.ok = ok
+        self.status = status
+        self.category = category
+        self.reasonCode = reasonCode
+    }
+
+    public static let stable = Self(ok: true, status: .stable, category: .none, reasonCode: "none")
+
+    public static func inputFailure(_ reasonCode: String) -> Self {
+        .init(ok: false, status: .failed, category: .input, reasonCode: reasonCode)
+    }
+
+    public static func failure(_ error: DesktopSettledGeometryValidationError) -> Self {
+        switch error {
+        case .invalidContract:
+            failed(.contract, "invalid-contract")
+        case .invalidSequence:
+            failed(.sequence, "invalid-sequence")
+        case .notQuiescent:
+            failed(.sequence, "not-quiescent")
+        case .insufficientSamples:
+            failed(.geometry, "insufficient-samples")
+        case .invalidCadence:
+            failed(.geometry, "invalid-cadence")
+        case .nonfiniteFrame:
+            failed(.contract, "nonfinite-frame")
+        case .contentSizeMismatch:
+            failed(.geometry, "content-size-mismatch")
+        case .duplicateRegion:
+            failed(.contract, "duplicate-region")
+        case .missingRegion:
+            failed(.contract, "missing-region")
+        case .unexpectedRegion:
+            failed(.contract, "unexpected-region")
+        case .regionOutsideWindow:
+            failed(.geometry, "region-outside-window")
+        case .sidebarDetailOverlap:
+            failed(.geometry, "sidebar-detail-overlap")
+        case .reposScrollOutsideDetail:
+            failed(.geometry, "repos-scroll-outside-detail")
+        case .reposSentinelOutsideScrollWidth:
+            failed(.geometry, "repos-sentinel-outside-scroll-width")
+        case .unstableCheckpoint:
+            failed(.geometry, "unstable-checkpoint")
+        case .unstableTransition:
+            failed(.geometry, "unstable-transition")
+        }
+    }
+
+    private static func failed(
+        _ category: DesktopSettledGeometryCheckCategory,
+        _ reasonCode: String
+    ) -> Self {
+        .init(ok: false, status: .failed, category: category, reasonCode: reasonCode)
+    }
+}
+
+public enum DesktopSettledGeometryScenarioAdvance: Equatable, Sendable {
+    case navigate(DesktopSection)
+    case complete
+}
+
+public enum DesktopSettledGeometryScenarioError: Error, Equatable, Sendable {
+    case unexpectedSection(expected: DesktopSection, actual: DesktopSection)
+    case alreadyComplete
+}
+
+public struct DesktopSettledGeometryScenarioCoordinator: Sendable {
+    public let scenario: DesktopSettledGeometryScenario
+    private var nextIndex = 0
+
+    public init(scenario: DesktopSettledGeometryScenario) {
+        self.scenario = scenario
+    }
+
+    public var expectedSection: DesktopSection? {
+        scenario.sections.indices.contains(nextIndex) ? scenario.sections[nextIndex] : nil
+    }
+
+    public var isComplete: Bool { expectedSection == nil }
+
+    public mutating func recordQuiescent(
+        section: DesktopSection
+    ) throws -> DesktopSettledGeometryScenarioAdvance {
+        guard let expectedSection else {
+            throw DesktopSettledGeometryScenarioError.alreadyComplete
+        }
+        guard section == expectedSection else {
+            throw DesktopSettledGeometryScenarioError.unexpectedSection(
+                expected: expectedSection,
+                actual: section
+            )
+        }
+        nextIndex += 1
+        if let next = self.expectedSection {
+            return .navigate(next)
+        }
+        return .complete
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopSettledGeometryTrace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopSettledGeometryTrace.swift
@@ -47,7 +47,11 @@ public struct DesktopSettledGeometryFrame: Codable, Equatable, Sendable {
     }
 
     fileprivate var isFiniteAndNonempty: Bool {
-        [x, y, width, height].allSatisfy(\.isFinite) && width > 0 && height > 0
+        let maxX = x + width
+        let maxY = y + height
+        return [x, y, width, height, maxX, maxY].allSatisfy(\.isFinite)
+            && width > 0
+            && height > 0
     }
 
     fileprivate func contains(_ other: Self, tolerance: Double) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopGeometryChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopGeometryChecks/main.swift
@@ -4,7 +4,6 @@ import NeonDiffDesktopEvaluationSupport
 
 private enum CheckerError: Error {
     case usage
-    case unsafeInput
 }
 
 private func emit(_ result: DesktopSettledGeometryCheckResult) {
@@ -22,15 +21,10 @@ private func emit(_ result: DesktopSettledGeometryCheckResult) {
 
 do {
     guard CommandLine.arguments.count == 2 else { throw CheckerError.usage }
-    let input = URL(fileURLWithPath: CommandLine.arguments[1]).standardizedFileURL
-    guard input.isFileURL,
-          input.path.hasPrefix("/"),
-          input.lastPathComponent == "settled-geometry.json" else {
-        throw CheckerError.unsafeInput
-    }
+    let input = try DesktopSettledGeometryInputPath.validate(rawArgument: CommandLine.arguments[1])
     let values = try input.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
     guard values.isRegularFile == true, values.isSymbolicLink != true else {
-        throw CheckerError.unsafeInput
+        throw DesktopSettledGeometryInputPathError.unsafeInput
     }
     let trace = try DesktopSettledGeometryTrace.decode(
         data: Data(contentsOf: input, options: [.mappedIfSafe])
@@ -40,7 +34,7 @@ do {
 } catch CheckerError.usage {
     emit(.inputFailure("usage"))
     exit(64)
-} catch CheckerError.unsafeInput {
+} catch DesktopSettledGeometryInputPathError.unsafeInput {
     emit(.inputFailure("unsafe-input"))
     exit(65)
 } catch let error as DesktopSettledGeometryValidationError {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopGeometryChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopGeometryChecks/main.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Foundation
+import NeonDiffDesktopEvaluationSupport
+
+private enum CheckerError: Error {
+    case usage
+    case unsafeInput
+}
+
+private func emit(_ result: DesktopSettledGeometryCheckResult) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(result) else {
+        FileHandle.standardOutput.write(Data(
+            "{\"category\":\"contract\",\"ok\":false,\"reasonCode\":\"checker-encoding-failed\",\"schemaVersion\":1,\"status\":\"failed\"}\n".utf8
+        ))
+        exit(70)
+    }
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+do {
+    guard CommandLine.arguments.count == 2 else { throw CheckerError.usage }
+    let input = URL(fileURLWithPath: CommandLine.arguments[1]).standardizedFileURL
+    guard input.isFileURL,
+          input.path.hasPrefix("/"),
+          input.lastPathComponent == "settled-geometry.json" else {
+        throw CheckerError.unsafeInput
+    }
+    let values = try input.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+    guard values.isRegularFile == true, values.isSymbolicLink != true else {
+        throw CheckerError.unsafeInput
+    }
+    let trace = try DesktopSettledGeometryTrace.decode(
+        data: Data(contentsOf: input, options: [.mappedIfSafe])
+    )
+    _ = try DesktopSettledGeometryValidator.validate(trace)
+    emit(.stable)
+} catch CheckerError.usage {
+    emit(.inputFailure("usage"))
+    exit(64)
+} catch CheckerError.unsafeInput {
+    emit(.inputFailure("unsafe-input"))
+    exit(65)
+} catch let error as DesktopSettledGeometryValidationError {
+    emit(.failure(error))
+    exit(65)
+} catch {
+    emit(.inputFailure("input-read-failed"))
+    exit(65)
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
@@ -40,16 +40,25 @@ import Testing
         #expect(source.contains(".accessibilityIdentifier(\"neondiff-repos-boundary\")"))
     }
 
-    @Test func settledGeometryBindingsPreserveContainedNativeRegions() throws {
+    @Test func settledGeometryBindingsAreFixtureOnlyAndPreserveNativeRegions() throws {
         let contentView = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views/ContentView.swift")
         let source = try sourceBoundaryText(at: contentView)
+        let app = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot()
+                .appendingPathComponent("Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift")
+        )
 
         for identifier in ["neondiff-chrome", "neondiff-sidebar", "neondiff-detail"] {
-            #expect(source.contains(".accessibilityIdentifier(\"\(identifier)\")"))
+            #expect(source.contains("\"\(identifier)\""))
         }
-        #expect(source.components(separatedBy: ".accessibilityElement(children: .contain)").count - 1 >= 3)
+        #expect(source.contains("enablesEvaluationRegionBindings: Bool = false"))
+        #expect(source.contains("evaluationAccessibilityRegion("))
+        #expect(source.contains("if enabled {"))
+        #expect(source.components(separatedBy: "accessibilityElement(children: .contain)").count - 1 == 1)
         #expect(source.contains("SidebarView(selection: $model.selectedSection)"))
         #expect(source.contains("DetailView("))
+        #expect(app.contains("enablesEvaluationRegionBindings: evaluationRegionBindingsEnabled"))
+        #expect(app.contains("evaluationContext != nil"))
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ReposReachabilityLayoutContractTests.swift
@@ -36,6 +36,20 @@ import Testing
         #expect(pageStack.lowerBound < readOnlyBoundary.lowerBound)
         #expect(source.contains(".frame(height: 360)"))
         #expect(!source.contains(".frame(minHeight: 360)"))
+        #expect(source.contains(".accessibilityIdentifier(\"neondiff-repos-outer-scroll\")"))
         #expect(source.contains(".accessibilityIdentifier(\"neondiff-repos-boundary\")"))
+    }
+
+    @Test func settledGeometryBindingsPreserveContainedNativeRegions() throws {
+        let contentView = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views/ContentView.swift")
+        let source = try sourceBoundaryText(at: contentView)
+
+        for identifier in ["neondiff-chrome", "neondiff-sidebar", "neondiff-detail"] {
+            #expect(source.contains(".accessibilityIdentifier(\"\(identifier)\")"))
+        }
+        #expect(source.components(separatedBy: ".accessibilityElement(children: .contain)").count - 1 >= 3)
+        #expect(source.contains("SidebarView(selection: $model.selectedSection)"))
+        #expect(source.contains("DetailView("))
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopSettledGeometryTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopSettledGeometryTraceTests.swift
@@ -1,0 +1,393 @@
+import Foundation
+import Testing
+import NeonDiffDesktopCore
+@testable import NeonDiffDesktopEvaluationSupport
+
+@Suite("Desktop settled geometry trace")
+struct DesktopSettledGeometryTraceTests {
+    @Test func acceptsStrictSameProcessOverviewReposOverviewTrace() throws {
+        let trace = makeTrace()
+
+        #expect(try DesktopSettledGeometryValidator.validate(trace) == .stable)
+        #expect(try DesktopSettledGeometryTrace.decode(data: JSONEncoder().encode(trace)) == trace)
+        #expect(DesktopSettledGeometryCheckResult.stable.ok)
+    }
+
+    @Test func bindsEveryRegionToOneUniquePublicAccessibilityIdentifier() {
+        let identifiers = DesktopSettledGeometryRegion.allCases.map(\.accessibilityIdentifier)
+
+        #expect(Set(identifiers).count == DesktopSettledGeometryRegion.allCases.count)
+        #expect(DesktopSettledGeometryRegion.chrome.accessibilityIdentifier == "neondiff-chrome")
+        #expect(DesktopSettledGeometryRegion.reposBottomSentinel.accessibilityIdentifier == "neondiff-repos-boundary")
+    }
+
+    @Test func decoderRejectsUnknownFieldsAtEveryLevel() throws {
+        let encoded = try JSONEncoder().encode(makeTrace())
+        var root = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        root["unexpected"] = true
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryTrace.decode(data: JSONSerialization.data(withJSONObject: root))
+        }
+
+        root = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        var checkpoints = try #require(root["checkpoints"] as? [[String: Any]])
+        var samples = try #require(checkpoints[1]["samples"] as? [[String: Any]])
+        var regions = try #require(samples[0]["regions"] as? [[String: Any]])
+        regions[0]["unexpected"] = true
+        samples[0]["regions"] = regions
+        checkpoints[1]["samples"] = samples
+        root["checkpoints"] = checkpoints
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryTrace.decode(data: JSONSerialization.data(withJSONObject: root))
+        }
+    }
+
+    @Test func requiresExactScenarioIdentityAndSequence() {
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(schemaVersion: 2))
+        }
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(fixtureId: "tab-repos"))
+        }
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(pid: 0))
+        }
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(windowNumber: 0))
+        }
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(
+                requestedContentSize: .init(width: 1280, height: 800)
+            ))
+        }
+
+        var checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .providers)
+        #expect(throws: DesktopSettledGeometryValidationError.invalidSequence(index: 1)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+    }
+
+    @Test func requiresExplicitQuiescenceAndThreeHundredMillisecondSamples() {
+        var checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, quiescent: false)
+        #expect(throws: DesktopSettledGeometryValidationError.notQuiescent(index: 1)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(
+            index: 1,
+            section: .repos,
+            samples: Array(samples(section: .repos).prefix(2))
+        )
+        #expect(throws: DesktopSettledGeometryValidationError.insufficientSamples(index: 1)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var wrongCadence = samples(section: .repos)
+        wrongCadence[2] = sample(section: .repos, elapsedMilliseconds: 350)
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: wrongCadence)
+        #expect(throws: DesktopSettledGeometryValidationError.invalidCadence(index: 1)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+    }
+
+    @Test func requiresExactGenericAndReposBindings() {
+        var missingChrome = samples(section: .overview)
+        missingChrome[0] = missingChrome[0].removing(.chrome)
+        var checkpoints = makeCheckpoints()
+        checkpoints[0] = checkpoint(index: 0, section: .overview, samples: missingChrome)
+        #expect(throws: DesktopSettledGeometryValidationError.missingRegion(
+            checkpoint: 0,
+            sample: 0,
+            region: .chrome
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var duplicateSentinel = samples(section: .repos)
+        duplicateSentinel[0] = duplicateSentinel[0].adding(.reposBottomSentinel, frame: sentinelFrame)
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: duplicateSentinel)
+        #expect(throws: DesktopSettledGeometryValidationError.duplicateRegion(
+            checkpoint: 1,
+            sample: 0,
+            region: .reposBottomSentinel
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var extraReposBinding = samples(section: .overview)
+        extraReposBinding[0] = extraReposBinding[0].adding(.reposOuterScroll, frame: reposScrollFrame)
+        checkpoints = makeCheckpoints()
+        checkpoints[0] = checkpoint(index: 0, section: .overview, samples: extraReposBinding)
+        #expect(throws: DesktopSettledGeometryValidationError.unexpectedRegion(
+            checkpoint: 0,
+            sample: 0,
+            region: .reposOuterScroll
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+    }
+
+    @Test func rejectsInvalidContainmentOverlapAndReposAncestryGeometry() {
+        var wrongContentSize = samples(section: .overview)
+        wrongContentSize[0] = sample(
+            section: .overview,
+            content: .init(x: 0, y: 0, width: 1038.9, height: 680)
+        )
+        var checkpoints = makeCheckpoints()
+        checkpoints[0] = checkpoint(index: 0, section: .overview, samples: wrongContentSize)
+        #expect(throws: DesktopSettledGeometryValidationError.contentSizeMismatch(
+            checkpoint: 0,
+            sample: 0
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var outsideWindow = samples(section: .overview)
+        outsideWindow[0] = sample(section: .overview, chrome: .init(x: -10, y: 0, width: 1040, height: 82))
+        checkpoints = makeCheckpoints()
+        checkpoints[0] = checkpoint(index: 0, section: .overview, samples: outsideWindow)
+        #expect(throws: DesktopSettledGeometryValidationError.regionOutsideWindow(
+            checkpoint: 0,
+            sample: 0,
+            region: .chrome
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var overlapping = samples(section: .overview)
+        overlapping[0] = sample(
+            section: .overview,
+            sidebar: .init(x: 0, y: 82, width: 300, height: 598),
+            detail: .init(x: 250, y: 82, width: 790, height: 598)
+        )
+        checkpoints = makeCheckpoints()
+        checkpoints[0] = checkpoint(index: 0, section: .overview, samples: overlapping)
+        #expect(throws: DesktopSettledGeometryValidationError.sidebarDetailOverlap(checkpoint: 0, sample: 0)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var wrongScroll = samples(section: .repos)
+        wrongScroll[0] = sample(
+            section: .repos,
+            reposScroll: .init(x: 100, y: 100, width: 900, height: 500)
+        )
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: wrongScroll)
+        #expect(throws: DesktopSettledGeometryValidationError.reposScrollOutsideDetail(checkpoint: 1, sample: 0)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var wrongSentinel = samples(section: .repos)
+        wrongSentinel[0] = sample(
+            section: .repos,
+            sentinel: .init(x: 100, y: 900, width: 120, height: 16)
+        )
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: wrongSentinel)
+        #expect(throws: DesktopSettledGeometryValidationError.reposSentinelOutsideScrollWidth(
+            checkpoint: 1,
+            sample: 0
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+    }
+
+    @Test func rejectsWithinCheckpointAndCrossTransitionDriftAboveOnePoint() {
+        var drifting = samples(section: .overview)
+        drifting[2] = sample(
+            section: .overview,
+            elapsedMilliseconds: 205,
+            chrome: .init(x: 0, y: 1.01, width: 1040, height: 82)
+        )
+        var checkpoints = makeCheckpoints()
+        checkpoints[0] = checkpoint(index: 0, section: .overview, samples: drifting)
+        #expect(throws: DesktopSettledGeometryValidationError.unstableCheckpoint(
+            checkpoint: 0,
+            region: .chrome
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        let shifted = samples(section: .repos).map {
+            $0.replacing(.sidebar, frame: .init(x: 0, y: 82, width: 231.01, height: 598))
+        }
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: shifted)
+        #expect(throws: DesktopSettledGeometryValidationError.unstableTransition(
+            checkpoint: 1,
+            region: .sidebar
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var transient = samples(section: .repos)
+        transient[0] = transient[0].replacing(
+            .sidebar,
+            frame: .init(x: 0, y: 82, width: 231.01, height: 598)
+        )
+        transient[1] = transient[1].replacing(
+            .sidebar,
+            frame: .init(x: 0, y: 82, width: 230.01, height: 598)
+        )
+        transient[2] = transient[2].replacing(
+            .sidebar,
+            frame: .init(x: 0, y: 82, width: 230.01, height: 598)
+        )
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: transient)
+        #expect(throws: DesktopSettledGeometryValidationError.unstableTransition(
+            checkpoint: 1,
+            region: .sidebar
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+    }
+
+    @Test func scenarioCoordinatorIsStrictFailClosedAndSingleUse() throws {
+        var coordinator = DesktopSettledGeometryScenarioCoordinator(scenario: .overviewReposOverview)
+        #expect(coordinator.expectedSection == .overview)
+        #expect(try coordinator.recordQuiescent(section: .overview) == .navigate(.repos))
+        #expect(try coordinator.recordQuiescent(section: .repos) == .navigate(.overview))
+        #expect(try coordinator.recordQuiescent(section: .overview) == .complete)
+        #expect(coordinator.isComplete)
+        #expect(throws: DesktopSettledGeometryScenarioError.alreadyComplete) {
+            try coordinator.recordQuiescent(section: .overview)
+        }
+
+        var wrong = DesktopSettledGeometryScenarioCoordinator(scenario: .overviewReposOverview)
+        #expect(throws: DesktopSettledGeometryScenarioError.unexpectedSection(
+            expected: .overview,
+            actual: .repos
+        )) {
+            try wrong.recordQuiescent(section: .repos)
+        }
+    }
+
+    @Test func checkerClassifiesContractSequenceAndGeometryFailures() {
+        #expect(DesktopSettledGeometryCheckResult.failure(.invalidContract).category == .contract)
+        #expect(DesktopSettledGeometryCheckResult.failure(.invalidSequence(index: 1)).reasonCode == "invalid-sequence")
+        #expect(DesktopSettledGeometryCheckResult.failure(.unstableTransition(
+            checkpoint: 2,
+            region: .detail
+        )).category == .geometry)
+        #expect(DesktopSettledGeometryCheckResult.inputFailure("unsafe-input").category == .input)
+    }
+}
+
+private let windowFrame = DesktopSettledGeometryFrame(x: 0, y: 0, width: 1040, height: 710)
+private let contentFrame = DesktopSettledGeometryFrame(x: 0, y: 0, width: 1040, height: 680)
+private let chromeFrame = DesktopSettledGeometryFrame(x: 0, y: 0, width: 1040, height: 82)
+private let sidebarFrame = DesktopSettledGeometryFrame(x: 0, y: 82, width: 230, height: 598)
+private let detailFrame = DesktopSettledGeometryFrame(x: 231, y: 82, width: 809, height: 598)
+private let reposScrollFrame = DesktopSettledGeometryFrame(x: 255, y: 120, width: 761, height: 520)
+private let sentinelFrame = DesktopSettledGeometryFrame(x: 279, y: 770, width: 713, height: 16)
+
+private func makeTrace(
+    schemaVersion: Int = 1,
+    fixtureId: String = "tab-overview",
+    pid: Int32 = 42,
+    windowNumber: Int = 7,
+    requestedContentSize: DesktopEvaluationContentSize = .init(width: 1040, height: 680),
+    checkpoints: [DesktopSettledGeometryCheckpoint] = makeCheckpoints()
+) -> DesktopSettledGeometryTrace {
+    .init(
+        schemaVersion: schemaVersion,
+        scenario: .overviewReposOverview,
+        fixtureId: fixtureId,
+        pid: pid,
+        windowNumber: windowNumber,
+        requestedContentSize: requestedContentSize,
+        tolerancePoints: 1,
+        sampleIntervalMilliseconds: 100,
+        checkpoints: checkpoints
+    )
+}
+
+private func makeCheckpoints() -> [DesktopSettledGeometryCheckpoint] {
+    [
+        checkpoint(index: 0, section: .overview),
+        checkpoint(index: 1, section: .repos),
+        checkpoint(index: 2, section: .overview)
+    ]
+}
+
+private func checkpoint(
+    index: Int,
+    section: DesktopSection,
+    quiescent: Bool = true,
+    samples providedSamples: [DesktopSettledGeometrySample]? = nil
+) -> DesktopSettledGeometryCheckpoint {
+    .init(
+        index: index,
+        section: section,
+        ready: true,
+        quiescent: quiescent,
+        acquisitionMilliseconds: 250,
+        samples: providedSamples ?? samples(section: section)
+    )
+}
+
+private func samples(section: DesktopSection) -> [DesktopSettledGeometrySample] {
+    [0, 100, 205].map { sample(section: section, elapsedMilliseconds: $0) }
+}
+
+private func sample(
+    section: DesktopSection,
+    elapsedMilliseconds: Int = 0,
+    content: DesktopSettledGeometryFrame = contentFrame,
+    chrome: DesktopSettledGeometryFrame = chromeFrame,
+    sidebar: DesktopSettledGeometryFrame = sidebarFrame,
+    detail: DesktopSettledGeometryFrame = detailFrame,
+    reposScroll: DesktopSettledGeometryFrame = reposScrollFrame,
+    sentinel: DesktopSettledGeometryFrame = sentinelFrame
+) -> DesktopSettledGeometrySample {
+    var regions: [DesktopSettledGeometryRegionFrame] = [
+        .init(id: .chrome, frame: chrome),
+        .init(id: .sidebar, frame: sidebar),
+        .init(id: .detail, frame: detail)
+    ]
+    if section == .repos {
+        regions.append(.init(id: .reposOuterScroll, frame: reposScroll))
+        regions.append(.init(id: .reposBottomSentinel, frame: sentinel))
+    }
+    return .init(
+        elapsedMilliseconds: elapsedMilliseconds,
+        windowFrame: windowFrame,
+        contentFrame: content,
+        regions: regions
+    )
+}
+
+private extension DesktopSettledGeometrySample {
+    func removing(_ id: DesktopSettledGeometryRegion) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            windowFrame: windowFrame,
+            contentFrame: contentFrame,
+            regions: regions.filter { $0.id != id }
+        )
+    }
+
+    func adding(_ id: DesktopSettledGeometryRegion, frame: DesktopSettledGeometryFrame) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            windowFrame: windowFrame,
+            contentFrame: contentFrame,
+            regions: regions + [.init(id: id, frame: frame)]
+        )
+    }
+
+    func replacing(_ id: DesktopSettledGeometryRegion, frame: DesktopSettledGeometryFrame) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            windowFrame: windowFrame,
+            contentFrame: contentFrame,
+            regions: regions.map { $0.id == id ? .init(id: id, frame: frame) : $0 }
+        )
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopSettledGeometryTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopSettledGeometryTraceTests.swift
@@ -165,6 +165,23 @@ struct DesktopSettledGeometryTraceTests {
     }
 
     @Test func rejectsInvalidContainmentOverlapAndReposAncestryGeometry() {
+        let overflowingCheckpoints = makeCheckpoints().map { checkpoint in
+            DesktopSettledGeometryCheckpoint(
+                index: checkpoint.index,
+                section: checkpoint.section,
+                ready: checkpoint.ready,
+                quiescent: checkpoint.quiescent,
+                acquisitionMilliseconds: checkpoint.acquisitionMilliseconds,
+                samples: checkpoint.samples.map(\.withOverflowingHorizontalEdges)
+            )
+        }
+        #expect(throws: DesktopSettledGeometryValidationError.nonfiniteFrame(
+            checkpoint: 0,
+            sample: 0
+        )) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: overflowingCheckpoints))
+        }
+
         var wrongContentSize = samples(section: .overview)
         wrongContentSize[0] = sample(
             section: .overview,
@@ -403,6 +420,24 @@ private func sample(
 }
 
 private extension DesktopSettledGeometrySample {
+    var withOverflowingHorizontalEdges: Self {
+        let origin = Double.greatestFiniteMagnitude
+        func moved(_ frame: DesktopSettledGeometryFrame) -> DesktopSettledGeometryFrame {
+            .init(x: origin, y: frame.y, width: frame.width, height: frame.height)
+        }
+        return .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            windowFrame: .init(
+                x: origin,
+                y: windowFrame.y,
+                width: Double.greatestFiniteMagnitude,
+                height: windowFrame.height
+            ),
+            contentFrame: moved(contentFrame),
+            regions: regions.map { .init(id: $0.id, frame: moved($0.frame)) }
+        )
+    }
+
     func withElapsedMilliseconds(_ elapsedMilliseconds: Int) -> Self {
         .init(
             elapsedMilliseconds: elapsedMilliseconds,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopSettledGeometryTraceTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopSettledGeometryTraceTests.swift
@@ -43,6 +43,7 @@ struct DesktopSettledGeometryTraceTests {
     }
 
     @Test func requiresExactScenarioIdentityAndSequence() {
+        #expect(makeTrace().coordinateSpace == .globalTopLeft)
         #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
             try DesktopSettledGeometryValidator.validate(makeTrace(schemaVersion: 2))
         }
@@ -65,6 +66,15 @@ struct DesktopSettledGeometryTraceTests {
         checkpoints[1] = checkpoint(index: 1, section: .providers)
         #expect(throws: DesktopSettledGeometryValidationError.invalidSequence(index: 1)) {
             try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        let encoded = try? JSONEncoder().encode(makeTrace())
+        var root = encoded.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        root?["coordinateSpace"] = "global-bottom-left"
+        #expect(throws: DesktopSettledGeometryValidationError.invalidContract) {
+            try DesktopSettledGeometryTrace.decode(
+                data: try #require(root).withJSONData()
+            )
         }
     }
 
@@ -91,6 +101,28 @@ struct DesktopSettledGeometryTraceTests {
         checkpoints[1] = checkpoint(index: 1, section: .repos, samples: wrongCadence)
         #expect(throws: DesktopSettledGeometryValidationError.invalidCadence(index: 1)) {
             try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+
+        var overflowingCadence = samples(section: .repos)
+        overflowingCadence[2] = overflowingCadence[2].withElapsedMilliseconds(Int.min)
+        checkpoints = makeCheckpoints()
+        checkpoints[1] = checkpoint(index: 1, section: .repos, samples: overflowingCadence)
+        #expect(throws: DesktopSettledGeometryValidationError.invalidCadence(index: 1)) {
+            try DesktopSettledGeometryValidator.validate(makeTrace(checkpoints: checkpoints))
+        }
+    }
+
+    @Test func checkerInputRequiresAnAbsoluteCanonicalArtifactPath() throws {
+        let accepted = try DesktopSettledGeometryInputPath.validate(
+            rawArgument: "/tmp/neondiff-focused/settled-geometry.json"
+        )
+        #expect(accepted.path == "/tmp/neondiff-focused/settled-geometry.json")
+
+        #expect(throws: DesktopSettledGeometryInputPathError.unsafeInput) {
+            try DesktopSettledGeometryInputPath.validate(rawArgument: "settled-geometry.json")
+        }
+        #expect(throws: DesktopSettledGeometryInputPathError.unsafeInput) {
+            try DesktopSettledGeometryInputPath.validate(rawArgument: "/tmp/not-the-contract.json")
         }
     }
 
@@ -301,11 +333,18 @@ private func makeTrace(
         fixtureId: fixtureId,
         pid: pid,
         windowNumber: windowNumber,
+        coordinateSpace: .globalTopLeft,
         requestedContentSize: requestedContentSize,
         tolerancePoints: 1,
         sampleIntervalMilliseconds: 100,
         checkpoints: checkpoints
     )
+}
+
+private extension Dictionary where Key == String, Value == Any {
+    func withJSONData() throws -> Data {
+        try JSONSerialization.data(withJSONObject: self)
+    }
 }
 
 private func makeCheckpoints() -> [DesktopSettledGeometryCheckpoint] {
@@ -364,6 +403,15 @@ private func sample(
 }
 
 private extension DesktopSettledGeometrySample {
+    func withElapsedMilliseconds(_ elapsedMilliseconds: Int) -> Self {
+        .init(
+            elapsedMilliseconds: elapsedMilliseconds,
+            windowFrame: windowFrame,
+            contentFrame: contentFrame,
+            regions: regions
+        )
+    }
+
     func removing(_ id: DesktopSettledGeometryRegion) -> Self {
         .init(
             elapsedMilliseconds: elapsedMilliseconds,

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -236,6 +236,37 @@ invalidate an existing macOS TCC Screen Recording or Accessibility grant. A TCC
 failure limits this local dev proof; it is not a Repos reachability result and
 must not be bypassed by touching privacy settings from the runner.
 
+## Contract-First Cross-Tab Settled Geometry
+
+`DesktopSettledGeometryTrace` is the strict schema seed for the next #517
+transition slice. Schema 1 admits only one same-process scenario:
+`overview -> repos -> overview`, starting from the public-safe `tab-overview`
+fixture at `1040x680`. Every checkpoint must explicitly report readiness and
+quiescence, complete within five seconds, and contain at least three stable
+samples at the 100ms cadence. The trace binds one positive PID and window
+number for the complete sequence.
+
+Every sample requires finite window/content frames plus uniquely identified
+chrome, sidebar, and detail regions. The Repos checkpoint additionally requires
+the outer page scroll and bottom sentinel bindings. The validator rejects
+unknown fields, missing or extra regions, invalid containment, sidebar/detail
+overlap, a Repos scroll outside the detail region, a sentinel that does not
+share the scroll surface's horizontal extent, within-checkpoint drift, and
+cross-transition window/content/chrome/sidebar/detail drift above one point.
+Sentinel presence is not treated as bottom reachability; that remains a later
+interaction proof.
+
+`DesktopSettledGeometryScenarioCoordinator` is a single-use, fail-closed state
+machine for that exact sequence. `NeonDiffDesktopGeometryChecks` emits one
+typed `input`, `contract`, `sequence`, or `geometry` result for an absolute
+regular file named `settled-geometry.json`.
+
+This slice establishes contracts and stable Accessibility bindings only. It
+does not run a real scenario, emit a capture packet, produce `.xcresult`, or
+prove click-to-click stability. A later focused runner must acquire all three
+checkpoints from one freshly launched DEBUG fixture PID before any real #517
+transition claim is allowed.
+
 The Swift desktop gate runs the fixture checks whenever evaluation sources or
 catalog files change. It keeps the normal debug bundle separate, stages an
 explicit release bundle under `dist-release`, and scans only the release

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -244,7 +244,10 @@ transition slice. Schema 1 admits only one same-process scenario:
 fixture at `1040x680`. Every checkpoint must explicitly report readiness and
 quiescence, complete within five seconds, and contain at least three stable
 samples at the 100ms cadence. The trace binds one positive PID and window
-number for the complete sequence.
+number for the complete sequence. Every frame uses one explicit
+`global-top-left` screen coordinate space. A future runner must normalize
+AppKit-authored window/content frames into that convention before comparison
+with Accessibility frames; mixed or implicit coordinate systems are invalid.
 
 Every sample requires finite window/content frames plus uniquely identified
 chrome, sidebar, and detail regions. The Repos checkpoint additionally requires
@@ -261,11 +264,14 @@ machine for that exact sequence. `NeonDiffDesktopGeometryChecks` emits one
 typed `input`, `contract`, `sequence`, or `geometry` result for an absolute
 regular file named `settled-geometry.json`.
 
-This slice establishes contracts and stable Accessibility bindings only. It
-does not run a real scenario, emit a capture packet, produce `.xcresult`, or
-prove click-to-click stability. A later focused runner must acquire all three
-checkpoints from one freshly launched DEBUG fixture PID before any real #517
-transition claim is allowed.
+This slice establishes contracts and DEBUG-fixture-only Accessibility bindings.
+The chrome/sidebar/detail container probes are default-off and enabled only
+when a resolved evaluation context exists, so normal debug launches and release
+builds retain the production VoiceOver hierarchy. It does not run a real
+scenario, emit a capture packet, produce `.xcresult`, or prove click-to-click
+stability. A later focused runner must acquire all three checkpoints from one
+freshly launched DEBUG fixture PID before any real #517 transition claim is
+allowed.
 
 The Swift desktop gate runs the fixture checks whenever evaluation sources or
 catalog files change. It keeps the normal debug bundle separate, stages an


### PR DESCRIPTION
## Summary

- define a strict schema-1 `overview -> repos -> overview` settled-geometry trace for one `tab-overview` DEBUG fixture at 1040x680;
- require one positive PID/window identity, an explicit `global-top-left` coordinate space, readiness and quiescence, three-or-more 100ms samples, exact region cardinality, canonical content size, one-point stability, containment, and non-overlap contracts;
- compare every sample in every checkpoint against the initial chrome/sidebar/detail/window/content baseline;
- add DEBUG-fixture-only chrome/sidebar/detail Accessibility bindings plus stable identifiers for the native Repos outer scroll and existing Boundary sentinel while preserving the normal app's VoiceOver hierarchy and native Table;
- add the fail-closed `NeonDiffDesktopGeometryChecks` result mapper and a single-use scenario coordinator.

Related: #517

This is a contract-first slice. #517 remains open for the real same-PID capture and its broader acceptance matrix.

## Exact source

- base: `3351ef44809adcf80b2392803d6a6856d6252dc5`
- head: `98f796a469a0488aa96398f97746dfee6adc8008`
- branch: `fix/517-cross-tab-settled-geometry`

## Failing-first proof

The focused Swift suite initially failed at compile time with 49 missing-type errors because `DesktopSettledGeometryTrace`, its validator/checker types, and the scenario coordinator did not exist. Adversarial review then exposed and regression-locked fail-closed/design defects: cross-transition validation must compare every sample, raw relative paths must be rejected before URL canonicalization, hostile timestamp integers must not overflow, every derived frame edge must remain finite, and all frames must declare one coordinate convention without adding production VoiceOver containers.

## Validation

- `NeonDiffDesktopEvaluationSupportTests`: 52/52 passed across four suites.
- New settled-geometry suite: 11/11 passed.
- `NeonDiffDesktopAppCoreTests`: 49/49 plus the 1/1 migration-ledger suite passed.
- Repos/native binding contract: 2/2 passed.
- Adjacent desktop-evaluation-boundary and Swift CI routing Vitest contracts: 16/16 passed.
- `NeonDiffDesktopGeometryChecks` builds; no-argument smoke emits typed `input/usage` and exits 64, while a relative-path smoke emits typed `input/unsafe-input` and exits 65.
- `git diff --check`, forbidden public-claim scan, and secret scan pass; the post-stage secret scan covered 720 tracked files.

## Safety and proof boundary

Chrome/sidebar/detail containment groups are default-off and enabled only for a resolved DEBUG evaluation fixture. Normal debug launches and release builds retain the production VoiceOver hierarchy. The change preserves the native SwiftUI app, native Repos `ScrollView`, and native inner `Table`; it does not script actions or touch runtime/provider/license/customer state.

This PR does not run a real cross-tab scenario, emit a capture packet, produce `.xcresult`, or prove click-to-click geometry stability. It does not expand the immutable `f844660` Repos action evidence. It does not prove remaining #517 states/sizes/input or accessibility modes, hosted XCUITest, signing/notarization, installed-app behavior, browser/native parity, release, GA, or customer readiness.

No npm publication, GitHub Release, appcast, website, live daemon/config/launchd, TCC, or customer state changed.
