### PR TITLE
fix(desktop): stabilize sidebar geometry at minimum size

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -5,6 +5,15 @@ struct LogsView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
+        ScrollView(.vertical) {
+            pageContent
+        }
+        .accessibilityIdentifier("neondiff-logs-outer-scroll")
+        .scrollContentBackground(.hidden)
+        .scrollIndicators(.visible, axes: .vertical)
+    }
+
+    private var pageContent: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 10) {
                 Button { model.refreshStatus() } label: {
@@ -25,7 +34,7 @@ struct LogsView: View {
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                     .scrollContentBackground(.hidden)
                     .textSelection(.enabled)
-                    .frame(minHeight: 420)
+                    .frame(height: 360)
                     .padding(8)
                     .background(Color.black.opacity(0.42))
                     .overlay {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -85,6 +85,87 @@ final class NeonDiffDesktopUITests: XCTestCase {
         )
     }
 
+    func testStrictFixtureSettlesAcrossEverySidebarSectionAtMinimumSize() throws {
+        let requestedContentSize = HostedContentSize(width: 1040, height: 680)
+        let route = [
+            HostedSidebarRouteStep(section: "overview", generation: 0),
+            HostedSidebarRouteStep(section: "repos", generation: 1),
+            HostedSidebarRouteStep(section: "providers", generation: 2),
+            HostedSidebarRouteStep(section: "license", generation: 3),
+            HostedSidebarRouteStep(section: "logs", generation: 4),
+            HostedSidebarRouteStep(section: "policy", generation: 5),
+            HostedSidebarRouteStep(section: "settings", generation: 6),
+            HostedSidebarRouteStep(section: "overview", generation: 7)
+        ]
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
+        )
+        let app = XCUIApplication()
+        defer { app.terminate() }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--disable-animations"
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["neondiff.fixture.tab-overview"]
+                .waitForExistence(timeout: 10)
+        )
+        XCTAssertEqual(app.state, .runningForeground)
+
+        var checkpoints: [HostedGeometryCheckpoint] = []
+        var navigationActions: [HostedNavigationAction] = []
+        for (routeIndex, step) in route.enumerated() {
+            if routeIndex > 0 {
+                let previous = route[routeIndex - 1]
+                navigationActions.append(
+                    try clickNavigation(
+                        app: app,
+                        index: routeIndex - 1,
+                        fromSection: previous.section,
+                        toSection: step.section,
+                        identifier: "neondiff-sidebar-section-\(step.section)"
+                    )
+                )
+            }
+            checkpoints.append(
+                try captureCheckpoint(
+                    app: app,
+                    section: step.section,
+                    generation: step.generation,
+                    markerIdentifier: "neondiff.evaluation.surface.\(step.section).\(step.generation).quiescent",
+                    requestedContentSize: requestedContentSize
+                )
+            )
+        }
+
+        XCTAssertEqual(checkpoints.count, 8)
+        XCTAssertEqual(navigationActions.count, 7)
+        assertStableAcrossTransitions(checkpoints)
+        try attach(
+            HostedSettledGeometryTrace(
+                schemaVersion: 2,
+                scenario: "overview-repos-providers-license-logs-policy-settings-overview",
+                fixtureId: "tab-overview",
+                requestedContentSize: requestedContentSize,
+                textSizeMode: "runner-default-no-test-override",
+                coordinateSpaces: HostedGeometryCoordinateSpaces(
+                    windowAndContent: "appkit-screen",
+                    regions: "swiftui-global"
+                ),
+                sampleIntervalMilliseconds: 100,
+                tolerancePoints: 1,
+                navigationActions: navigationActions,
+                checkpoints: checkpoints,
+                proofBoundary: "hosted-every-sidebar-destination-minimum-size-geometry-only"
+            )
+        )
+    }
+
     private func captureCheckpoint(
         app: XCUIApplication,
         section: String,
@@ -410,6 +491,11 @@ final class NeonDiffDesktopUITests: XCTestCase {
 private struct HostedContentSize: Codable {
     let width: Int
     let height: Int
+}
+
+private struct HostedSidebarRouteStep {
+    let section: String
+    let generation: Int
 }
 
 private struct HostedGeometryFrame: Codable, Equatable {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -426,37 +426,43 @@ final class NeonDiffDesktopUITests: XCTestCase {
     }
 
     private func assertStableAcrossTransitions(_ checkpoints: [HostedGeometryCheckpoint]) {
-        let samples = checkpoints.flatMap(\.samples)
-        guard let baseline = samples.first else {
+        guard let baseline = checkpoints.first?.samples.first else {
             XCTFail("Missing hosted geometry checkpoints")
             return
         }
-        for sample in samples.dropFirst() {
-            XCTAssertFalse(
-                baseline.windowFrame.differs(from: sample.windowFrame, byMoreThan: 1),
-                "Window drift exceeded one point across transitions"
-            )
-            XCTAssertFalse(
-                baseline.contentFrame.differs(from: sample.contentFrame, byMoreThan: 1),
-                "Content drift exceeded one point across transitions"
-            )
-            XCTAssertEqual(
-                baseline.backingScale,
-                sample.backingScale,
-                accuracy: 0.01,
-                "Backing scale drifted across transitions"
-            )
-            for region in baseline.regions {
-                guard let candidate = sample.regions.first(where: {
-                    $0.identifier == region.identifier
-                }) else {
-                    XCTFail("Missing \(region.identifier) across transitions")
-                    continue
-                }
+        for checkpoint in checkpoints {
+            for sample in checkpoint.samples {
+                let context = "\(checkpoint.section)-\(checkpoint.surfaceGeneration)-\(sample.elapsedMilliseconds)ms"
                 XCTAssertFalse(
-                    region.frame.differs(from: candidate.frame, byMoreThan: 1),
-                    "\(region.identifier) drift exceeded one point across transitions"
+                    baseline.windowFrame.differs(from: sample.windowFrame, byMoreThan: 1),
+                    "Window drift exceeded one point across transitions at \(context): "
+                        + "baseline=\(baseline.windowFrame) candidate=\(sample.windowFrame)"
                 )
+                XCTAssertFalse(
+                    baseline.contentFrame.differs(from: sample.contentFrame, byMoreThan: 1),
+                    "Content drift exceeded one point across transitions at \(context): "
+                        + "baseline=\(baseline.contentFrame) candidate=\(sample.contentFrame)"
+                )
+                XCTAssertEqual(
+                    baseline.backingScale,
+                    sample.backingScale,
+                    accuracy: 0.01,
+                    "Backing scale drifted across transitions at \(context): "
+                        + "baseline=\(baseline.backingScale) candidate=\(sample.backingScale)"
+                )
+                for region in baseline.regions {
+                    guard let candidate = sample.regions.first(where: {
+                        $0.identifier == region.identifier
+                    }) else {
+                        XCTFail("Missing \(region.identifier) across transitions at \(context)")
+                        continue
+                    }
+                    XCTAssertFalse(
+                        region.frame.differs(from: candidate.frame, byMoreThan: 1),
+                        "\(region.identifier) drift exceeded one point across transitions at \(context): "
+                            + "baseline=\(region.frame) candidate=\(candidate.frame)"
+                    )
+                }
             }
         }
     }

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -159,6 +159,30 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(source).not.toContain("createDirectory");
   });
 
+  it("covers every sidebar destination in one minimum-size settled circuit", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+
+    expect(source).toContain(
+      "testStrictFixtureSettlesAcrossEverySidebarSectionAtMinimumSize"
+    );
+    expect(source).toContain(
+      'scenario: "overview-repos-providers-license-logs-policy-settings-overview"'
+    );
+    expect(source).toContain(
+      'proofBoundary: "hosted-every-sidebar-destination-minimum-size-geometry-only"'
+    );
+    expect(source).toContain('HostedSidebarRouteStep(section: "overview", generation: 0)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "repos", generation: 1)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "providers", generation: 2)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "license", generation: 3)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "logs", generation: 4)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "policy", generation: 5)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "settings", generation: 6)');
+    expect(source).toContain('HostedSidebarRouteStep(section: "overview", generation: 7)');
+    expect(source).toContain("XCTAssertEqual(checkpoints.count, 8)");
+    expect(source).toContain("XCTAssertEqual(navigationActions.count, 7)");
+  });
+
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow).toContain("Hosted XCUITest smoke");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -161,6 +161,10 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
 
   it("covers every sidebar destination in one minimum-size settled circuit", () => {
     const source = readFileSync(uiTestPath, "utf8");
+    const logs = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift",
+      "utf8"
+    );
 
     expect(source).toContain(
       "testStrictFixtureSettlesAcrossEverySidebarSectionAtMinimumSize"
@@ -185,6 +189,10 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
       'let context = "\\(checkpoint.section)-\\(checkpoint.surfaceGeneration)-\\(sample.elapsedMilliseconds)ms"'
     );
     expect(source).toContain('"baseline=\\(region.frame) candidate=\\(candidate.frame)"');
+    expect(logs).toContain("ScrollView(.vertical)");
+    expect(logs).toContain('.accessibilityIdentifier("neondiff-logs-outer-scroll")');
+    expect(logs).toContain(".frame(height: 360)");
+    expect(logs).not.toContain(".frame(minHeight: 420)");
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -181,6 +181,10 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(source).toContain('HostedSidebarRouteStep(section: "overview", generation: 7)');
     expect(source).toContain("XCTAssertEqual(checkpoints.count, 8)");
     expect(source).toContain("XCTAssertEqual(navigationActions.count, 7)");
+    expect(source).toContain(
+      'let context = "\\(checkpoint.section)-\\(checkpoint.surfaceGeneration)-\\(sample.elapsedMilliseconds)ms"'
+    );
+    expect(source).toContain('"baseline=\\(region.frame) candidate=\\(candidate.frame)"');
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {


### PR DESCRIPTION
Related: #517

## Scope

Adds one strict hosted DEBUG XCUITest that runs the minimum-size, runner-default-text sidebar circuit:

`Overview -> Repos -> Providers -> License -> Logs -> Policy -> Settings -> Overview`

Each destination requires its exact app-authored quiescent generation, three settled samples, one native single-attempt sidebar click, requested/observed 1040x680 content, and the existing one-point window/content/chrome/sidebar/detail stability rules. The existing Overview -> Repos -> Overview test remains intact.

The hosted RED identified one product-layout defect at Logs: its unbounded page stack and 420-point editor minimum displaced the full chrome upward by 102 points at minimum size. `LogsView` now uses an identifiable outer vertical page `ScrollView` with visible indicator and a fixed 360-point native `TextEditor`, preserving the editor's inner native scroll while bounding root geometry. No other product, release, runtime, signing, updater, license, provider, customer, or TCC behavior changes.

## Failing first

- The initial source contract was 1 failed / 4 passed because the all-sidebar scenario was absent.
- Hosted heads `e21e0b0` and diagnostic `44406f1` then failed 1/2 after reaching all checkpoints. The exact diagnostic was `logs-4-0ms`: chrome baseline `y=28` versus candidate `y=-74`.
- The Logs page scroll contract failed 1/5 before the product fix and passed 5/5 afterward.

## Exact-head validation

Head: `0a1d81fa416c832cf77e5c0576de72cd77dd57d8`

- CI run 29399321556: passed, including the repository-wide remote suite, public-claims scan, and secret scan
- CodeQL run 29399318320: passed for Actions, JavaScript/TypeScript, and Python
- Swift Desktop Gate run 29399321597: passed all jobs; hosted XCUITest 2/2
- hosted artifact digest: `sha256:f0aee328a6fa1cfd541daef4452bf5b22ae61acc8df677df423ff41d93c64819`
- downloaded xcresult ZIP SHA-256: `bad336ef166d3894d58dfe425a6c2de67647eefe21176734a0724d74f1a97abd`
- full-circuit geometry attachment SHA-256: `8a57c67d57e1878e1c4b2d4bf35504cde29a2c5e28500aa7f4f5fda4c17aa505`
- original Overview -> Repos -> Overview attachment SHA-256: `bd9124ea6748c5f83ab98c86ac5bdb5b3b4ccd054e4da43885eaf0af1fb8dafc`
- local focused contract: 5/5; Xcode 26.6 `build-for-testing`: succeeded; public-claims, 731-file secret, and diff checks: passed

The full-circuit trace contains eight checkpoints, 24 settled samples, and seven one-attempt successful native clicks. Every sample retained the same 1040x680 content and the same chrome/sidebar/detail frames within the one-point rule.

## Proof boundary

This establishes only stable hosted DEBUG geometry for every sidebar destination in the named 1040x680/default-text circuit. It does not establish bottom-sentinel visibility or reachability, other sizes, large text, overflow rows, onboarding, the separate Settings scene, action/result/error insertions, keyboard/VoiceOver, signed/notarized or installed-app behavior, updates/rollback, parity, release, GA, runtime, or customer readiness. #517 and #503 remain open.
