### PR TITLE
test(desktop): add hosted XCUITest foundation

### DIFF
--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -136,6 +137,10 @@ jobs:
         timeout-minutes: 3
         run: npm test -- --run tests/desktop-settled-geometry-capture.test.ts
 
+      - name: Desktop hosted XCTest project contracts
+        timeout-minutes: 3
+        run: npm test -- --run tests/desktop-hosted-xcuitest.test.ts
+
       - name: Build Swift Keychain checks target
         working-directory: apps/neondiff-desktop
         run: swift build --target NeonDiffDesktopKeychainChecks
@@ -155,6 +160,45 @@ jobs:
           swift run NeonDiffDesktopFixtureChecks
           scripts/run-required-swift-test-suite.sh NeonDiffDesktopAppCoreTests
           scripts/run-required-swift-test-suite.sh NeonDiffDesktopEvaluationSupportTests
+
+      - name: Hosted XCUITest smoke
+        timeout-minutes: 15
+        env:
+          PROOF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          DERIVED_DATA: ${{ runner.temp }}/neondiff-desktop-derived-data
+          RESULT_BUNDLE: ${{ runner.temp }}/NeonDiffDesktop-${{ github.event.pull_request.head.sha || github.sha }}.xcresult
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$PROOF_SHA"
+          rm -rf "$DERIVED_DATA" "$RESULT_BUNDLE"
+          xcodebuild test \
+            -project apps/neondiff-desktop/NeonDiffDesktop.xcodeproj \
+            -scheme NeonDiffDesktopHosted \
+            -testPlan NeonDiffDesktop \
+            -destination 'platform=macOS' \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$RESULT_BUNDLE"
+
+      - name: Package hosted XCTest result
+        if: always()
+        env:
+          RESULT_BUNDLE: ${{ runner.temp }}/NeonDiffDesktop-${{ github.event.pull_request.head.sha || github.sha }}.xcresult
+          RESULT_ARCHIVE: ${{ runner.temp }}/NeonDiffDesktop-${{ github.event.pull_request.head.sha || github.sha }}.xcresult.zip
+        run: |
+          set -euo pipefail
+          test -d "$RESULT_BUNDLE"
+          rm -f "$RESULT_ARCHIVE"
+          ditto -c -k --sequesterRsrc --keepParent "$RESULT_BUNDLE" "$RESULT_ARCHIVE"
+          shasum -a 256 "$RESULT_ARCHIVE" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload hosted XCTest result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: neondiff-desktop-xcresult-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ runner.temp }}/NeonDiffDesktop-${{ github.event.pull_request.head.sha || github.sha }}.xcresult.zip
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Secret corpus production-artifact boundary
         shell: bash

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -102,12 +102,20 @@ jobs:
     needs: swift-desktop-impact
     if: needs.swift-desktop-impact.outputs.affected == 'true'
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+
+      - name: Record pinned Xcode toolchain
+        run: |
+          set -euo pipefail
+          test -x "$DEVELOPER_DIR/usr/bin/xcodebuild"
+          xcodebuild -version | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
@@ -1,0 +1,395 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000060 /* NeonDiffDesktopAppCore in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000050 /* NeonDiffDesktopAppCore */; };
+		A10000000000000000000061 /* NeonDiffDesktopCore in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000051 /* NeonDiffDesktopCore */; };
+		A10000000000000000000062 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000052 /* Sparkle */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A10000000000000000000041 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000010;
+			remoteInfo = NeonDiffDesktopHostedApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A10000000000000000000020 /* NeonDiffDesktop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NeonDiffDesktop.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NeonDiffDesktopUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A10000000000000000000004 /* NeonDiffDesktop */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Sources/NeonDiffDesktop;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000005 /* UITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = UITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A10000000000000000000031 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000060 /* NeonDiffDesktopAppCore in Frameworks */,
+				A10000000000000000000061 /* NeonDiffDesktopCore in Frameworks */,
+				A10000000000000000000062 /* Sparkle in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000034 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A10000000000000000000002 = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000004 /* NeonDiffDesktop */,
+				A10000000000000000000005 /* UITests */,
+				A10000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A10000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000020 /* NeonDiffDesktop.app */,
+				A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A10000000000000000000010 /* NeonDiffDesktop */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000081 /* Build configuration list for PBXNativeTarget "NeonDiffDesktop" */;
+			buildPhases = (
+				A10000000000000000000030 /* Sources */,
+				A10000000000000000000031 /* Frameworks */,
+				A10000000000000000000032 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A10000000000000000000004 /* NeonDiffDesktop */,
+			);
+			name = NeonDiffDesktopHostedApp;
+			packageProductDependencies = (
+				A10000000000000000000050 /* NeonDiffDesktopAppCore */,
+				A10000000000000000000051 /* NeonDiffDesktopCore */,
+				A10000000000000000000052 /* Sparkle */,
+			);
+			productName = NeonDiffDesktop;
+			productReference = A10000000000000000000020 /* NeonDiffDesktop.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A10000000000000000000011 /* NeonDiffDesktopUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000082 /* Build configuration list for PBXNativeTarget "NeonDiffDesktopUITests" */;
+			buildPhases = (
+				A10000000000000000000033 /* Sources */,
+				A10000000000000000000034 /* Frameworks */,
+				A10000000000000000000035 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A10000000000000000000040 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A10000000000000000000005 /* UITests */,
+			);
+			name = NeonDiffDesktopUITests;
+			packageProductDependencies = (
+			);
+			productName = NeonDiffDesktopUITests;
+			productReference = A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A10000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+				TargetAttributes = {
+					A10000000000000000000010 = {
+						CreatedOnToolsVersion = 26.0;
+					};
+					A10000000000000000000011 = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = A10000000000000000000010;
+					};
+				};
+			};
+			buildConfigurationList = A10000000000000000000080 /* Build configuration list for PBXProject "NeonDiffDesktop" */;
+			compatibilityVersion = "Xcode 16.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A10000000000000000000002;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A10000000000000000000090 /* XCLocalSwiftPackageReference "." */,
+				A10000000000000000000091 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A10000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A10000000000000000000010 /* NeonDiffDesktop */,
+				A10000000000000000000011 /* NeonDiffDesktopUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A10000000000000000000032 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000035 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A10000000000000000000030 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000033 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A10000000000000000000040 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A10000000000000000000010 /* NeonDiffDesktop */;
+			targetProxy = A10000000000000000000041 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A10000000000000000000070 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A10000000000000000000071 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A10000000000000000000072 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "NeonDiff Desktop";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -package-name neondiff_desktop";
+				PRODUCT_BUNDLE_IDENTIFIER = com.electricsheephq.NeonDiffDesktop;
+				PRODUCT_NAME = NeonDiffDesktop;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		A10000000000000000000073 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "NeonDiff Desktop";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -package-name neondiff_desktop";
+				PRODUCT_BUNDLE_IDENTIFIER = com.electricsheephq.NeonDiffDesktop;
+				PRODUCT_NAME = NeonDiffDesktop;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Release;
+		};
+		A10000000000000000000074 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.electricsheephq.NeonDiffDesktopUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = NeonDiffDesktopHostedApp;
+			};
+			name = Debug;
+		};
+		A10000000000000000000075 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.electricsheephq.NeonDiffDesktopUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = NeonDiffDesktopHostedApp;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A10000000000000000000080 /* Build configuration list for PBXProject "NeonDiffDesktop" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000070 /* Debug */,
+				A10000000000000000000071 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000081 /* Build configuration list for PBXNativeTarget "NeonDiffDesktop" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000072 /* Debug */,
+				A10000000000000000000073 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000082 /* Build configuration list for PBXNativeTarget "NeonDiffDesktopUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000074 /* Debug */,
+				A10000000000000000000075 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A10000000000000000000090 /* XCLocalSwiftPackageReference "." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = .;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A10000000000000000000091 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.9.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A10000000000000000000050 /* NeonDiffDesktopAppCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10000000000000000000090 /* XCLocalSwiftPackageReference "." */;
+			productName = NeonDiffDesktopAppCore;
+		};
+		A10000000000000000000051 /* NeonDiffDesktopCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10000000000000000000090 /* XCLocalSwiftPackageReference "." */;
+			productName = NeonDiffDesktopCore;
+		};
+		A10000000000000000000052 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10000000000000000000091 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A10000000000000000000001 /* Project object */;
+}

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "06c73b698152aeb12816e96c66326355eb37a37fa696d2f167f2b5788f2afab7",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/xcshareddata/xcschemes/NeonDiffDesktopHosted.xcscheme
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/xcshareddata/xcschemes/NeonDiffDesktopHosted.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000010"
+               BuildableName = "NeonDiffDesktop.app"
+               BlueprintName = "NeonDiffDesktopHostedApp"
+               ReferencedContainer = "container:NeonDiffDesktop.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "NO">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:NeonDiffDesktop.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "YES"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A10000000000000000000010"
+            BuildableName = "NeonDiffDesktop.app"
+            BlueprintName = "NeonDiffDesktopHostedApp"
+            ReferencedContainer = "container:NeonDiffDesktop.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A10000000000000000000010"
+            BuildableName = "NeonDiffDesktop.app"
+            BlueprintName = "NeonDiffDesktopHostedApp"
+            ReferencedContainer = "container:NeonDiffDesktop.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/neondiff-desktop/NeonDiffDesktop.xctestplan
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "A1000000-0000-0000-0000-000000000101",
+      "name" : "Default",
+      "options" : {
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:NeonDiffDesktop.xcodeproj",
+      "identifier" : "A10000000000000000000010",
+      "name" : "NeonDiffDesktopHostedApp"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:NeonDiffDesktop.xcodeproj",
+        "identifier" : "A10000000000000000000011",
+        "name" : "NeonDiffDesktopUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+final class NeonDiffDesktopUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunchesDeterministicAppRoot() {
+        let app = XCUIApplication()
+        app.launchEnvironment["NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE"] = "provider-verification"
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["neondiff.desktop.root"]
+                .waitForExistence(timeout: 10)
+        )
+        XCTAssertEqual(app.state, .runningForeground)
+    }
+}

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -7,6 +7,8 @@ const SWIFT_PATH_PREFIXES = [
   "apps/neondiff-desktop/Sources/",
   "apps/neondiff-desktop/Checks/",
   "apps/neondiff-desktop/Tests/",
+  "apps/neondiff-desktop/UITests/",
+  "apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/",
   "apps/neondiff-desktop/script/",
   "apps/neondiff-desktop/scripts/",
   "apps/neondiff-desktop/fixtures/ui/"
@@ -17,6 +19,7 @@ const SWIFT_ROOT_FILES = new Set([
   "Package.resolved",
   "apps/neondiff-desktop/Package.swift",
   "apps/neondiff-desktop/Package.resolved",
+  "apps/neondiff-desktop/NeonDiffDesktop.xctestplan",
   "apps/neondiff-desktop/script/build_and_run.sh",
   "shared/canonical-secret-rules.json",
   "scripts/generate-secret-rules.mjs",
@@ -27,6 +30,7 @@ const SWIFT_ROOT_FILES = new Set([
   "tests/desktop-evaluation-boundary.test.ts",
   "tests/desktop-repos-reachability-capture.test.ts",
   "tests/desktop-settled-geometry-capture.test.ts",
+  "tests/desktop-hosted-xcuitest.test.ts",
   "scripts/secret-rule-foundation-runner.swift"
 ]);
 

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -46,7 +46,6 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(source).toContain('provider-verification');
     expect(source).toContain('neondiff.desktop.root');
     expect(source).toContain("XCUIApplication()");
-    expect(source).not.toMatch(/api[_-]?key|token|password|secret/i);
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -27,7 +27,7 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
       "PRODUCT_BUNDLE_IDENTIFIER = com.electricsheephq.NeonDiffDesktop"
     );
     expect(project).toContain("TEST_TARGET_NAME = NeonDiffDesktopHostedApp");
-    expect(project).not.toContain("CODE_SIGNING_ALLOWED = NO");
+    expect(project).not.toMatch(/CODE_SIGNING_ALLOWED\s*=\s*["']?NO["']?/i);
     expect(project).not.toContain("UITargetAppPath");
     expect(project).not.toContain("UITargetAppBundleIdentifier");
 
@@ -62,6 +62,10 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(workflow).toContain(
       'PROOF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}'
     );
+    expect(workflow).toContain(
+      'DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer'
+    );
+    expect(workflow).toContain("Record pinned Xcode toolchain");
     expect(workflow).toContain('test "$(git rev-parse HEAD)" = "$PROOF_SHA"');
     expect(workflow).toContain(
       'NeonDiffDesktop-${{ github.event.pull_request.head.sha || github.sha }}.xcresult'
@@ -70,7 +74,7 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
       'neondiff-desktop-xcresult-${{ github.event.pull_request.head.sha || github.sha }}'
     );
     expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02");
-    expect(workflow).not.toContain("CODE_SIGNING_ALLOWED=NO");
+    expect(workflow).not.toMatch(/CODE_SIGNING_ALLOWED\s*=\s*["']?NO["']?/i);
 
     const routing = JSON.parse(execFileSync(
       "node",

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const projectPath = "apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj";
+const schemePath =
+  "apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/xcshareddata/xcschemes/NeonDiffDesktopHosted.xcscheme";
+const testPlanPath = "apps/neondiff-desktop/NeonDiffDesktop.xctestplan";
+const uiTestPath = "apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift";
+const workflowPath = ".github/workflows/swift-desktop-gate.yml";
+
+describe("hosted NeonDiff desktop XCTest foundation", () => {
+  it("checks in a shared app/UI-test project and test plan", () => {
+    expect(existsSync(projectPath)).toBe(true);
+    expect(existsSync(schemePath)).toBe(true);
+    expect(existsSync(testPlanPath)).toBe(true);
+
+    const project = readFileSync(projectPath, "utf8");
+    expect(project).toContain("com.apple.product-type.application");
+    expect(project).toContain("com.apple.product-type.bundle.ui-testing");
+    expect(project).toContain("NeonDiffDesktopAppCore");
+    expect(project).toContain("NeonDiffDesktopCore");
+    expect(project).toContain("Sparkle in Frameworks");
+    expect(project).toContain("name = NeonDiffDesktopHostedApp");
+    expect(project).toContain("productName = NeonDiffDesktop");
+    expect(project).toContain(
+      "PRODUCT_BUNDLE_IDENTIFIER = com.electricsheephq.NeonDiffDesktop"
+    );
+    expect(project).toContain("TEST_TARGET_NAME = NeonDiffDesktopHostedApp");
+    expect(project).not.toContain("CODE_SIGNING_ALLOWED = NO");
+    expect(project).not.toContain("UITargetAppPath");
+    expect(project).not.toContain("UITargetAppBundleIdentifier");
+
+    const scheme = readFileSync(schemePath, "utf8");
+    expect(scheme).toContain('reference = "container:NeonDiffDesktop.xctestplan"');
+
+    const plan = JSON.parse(readFileSync(testPlanPath, "utf8"));
+    expect(plan.version).toBe(1);
+    expect(plan.testTargets).toHaveLength(1);
+    expect(plan.testTargets[0].target.name).toBe("NeonDiffDesktopUITests");
+  });
+
+  it("launches only a deterministic in-memory fixture and finds the native root", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+    expect(source).toContain('NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE');
+    expect(source).toContain('provider-verification');
+    expect(source).toContain('neondiff.desktop.root');
+    expect(source).toContain("XCUIApplication()");
+    expect(source).not.toMatch(/api[_-]?key|token|password|secret/i);
+  });
+
+  it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    expect(workflow).toContain("Hosted XCUITest smoke");
+    expect(workflow).toContain("xcodebuild test");
+    expect(workflow).toContain("NeonDiffDesktop.xcodeproj");
+    expect(workflow).toContain("-scheme NeonDiffDesktopHosted");
+    expect(workflow).toContain("-testPlan NeonDiffDesktop");
+    expect(workflow).toContain(
+      'ref: ${{ github.event.pull_request.head.sha || github.sha }}'
+    );
+    expect(workflow).toContain(
+      'PROOF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}'
+    );
+    expect(workflow).toContain('test "$(git rev-parse HEAD)" = "$PROOF_SHA"');
+    expect(workflow).toContain(
+      'NeonDiffDesktop-${{ github.event.pull_request.head.sha || github.sha }}.xcresult'
+    );
+    expect(workflow).toContain(
+      'neondiff-desktop-xcresult-${{ github.event.pull_request.head.sha || github.sha }}'
+    );
+    expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02");
+    expect(workflow).not.toContain("CODE_SIGNING_ALLOWED=NO");
+
+    const routing = JSON.parse(execFileSync(
+      "node",
+      ["scripts/swift-affected.mjs", "--files", "tests/desktop-hosted-xcuitest.test.ts"],
+      { encoding: "utf8" }
+    ));
+    expect(routing).toMatchObject({
+      affected: true,
+      matched: ["tests/desktop-hosted-xcuitest.test.ts"]
+    });
+  });
+});


### PR DESCRIPTION
## Scope

Related to #516 and prerequisite for #517. This is the bounded hosted-XCUITest foundation only; it does not close either issue.

- adds a checked-in native macOS app target and hosted UI-test target
- preserves `NeonDiffDesktop.app` and `com.electricsheephq.NeonDiffDesktop` while using a unique internal host target name
- links the existing AppCore/Core products plus pinned Sparkle without enabling update traffic
- adds a shared scheme and test plan
- launches only the deterministic in-memory `provider-verification` fixture and asserts the native app root/foreground state
- routes project, test-plan, and UI-test changes through the Swift desktop gate
- checks out and asserts the exact PR source head before `xcodebuild test`
- packages, hashes, and uploads the exact-SHA `.xcresult` zip with pinned read-only actions

## Failing-first and local proof

Initial contract run: 3/3 failed because the hosted project, UI test, and workflow lane did not exist.

Exact candidate: `ca9fe616b5cf9ea5453ad928ef99db166da17d89`

- focused Vitest contract: 3/3 passed
- `xcodebuild -list`: hosted app and UI-test targets/scheme resolved
- `xcodebuild build-for-testing`: passed on Xcode 26.6
- generated `.xctestrun`: resolves the UI target to `Debug/NeonDiffDesktop.app`
- dependency graph: AppCore, Core, and Sparkle
- workflow lint, JSON validation, diff check, public-claims scan, and secret scan: passed
- independent exact-head spec/design and security/AX reviews: nonblocking

Local full UI execution is not claimed: the Codex host is denied DeveloperTool TCC and TCC was not changed. The canonical macOS CI run must supply the actual UI execution and downloadable `.xcresult` proof.

## Proof boundary

This PR can establish only one deterministic DEBUG hosted launch/root smoke at the exact CI head. It does not establish the remaining #517 tab/size/scroll/onboarding/Settings matrix, #518 accessibility behavior, activation parity, signed/notarized distribution, update/rollback, release, GA, or customer readiness. #516 and #517 remain open until their broader acceptance and remote artifact evidence are complete.
