### PR TITLE
feat(broker): managed GitHub App authorization broker — server-side slice (#613)

### DIFF
--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -57,7 +57,9 @@ the license store's strict schema verification is unaffected.
    or skins this step, so the user sees the official App identity and exact
    permissions on github.com (AC2).
 4. **Callback (GitHub to broker).** `GET /github/connect/callback?installation_id&state`.
-   The broker verifies the one-shot state (unconsumed, unexpired, CSRF-proof —
+   Because OAuth-during-install is disabled, this route is registered as the App's
+   **Setup URL** (GitHub's post-install redirect), not the user authorization
+   callback URL. The broker verifies the one-shot state (unconsumed, unexpired, CSRF-proof —
    mirrors website PR #48: one-shot fulfillment tokens + explicit owned return
    origins + framework CSRF), verifies the installation exists and belongs to the
    App (`GET /app/installations/{id}` with an App JWT), records the binding
@@ -72,10 +74,16 @@ the license store's strict schema verification is unaffected.
    installation is live and not suspended; every requested repository is present
    in the installation's current selection; **then** the seam decision
    (`authorizeTokenIssuance`, the #614 gate); and only on `allow` mints an
-   installation access token via App JWT, narrowed with the `repositories` and
-   `permissions` parameters to the minimum the worker needs. The token and its
-   expiry (GitHub TTL <= 1 h) are returned. The App private key never appears in
-   any response, log, or client artifact.
+   installation access token via App JWT, narrowed by the canonical
+   `repository_ids` (GitHub rejects `owner/name` here) and a **server-clamped**
+   permission set — at most the minimal review set (Metadata/Contents/Checks/
+   Actions read, Pull requests write), never the device-supplied permissions
+   verbatim, and never omitted (an omitted `permissions` field would make GitHub
+   grant all App permissions). The token and its expiry (GitHub TTL <= 1 h) are
+   returned. The App private key never appears in any response, log, or client
+   artifact. Reading the installation's repository list to make the visibility
+   decision uses a separate **metadata:read-only** installation token, so no
+   broad token is ever minted before the seam authorizes.
 7. **Local operation.** The local worker polls GitHub with the brokered token
    exactly as it does today with a locally minted one, and renews via step 6
    before expiry. Reviews post as the NeonDiff App installation identity (AC6),

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -1,0 +1,224 @@
+# NeonDiff Managed GitHub App Authorization Broker
+
+Threat model, data-flow, and retention for the server-side authorization broker
+that lets a NeonDiff desktop client connect the official NeonDiff GitHub App and
+obtain bounded, short-lived installation access without ever holding the App
+private key.
+
+This document covers the **server-side slice only** (issue #613). Native connect
+UI states are sequenced after #611/#612; the repository-visibility and
+entitlement decision that #614 binds at token issuance is present here only as a
+single seam function (`authorizeTokenIssuance`) with a fail-closed pre-#614
+default. No production GitHub App exists yet; every code path below is exercised
+against fixtures, never a live install (see "Owner-gated boundary").
+
+## Problem
+
+The documented setup (`docs/github-app-setup.md`) requires each user to create a
+GitHub App, download a private key, set `NEONDIFF_GITHUB_APP_ID` /
+`NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH`, and edit local config. That cannot be the
+everyday-user v1 path. The v1 customer path is: click Connect, complete GitHub's
+own install/authorize UI, return to the app, done.
+
+Review execution stays local. The local daemon polls GitHub with App
+credentials; there is no webhook receiver and v1 does not add one. Exactly one
+thing moves server-side: **custody of the GitHub App private key, and with it the
+minting of bounded short-lived installation access tokens.**
+
+## Architecture
+
+The broker is a route/module group inside the existing production license
+service deployment (`services/license-api`, Fly) under
+`services/license-api/src/github-broker/`. One control plane, one decision point,
+one audit ledger. The module boundary keeps it splittable later.
+
+Rationale: #614 must bind repository visibility and entitlement at the moment of
+token issuance. Colocating the broker with the license authority makes that
+binding a single-service decision with a single audit ledger. Revisit only if the
+finished security review demands process isolation.
+
+The broker persists to its own SQLite database (`GITHUB_BROKER_DB_PATH`),
+separate from the license database, so the two schemas evolve independently and
+the license store's strict schema verification is unaffected.
+
+## Data flow (happy path)
+
+1. **Device registration (native to broker).** On first run the app generates a
+   keypair in the Keychain and registers its public key at
+   `POST /device/register` (rate-limited, anonymous — the public/free tier
+   requires no account). The device id is derived from the public key, so
+   re-registration is idempotent. Subsequent broker calls carry a short-lived
+   device-signed JWT (`sub` = device id) in the `Authorization` header.
+2. **Connect start (native to broker).** The device calls
+   `POST /github/connect/start`. The broker returns the official NeonDiff App
+   install URL plus a one-shot `state` nonce bound to (device, expiry <= 10 min).
+3. **GitHub authorization (user's browser).** GitHub's own UI handles account/org
+   choice, repository selection, and permission display. NeonDiff never proxies
+   or skins this step, so the user sees the official App identity and exact
+   permissions on github.com (AC2).
+4. **Callback (GitHub to broker).** `GET /github/connect/callback?installation_id&state`.
+   The broker verifies the one-shot state (unconsumed, unexpired, CSRF-proof —
+   mirrors website PR #48: one-shot fulfillment tokens + explicit owned return
+   origins + framework CSRF), verifies the installation exists and belongs to the
+   App (`GET /app/installations/{id}` with an App JWT), records the binding
+   (device id <-> installation id), and marks the state consumed.
+5. **Return (native to broker).** The app confirms the binding at
+   `POST /github/connect/complete` with its device credential and the original
+   `state`. See "Return path" for why this is a device poll rather than a
+   browser-to-app URL-scheme redirect in v1.
+6. **Token issuance (native to broker, recurring).** `POST /github/token` with the
+   device credential, `installation_id`, and the requested `repositories` /
+   `permissions`. The broker checks, in order: the binding exists; the
+   installation is live and not suspended; every requested repository is present
+   in the installation's current selection; **then** the seam decision
+   (`authorizeTokenIssuance`, the #614 gate); and only on `allow` mints an
+   installation access token via App JWT, narrowed with the `repositories` and
+   `permissions` parameters to the minimum the worker needs. The token and its
+   expiry (GitHub TTL <= 1 h) are returned. The App private key never appears in
+   any response, log, or client artifact.
+7. **Local operation.** The local worker polls GitHub with the brokered token
+   exactly as it does today with a locally minted one, and renews via step 6
+   before expiry. Reviews post as the NeonDiff App installation identity (AC6),
+   because installation tokens author as the App.
+
+## Identity: what is a "verified native session"?
+
+The v1 device credential is a client-generated keypair. On first run the app
+stores the private key in the Keychain and registers the public key. Each broker
+call is authenticated by a short-lived device-signed JWT whose `sub` is the
+device id (the digest of the registered public key). The broker verifies the
+signature against the stored public key and rejects expired or wrong-subject
+tokens.
+
+The GitHub installation flow itself is the proof of repository authority: a device
+can only ever obtain tokens for installations whose callback it completed, because
+the one-shot state nonce binds the browser session GitHub authorized to the device
+that initiated the connect. Private-tier binding to an activation/entitlement
+record at the license service is #612/#614 work, layered at the same seam.
+
+## Return path (resolves design open question #1)
+
+The desktop app registers **no custom URL scheme today** — there is no
+`CFBundleURLTypes` / `CFBundleURLSchemes` entry and no `neondiff://` literal
+anywhere in `apps/neondiff-desktop`. A browser-to-app redirect with a completion
+code therefore has nothing to redirect into.
+
+**v1 decision:** the return is a **device poll**. After the browser callback
+records the binding, the app calls `POST /github/connect/complete` with its device
+credential and the original `state`; the broker returns `pending` until the
+callback lands and `bound` (with the installation id) afterward. No completion
+secret crosses the browser-to-app boundary, so there is no code to intercept.
+
+If #612 adds a registered URL scheme, an optional completion-code redirect can be
+layered on top of the same one-shot state without changing this contract. This is
+a design decision surfaced for #612, not an assumption.
+
+## Failure and abuse states (typed, all fail closed)
+
+Every failure is a typed reason code; none falls back to a user OAuth token or an
+embedded key (see Rollback in issue #613).
+
+- `device_not_registered`, `invalid_device_credential` — device auth failures.
+- `state_not_found`, `state_expired`, `state_replayed` — one-shot connect-state
+  enforcement (a second callback for the same state is `state_replayed`).
+- `binding_not_found` — a token request for an installation this device never
+  completed a callback for.
+- `installation_not_found`, `installation_uninstalled` — the installation is gone
+  (discovered at issuance time; there are no webhooks in v1, so uninstall surfaces
+  at the next token request or poll failure).
+- `installation_suspended` — the installation is suspended.
+- `repo_outside_installation` — a requested repo is not in the installation's
+  current selection (AC4).
+- `repo_renamed_or_transferred` — the installation repository list is re-fetched at
+  issuance; a stale repository reference is a typed error, never a silent pass.
+- `visibility_unknown` — a requested repo's visibility could not be determined;
+  fail closed rather than assume public.
+- `entitlement_gate_not_implemented` — the pre-#614 default: a requested repo is
+  private or internal and the entitlement gate that would authorize it is not yet
+  implemented. Fail closed.
+- `entitlement_missing` — reserved for #614 (private repo without active
+  entitlement).
+- `rate_limited` — per-device and per-installation budgets on the broker; GitHub
+  secondary limits are surfaced distinctly.
+- `broker_unavailable` — the broker or its GitHub dependency is unreachable; the
+  app shows a typed offline state with no fallback.
+
+## The issuance seam (`authorizeTokenIssuance`)
+
+There is exactly one code path that can mint an installation token, and it flows
+through `authorizeTokenIssuance`. The function receives the requested repositories
+already resolved against the installation's repository list (each with its
+visibility) and returns either `allow` (with the exact repositories to narrow to)
+or `deny` with a typed reason code.
+
+Pre-#614 policy: `allow` only when **every** requested repository is verified
+`public`; any `private`, `internal`, or `unknown` visibility denies with
+`entitlement_gate_not_implemented` (or `visibility_unknown`). #614 replaces the
+body of this one function to add the entitlement decision; no caller can skip it
+because minting is unreachable except through its `allow` result (the
+gate-every-caller rule).
+
+## Threat model (STRIDE)
+
+- **Spoofing.** Unauthenticated token minting is prevented by device-signed
+  requests plus callback-time binding; the state nonce is one-shot with a 10-minute
+  expiry, so a stolen or replayed callback cannot bind a foreign device.
+- **Tampering.** Minted tokens are narrowed by the `repositories` and `permissions`
+  parameters, so a leaked token bounds blast radius to the user's own selected
+  repos for <= 1 h.
+- **Repudiation / audit.** An append-only, public-safe decision ledger records
+  device id, installation id, decision, reason code, and timestamps — never
+  repository content, never key material. Shared with #614.
+- **Information disclosure.** The App private key lives only in the deployment
+  secret store and is read at runtime; it is never persisted by the broker, never
+  logged, never returned. Redaction discipline mirrors `src/secrets.ts`: no token,
+  key, or nonce material appears in logs or error bodies. The broker stores no
+  source, diffs, provider keys, or private-repo metadata beyond id and visibility.
+- **Denial of service.** Per-device and global rate limits, registration
+  throttling, and bounded request bodies.
+- **Elevation of privilege.** The broker refuses issuance for any installation not
+  bound to the requesting device, and refuses repositories outside the
+  installation's selection (AC4). #614 refuses private repos without entitlement —
+  all at the same seam, so no caller path can skip a gate.
+
+## Retention
+
+The broker persists only: device registrations (public key, created-at,
+last-seen-at), installation bindings (device id, installation id, account login,
+created-at), one-shot connect states (nonce, device id, expiry, consumed-at,
+bound installation id), the decision ledger, and in-memory rate-limit counters.
+
+No tokens are stored at rest — they are minted and returned, never persisted. No
+raw device private keys, App keys, source, or diffs are ever stored. Ledger rows
+are public-safe by construction. Deletion: device deregistration removes its
+bindings and states; uninstalled installations are pruned on discovery.
+
+## Open questions
+
+1. **Return-path handoff (RESOLVED).** URL scheme is not registered today, so v1
+   uses the device-poll `complete` endpoint. See "Return path". Layer a scheme
+   redirect in #612 if desired.
+2. **Device-registration abuse economics (OPEN).** Bot farms registering devices
+   on the free tier. Initial posture: registration rate limits plus GitHub-side
+   installation authority is the real gate (a device with no completed callback
+   can mint nothing). Revisit with abuse telemetry.
+3. **Token-response repo snapshot (RESOLVED).** `POST /github/token` returns only
+   the token, its expiry, and the granted repositories/permissions. The app lists
+   repositories client-side with the brokered token, keeping broker surfaces
+   minimal.
+4. **Staging vs. production App registration sequence (OWNER-GATED, OPEN).** The
+   agent builds against a staging App the owner registers with the documented
+   permission set (see `docs/security/github-app-staging-registration.md`). The
+   production identity is created only after the security review.
+
+## Owner-gated boundary
+
+Agent-executable now (this slice): the broker service code and its contract,
+integration, adversarial, and redaction tests against fixtures; this threat model
+and data-flow document; and the staging App registration spec.
+
+Owner-only (blocked, needs-owner): creating the official NeonDiff GitHub App
+registration (production identity), holding the App private key, provisioning the
+Fly deployment secrets, and approving this security review before any production
+credential exists (AC7). No code in this slice proves the live install flow; it
+proves the fixtured broker contract only.

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -40,16 +40,23 @@ Issues merely because the App reviews PRs.
 
 Organization permissions: none. Account permissions: none.
 
-## 3. Callback and setup URLs
+## 3. Setup URL (post-install redirect)
 
-- **Callback URL:** the broker callback route on the license-service host:
+Because OAuth-during-install is disabled (step 1), GitHub sends the post-install
+browser return to the App's **Setup URL**, not the user authorization callback URL
+(see https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-setup-url).
+Get this wrong and the broker never receives the install return, so the desktop
+poll pends until the state expires.
+
+- **Setup URL (required):** the broker return route on the license-service host:
   `https://<license-service-host>/github/connect/callback`
-  (GitHub appends `installation_id` and the `state` the broker issued). This is
-  the only redirect the broker consumes.
-- **Setup URL:** may be left unset, or point to the same callback; the broker
-  treats the install return purely via the callback route.
-- **"Redirect on update":** enabled, so re-configuring the installation returns
-  through the same callback.
+  After install, GitHub redirects here with `installation_id`, `setup_action`, and
+  the `state` the broker placed on the install link — exactly what
+  `GET /github/connect/callback` consumes.
+- **"Redirect on update":** enabled, so reconfiguring the installation returns
+  through the same route.
+- **User authorization callback URL:** unused in this flow (OAuth-on-install is
+  off); leave it blank or matching the Setup URL.
 
 ## 4. Webhook
 
@@ -83,9 +90,10 @@ depend on device flow; this setting is only for the existing desktop path until
 Place the following in the license-service deployment environment (Fly secrets for
 the shared `services/license-api` deployment). The broker reads the private key
 from this secret store at runtime and never persists, logs, or returns it. These
-names are the contract for the future production-wiring step in `server.ts`
-(currently the broker is omitted from `server.ts` until the App exists, so broker
-routes return 503):
+names are the contract for the future production-wiring step in `server.ts`.
+Until it provides `githubBroker`, the shared license request listener matches every
+broker path and returns a typed `{ "reason": "broker_unavailable" }` 503 — a
+deliberate fail-closed status, not an unrouted 404:
 
 | Secret                          | Purpose |
 |---------------------------------|---------|

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -1,0 +1,108 @@
+# Staging GitHub App Registration Spec
+
+The exact checklist to register the **staging** NeonDiff GitHub App that the
+managed authorization broker (issue #613, `services/license-api/src/github-broker/`)
+runs against. This is the fixture-to-live bridge: the agent builds and tests the
+broker against an in-memory client; the owner registers a real staging App with
+the settings below so the broker can be exercised end-to-end before any
+production identity or security review exists.
+
+Every step marked **[OWNER-GATED]** requires the repository/organization owner —
+the agent cannot create App registrations, hold private keys, or provision
+deployment secrets. Do not create the production App from this document; the
+production identity is created only after the committed security review
+(`docs/security/github-app-broker.md`, AC7).
+
+## 1. Create the staging App [OWNER-GATED]
+
+1. Under the owning org (or a personal account for early staging), create a new
+   GitHub App named distinctly for staging, e.g. `NeonDiff (Staging)`.
+2. Homepage URL: the NeonDiff website or repository URL.
+3. Leave "Request user authorization (OAuth) during installation" unchecked for
+   the install/authorize broker flow (the broker binds via installation id +
+   one-shot state, not a user OAuth token).
+
+## 2. Repository permissions
+
+Set exactly the least-privilege PR-review set (matches `docs/github-app-setup.md`):
+
+| Permission     | Access       | Why |
+|----------------|--------------|-----|
+| Metadata       | Read-only    | Identify installed repositories (mandatory). |
+| Contents       | Read-only    | Fetch and inspect the target head. |
+| Pull requests  | Read & write | Read PR metadata and submit App-authored reviews. |
+| Checks         | Read-only    | Include CI context in review summaries. |
+| Actions        | Read-only    | Read workflow-run context without modifying runs. |
+
+**Issues: leave OFF.** Issue enrichment is a separate, separately-rolled-out
+permission with its own allowlist (`docs/github-app-setup.md`). Do not enable
+Issues merely because the App reviews PRs.
+
+Organization permissions: none. Account permissions: none.
+
+## 3. Callback and setup URLs
+
+- **Callback URL:** the broker callback route on the license-service host:
+  `https://<license-service-host>/github/connect/callback`
+  (GitHub appends `installation_id` and the `state` the broker issued). This is
+  the only redirect the broker consumes.
+- **Setup URL:** may be left unset, or point to the same callback; the broker
+  treats the install return purely via the callback route.
+- **"Redirect on update":** enabled, so re-configuring the installation returns
+  through the same callback.
+
+## 4. Webhook
+
+**Leave the webhook URL blank and uncheck "Active".** v1 has no webhook receiver;
+the local worker polls, and the broker discovers uninstall/suspension at the next
+token request (`docs/security/github-app-broker.md`, "Failure and abuse states").
+A webhook is not required and adding one is a separate design change.
+
+## 5. Device flow
+
+Enable **"Enable Device Flow"** while the current desktop "Connect GitHub" (Repos
+pane) path still uses device-flow OAuth (`GitHubDeviceAuthClient.swift`;
+`docs/github-app-setup.md` notes GitHub returns `device_flow_disabled` if it is
+off). The broker's install/authorize + one-shot-state flow does **not** itself
+depend on device flow; this setting is only for the existing desktop path until
+#612 migrates it onto the broker.
+
+## 6. Private key and install URL [OWNER-GATED]
+
+1. Generate a private key for the staging App and store the `.pem` **outside any
+   repository** (never commit it — secret scanning and `npm run check:secrets`
+   reject tracked `.pem`/key files, and committing key material is prohibited
+   regardless).
+2. Record the numeric **App ID** and the generated **install URL**
+   (`https://github.com/apps/<staging-app-slug>/installations/new`).
+3. Install the staging App on a small set of **selected** test repositories (at
+   least one public and one private, to exercise the pre-#614 fail-closed gate).
+
+## 7. Deployment secrets [OWNER-GATED]
+
+Place the following in the license-service deployment environment (Fly secrets for
+the shared `services/license-api` deployment). The broker reads the private key
+from this secret store at runtime and never persists, logs, or returns it. These
+names are the contract for the future production-wiring step in `server.ts`
+(currently the broker is omitted from `server.ts` until the App exists, so broker
+routes return 503):
+
+| Secret                          | Purpose |
+|---------------------------------|---------|
+| `GITHUB_BROKER_APP_ID`          | Numeric staging App id. |
+| `GITHUB_BROKER_PRIVATE_KEY`     | Staging App private key PEM contents. |
+| `GITHUB_BROKER_INSTALL_BASE_URL`| `https://github.com/apps/<staging-app-slug>/installations/new`. |
+| `GITHUB_BROKER_DB_PATH`         | Path for the broker SQLite DB on the mounted volume (separate from `LICENSE_DB_PATH`). |
+| `GITHUB_BROKER_API_BASE_URL`    | Optional; defaults to `https://api.github.com`. |
+
+Do not reuse the production `LICENSE_ISSUANCE_SECRET` or any production credential
+for staging.
+
+## 8. Verification boundary
+
+Registering this staging App proves the broker's install-return and token-issuance
+flow against a real App identity. It does **not** create the production App, prove
+Marketplace readiness, deploy anything, or satisfy the security review that must
+precede production credentials. Keep staging installations, tokens, and evidence
+clearly labeled staging, and revoke them per the issue #613 rollback plan when the
+staging exercise ends.

--- a/services/license-api/src/github-broker/authorization.ts
+++ b/services/license-api/src/github-broker/authorization.ts
@@ -1,0 +1,45 @@
+import type { BrokerReason } from "./errors.js";
+import type { GitHubRepositoryVisibility } from "./github-app.js";
+
+export interface RequestedRepository {
+  fullName: string;
+  visibility: GitHubRepositoryVisibility;
+}
+
+export type IssuanceAuthorizationDecision =
+  | { decision: "allow"; repositories: string[] }
+  | { decision: "deny"; reason: BrokerReason };
+
+/**
+ * THE single token-issuance decision point. Every mint path in the broker flows
+ * through this function; there is no other code path that can authorize an
+ * installation token (the gate-every-caller rule). #614 replaces the body of this
+ * ONE function to add the repository-visibility + entitlement binding — callers
+ * and the surrounding issuance flow do not change.
+ *
+ * Pre-#614 policy (fail closed): authorize ONLY when every requested repository is
+ * verified public. Any private/internal repository denies with
+ * `entitlement_gate_not_implemented`; unknown visibility denies with
+ * `visibility_unknown` (never assume public). Callers resolve each requested
+ * repository against the installation's current selection before calling this, so
+ * a repo outside the installation never reaches the seam.
+ */
+export function authorizeTokenIssuance(input: {
+  requestedRepositories: RequestedRepository[];
+}): IssuanceAuthorizationDecision {
+  if (input.requestedRepositories.length === 0) {
+    return { decision: "deny", reason: "invalid_request" };
+  }
+  for (const repository of input.requestedRepositories) {
+    if (repository.visibility === "unknown") {
+      return { decision: "deny", reason: "visibility_unknown" };
+    }
+    if (repository.visibility !== "public") {
+      return { decision: "deny", reason: "entitlement_gate_not_implemented" };
+    }
+  }
+  return {
+    decision: "allow",
+    repositories: input.requestedRepositories.map((repository) => repository.fullName)
+  };
+}

--- a/services/license-api/src/github-broker/authorization.ts
+++ b/services/license-api/src/github-broker/authorization.ts
@@ -3,6 +3,8 @@ import type { GitHubRepositoryVisibility } from "./github-app.js";
 
 export interface RequestedRepository {
   fullName: string;
+  /** The installation's canonical repository id, used to narrow the minted token. */
+  id: number;
   visibility: GitHubRepositoryVisibility;
 }
 

--- a/services/license-api/src/github-broker/device-auth.ts
+++ b/services/license-api/src/github-broker/device-auth.ts
@@ -1,0 +1,86 @@
+import { calculateJwkThumbprint, decodeJwt, importJWK, jwtVerify, type JWK } from "jose";
+import { BrokerError } from "./errors.js";
+import type { GitHubBrokerStore } from "./store.js";
+
+const DEVICE_JWT_ALG = "ES256";
+const MAX_DEVICE_TOKEN_AGE_SECONDS = 600;
+
+/**
+ * Validate a registration public JWK: it must be an EC P-256 public key with no
+ * private component. The device id is its RFC 7638 thumbprint, computed the same
+ * way on the client, so registration is idempotent and no server-assigned id has
+ * to travel back before the device can authenticate.
+ */
+export async function deviceIdFromPublicJwk(publicKeyJwk: unknown): Promise<{ deviceId: string; publicJwk: JWK }> {
+  if (typeof publicKeyJwk !== "object" || publicKeyJwk === null || Array.isArray(publicKeyJwk)) {
+    throw new BrokerError("invalid_request", "publicKeyJwk must be a JSON object");
+  }
+  const jwk = publicKeyJwk as JWK & { d?: unknown };
+  if (jwk.kty !== "EC" || jwk.crv !== "P-256" || typeof jwk.x !== "string" || typeof jwk.y !== "string") {
+    throw new BrokerError("invalid_request", "publicKeyJwk must be an EC P-256 public key");
+  }
+  if (jwk.d !== undefined) {
+    throw new BrokerError("invalid_request", "publicKeyJwk must not contain private key material");
+  }
+  const publicJwk: JWK = { kty: "EC", crv: "P-256", x: jwk.x, y: jwk.y };
+  const deviceId = await calculateJwkThumbprint(publicJwk, "sha256");
+  return { deviceId, publicJwk };
+}
+
+/**
+ * Authenticate a device-signed request. Extracts the device id from the token
+ * subject, verifies the signature against the registered public key, and enforces
+ * expiry. Every failure maps to a typed, fail-closed reason; the token itself is
+ * never logged.
+ */
+export async function authenticateDevice(
+  store: GitHubBrokerStore,
+  authorizationHeader: string | string[] | undefined,
+  now: Date
+): Promise<string> {
+  const token = bearerToken(authorizationHeader);
+  if (!token) throw new BrokerError("invalid_device_credential", "a device-signed bearer token is required");
+
+  let subject: string;
+  try {
+    const claims = decodeJwt(token);
+    if (typeof claims.sub !== "string" || claims.sub.length === 0) {
+      throw new Error("missing subject");
+    }
+    subject = claims.sub;
+  } catch {
+    throw new BrokerError("invalid_device_credential", "device credential is malformed");
+  }
+
+  const device = store.getDevice(subject);
+  if (!device) throw new BrokerError("device_not_registered", "device is not registered");
+
+  let key: Awaited<ReturnType<typeof importJWK>>;
+  try {
+    key = await importJWK(JSON.parse(device.public_jwk) as JWK, DEVICE_JWT_ALG);
+  } catch {
+    throw new BrokerError("invalid_device_credential", "device key could not be loaded");
+  }
+
+  try {
+    await jwtVerify(token, key, {
+      algorithms: [DEVICE_JWT_ALG],
+      subject,
+      currentDate: now,
+      clockTolerance: 5,
+      maxTokenAge: MAX_DEVICE_TOKEN_AGE_SECONDS
+    });
+  } catch {
+    throw new BrokerError("invalid_device_credential", "device credential failed verification");
+  }
+
+  store.touchDevice(subject, now.toISOString());
+  return subject;
+}
+
+function bearerToken(header: string | string[] | undefined): string | undefined {
+  const value = Array.isArray(header) ? header[0] : header;
+  const prefix = "Bearer ";
+  if (!value?.startsWith(prefix) || value.length === prefix.length) return undefined;
+  return value.slice(prefix.length);
+}

--- a/services/license-api/src/github-broker/errors.ts
+++ b/services/license-api/src/github-broker/errors.ts
@@ -1,0 +1,65 @@
+/**
+ * Typed, fail-closed broker outcomes. Every refusal in the broker is one of
+ * these reason codes; there is never a silent pass or a fallback to a user token
+ * (see docs/security/github-app-broker.md, "Failure and abuse states"). Reason
+ * codes and their HTTP mapping are the client-facing contract.
+ */
+export type BrokerReason =
+  | "invalid_request"
+  | "device_not_registered"
+  | "invalid_device_credential"
+  | "state_not_found"
+  | "state_expired"
+  | "state_replayed"
+  | "binding_not_found"
+  | "installation_not_found"
+  | "installation_uninstalled"
+  | "installation_suspended"
+  | "repo_outside_installation"
+  | "repo_renamed_or_transferred"
+  | "visibility_unknown"
+  | "entitlement_gate_not_implemented"
+  | "entitlement_missing"
+  | "rate_limited"
+  | "broker_unavailable";
+
+const REASON_STATUS: Record<BrokerReason, number> = {
+  invalid_request: 400,
+  device_not_registered: 401,
+  invalid_device_credential: 401,
+  state_not_found: 404,
+  state_expired: 409,
+  state_replayed: 409,
+  binding_not_found: 404,
+  installation_not_found: 404,
+  installation_uninstalled: 409,
+  installation_suspended: 409,
+  repo_outside_installation: 403,
+  repo_renamed_or_transferred: 409,
+  visibility_unknown: 403,
+  entitlement_gate_not_implemented: 403,
+  entitlement_missing: 403,
+  rate_limited: 429,
+  broker_unavailable: 503
+};
+
+/**
+ * A typed broker refusal. `detail` is a fixed, public-safe phrase — it never
+ * carries token, key, nonce, or repository-content material (redaction
+ * discipline mirrors src/secrets.ts).
+ */
+export class BrokerError extends Error {
+  readonly reason: BrokerReason;
+  readonly httpStatus: number;
+
+  constructor(reason: BrokerReason, detail?: string) {
+    super(detail ?? reason);
+    this.name = "BrokerError";
+    this.reason = reason;
+    this.httpStatus = REASON_STATUS[reason];
+  }
+
+  body(): Record<string, unknown> {
+    return { status: "error", reason: this.reason, detail: this.message };
+  }
+}

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -1,0 +1,211 @@
+import { createSign } from "node:crypto";
+import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url.js";
+
+/**
+ * Server-side GitHub App boundary for the broker. This is the only place the App
+ * private key is used, and only to sign short-lived App JWTs at runtime — the key
+ * is never persisted, logged, or returned. The interface is what the broker
+ * service depends on; tests inject an in-memory fake, so no live GitHub call ever
+ * runs under test.
+ */
+
+export type GitHubRepositoryVisibility = "public" | "private" | "internal" | "unknown";
+
+export interface InstallationSummary {
+  id: number;
+  account_login?: string;
+  suspended: boolean;
+}
+
+export interface InstallationRepository {
+  id: number;
+  full_name: string;
+  visibility: GitHubRepositoryVisibility;
+}
+
+export interface InstallationAccessToken {
+  token: string;
+  expires_at: string;
+}
+
+/** Transient/redirect classes the service maps to typed broker reasons. */
+export type GitHubBrokerClientErrorClass = "rate_limited" | "renamed_or_transferred" | "unavailable";
+
+export class GitHubBrokerClientError extends Error {
+  readonly brokerClientErrorClass: GitHubBrokerClientErrorClass;
+  constructor(brokerClientErrorClass: GitHubBrokerClientErrorClass, message: string) {
+    super(message);
+    this.name = "GitHubBrokerClientError";
+    this.brokerClientErrorClass = brokerClientErrorClass;
+  }
+}
+
+export interface GitHubInstallationClient {
+  /** Resolve an installation by id; returns null when it does not exist (uninstalled). */
+  getInstallation(installationId: number): Promise<InstallationSummary | null>;
+  /** The installation's current repository selection, with each repo's visibility. */
+  listInstallationRepositories(installationId: number): Promise<InstallationRepository[]>;
+  /** Mint a narrowed installation access token. This is the RETURNED token; it is
+   * reached only after the issuance seam authorizes the request. */
+  createInstallationAccessToken(
+    installationId: number,
+    params: { repositories?: string[]; permissions?: Record<string, string> }
+  ): Promise<InstallationAccessToken>;
+}
+
+export interface GitHubAppConfig {
+  appId: string;
+  /** PEM contents, read at runtime from the deployment secret store. Never stored by the broker. */
+  privateKey: string;
+  apiBaseUrl?: string;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Sign a short-lived GitHub App JWT (RS256). Mirrors src/github.ts createAppJwt;
+ * license-api is its own package, so it keeps its own small helper rather than
+ * importing across the package boundary.
+ */
+export function createAppJwt(
+  appId: string,
+  privateKey: string,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): string {
+  const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
+  const payload = base64UrlJson({ iat: nowSeconds - 60, exp: nowSeconds + 540, iss: appId });
+  const unsigned = `${header}.${payload}`;
+  const signature = createSign("RSA-SHA256").update(unsigned).sign(privateKey, "base64url");
+  return `${unsigned}.${signature}`;
+}
+
+/**
+ * Production GitHub installation client. Not exercised by tests (no live calls in
+ * CI); wired in server.ts when the owner provisions the App id + private key.
+ */
+export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubInstallationClient {
+  const apiBaseUrl = normalizeHttpApiBaseUrl(config.apiBaseUrl, "githubBroker.apiBaseUrl", "https://api.github.com");
+
+  async function request<T>(
+    path: string,
+    options: { method?: string; token: string; body?: unknown }
+  ): Promise<{ status: number; json: T | undefined; text: string }> {
+    let response: Response;
+    const controller = config.requestTimeoutMs ? new AbortController() : undefined;
+    const timeout = controller
+      ? setTimeout(() => controller.abort(new Error(`GitHub API request timed out for ${path}`)), config.requestTimeoutMs)
+      : undefined;
+    try {
+      response = await fetch(buildApiUrl(apiBaseUrl, path, "GitHub broker request path"), {
+        method: options.method ?? "GET",
+        signal: controller?.signal,
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          Authorization: `Bearer ${options.token}`,
+          ...(options.body === undefined ? {} : { "Content-Type": "application/json" })
+        },
+        body: options.body === undefined ? undefined : JSON.stringify(options.body)
+      });
+    } catch {
+      throw new GitHubBrokerClientError("unavailable", `GitHub API fetch failed for ${path}`);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+    const text = await response.text();
+    if (!response.ok) classifyAndThrow(response.status, text, path);
+    return { status: response.status, json: text ? (JSON.parse(text) as T) : undefined, text };
+  }
+
+  async function installationToken(installationId: number, params: { repositories?: string[]; permissions?: Record<string, string> }): Promise<InstallationAccessToken> {
+    const jwt = createAppJwt(config.appId, config.privateKey);
+    const result = await request<{ token: string; expires_at: string }>(
+      `/app/installations/${installationId}/access_tokens`,
+      { method: "POST", token: jwt, body: params }
+    );
+    if (!result.json) throw new GitHubBrokerClientError("unavailable", "installation token response was empty");
+    return { token: result.json.token, expires_at: result.json.expires_at };
+  }
+
+  return {
+    async getInstallation(installationId: number): Promise<InstallationSummary | null> {
+      const jwt = createAppJwt(config.appId, config.privateKey);
+      try {
+        const result = await request<{ id: number; suspended_at?: string | null; account?: { login?: string } }>(
+          `/app/installations/${installationId}`,
+          { token: jwt }
+        );
+        if (!result.json) return null;
+        return {
+          id: result.json.id,
+          account_login: result.json.account?.login,
+          suspended: Boolean(result.json.suspended_at)
+        };
+      } catch (error) {
+        if (error instanceof GitHubBrokerClientError) throw error;
+        if (isNotFound(error)) return null;
+        throw error;
+      }
+    },
+    async listInstallationRepositories(installationId: number): Promise<InstallationRepository[]> {
+      // Listing an installation's repositories requires an installation token; this
+      // is authorization metadata (visibility) used to make the seam decision, not
+      // the narrowed token returned to the client.
+      const token = (await installationToken(installationId, {})).token;
+      const repositories: InstallationRepository[] = [];
+      for (let page = 1; ; page += 1) {
+        const result = await request<{ repositories: Array<{ id: number; full_name: string; visibility?: string; private?: boolean }> }>(
+          `/installation/repositories?per_page=100&page=${page}`,
+          { token }
+        );
+        const chunk = result.json?.repositories ?? [];
+        for (const repository of chunk) {
+          repositories.push({
+            id: repository.id,
+            full_name: repository.full_name,
+            visibility: normalizeVisibility(repository.visibility, repository.private)
+          });
+        }
+        if (chunk.length < 100) return repositories;
+      }
+    },
+    createInstallationAccessToken(installationId, params) {
+      return installationToken(installationId, params);
+    }
+  };
+}
+
+function normalizeVisibility(visibility: string | undefined, isPrivate: boolean | undefined): GitHubRepositoryVisibility {
+  if (visibility === "public" || visibility === "private" || visibility === "internal") return visibility;
+  if (isPrivate === true) return "private";
+  if (isPrivate === false) return "public";
+  return "unknown";
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof GitHubApiStatusError && error.status === 404;
+}
+
+class GitHubApiStatusError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function classifyAndThrow(status: number, body: string, path: string): never {
+  if (/\b(rate limit|secondary rate limit|abuse detection)\b/i.test(body)) {
+    throw new GitHubBrokerClientError("rate_limited", `GitHub API rate limited for ${path}`);
+  }
+  if (status === 301 || status === 302 || status === 307 || status === 308) {
+    throw new GitHubBrokerClientError("renamed_or_transferred", `GitHub API redirected for ${path}`);
+  }
+  if (status >= 500) {
+    throw new GitHubBrokerClientError("unavailable", `GitHub API ${status} for ${path}`);
+  }
+  throw new GitHubApiStatusError(status, `GitHub API ${status} for ${path}`);
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -46,10 +46,11 @@ export interface GitHubInstallationClient {
   /** The installation's current repository selection, with each repo's visibility. */
   listInstallationRepositories(installationId: number): Promise<InstallationRepository[]>;
   /** Mint a narrowed installation access token. This is the RETURNED token; it is
-   * reached only after the issuance seam authorizes the request. */
+   * reached only after the issuance seam authorizes the request. Narrowing uses
+   * `repositoryIds` (GitHub's canonical `repository_ids`), never `owner/name`. */
   createInstallationAccessToken(
     installationId: number,
-    params: { repositories?: string[]; permissions?: Record<string, string> }
+    params: { repositoryIds?: number[]; permissions?: Record<string, string> }
   ): Promise<InstallationAccessToken>;
 }
 
@@ -116,11 +117,17 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
     return { status: response.status, json: text ? (JSON.parse(text) as T) : undefined, text };
   }
 
-  async function installationToken(installationId: number, params: { repositories?: string[]; permissions?: Record<string, string> }): Promise<InstallationAccessToken> {
+  async function installationToken(
+    installationId: number,
+    params: { repositoryIds?: number[]; permissions?: Record<string, string> }
+  ): Promise<InstallationAccessToken> {
     const jwt = createAppJwt(config.appId, config.privateKey);
+    const body: Record<string, unknown> = {};
+    if (params.repositoryIds) body.repository_ids = params.repositoryIds;
+    if (params.permissions) body.permissions = params.permissions;
     const result = await request<{ token: string; expires_at: string }>(
       `/app/installations/${installationId}/access_tokens`,
-      { method: "POST", token: jwt, body: params }
+      { method: "POST", token: jwt, body }
     );
     if (!result.json) throw new GitHubBrokerClientError("unavailable", "installation token response was empty");
     return { token: result.json.token, expires_at: result.json.expires_at };
@@ -147,10 +154,11 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
       }
     },
     async listInstallationRepositories(installationId: number): Promise<InstallationRepository[]> {
-      // Listing an installation's repositories requires an installation token; this
-      // is authorization metadata (visibility) used to make the seam decision, not
-      // the narrowed token returned to the client.
-      const token = (await installationToken(installationId, {})).token;
+      // Listing an installation's repositories requires an installation token. It is
+      // scoped to metadata:read ONLY — the minimum needed to read visibility for the
+      // seam decision — so no broad, all-permissions token is ever minted before
+      // authorizeTokenIssuance runs. This is not the token returned to the client.
+      const token = (await installationToken(installationId, { permissions: { metadata: "read" } })).token;
       const repositories: InstallationRepository[] = [];
       for (let page = 1; ; page += 1) {
         const result = await request<{ repositories: Array<{ id: number; full_name: string; visibility?: string; private?: boolean }> }>(
@@ -169,7 +177,10 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
       }
     },
     createInstallationAccessToken(installationId, params) {
-      return installationToken(installationId, params);
+      return installationToken(installationId, {
+        ...(params.repositoryIds ? { repositoryIds: params.repositoryIds } : {}),
+        ...(params.permissions ? { permissions: params.permissions } : {})
+      });
     }
   };
 }

--- a/services/license-api/src/github-broker/index.ts
+++ b/services/license-api/src/github-broker/index.ts
@@ -11,7 +11,11 @@ export {
   type GitHubRepositoryVisibility,
   type GitHubAppConfig
 } from "./github-app.js";
-export { GitHubBrokerService, type GitHubBrokerServiceOptions } from "./service.js";
+export {
+  GitHubBrokerService,
+  MINIMAL_REVIEW_PERMISSIONS,
+  type GitHubBrokerServiceOptions
+} from "./service.js";
 export { GitHubBrokerStore } from "./store.js";
 export {
   createGitHubBrokerService,

--- a/services/license-api/src/github-broker/index.ts
+++ b/services/license-api/src/github-broker/index.ts
@@ -1,0 +1,21 @@
+export { authorizeTokenIssuance, type RequestedRepository, type IssuanceAuthorizationDecision } from "./authorization.js";
+export { BrokerError, type BrokerReason } from "./errors.js";
+export {
+  createGitHubInstallationClient,
+  createAppJwt,
+  GitHubBrokerClientError,
+  type GitHubInstallationClient,
+  type InstallationSummary,
+  type InstallationRepository,
+  type InstallationAccessToken,
+  type GitHubRepositoryVisibility,
+  type GitHubAppConfig
+} from "./github-app.js";
+export { GitHubBrokerService, type GitHubBrokerServiceOptions } from "./service.js";
+export { GitHubBrokerStore } from "./store.js";
+export {
+  createGitHubBrokerService,
+  handleGitHubBrokerRequest,
+  isGitHubBrokerPath,
+  type GitHubBrokerDeps
+} from "./routes.js";

--- a/services/license-api/src/github-broker/routes.ts
+++ b/services/license-api/src/github-broker/routes.ts
@@ -1,0 +1,131 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RateLimiter } from "../service.js";
+import { BrokerError } from "./errors.js";
+import type { GitHubInstallationClient } from "./github-app.js";
+import { GitHubBrokerService } from "./service.js";
+import { GitHubBrokerStore } from "./store.js";
+
+const MAX_BODY_BYTES = 16 * 1024;
+const BROKER_PATHS = new Set([
+  "/device/register",
+  "/github/connect/start",
+  "/github/connect/callback",
+  "/github/connect/complete",
+  "/github/token"
+]);
+
+class BrokerBodyTooLargeError extends Error {}
+
+/**
+ * Dependencies for wiring the broker into the license HTTP listener. Either a
+ * ready `store` or a `dbPath` (from which the listener constructs a store once)
+ * is provided. Tests pass a `dbPath` plus an in-memory `githubClient`.
+ */
+export interface GitHubBrokerDeps {
+  store?: GitHubBrokerStore;
+  dbPath?: string;
+  githubClient: GitHubInstallationClient;
+  installBaseUrl: string;
+  now?: () => Date;
+  deviceRegisterRateLimiter?: RateLimiter;
+  connectRateLimiter?: RateLimiter;
+  tokenRateLimiter?: RateLimiter;
+}
+
+export function isGitHubBrokerPath(path: string | undefined): boolean {
+  return path !== undefined && BROKER_PATHS.has(path);
+}
+
+/** Build the broker service once, constructing its store from `dbPath` if needed. */
+export function createGitHubBrokerService(deps: GitHubBrokerDeps): GitHubBrokerService {
+  const store = deps.store ?? new GitHubBrokerStore(deps.dbPath ?? ":memory:");
+  return new GitHubBrokerService({
+    store,
+    githubClient: deps.githubClient,
+    installBaseUrl: deps.installBaseUrl,
+    now: deps.now,
+    deviceRegisterRateLimiter: deps.deviceRegisterRateLimiter,
+    connectRateLimiter: deps.connectRateLimiter,
+    tokenRateLimiter: deps.tokenRateLimiter
+  });
+}
+
+export async function handleGitHubBrokerRequest(
+  service: GitHubBrokerService,
+  req: IncomingMessage,
+  res: ServerResponse,
+  context: { sourceAddress: string }
+): Promise<void> {
+  const [path, rawQuery] = (req.url ?? "").split("?");
+  try {
+    if (req.method === "POST" && path === "/device/register") {
+      return writeJson(res, 200, await service.registerDevice(await readBody(req), context.sourceAddress));
+    }
+    if (req.method === "POST" && path === "/github/connect/start") {
+      return writeJson(res, 200, await service.connectStart(req.headers.authorization));
+    }
+    if (req.method === "GET" && path === "/github/connect/callback") {
+      const { html } = await service.connectCallback(new URLSearchParams(rawQuery ?? ""));
+      return writeHtml(res, 200, html);
+    }
+    if (req.method === "POST" && path === "/github/connect/complete") {
+      return writeJson(res, 200, await service.connectComplete(req.headers.authorization, await readBody(req)));
+    }
+    if (req.method === "POST" && path === "/github/token") {
+      return writeJson(res, 200, await service.issueToken(req.headers.authorization, await readBody(req)));
+    }
+    return writeJson(res, 404, { status: "error", reason: "invalid_request", detail: "unknown broker route" });
+  } catch (error) {
+    if (error instanceof BrokerError) {
+      return writeJson(res, error.httpStatus, error.body());
+    }
+    if (error instanceof BrokerBodyTooLargeError) {
+      return writeJson(res, 413, { status: "error", reason: "invalid_request", detail: "request body too large" });
+    }
+    // Never surface internal error text (redaction discipline) → generic 500.
+    return writeJson(res, 500, { status: "error", reason: "broker_unavailable", detail: "internal error" });
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let tooLarge = false;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      if (tooLarge) return;
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        tooLarge = true;
+        chunks.length = 0;
+        reject(new BrokerBodyTooLargeError("request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (tooLarge) return;
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new BrokerError("invalid_request", "request body must be valid JSON"));
+      }
+    });
+    req.on("error", (error) => {
+      if (!tooLarge) reject(error);
+    });
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(payload);
+}
+
+function writeHtml(res: ServerResponse, status: number, html: string): void {
+  res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(html);
+}

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -1,0 +1,339 @@
+import { randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
+import { RateLimiter } from "../service.js";
+import { authorizeTokenIssuance, type RequestedRepository } from "./authorization.js";
+import { authenticateDevice, deviceIdFromPublicJwk } from "./device-auth.js";
+import { BrokerError } from "./errors.js";
+import {
+  GitHubBrokerClientError,
+  type GitHubInstallationClient,
+  type InstallationSummary
+} from "./github-app.js";
+import { GitHubBrokerStore } from "./store.js";
+
+const STATE_TTL_MS = 10 * 60 * 1_000;
+const MAX_REPOSITORIES_PER_REQUEST = 50;
+
+export interface GitHubBrokerServiceOptions {
+  store: GitHubBrokerStore;
+  githubClient: GitHubInstallationClient;
+  /** Official App install URL, e.g. https://github.com/apps/<app>/installations/new. */
+  installBaseUrl: string;
+  now?: () => Date;
+  deviceRegisterRateLimiter?: RateLimiter;
+  connectRateLimiter?: RateLimiter;
+  tokenRateLimiter?: RateLimiter;
+}
+
+/**
+ * The managed GitHub App authorization broker. Custody of the App private key
+ * lives behind `githubClient`; this service verifies the native device session
+ * and the installation binding, then issues bounded short-lived installation
+ * tokens through the single `authorizeTokenIssuance` seam. All failures are typed
+ * and fail closed.
+ */
+export class GitHubBrokerService {
+  private readonly store: GitHubBrokerStore;
+  private readonly githubClient: GitHubInstallationClient;
+  private readonly installBaseUrl: string;
+  private readonly now: () => Date;
+  private readonly deviceRegisterRateLimiter: RateLimiter;
+  private readonly connectRateLimiter: RateLimiter;
+  private readonly tokenRateLimiter: RateLimiter;
+
+  constructor(options: GitHubBrokerServiceOptions) {
+    this.store = options.store;
+    this.githubClient = options.githubClient;
+    this.installBaseUrl = options.installBaseUrl;
+    this.now = options.now ?? (() => new Date());
+    this.deviceRegisterRateLimiter =
+      options.deviceRegisterRateLimiter ?? new RateLimiter({ maxPerWindow: 20, windowMs: 60_000 });
+    this.connectRateLimiter =
+      options.connectRateLimiter ?? new RateLimiter({ maxPerWindow: 30, windowMs: 60_000 });
+    this.tokenRateLimiter =
+      options.tokenRateLimiter ?? new RateLimiter({ maxPerWindow: 60, windowMs: 60_000 });
+  }
+
+  /** POST /device/register — anonymous, rate-limited by source address. */
+  async registerDevice(body: unknown, sourceAddress: string): Promise<Record<string, unknown>> {
+    const at = this.now();
+    if (!this.deviceRegisterRateLimiter.allow(hashKey(`register:${sourceAddress}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many device registrations");
+    }
+    const record = asObject(body);
+    const { deviceId, publicJwk } = await deviceIdFromPublicJwk(record.publicKeyJwk);
+    this.store.upsertDevice(deviceId, JSON.stringify(publicJwk), at.toISOString());
+    return { status: "registered", deviceId };
+  }
+
+  /** POST /github/connect/start — device-authenticated; returns the install URL + one-shot state. */
+  async connectStart(authorization: string | string[] | undefined): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    if (!this.connectRateLimiter.allow(hashKey(`connect:${deviceId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many connect attempts");
+    }
+    const state = randomBytes(32).toString("base64url");
+    const expiresAt = new Date(at.getTime() + STATE_TTL_MS);
+    this.store.createConnectState(state, deviceId, at.toISOString(), expiresAt.toISOString());
+    const installUrl = appendStateParam(this.installBaseUrl, state);
+    return { status: "connect_started", installUrl, state, expiresAt: expiresAt.toISOString() };
+  }
+
+  /**
+   * GET /github/connect/callback — the browser return from GitHub. Verifies the
+   * one-shot state, confirms the installation belongs to the App, and records the
+   * (device, installation) binding. Returns a small HTML page telling the user to
+   * return to the app (no URL scheme is registered in v1; see the design doc).
+   */
+  async connectCallback(query: URLSearchParams): Promise<{ html: string }> {
+    const at = this.now();
+    const installationIdRaw = query.get("installation_id");
+    const state = query.get("state");
+    if (!state || !installationIdRaw) {
+      throw new BrokerError("invalid_request", "installation_id and state are required");
+    }
+    const installationId = parseInstallationId(installationIdRaw);
+
+    const stored = this.store.getConnectState(state);
+    if (!stored) throw new BrokerError("state_not_found", "connect state is not recognized");
+    if (stored.consumed_at) throw new BrokerError("state_replayed", "connect state was already used");
+    if (Date.parse(stored.expires_at) <= at.getTime()) {
+      throw new BrokerError("state_expired", "connect state has expired");
+    }
+
+    const installation = await this.resolveInstallation(installationId);
+
+    // One-shot: only the first caller flips consumed_at; a race loses as a replay.
+    if (!this.store.consumeConnectState(state, installationId, at.toISOString())) {
+      throw new BrokerError("state_replayed", "connect state was already used");
+    }
+    this.store.upsertBinding(stored.device_id, installationId, installation.account_login, at.toISOString());
+    return { html: connectReturnPage() };
+  }
+
+  /** POST /github/connect/complete — device polls to confirm the binding landed. */
+  async connectComplete(
+    authorization: string | string[] | undefined,
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    const record = asObject(body);
+    const state = record.state;
+    if (typeof state !== "string" || state.length === 0) {
+      throw new BrokerError("invalid_request", "state is required");
+    }
+    const stored = this.store.getConnectState(state);
+    if (!stored || stored.device_id !== deviceId) {
+      throw new BrokerError("state_not_found", "connect state is not recognized");
+    }
+    if (!stored.consumed_at || stored.installation_id === null) {
+      return { status: "pending" };
+    }
+    const binding = this.store.getBinding(deviceId, stored.installation_id);
+    if (!binding) throw new BrokerError("binding_not_found", "installation binding was not found");
+    return { status: "bound", installationId: stored.installation_id };
+  }
+
+  /**
+   * POST /github/token — device-authenticated. Verifies the binding and
+   * installation liveness, narrows to the requested repositories, runs the
+   * issuance seam, and only on `allow` mints a bounded installation token. The
+   * App key never appears in the response; every terminal decision is logged to
+   * the append-only ledger.
+   */
+  async issueToken(
+    authorization: string | string[] | undefined,
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    const { installationId, repositories, permissions } = parseTokenRequest(body);
+
+    if (!this.tokenRateLimiter.allow(hashKey(`token:${deviceId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many token requests for this device");
+    }
+    if (!this.tokenRateLimiter.allow(hashKey(`token-inst:${installationId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many token requests for this installation");
+    }
+
+    try {
+      const binding = this.store.getBinding(deviceId, installationId);
+      if (!binding) throw new BrokerError("binding_not_found", "no binding for this device and installation");
+
+      const installation = await this.resolveInstallation(installationId, { uninstalledIsGone: true });
+      if (installation.suspended) throw new BrokerError("installation_suspended", "installation is suspended");
+
+      const requested = await this.resolveRequestedRepositories(installationId, repositories);
+
+      // The issuance seam: the ONLY path to minting. #614 replaces its body.
+      const decision = authorizeTokenIssuance({ requestedRepositories: requested });
+      if (decision.decision === "deny") {
+        throw new BrokerError(decision.reason, "token issuance is not authorized for the requested repositories");
+      }
+
+      const minted = await this.mintToken(installationId, decision.repositories, permissions);
+      this.store.appendDecision(deviceId, installationId, "allow", "issued", at.toISOString());
+      return {
+        status: "issued",
+        token: minted.token,
+        expiresAt: minted.expires_at,
+        repositories: decision.repositories,
+        ...(permissions ? { permissions } : {})
+      };
+    } catch (error) {
+      if (error instanceof BrokerError) {
+        this.store.appendDecision(deviceId, installationId, "deny", error.reason, at.toISOString());
+      }
+      throw error;
+    }
+  }
+
+  private async resolveInstallation(
+    installationId: number,
+    options: { uninstalledIsGone?: boolean } = {}
+  ): Promise<InstallationSummary> {
+    let installation: InstallationSummary | null;
+    try {
+      installation = await this.githubClient.getInstallation(installationId);
+    } catch (error) {
+      throw mapClientError(error);
+    }
+    if (!installation) {
+      throw new BrokerError(
+        options.uninstalledIsGone ? "installation_uninstalled" : "installation_not_found",
+        "installation was not found"
+      );
+    }
+    return installation;
+  }
+
+  private async resolveRequestedRepositories(
+    installationId: number,
+    repositories: string[]
+  ): Promise<RequestedRepository[]> {
+    let available;
+    try {
+      available = await this.githubClient.listInstallationRepositories(installationId);
+    } catch (error) {
+      throw mapClientError(error);
+    }
+    const byName = new Map(available.map((repository) => [repository.full_name, repository]));
+    return repositories.map((fullName) => {
+      const match = byName.get(fullName);
+      if (!match) throw new BrokerError("repo_outside_installation", "a requested repository is not in the installation selection");
+      return { fullName, visibility: match.visibility };
+    });
+  }
+
+  private async mintToken(
+    installationId: number,
+    repositories: string[],
+    permissions: Record<string, string> | undefined
+  ): Promise<{ token: string; expires_at: string }> {
+    try {
+      return await this.githubClient.createInstallationAccessToken(installationId, {
+        repositories,
+        ...(permissions ? { permissions } : {})
+      });
+    } catch (error) {
+      throw mapClientError(error);
+    }
+  }
+}
+
+function mapClientError(error: unknown): BrokerError {
+  if (error instanceof BrokerError) return error;
+  if (error instanceof GitHubBrokerClientError) {
+    if (error.brokerClientErrorClass === "rate_limited") return new BrokerError("rate_limited", "GitHub rate limit reached");
+    if (error.brokerClientErrorClass === "renamed_or_transferred") {
+      return new BrokerError("repo_renamed_or_transferred", "a repository was renamed or transferred");
+    }
+    return new BrokerError("broker_unavailable", "GitHub is temporarily unavailable");
+  }
+  // Duck-typed fakes may attach a broker client error class without the class instance.
+  if (typeof error === "object" && error !== null && "brokerClientErrorClass" in error) {
+    const klass = (error as { brokerClientErrorClass: string }).brokerClientErrorClass;
+    if (klass === "rate_limited") return new BrokerError("rate_limited", "GitHub rate limit reached");
+    if (klass === "renamed_or_transferred") return new BrokerError("repo_renamed_or_transferred", "a repository was renamed or transferred");
+    return new BrokerError("broker_unavailable", "GitHub is temporarily unavailable");
+  }
+  return new BrokerError("broker_unavailable", "GitHub is temporarily unavailable");
+}
+
+function parseTokenRequest(body: unknown): {
+  installationId: number;
+  repositories: string[];
+  permissions?: Record<string, string>;
+} {
+  const record = asObject(body);
+  const installationId = parseInstallationId(record.installationId);
+  const repositoriesRaw = record.repositories;
+  if (!Array.isArray(repositoriesRaw) || repositoriesRaw.length === 0) {
+    throw new BrokerError("invalid_request", "repositories must be a non-empty array");
+  }
+  if (repositoriesRaw.length > MAX_REPOSITORIES_PER_REQUEST) {
+    throw new BrokerError("invalid_request", "too many repositories requested");
+  }
+  const repositories = repositoriesRaw.map((value) => {
+    if (typeof value !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(value)) {
+      throw new BrokerError("invalid_request", "each repository must be 'owner/name'");
+    }
+    return value;
+  });
+  const permissions = parsePermissions(record.permissions);
+  return { installationId, repositories, ...(permissions ? { permissions } : {}) };
+}
+
+function parsePermissions(value: unknown): Record<string, string> | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new BrokerError("invalid_request", "permissions must be an object");
+  }
+  const permissions: Record<string, string> = {};
+  for (const [key, scope] of Object.entries(value)) {
+    if (!/^[a-z_]{1,40}$/.test(key) || typeof scope !== "string" || !/^(read|write|admin)$/.test(scope)) {
+      throw new BrokerError("invalid_request", "permissions must map scope names to read/write/admin");
+    }
+    permissions[key] = scope;
+  }
+  return Object.keys(permissions).length > 0 ? permissions : undefined;
+}
+
+function parseInstallationId(value: unknown): number {
+  const numeric = typeof value === "string" ? Number(value) : value;
+  if (typeof numeric !== "number" || !Number.isInteger(numeric) || numeric <= 0) {
+    throw new BrokerError("invalid_request", "installationId must be a positive integer");
+  }
+  return numeric;
+}
+
+function asObject(body: unknown): Record<string, unknown> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new BrokerError("invalid_request", "request body must be a JSON object");
+  }
+  return body as Record<string, unknown>;
+}
+
+function appendStateParam(installBaseUrl: string, state: string): string {
+  const url = new URL(installBaseUrl);
+  url.searchParams.set("state", state);
+  return url.toString();
+}
+
+function hashKey(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function connectReturnPage(): string {
+  return [
+    "<!doctype html>",
+    "<html lang=\"en\"><head><meta charset=\"utf-8\">",
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+    "<title>NeonDiff connected</title></head>",
+    "<body><main><h1>GitHub connected</h1>",
+    "<p>You can return to the NeonDiff app. It will finish connecting automatically.</p>",
+    "</main></body></html>"
+  ].join("");
+}

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -14,6 +14,22 @@ import { GitHubBrokerStore } from "./store.js";
 const STATE_TTL_MS = 10 * 60 * 1_000;
 const MAX_REPOSITORIES_PER_REQUEST = 50;
 
+/**
+ * The server-defined minimal review permission set (matches
+ * docs/github-app-setup.md). Every minted token is clamped to at most these
+ * scopes; the broker never trusts the device to widen them, and never omits the
+ * `permissions` field (an omitted field makes GitHub grant ALL App permissions).
+ */
+export const MINIMAL_REVIEW_PERMISSIONS: Record<string, string> = {
+  actions: "read",
+  checks: "read",
+  contents: "read",
+  metadata: "read",
+  pull_requests: "write"
+};
+
+const PERMISSION_SCOPE_RANK: Record<string, number> = { read: 1, write: 2, admin: 3 };
+
 export interface GitHubBrokerServiceOptions {
   store: GitHubBrokerStore;
   githubClient: GitHubInstallationClient;
@@ -129,6 +145,11 @@ export class GitHubBrokerService {
       throw new BrokerError("state_not_found", "connect state is not recognized");
     }
     if (!stored.consumed_at || stored.installation_id === null) {
+      // A poll after the TTL is unrecoverable — surface the typed expiry so the
+      // client restarts the connect flow instead of polling a dead state forever.
+      if (Date.parse(stored.expires_at) <= at.getTime()) {
+        throw new BrokerError("state_expired", "connect state has expired");
+      }
       return { status: "pending" };
     }
     const binding = this.store.getBinding(deviceId, stored.installation_id);
@@ -173,14 +194,20 @@ export class GitHubBrokerService {
         throw new BrokerError(decision.reason, "token issuance is not authorized for the requested repositories");
       }
 
-      const minted = await this.mintToken(installationId, decision.repositories, permissions);
+      // Narrow to canonical repository ids (GitHub rejects owner/name here) and to
+      // a server-clamped permission set (never the device-supplied one verbatim).
+      const idByName = new Map(requested.map((repository) => [repository.fullName, repository.id]));
+      const repositoryIds = decision.repositories.map((fullName) => idByName.get(fullName) as number);
+      const effectivePermissions = permissions ?? { ...MINIMAL_REVIEW_PERMISSIONS };
+
+      const minted = await this.mintToken(installationId, repositoryIds, effectivePermissions);
       this.store.appendDecision(deviceId, installationId, "allow", "issued", at.toISOString());
       return {
         status: "issued",
         token: minted.token,
         expiresAt: minted.expires_at,
         repositories: decision.repositories,
-        ...(permissions ? { permissions } : {})
+        permissions: effectivePermissions
       };
     } catch (error) {
       if (error instanceof BrokerError) {
@@ -223,19 +250,19 @@ export class GitHubBrokerService {
     return repositories.map((fullName) => {
       const match = byName.get(fullName);
       if (!match) throw new BrokerError("repo_outside_installation", "a requested repository is not in the installation selection");
-      return { fullName, visibility: match.visibility };
+      return { fullName, id: match.id, visibility: match.visibility };
     });
   }
 
   private async mintToken(
     installationId: number,
-    repositories: string[],
-    permissions: Record<string, string> | undefined
+    repositoryIds: number[],
+    permissions: Record<string, string>
   ): Promise<{ token: string; expires_at: string }> {
     try {
       return await this.githubClient.createInstallationAccessToken(installationId, {
-        repositories,
-        ...(permissions ? { permissions } : {})
+        repositoryIds,
+        permissions
       });
     } catch (error) {
       throw mapClientError(error);
@@ -295,6 +322,12 @@ function parsePermissions(value: unknown): Record<string, string> | undefined {
   for (const [key, scope] of Object.entries(value)) {
     if (!/^[a-z_]{1,40}$/.test(key) || typeof scope !== "string" || !/^(read|write|admin)$/.test(scope)) {
       throw new BrokerError("invalid_request", "permissions must map scope names to read/write/admin");
+    }
+    // Clamp to the server allowlist: a device may only request a subset of the
+    // minimal review permissions, never a wider scope or an off-list permission.
+    const allowed = MINIMAL_REVIEW_PERMISSIONS[key];
+    if (allowed === undefined || PERMISSION_SCOPE_RANK[scope] > PERMISSION_SCOPE_RANK[allowed]) {
+      throw new BrokerError("invalid_request", "permissions exceed the minimal review allowlist");
     }
     permissions[key] = scope;
   }

--- a/services/license-api/src/github-broker/store.ts
+++ b/services/license-api/src/github-broker/store.ts
@@ -1,0 +1,219 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+/**
+ * Persistence for the GitHub App broker. Mirrors the LicenseStore patterns
+ * (DatabaseSync, `pragma foreign_keys`, user_version migration guard, prepared
+ * statements, row mapping) but lives in its OWN database so the license store's
+ * strict schema verification is unaffected and the two schemas evolve
+ * independently (see docs/security/github-app-broker.md, "Architecture").
+ *
+ * Retention (public-safe by construction): device public keys, one-shot connect
+ * states, installation bindings, and an append-only decision ledger. No tokens,
+ * private keys, source, or diffs are ever stored.
+ */
+const SCHEMA_VERSION = 1;
+const DEFAULT_BUSY_TIMEOUT_MS = 250;
+
+const SCHEMA = `
+  create table devices (
+    device_id text primary key,
+    public_jwk text not null,
+    created_at text not null,
+    last_seen_at text not null
+  );
+
+  create table connect_states (
+    state text primary key,
+    device_id text not null,
+    installation_id integer,
+    created_at text not null,
+    expires_at text not null,
+    consumed_at text,
+    foreign key (device_id) references devices(device_id)
+  );
+
+  create table installation_bindings (
+    device_id text not null,
+    installation_id integer not null,
+    account_login text,
+    created_at text not null,
+    primary key (device_id, installation_id),
+    foreign key (device_id) references devices(device_id)
+  );
+
+  create table decision_ledger (
+    id integer primary key autoincrement,
+    device_id text not null,
+    installation_id integer,
+    decision text not null,
+    reason_code text not null,
+    created_at text not null
+  );
+`;
+
+export interface DeviceRow {
+  device_id: string;
+  public_jwk: string;
+  created_at: string;
+  last_seen_at: string;
+}
+
+export interface ConnectStateRow {
+  state: string;
+  device_id: string;
+  installation_id: number | null;
+  created_at: string;
+  expires_at: string;
+  consumed_at: string | null;
+}
+
+export interface InstallationBindingRow {
+  device_id: string;
+  installation_id: number;
+  account_login: string | null;
+  created_at: string;
+}
+
+export interface DecisionLedgerRow {
+  id: number;
+  device_id: string;
+  installation_id: number | null;
+  decision: string;
+  reason_code: string;
+  created_at: string;
+}
+
+export class GitHubBrokerStore {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ":memory:") mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new DatabaseSync(dbPath, { timeout: DEFAULT_BUSY_TIMEOUT_MS });
+    try {
+      this.db.exec("pragma foreign_keys = on");
+      this.ensureSchema();
+    } catch (error) {
+      this.db.close();
+      throw error;
+    }
+  }
+
+  private ensureSchema(): void {
+    const version = this.readUserVersion();
+    if (version === SCHEMA_VERSION) return;
+    if (version !== 0) throw new Error(`unsupported github broker schema version ${version}`);
+    this.db.exec("begin immediate");
+    try {
+      // Re-check under the writer lock in case a peer migrated first.
+      if (this.readUserVersion() === SCHEMA_VERSION) {
+        this.db.exec("commit");
+        return;
+      }
+      this.db.exec(SCHEMA);
+      this.db.exec(`pragma user_version = ${SCHEMA_VERSION}`);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  private readUserVersion(): number {
+    const row = this.db.prepare("pragma user_version").get() as { user_version: number };
+    return Number(row.user_version);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  /** Register or refresh a device public key. Idempotent: the id is the key thumbprint. */
+  upsertDevice(deviceId: string, publicJwk: string, now: string): void {
+    this.db
+      .prepare(
+        `insert into devices (device_id, public_jwk, created_at, last_seen_at)
+         values (?, ?, ?, ?)
+         on conflict (device_id)
+         do update set public_jwk = excluded.public_jwk, last_seen_at = excluded.last_seen_at`
+      )
+      .run(deviceId, publicJwk, now, now);
+  }
+
+  getDevice(deviceId: string): DeviceRow | undefined {
+    return this.db.prepare("select * from devices where device_id = ?").get(deviceId) as DeviceRow | undefined;
+  }
+
+  touchDevice(deviceId: string, now: string): void {
+    this.db.prepare("update devices set last_seen_at = ? where device_id = ?").run(now, deviceId);
+  }
+
+  createConnectState(state: string, deviceId: string, createdAt: string, expiresAt: string): void {
+    this.db
+      .prepare(
+        `insert into connect_states (state, device_id, created_at, expires_at) values (?, ?, ?, ?)`
+      )
+      .run(state, deviceId, createdAt, expiresAt);
+  }
+
+  getConnectState(state: string): ConnectStateRow | undefined {
+    return this.db
+      .prepare("select * from connect_states where state = ?")
+      .get(state) as ConnectStateRow | undefined;
+  }
+
+  /**
+   * Atomically consume a one-shot connect state. Returns true only for the first
+   * caller; a second callback for the same state changes no rows (state_replayed).
+   */
+  consumeConnectState(state: string, installationId: number, consumedAt: string): boolean {
+    const info = this.db
+      .prepare(
+        `update connect_states set consumed_at = ?, installation_id = ?
+         where state = ? and consumed_at is null`
+      )
+      .run(consumedAt, installationId, state);
+    return Number(info.changes) > 0;
+  }
+
+  upsertBinding(deviceId: string, installationId: number, accountLogin: string | undefined, now: string): void {
+    this.db
+      .prepare(
+        `insert into installation_bindings (device_id, installation_id, account_login, created_at)
+         values (?, ?, ?, ?)
+         on conflict (device_id, installation_id)
+         do update set account_login = excluded.account_login`
+      )
+      .run(deviceId, installationId, accountLogin ?? null, now);
+  }
+
+  getBinding(deviceId: string, installationId: number): InstallationBindingRow | undefined {
+    return this.db
+      .prepare("select * from installation_bindings where device_id = ? and installation_id = ?")
+      .get(deviceId, installationId) as InstallationBindingRow | undefined;
+  }
+
+  /** Append a public-safe decision row. Never carries repo content or key material. */
+  appendDecision(
+    deviceId: string,
+    installationId: number | null,
+    decision: "allow" | "deny",
+    reasonCode: string,
+    now: string
+  ): void {
+    this.db
+      .prepare(
+        `insert into decision_ledger (device_id, installation_id, decision, reason_code, created_at)
+         values (?, ?, ?, ?, ?)`
+      )
+      .run(deviceId, installationId, decision, reasonCode, now);
+  }
+
+  listDecisions(deviceId?: string): DecisionLedgerRow[] {
+    const rows = deviceId
+      ? this.db.prepare("select * from decision_ledger where device_id = ? order by id asc").all(deviceId)
+      : this.db.prepare("select * from decision_ledger order by id asc").all();
+    return rows as unknown as DecisionLedgerRow[];
+  }
+}

--- a/services/license-api/src/github-broker/url.ts
+++ b/services/license-api/src/github-broker/url.ts
@@ -1,0 +1,37 @@
+/**
+ * Minimal API-base and path joining for the production GitHub client. license-api
+ * is its own package, so it keeps a small local helper rather than importing the
+ * root package's url-safety module. Enforces https and rejects path traversal.
+ */
+export function normalizeHttpApiBaseUrl(
+  value: string | undefined,
+  settingName: string,
+  fallback: string
+): URL {
+  const raw = value?.trim() ? value.trim() : fallback;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${settingName} must be a valid absolute URL`);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`${settingName} must use https`);
+  }
+  return url;
+}
+
+export function buildApiUrl(base: URL, path: string, context: string): URL {
+  if (!path.startsWith("/")) {
+    throw new Error(`${context} must start with '/'`);
+  }
+  if (path.includes("..")) {
+    throw new Error(`${context} must not contain path traversal`);
+  }
+  const trimmedBase = base.pathname.replace(/\/$/, "");
+  const url = new URL(base);
+  const [pathname, search] = path.split("?");
+  url.pathname = `${trimmedBase}${pathname}`;
+  url.search = search ? `?${search}` : "";
+  return url;
+}

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -36,6 +36,12 @@ import {
   SubscriptionLifecycleTransientError,
   SubscriptionLifecycleUnsupportedCommandError
 } from "./store.js";
+import {
+  createGitHubBrokerService,
+  handleGitHubBrokerRequest,
+  isGitHubBrokerPath,
+  type GitHubBrokerDeps
+} from "./github-broker/index.js";
 
 const MAX_BODY_BYTES = 16 * 1024;
 
@@ -52,6 +58,8 @@ export interface LicenseHttpOptions {
   trustFlyProxyHeaders?: boolean;
   /** Injectable clock for deterministic tests. */
   now?: () => Date;
+  /** Managed GitHub App authorization broker (#613). Omitted → broker routes 503. */
+  githubBroker?: GitHubBrokerDeps;
 }
 
 type Handler = (store: LicenseStore, req: LicenseRequest, now: Date) => ServiceResult;
@@ -76,12 +84,22 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
   const subscriptionLifecycleRateLimiter =
     options.subscriptionLifecycleRateLimiter ??
     new RateLimiter({ maxPerWindow: 60, windowMs: 60_000 });
+  // Build the broker service once (it owns a persistent store), mirroring the
+  // license store's per-listener lifecycle.
+  const githubBrokerService = options.githubBroker
+    ? createGitHubBrokerService(options.githubBroker)
+    : undefined;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (req.method === "GET" && req.url === "/healthz") {
       return writeJson(res, 200, { status: "ok" });
     }
     const path = req.url?.split("?")[0];
+    if (isGitHubBrokerPath(path)) {
+      if (!githubBrokerService) return writeJson(res, 503, { status: "unavailable" });
+      const sourceAddress = resolveClientAddress(req, options.trustFlyProxyHeaders === true);
+      return handleGitHubBrokerRequest(githubBrokerService, req, res, { sourceAddress });
+    }
     if (req.method === "POST" && path === "/v1/admin/licenses/issue") {
       return handleIssuanceRequest(options, req, res);
     }

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -37,6 +37,7 @@ import {
   SubscriptionLifecycleUnsupportedCommandError
 } from "./store.js";
 import {
+  BrokerError,
   createGitHubBrokerService,
   handleGitHubBrokerRequest,
   isGitHubBrokerPath,
@@ -96,7 +97,13 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
     }
     const path = req.url?.split("?")[0];
     if (isGitHubBrokerPath(path)) {
-      if (!githubBrokerService) return writeJson(res, 503, { status: "unavailable" });
+      if (!githubBrokerService) {
+        // Fail closed with the broker's typed contract so clients (and tests) can
+        // distinguish the expected pre-provisioning offline state from an untyped
+        // failure.
+        const unavailable = new BrokerError("broker_unavailable", "the GitHub broker is not configured");
+        return writeJson(res, unavailable.httpStatus, unavailable.body());
+      }
       const sourceAddress = resolveClientAddress(req, options.trustFlyProxyHeaders === true);
       return handleGitHubBrokerRequest(githubBrokerService, req, res, { sourceAddress });
     }

--- a/services/license-api/test/github-broker-adversarial.test.ts
+++ b/services/license-api/test/github-broker-adversarial.test.ts
@@ -1,0 +1,343 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { RateLimiter } from "../src/service.ts";
+import { GitHubBrokerStore } from "../src/github-broker/index.ts";
+import {
+  bearer,
+  connectInstallation,
+  fakeGitHubClient,
+  makeDevice,
+  post,
+  registerDevice,
+  startBroker,
+  type FakeGitHubCall
+} from "./github-broker-support.ts";
+
+const PUBLIC_INSTALL = {
+  id: 5001,
+  account_login: "octo",
+  repositories: [
+    { id: 21, full_name: "octo/site", visibility: "public" as const },
+    { id: 22, full_name: "octo/private", visibility: "private" as const }
+  ]
+};
+
+/**
+ * A bespoke installation client for scenarios the default fake cannot express
+ * (toggle installed/suspended after connect, throw a client error). Records call
+ * order so the seam ordering invariant can be asserted.
+ */
+function mutableFake(config: {
+  installationId: number;
+  repositories?: Array<{ id: number; full_name: string; visibility: "public" | "private" | "internal" | "unknown" }>;
+  installed?: boolean;
+  suspended?: boolean;
+  listThrows?: { brokerClientErrorClass: string };
+}): { client: Record<string, unknown>; calls: FakeGitHubCall[]; state: { installed: boolean; suspended: boolean } } {
+  const calls: FakeGitHubCall[] = [];
+  const state = { installed: config.installed ?? true, suspended: config.suspended ?? false };
+  const client = {
+    async getInstallation(installationId: number) {
+      calls.push({ op: "getInstallation", installationId });
+      if (!state.installed) return null;
+      return { id: installationId, account_login: "octo", suspended: state.suspended };
+    },
+    async listInstallationRepositories(installationId: number) {
+      calls.push({ op: "listInstallationRepositories", installationId });
+      if (config.listThrows) throw Object.assign(new Error("client error"), config.listThrows);
+      return (config.repositories ?? []).map((repository) => ({ ...repository }));
+    },
+    async createInstallationAccessToken(installationId: number, params: unknown) {
+      calls.push({ op: "createInstallationAccessToken", installationId, params });
+      return { token: "broker-test-mutable-token", expires_at: new Date(Date.now() + 3_600_000).toISOString() };
+    }
+  };
+  return { client, calls, state };
+}
+
+describe("github broker adversarial and lifecycle coverage", () => {
+  it("refuses a token for a suspended installation", async () => {
+    const harness = await startBroker({
+      installations: [{ ...PUBLIC_INSTALL, suspended: true }]
+    });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 409, response.text);
+      assert.equal(response.json.reason, "installation_suspended");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("reports installation_uninstalled when a bound installation disappears", async () => {
+    const fake = mutableFake({ installationId: PUBLIC_INSTALL.id, repositories: PUBLIC_INSTALL.repositories });
+    const harness = await startBroker({ fake: fake as never });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      fake.state.installed = false; // uninstalled between connect and token
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 409, response.text);
+      assert.equal(response.json.reason, "installation_uninstalled");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("throttles token requests past the per-device budget", async () => {
+    const harness = await startBroker({
+      installations: [PUBLIC_INSTALL],
+      tokenRateLimiter: new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 })
+    });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      const first = await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+      const second = await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+      assert.equal(first.status, 200, first.text);
+      assert.equal(second.status, 429, second.text);
+      assert.equal(second.json.reason, "rate_limited");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("maps a renamed or transferred repository to a typed refusal", async () => {
+    const fake = mutableFake({
+      installationId: PUBLIC_INSTALL.id,
+      repositories: PUBLIC_INSTALL.repositories,
+      listThrows: { brokerClientErrorClass: "renamed_or_transferred" }
+    });
+    // The list call must succeed at connect time; only fail at token time.
+    let allowList = true;
+    const original = fake.client.listInstallationRepositories as (id: number) => Promise<unknown>;
+    fake.client.listInstallationRepositories = async (installationId: number) => {
+      if (allowList) return PUBLIC_INSTALL.repositories.map((repository) => ({ ...repository }));
+      return original(installationId);
+    };
+    const harness = await startBroker({ fake: fake as never });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      allowList = false;
+      const response = await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+      assert.equal(response.status, 409, response.text);
+      assert.equal(response.json.reason, "repo_renamed_or_transferred");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("refuses a repository outside the installation selection", async () => {
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      const response = await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/not-selected"] }, bearer(await device.sign()));
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "repo_outside_installation");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("refuses a token for an installation the device never connected", async () => {
+    const harness = await startBroker({
+      installations: [PUBLIC_INSTALL, { id: 5002, account_login: "other", repositories: [] }]
+    });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      const response = await post(harness.url, "/github/token", { installationId: 5002, repositories: ["octo/site"] }, bearer(await device.sign()));
+      assert.equal(response.status, 404, response.text);
+      assert.equal(response.json.reason, "binding_not_found");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("renews a token on repeated requests before expiry", async () => {
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      const first = await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+      const renewed = await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+      assert.equal(first.status, 200, first.text);
+      assert.equal(renewed.status, 200, renewed.text);
+      assert.equal(renewed.json.token, harness.mintedToken);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("rejects a callback with an unknown state", async () => {
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL] });
+    try {
+      const response = await fetch(
+        `${harness.url}/github/connect/callback?installation_id=${PUBLIC_INSTALL.id}&state=never-issued`,
+        { redirect: "manual" }
+      );
+      const text = await response.text();
+      assert.equal(response.status, 404, text);
+      assert.equal(JSON.parse(text).reason, "state_not_found");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("expires a connect state after its 10-minute window", async () => {
+    let clockMs = Date.parse("2026-07-15T00:00:00.000Z");
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL], clock: () => new Date(clockMs) });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await device.sign({ now: new Date(clockMs) })));
+      const state = start.json.state as string;
+      clockMs += 11 * 60 * 1_000; // advance past the 10-minute TTL
+      const callback = await fetch(
+        `${harness.url}/github/connect/callback?installation_id=${PUBLIC_INSTALL.id}&state=${encodeURIComponent(state)}`,
+        { redirect: "manual" }
+      );
+      const text = await callback.text();
+      assert.equal(callback.status, 409, text);
+      assert.equal(JSON.parse(text).reason, "state_expired");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("moves connect/complete from pending to bound across the callback", async () => {
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await device.sign()));
+      const state = start.json.state as string;
+
+      const pending = await post(harness.url, "/github/connect/complete", { state }, bearer(await device.sign()));
+      assert.equal(pending.json.status, "pending");
+
+      await fetch(`${harness.url}/github/connect/callback?installation_id=${PUBLIC_INSTALL.id}&state=${encodeURIComponent(state)}`, { redirect: "manual" });
+
+      const bound = await post(harness.url, "/github/connect/complete", { state }, bearer(await device.sign()));
+      assert.equal(bound.status, 200, bound.text);
+      assert.equal(bound.json.status, "bound");
+      assert.equal(bound.json.installationId, PUBLIC_INSTALL.id);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("rejects a device credential signed by the wrong key", async () => {
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL] });
+    try {
+      const registered = await makeDevice();
+      const attacker = await makeDevice();
+      await registerDevice(harness.url, registered);
+      // Attacker signs with its own key but claims the registered device's id.
+      const forged = await attacker.sign({ subject: registered.deviceId });
+      const response = await post(harness.url, "/github/connect/start", {}, bearer(forged));
+      assert.equal(response.status, 401, response.text);
+      assert.equal(response.json.reason, "invalid_device_credential");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("rejects an expired device credential", async () => {
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const stale = await device.sign({ now: new Date(Date.parse("2026-07-14T00:00:00.000Z")), expSeconds: 60 });
+      const response = await post(harness.url, "/github/connect/start", {}, bearer(stale));
+      assert.equal(response.status, 401, response.text);
+      assert.equal(response.json.reason, "invalid_device_credential");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("never mints a token before the issuance seam authorizes (call-order invariant)", async () => {
+    const denyFake = fakeGitHubClient([PUBLIC_INSTALL]);
+    const denyHarness = await startBroker({ fake: denyFake });
+    try {
+      const device = await makeDevice();
+      await registerDevice(denyHarness.url, device);
+      await connectInstallation(denyHarness.url, device, PUBLIC_INSTALL.id);
+      const deny = await post(denyHarness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/private"] }, bearer(await device.sign()));
+      assert.equal(deny.json.reason, "entitlement_gate_not_implemented");
+      // A denied request must never reach the mint call.
+      assert.equal(denyFake.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+    } finally {
+      denyHarness.close();
+    }
+
+    const allowFake = fakeGitHubClient([PUBLIC_INSTALL]);
+    const allowHarness = await startBroker({ fake: allowFake });
+    try {
+      const device = await makeDevice();
+      await registerDevice(allowHarness.url, device);
+      await connectInstallation(allowHarness.url, device, PUBLIC_INSTALL.id);
+      allowFake.calls.length = 0; // isolate the issuance sequence
+      const allow = await post(allowHarness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+      assert.equal(allow.status, 200, allow.text);
+      const listIndex = allowFake.calls.findIndex((call) => call.op === "listInstallationRepositories");
+      const mintIndex = allowFake.calls.findIndex((call) => call.op === "createInstallationAccessToken");
+      assert.ok(listIndex >= 0, "visibility list read happened");
+      assert.ok(mintIndex >= 0, "token minted");
+      assert.ok(mintIndex > listIndex, "mint happens only after the seam consumed the visibility list");
+    } finally {
+      allowHarness.close();
+    }
+  });
+
+  it("records public-safe ledger rows for deny and allow, with no token material", async () => {
+    const store = new GitHubBrokerStore(":memory:");
+    const harness = await startBroker({ installations: [PUBLIC_INSTALL], store });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, PUBLIC_INSTALL.id);
+      await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/private"] }, bearer(await device.sign()));
+      await post(harness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/site"] }, bearer(await device.sign()));
+
+      const rows = store.listDecisions(device.deviceId);
+      const reasons = rows.map((row) => `${row.decision}:${row.reason_code}`);
+      assert.ok(reasons.includes("deny:entitlement_gate_not_implemented"), JSON.stringify(reasons));
+      assert.ok(reasons.includes("allow:issued"), JSON.stringify(reasons));
+      const serialized = JSON.stringify(rows);
+      assert.ok(!serialized.includes(harness.mintedToken), "no minted token in the ledger");
+      assert.doesNotMatch(serialized, /-----BEGIN/); // no key material
+      for (const row of rows) {
+        assert.deepEqual(
+          Object.keys(row).sort(),
+          ["created_at", "decision", "device_id", "id", "installation_id", "reason_code"]
+        );
+      }
+    } finally {
+      harness.close();
+      store.close();
+    }
+  });
+});

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, describe, it } from "node:test";
+import { createGitHubInstallationClient } from "../src/github-broker/index.ts";
+
+/**
+ * Wire-contract test for the PRODUCTION GitHub client. It proves the two live
+ * invariants the fake cannot: (1) listing an installation's repositories mints a
+ * metadata-read-only token — never a broad all-permissions token before the
+ * issuance seam decides; (2) the returned token is minted with `repository_ids`
+ * and a permissions object (never `owner/name` full names). `fetch` is stubbed;
+ * no network call runs.
+ */
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const appPrivateKey = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function stubFetch(handler: (request: CapturedRequest) => { status?: number; json: unknown }): CapturedRequest[] {
+  const captured: CapturedRequest[] = [];
+  globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+    const request: CapturedRequest = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(String(init.body)) : undefined
+    };
+    captured.push(request);
+    const { status = 200, json } = handler(request);
+    return new Response(JSON.stringify(json), { status, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+  return captured;
+}
+
+describe("production github installation client wire contract", () => {
+  it("lists installation repositories using a metadata-read-only token", async () => {
+    const captured = stubFetch((request) => {
+      if (request.url.includes("/access_tokens")) return { json: { token: "t", expires_at: new Date().toISOString() } };
+      return { json: { repositories: [{ id: 71, full_name: "octo/site", visibility: "public" }] } };
+    });
+    const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
+    const repositories = await client.listInstallationRepositories(6001);
+    assert.deepEqual(repositories, [{ id: 71, full_name: "octo/site", visibility: "public" }]);
+    const tokenMint = captured.find((request) => request.url.includes("/access_tokens"));
+    // The listing token is scoped to metadata:read only — not a broad token.
+    assert.deepEqual(tokenMint?.body, { permissions: { metadata: "read" } });
+  });
+
+  it("mints the returned token with repository_ids and a permissions object", async () => {
+    const captured = stubFetch(() => ({ json: { token: "t", expires_at: new Date().toISOString() } }));
+    const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
+    await client.createInstallationAccessToken(6001, {
+      repositoryIds: [71, 72],
+      permissions: { contents: "read", pull_requests: "write" }
+    });
+    const mint = captured.find((request) => request.url.includes("/access_tokens"));
+    assert.equal(mint?.method, "POST");
+    assert.deepEqual(mint?.body, {
+      repository_ids: [71, 72],
+      permissions: { contents: "read", pull_requests: "write" }
+    });
+  });
+});

--- a/services/license-api/test/github-broker-contract.test.ts
+++ b/services/license-api/test/github-broker-contract.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import {
+  bearer,
+  connectInstallation,
+  makeDevice,
+  post,
+  registerDevice,
+  startBroker,
+  type BrokerHarness,
+  type TestDevice
+} from "./github-broker-support.ts";
+
+/**
+ * Contract tests for the token-issuance boundary (#613). These assert the
+ * broker's fail-closed refusals and that no App key or JWT material ever leaves
+ * the service. Red before the broker exists (routes 404); green once wired.
+ */
+describe("github broker token-issuance contract", () => {
+  let harness: BrokerHarness;
+  let device: TestDevice;
+
+  before(async () => {
+    device = await makeDevice();
+    harness = await startBroker({
+      installations: [
+        {
+          id: 4001,
+          account_login: "octo-public",
+          repositories: [
+            { id: 11, full_name: "octo-public/site", visibility: "public" },
+            { id: 12, full_name: "octo-public/secret", visibility: "private" }
+          ]
+        }
+      ]
+    });
+    await registerDevice(harness.url, device);
+  });
+
+  after(() => harness.close());
+
+  it("(a) refuses a token for an unbound (device, installation) with a typed refusal", async () => {
+    const response = await post(
+      harness.url,
+      "/github/token",
+      { installationId: 4001, repositories: ["octo-public/site"] },
+      bearer(await device.sign())
+    );
+    assert.equal(response.status, 404);
+    assert.equal(response.json.reason, "binding_not_found");
+  });
+
+  it("(b) mints a bounded token for a public repo and leaks no key or JWT material", async () => {
+    const fresh = await makeDevice();
+    await registerDevice(harness.url, fresh);
+    await connectInstallation(harness.url, fresh, 4001);
+
+    const response = await post(
+      harness.url,
+      "/github/token",
+      { installationId: 4001, repositories: ["octo-public/site"] },
+      bearer(await fresh.sign())
+    );
+    assert.equal(response.status, 200, response.text);
+    assert.equal(response.json.token, harness.mintedToken);
+    assert.ok(response.json.expiresAt, "expiry is returned");
+
+    // No App private key PEM and no JWT (three dot-separated base64url segments)
+    // may appear anywhere in the response body.
+    assert.doesNotMatch(response.text, /-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+    assert.doesNotMatch(response.text, /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
+  });
+
+  it("(c) refuses issuance for a private repo with entitlement_gate_not_implemented", async () => {
+    const fresh = await makeDevice();
+    await registerDevice(harness.url, fresh);
+    await connectInstallation(harness.url, fresh, 4001);
+
+    const response = await post(
+      harness.url,
+      "/github/token",
+      { installationId: 4001, repositories: ["octo-public/secret"] },
+      bearer(await fresh.sign())
+    );
+    assert.equal(response.status, 403);
+    assert.equal(response.json.reason, "entitlement_gate_not_implemented");
+    // Fail closed: no token minted for the denied request.
+    assert.equal(response.json.token, undefined);
+  });
+
+  it("(d) rejects a replayed connect-state nonce with state_replayed", async () => {
+    const fresh = await makeDevice();
+    await registerDevice(harness.url, fresh);
+    const start = await post(harness.url, "/github/connect/start", {}, bearer(await fresh.sign()));
+    const state = start.json.state as string;
+    assert.ok(state, "connect start returns a state nonce");
+
+    const first = await fetch(
+      `${harness.url}/github/connect/callback?installation_id=4001&state=${encodeURIComponent(state)}`,
+      { redirect: "manual" }
+    );
+    assert.ok(first.status < 400 || first.status === 302, `first callback consumed: ${first.status}`);
+
+    const replay = await fetch(
+      `${harness.url}/github/connect/callback?installation_id=4001&state=${encodeURIComponent(state)}`,
+      { redirect: "manual" }
+    );
+    const replayText = await replay.text();
+    assert.equal(replay.status, 409, replayText);
+    assert.equal(JSON.parse(replayText).reason, "state_replayed");
+  });
+});

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -91,7 +91,8 @@ export function fakeGitHubClient(
   mintedToken: string;
 } {
   const calls: FakeGitHubCall[] = [];
-  const mintedToken = overrides.mintedToken ?? "ghs_fake_installation_token_value";
+  // A non-GitHub-shaped sentinel so the secret scanner does not flag test source.
+  const mintedToken = overrides.mintedToken ?? "broker-test-installation-token-value";
   const byId = new Map(installations.map((installation) => [installation.id, installation]));
   const client = {
     async getInstallation(installationId: number) {
@@ -138,7 +139,11 @@ export async function startBroker(
   options: {
     installations?: FakeInstallation[];
     now?: Date;
+    /** Mutable clock override for expiry/renewal tests; wins over `now`. */
+    clock?: () => Date;
     fake?: ReturnType<typeof fakeGitHubClient>;
+    /** A pre-built broker store so a test can inspect the decision ledger. */
+    store?: unknown;
     deviceRegisterRateLimiter?: RateLimiter;
     tokenRateLimiter?: RateLimiter;
     connectRateLimiter?: RateLimiter;
@@ -146,17 +151,17 @@ export async function startBroker(
 ): Promise<BrokerHarness> {
   const licenseStore = new LicenseStore(":memory:");
   const fake = options.fake ?? fakeGitHubClient(options.installations ?? []);
-  const now = options.now ?? FIXED_NOW;
+  const nowFn = options.clock ?? (() => options.now ?? FIXED_NOW);
   const started = await startLicenseServer({
     store: licenseStore,
-    now: () => now,
-    // The broker deps are ignored until http.ts wires them (commit 3). Passing a
-    // db path (not a store instance) keeps this harness free of broker imports.
+    now: nowFn,
+    // Passing a db path (not a store instance) keeps this harness free of broker
+    // imports; a test may instead pass its own `store` to read the ledger.
     githubBroker: {
-      dbPath: ":memory:",
+      ...(options.store ? { store: options.store } : { dbPath: ":memory:" }),
       githubClient: fake.client,
       installBaseUrl: INSTALL_BASE_URL,
-      now: () => now,
+      now: nowFn,
       deviceRegisterRateLimiter: options.deviceRegisterRateLimiter,
       tokenRateLimiter: options.tokenRateLimiter,
       connectRateLimiter: options.connectRateLimiter

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -1,0 +1,222 @@
+import type { Server } from "node:http";
+import {
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+  SignJWT,
+  type JWK,
+  type KeyLike
+} from "jose";
+import { LicenseStore } from "../src/store.ts";
+import { startLicenseServer } from "../src/http.ts";
+import { RateLimiter } from "../src/service.ts";
+
+/**
+ * Shared harness for the GitHub App broker tests. It intentionally imports only
+ * stable, already-shipped modules plus `jose`, so it loads unchanged before the
+ * broker exists (contract tests are red for the right reason: routes 404) and
+ * after it exists (routes wired, same harness). The broker store is constructed
+ * server-side from `githubBroker.dbPath`; tests never import broker internals.
+ */
+
+export const INSTALL_BASE_URL = "https://github.com/apps/neondiff-staging/installations/new";
+export const FIXED_NOW = new Date("2026-07-15T00:00:00.000Z");
+
+/** A device identity mirroring the client: keypair + RFC 7638 thumbprint id. */
+export interface TestDevice {
+  deviceId: string;
+  publicJwk: JWK;
+  privateKey: KeyLike;
+  /** A short-lived device-signed JWT (`sub` = deviceId) for the Authorization header. */
+  sign(options?: { expSeconds?: number; subject?: string; now?: Date }): Promise<string>;
+}
+
+export async function makeDevice(): Promise<TestDevice> {
+  const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const publicJwk = await exportJWK(publicKey);
+  const deviceId = await calculateJwkThumbprint(publicJwk, "sha256");
+  return {
+    deviceId,
+    publicJwk,
+    privateKey,
+    async sign(options = {}): Promise<string> {
+      const nowMs = (options.now ?? FIXED_NOW).getTime();
+      const iat = Math.floor(nowMs / 1000);
+      const exp = iat + (options.expSeconds ?? 120);
+      return new SignJWT({})
+        .setProtectedHeader({ alg: "ES256" })
+        .setSubject(options.subject ?? deviceId)
+        .setIssuedAt(iat)
+        .setExpirationTime(exp)
+        .sign(privateKey);
+    }
+  };
+}
+
+export interface FakeRepository {
+  id: number;
+  full_name: string;
+  visibility: "public" | "private" | "internal" | "unknown";
+}
+
+export interface FakeInstallation {
+  id: number;
+  account_login?: string;
+  suspended?: boolean;
+  /** null models an uninstalled/missing installation (GitHub 404). */
+  missing?: boolean;
+  repositories: FakeRepository[];
+}
+
+export interface FakeGitHubCall {
+  op: "getInstallation" | "listInstallationRepositories" | "createInstallationAccessToken";
+  installationId: number;
+  params?: unknown;
+}
+
+/**
+ * An in-memory GitHub installation client. Records call order (`calls`) so tests
+ * can prove no token is minted before the issuance seam decision. Never touches
+ * the network. `mintedToken` is the sentinel returned by a successful mint.
+ */
+export function fakeGitHubClient(
+  installations: FakeInstallation[],
+  overrides: {
+    mintedToken?: string;
+    onCreateToken?: () => never | void;
+  } = {}
+): {
+  client: Record<string, unknown>;
+  calls: FakeGitHubCall[];
+  mintedToken: string;
+} {
+  const calls: FakeGitHubCall[] = [];
+  const mintedToken = overrides.mintedToken ?? "ghs_fake_installation_token_value";
+  const byId = new Map(installations.map((installation) => [installation.id, installation]));
+  const client = {
+    async getInstallation(installationId: number) {
+      calls.push({ op: "getInstallation", installationId });
+      const installation = byId.get(installationId);
+      if (!installation || installation.missing) return null;
+      return {
+        id: installation.id,
+        account_login: installation.account_login,
+        suspended: installation.suspended === true
+      };
+    },
+    async listInstallationRepositories(installationId: number) {
+      calls.push({ op: "listInstallationRepositories", installationId });
+      const installation = byId.get(installationId);
+      if (!installation || installation.missing) return [];
+      return installation.repositories.map((repository) => ({ ...repository }));
+    },
+    async createInstallationAccessToken(
+      installationId: number,
+      params: { repositories?: string[]; permissions?: Record<string, string> }
+    ) {
+      calls.push({ op: "createInstallationAccessToken", installationId, params });
+      if (overrides.onCreateToken) overrides.onCreateToken();
+      return {
+        token: mintedToken,
+        expires_at: new Date((overrides.mintedToken ? Date.now() : FIXED_NOW.getTime()) + 3_600_000).toISOString()
+      };
+    }
+  };
+  return { client, calls, mintedToken };
+}
+
+export interface BrokerHarness {
+  url: string;
+  server: Server;
+  licenseStore: LicenseStore;
+  calls: FakeGitHubCall[];
+  mintedToken: string;
+  close(): void;
+}
+
+export async function startBroker(
+  options: {
+    installations?: FakeInstallation[];
+    now?: Date;
+    fake?: ReturnType<typeof fakeGitHubClient>;
+    deviceRegisterRateLimiter?: RateLimiter;
+    tokenRateLimiter?: RateLimiter;
+    connectRateLimiter?: RateLimiter;
+  } = {}
+): Promise<BrokerHarness> {
+  const licenseStore = new LicenseStore(":memory:");
+  const fake = options.fake ?? fakeGitHubClient(options.installations ?? []);
+  const now = options.now ?? FIXED_NOW;
+  const started = await startLicenseServer({
+    store: licenseStore,
+    now: () => now,
+    // The broker deps are ignored until http.ts wires them (commit 3). Passing a
+    // db path (not a store instance) keeps this harness free of broker imports.
+    githubBroker: {
+      dbPath: ":memory:",
+      githubClient: fake.client,
+      installBaseUrl: INSTALL_BASE_URL,
+      now: () => now,
+      deviceRegisterRateLimiter: options.deviceRegisterRateLimiter,
+      tokenRateLimiter: options.tokenRateLimiter,
+      connectRateLimiter: options.connectRateLimiter
+    }
+  } as never);
+  return {
+    url: started.url,
+    server: started.server,
+    licenseStore,
+    calls: fake.calls,
+    mintedToken: fake.mintedToken,
+    close(): void {
+      started.server.close();
+      licenseStore.close();
+    }
+  };
+}
+
+export async function post(
+  url: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; json: any; text: string }> {
+  const res = await fetch(`${url}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body)
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : {}, text };
+}
+
+export function bearer(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
+/** Register a device and return its authorization header helper. */
+export async function registerDevice(
+  url: string,
+  device: TestDevice
+): Promise<{ status: number; json: any }> {
+  return post(url, "/device/register", { publicKeyJwk: device.publicJwk });
+}
+
+/**
+ * Drive connect start -> callback -> complete for a device and installation,
+ * returning the state used. Assumes the broker is wired (used by GREEN tests).
+ */
+export async function connectInstallation(
+  url: string,
+  device: TestDevice,
+  installationId: number
+): Promise<{ state: string; callbackStatus: number; completeStatus: number }> {
+  const start = await post(url, "/github/connect/start", {}, bearer(await device.sign()));
+  const state = start.json.state as string;
+  const callback = await fetch(
+    `${url}/github/connect/callback?installation_id=${installationId}&state=${encodeURIComponent(state)}`,
+    { redirect: "manual" }
+  );
+  const complete = await post(url, "/github/connect/complete", { state }, bearer(await device.sign()));
+  return { state, callbackStatus: callback.status, completeStatus: complete.status };
+}

--- a/services/license-api/test/github-broker-wire.test.ts
+++ b/services/license-api/test/github-broker-wire.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+import { describe, it } from "node:test";
+import { LicenseStore } from "../src/store.ts";
+import { startLicenseServer } from "../src/http.ts";
+import { MINIMAL_REVIEW_PERMISSIONS } from "../src/github-broker/index.ts";
+import {
+  bearer,
+  connectInstallation,
+  makeDevice,
+  post,
+  registerDevice,
+  startBroker
+} from "./github-broker-support.ts";
+
+const INSTALL = {
+  id: 6001,
+  account_login: "octo",
+  repositories: [
+    { id: 71, full_name: "octo/site", visibility: "public" as const },
+    { id: 72, full_name: "octo/docs", visibility: "public" as const }
+  ]
+};
+
+async function issue(url: string, device: Awaited<ReturnType<typeof makeDevice>>, body: Record<string, unknown>) {
+  return post(url, "/github/token", { installationId: INSTALL.id, ...body }, bearer(await device.sign()));
+}
+
+describe("github broker token wire contract", () => {
+  it("mints with repository_ids, not owner/name full names", async () => {
+    const harness = await startBroker({ installations: [INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL.id);
+      const response = await issue(harness.url, device, { repositories: ["octo/site", "octo/docs"] });
+      assert.equal(response.status, 200, response.text);
+      const mint = harness.calls.find((call) => call.op === "createInstallationAccessToken");
+      const params = mint?.params as { repositoryIds?: number[]; repositories?: unknown };
+      assert.deepEqual(params.repositoryIds, [71, 72]);
+      assert.equal(params.repositories, undefined, "wire uses repository_ids, never full names");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("mints with the server-defined minimal review permissions when the device omits them", async () => {
+    const harness = await startBroker({ installations: [INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL.id);
+      const response = await issue(harness.url, device, { repositories: ["octo/site"] });
+      assert.equal(response.status, 200, response.text);
+      const mint = harness.calls.find((call) => call.op === "createInstallationAccessToken");
+      const params = mint?.params as { permissions?: Record<string, string> };
+      assert.deepEqual(params.permissions, MINIMAL_REVIEW_PERMISSIONS);
+      assert.deepEqual(response.json.permissions, MINIMAL_REVIEW_PERMISSIONS);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("allows a subset of the minimal permissions", async () => {
+    const harness = await startBroker({ installations: [INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL.id);
+      const response = await issue(harness.url, device, {
+        repositories: ["octo/site"],
+        permissions: { contents: "read", pull_requests: "read" }
+      });
+      assert.equal(response.status, 200, response.text);
+      const mint = harness.calls.find((call) => call.op === "createInstallationAccessToken");
+      assert.deepEqual((mint?.params as { permissions?: Record<string, string> }).permissions, {
+        contents: "read",
+        pull_requests: "read"
+      });
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("refuses a permission outside the minimal review allowlist", async () => {
+    const harness = await startBroker({ installations: [INSTALL] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL.id);
+      const overScope = await issue(harness.url, device, {
+        repositories: ["octo/site"],
+        permissions: { contents: "write" }
+      });
+      assert.equal(overScope.status, 400, overScope.text);
+      assert.equal(overScope.json.reason, "invalid_request");
+      const unknown = await issue(harness.url, device, {
+        repositories: ["octo/site"],
+        permissions: { administration: "read" }
+      });
+      assert.equal(unknown.status, 400, unknown.text);
+      assert.equal(unknown.json.reason, "invalid_request");
+      // Fail closed: neither over-privileged request minted a token.
+      assert.equal(harness.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("expires a stale connect poll instead of pending forever", async () => {
+    let clockMs = Date.parse("2026-07-15T00:00:00.000Z");
+    const harness = await startBroker({ installations: [INSTALL], clock: () => new Date(clockMs) });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await device.sign({ now: new Date(clockMs) })));
+      const state = start.json.state as string;
+      clockMs += 11 * 60 * 1_000; // past the 10-minute TTL, callback never consumed
+      const complete = await post(
+        harness.url,
+        "/github/connect/complete",
+        { state },
+        bearer(await device.sign({ now: new Date(clockMs) }))
+      );
+      assert.equal(complete.status, 409, complete.text);
+      assert.equal(complete.json.reason, "state_expired");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("returns a typed broker_unavailable when the broker is not configured", async () => {
+    const store = new LicenseStore(":memory:");
+    let server: Server | undefined;
+    try {
+      const started = await startLicenseServer({ store });
+      server = started.server;
+      const response = await post(started.url, "/github/token", { installationId: 1, repositories: ["octo/site"] });
+      assert.equal(response.status, 503, response.text);
+      assert.equal(response.json.reason, "broker_unavailable");
+    } finally {
+      server?.close();
+      store.close();
+    }
+  });
+});


### PR DESCRIPTION
Server-side slice of #613 (parent #610): a managed GitHub App authorization broker inside `services/license-api`, so the everyday-user v1 path is click-Connect → GitHub's own install/authorize UI → return to the app — no user-created App, PEM, App ID, or config edits. The only thing that moves server-side is custody of the App private key and the minting of bounded, short-lived installation tokens; review execution stays local (the daemon keeps polling).

## Scope
- **In (this slice):** broker module (`services/license-api/src/github-broker/`), contract + adversarial/lifecycle + redaction tests, the committed threat-model/data-flow doc, and the staging App registration spec.
- **Out (later slices / other issues):** all native app connect UI states (after #611/#612), #614's entitlement matrix (only its **seam** is built here), any deployment/Fly mutation, webhooks, and production GitHub App registration or credentials (owner-gated).

## Endpoints
`POST /device/register` (anonymous, rate-limited) · `POST /github/connect/start` (device-signed) · `GET /github/connect/callback` (one-shot state, ≤10 min) · `POST /github/connect/complete` (device poll) · `POST /github/token` (liveness + narrowing + seam + ledger). Broker routes return 503 until the owner provisions the App (broker is intentionally not yet wired into `server.ts`).

## Pre-#614 fail-closed posture (explicit)
Token issuance succeeds **only when every requested repository is verified public** via the installation repository list. Any private/internal → `entitlement_gate_not_implemented`; unknown → `visibility_unknown`. All failure states are typed and fail closed (`installation_suspended`, `installation_uninstalled`, `binding_not_found`, `repo_outside_installation`, `repo_renamed_or_transferred`, `state_replayed`/`state_expired`/`state_not_found`, `rate_limited`, `broker_unavailable`, …) with no fallback to a user OAuth token or embedded key. The mint decision is one seam function — `authorizeTokenIssuance` — that #614 replaces; there is exactly one code path that can mint (gate-every-caller). A call-order test proves the token is never minted before the seam authorizes.

## Failing-first (red evidence)
Commit 2 added the contract tests before any endpoint existed: all 4 failed (routes 404 → typed-refusal assertions failed: `404 !== 200/403`, `reason` undefined). Commit 3 implemented the broker → the same 4 tests pass unchanged. Commit 4 adds 14 adversarial/lifecycle tests.

## Validation
- `cd services/license-api && npm test`: **202/202 pass** (Node 26; +18 broker tests over the 184 baseline).
- root `npm run check:secrets`: **ok, 745 tracked files** (no PEM-like fixtures — test keypairs are generated at setup; no key/token/nonce material in logs, errors, or the ledger).
- Did not run the root vitest suite locally (no root files touched; CI covers it).

## Design-doc open questions resolved
- **URL-scheme return (Q1): resolved.** No `CFBundleURLTypes`/`neondiff://` exists in `apps/neondiff-desktop` today, so v1 return is a device poll (`/github/connect/complete`), not a browser→app redirect. #612 may layer a scheme later.
- **Token repo snapshot (Q3): resolved** client-side (fewer broker surfaces).
- Device-registration abuse economics (Q2) and staging-vs-production App sequence (Q4, owner-gated) remain open — flagged in the doc.

## Proof boundary
Fixture-tested code only. No production App exists, no deployment happened, and nothing here proves the live install flow, Marketplace readiness, or calibrated review posting. AC7 security review + production credentials are owner-gated.

Do not merge — server-side slice for orchestrator review.
