### PR TITLE
test(desktop): exercise strict hosted fixture contract

### DIFF
--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -259,6 +259,9 @@ jobs:
           NEONDIFF_DESKTOP_DIST_DIR="$PWD/apps/neondiff-desktop/dist-release" \
             apps/neondiff-desktop/script/build_and_run.sh release-bundle-check
           release_bin="$(cd apps/neondiff-desktop && swift build -c release --show-bin-path)"
+          npm run check:secret-corpus-boundary -- \
+            "$RELEASE_ARCHIVE" \
+            "apps/neondiff-desktop/dist-release/NeonDiffDesktop.app"
           npm run check:desktop-fixture-boundary -- \
             "$release_bin/NeonDiffDesktop" \
             "$release_bin/NeonDiffDesktopCore.build" \

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -234,8 +234,26 @@ jobs:
         working-directory: apps/neondiff-desktop
         run: script/build_and_run.sh bundle-check
 
+      - name: Archive Release fixture boundary
+        shell: bash
+        env:
+          PROOF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RELEASE_ARCHIVE: ${{ runner.temp }}/NeonDiffDesktop-release.xcarchive
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$PROOF_SHA"
+          rm -rf "$RELEASE_ARCHIVE"
+          xcodebuild archive \
+            -project apps/neondiff-desktop/NeonDiffDesktop.xcodeproj \
+            -scheme NeonDiffDesktopHosted \
+            -destination 'generic/platform=macOS' \
+            -archivePath "$RELEASE_ARCHIVE"
+          test -d "$RELEASE_ARCHIVE"
+
       - name: Evaluation fixture production-artifact boundary
         shell: bash
+        env:
+          RELEASE_ARCHIVE: ${{ runner.temp }}/NeonDiffDesktop-release.xcarchive
         run: |
           set -euo pipefail
           NEONDIFF_DESKTOP_DIST_DIR="$PWD/apps/neondiff-desktop/dist-release" \
@@ -247,7 +265,8 @@ jobs:
             "$release_bin/NeonDiffDesktopAppCore.build" \
             "$release_bin/Modules/NeonDiffDesktopCore.swiftmodule" \
             "$release_bin/Modules/NeonDiffDesktopAppCore.swiftmodule" \
-            "apps/neondiff-desktop/dist-release/NeonDiffDesktop.app"
+            "apps/neondiff-desktop/dist-release/NeonDiffDesktop.app" \
+            "$RELEASE_ARCHIVE"
 
   swift-desktop-gate:
     name: Swift desktop gate

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		A10000000000000000000060 /* NeonDiffDesktopAppCore in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000050 /* NeonDiffDesktopAppCore */; };
 		A10000000000000000000061 /* NeonDiffDesktopCore in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000051 /* NeonDiffDesktopCore */; };
 		A10000000000000000000062 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000052 /* Sparkle */; };
+		A10000000000000000000063 /* NeonDiffDesktopEvaluationSupport in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000053 /* NeonDiffDesktopEvaluationSupport */; };
+		A10000000000000000000064 /* tab-overview.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000023 /* tab-overview.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -20,11 +22,20 @@
 			remoteGlobalIDString = A10000000000000000000010;
 			remoteInfo = NeonDiffDesktopHostedApp;
 		};
+		A10000000000000000000042 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000012;
+			remoteInfo = NeonDiffDesktopFixtureResolve;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		A10000000000000000000020 /* NeonDiffDesktop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NeonDiffDesktop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NeonDiffDesktopUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000022 /* NeonDiffDesktopFixtureResolve */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = NeonDiffDesktopFixtureResolve; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000023 /* tab-overview.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/tab-overview.json; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -36,6 +47,11 @@
 		A10000000000000000000005 /* UITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = UITests;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000006 /* NeonDiffDesktopFixtureResolve */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Sources/NeonDiffDesktopFixtureResolve;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -58,6 +74,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10000000000000000000036 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000063 /* NeonDiffDesktopEvaluationSupport in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -66,6 +90,8 @@
 			children = (
 				A10000000000000000000004 /* NeonDiffDesktop */,
 				A10000000000000000000005 /* UITests */,
+				A10000000000000000000006 /* NeonDiffDesktopFixtureResolve */,
+				A10000000000000000000023 /* tab-overview.json */,
 				A10000000000000000000003 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -75,6 +101,7 @@
 			children = (
 				A10000000000000000000020 /* NeonDiffDesktop.app */,
 				A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */,
+				A10000000000000000000022 /* NeonDiffDesktopFixtureResolve */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -89,10 +116,12 @@
 				A10000000000000000000030 /* Sources */,
 				A10000000000000000000031 /* Frameworks */,
 				A10000000000000000000032 /* Resources */,
+				A10000000000000000000038 /* Embed Debug Fixture Resolver */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				A10000000000000000000043 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				A10000000000000000000004 /* NeonDiffDesktop */,
@@ -130,6 +159,28 @@
 			productReference = A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		A10000000000000000000012 /* NeonDiffDesktopFixtureResolve */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000083 /* Build configuration list for PBXNativeTarget "NeonDiffDesktopFixtureResolve" */;
+			buildPhases = (
+				A10000000000000000000037 /* Sources */,
+				A10000000000000000000036 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A10000000000000000000006 /* NeonDiffDesktopFixtureResolve */,
+			);
+			name = NeonDiffDesktopFixtureResolve;
+			packageProductDependencies = (
+				A10000000000000000000053 /* NeonDiffDesktopEvaluationSupport */,
+			);
+			productName = NeonDiffDesktopFixtureResolve;
+			productReference = A10000000000000000000022 /* NeonDiffDesktopFixtureResolve */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -146,6 +197,9 @@
 					A10000000000000000000011 = {
 						CreatedOnToolsVersion = 26.0;
 						TestTargetID = A10000000000000000000010;
+					};
+					A10000000000000000000012 = {
+						CreatedOnToolsVersion = 26.0;
 					};
 				};
 			};
@@ -170,6 +224,7 @@
 			targets = (
 				A10000000000000000000010 /* NeonDiffDesktop */,
 				A10000000000000000000011 /* NeonDiffDesktopUITests */,
+				A10000000000000000000012 /* NeonDiffDesktopFixtureResolve */,
 			);
 		};
 /* End PBXProject section */
@@ -186,6 +241,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A10000000000000000000064 /* tab-overview.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,13 +262,44 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10000000000000000000037 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A10000000000000000000038 /* Embed Debug Fixture Resolver */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/NeonDiffDesktopFixtureResolve",
+			);
+			name = "Embed Debug Fixture Resolver";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Helpers/NeonDiffDesktopFixtureResolve",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\nhelpers_dir=\"$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH/Helpers\"\nif [ \"$CONFIGURATION\" != \"Debug\" ]; then\n  rm -f \"$helpers_dir/NeonDiffDesktopFixtureResolve\"\n  exit 0\nfi\ninstall -d -m 0755 \"$helpers_dir\"\ninstall -m 0755 \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		A10000000000000000000040 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A10000000000000000000010 /* NeonDiffDesktop */;
 			targetProxy = A10000000000000000000041 /* PBXContainerItemProxy */;
+		};
+		A10000000000000000000043 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A10000000000000000000012 /* NeonDiffDesktopFixtureResolve */;
+			targetProxy = A10000000000000000000042 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -323,6 +410,32 @@
 			};
 			name = Release;
 		};
+		A10000000000000000000076 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -package-name neondiff_desktop";
+				PRODUCT_NAME = NeonDiffDesktopFixtureResolve;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A10000000000000000000077 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -package-name neondiff_desktop";
+				PRODUCT_NAME = NeonDiffDesktopFixtureResolve;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -349,6 +462,15 @@
 			buildConfigurations = (
 				A10000000000000000000074 /* Debug */,
 				A10000000000000000000075 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000083 /* Build configuration list for PBXNativeTarget "NeonDiffDesktopFixtureResolve" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000076 /* Debug */,
+				A10000000000000000000077 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -388,6 +510,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A10000000000000000000091 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		A10000000000000000000053 /* NeonDiffDesktopEvaluationSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10000000000000000000090 /* XCLocalSwiftPackageReference "." */;
+			productName = NeonDiffDesktopEvaluationSupport;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
@@ -22,13 +22,6 @@
 			remoteGlobalIDString = A10000000000000000000010;
 			remoteInfo = NeonDiffDesktopHostedApp;
 		};
-		A10000000000000000000042 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A10000000000000000000001 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A10000000000000000000012;
-			remoteInfo = NeonDiffDesktopFixtureResolve;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -121,7 +114,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				A10000000000000000000043 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				A10000000000000000000004 /* NeonDiffDesktop */,
@@ -274,11 +266,11 @@
 /* Begin PBXShellScriptBuildPhase section */
 		A10000000000000000000038 /* Embed Debug Fixture Resolver */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/NeonDiffDesktopFixtureResolve",
 			);
 			name = "Embed Debug Fixture Resolver";
 			outputPaths = (
@@ -286,7 +278,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -euo pipefail\nhelpers_dir=\"$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH/Helpers\"\nif [ \"$CONFIGURATION\" != \"Debug\" ]; then\n  rm -f \"$helpers_dir/NeonDiffDesktopFixtureResolve\"\n  exit 0\nfi\ninstall -d -m 0755 \"$helpers_dir\"\ninstall -m 0755 \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			shellScript = "set -euo pipefail\nhelpers_dir=\"$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH/Helpers\"\nif [ \"$CONFIGURATION\" != \"Debug\" ]; then\n  rm -f \"$helpers_dir/NeonDiffDesktopFixtureResolve\"\n  exit 0\nfi\nresolver=\"$BUILT_PRODUCTS_DIR/NeonDiffDesktopFixtureResolve\"\ntest -f \"$resolver\"\ntest ! -L \"$resolver\"\ntest -x \"$resolver\"\ninstall -d -m 0755 \"$helpers_dir\"\ninstall -m 0755 \"$resolver\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -295,11 +287,6 @@
 			isa = PBXTargetDependency;
 			target = A10000000000000000000010 /* NeonDiffDesktop */;
 			targetProxy = A10000000000000000000041 /* PBXContainerItemProxy */;
-		};
-		A10000000000000000000043 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = A10000000000000000000012 /* NeonDiffDesktopFixtureResolve */;
-			targetProxy = A10000000000000000000042 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/xcshareddata/xcschemes/NeonDiffDesktopHosted.xcscheme
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/xcshareddata/xcschemes/NeonDiffDesktopHosted.xcscheme
@@ -3,10 +3,24 @@
    LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000012"
+               BuildableName = "NeonDiffDesktopFixtureResolve"
+               BlueprintName = "NeonDiffDesktopFixtureResolve"
+               ReferencedContainer = "container:NeonDiffDesktop.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"

--- a/apps/neondiff-desktop/Package.swift
+++ b/apps/neondiff-desktop/Package.swift
@@ -10,7 +10,11 @@ let package = Package(
         .executable(name: "NeonDiffDesktop", targets: ["NeonDiffDesktop"]),
         .executable(name: "NeonDiffDesktopCoreSmoke", targets: ["NeonDiffDesktopCoreSmoke"]),
         .library(name: "NeonDiffDesktopCore", targets: ["NeonDiffDesktopCore"]),
-        .library(name: "NeonDiffDesktopAppCore", targets: ["NeonDiffDesktopAppCore"])
+        .library(name: "NeonDiffDesktopAppCore", targets: ["NeonDiffDesktopAppCore"]),
+        .library(
+            name: "NeonDiffDesktopEvaluationSupport",
+            targets: ["NeonDiffDesktopEvaluationSupport"]
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0")

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -9,31 +9,14 @@ final class NeonDiffDesktopUITests: XCTestCase {
         let fixtureURL = try XCTUnwrap(
             Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
         )
-        let runID = UUID().uuidString.prefix(8)
-        let runRoot = URL(fileURLWithPath: "/tmp/neondiff-desktop-evaluation.\(runID)")
-        let caseDirectory = runRoot.appendingPathComponent("hosted", isDirectory: true)
-        let readyURL = caseDirectory.appendingPathComponent("ready.json")
-        for directory in [runRoot, caseDirectory] {
-            try FileManager.default.createDirectory(
-                at: directory,
-                withIntermediateDirectories: false,
-                attributes: nil
-            )
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o700],
-                ofItemAtPath: directory.path
-            )
-        }
-        defer { try? FileManager.default.removeItem(at: runRoot) }
-
         let app = XCUIApplication()
+        defer { app.terminate() }
         app.launchArguments = [
             "--ui-testing",
             "--ui-fixture", fixtureURL.path,
             "--content-size", "1040x680",
             "--disable-animations"
         ]
-        app.launchEnvironment["NEONDIFF_DESKTOP_EVALUATION_READY_PATH"] = readyURL.path
         app.launch()
 
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
@@ -42,23 +25,5 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 .waitForExistence(timeout: 10)
         )
         XCTAssertEqual(app.state, .runningForeground)
-
-        let readiness = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in
-                FileManager.default.fileExists(atPath: readyURL.path)
-            },
-            object: nil
-        )
-        XCTAssertEqual(XCTWaiter.wait(for: [readiness], timeout: 10), .completed)
-
-        let payload = try XCTUnwrap(
-            try JSONSerialization.jsonObject(with: Data(contentsOf: readyURL))
-                as? [String: Any]
-        )
-        XCTAssertEqual(payload["fixtureId"] as? String, "tab-overview")
-        XCTAssertEqual(payload["ready"] as? Bool, true)
-        let contentFrame = try XCTUnwrap(payload["contentFrame"] as? [String: Double])
-        XCTAssertEqual(try XCTUnwrap(contentFrame["width"]), 1040, accuracy: 0.5)
-        XCTAssertEqual(try XCTUnwrap(contentFrame["height"]), 680, accuracy: 0.5)
     }
 }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -13,12 +13,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
         let runRoot = URL(fileURLWithPath: "/tmp/neondiff-desktop-evaluation.\(runID)")
         let caseDirectory = runRoot.appendingPathComponent("hosted", isDirectory: true)
         let readyURL = caseDirectory.appendingPathComponent("ready.json")
-        try FileManager.default.createDirectory(
-            at: caseDirectory,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
-        )
         for directory in [runRoot, caseDirectory] {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: false,
+                attributes: nil
+            )
             try FileManager.default.setAttributes(
                 [.posixPermissions: 0o700],
                 ofItemAtPath: directory.path

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -5,16 +5,60 @@ final class NeonDiffDesktopUITests: XCTestCase {
         continueAfterFailure = false
     }
 
-    func testLaunchesDeterministicAppRoot() {
+    func testLaunchesStrictDeterministicFixtureRoot() throws {
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
+        )
+        let runID = UUID().uuidString.prefix(8)
+        let runRoot = URL(fileURLWithPath: "/tmp/neondiff-desktop-evaluation.\(runID)")
+        let caseDirectory = runRoot.appendingPathComponent("hosted", isDirectory: true)
+        let readyURL = caseDirectory.appendingPathComponent("ready.json")
+        try FileManager.default.createDirectory(
+            at: caseDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        for directory in [runRoot, caseDirectory] {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: directory.path
+            )
+        }
+        defer { try? FileManager.default.removeItem(at: runRoot) }
+
         let app = XCUIApplication()
-        app.launchEnvironment["NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE"] = "provider-verification"
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--disable-animations"
+        ]
+        app.launchEnvironment["NEONDIFF_DESKTOP_EVALUATION_READY_PATH"] = readyURL.path
         app.launch()
 
         XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
         XCTAssertTrue(
-            app.descendants(matching: .any)["neondiff.desktop.root"]
+            app.descendants(matching: .any)["neondiff.fixture.tab-overview"]
                 .waitForExistence(timeout: 10)
         )
         XCTAssertEqual(app.state, .runningForeground)
+
+        let readiness = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                FileManager.default.fileExists(atPath: readyURL.path)
+            },
+            object: nil
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [readiness], timeout: 10), .completed)
+
+        let payload = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: readyURL))
+                as? [String: Any]
+        )
+        XCTAssertEqual(payload["fixtureId"] as? String, "tab-overview")
+        XCTAssertEqual(payload["ready"] as? Bool, true)
+        let contentFrame = try XCTUnwrap(payload["contentFrame"] as? [String: Double])
+        XCTAssertEqual(try XCTUnwrap(contentFrame["width"]), 1040, accuracy: 0.5)
+        XCTAssertEqual(try XCTUnwrap(contentFrame["height"]), 680, accuracy: 0.5)
     }
 }

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -28,6 +28,18 @@ const FORBIDDEN_MARKERS = [
   "VisualProofDesktopDependencies",
   "VisualProofSecretStore"
 ];
+const FORBIDDEN_CONTENT_MARKERS = [
+  ...FORBIDDEN_MARKERS.map((marker) => ({ marker, bytes: Buffer.from(marker) })),
+  { marker: "content:tab-overview", bytes: Buffer.from('"tab-overview"') }
+];
+const FORBIDDEN_PATH_MARKERS = [
+  { marker: "path:fixtures/ui", matches: (path) => path.includes("/fixtures/ui/") },
+  { marker: "path:tab-overview.json", matches: (path) => path.endsWith("/tab-overview.json") },
+  {
+    marker: "path:NeonDiffDesktopFixtureResolve",
+    matches: (path) => path.includes("/neondiffdesktopfixtureresolve")
+  }
+];
 
 function collectFiles(inputPaths) {
   const files = [];
@@ -62,7 +74,11 @@ function collectFiles(inputPaths) {
     if (visitedFiles.has(realPath)) continue;
     visitedFiles.add(realPath);
     if (stat.size > MAX_FILE_BYTES) throw new Error(`artifact file exceeds scan bound: ${path}`);
-    files.push({ path: realPath, size: stat.size });
+    files.push({
+      path: realPath,
+      relativePath: `/${relative(root, realPath).split(sep).join("/")}`,
+      size: stat.size
+    });
     if (files.length > MAX_FILES) throw new Error("artifact file count exceeds scan bound");
   }
   return files.sort((left, right) => left.path.localeCompare(right.path));
@@ -76,9 +92,15 @@ function scan(inputPaths) {
   for (const file of files) {
     scannedBytes += file.size;
     if (scannedBytes > MAX_TOTAL_BYTES) throw new Error("artifact bytes exceed scan bound");
+    const normalizedPath = file.relativePath.toLowerCase();
+    for (const rule of FORBIDDEN_PATH_MARKERS) {
+      if (rule.matches(normalizedPath)) {
+        violations.push({ path: file.path, marker: rule.marker });
+      }
+    }
     const data = readFileSync(file.path);
-    for (const marker of FORBIDDEN_MARKERS) {
-      if (data.includes(Buffer.from(marker))) violations.push({ path: file.path, marker });
+    for (const rule of FORBIDDEN_CONTENT_MARKERS) {
+      if (data.includes(rule.bytes)) violations.push({ path: file.path, marker: rule.marker });
     }
   }
   return {

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -95,6 +95,37 @@ describe("desktop fixture release-artifact boundary", () => {
     expect(result.stderr).toMatch(/symlink escapes artifact root/);
   });
 
+  it("rejects the canonical fixture at an archive-like resource path", () => {
+    const artifacts = releaseArtifacts();
+    const fixturePath = join(
+      artifacts.root,
+      "NeonDiffDesktop.xcarchive",
+      "Products",
+      "Applications",
+      "NeonDiffDesktop.app",
+      "Contents",
+      "Resources",
+      "fixtures",
+      "ui",
+      "tab-overview.json"
+    );
+    mkdirSync(join(fixturePath, ".."), { recursive: true });
+    writeFileSync(
+      fixturePath,
+      readFileSync("apps/neondiff-desktop/fixtures/ui/tab-overview.json")
+    );
+
+    const result = scan([join(artifacts.root, "NeonDiffDesktop.xcarchive")]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "path:fixtures/ui" }),
+        expect.objectContaining({ marker: "content:tab-overview" })
+      ])
+    });
+  });
+
   it("scans only release fixture surfaces and all debug/release Core and AppCore secret surfaces", () => {
     const gate = readFileSync(".github/workflows/swift-desktop-gate.yml", "utf8");
 
@@ -104,7 +135,11 @@ describe("desktop fixture release-artifact boundary", () => {
     expect(gate).toContain('"$release_bin/Modules/NeonDiffDesktopCore.swiftmodule"');
     expect(gate).toContain('"$release_bin/Modules/NeonDiffDesktopAppCore.swiftmodule"');
     expect(gate).toContain('"apps/neondiff-desktop/dist-release/NeonDiffDesktop.app"');
+    expect(gate).toContain('"$RELEASE_ARCHIVE"');
     expect(gate).not.toMatch(/npm run check:desktop-fixture-boundary --[\s\S]*?"\$debug_bin\/NeonDiffDesktop/);
+    expect(gate).toMatch(
+      /Archive Release fixture boundary[\s\S]*?npm run check:secret-corpus-boundary --[\s\S]*?"\$RELEASE_ARCHIVE"/
+    );
 
     for (const target of [
       '"$debug_bin/NeonDiffDesktop"',

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -40,12 +40,25 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(plan.testTargets[0].target.name).toBe("NeonDiffDesktopUITests");
   });
 
-  it("launches only a deterministic in-memory fixture and finds the native root", () => {
+  it("launches the strict deterministic fixture contract and finds its native root", () => {
+    const project = readFileSync(projectPath, "utf8");
     const source = readFileSync(uiTestPath, "utf8");
-    expect(source).toContain('NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE');
-    expect(source).toContain('provider-verification');
-    expect(source).toContain('neondiff.desktop.root');
+    expect(project).toContain("NeonDiffDesktopFixtureResolve");
+    expect(project).toContain("NeonDiffDesktopEvaluationSupport in Frameworks");
+    expect(project).toContain("$(CONTENTS_FOLDER_PATH)/Helpers");
+    expect(project).toContain('$CONFIGURATION\\" != \\"Debug');
+    expect(project.match(/SKIP_INSTALL = YES;/g)).toHaveLength(2);
+    expect(project).toContain("tab-overview.json in Resources");
+    expect(source).toContain('"--ui-testing"');
+    expect(source).toContain('"--ui-fixture"');
+    expect(source).toContain('"--content-size"');
+    expect(source).toContain('"1040x680"');
+    expect(source).toContain('"--disable-animations"');
+    expect(source).toContain('"tab-overview"');
+    expect(source).toContain('"neondiff.fixture.tab-overview"');
+    expect(source).toContain(".posixPermissions: 0o700");
     expect(source).toContain("XCUIApplication()");
+    expect(source).not.toContain('NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE');
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -57,6 +57,7 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(source).toContain('"tab-overview"');
     expect(source).toContain('"neondiff.fixture.tab-overview"');
     expect(source).toContain(".posixPermissions: 0o700");
+    expect(source.match(/withIntermediateDirectories: false/g)).toHaveLength(1);
     expect(source).toContain("XCUIApplication()");
     expect(source).not.toContain('NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE');
   });

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -43,10 +43,12 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
   it("launches the strict deterministic fixture contract and finds its native root", () => {
     const project = readFileSync(projectPath, "utf8");
     const source = readFileSync(uiTestPath, "utf8");
+    const scheme = readFileSync(schemePath, "utf8");
     expect(project).toContain("NeonDiffDesktopFixtureResolve");
     expect(project).toContain("NeonDiffDesktopEvaluationSupport in Frameworks");
     expect(project).toContain("$(CONTENTS_FOLDER_PATH)/Helpers");
     expect(project).toContain('$CONFIGURATION\\" != \\"Debug');
+    expect(project).toContain("alwaysOutOfDate = 1;");
     expect(project.match(/SKIP_INSTALL = YES;/g)).toHaveLength(2);
     expect(project).toContain("tab-overview.json in Resources");
     expect(source).toContain('"--ui-testing"');
@@ -56,8 +58,14 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(source).toContain('"--disable-animations"');
     expect(source).toContain('"tab-overview"');
     expect(source).toContain('"neondiff.fixture.tab-overview"');
-    expect(source).toContain(".posixPermissions: 0o700");
-    expect(source.match(/withIntermediateDirectories: false/g)).toHaveLength(1);
+    expect(source).not.toContain("createDirectory");
+    expect(source).not.toContain("setAttributes");
+    expect(source).not.toContain("NEONDIFF_DESKTOP_EVALUATION_READY_PATH");
+    expect(scheme).toContain('parallelizeBuildables = "NO"');
+    expect(scheme).toMatch(
+      /buildForArchiving = "NO"[\s\S]{0,700}BlueprintIdentifier = "A10000000000000000000012"/
+    );
+    expect(project).not.toContain("remoteInfo = NeonDiffDesktopFixtureResolve");
     expect(source).toContain("XCUIApplication()");
     expect(source).not.toContain('NEONDIFF_DESKTOP_VISUAL_PROOF_FIXTURE');
   });
@@ -87,6 +95,9 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
       'neondiff-desktop-xcresult-${{ github.event.pull_request.head.sha || github.sha }}'
     );
     expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02");
+    expect(workflow).toContain("xcodebuild archive");
+    expect(workflow).toContain('RELEASE_ARCHIVE: ${{ runner.temp }}/NeonDiffDesktop-release.xcarchive');
+    expect(workflow).toContain('"$RELEASE_ARCHIVE"');
     expect(workflow).not.toMatch(/CODE_SIGNING_ALLOWED\s*=\s*["']?NO["']?/i);
 
     const routing = JSON.parse(execFileSync(


### PR DESCRIPTION
## Summary

- candidate head: `666f541dcc69171e8e1eb30d09c66233a058cc5c`
- add a native hosted `NeonDiffDesktopFixtureResolve` target and embed it only in Debug app builds before signing
- bundle the canonical `tab-overview` fixture into the hosted UI-test target
- replace the legacy environment-only smoke with the strict `--ui-testing`, `--ui-fixture`, `--content-size 1040x680`, and `--disable-animations` launch contract
- require the fixture-specific native root while leaving the separate `/tmp` readiness channel unchanged for capture tooling
- keep the complete Release archive, including dSYMs, free of resolver and fixture material

Related: #516

## Failing-first proof

- focused hosted-XCTest contract: 1 failed / 2 passed before the native resolver target and strict launch wiring existed
- same focused contract after implementation: 3/3 passed
- hosted execution at `a98d7436` proved the sandboxed XCUITest runner cannot create the capture lane's strict `/tmp` workspace (NSCocoa 513 / POSIX EPERM)
- independent review then proved the Release archive still carried the resolver dSYM despite the clean app bundle
- an expanded focused contract failed 2/3 before the current workspace-free hosted smoke and archive-graph isolation; it now passes 3/3
- archive-like canonical-fixture and post-archive secret-coverage regressions then failed 2/8 before scanner hardening; the focused fixture boundary now passes 8/8

## Local validation

- `NeonDiffDesktopEvaluationSupportTests`: 55/55 passed
- `NeonDiffDesktopFixtureChecks`: passed
- Xcode project parse/list: passed
- Xcode Debug `build-for-testing`: passed with the resolver embedded in the app
- Debug app contains an executable trusted resolver; the resolver accepted the canonical strict fixture arguments
- Debug app `codesign --verify --deep --strict`: passed
- Xcode Release build: passed
- Release app contains no embedded fixture resolver
- Release archive: passed; the resolver target is excluded from the archive build graph
- Archived app `codesign --verify --deep --strict`: passed
- Complete `.xcarchive` fixture-boundary scan: 87 files / 46,740,602 bytes / 0 violations; no resolver dSYM
- Complete `.xcarchive` canonical secret-corpus scan: 20 samples absent
- fixture scanner rejects canonical fixture paths and content, including case-normalized helper paths
- repository secret scan: 729 tracked files / passed
- forbidden public-claims scan and `git diff --check`: passed
- prior-head re-reviews correctly returned BLOCKER on the hosted `/tmp` write, resolver dSYM, incomplete canonical-fixture detection, and missing archive secret scan
- current-head independent security/build-boundary and spec/product/design re-reviews: NONBLOCKER, no P0–P3 findings

## Exact-head remote proof

- CI run `29388135207`: passed
- Swift Desktop Gate run `29388135168`: passed all contracts, hosted smoke, archive, secret, and fixture-boundary steps
- pinned hosted toolchain: Xcode 16.4 (`16F6`) on macOS 15.7.7 arm64
- hosted strict fixture test: 1 passed / 0 failed; exact test head `666f541dcc69171e8e1eb30d09c66233a058cc5c`
- immutable artifact `8332257268`; GitHub wrapper digest `sha256:e73d277b7d3baf9d3bc0f9b7f330b7e12f7213a45ecee9b3fd79cceb7259148c`
- independently downloaded `.xcresult.zip` SHA-256 `14ee80fad6c75fe6a5e34f85fba94b06e332165682b7a2a80ce356c6b4a19b11`; `xcresulttool` reports Passed, 1/1
- remote complete artifact fixture scan: 225 files / 59,321,589 bytes / 0 violations
- remote post-archive secret scan: 20 canonical samples absent from the complete archive and dist app
- CodeQL, Socket, and evaOS current-head review: passed/completed; evaOS posted no validated inline findings
- review threads: the sole prior-head cleanup thread is resolved and outdated

## Proof boundary

This PR is a hosted test-contract slice. Exact-head remote CI proves the strict four-argument fixture launch and native fixture root on the pinned hosted Xcode/macOS runner, publishes an immutable exact-SHA `.xcresult`, and scans the complete Release archive. It does not establish exact content geometry, the broader #517 matrix, parity, signed/notarized distribution, installed updates, release, GA, runtime, or customer readiness.
