### PR TITLE
test(desktop): prove sidebar page-bottom reachability

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
@@ -33,7 +33,11 @@ struct LicenseView: View {
                 }
             }
             .padding(24)
+            .overlay(alignment: .bottom) {
+                PageBottomSentinel(section: "license")
+            }
         }
+        .accessibilityIdentifier("neondiff-license-outer-scroll")
         .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -52,5 +52,8 @@ struct LogsView: View {
             }
         }
         .padding(24)
+        .overlay(alignment: .bottom) {
+            PageBottomSentinel(section: "logs")
+        }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -220,6 +220,20 @@ struct OperatorCommandText: View {
     }
 }
 
+struct PageBottomSentinel: View {
+    let section: String
+
+    var body: some View {
+        Color.clear
+            .frame(maxWidth: .infinity)
+            .frame(height: 1)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Bottom of \(section) page")
+            .accessibilityIdentifier("neondiff-\(section)-page-bottom")
+            .allowsHitTesting(false)
+    }
+}
+
 struct OperatorButtonStyle: ButtonStyle {
     var solid = false
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -223,16 +223,27 @@ struct OperatorCommandText: View {
 struct PageBottomSentinel: View {
     let section: String
 
+    @ViewBuilder
     var body: some View {
-        Color.clear
-            .frame(maxWidth: .infinity)
-            .frame(height: 1)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Bottom of \(section) page")
-            .accessibilityIdentifier("neondiff-\(section)-page-bottom")
-            .allowsHitTesting(false)
+        #if DEBUG
+        if HostedEvaluationAccessibility.isActive {
+            Color.clear
+                .frame(maxWidth: .infinity)
+                .frame(height: 1)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Bottom of \(section) page")
+                .accessibilityIdentifier("neondiff-\(section)-page-bottom")
+                .allowsHitTesting(false)
+        }
+        #endif
     }
 }
+
+#if DEBUG
+private enum HostedEvaluationAccessibility {
+    static let isActive = ProcessInfo.processInfo.arguments.contains("--ui-testing")
+}
+#endif
 
 struct OperatorButtonStyle: ButtonStyle {
     var solid = false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -233,6 +233,7 @@ struct PageBottomSentinel: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel("Bottom of \(section) page")
                 .accessibilityIdentifier("neondiff-\(section)-page-bottom")
+                .accessibilityRespondsToUserInteraction(false)
                 .allowsHitTesting(false)
         }
         #endif

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -98,7 +98,11 @@ struct OverviewView: View {
                 }
             }
             .padding(24)
+            .overlay(alignment: .bottom) {
+                PageBottomSentinel(section: "overview")
+            }
         }
+        .accessibilityIdentifier("neondiff-overview-outer-scroll")
         .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
@@ -184,8 +184,12 @@ struct PolicyView: View {
                 .foregroundStyle(NeonDiffTheme.textSecondary)
             }
             .padding(24)
+            .overlay(alignment: .bottom) {
+                PageBottomSentinel(section: "policy")
+            }
             .disabled(!model.canEditProviderConfiguration)
         }
+        .accessibilityIdentifier("neondiff-policy-outer-scroll")
         .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -94,7 +94,11 @@ struct ProviderSettingsView: View {
                 .disabled(!model.canEditProviderConfiguration)
             }
             .padding(24)
+            .overlay(alignment: .bottom) {
+                PageBottomSentinel(section: "providers")
+            }
         }
+        .accessibilityIdentifier("neondiff-providers-outer-scroll")
         .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -272,6 +272,9 @@ struct ReposView: View {
             }
         }
         .padding(24)
+        .overlay(alignment: .bottom) {
+            PageBottomSentinel(section: "repos")
+        }
         .disabled(!model.canEditProviderConfiguration)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -69,7 +69,11 @@ struct SettingsPane: View {
                 }
             }
             .padding(24)
+            .overlay(alignment: .bottom) {
+                PageBottomSentinel(section: "settings")
+            }
         }
+        .accessibilityIdentifier("neondiff-settings-outer-scroll")
         .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -166,6 +166,296 @@ final class NeonDiffDesktopUITests: XCTestCase {
         )
     }
 
+    func testStrictFixtureReachesEverySidebarPageBottomAtMinimumSize() throws {
+        let requestedContentSize = HostedContentSize(width: 1040, height: 680)
+        let route = [
+            HostedPageBottomRouteStep(
+                section: "overview",
+                generation: 0,
+                outerScrollIdentifier: "neondiff-overview-outer-scroll",
+                sentinelIdentifier: "neondiff-overview-page-bottom"
+            ),
+            HostedPageBottomRouteStep(
+                section: "repos",
+                generation: 1,
+                outerScrollIdentifier: "neondiff-repos-outer-scroll",
+                sentinelIdentifier: "neondiff-repos-page-bottom"
+            ),
+            HostedPageBottomRouteStep(
+                section: "providers",
+                generation: 2,
+                outerScrollIdentifier: "neondiff-providers-outer-scroll",
+                sentinelIdentifier: "neondiff-providers-page-bottom"
+            ),
+            HostedPageBottomRouteStep(
+                section: "license",
+                generation: 3,
+                outerScrollIdentifier: "neondiff-license-outer-scroll",
+                sentinelIdentifier: "neondiff-license-page-bottom"
+            ),
+            HostedPageBottomRouteStep(
+                section: "logs",
+                generation: 4,
+                outerScrollIdentifier: "neondiff-logs-outer-scroll",
+                sentinelIdentifier: "neondiff-logs-page-bottom"
+            ),
+            HostedPageBottomRouteStep(
+                section: "policy",
+                generation: 5,
+                outerScrollIdentifier: "neondiff-policy-outer-scroll",
+                sentinelIdentifier: "neondiff-policy-page-bottom"
+            ),
+            HostedPageBottomRouteStep(
+                section: "settings",
+                generation: 6,
+                outerScrollIdentifier: "neondiff-settings-outer-scroll",
+                sentinelIdentifier: "neondiff-settings-page-bottom"
+            )
+        ]
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
+        )
+        let app = XCUIApplication()
+        defer { app.terminate() }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--disable-animations"
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["neondiff.fixture.tab-overview"]
+                .waitForExistence(timeout: 10)
+        )
+        XCTAssertEqual(app.state, .runningForeground)
+
+        var checkpoints: [HostedPageBottomCheckpoint] = []
+        var navigationActions: [HostedNavigationAction] = []
+        for (routeIndex, step) in route.enumerated() {
+            if routeIndex > 0 {
+                let previous = route[routeIndex - 1]
+                navigationActions.append(
+                    try clickNavigation(
+                        app: app,
+                        index: routeIndex - 1,
+                        fromSection: previous.section,
+                        toSection: step.section,
+                        identifier: "neondiff-sidebar-section-\(step.section)"
+                    )
+                )
+            }
+
+            let markerIdentifier =
+                "neondiff.evaluation.surface.\(step.section).\(step.generation).quiescent"
+            _ = try captureCheckpoint(
+                app: app,
+                section: step.section,
+                generation: step.generation,
+                markerIdentifier: markerIdentifier,
+                requestedContentSize: requestedContentSize
+            )
+            checkpoints.append(
+                try capturePageBottomCheckpoint(
+                    app: app,
+                    section: step.section,
+                    generation: step.generation,
+                    markerIdentifier: markerIdentifier,
+                    outerScrollIdentifier: step.outerScrollIdentifier,
+                    sentinelIdentifier: step.sentinelIdentifier
+                )
+            )
+        }
+
+        XCTAssertEqual(checkpoints.count, 7)
+        XCTAssertEqual(navigationActions.count, 6)
+        try attach(
+            HostedPageBottomReachabilityTrace(
+                schemaVersion: 1,
+                scenario: "every-sidebar-page-bottom-at-minimum-size",
+                fixtureId: "tab-overview",
+                requestedContentSize: requestedContentSize,
+                textSizeMode: "runner-default-no-test-override",
+                coordinateSpace: "xcui-screen",
+                sampleIntervalMilliseconds: 100,
+                tolerancePoints: 1,
+                navigationActions: navigationActions,
+                checkpoints: checkpoints,
+                proofBoundary: "hosted-outer-page-bottom-reachability-only-inner-scroll-exhaustion-excluded"
+            )
+        )
+    }
+
+    private func capturePageBottomCheckpoint(
+        app: XCUIApplication,
+        section: String,
+        generation: Int,
+        markerIdentifier: String,
+        outerScrollIdentifier: String,
+        sentinelIdentifier: String
+    ) throws -> HostedPageBottomCheckpoint {
+        let outerPageScroll = app.descendants(matching: .any)[outerScrollIdentifier]
+        let bottomSentinel = app.descendants(matching: .any)[sentinelIdentifier]
+        let detailRegion = app.descendants(matching: .any)["neondiff-detail"]
+        XCTAssertTrue(
+            outerPageScroll.waitForExistence(timeout: 2),
+            "Missing outer page scroll \(outerScrollIdentifier)"
+        )
+        XCTAssertTrue(
+            bottomSentinel.waitForExistence(timeout: 2),
+            "Missing page-bottom sentinel \(sentinelIdentifier)"
+        )
+        XCTAssertTrue(detailRegion.waitForExistence(timeout: 2), "Missing detail region")
+        XCTAssertFalse(bottomSentinel.isHittable, "Page-bottom sentinel must remain non-hittable")
+
+        let preActionSamples = capturePageBottomSamples(
+            outerPageScroll: outerPageScroll,
+            bottomSentinel: bottomSentinel,
+            detailRegion: detailRegion,
+            context: "\(section)-pre"
+        )
+        let preActionSample = try XCTUnwrap(preActionSamples.last)
+        let scrollAction: HostedPageScrollAction?
+        let postActionSamples: [HostedPageBottomSample]
+        if preActionSample.sentinelFullyContainedInOuterScroll
+            && preActionSample.sentinelFullyContainedInDetailRegion {
+            scrollAction = nil
+            postActionSamples = preActionSamples
+        } else {
+            outerPageScroll.scroll(byDeltaX: 0, deltaY: -10_000)
+            scrollAction = HostedPageScrollAction(
+                controlIdentifier: outerScrollIdentifier,
+                deltaX: 0,
+                deltaY: -10_000,
+                attemptCount: 1,
+                result: "success"
+            )
+            postActionSamples = capturePageBottomSamples(
+                outerPageScroll: outerPageScroll,
+                bottomSentinel: bottomSentinel,
+                detailRegion: detailRegion,
+                context: "\(section)-post"
+            )
+        }
+
+        let postActionSample = try XCTUnwrap(postActionSamples.last)
+        assertFullyContained(
+            postActionSample.sentinelFrame,
+            in: postActionSample.outerScrollFrame,
+            context: "\(section) outer scroll"
+        )
+        assertFullyContained(
+            postActionSample.sentinelFrame,
+            in: postActionSample.detailRegionFrame,
+            context: "\(section) detail region"
+        )
+        return HostedPageBottomCheckpoint(
+            section: section,
+            surfaceGeneration: generation,
+            quiescenceMarkerIdentifier: markerIdentifier,
+            outerScrollIdentifier: outerScrollIdentifier,
+            sentinelIdentifier: sentinelIdentifier,
+            preActionSamples: preActionSamples,
+            scrollAction: scrollAction,
+            postActionSamples: postActionSamples
+        )
+    }
+
+    private func capturePageBottomSamples(
+        outerPageScroll: XCUIElement,
+        bottomSentinel: XCUIElement,
+        detailRegion: XCUIElement,
+        context: String
+    ) -> [HostedPageBottomSample] {
+        let start = ProcessInfo.processInfo.systemUptime
+        var samples: [HostedPageBottomSample] = []
+        for index in 0..<3 {
+            if index > 0 {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            }
+            let outerScrollFrame = HostedGeometryFrame(outerPageScroll.frame)
+            let sentinelFrame = HostedGeometryFrame(bottomSentinel.frame)
+            let detailRegionFrame = HostedGeometryFrame(detailRegion.frame)
+            XCTAssertTrue(outerScrollFrame.isFiniteAndNonempty, "Invalid outer scroll frame for \(context)")
+            XCTAssertTrue(sentinelFrame.isFiniteAndNonempty, "Invalid sentinel frame for \(context)")
+            XCTAssertTrue(detailRegionFrame.isFiniteAndNonempty, "Invalid detail frame for \(context)")
+            samples.append(
+                HostedPageBottomSample(
+                    elapsedMilliseconds: Int(
+                        ((ProcessInfo.processInfo.systemUptime - start) * 1_000).rounded()
+                    ),
+                    outerScrollFrame: outerScrollFrame,
+                    sentinelFrame: sentinelFrame,
+                    detailRegionFrame: detailRegionFrame,
+                    sentinelFullyContainedInOuterScroll: sentinelFrame.isFullyContained(
+                        in: outerScrollFrame,
+                        tolerance: 1
+                    ),
+                    sentinelFullyContainedInDetailRegion: sentinelFrame.isFullyContained(
+                        in: detailRegionFrame,
+                        tolerance: 1
+                    )
+                )
+            )
+        }
+        assertValidPageBottomCadence(samples, context: context)
+        assertStablePageBottomSamples(samples, context: context)
+        return samples
+    }
+
+    private func assertValidPageBottomCadence(
+        _ samples: [HostedPageBottomSample],
+        context: String
+    ) {
+        XCTAssertEqual(samples.count, 3, "Wrong page-bottom sample count for \(context)")
+        guard samples.count == 3 else { return }
+        XCTAssertGreaterThanOrEqual(samples[0].elapsedMilliseconds, 0)
+        XCTAssertLessThanOrEqual(samples[0].elapsedMilliseconds, 25)
+        for (lhs, rhs) in zip(samples, samples.dropFirst()) {
+            let interval = rhs.elapsedMilliseconds - lhs.elapsedMilliseconds
+            XCTAssertGreaterThanOrEqual(interval, 90, "Short sample interval for \(context)")
+            XCTAssertLessThanOrEqual(interval, 175, "Long sample interval for \(context)")
+        }
+    }
+
+    private func assertStablePageBottomSamples(
+        _ samples: [HostedPageBottomSample],
+        context: String
+    ) {
+        guard let baseline = samples.first else {
+            XCTFail("Missing page-bottom samples for \(context)")
+            return
+        }
+        for sample in samples.dropFirst() {
+            XCTAssertFalse(
+                baseline.outerScrollFrame.differs(from: sample.outerScrollFrame, byMoreThan: 1),
+                "Outer scroll drift exceeded one point for \(context)"
+            )
+            XCTAssertFalse(
+                baseline.sentinelFrame.differs(from: sample.sentinelFrame, byMoreThan: 1),
+                "Page-bottom sentinel drift exceeded one point for \(context)"
+            )
+            XCTAssertFalse(
+                baseline.detailRegionFrame.differs(from: sample.detailRegionFrame, byMoreThan: 1),
+                "Detail region drift exceeded one point for \(context)"
+            )
+        }
+    }
+
+    private func assertFullyContained(
+        _ frame: HostedGeometryFrame,
+        in container: HostedGeometryFrame,
+        context: String
+    ) {
+        XCTAssertTrue(
+            frame.isFullyContained(in: container, tolerance: 1),
+            "Page-bottom sentinel is not fully contained in \(context): "
+                + "sentinel=\(frame) container=\(container)"
+        )
+    }
+
     private func captureCheckpoint(
         app: XCUIApplication,
         section: String,
@@ -479,6 +769,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
         add(attachment)
     }
 
+    private func attach(_ trace: HostedPageBottomReachabilityTrace) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let attachment = XCTAttachment(
+            data: try encoder.encode(trace),
+            uniformTypeIdentifier: "public.json"
+        )
+        attachment.name = "neondiff-hosted-page-bottom-reachability.json"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func attachTransportDiagnostic(_ diagnostic: HostedTransportDiagnostic) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -502,6 +804,13 @@ private struct HostedContentSize: Codable {
 private struct HostedSidebarRouteStep {
     let section: String
     let generation: Int
+}
+
+private struct HostedPageBottomRouteStep {
+    let section: String
+    let generation: Int
+    let outerScrollIdentifier: String
+    let sentinelIdentifier: String
 }
 
 private struct HostedGeometryFrame: Codable, Equatable {
@@ -535,6 +844,13 @@ private struct HostedGeometryFrame: Codable, Equatable {
             || abs(y - other.y) > tolerance
             || abs(width - other.width) > tolerance
             || abs(height - other.height) > tolerance
+    }
+
+    func isFullyContained(in container: Self, tolerance: Double) -> Bool {
+        x >= container.x - tolerance
+            && y >= container.y - tolerance
+            && x + width <= container.x + container.width + tolerance
+            && y + height <= container.y + container.height + tolerance
     }
 }
 
@@ -641,6 +957,48 @@ private struct HostedSettledGeometryTrace: Codable {
     let tolerancePoints: Double
     let navigationActions: [HostedNavigationAction]
     let checkpoints: [HostedGeometryCheckpoint]
+    let proofBoundary: String
+}
+
+private struct HostedPageBottomSample: Codable, Equatable {
+    let elapsedMilliseconds: Int
+    let outerScrollFrame: HostedGeometryFrame
+    let sentinelFrame: HostedGeometryFrame
+    let detailRegionFrame: HostedGeometryFrame
+    let sentinelFullyContainedInOuterScroll: Bool
+    let sentinelFullyContainedInDetailRegion: Bool
+}
+
+private struct HostedPageScrollAction: Codable, Equatable {
+    let controlIdentifier: String
+    let deltaX: Double
+    let deltaY: Double
+    let attemptCount: Int
+    let result: String
+}
+
+private struct HostedPageBottomCheckpoint: Codable, Equatable {
+    let section: String
+    let surfaceGeneration: Int
+    let quiescenceMarkerIdentifier: String
+    let outerScrollIdentifier: String
+    let sentinelIdentifier: String
+    let preActionSamples: [HostedPageBottomSample]
+    let scrollAction: HostedPageScrollAction?
+    let postActionSamples: [HostedPageBottomSample]
+}
+
+private struct HostedPageBottomReachabilityTrace: Codable {
+    let schemaVersion: Int
+    let scenario: String
+    let fixtureId: String
+    let requestedContentSize: HostedContentSize
+    let textSizeMode: String
+    let coordinateSpace: String
+    let sampleIntervalMilliseconds: Int
+    let tolerancePoints: Double
+    let navigationActions: [HostedNavigationAction]
+    let checkpoints: [HostedPageBottomCheckpoint]
     let proofBoundary: String
 }
 

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -271,6 +271,9 @@ final class NeonDiffDesktopUITests: XCTestCase {
 
         XCTAssertEqual(checkpoints.count, 7)
         XCTAssertEqual(navigationActions.count, 6)
+        guard (testRun?.failureCount ?? 0) == 0 else {
+            throw HostedPageBottomTraceError.priorValidationFailure
+        }
         try attach(
             HostedPageBottomReachabilityTrace(
                 schemaVersion: 1,
@@ -279,7 +282,8 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 requestedContentSize: requestedContentSize,
                 textSizeMode: "runner-default-no-test-override",
                 coordinateSpace: "xcui-screen",
-                sampleIntervalMilliseconds: 100,
+                minimumSampleIntervalMilliseconds: 100,
+                samplingDeadlineMilliseconds: 5_000,
                 tolerancePoints: 1,
                 navigationActions: navigationActions,
                 checkpoints: checkpoints,
@@ -299,40 +303,36 @@ final class NeonDiffDesktopUITests: XCTestCase {
         let outerPageScroll = app.descendants(matching: .any)[outerScrollIdentifier]
         let bottomSentinel = app.descendants(matching: .any)[sentinelIdentifier]
         let detailRegion = app.descendants(matching: .any)["neondiff-detail"]
-        XCTAssertTrue(
-            outerPageScroll.waitForExistence(timeout: 2),
-            "Missing outer page scroll \(outerScrollIdentifier)"
-        )
-        XCTAssertTrue(
-            bottomSentinel.waitForExistence(timeout: 2),
-            "Missing page-bottom sentinel \(sentinelIdentifier)"
-        )
-        XCTAssertTrue(detailRegion.waitForExistence(timeout: 2), "Missing detail region")
-        XCTAssertFalse(bottomSentinel.isHittable, "Page-bottom sentinel must remain non-hittable")
+        guard outerPageScroll.waitForExistence(timeout: 2) else {
+            throw HostedPageBottomTraceError.missingElement(outerScrollIdentifier)
+        }
+        guard bottomSentinel.waitForExistence(timeout: 2) else {
+            throw HostedPageBottomTraceError.missingElement(sentinelIdentifier)
+        }
+        guard detailRegion.waitForExistence(timeout: 2) else {
+            throw HostedPageBottomTraceError.missingElement("neondiff-detail")
+        }
+        guard !bottomSentinel.isHittable else {
+            throw HostedPageBottomTraceError.hittableSentinel(sentinelIdentifier)
+        }
 
-        let preActionSamples = capturePageBottomSamples(
+        let preActionSamples = try capturePageBottomSamples(
             outerPageScroll: outerPageScroll,
             bottomSentinel: bottomSentinel,
             detailRegion: detailRegion,
             context: "\(section)-pre"
         )
         let preActionSample = try XCTUnwrap(preActionSamples.last)
-        let scrollAction: HostedPageScrollAction?
+        let didIssueScroll: Bool
         let postActionSamples: [HostedPageBottomSample]
         if preActionSample.sentinelFullyContainedInOuterScroll
             && preActionSample.sentinelFullyContainedInDetailRegion {
-            scrollAction = nil
+            didIssueScroll = false
             postActionSamples = preActionSamples
         } else {
             outerPageScroll.scroll(byDeltaX: 0, deltaY: -10_000)
-            scrollAction = HostedPageScrollAction(
-                controlIdentifier: outerScrollIdentifier,
-                deltaX: 0,
-                deltaY: -10_000,
-                attemptCount: 1,
-                result: "success"
-            )
-            postActionSamples = capturePageBottomSamples(
+            didIssueScroll = true
+            postActionSamples = try capturePageBottomSamples(
                 outerPageScroll: outerPageScroll,
                 bottomSentinel: bottomSentinel,
                 detailRegion: detailRegion,
@@ -341,16 +341,26 @@ final class NeonDiffDesktopUITests: XCTestCase {
         }
 
         let postActionSample = try XCTUnwrap(postActionSamples.last)
-        assertFullyContained(
+        try requireFullyContained(
             postActionSample.sentinelFrame,
             in: postActionSample.outerScrollFrame,
             context: "\(section) outer scroll"
         )
-        assertFullyContained(
+        try requireFullyContained(
             postActionSample.sentinelFrame,
             in: postActionSample.detailRegionFrame,
             context: "\(section) detail region"
         )
+        let scrollAction = didIssueScroll
+            ? HostedPageScrollAction(
+                controlIdentifier: outerScrollIdentifier,
+                deltaX: 0,
+                deltaY: -10_000,
+                attemptCount: 1,
+                result: "returned",
+                effectProven: true
+            )
+            : nil
         return HostedPageBottomCheckpoint(
             section: section,
             surfaceGeneration: generation,
@@ -368,24 +378,37 @@ final class NeonDiffDesktopUITests: XCTestCase {
         bottomSentinel: XCUIElement,
         detailRegion: XCUIElement,
         context: String
-    ) -> [HostedPageBottomSample] {
+    ) throws -> [HostedPageBottomSample] {
         let start = ProcessInfo.processInfo.systemUptime
         var samples: [HostedPageBottomSample] = []
+        var previousSampleStart: TimeInterval?
         for index in 0..<3 {
-            if index > 0 {
-                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            if index > 0, let previousSampleStart {
+                let elapsedSincePrevious =
+                    ProcessInfo.processInfo.systemUptime - previousSampleStart
+                let remainingDelay = max(0, 0.1 - elapsedSincePrevious)
+                if remainingDelay > 0 {
+                    RunLoop.current.run(until: Date().addingTimeInterval(remainingDelay))
+                }
             }
+            let sampleStart = ProcessInfo.processInfo.systemUptime
+            previousSampleStart = sampleStart
+            let elapsedMilliseconds = Int(((sampleStart - start) * 1_000).rounded())
             let outerScrollFrame = HostedGeometryFrame(outerPageScroll.frame)
             let sentinelFrame = HostedGeometryFrame(bottomSentinel.frame)
             let detailRegionFrame = HostedGeometryFrame(detailRegion.frame)
-            XCTAssertTrue(outerScrollFrame.isFiniteAndNonempty, "Invalid outer scroll frame for \(context)")
-            XCTAssertTrue(sentinelFrame.isFiniteAndNonempty, "Invalid sentinel frame for \(context)")
-            XCTAssertTrue(detailRegionFrame.isFiniteAndNonempty, "Invalid detail frame for \(context)")
+            guard outerScrollFrame.isFiniteAndNonempty else {
+                throw HostedPageBottomTraceError.invalidFrame("\(context) outer scroll")
+            }
+            guard sentinelFrame.isFiniteAndNonempty else {
+                throw HostedPageBottomTraceError.invalidFrame("\(context) sentinel")
+            }
+            guard detailRegionFrame.isFiniteAndNonempty else {
+                throw HostedPageBottomTraceError.invalidFrame("\(context) detail")
+            }
             samples.append(
                 HostedPageBottomSample(
-                    elapsedMilliseconds: Int(
-                        ((ProcessInfo.processInfo.systemUptime - start) * 1_000).rounded()
-                    ),
+                    elapsedMilliseconds: elapsedMilliseconds,
                     outerScrollFrame: outerScrollFrame,
                     sentinelFrame: sentinelFrame,
                     detailRegionFrame: detailRegionFrame,
@@ -400,60 +423,67 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 )
             )
         }
-        assertValidPageBottomCadence(samples, context: context)
-        assertStablePageBottomSamples(samples, context: context)
+        try validatePageBottomCadence(samples, context: context)
+        try validateStablePageBottomSamples(samples, context: context)
         return samples
     }
 
-    private func assertValidPageBottomCadence(
+    private func validatePageBottomCadence(
         _ samples: [HostedPageBottomSample],
         context: String
-    ) {
-        XCTAssertEqual(samples.count, 3, "Wrong page-bottom sample count for \(context)")
-        guard samples.count == 3 else { return }
-        XCTAssertGreaterThanOrEqual(samples[0].elapsedMilliseconds, 0)
-        XCTAssertLessThanOrEqual(samples[0].elapsedMilliseconds, 25)
+    ) throws {
+        guard samples.count == 3 else {
+            throw HostedPageBottomTraceError.invalidCadence(context)
+        }
+        guard samples[0].elapsedMilliseconds >= 0,
+              samples[0].elapsedMilliseconds <= 25,
+              let finalElapsed = samples.last?.elapsedMilliseconds,
+              finalElapsed <= 5_000 else {
+            throw HostedPageBottomTraceError.invalidCadence(context)
+        }
         for (lhs, rhs) in zip(samples, samples.dropFirst()) {
             let interval = rhs.elapsedMilliseconds - lhs.elapsedMilliseconds
-            XCTAssertGreaterThanOrEqual(interval, 90, "Short sample interval for \(context)")
-            XCTAssertLessThanOrEqual(interval, 175, "Long sample interval for \(context)")
+            guard interval >= 90 else {
+                throw HostedPageBottomTraceError.invalidCadence(context)
+            }
         }
     }
 
-    private func assertStablePageBottomSamples(
+    private func validateStablePageBottomSamples(
         _ samples: [HostedPageBottomSample],
         context: String
-    ) {
+    ) throws {
         guard let baseline = samples.first else {
-            XCTFail("Missing page-bottom samples for \(context)")
-            return
+            throw HostedPageBottomTraceError.missingSamples(context)
         }
         for sample in samples.dropFirst() {
-            XCTAssertFalse(
-                baseline.outerScrollFrame.differs(from: sample.outerScrollFrame, byMoreThan: 1),
-                "Outer scroll drift exceeded one point for \(context)"
-            )
-            XCTAssertFalse(
-                baseline.sentinelFrame.differs(from: sample.sentinelFrame, byMoreThan: 1),
-                "Page-bottom sentinel drift exceeded one point for \(context)"
-            )
-            XCTAssertFalse(
-                baseline.detailRegionFrame.differs(from: sample.detailRegionFrame, byMoreThan: 1),
-                "Detail region drift exceeded one point for \(context)"
-            )
+            guard !baseline.outerScrollFrame.differs(
+                from: sample.outerScrollFrame,
+                byMoreThan: 1
+            ), !baseline.sentinelFrame.differs(
+                from: sample.sentinelFrame,
+                byMoreThan: 1
+            ), !baseline.detailRegionFrame.differs(
+                from: sample.detailRegionFrame,
+                byMoreThan: 1
+            ) else {
+                throw HostedPageBottomTraceError.unstableGeometry(context)
+            }
         }
     }
 
-    private func assertFullyContained(
+    private func requireFullyContained(
         _ frame: HostedGeometryFrame,
         in container: HostedGeometryFrame,
         context: String
-    ) {
-        XCTAssertTrue(
-            frame.isFullyContained(in: container, tolerance: 1),
-            "Page-bottom sentinel is not fully contained in \(context): "
-                + "sentinel=\(frame) container=\(container)"
-        )
+    ) throws {
+        guard frame.isFullyContained(in: container, tolerance: 1) else {
+            throw HostedPageBottomTraceError.sentinelNotContained(
+                context: context,
+                sentinel: frame,
+                container: container
+            )
+        }
     }
 
     private func captureCheckpoint(
@@ -975,6 +1005,7 @@ private struct HostedPageScrollAction: Codable, Equatable {
     let deltaY: Double
     let attemptCount: Int
     let result: String
+    let effectProven: Bool
 }
 
 private struct HostedPageBottomCheckpoint: Codable, Equatable {
@@ -995,7 +1026,8 @@ private struct HostedPageBottomReachabilityTrace: Codable {
     let requestedContentSize: HostedContentSize
     let textSizeMode: String
     let coordinateSpace: String
-    let sampleIntervalMilliseconds: Int
+    let minimumSampleIntervalMilliseconds: Int
+    let samplingDeadlineMilliseconds: Int
     let tolerancePoints: Double
     let navigationActions: [HostedNavigationAction]
     let checkpoints: [HostedPageBottomCheckpoint]
@@ -1015,6 +1047,43 @@ private struct HostedTransportDiagnostic: Codable {
     let expectedPrefixMatched: Bool?
     let base64DecodedByteCount: Int?
     let equalsUnavailableSentinel: Bool
+}
+
+private enum HostedPageBottomTraceError: LocalizedError {
+    case priorValidationFailure
+    case missingElement(String)
+    case hittableSentinel(String)
+    case invalidFrame(String)
+    case missingSamples(String)
+    case invalidCadence(String)
+    case unstableGeometry(String)
+    case sentinelNotContained(
+        context: String,
+        sentinel: HostedGeometryFrame,
+        container: HostedGeometryFrame
+    )
+
+    var errorDescription: String? {
+        switch self {
+        case .priorValidationFailure:
+            "Hosted page-bottom trace withheld after an earlier validation failure"
+        case .missingElement(let identifier):
+            "Missing hosted page-bottom element: \(identifier)"
+        case .hittableSentinel(let identifier):
+            "Hosted page-bottom sentinel must remain non-hittable: \(identifier)"
+        case .invalidFrame(let context):
+            "Invalid hosted page-bottom frame: \(context)"
+        case .missingSamples(let context):
+            "Missing hosted page-bottom samples: \(context)"
+        case .invalidCadence(let context):
+            "Invalid hosted page-bottom sample cadence: \(context)"
+        case .unstableGeometry(let context):
+            "Hosted page-bottom geometry drift exceeded one point: \(context)"
+        case let .sentinelNotContained(context, sentinel, container):
+            "Hosted page-bottom sentinel is not fully contained in \(context): "
+                + "sentinel=\(sentinel) container=\(container)"
+        }
+    }
 }
 
 private enum HostedGeometryTraceError: LocalizedError {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -312,10 +312,6 @@ final class NeonDiffDesktopUITests: XCTestCase {
         guard detailRegion.waitForExistence(timeout: 2) else {
             throw HostedPageBottomTraceError.missingElement("neondiff-detail")
         }
-        guard !bottomSentinel.isHittable else {
-            throw HostedPageBottomTraceError.hittableSentinel(sentinelIdentifier)
-        }
-
         let preActionSamples = try capturePageBottomSamples(
             outerPageScroll: outerPageScroll,
             bottomSentinel: bottomSentinel,
@@ -1054,7 +1050,6 @@ private struct HostedTransportDiagnostic: Codable {
 private enum HostedPageBottomTraceError: LocalizedError {
     case priorValidationFailure
     case missingElement(String)
-    case hittableSentinel(String)
     case invalidFrame(String)
     case missingSamples(String)
     case invalidCadence(String)
@@ -1071,8 +1066,6 @@ private enum HostedPageBottomTraceError: LocalizedError {
             "Hosted page-bottom trace withheld after an earlier validation failure"
         case .missingElement(let identifier):
             "Missing hosted page-bottom element: \(identifier)"
-        case .hittableSentinel(let identifier):
-            "Hosted page-bottom sentinel must remain non-hittable: \(identifier)"
         case .invalidFrame(let context):
             "Invalid hosted page-bottom frame: \(context)"
         case .missingSamples(let context):

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -322,11 +322,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
             detailRegion: detailRegion,
             context: "\(section)-pre"
         )
-        let preActionSample = try XCTUnwrap(preActionSamples.last)
         let didIssueScroll: Bool
         let postActionSamples: [HostedPageBottomSample]
-        if preActionSample.sentinelFullyContainedInOuterScroll
-            && preActionSample.sentinelFullyContainedInDetailRegion {
+        if preActionSamples.allSatisfy({
+            $0.sentinelFullyContainedInOuterScroll
+                && $0.sentinelFullyContainedInDetailRegion
+        }) {
             didIssueScroll = false
             postActionSamples = preActionSamples
         } else {
@@ -340,17 +341,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
             )
         }
 
-        let postActionSample = try XCTUnwrap(postActionSamples.last)
-        try requireFullyContained(
-            postActionSample.sentinelFrame,
-            in: postActionSample.outerScrollFrame,
-            context: "\(section) outer scroll"
-        )
-        try requireFullyContained(
-            postActionSample.sentinelFrame,
-            in: postActionSample.detailRegionFrame,
-            context: "\(section) detail region"
-        )
+        for (sampleIndex, postActionSample) in postActionSamples.enumerated() {
+            try requireFullyContained(
+                postActionSample.sentinelFrame,
+                in: postActionSample.outerScrollFrame,
+                context: "\(section) outer scroll sample \(sampleIndex)"
+            )
+            try requireFullyContained(
+                postActionSample.sentinelFrame,
+                in: postActionSample.detailRegionFrame,
+                context: "\(section) detail region sample \(sampleIndex)"
+            )
+        }
         let scrollAction = didIssueScroll
             ? HostedPageScrollAction(
                 controlIdentifier: outerScrollIdentifier,

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -9,6 +9,86 @@ const testPlanPath = "apps/neondiff-desktop/NeonDiffDesktop.xctestplan";
 const uiTestPath = "apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift";
 const workflowPath = ".github/workflows/swift-desktop-gate.yml";
 
+function extractBalancedSwiftDeclaration(
+  source: string,
+  declaration: string
+): string {
+  const declarationStart = source.indexOf(declaration);
+  if (declarationStart < 0) {
+    throw new Error(`Missing Swift declaration: ${declaration}`);
+  }
+
+  const bodyStart = source.indexOf("{", declarationStart);
+  if (bodyStart < 0) {
+    throw new Error(`Missing Swift declaration body: ${declaration}`);
+  }
+
+  let depth = 0;
+  let blockCommentDepth = 0;
+  let inLineComment = false;
+  let inString = false;
+  let inMultilineString = false;
+  let escaping = false;
+
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+    const nextTwo = source.slice(index, index + 3);
+
+    if (inLineComment) {
+      if (current === "\n") inLineComment = false;
+      continue;
+    }
+    if (blockCommentDepth > 0) {
+      if (current === "/" && next === "*") {
+        blockCommentDepth += 1;
+        index += 1;
+      } else if (current === "*" && next === "/") {
+        blockCommentDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    if (inMultilineString) {
+      if (nextTwo === '\"\"\"') {
+        inMultilineString = false;
+        index += 2;
+      }
+      continue;
+    }
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (current === "\\") {
+        escaping = true;
+      } else if (current === '\"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      inLineComment = true;
+      index += 1;
+    } else if (current === "/" && next === "*") {
+      blockCommentDepth = 1;
+      index += 1;
+    } else if (nextTwo === '\"\"\"') {
+      inMultilineString = true;
+      index += 2;
+    } else if (current === '\"') {
+      inString = true;
+    } else if (current === "{") {
+      depth += 1;
+    } else if (current === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(declarationStart, index + 1);
+    }
+  }
+
+  throw new Error(`Unbalanced Swift declaration body: ${declaration}`);
+}
+
 describe("hosted NeonDiff desktop XCTest foundation", () => {
   it("checks in a shared app/UI-test project and test plan", () => {
     expect(existsSync(projectPath)).toBe(true);
@@ -195,7 +275,7 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(logs).not.toContain(".frame(minHeight: 420)");
   });
 
-  it("proves each sidebar page outer scroll reaches its bottom sentinel", () => {
+  it("encodes the hosted contract for each sidebar page outer-scroll bottom reachability", () => {
     const source = readFileSync(uiTestPath, "utf8");
     const pageSources = [
       ["overview", "OverviewView.swift"],
@@ -219,16 +299,10 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(
       source.match(/outerPageScroll\.scroll\(byDeltaX: 0, deltaY: -10_000\)/g)
     ).toHaveLength(1);
-    const checkpointStart = source.indexOf(
+    const checkpointSource = extractBalancedSwiftDeclaration(
+      source,
       "private func capturePageBottomCheckpoint("
     );
-    const checkpointEnd = source.indexOf(
-      "private func capturePageBottomSamples(",
-      checkpointStart
-    );
-    expect(checkpointStart).toBeGreaterThan(-1);
-    expect(checkpointEnd).toBeGreaterThan(checkpointStart);
-    const checkpointSource = source.slice(checkpointStart, checkpointEnd);
     expect(checkpointSource.match(/\.scroll\s*\(/g)).toHaveLength(1);
     expect(checkpointSource).not.toMatch(
       /\.(?:swipe\w*|tap|click|press|drag|coordinate)\s*\(/

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -13,74 +13,25 @@ function extractBalancedSwiftDeclaration(
   source: string,
   declaration: string
 ): string {
-  const declarationStart = source.indexOf(declaration);
+  const code = maskSwiftCommentsAndLiterals(source);
+  const declarationStart = code.indexOf(declaration);
   if (declarationStart < 0) {
     throw new Error(`Missing Swift declaration: ${declaration}`);
   }
+  if (code.indexOf(declaration, declarationStart + declaration.length) >= 0) {
+    throw new Error(`Ambiguous Swift declaration: ${declaration}`);
+  }
 
-  const bodyStart = source.indexOf("{", declarationStart);
+  const bodyStart = code.indexOf("{", declarationStart);
   if (bodyStart < 0) {
     throw new Error(`Missing Swift declaration body: ${declaration}`);
   }
 
   let depth = 0;
-  let blockCommentDepth = 0;
-  let inLineComment = false;
-  let inString = false;
-  let inMultilineString = false;
-  let escaping = false;
-
-  for (let index = bodyStart; index < source.length; index += 1) {
-    const current = source[index];
-    const next = source[index + 1];
-    const nextTwo = source.slice(index, index + 3);
-
-    if (inLineComment) {
-      if (current === "\n") inLineComment = false;
-      continue;
-    }
-    if (blockCommentDepth > 0) {
-      if (current === "/" && next === "*") {
-        blockCommentDepth += 1;
-        index += 1;
-      } else if (current === "*" && next === "/") {
-        blockCommentDepth -= 1;
-        index += 1;
-      }
-      continue;
-    }
-    if (inMultilineString) {
-      if (nextTwo === '\"\"\"') {
-        inMultilineString = false;
-        index += 2;
-      }
-      continue;
-    }
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-      } else if (current === "\\") {
-        escaping = true;
-      } else if (current === '\"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (current === "/" && next === "/") {
-      inLineComment = true;
-      index += 1;
-    } else if (current === "/" && next === "*") {
-      blockCommentDepth = 1;
-      index += 1;
-    } else if (nextTwo === '\"\"\"') {
-      inMultilineString = true;
-      index += 2;
-    } else if (current === '\"') {
-      inString = true;
-    } else if (current === "{") {
+  for (let index = bodyStart; index < code.length; index += 1) {
+    if (code[index] === "{") {
       depth += 1;
-    } else if (current === "}") {
+    } else if (code[index] === "}") {
       depth -= 1;
       if (depth === 0) return source.slice(declarationStart, index + 1);
     }
@@ -89,7 +40,160 @@ function extractBalancedSwiftDeclaration(
   throw new Error(`Unbalanced Swift declaration body: ${declaration}`);
 }
 
+function maskSwiftCommentsAndLiterals(source: string): string {
+  const masked = [...source];
+  let index = 0;
+
+  while (index < source.length) {
+    if (source.startsWith("//", index)) {
+      const end = source.indexOf("\n", index + 2);
+      index = maskSwiftRange(masked, index, end < 0 ? source.length : end);
+      continue;
+    }
+    if (source.startsWith("/*", index)) {
+      let end = index + 2;
+      let depth = 1;
+      while (end < source.length && depth > 0) {
+        if (source.startsWith("/*", end)) {
+          depth += 1;
+          end += 2;
+        } else if (source.startsWith("*/", end)) {
+          depth -= 1;
+          end += 2;
+        } else {
+          end += 1;
+        }
+      }
+      if (depth !== 0) throw new Error("Unterminated Swift block comment");
+      index = maskSwiftRange(masked, index, end);
+      continue;
+    }
+
+    const poundCount = countLeadingPounds(source, index);
+    const literalStart = index + poundCount;
+    const quoteCount = source.startsWith('\"\"\"', literalStart)
+      ? 3
+      : source[literalStart] === '\"'
+        ? 1
+        : 0;
+    if (quoteCount > 0) {
+      const closing = '\"'.repeat(quoteCount) + "#".repeat(poundCount);
+      let end = literalStart + quoteCount;
+      let closed = false;
+      while (end < source.length) {
+        if (poundCount === 0 && source[end] === "\\") {
+          end += 2;
+        } else if (source.startsWith(closing, end)) {
+          end += closing.length;
+          closed = true;
+          break;
+        } else {
+          end += 1;
+        }
+      }
+      if (!closed) throw new Error("Unterminated Swift string literal");
+      index = maskSwiftRange(masked, index, end);
+      continue;
+    }
+
+    if (poundCount > 0 && source[literalStart] === "/") {
+      const end = findSwiftRegexEnd(
+        source,
+        literalStart + 1,
+        "/" + "#".repeat(poundCount)
+      );
+      index = maskSwiftRange(masked, index, end);
+      continue;
+    }
+    if (
+      source[index] === "/" &&
+      source[index + 1] !== "/" &&
+      source[index + 1] !== "*" &&
+      isSwiftBareRegexStart(masked, index)
+    ) {
+      const end = findSwiftRegexEnd(source, index + 1, "/");
+      index = maskSwiftRange(masked, index, end);
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return masked.join("");
+}
+
+function countLeadingPounds(source: string, start: number): number {
+  let count = 0;
+  while (source[start + count] === "#") count += 1;
+  return count;
+}
+
+function maskSwiftRange(masked: string[], start: number, end: number): number {
+  for (let index = start; index < end; index += 1) {
+    if (masked[index] !== "\n") masked[index] = " ";
+  }
+  return end;
+}
+
+function isSwiftBareRegexStart(masked: string[], index: number): boolean {
+  let previousIndex = index - 1;
+  while (previousIndex >= 0 && /\s/.test(masked[previousIndex])) {
+    previousIndex -= 1;
+  }
+  if (previousIndex < 0) return true;
+  return "=([{,:;!&|?+-*%^~<>".includes(masked[previousIndex]);
+}
+
+function findSwiftRegexEnd(
+  source: string,
+  contentStart: number,
+  closing: string
+): number {
+  let inCharacterClass = false;
+  let escaping = false;
+  for (let index = contentStart; index < source.length; index += 1) {
+    const current = source[index];
+    if (escaping) {
+      escaping = false;
+    } else if (current === "\\") {
+      escaping = true;
+    } else if (current === "[") {
+      inCharacterClass = true;
+    } else if (current === "]") {
+      inCharacterClass = false;
+    } else if (!inCharacterClass && source.startsWith(closing, index)) {
+      return index + closing.length;
+    }
+  }
+  throw new Error("Unterminated Swift regex literal");
+}
+
 describe("hosted NeonDiff desktop XCTest foundation", () => {
+  it("extracts a Swift declaration without literal or comment decoys", () => {
+    const source = `
+let decoy = #"private func target() { decoy() }"#
+/* private func target() { commentDecoy() } */
+private func target() {
+  let raw = #"quote \" and brace } stay literal"#
+  let multiline = ##"""
+  quote " and brace } stay literal
+  """##
+  let pattern = /[}]/
+  let extendedPattern = #/[}]/#
+  expected()
+}
+`;
+
+    expect(extractBalancedSwiftDeclaration(source, "private func target()"))
+      .toContain("expected()");
+    expect(() =>
+      extractBalancedSwiftDeclaration(
+        `${source}\nprivate func target() { duplicate() }`,
+        "private func target()"
+      )
+    ).toThrow(/Ambiguous Swift declaration/);
+  });
+
   it("checks in a shared app/UI-test project and test plan", () => {
     expect(existsSync(projectPath)).toBe(true);
     expect(existsSync(schemePath)).toBe(true);
@@ -299,6 +403,7 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(
       source.match(/outerPageScroll\.scroll\(byDeltaX: 0, deltaY: -10_000\)/g)
     ).toHaveLength(1);
+    expect(source.match(/\.scroll\s*\(/g)).toHaveLength(1);
     const checkpointSource = extractBalancedSwiftDeclaration(
       source,
       "private func capturePageBottomCheckpoint("

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -216,8 +216,20 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(source).toContain(
       'proofBoundary: "hosted-outer-page-bottom-reachability-only-inner-scroll-exhaustion-excluded"'
     );
-    expect(source).toContain("outerPageScroll.scroll(byDeltaX: 0, deltaY: -10_000)");
-    expect(source).toContain("assertFullyContained(");
+    expect(
+      source.match(/outerPageScroll\.scroll\(byDeltaX: 0, deltaY: -10_000\)/g)
+    ).toHaveLength(1);
+    expect(source).not.toContain(".swipeUp(");
+    expect(source).not.toContain(".swipeDown(");
+    expect(source).not.toContain("coordinate(withNormalizedOffset:");
+    expect(source).toContain("try requireFullyContained(");
+    expect(source).toContain('result: "returned"');
+    expect(source).toContain("effectProven: true");
+    expect(source).toContain("throw HostedPageBottomTraceError");
+    expect(source).toContain("testRun?.failureCount");
+    expect(source).toContain("priorValidationFailure");
+    expect(source).toContain("minimumSampleIntervalMilliseconds: 100");
+    expect(source).toContain("samplingDeadlineMilliseconds: 5_000");
     expect(source).toContain("neondiff-hosted-page-bottom-reachability.json");
 
     for (const [section, fileName] of pageSources) {
@@ -231,6 +243,14 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
       expect(page).toContain(`PageBottomSentinel(section: "${section}")`);
       expect(source).toContain(`"neondiff-${section}-page-bottom"`);
     }
+
+    const theme = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift",
+      "utf8"
+    );
+    expect(theme).toContain("HostedEvaluationAccessibility.isActive");
+    expect(theme).toContain('arguments.contains("--ui-testing")');
+    expect(theme).toMatch(/PageBottomSentinel[\s\S]*#if DEBUG/);
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -236,6 +236,8 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(checkpointSource).not.toMatch(
       /AXUIElement|CGEvent|NSEvent|XCUIRemote|performAction|setAttributeValue/
     );
+    expect(checkpointSource).not.toContain("bottomSentinel.isHittable");
+    expect(source).not.toContain("case hittableSentinel");
     expect(checkpointSource).toContain("preActionSamples.allSatisfy");
     expect(checkpointSource).toContain(
       "for (sampleIndex, postActionSample) in postActionSamples.enumerated()"

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -219,9 +219,27 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(
       source.match(/outerPageScroll\.scroll\(byDeltaX: 0, deltaY: -10_000\)/g)
     ).toHaveLength(1);
-    expect(source).not.toContain(".swipeUp(");
-    expect(source).not.toContain(".swipeDown(");
-    expect(source).not.toContain("coordinate(withNormalizedOffset:");
+    const checkpointStart = source.indexOf(
+      "private func capturePageBottomCheckpoint("
+    );
+    const checkpointEnd = source.indexOf(
+      "private func capturePageBottomSamples(",
+      checkpointStart
+    );
+    expect(checkpointStart).toBeGreaterThan(-1);
+    expect(checkpointEnd).toBeGreaterThan(checkpointStart);
+    const checkpointSource = source.slice(checkpointStart, checkpointEnd);
+    expect(checkpointSource.match(/\.scroll\s*\(/g)).toHaveLength(1);
+    expect(checkpointSource).not.toMatch(
+      /\.(?:swipe\w*|tap|click|press|drag|coordinate)\s*\(/
+    );
+    expect(checkpointSource).not.toMatch(
+      /AXUIElement|CGEvent|NSEvent|XCUIRemote|performAction|setAttributeValue/
+    );
+    expect(checkpointSource).toContain("preActionSamples.allSatisfy");
+    expect(checkpointSource).toContain(
+      "for (sampleIndex, postActionSample) in postActionSamples.enumerated()"
+    );
     expect(source).toContain("try requireFullyContained(");
     expect(source).toContain('result: "returned"');
     expect(source).toContain("effectProven: true");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -195,6 +195,44 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     expect(logs).not.toContain(".frame(minHeight: 420)");
   });
 
+  it("proves each sidebar page outer scroll reaches its bottom sentinel", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+    const pageSources = [
+      ["overview", "OverviewView.swift"],
+      ["repos", "ReposView.swift"],
+      ["providers", "ProviderSettingsView.swift"],
+      ["license", "LicenseView.swift"],
+      ["logs", "LogsView.swift"],
+      ["policy", "PolicyView.swift"],
+      ["settings", "SettingsPane.swift"]
+    ] as const;
+
+    expect(source).toContain(
+      "testStrictFixtureReachesEverySidebarPageBottomAtMinimumSize"
+    );
+    expect(source).toContain(
+      'scenario: "every-sidebar-page-bottom-at-minimum-size"'
+    );
+    expect(source).toContain(
+      'proofBoundary: "hosted-outer-page-bottom-reachability-only-inner-scroll-exhaustion-excluded"'
+    );
+    expect(source).toContain("outerPageScroll.scroll(byDeltaX: 0, deltaY: -10_000)");
+    expect(source).toContain("assertFullyContained(");
+    expect(source).toContain("neondiff-hosted-page-bottom-reachability.json");
+
+    for (const [section, fileName] of pageSources) {
+      const page = readFileSync(
+        `apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/${fileName}`,
+        "utf8"
+      );
+      expect(page).toContain(
+        `.accessibilityIdentifier("neondiff-${section}-outer-scroll")`
+      );
+      expect(page).toContain(`PageBottomSentinel(section: "${section}")`);
+      expect(source).toContain(`"neondiff-${section}-page-bottom"`);
+    }
+  });
+
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow).toContain("Hosted XCUITest smoke");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -268,7 +268,19 @@ describe("hosted NeonDiff desktop XCTest foundation", () => {
     );
     expect(theme).toContain("HostedEvaluationAccessibility.isActive");
     expect(theme).toContain('arguments.contains("--ui-testing")');
-    expect(theme).toMatch(/PageBottomSentinel[\s\S]*#if DEBUG/);
+    const sentinelStart = theme.indexOf("struct PageBottomSentinel: View");
+    const sentinelEnd = theme.indexOf(
+      "private enum HostedEvaluationAccessibility",
+      sentinelStart
+    );
+    expect(sentinelStart).toBeGreaterThan(-1);
+    expect(sentinelEnd).toBeGreaterThan(sentinelStart);
+    const sentinelSource = theme.slice(sentinelStart, sentinelEnd);
+    expect(sentinelSource).toContain("#if DEBUG");
+    expect(sentinelSource).toContain(".allowsHitTesting(false)");
+    expect(sentinelSource).toContain(
+      ".accessibilityRespondsToUserInteraction(false)"
+    );
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {


### PR DESCRIPTION
## Summary

- add explicit accessibility identifiers for all seven sidebar page-level `ScrollView`s
- add layout-neutral bottom geometry markers only in the explicit hosted DEBUG `--ui-testing` context, explicitly disabling both SwiftUI hit testing and accessibility interaction while keeping ordinary debug and Release accessibility trees unchanged
- add a strict hosted DEBUG/default-text/1040x680 XCUITest that waits for each exact generation-bound app quiescence marker, records three stable pre/post XCUI frame samples, and performs at most one public macOS `scroll(byDeltaX:deltaY:)` action when the sentinel begins outside the page viewport
- retain one proof-last JSON attachment only after all seven page bottoms are fully contained in both the outer scroll viewport and detail region

## Failing first

- initial RED: focused hosted contract ran 6 tests with 1 expected failure because the page-bottom test and identifiers did not exist
- hosted RED at superseded head `c3b0676`: 2/3 existing controls passed, while the new test failed before any scroll because its first timestamp incorrectly included 175 ms of AX query latency; artifact digest `sha256:5578e851b235fff92161b8bd8029e92342c63f97584ce2ed547b25e6f0cfc70a`
- hosted RED at superseded head `3c6038d`: 2/3 controls passed, while the new test failed on the License sentinel being AX-hittable despite layout hit-testing already being disabled; artifact digest `sha256:21c2ea673ad813652f7c21a5a6b67c8d89965dd1cd83875ea7deb0d7a570d3b0`
- hosted RED at superseded head `8d7c698`: after explicitly disabling accessibility interaction too, XCUITest still reported the visibly reachable License geometry marker as `isHittable`; artifact digest `sha256:faa489d895553f42cba79102b14c2958e831fd06c9e3549939f95aedd7f79bbb`. The current test therefore treats `isHittable` as visibility/coordinate reachability rather than an action-capability assertion, while the scoped source contract requires both non-interactivity modifiers.
- review RED: the source contract then failed until the cadence timestamp, proof-last fail-closed behavior, DEBUG-only sentinel gate, and exact one-action/no-fallback invariants were implemented; a later rereview blocked on accepting only the final settled containment sample, so the current head requires every pre/post settled sample to be contained and isolates the action helper for stricter no-fallback coverage
- review RED at superseded green head `7e1ba91`: reviewers identified an overstated static-test title and a function slice tied to helper ordering; head `576cf1e` renamed the static contract accurately and introduced balanced declaration extraction
- adversarial extractor RED at superseded head `576cf1e`: a raw-string declaration decoy caused the new fixture to fail 1/7 by returning the decoy instead of the real function. Current head `42312c2` masks nested comments, ordinary/raw/multiline strings, and bare/extended regex literals before locating and balancing the unique declaration, fails closed on ambiguous declarations, and globally requires exactly one `.scroll(` call in the hosted UI-test source
- current local GREEN: focused hosted contract passes 7/7

## Narrow local checks

- Xcode 26.6 `build-for-testing`: passed
- Xcode 26.6 Release product build: passed; all seven synthetic sentinel strings are absent from the Release binary
- no local UI action result is used: an advisory helper started an out-of-scope local run, the owner terminated it, and all of that run's outputs are excluded from proof
- public claims scan: passed
- secret scan: passed across 731 tracked files
- diff check: passed

## Proof boundary

Superseded head `7e1ba91` passed the hosted gate 3/3 and emitted a proof-last schema-1 packet for all seven pages: six pages required exactly one public `scroll(byDeltaX: 0, deltaY: -10_000)` action and License required none; every post sample was stable and fully contained. Immutable xcresult artifact wrapper digest: `sha256:25f3db03e7deae9d0548f78b0bea70ccb4b656b0c66493cd2f3fa19058fca741`; downloaded archive SHA-256: `477c90e13ed2c16cb3524acd3aad506484437bf755df799a850ac357b17f4501`; proof attachment SHA-256: `90863dc16baf285c290d6c245b8b17de34889a667342e282497942e7752eea7a`.

Exact current head `42312c29ba68bf51cefe900c48e951f1aeb7cbcb` passed the hosted gate 3/3 and all Swift packaging/boundary jobs. Its proof-last schema-1 packet records all seven pages: six pages required exactly one public `scroll(byDeltaX: 0, deltaY: -10_000)` action and License required none; every post sample was stable and fully contained. Immutable xcresult artifact wrapper digest: `sha256:6e2594bffe31a8eed8d6ee174c6f70d02da8a45f6eae7fdd902ba646dc95a236`; downloaded archive SHA-256: `5c4fe79e2482c11302928dcd1abb2cbcf6a36c732340a2432a00dce67bef5b69`; proof attachment SHA-256: `bc5a4ffcb2a28b38c051305d88a8ed693e64eeb74c9d13573d5178f93e821278`. The failed `c3b0676`, `3c6038d`, and `8d7c698` runs prove no reachability.

This slice covers only outer page-bottom reachability for the seven current sidebar destinations in the strict hosted DEBUG `tab-overview` fixture at runner-default text and 1040x680. It explicitly excludes native Table/TextEditor inner-scroll exhaustion, other sizes, large text, conditional states, onboarding, the separate Settings scene, keyboard/VoiceOver behavior, manual exact-artifact evaluation, signed/installed behavior, release, GA, runtime, parity, and customer readiness.

Related to #517. The broader issue must remain open.
