### PR TITLE
fix(ci): distinguish dSYM source metadata

### DIFF
--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -48,7 +48,7 @@ const ALLOWED_DSYM_DEBUG_SOURCE_PATHS = [
   "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift",
   "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift"
 ];
-const ALLOWED_DSYM_DWARF_PATH = "/dsyms/neondiffdesktop.app.dsym/contents/resources/dwarf/neondiffdesktop";
+const ALLOWED_DSYM_DWARF_PATH = "/dSYMs/NeonDiffDesktop.app.dSYM/Contents/Resources/DWARF/NeonDiffDesktop";
 const ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES = ALLOWED_DSYM_DEBUG_SOURCE_PATHS
   .map((sourcePath) => Buffer.from(basename(sourcePath)));
 
@@ -153,7 +153,7 @@ function scan(inputPaths) {
     const data = readFileSync(file.physicalPath);
     const isArchiveDsymDwarf = file.isArchiveRoot
       && !file.throughSymlink
-      && normalizedPath === ALLOWED_DSYM_DWARF_PATH;
+      && file.relativePath === ALLOWED_DSYM_DWARF_PATH;
     const content = isArchiveDsymDwarf
       ? maskAllowedDsymSourceFilenames(data)
       : data;

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -74,12 +74,11 @@ function collectFiles(inputPaths) {
     const stat = lstatSync(path);
     const root = realpathSync(stat.isDirectory() ? path : dirname(path));
     const isArchiveRoot = stat.isDirectory() && path.toLowerCase().endsWith(".xcarchive");
-    return { path, root, isArchiveRoot };
+    const logicalPath = stat.isDirectory() ? "" : relative(root, path);
+    return { path, root, logicalPath, isArchiveRoot, throughSymlink: false, ancestorDirectories: [] };
   });
-  const visitedDirectories = new Set();
-  const visitedFiles = new Set();
   while (pending.length > 0) {
-    const { path, root, isArchiveRoot } = pending.pop();
+    const { path, root, logicalPath, isArchiveRoot, throughSymlink, ancestorDirectories } = pending.pop();
     const stat = lstatSync(path);
     if (stat.isSymbolicLink()) {
       const target = realpathSync(path);
@@ -87,27 +86,43 @@ function collectFiles(inputPaths) {
       if (targetRelativePath === ".." || targetRelativePath.startsWith(`..${sep}`) || isAbsolute(targetRelativePath)) {
         throw new Error(`symlink escapes artifact root: ${path}`);
       }
-      pending.push({ path: target, root, isArchiveRoot });
+      pending.push({
+        path: target,
+        root,
+        logicalPath,
+        isArchiveRoot,
+        throughSymlink: true,
+        ancestorDirectories
+      });
       continue;
     }
     const realPath = realpathSync(path);
     if (stat.isDirectory()) {
-      if (visitedDirectories.has(realPath)) continue;
-      visitedDirectories.add(realPath);
+      if (ancestorDirectories.includes(realPath)) {
+        throw new Error(`symlink cycle inside artifact root: ${resolve(root, logicalPath)}`);
+      }
+      const childAncestors = [...ancestorDirectories, realPath];
       for (const entry of readdirSync(realPath)) {
-        pending.push({ path: resolve(realPath, entry), root, isArchiveRoot });
+        pending.push({
+          path: resolve(realPath, entry),
+          root,
+          logicalPath: logicalPath ? `${logicalPath}${sep}${entry}` : entry,
+          isArchiveRoot,
+          throughSymlink,
+          ancestorDirectories: childAncestors
+        });
       }
       continue;
     }
     if (!stat.isFile()) continue;
-    if (visitedFiles.has(realPath)) continue;
-    visitedFiles.add(realPath);
     if (stat.size > MAX_FILE_BYTES) throw new Error(`artifact file exceeds scan bound: ${path}`);
     files.push({
-      path: realPath,
-      relativePath: `/${relative(root, realPath).split(sep).join("/")}`,
+      path: resolve(root, logicalPath),
+      physicalPath: realPath,
+      relativePath: `/${logicalPath.split(sep).join("/")}`,
       size: stat.size,
-      isArchiveRoot
+      isArchiveRoot,
+      throughSymlink
     });
     if (files.length > MAX_FILES) throw new Error("artifact file count exceeds scan bound");
   }
@@ -128,8 +143,9 @@ function scan(inputPaths) {
         violations.push({ path: file.path, marker: rule.marker });
       }
     }
-    const data = readFileSync(file.path);
+    const data = readFileSync(file.physicalPath);
     const isArchiveDsymDwarf = file.isArchiveRoot
+      && !file.throughSymlink
       && /^\/dsyms\/[^/]+\.dsym\/contents\/resources\/dwarf\/[^/]+$/.test(normalizedPath);
     const content = isArchiveDsymDwarf
       ? maskAllowedDsymSourceFilenames(data)

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -42,15 +42,9 @@ const FORBIDDEN_PATH_MARKERS = [
 ];
 const ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES = [
   "DesktopEvaluationDependencies.swift",
-  "DesktopEvaluationEvidenceManifest.swift",
-  "DesktopEvaluationFixture.swift",
-  "DesktopEvaluationFixtureCatalog.swift",
-  "DesktopEvaluationLaunchContext.swift",
-  "DesktopEvaluationLaunchOptions.swift",
   "DesktopEvaluationModelAdapter.swift",
   "DesktopEvaluationReadiness.swift",
   "DesktopResolvedEvaluationFixture.swift",
-  "RecordingDesktopDependencies.swift",
   "VisualProofDesktopDependencies.swift"
 ].map((filename) => Buffer.from(filename));
 
@@ -59,7 +53,12 @@ function maskAllowedDsymSourceFilenames(data) {
   for (const filename of ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES) {
     let offset = 0;
     while ((offset = masked.indexOf(filename, offset)) >= 0) {
-      masked.fill(0, offset, offset + filename.length);
+      const precedingByte = offset === 0 ? 0 : masked[offset - 1];
+      const followingByte = masked[offset + filename.length];
+      const beginsPathComponent = precedingByte === 0 || precedingByte === 47 || precedingByte === 92;
+      if (beginsPathComponent && followingByte === 0) {
+        masked.fill(0, offset, offset + filename.length);
+      }
       offset += filename.length;
     }
   }
@@ -72,12 +71,13 @@ function collectFiles(inputPaths) {
     const path = resolve(inputPath);
     const stat = lstatSync(path);
     const root = realpathSync(stat.isDirectory() ? path : dirname(path));
-    return { path, root };
+    const isArchiveRoot = stat.isDirectory() && path.toLowerCase().endsWith(".xcarchive");
+    return { path, root, isArchiveRoot };
   });
   const visitedDirectories = new Set();
   const visitedFiles = new Set();
   while (pending.length > 0) {
-    const { path, root } = pending.pop();
+    const { path, root, isArchiveRoot } = pending.pop();
     const stat = lstatSync(path);
     if (stat.isSymbolicLink()) {
       const target = realpathSync(path);
@@ -85,14 +85,16 @@ function collectFiles(inputPaths) {
       if (targetRelativePath === ".." || targetRelativePath.startsWith(`..${sep}`) || isAbsolute(targetRelativePath)) {
         throw new Error(`symlink escapes artifact root: ${path}`);
       }
-      pending.push({ path: target, root });
+      pending.push({ path: target, root, isArchiveRoot });
       continue;
     }
     const realPath = realpathSync(path);
     if (stat.isDirectory()) {
       if (visitedDirectories.has(realPath)) continue;
       visitedDirectories.add(realPath);
-      for (const entry of readdirSync(realPath)) pending.push({ path: resolve(realPath, entry), root });
+      for (const entry of readdirSync(realPath)) {
+        pending.push({ path: resolve(realPath, entry), root, isArchiveRoot });
+      }
       continue;
     }
     if (!stat.isFile()) continue;
@@ -102,7 +104,8 @@ function collectFiles(inputPaths) {
     files.push({
       path: realPath,
       relativePath: `/${relative(root, realPath).split(sep).join("/")}`,
-      size: stat.size
+      size: stat.size,
+      isArchiveRoot
     });
     if (files.length > MAX_FILES) throw new Error("artifact file count exceeds scan bound");
   }
@@ -124,8 +127,9 @@ function scan(inputPaths) {
       }
     }
     const data = readFileSync(file.path);
-    const normalizedRealPath = file.path.split(sep).join("/").toLowerCase();
-    const content = normalizedRealPath.includes(".dsym/contents/resources/dwarf/")
+    const isArchiveDsymDwarf = file.isArchiveRoot
+      && /^\/dsyms\/[^/]+\.dsym\/contents\/resources\/dwarf\/[^/]+$/.test(normalizedPath);
+    const content = isArchiveDsymDwarf
       ? maskAllowedDsymSourceFilenames(data)
       : data;
     for (const rule of FORBIDDEN_CONTENT_MARKERS) {

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 const MAX_FILES = 20_000;
 const MAX_FILE_BYTES = 128 * 1024 * 1024;
@@ -40,13 +40,15 @@ const FORBIDDEN_PATH_MARKERS = [
     matches: (path) => path.includes("/neondiffdesktopfixtureresolve")
   }
 ];
-const ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES = [
-  "DesktopEvaluationDependencies.swift",
-  "DesktopEvaluationModelAdapter.swift",
-  "DesktopEvaluationReadiness.swift",
-  "DesktopResolvedEvaluationFixture.swift",
-  "VisualProofDesktopDependencies.swift"
-].map((filename) => Buffer.from(filename));
+const ALLOWED_DSYM_DEBUG_SOURCE_PATHS = [
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopEvaluationModelAdapter.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopEvaluationReadiness.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift"
+];
+const ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES = ALLOWED_DSYM_DEBUG_SOURCE_PATHS
+  .map((sourcePath) => Buffer.from(basename(sourcePath)));
 
 function maskAllowedDsymSourceFilenames(data) {
   const masked = Buffer.from(data);

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -40,6 +40,31 @@ const FORBIDDEN_PATH_MARKERS = [
     matches: (path) => path.includes("/neondiffdesktopfixtureresolve")
   }
 ];
+const ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES = [
+  "DesktopEvaluationDependencies.swift",
+  "DesktopEvaluationEvidenceManifest.swift",
+  "DesktopEvaluationFixture.swift",
+  "DesktopEvaluationFixtureCatalog.swift",
+  "DesktopEvaluationLaunchContext.swift",
+  "DesktopEvaluationLaunchOptions.swift",
+  "DesktopEvaluationModelAdapter.swift",
+  "DesktopEvaluationReadiness.swift",
+  "DesktopResolvedEvaluationFixture.swift",
+  "RecordingDesktopDependencies.swift",
+  "VisualProofDesktopDependencies.swift"
+].map((filename) => Buffer.from(filename));
+
+function maskAllowedDsymSourceFilenames(data) {
+  const masked = Buffer.from(data);
+  for (const filename of ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES) {
+    let offset = 0;
+    while ((offset = masked.indexOf(filename, offset)) >= 0) {
+      masked.fill(0, offset, offset + filename.length);
+      offset += filename.length;
+    }
+  }
+  return masked;
+}
 
 function collectFiles(inputPaths) {
   const files = [];
@@ -99,8 +124,12 @@ function scan(inputPaths) {
       }
     }
     const data = readFileSync(file.path);
+    const normalizedRealPath = file.path.split(sep).join("/").toLowerCase();
+    const content = normalizedRealPath.includes(".dsym/contents/resources/dwarf/")
+      ? maskAllowedDsymSourceFilenames(data)
+      : data;
     for (const rule of FORBIDDEN_CONTENT_MARKERS) {
-      if (data.includes(rule.bytes)) violations.push({ path: file.path, marker: rule.marker });
+      if (content.includes(rule.bytes)) violations.push({ path: file.path, marker: rule.marker });
     }
   }
   return {

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -48,6 +48,7 @@ const ALLOWED_DSYM_DEBUG_SOURCE_PATHS = [
   "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift",
   "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift"
 ];
+const ALLOWED_DSYM_DWARF_PATH = "/dsyms/neondiffdesktop.app.dsym/contents/resources/dwarf/neondiffdesktop";
 const ALLOWED_DSYM_DEBUG_SOURCE_FILENAMES = ALLOWED_DSYM_DEBUG_SOURCE_PATHS
   .map((sourcePath) => Buffer.from(basename(sourcePath)));
 
@@ -152,7 +153,7 @@ function scan(inputPaths) {
     const data = readFileSync(file.physicalPath);
     const isArchiveDsymDwarf = file.isArchiveRoot
       && !file.throughSymlink
-      && /^\/dsyms\/[^/]+\.dsym\/contents\/resources\/dwarf\/[^/]+$/.test(normalizedPath);
+      && normalizedPath === ALLOWED_DSYM_DWARF_PATH;
     const content = isArchiveDsymDwarf
       ? maskAllowedDsymSourceFilenames(data)
       : data;

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -3,6 +3,7 @@ import { lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 const MAX_FILES = 20_000;
+const MAX_TRAVERSAL_ENTRIES = MAX_FILES * 2;
 const MAX_FILE_BYTES = 128 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 512 * 1024 * 1024;
 const FORBIDDEN_MARKERS = [
@@ -77,7 +78,12 @@ function collectFiles(inputPaths) {
     const logicalPath = stat.isDirectory() ? "" : relative(root, path);
     return { path, root, logicalPath, isArchiveRoot, throughSymlink: false, ancestorDirectories: [] };
   });
+  let traversalEntries = 0;
   while (pending.length > 0) {
+    traversalEntries += 1;
+    if (traversalEntries > MAX_TRAVERSAL_ENTRIES) {
+      throw new Error("artifact traversal exceeds scan bound");
+    }
     const { path, root, logicalPath, isArchiveRoot, throughSymlink, ancestorDirectories } = pending.pop();
     const stat = lstatSync(path);
     if (stat.isSymbolicLink()) {

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -227,7 +227,7 @@ describe("desktop fixture release-artifact boundary", () => {
     });
   });
 
-  it("rejects an allowlisted basename outside a source-path string-table record", () => {
+  it("rejects an allowlisted basename without a path-component boundary", () => {
     const artifacts = releaseArtifacts();
     const dwarf = join(
       artifacts.root,
@@ -291,6 +291,31 @@ describe("desktop fixture release-artifact boundary", () => {
       "Resources",
       "DWARF",
       "Other"
+    );
+    mkdirSync(dirname(dwarf), { recursive: true });
+    writeFileSync(dwarf, "/build/Support/DesktopEvaluationReadiness.swift\0");
+
+    const result = scan([archive]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+  });
+
+  it("rejects an allowed source filename in an alternate-case app dSYM path", () => {
+    const artifacts = releaseArtifacts();
+    const archive = join(artifacts.root, "NeonDiffDesktop.xcarchive");
+    const dwarf = join(
+      archive,
+      "dSyMs",
+      "NeonDiffDesktop.App.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "NeonDiffDesktop"
     );
     mkdirSync(dirname(dwarf), { recursive: true });
     writeFileSync(dwarf, "/build/Support/DesktopEvaluationReadiness.swift\0");

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -22,6 +22,13 @@ const fixtureMarkers = [
   "applyInitialState",
   "NEONDIFF_DESKTOP_EVALUATION_READY_PATH"
 ];
+const allowedDsymDebugSourcePaths = [
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopEvaluationModelAdapter.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopEvaluationReadiness.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift",
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift"
+];
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -54,6 +61,17 @@ function scan(paths: string[]) {
 }
 
 describe("desktop fixture release-artifact boundary", () => {
+  it("anchors every allowed dSYM basename to an existing whole-file DEBUG app source", () => {
+    const scannerSource = readFileSync("scripts/check-desktop-fixture-boundary.mjs", "utf8");
+
+    for (const sourcePath of allowedDsymDebugSourcePaths) {
+      expect(scannerSource, sourcePath).toContain(`"${sourcePath}"`);
+      const source = readFileSync(sourcePath, "utf8").trim();
+      expect(source, sourcePath).toMatch(/^#if DEBUG\n/);
+      expect(source, sourcePath).toMatch(/\n#endif$/);
+    }
+  });
+
   it("accepts clean AppCore objects, modules, resources, and frameworks", () => {
     const artifacts = releaseArtifacts();
     for (const path of [artifacts.object, artifacts.module, artifacts.resource, artifacts.framework]) {

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -181,6 +181,86 @@ describe("desktop fixture release-artifact boundary", () => {
     });
   });
 
+  it("rejects an allowlisted basename outside a source-path string-table record", () => {
+    const artifacts = releaseArtifacts();
+    const dwarf = join(
+      artifacts.root,
+      "NeonDiffDesktop.xcarchive",
+      "dSYMs",
+      "NeonDiffDesktop.app.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "NeonDiffDesktop"
+    );
+    mkdirSync(join(dwarf, ".."), { recursive: true });
+    writeFileSync(dwarf, "leaked DesktopEvaluationReadiness.swift\0");
+
+    const result = scan([join(artifacts.root, "NeonDiffDesktop.xcarchive")]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+  });
+
+  it("rejects a fake nested dSYM path inside a release app resource", () => {
+    const artifacts = releaseArtifacts();
+    const payload = join(
+      artifacts.appBundle,
+      "Contents",
+      "Resources",
+      "payload.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "payload"
+    );
+    mkdirSync(join(payload, ".."), { recursive: true });
+    writeFileSync(
+      payload,
+      "/build/Sources/NeonDiffDesktop/Support/DesktopEvaluationReadiness.swift\0"
+    );
+
+    const result = scan([artifacts.appBundle]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+  });
+
+  it("rejects a top-level dSYMs tree when the scan root is not an xcarchive", () => {
+    const artifacts = releaseArtifacts();
+    const dwarf = join(
+      artifacts.root,
+      "dSYMs",
+      "NeonDiffDesktop.app.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "NeonDiffDesktop"
+    );
+    mkdirSync(join(dwarf, ".."), { recursive: true });
+    writeFileSync(
+      dwarf,
+      "/build/Sources/NeonDiffDesktop/Support/DesktopEvaluationReadiness.swift\0"
+    );
+
+    const result = scan([artifacts.root]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+  });
+
   it("scans only release fixture surfaces and all debug/release Core and AppCore secret surfaces", () => {
     const gate = readFileSync(".github/workflows/swift-desktop-gate.yml", "utf8");
 

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -126,6 +126,61 @@ describe("desktop fixture release-artifact boundary", () => {
     });
   });
 
+  it("accepts an excluded DEBUG source filename in dSYM metadata", () => {
+    const artifacts = releaseArtifacts();
+    const dwarf = join(
+      artifacts.root,
+      "NeonDiffDesktop.xcarchive",
+      "dSYMs",
+      "NeonDiffDesktop.app.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "NeonDiffDesktop"
+    );
+    mkdirSync(join(dwarf, ".."), { recursive: true });
+    writeFileSync(
+      dwarf,
+      "/build/Sources/NeonDiffDesktop/Support/DesktopEvaluationReadiness.swift\0"
+    );
+
+    const result = scan([join(artifacts.root, "NeonDiffDesktop.xcarchive")]);
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      violationCount: 0,
+      scannedFiles: 1
+    });
+  });
+
+  it("rejects an evaluation symbol in dSYM metadata after an allowed source filename", () => {
+    const artifacts = releaseArtifacts();
+    const dwarf = join(
+      artifacts.root,
+      "NeonDiffDesktop.xcarchive",
+      "dSYMs",
+      "NeonDiffDesktop.app.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "NeonDiffDesktop"
+    );
+    mkdirSync(join(dwarf, ".."), { recursive: true });
+    writeFileSync(
+      dwarf,
+      "/build/Support/DesktopEvaluationReadiness.swift\0_$s15NeonDiffDesktop26DesktopEvaluationReadinessV"
+    );
+
+    const result = scan([join(artifacts.root, "NeonDiffDesktop.xcarchive")]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+  });
+
   it("scans only release fixture surfaces and all debug/release Core and AppCore secret surfaces", () => {
     const gate = readFileSync(".github/workflows/swift-desktop-gate.yml", "utf8");
 

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -280,6 +280,31 @@ describe("desktop fixture release-artifact boundary", () => {
     });
   });
 
+  it("rejects an allowed source filename in an unrelated top-level archive dSYM", () => {
+    const artifacts = releaseArtifacts();
+    const archive = join(artifacts.root, "NeonDiffDesktop.xcarchive");
+    const dwarf = join(
+      archive,
+      "dSYMs",
+      "Other.framework.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "Other"
+    );
+    mkdirSync(dirname(dwarf), { recursive: true });
+    writeFileSync(dwarf, "/build/Support/DesktopEvaluationReadiness.swift\0");
+
+    const result = scan([archive]);
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+  });
+
   it("scans an archive dSYM file again without masking through an app-resource symlink", () => {
     const artifacts = releaseArtifacts();
     const archive = join(artifacts.root, "NeonDiffDesktop.xcarchive");

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -121,6 +121,26 @@ describe("desktop fixture release-artifact boundary", () => {
     expect(result.stderr).toMatch(/symlink escapes artifact root/);
   });
 
+  it("fails closed when an empty directory symlink DAG exceeds the traversal bound", () => {
+    const artifacts = releaseArtifacts();
+    const archive = join(artifacts.root, "NeonDiffDesktop.xcarchive");
+    const layers = join(archive, "empty-alias-layers");
+    const depth = 14;
+    for (let index = 0; index <= depth; index += 1) {
+      mkdirSync(join(layers, `layer-${index}`), { recursive: true });
+    }
+    for (let index = 0; index < depth; index += 1) {
+      const layer = join(layers, `layer-${index}`);
+      const target = `../layer-${index + 1}`;
+      symlinkSync(target, join(layer, "left"));
+      symlinkSync(target, join(layer, "right"));
+    }
+
+    const result = scan([archive]);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/artifact traversal exceeds scan bound/);
+  });
+
   it("rejects the canonical fixture at an archive-like resource path", () => {
     const artifacts = releaseArtifacts();
     const fixturePath = join(

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const roots: string[] = [];
@@ -21,13 +21,6 @@ const fixtureMarkers = [
   "DesktopModelInitialState",
   "applyInitialState",
   "NEONDIFF_DESKTOP_EVALUATION_READY_PATH"
-];
-const allowedDsymDebugSourcePaths = [
-  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift",
-  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopEvaluationModelAdapter.swift",
-  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopEvaluationReadiness.swift",
-  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift",
-  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift"
 ];
 
 afterEach(() => {
@@ -63,12 +56,27 @@ function scan(paths: string[]) {
 describe("desktop fixture release-artifact boundary", () => {
   it("anchors every allowed dSYM basename to an existing whole-file DEBUG app source", () => {
     const scannerSource = readFileSync("scripts/check-desktop-fixture-boundary.mjs", "utf8");
+    const manifestMatch = scannerSource.match(/const ALLOWED_DSYM_DEBUG_SOURCE_PATHS = (\[[\s\S]*?\]);/);
+    expect(manifestMatch).not.toBeNull();
+    const sourcePaths = JSON.parse(manifestMatch![1]) as unknown;
+    expect(Array.isArray(sourcePaths)).toBe(true);
+    expect(sourcePaths).toHaveLength(5);
+    expect(sourcePaths.every((sourcePath) => typeof sourcePath === "string")).toBe(true);
 
-    for (const sourcePath of allowedDsymDebugSourcePaths) {
-      expect(scannerSource, sourcePath).toContain(`"${sourcePath}"`);
+    const typedSourcePaths = sourcePaths as string[];
+    expect(new Set(typedSourcePaths).size).toBe(typedSourcePaths.length);
+    const appSourceRoot = "apps/neondiff-desktop/Sources/NeonDiffDesktop";
+    const appSwiftPaths = readdirSync(appSourceRoot, { recursive: true, encoding: "utf8" })
+      .filter((entry) => entry.endsWith(".swift"))
+      .map((entry) => join(appSourceRoot, entry));
+
+    for (const sourcePath of typedSourcePaths) {
+      expect(sourcePath.startsWith(`${appSourceRoot}/`), sourcePath).toBe(true);
       const source = readFileSync(sourcePath, "utf8").trim();
       expect(source, sourcePath).toMatch(/^#if DEBUG\n/);
       expect(source, sourcePath).toMatch(/\n#endif$/);
+      const basename = sourcePath.split("/").at(-1);
+      expect(appSwiftPaths.filter((path) => path.endsWith(`/${basename}`)), sourcePath).toEqual([sourcePath]);
     }
   });
 
@@ -250,6 +258,50 @@ describe("desktop fixture release-artifact boundary", () => {
         expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
       ])
     });
+  });
+
+  it("scans an archive dSYM file again without masking through an app-resource symlink", () => {
+    const artifacts = releaseArtifacts();
+    const archive = join(artifacts.root, "NeonDiffDesktop.xcarchive");
+    const dwarf = join(
+      archive,
+      "dSYMs",
+      "NeonDiffDesktop.app.dSYM",
+      "Contents",
+      "Resources",
+      "DWARF",
+      "NeonDiffDesktop"
+    );
+    mkdirSync(dirname(dwarf), { recursive: true });
+    writeFileSync(dwarf, "/build/Support/DesktopEvaluationReadiness.swift\0");
+
+    const alias = join(
+      archive,
+      "Products",
+      "Applications",
+      "NeonDiffDesktop.app",
+      "Contents",
+      "Resources",
+      "leaked-debug-payload"
+    );
+    mkdirSync(dirname(alias), { recursive: true });
+    symlinkSync(relative(dirname(alias), dwarf), alias);
+
+    const result = scan([archive]);
+    expect(result.status).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report).toMatchObject({
+      ok: false,
+      violations: expect.arrayContaining([
+        expect.objectContaining({ marker: "DesktopEvaluationReadiness" })
+      ])
+    });
+    const aliasViolation = report.violations.find(
+      (violation: { path: string; marker: string }) => violation.marker === "DesktopEvaluationReadiness"
+    );
+    expect(aliasViolation.path).toMatch(
+      /\/Products\/Applications\/NeonDiffDesktop\.app\/Contents\/Resources\/leaked-debug-payload$/
+    );
   });
 
   it("rejects a top-level dSYMs tree when the scan root is not an xcarchive", () => {


### PR DESCRIPTION
## Summary

- preserve whole-archive Release fixture scanning while treating five hosted-app DEBUG-only Swift basenames as DWARF source metadata
- derive those basenames from five exact repo-relative, whole-file `#if DEBUG` app sources and mask only path-component and NUL-delimited source-filename byte occurrences in the exact, case-preserving direct `dSYMs/NeonDiffDesktop.app.dSYM/Contents/Resources/DWARF/NeonDiffDesktop` leaf
- preserve logical artifact paths separately from physical read targets so symlink aliases cannot inherit dSYM masking
- cap every traversal work item so empty acyclic directory-symlink DAGs fail closed without relying on file or byte limits
- continue rejecting real evaluation symbols/content in every app, helper, resource, framework, module, fake dSYM, symlink alias, and non-archive surface

## Failing-first and focused validation

- RED: the initial synthetic dSYM source-filename case failed because `DesktopEvaluationReadiness.swift` triggered the broader marker
- RED: an archive-internal app-resource symlink to a canonical dSYM file bypassed the prior physical-path implementation
- RED: the empty binary directory-symlink DAG regression failed 1/16 on the prior scanner because it exited successfully with zero files
- RED: an unrelated top-level archive dSYM could hide an allowlisted forbidden basename under the prior generic dSYM-path matcher
- RED: an alternate-case fake app dSYM path inherited masking under the prior lowercase comparison
- GREEN at exact head `d471b0f9ea3a7713c635e4c2d878f4483a7ea1ca`: focused fixture-boundary suite passed 18/18; Node syntax and diff checks passed
- both preserved Xcode 26.6 diagnostic Release archives independently scanned 198 files / 52,772,444 bytes / zero violations
- public-claims scan and 731-file secret scan passed

## Review correction

Independent reviews blocked earlier candidates for an overbroad source allowlist, an unanchored allowlist, a logical-path symlink bypass, unbounded directory-only alias expansion, a generic top-level dSYM-path exception, and case-folded canonical matching. The description also now states the exact byte-boundary behavior without claiming DWARF parsing. Exact head `d471b0f9ea3a7713c635e4c2d878f4483a7ea1ca` contains the complete correction. All prior-head review and CI evidence is superseded; current-head remote CI, Swift archive scanning, and reviews remain mandatory before merge.

## Incident boundary

PR #609 run 29408391903 attempt 1 failed only on `DesktopEvaluationReadiness` in the Release dSYM after hosted XCUITest passed 4/4. Attempt 2 at the identical SHA passed with a different archive byte count. This change addresses that source-metadata ambiguity without skipping dSYMs or weakening real marker detection.

This is CI/release-boundary hardening, not main-branch proof, signed/notarized distribution, publication, GA, runtime, parity, or customer-readiness proof. Issue #616 must remain open until fresh post-merge main verification succeeds.

Related to #616.
