### PR TITLE
feat(design): live-site design source of truth, contract check, and Overview reference screen (#611)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
           npm pack --dry-run --json > pack.json
           node scripts/check-packlist.mjs pack.json
 
+      - name: Design-source contract
+        run: node scripts/check-design-source-contract.mjs
+
       - name: Forbidden public claims scan
         run: node scripts/check-public-claims.mjs
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ substitute `./dist/src/cli.js` anywhere this guide calls `neondiff`.
 
 ## Set Up
 
-Follow [docs/SETUP.md](docs/SETUP.md) for the full first-run path. The short
-version is:
+Follow [docs/SETUP.md](docs/SETUP.md) for the CLI-first setup path (the
+first-run path on non-Mac platforms and the operator/advanced path on Mac). The
+short version is:
 
 ```bash
 neondiff init --config config.local.json

--- a/README.md
+++ b/README.md
@@ -123,9 +123,12 @@ neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
-The local HTML dashboard is the first-run setup surface. It shows license status,
-GitHub App status, daemon status, and provider readiness, and its provider card
-includes a `Verify API Key` control that reports redacted pass/fail output.
+For the Mac customer journey, the native macOS app (`apps/neondiff-desktop`) is
+the human first-run surface. The local HTML dashboard is an operator/diagnostic
+surface for CLI-first and non-Mac setups, not the product UI. It shows license
+status, GitHub App status, daemon status, and provider readiness, and its
+provider card includes a `Verify API Key` control that reports redacted
+pass/fail output.
 The native Providers pane reads and edits the saved `providers` registry, not
 the legacy `desktop.openAICompatibleEndpoint` field. Load config, Preview, and
 Apply the exact selected provider before Verify is enabled; verification pins

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -62,6 +62,7 @@ struct NeonDiffDesktopApp: App {
                     minWidth: CGFloat(minimumContentSize.width),
                     minHeight: CGFloat(minimumContentSize.height)
                 )
+                .applyingEvaluationDynamicTypeSize(evaluationDynamicTypeSize)
                 .environment(\.locale, evaluationLocale)
                 .transaction { transaction in
                     if disablesAnimations {
@@ -169,6 +170,31 @@ struct NeonDiffDesktopApp: App {
 #endif
     }
 
+    // DEBUG-only hook so design-reference evidence can capture the large-text
+    // appearance of a working screen. Gated on an env var and never set by the
+    // hosted geometry harness, so it does not affect any geometry contract.
+    private var evaluationDynamicTypeSize: DynamicTypeSize? {
+#if DEBUG
+        guard let raw = ProcessInfo.processInfo.environment["NEONDIFF_DESKTOP_EVALUATION_DYNAMIC_TYPE"] else {
+            return nil
+        }
+        switch raw {
+        case "large": return .large
+        case "xLarge": return .xLarge
+        case "xxLarge": return .xxLarge
+        case "xxxLarge": return .xxxLarge
+        case "accessibility1": return .accessibility1
+        case "accessibility2": return .accessibility2
+        case "accessibility3": return .accessibility3
+        case "accessibility4": return .accessibility4
+        case "accessibility5": return .accessibility5
+        default: return nil
+        }
+#else
+        return nil
+#endif
+    }
+
     private var evaluationLocale: Locale {
 #if DEBUG
         evaluationContext.map { Locale(identifier: $0.fixture.environment.locale) } ?? .current
@@ -230,6 +256,17 @@ struct NeonDiffDesktopApp: App {
 #else
         nil
 #endif
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func applyingEvaluationDynamicTypeSize(_ size: DynamicTypeSize?) -> some View {
+        if let size {
+            self.dynamicTypeSize(size)
+        } else {
+            self
+        }
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -1,4 +1,158 @@
+import AppKit
 import SwiftUI
+import NeonDiffDesktopAppCore
+
+// MARK: - NeonDiff design contract (#611)
+//
+// Semantic token + type + component layer derived from the live production
+// website (https://neondiff.com, captured 2026-07-15). Values live as pure
+// sRGB in NeonDiffDesktopAppCore.NDDesignTokens (unit-tested for existence and
+// WCAG contrast); this layer resolves them into SwiftUI for both appearances.
+// See docs/design/live-site-design-source.md. This is additive translation, not
+// a rewrite of the existing NeonDiffTheme operator styling.
+
+/// Appearance-resolving SwiftUI colors for the ten semantic roles.
+enum NDColor {
+    static let background = dynamic(NDDesignTokens.background)
+    static let surface = dynamic(NDDesignTokens.surface)
+    static let textPrimary = dynamic(NDDesignTokens.textPrimary)
+    static let textSecondary = dynamic(NDDesignTokens.textSecondary)
+    static let accentPrimary = dynamic(NDDesignTokens.accentPrimary)
+    static let accentMagenta = dynamic(NDDesignTokens.accentMagenta)
+    static let warning = dynamic(NDDesignTokens.warning)
+    static let danger = dynamic(NDDesignTokens.danger)
+    static let borderPrimary = dynamic(NDDesignTokens.borderPrimary)
+    static let borderInput = dynamic(NDDesignTokens.borderInput)
+
+    static func dynamic(_ token: NDSemanticColor) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let value = isDark ? token.dark : token.light
+            return NSColor(srgbRed: value.red, green: value.green, blue: value.blue, alpha: value.opacity)
+        })
+    }
+}
+
+/// The mono label/console type system — the strongest carry-over identity
+/// element. Relative text styles so everything scales with Dynamic Type.
+enum NDFont {
+    /// Section labels, status chips, stat-row labels. Apply with `ndSectionLabel()`.
+    static let label = Font.system(.caption, design: .monospaced).weight(.semibold)
+    /// Console/key-value values.
+    static let mono = Font.system(.footnote, design: .monospaced)
+}
+
+extension View {
+    /// `SECTION // LABEL`-style uppercase mono header in working screens.
+    func ndSectionLabel() -> some View {
+        self.font(NDFont.label)
+            .tracking(1.8)
+            .textCase(.uppercase)
+            .foregroundStyle(NDColor.textSecondary)
+    }
+}
+
+/// `[ TITLE ]` bracket CTA for the ONE primary action per screen. Square
+/// corners, accentPrimary @6% fill, primary border @40% stepping to full alpha
+/// under Increase Contrast, disabled/pressed states. Keyboard focus preserved.
+struct NDBracketButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        NDBracketButtonBody(configuration: configuration)
+    }
+
+    private struct NDBracketButtonBody: View {
+        let configuration: ButtonStyleConfiguration
+        @Environment(\.colorSchemeContrast) private var contrast
+        @Environment(\.isEnabled) private var isEnabled
+
+        var body: some View {
+            let increased = contrast == .increased
+            let borderAlpha = increased ? 1.0 : (configuration.isPressed ? 0.7 : 0.4)
+            let fillAlpha = configuration.isPressed ? 0.12 : 0.06
+
+            HStack(spacing: 6) {
+                Text("[").font(NDFont.label)
+                configuration.label
+                    .font(NDFont.label)
+                    .textCase(.uppercase)
+                    .tracking(1.8)
+                Text("]").font(NDFont.label)
+            }
+            .foregroundStyle(NDColor.accentPrimary.opacity(isEnabled ? 1 : 0.45))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Rectangle().fill(NDColor.accentPrimary.opacity(isEnabled ? fillAlpha : 0.03)))
+            .overlay(Rectangle().stroke(NDColor.accentPrimary.opacity(isEnabled ? borderAlpha : 0.25), lineWidth: 1))
+            .contentShape(Rectangle())
+        }
+    }
+}
+
+/// Console/evidence surface: surface background, 1px primary border, corner
+/// ticks. Border steps to full-alpha accent under Increase Contrast.
+struct NDConsolePanel<Content: View>: View {
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        NDConsolePanelBody { content }
+    }
+
+    private struct NDConsolePanelBody<Inner: View>: View {
+        @Environment(\.colorSchemeContrast) private var contrast
+        private let inner: Inner
+
+        init(@ViewBuilder inner: () -> Inner) {
+            self.inner = inner()
+        }
+
+        var body: some View {
+            let increased = contrast == .increased
+            inner
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(Rectangle().fill(NDColor.surface))
+                .overlay(
+                    Rectangle().stroke(increased ? NDColor.accentPrimary : NDColor.borderPrimary, lineWidth: 1)
+                )
+                .overlay(NDConsoleCornerTicks(color: NDColor.accentPrimary.opacity(increased ? 1 : 0.7)))
+        }
+    }
+}
+
+private struct NDConsoleCornerTicks: View {
+    var color: Color
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let height = proxy.size.height
+            let length: CGFloat = 14
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: length))
+                path.addLine(to: .zero)
+                path.addLine(to: CGPoint(x: length, y: 0))
+
+                path.move(to: CGPoint(x: width - length, y: 0))
+                path.addLine(to: CGPoint(x: width, y: 0))
+                path.addLine(to: CGPoint(x: width, y: length))
+
+                path.move(to: CGPoint(x: width, y: height - length))
+                path.addLine(to: CGPoint(x: width, y: height))
+                path.addLine(to: CGPoint(x: width - length, y: height))
+
+                path.move(to: CGPoint(x: length, y: height))
+                path.addLine(to: CGPoint(x: 0, y: height))
+                path.addLine(to: CGPoint(x: 0, y: height - length))
+            }
+            .stroke(color, lineWidth: 1)
+        }
+        .allowsHitTesting(false)
+    }
+}
 
 enum NeonDiffTheme {
     static let shell = Color(red: 0.020, green: 0.024, blue: 0.031)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -92,6 +92,39 @@ struct NDBracketButtonStyle: ButtonStyle {
     }
 }
 
+/// Secondary/tertiary actions on tokenized surfaces. Legible in both
+/// appearances (textPrimary label, 1px borderInput outline, square corners per
+/// the contract — the angled/bracket treatment is reserved for the ONE primary
+/// action per screen). Not neon, so the bracket primary stays unambiguous.
+struct NDSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        NDSecondaryButtonBody(configuration: configuration)
+    }
+
+    private struct NDSecondaryButtonBody: View {
+        let configuration: ButtonStyleConfiguration
+        @Environment(\.colorScheme) private var colorScheme
+        @Environment(\.colorSchemeContrast) private var contrast
+        @Environment(\.isEnabled) private var isEnabled
+
+        var body: some View {
+            let palette = NDPalette(scheme: colorScheme)
+            let increased = contrast == .increased
+            let borderColor = increased ? palette.accentPrimary : palette.borderInput
+            configuration.label
+                .font(.callout.weight(.medium))
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .foregroundStyle(palette.textPrimary.opacity(isEnabled ? (configuration.isPressed ? 0.7 : 1) : 0.4))
+                .padding(.horizontal, 11)
+                .padding(.vertical, 7)
+                .background(Rectangle().fill(palette.surface.opacity(configuration.isPressed ? 0.6 : 1)))
+                .overlay(Rectangle().stroke(borderColor, lineWidth: 1))
+                .contentShape(Rectangle())
+        }
+    }
+}
+
 /// Console/evidence surface: surface background, 1px primary border, corner
 /// ticks. Border steps to full-alpha accent under Increase Contrast.
 struct NDConsolePanel<Content: View>: View {
@@ -369,11 +402,15 @@ struct OperatorTextField: View {
 struct OperatorCommandText: View {
     var text: String
     var lineLimit: Int? = 3
+    /// When set, the command text resolves `textSecondary` from the #611 token
+    /// palette so it stays legible on tokenized light-mode surfaces. Legacy
+    /// callers keep the dark operator color.
+    var palette: NDPalette? = nil
 
     var body: some View {
         Text(text)
             .font(NeonDiffTheme.commandFont)
-            .foregroundStyle(NeonDiffTheme.textSecondary)
+            .foregroundStyle(palette?.textSecondary ?? NeonDiffTheme.textSecondary)
             .textSelection(.enabled)
             .lineLimit(lineLimit)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 import NeonDiffDesktopAppCore
 
@@ -11,26 +10,29 @@ import NeonDiffDesktopAppCore
 // See docs/design/live-site-design-source.md. This is additive translation, not
 // a rewrite of the existing NeonDiffTheme operator styling.
 
-/// Appearance-resolving SwiftUI colors for the ten semantic roles.
-enum NDColor {
-    static let background = dynamic(NDDesignTokens.background)
-    static let surface = dynamic(NDDesignTokens.surface)
-    static let textPrimary = dynamic(NDDesignTokens.textPrimary)
-    static let textSecondary = dynamic(NDDesignTokens.textSecondary)
-    static let accentPrimary = dynamic(NDDesignTokens.accentPrimary)
-    static let accentMagenta = dynamic(NDDesignTokens.accentMagenta)
-    static let warning = dynamic(NDDesignTokens.warning)
-    static let danger = dynamic(NDDesignTokens.danger)
-    static let borderPrimary = dynamic(NDDesignTokens.borderPrimary)
-    static let borderInput = dynamic(NDDesignTokens.borderInput)
+/// Resolves the ten semantic roles into plain SwiftUI colors for a given
+/// appearance. Built from SwiftUI's `\.colorScheme` (NOT an NSColor dynamic
+/// provider) so it follows `.preferredColorScheme` and the evaluation fixture's
+/// appearance override — an NSColor dynamic provider resolves against the
+/// window/system appearance and silently ignores the SwiftUI scheme.
+struct NDPalette {
+    var scheme: ColorScheme
 
-    static func dynamic(_ token: NDSemanticColor) -> Color {
-        Color(nsColor: NSColor(name: nil) { appearance in
-            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            let value = isDark ? token.dark : token.light
-            return NSColor(srgbRed: value.red, green: value.green, blue: value.blue, alpha: value.opacity)
-        })
+    private func resolve(_ token: NDSemanticColor) -> Color {
+        let value = scheme == .dark ? token.dark : token.light
+        return Color(.sRGB, red: value.red, green: value.green, blue: value.blue, opacity: value.opacity)
     }
+
+    var background: Color { resolve(NDDesignTokens.background) }
+    var surface: Color { resolve(NDDesignTokens.surface) }
+    var textPrimary: Color { resolve(NDDesignTokens.textPrimary) }
+    var textSecondary: Color { resolve(NDDesignTokens.textSecondary) }
+    var accentPrimary: Color { resolve(NDDesignTokens.accentPrimary) }
+    var accentMagenta: Color { resolve(NDDesignTokens.accentMagenta) }
+    var warning: Color { resolve(NDDesignTokens.warning) }
+    var danger: Color { resolve(NDDesignTokens.danger) }
+    var borderPrimary: Color { resolve(NDDesignTokens.borderPrimary) }
+    var borderInput: Color { resolve(NDDesignTokens.borderInput) }
 }
 
 /// The mono label/console type system — the strongest carry-over identity
@@ -44,11 +46,11 @@ enum NDFont {
 
 extension View {
     /// `SECTION // LABEL`-style uppercase mono header in working screens.
-    func ndSectionLabel() -> some View {
+    func ndSectionLabel(_ palette: NDPalette) -> some View {
         self.font(NDFont.label)
             .tracking(1.8)
             .textCase(.uppercase)
-            .foregroundStyle(NDColor.textSecondary)
+            .foregroundStyle(palette.textSecondary)
     }
 }
 
@@ -62,10 +64,12 @@ struct NDBracketButtonStyle: ButtonStyle {
 
     private struct NDBracketButtonBody: View {
         let configuration: ButtonStyleConfiguration
+        @Environment(\.colorScheme) private var colorScheme
         @Environment(\.colorSchemeContrast) private var contrast
         @Environment(\.isEnabled) private var isEnabled
 
         var body: some View {
+            let palette = NDPalette(scheme: colorScheme)
             let increased = contrast == .increased
             let borderAlpha = increased ? 1.0 : (configuration.isPressed ? 0.7 : 0.4)
             let fillAlpha = configuration.isPressed ? 0.12 : 0.06
@@ -78,11 +82,11 @@ struct NDBracketButtonStyle: ButtonStyle {
                     .tracking(1.8)
                 Text("]").font(NDFont.label)
             }
-            .foregroundStyle(NDColor.accentPrimary.opacity(isEnabled ? 1 : 0.45))
+            .foregroundStyle(palette.accentPrimary.opacity(isEnabled ? 1 : 0.45))
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
-            .background(Rectangle().fill(NDColor.accentPrimary.opacity(isEnabled ? fillAlpha : 0.03)))
-            .overlay(Rectangle().stroke(NDColor.accentPrimary.opacity(isEnabled ? borderAlpha : 0.25), lineWidth: 1))
+            .background(Rectangle().fill(palette.accentPrimary.opacity(isEnabled ? fillAlpha : 0.03)))
+            .overlay(Rectangle().stroke(palette.accentPrimary.opacity(isEnabled ? borderAlpha : 0.25), lineWidth: 1))
             .contentShape(Rectangle())
         }
     }
@@ -102,6 +106,7 @@ struct NDConsolePanel<Content: View>: View {
     }
 
     private struct NDConsolePanelBody<Inner: View>: View {
+        @Environment(\.colorScheme) private var colorScheme
         @Environment(\.colorSchemeContrast) private var contrast
         private let inner: Inner
 
@@ -110,15 +115,16 @@ struct NDConsolePanel<Content: View>: View {
         }
 
         var body: some View {
+            let palette = NDPalette(scheme: colorScheme)
             let increased = contrast == .increased
             inner
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
-                .background(Rectangle().fill(NDColor.surface))
+                .background(Rectangle().fill(palette.surface))
                 .overlay(
-                    Rectangle().stroke(increased ? NDColor.accentPrimary : NDColor.borderPrimary, lineWidth: 1)
+                    Rectangle().stroke(increased ? palette.accentPrimary : palette.borderPrimary, lineWidth: 1)
                 )
-                .overlay(NDConsoleCornerTicks(color: NDColor.accentPrimary.opacity(increased ? 1 : 0.7)))
+                .overlay(NDConsoleCornerTicks(color: palette.accentPrimary.opacity(increased ? 1 : 0.7)))
         }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -126,7 +126,11 @@ struct NDSecondaryButtonStyle: ButtonStyle {
 }
 
 /// Console/evidence surface: surface background, 1px primary border, corner
-/// ticks. Border steps to full-alpha accent under Increase Contrast.
+/// ticks. Border steps to full-alpha accent under Increase Contrast. The
+/// corner-tick flourish is the one decorative brand treatment a screen may
+/// spend (neon budget), so it is reserved for evidence/log/review surfaces
+/// where it is the sole treatment — the Overview reference screen spends its
+/// budget on the bracket CTA instead. Downstream adoption is #520-owned.
 struct NDConsolePanel<Content: View>: View {
     private let content: Content
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -50,15 +50,17 @@ struct OverviewView: View {
                         Button { model.openDashboard() } label: {
                             Label("Open Browser Dashboard", systemImage: "safari")
                         }
+                        .buttonStyle(NDSecondaryButtonStyle())
                         .accessibilityIdentifier("neondiff-open-browser-dashboard")
 
                         Button { model.copyCommand(model.dashboardCommand) } label: {
                             Label("Copy Dashboard Command", systemImage: "doc.on.doc")
                         }
+                        .buttonStyle(NDSecondaryButtonStyle())
                         .accessibilityIdentifier("neondiff-copy-dashboard-command")
                     }
 
-                    OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 3)
+                    OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 3, palette: nd)
                 }
 
                 CommandPanel(commands: [
@@ -120,7 +122,7 @@ struct OverviewView: View {
                 }
 
                 OverviewSection(title: "Last Command // Log", palette: nd) {
-                    OperatorCommandText(text: model.lastCommandLine, lineLimit: 4)
+                    OperatorCommandText(text: model.lastCommandLine, lineLimit: 4, palette: nd)
                 }
             }
             .padding(24)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -5,8 +5,9 @@ import NeonDiffDesktopCore
 // Reference screen for issue #611: applies the live-site design contract
 // (docs/design/live-site-design-source.md) as native translation — tokenized
 // colors for both appearances, mono uppercase section labels, status rows with
-// glyph + text (never color alone), one bracket primary action, and a
-// corner-ticked readiness console. Colors resolve from the SwiftUI
+// glyph + text (never color alone), and one bracket primary action as the
+// screen's single decorative brand treatment (one-treatment neon budget: the
+// readiness panel is a plain tokenized surface, not corner-ticked). Colors resolve from the SwiftUI
 // `\.colorScheme` (NDPalette) so light mode actually renders light. Behavior,
 // bindings, accessibility identifiers, and the #517 geometry sentinel
 // (neondiff-overview-start-dashboard) are preserved; structural Home redesign
@@ -19,19 +20,26 @@ struct OverviewView: View {
         let nd = NDPalette(scheme: colorScheme)
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                NDConsolePanel {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Readiness // Overview").ndSectionLabel(nd)
-                        StatusRow(title: "Runtime", value: model.status.healthState, palette: nd)
-                        StatusRow(title: "Repos", value: "\(model.status.monitoredRepos.count)", palette: nd)
-                        StatusRow(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing", palette: nd)
-                        StatusRow(
-                            title: "Dashboard",
-                            value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched",
-                            palette: nd
-                        )
-                    }
+                // Readiness console: tokenized bordered surface with mono labels
+                // and glyph+text status rows. The corner-tick flourish
+                // (NDConsolePanel) is intentionally omitted here so the bracket
+                // CTA below is the screen's single decorative brand treatment,
+                // honoring the one-treatment neon budget (#611).
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Readiness // Overview").ndSectionLabel(nd)
+                    StatusRow(title: "Runtime", value: model.status.healthState, palette: nd)
+                    StatusRow(title: "Repos", value: "\(model.status.monitoredRepos.count)", palette: nd)
+                    StatusRow(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing", palette: nd)
+                    StatusRow(
+                        title: "Dashboard",
+                        value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched",
+                        palette: nd
+                    )
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(Rectangle().fill(nd.surface))
+                .overlay(Rectangle().stroke(nd.borderPrimary, lineWidth: 1))
 
                 OverviewSection(title: "Local Dashboard Launcher // Operator", palette: nd) {
                     Text("The Mac app stays in control on launch. Start the local dashboard service here, then open the browser dashboard only when you choose to inspect the full HTML setup surface.")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -2,45 +2,58 @@ import SwiftUI
 import NeonDiffDesktopAppCore
 import NeonDiffDesktopCore
 
+// Reference screen for issue #611: applies the live-site design contract
+// (docs/design/live-site-design-source.md) as native translation — tokenized
+// colors for both appearances, mono uppercase section labels, status rows with
+// glyph + text (never color alone), one bracket primary action, and a
+// corner-ticked readiness console. Behavior, bindings, accessibility
+// identifiers, and the #517 geometry sentinel (neondiff-overview-start-dashboard)
+// are preserved; structural Home redesign remains owned by #521.
 struct OverviewView: View {
     @ObservedObject var model: NeonDiffDesktopModel
-    private let statusColumns = [GridItem(.adaptive(minimum: 160), spacing: 12)]
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                LazyVGrid(columns: statusColumns, alignment: .leading, spacing: 12) {
-                    StatusTile(title: "Runtime", value: model.status.healthState, systemImage: "bolt.horizontal.circle")
-                    StatusTile(title: "Repos", value: "\(model.status.monitoredRepos.count)", systemImage: "folder")
-                    StatusTile(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing", systemImage: "key")
-                    StatusTile(title: "Dashboard", value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched", systemImage: "macwindow")
+                NDConsolePanel {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Readiness // Overview").ndSectionLabel()
+                        StatusRow(title: "Runtime", value: model.status.healthState)
+                        StatusRow(title: "Repos", value: "\(model.status.monitoredRepos.count)")
+                        StatusRow(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing")
+                        StatusRow(
+                            title: "Dashboard",
+                            value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched"
+                        )
+                    }
                 }
 
-                OperatorSection("Local Dashboard Launcher") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("The Mac app stays in control on launch. Start the local dashboard service here, then open the browser dashboard only when you choose to inspect the full HTML setup surface.")
-                            .operatorBodyText()
-                            .fixedSize(horizontal: false, vertical: true)
+                OverviewSection(title: "Local Dashboard Launcher // Operator") {
+                    Text("The Mac app stays in control on launch. Start the local dashboard service here, then open the browser dashboard only when you choose to inspect the full HTML setup surface.")
+                        .font(.body)
+                        .foregroundStyle(NDColor.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
 
-                        HStack(spacing: 10) {
-                            Button { model.startDashboardServer() } label: {
-                                Label("Start Local Dashboard", systemImage: "play.circle")
-                            }
-                            .accessibilityIdentifier("neondiff-start-dashboard-server")
-
-                            Button { model.openDashboard() } label: {
-                                Label("Open Browser Dashboard", systemImage: "safari")
-                            }
-                            .accessibilityIdentifier("neondiff-open-browser-dashboard")
-
-                            Button { model.copyCommand(model.dashboardCommand) } label: {
-                                Label("Copy Dashboard Command", systemImage: "doc.on.doc")
-                            }
-                            .accessibilityIdentifier("neondiff-copy-dashboard-command")
+                    HStack(spacing: 10) {
+                        // The one bracket primary action for this screen.
+                        Button { model.startDashboardServer() } label: {
+                            Text("Start Local Dashboard")
                         }
+                        .buttonStyle(NDBracketButtonStyle())
+                        .accessibilityIdentifier("neondiff-start-dashboard-server")
 
-                        OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 3)
+                        Button { model.openDashboard() } label: {
+                            Label("Open Browser Dashboard", systemImage: "safari")
+                        }
+                        .accessibilityIdentifier("neondiff-open-browser-dashboard")
+
+                        Button { model.copyCommand(model.dashboardCommand) } label: {
+                            Label("Copy Dashboard Command", systemImage: "doc.on.doc")
+                        }
+                        .accessibilityIdentifier("neondiff-copy-dashboard-command")
                     }
+
+                    OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 3)
                 }
 
                 CommandPanel(commands: [
@@ -87,13 +100,21 @@ struct OverviewView: View {
                 }
 
                 if let lastError = model.lastError, !lastError.isEmpty {
-                    Text(lastError)
-                        .foregroundStyle(NeonDiffTheme.warning)
-                        .font(.callout)
-                        .operatorPanel()
+                    HStack(alignment: .top, spacing: 8) {
+                        Text("◆")
+                            .foregroundStyle(NDColor.danger)
+                            .accessibilityHidden(true)
+                        Text(lastError)
+                            .foregroundStyle(NDColor.danger)
+                            .font(.callout)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(Rectangle().fill(NDColor.surface))
+                    .overlay(Rectangle().stroke(NDColor.danger.opacity(0.5), lineWidth: 1))
                 }
 
-                OperatorSection("Last Command") {
+                OverviewSection(title: "Last Command // Log") {
                     OperatorCommandText(text: model.lastCommandLine, lineLimit: 4)
                 }
             }
@@ -102,28 +123,73 @@ struct OverviewView: View {
                 PageBottomSentinel(section: "overview")
             }
         }
+        .background(NDColor.background)
         .accessibilityIdentifier("neondiff-overview-outer-scroll")
         .scrollContentBackground(.hidden)
     }
 }
 
-private struct StatusTile: View {
-    var title: String
-    var value: String
-    var systemImage: String
+/// A working-screen section: mono uppercase label header over a tokenized
+/// surface. Local to the reference screen; the shared component system is #520.
+private struct OverviewSection<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label(title, systemImage: systemImage)
-                .font(NeonDiffTheme.badgeFont)
-                .foregroundStyle(NeonDiffTheme.textSecondary)
-            Text(value)
-                .font(.system(.title3, design: .monospaced).weight(.black))
-                .foregroundStyle(NeonDiffTheme.statusColor(value))
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title).ndSectionLabel()
+            content
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .operatorPanel(active: true)
+        .padding(16)
+        .background(Rectangle().fill(NDColor.surface))
+        .overlay(Rectangle().stroke(NDColor.borderInput, lineWidth: 1))
+    }
+}
+
+/// Key-value status row: mono uppercase label left, glyph + mono value right.
+/// Status is carried by glyph + text, not color alone.
+private struct StatusRow: View {
+    var title: String
+    var value: String
+
+    var body: some View {
+        LabeledContent {
+            HStack(spacing: 6) {
+                Text(glyph)
+                    .font(NDFont.mono)
+                    .foregroundStyle(color)
+                    .accessibilityHidden(true)
+                Text(value)
+                    .font(NDFont.mono)
+                    .foregroundStyle(color)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+        } label: {
+            Text(title).ndSectionLabel()
+        }
+    }
+
+    private var normalized: String { value.lowercased() }
+
+    private var isHealthy: Bool {
+        ["ok", "stored", "ready", "active", "launched"].contains { normalized.contains($0) }
+    }
+
+    private var isAttention: Bool {
+        ["missing", "blocked", "error", "unknown", "stopped"].contains { normalized.contains($0) }
+    }
+
+    private var glyph: String {
+        if isHealthy { return "●" }
+        if isAttention { return "◆" }
+        return "◇"
+    }
+
+    private var color: Color {
+        if isHealthy { return NDColor.accentPrimary }
+        if isAttention { return NDColor.warning }
+        return NDColor.textSecondary
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -174,7 +174,7 @@ private struct StatusRow: View {
     private var normalized: String { value.lowercased() }
 
     private var isHealthy: Bool {
-        ["ok", "stored", "ready", "active", "launched"].contains { normalized.contains($0) }
+        ["ok", "healthy", "stored", "ready", "active", "launched", "connected"].contains { normalized.contains($0) }
     }
 
     private var isAttention: Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -6,32 +6,37 @@ import NeonDiffDesktopCore
 // (docs/design/live-site-design-source.md) as native translation — tokenized
 // colors for both appearances, mono uppercase section labels, status rows with
 // glyph + text (never color alone), one bracket primary action, and a
-// corner-ticked readiness console. Behavior, bindings, accessibility
-// identifiers, and the #517 geometry sentinel (neondiff-overview-start-dashboard)
-// are preserved; structural Home redesign remains owned by #521.
+// corner-ticked readiness console. Colors resolve from the SwiftUI
+// `\.colorScheme` (NDPalette) so light mode actually renders light. Behavior,
+// bindings, accessibility identifiers, and the #517 geometry sentinel
+// (neondiff-overview-start-dashboard) are preserved; structural Home redesign
+// remains owned by #521.
 struct OverviewView: View {
     @ObservedObject var model: NeonDiffDesktopModel
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
+        let nd = NDPalette(scheme: colorScheme)
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 NDConsolePanel {
                     VStack(alignment: .leading, spacing: 12) {
-                        Text("Readiness // Overview").ndSectionLabel()
-                        StatusRow(title: "Runtime", value: model.status.healthState)
-                        StatusRow(title: "Repos", value: "\(model.status.monitoredRepos.count)")
-                        StatusRow(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing")
+                        Text("Readiness // Overview").ndSectionLabel(nd)
+                        StatusRow(title: "Runtime", value: model.status.healthState, palette: nd)
+                        StatusRow(title: "Repos", value: "\(model.status.monitoredRepos.count)", palette: nd)
+                        StatusRow(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing", palette: nd)
                         StatusRow(
                             title: "Dashboard",
-                            value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched"
+                            value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched",
+                            palette: nd
                         )
                     }
                 }
 
-                OverviewSection(title: "Local Dashboard Launcher // Operator") {
+                OverviewSection(title: "Local Dashboard Launcher // Operator", palette: nd) {
                     Text("The Mac app stays in control on launch. Start the local dashboard service here, then open the browser dashboard only when you choose to inspect the full HTML setup surface.")
                         .font(.body)
-                        .foregroundStyle(NDColor.textSecondary)
+                        .foregroundStyle(nd.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
 
                     HStack(spacing: 10) {
@@ -102,19 +107,19 @@ struct OverviewView: View {
                 if let lastError = model.lastError, !lastError.isEmpty {
                     HStack(alignment: .top, spacing: 8) {
                         Text("◆")
-                            .foregroundStyle(NDColor.danger)
+                            .foregroundStyle(nd.danger)
                             .accessibilityHidden(true)
                         Text(lastError)
-                            .foregroundStyle(NDColor.danger)
+                            .foregroundStyle(nd.danger)
                             .font(.callout)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)
-                    .background(Rectangle().fill(NDColor.surface))
-                    .overlay(Rectangle().stroke(NDColor.danger.opacity(0.5), lineWidth: 1))
+                    .background(Rectangle().fill(nd.surface))
+                    .overlay(Rectangle().stroke(nd.danger.opacity(0.5), lineWidth: 1))
                 }
 
-                OverviewSection(title: "Last Command // Log") {
+                OverviewSection(title: "Last Command // Log", palette: nd) {
                     OperatorCommandText(text: model.lastCommandLine, lineLimit: 4)
                 }
             }
@@ -123,7 +128,7 @@ struct OverviewView: View {
                 PageBottomSentinel(section: "overview")
             }
         }
-        .background(NDColor.background)
+        .background(nd.background)
         .accessibilityIdentifier("neondiff-overview-outer-scroll")
         .scrollContentBackground(.hidden)
     }
@@ -133,17 +138,18 @@ struct OverviewView: View {
 /// surface. Local to the reference screen; the shared component system is #520.
 private struct OverviewSection<Content: View>: View {
     let title: String
+    let palette: NDPalette
     @ViewBuilder var content: Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(title).ndSectionLabel()
+            Text(title).ndSectionLabel(palette)
             content
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Rectangle().fill(NDColor.surface))
-        .overlay(Rectangle().stroke(NDColor.borderInput, lineWidth: 1))
+        .background(Rectangle().fill(palette.surface))
+        .overlay(Rectangle().stroke(palette.borderInput, lineWidth: 1))
     }
 }
 
@@ -152,6 +158,7 @@ private struct OverviewSection<Content: View>: View {
 private struct StatusRow: View {
     var title: String
     var value: String
+    var palette: NDPalette
 
     var body: some View {
         LabeledContent {
@@ -167,7 +174,7 @@ private struct StatusRow: View {
                     .minimumScaleFactor(0.7)
             }
         } label: {
-            Text(title).ndSectionLabel()
+            Text(title).ndSectionLabel(palette)
         }
     }
 
@@ -188,8 +195,8 @@ private struct StatusRow: View {
     }
 
     private var color: Color {
-        if isHealthy { return NDColor.accentPrimary }
-        if isAttention { return NDColor.warning }
-        return NDColor.textSecondary
+        if isHealthy { return palette.accentPrimary }
+        if isAttention { return palette.warning }
+        return palette.textSecondary
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
@@ -194,22 +194,27 @@ struct PolicyView: View {
     }
 }
 
+// Overview-only CLI-equivalents list. Tokenized via `NDPalette` so it renders
+// correctly in both appearances (the retired operator dark chrome broke in
+// light). Square surfaces + borderInput, no corner-tick flourish — the bracket
+// CTA stays the screen's single decorative brand moment (#611 neon budget). The
+// CLI-equivalents *content* is #521-owned; this is a color/style pass only.
 struct CommandPanel: View {
     var commands: [DesktopCommand]
     var copy: (DesktopCommand) -> Void
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
+        let nd = NDPalette(scheme: colorScheme)
         VStack(alignment: .leading, spacing: 10) {
-            Text("CLI Equivalents")
-                .font(NeonDiffTheme.headlineFont)
-                .foregroundStyle(NeonDiffTheme.accentSoft)
+            Text("CLI Equivalents // Reference").ndSectionLabel(nd)
             ForEach(commands) { command in
                 HStack(alignment: .firstTextBaseline) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(command.title)
                             .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(NeonDiffTheme.textPrimary)
-                        OperatorCommandText(text: command.commandLine)
+                            .foregroundStyle(nd.textPrimary)
+                        OperatorCommandText(text: command.commandLine, palette: nd)
                     }
                     Spacer()
                     Button {
@@ -218,8 +223,12 @@ struct CommandPanel: View {
                         Image(systemName: "doc.on.doc")
                     }
                     .help("Copy command")
+                    .foregroundStyle(nd.textSecondary)
                 }
-                .operatorPanel(padding: 10)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Rectangle().fill(nd.surface))
+                .overlay(Rectangle().stroke(nd.borderInput, lineWidth: 1))
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
@@ -224,6 +224,9 @@ struct CommandPanel: View {
                     }
                     .help("Copy command")
                     .foregroundStyle(nd.textSecondary)
+                    // Image-only control: name the exact command for VoiceOver so
+                    // the repeated copy buttons are distinguishable (a11y floor).
+                    .accessibilityLabel("Copy command: \(command.title)")
                 }
                 .padding(10)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/NDDesignTokens.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/NDDesignTokens.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// Semantic design tokens for issue #611, derived from the live production
+// website (https://neondiff.com, captured 2026-07-15). These are pure sRGB
+// values with no SwiftUI/AppKit dependency so they can be unit-tested for
+// existence and WCAG contrast, and consumed by the SwiftUI theme layer
+// (NeonDiffTheme.NDColor) for appearance resolution. See
+// docs/design/live-site-design-source.md for the authoritative token table.
+
+package struct NDColorValue: Equatable, Sendable {
+    package let red: Double
+    package let green: Double
+    package let blue: Double
+    package let opacity: Double
+
+    package init(red: Double, green: Double, blue: Double, opacity: Double = 1) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.opacity = opacity
+    }
+
+    /// 24-bit `0xRRGGBB` sRGB value, optionally at a reduced alpha.
+    package init(hex: UInt32, opacity: Double = 1) {
+        self.red = Double((hex >> 16) & 0xFF) / 255
+        self.green = Double((hex >> 8) & 0xFF) / 255
+        self.blue = Double(hex & 0xFF) / 255
+        self.opacity = opacity
+    }
+}
+
+/// A semantic role expressed in both the brand-native dark appearance and the
+/// first-class light translation (never a naive inversion).
+package struct NDSemanticColor: Sendable {
+    package let dark: NDColorValue
+    package let light: NDColorValue
+
+    package init(dark: NDColorValue, light: NDColorValue) {
+        self.dark = dark
+        self.light = light
+    }
+}
+
+package enum NDDesignTokens {
+    package static let background = NDSemanticColor(dark: NDColorValue(hex: 0x000000), light: NDColorValue(hex: 0xFAFAF8))
+    package static let surface = NDSemanticColor(dark: NDColorValue(hex: 0x0A0F0C), light: NDColorValue(hex: 0xFFFFFF))
+    package static let textPrimary = NDSemanticColor(dark: NDColorValue(hex: 0xD9FFE6), light: NDColorValue(hex: 0x1A211C))
+    package static let textSecondary = NDSemanticColor(dark: NDColorValue(hex: 0x6D8A75), light: NDColorValue(hex: 0x5A6B5F))
+    package static let accentPrimary = NDSemanticColor(dark: NDColorValue(hex: 0x39FF88), light: NDColorValue(hex: 0x0F7A3D))
+    package static let accentMagenta = NDSemanticColor(dark: NDColorValue(hex: 0xFF2BD6), light: NDColorValue(hex: 0xB01E96))
+    package static let warning = NDSemanticColor(dark: NDColorValue(hex: 0xFFCC33), light: NDColorValue(hex: 0x8A6D00))
+    package static let danger = NDSemanticColor(dark: NDColorValue(hex: 0xFF3B6B), light: NDColorValue(hex: 0xC21E44))
+    package static let borderPrimary = NDSemanticColor(dark: NDColorValue(hex: 0x39FF88, opacity: 0.22), light: NDColorValue(hex: 0x0F7A3D, opacity: 0.35))
+    package static let borderInput = NDSemanticColor(dark: NDColorValue(hex: 0x39FF88, opacity: 0.18), light: NDColorValue(hex: 0x0F7A3D, opacity: 0.30))
+
+    /// Stable name → value listing for contract enforcement.
+    package static let all: [(name: String, color: NDSemanticColor)] = [
+        ("background", background),
+        ("surface", surface),
+        ("textPrimary", textPrimary),
+        ("textSecondary", textSecondary),
+        ("accentPrimary", accentPrimary),
+        ("accentMagenta", accentMagenta),
+        ("warning", warning),
+        ("danger", danger),
+        ("borderPrimary", borderPrimary),
+        ("borderInput", borderInput)
+    ]
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import NeonDiffDesktopAppCore
+
+// Contract for issue #611: the semantic design tokens derived from the live
+// production site (https://neondiff.com, captured 2026-07-15) must exist for
+// both appearances and clear the WCAG accessibility floors documented in
+// docs/design/live-site-design-source.md. The WCAG relative-luminance formula
+// is implemented here so the floor is proven, not asserted by fiat.
+@Suite struct NDDesignTokenContractTests {
+    private func relativeLuminance(_ color: NDColorValue) -> Double {
+        func linearize(_ channel: Double) -> Double {
+            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linearize(color.red)
+            + 0.7152 * linearize(color.green)
+            + 0.0722 * linearize(color.blue)
+    }
+
+    private func contrastRatio(_ lhs: NDColorValue, _ rhs: NDColorValue) -> Double {
+        let a = relativeLuminance(lhs)
+        let b = relativeLuminance(rhs)
+        let lighter = max(a, b)
+        let darker = min(a, b)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    @Test func allTenSemanticTokensExist() {
+        let expected = [
+            "background", "surface", "textPrimary", "textSecondary",
+            "accentPrimary", "accentMagenta", "warning", "danger",
+            "borderPrimary", "borderInput"
+        ]
+        let names = Set(NDDesignTokens.all.map(\.name))
+        #expect(NDDesignTokens.all.count == expected.count)
+        for token in expected {
+            #expect(names.contains(token), "missing semantic token \(token)")
+        }
+    }
+
+    @Test func darkAndLightDifferForKeyRoles() {
+        for token in [NDDesignTokens.background, NDDesignTokens.textPrimary, NDDesignTokens.accentPrimary] {
+            #expect(token.dark != token.light, "dark and light values must differ for a first-class light mode")
+        }
+    }
+
+    @Test func contrastFloorsHoldInBothAppearances() {
+        let floor = 4.5
+        let darkText = contrastRatio(NDDesignTokens.textPrimary.dark, NDDesignTokens.background.dark)
+        let darkAccent = contrastRatio(NDDesignTokens.accentPrimary.dark, NDDesignTokens.background.dark)
+        let lightText = contrastRatio(NDDesignTokens.textPrimary.light, NDDesignTokens.background.light)
+        let lightAccent = contrastRatio(NDDesignTokens.accentPrimary.light, NDDesignTokens.background.light)
+
+        #expect(darkText >= floor, "textPrimary-on-background (dark) = \(darkText)")
+        #expect(darkAccent >= floor, "accentPrimary-on-background (dark) = \(darkAccent)")
+        #expect(lightText >= floor, "textPrimary-on-background (light) = \(lightText)")
+        #expect(lightAccent >= floor, "accentPrimary-on-background (light) = \(lightAccent)")
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import NeonDiffDesktopAppCore
 
@@ -49,6 +50,11 @@ import Testing
         let darkAccent = contrastRatio(NDDesignTokens.accentPrimary.dark, NDDesignTokens.background.dark)
         let lightText = contrastRatio(NDDesignTokens.textPrimary.light, NDDesignTokens.background.light)
         let lightAccent = contrastRatio(NDDesignTokens.accentPrimary.light, NDDesignTokens.background.light)
+
+        print(String(format: "NDContrast textPrimary/background dark  = %.2f:1", darkText))
+        print(String(format: "NDContrast accentPrimary/background dark = %.2f:1", darkAccent))
+        print(String(format: "NDContrast textPrimary/background light = %.2f:1", lightText))
+        print(String(format: "NDContrast accentPrimary/background light= %.2f:1", lightAccent))
 
         #expect(darkText >= floor, "textPrimary-on-background (dark) = \(darkText)")
         #expect(darkAccent >= floor, "accentPrimary-on-background (dark) = \(darkAccent)")

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -220,7 +220,9 @@ neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
-The local HTML dashboard is the human first-run surface. It shows license
+This SETUP guide is the operator/advanced CLI-first path. The local HTML
+dashboard is the operator/diagnostic surface it drives; on Mac, the native
+macOS app is the human first-run product surface. The dashboard shows license
 status, GitHub App status, daemon status, and provider readiness with redacted
 output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,8 +1,12 @@
 # NeonDiff Setup
 
-This guide is the first-run path for the current source-available release. The
-recommended path installs the `neondiff` npm package; source checkout remains a
-fallback for contributors and reviewers who want to inspect or build locally. See
+This guide is the CLI-first setup path for the current source-available release,
+and the first-run path on non-Mac platforms. On macOS the native app
+(`apps/neondiff-desktop`) is the human first-run surface; until the native
+broker/launchd proof lands (see the native-broker note below) it hands off to
+this operator/advanced path for setup actions it cannot yet complete natively.
+The recommended path installs the `neondiff` npm package; source checkout remains
+a fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
 for the public/private repo license boundary, and [docs/pricing.md](pricing.md)
 for the support-tier pricing contract.
@@ -220,11 +224,13 @@ neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
-This SETUP guide is the operator/advanced CLI-first path. The local HTML
-dashboard is the operator/diagnostic surface it drives; on Mac, the native
-macOS app is the human first-run product surface. The dashboard shows license
-status, GitHub App status, daemon status, and provider readiness with redacted
-output. Use the provider card's `Verify API Key` button before launch/use; the
+This SETUP guide is the operator/advanced CLI-first path, and the first-run path
+on non-Mac platforms. The local HTML dashboard is the operator/diagnostic surface
+it drives. On Mac, the native macOS app is the human first-run product surface —
+the customer starts there; until the native broker/launchd proof lands (see the
+native-broker note above) the app hands off to this operator path for the setup
+actions it cannot yet complete natively. The dashboard shows license status,
+GitHub App status, daemon status, and provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing
 the submitted key.
 

--- a/docs/design/live-site-design-source.md
+++ b/docs/design/live-site-design-source.md
@@ -1,0 +1,112 @@
+# NeonDiff design source of truth — live production website
+
+Captured: 2026-07-15
+Source: https://neondiff.com (live production site; computed-style token extraction + full-page review)
+Owner ratification: the current live website is the ONLY approved visual source (epic #610, issue #611).
+The unshipped website redesign is rejected. Browser-dashboard parity and WebView product UI are rejected.
+The advanced native SwiftUI Mac app is the product surface; this document defines how the live site's
+brand translates into native macOS — translation, not pixel cloning.
+
+## Design authority
+
+- Canonical brand reference: https://neondiff.com as captured 2026-07-15.
+- Product UI: native SwiftUI macOS app (`apps/neondiff-desktop`). Native interaction, typography,
+  accessibility, navigation, and window behavior always win over web mimicry.
+- The rejected unshipped website redesign ("industrial workstation", carbon neutrals, 6/10/14pt radii)
+  must not be implemented anywhere. Where older issues describe it, this document supersedes the
+  aesthetic description (#520 reconciles against this contract).
+- Marketing theater (animated review console, glitch effects, hero scale) belongs to the website, not
+  the app. The app earns trust through calm, legible, native surfaces that carry the same identity.
+
+## Token table
+
+Raw live-site values → semantic roles → native mapping. Dark appearance is the brand-native mode.
+
+| Role | Site value (dark) | Native dark | Native light | Usage |
+|---|---|---|---|---|
+| background | #000 | #000000 | #FAFAF8 | window/content background |
+| surface | #000 + green-tinted border | #0A0F0C | #FFFFFF | cards, consoles, panels |
+| textPrimary | #d9ffe6 | #D9FFE6 | #1A211C | primary text |
+| textSecondary | #6d8a75 | #6D8A75 | #5A6B5F | secondary/muted text |
+| accentPrimary | #39ff88 | #39FF88 | #0F7A3D | primary action, live/healthy status ONLY |
+| accentMagenta | #ff2bd6 | #FF2BD6 | #B01E96 | PR identity, attention accents |
+| warning | #ffcc33 | #FFCC33 | #8A6D00 | warning text/icons |
+| danger | #ff3b6b | #FF3B6B | #C21E44 | destructive/error |
+| borderPrimary | #39ff88 @ 22% | same | #0F7A3D @ 35% | panel/console borders |
+| borderInput | #39ff88 @ 18% | same | #0F7A3D @ 30% | field borders |
+
+Corners: the site renders square components. Native translation: sharp (0–2pt) corners on brand
+surfaces (consoles, evidence panels, bracket buttons); standard macOS radii on system controls
+(menus, sheets, alerts) — do not fight AppKit.
+
+## Type system
+
+| Site | Native | Rule |
+|---|---|---|
+| Orbitron 500 uppercase (display) | SF Pro Display, heavy tracking uppercase — or nothing | Brand display voice is for brand moments only (About, onboarding welcome). Never in working screens. |
+| Inter (body) | SF Pro Text (system default) | All body/control text is system type at system sizes. |
+| JetBrains Mono uppercase, ~2.6px tracking @ 10–11px (labels/nav/status) | SF Mono, semibold, 11pt equivalent, tracking 1.5–2.0, uppercase | Section labels, status chips, key-value stat rows, console text. This is the strongest carry-over identity element. |
+
+Dynamic Type: all roles must scale with the user's text size; the mono label system uses relative
+text styles, not fixed pixel sizes.
+
+## Component translation
+
+| Live-site motif | Native translation |
+|---|---|
+| `[ BRACKET CTA ]` button (1px primary border @40%, 6% fill, square, mono uppercase) | `NDBracketButtonStyle` for the ONE primary action per screen; keyboard focus ring preserved; standard buttons elsewhere |
+| Console/terminal card (thin green border, corner tick marks, mono content) | Evidence/log/review surfaces: `NDConsolePanel` container with 1px borderPrimary + corner ticks |
+| `SECTION // LABEL` mono headers | Section headers in working screens: uppercase SF Mono textSecondary |
+| Key-value stat rows (label left, mono value right) | `LabeledContent` styled with mono values — status/readiness rows |
+| ◆ / ◇ / ● status glyphs | Status indicators alongside semantic color (never color alone) |
+| `[✓]` / `[→]` roadmap markers | Checklist/step rows in onboarding and readiness lists |
+| Traffic-light dots on cards | Do not clone — macOS already has window chrome |
+
+## Neon budget
+
+- accentPrimary (#39FF88) appears ONLY as: the one primary action per screen, live/healthy status,
+  and panel borders at reduced alpha. Never body text, never large fills, never multiple competing
+  green elements.
+- accentMagenta is rarer still: PR identity and attention moments.
+- At most ONE decorative brand treatment per screen (a corner-ticked panel OR a bracket CTA header
+  moment — not both stacked).
+- Empty/loading/error states use textSecondary + semantic colors, not neon.
+
+## Forbidden clones
+
+- No scanlines, glitch/chromatic-aberration, or animated marketing console in working screens.
+- No WebView/browser-embedded product surfaces (rejected direction).
+- No cloning of HTML layout/spacing; native spacing and hit targets govern.
+- No clipped/angled corners on standard form controls; brand corner-clipping is reserved for the
+  primary bracket CTA.
+- No dark-only design: every screen must be fully designed in both appearances.
+
+## Light mode
+
+Light mode is a first-class translation, not an inversion: near-white background, ink-green text,
+accentPrimary darkened to #0F7A3D (4.5:1+ on white), borders at higher alpha to survive light
+backgrounds. Brand identity carries via the mono label system, bracket CTA, panel structure, and
+status glyph language — not via neon-on-black.
+
+## Accessibility floors
+
+- Text contrast ≥ 4.5:1 in both appearances (large text ≥ 3:1). Measured: #39FF88 on #000 ≈ 15.8:1;
+  #0F7A3D on white ≈ 5.4:1; #6D8A75 on #000 ≈ 5.5:1; #FF2BD6 on #000 ≈ 6.6:1.
+- Status is never conveyed by color alone (glyph + text always).
+- Full VoiceOver labels on all reference-screen controls; keyboard reachability preserved.
+- Respects Reduce Motion (no brand animation), Increase Contrast (borders step up to full alpha),
+  and Dynamic Type.
+
+## Reference screen
+
+`OverviewView` (default landing tab) demonstrates this contract: tokenized colors/type, mono section
+labels, one bracket primary action, status rows with glyphs, corner-ticked readiness panel.
+Structural redesign of Home hierarchy remains owned by #521; onboarding by #519; the full component
+system by #520 (grounded in this document).
+
+## Contract enforcement
+
+`npm run check:design-source` (scripts/check-design-source-contract.mjs) fails the build if this
+document is missing/stripped or if retired-direction claims (dashboard-as-first-run-surface,
+browser-dashboard parity, WebView product UI) reappear in README.md, docs/SETUP.md, or
+docs/neondiff-desktop.md.

--- a/docs/design/live-site-design-source.md
+++ b/docs/design/live-site-design-source.md
@@ -90,8 +90,14 @@ status glyph language — not via neon-on-black.
 
 ## Accessibility floors
 
-- Text contrast ≥ 4.5:1 in both appearances (large text ≥ 3:1). Measured: #39FF88 on #000 ≈ 15.8:1;
-  #0F7A3D on white ≈ 5.4:1; #6D8A75 on #000 ≈ 5.5:1; #FF2BD6 on #000 ≈ 6.6:1.
+- Text contrast ≥ 4.5:1 in both appearances (large text ≥ 3:1). Measured (dark, on #000): textPrimary
+  #D9FFE6 ≈ 19.4:1; accentPrimary #39FF88 ≈ 15.8:1; textSecondary #6D8A75 ≈ 5.5:1; accentMagenta
+  #FF2BD6 ≈ 6.6:1. Measured (light, on #FAFAF8): textPrimary #1A211C ≈ 15.7:1; accentPrimary #0F7A3D
+  ≈ 5.2:1; textSecondary #5A6B5F ≈ 5.4:1.
+  Method: these ratios use the WCAG 2.x relative-luminance formula computed in
+  `apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift`, which fails
+  the build below the 4.5:1 floor for textPrimary/background and accentPrimary/background in both
+  appearances; the reference-screen run is recorded in the evidence `contrast.txt`.
 - Status is never conveyed by color alone (glyph + text always).
 - Full VoiceOver labels on all reference-screen controls; keyboard reachability preserved.
 - Respects Reduce Motion (no brand animation), Increase Contrast (borders step up to full alpha),

--- a/docs/design/live-site-design-source.md
+++ b/docs/design/live-site-design-source.md
@@ -94,10 +94,13 @@ status glyph language — not via neon-on-black.
   #D9FFE6 ≈ 19.4:1; accentPrimary #39FF88 ≈ 15.8:1; textSecondary #6D8A75 ≈ 5.5:1; accentMagenta
   #FF2BD6 ≈ 6.6:1. Measured (light, on #FAFAF8): textPrimary #1A211C ≈ 15.7:1; accentPrimary #0F7A3D
   ≈ 5.2:1; textSecondary #5A6B5F ≈ 5.4:1.
-  Method: these ratios use the WCAG 2.x relative-luminance formula computed in
-  `apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift`, which fails
-  the build below the 4.5:1 floor for textPrimary/background and accentPrimary/background in both
-  appearances; the reference-screen run is recorded in the evidence `contrast.txt`.
+  Method: these ratios use the WCAG 2.x relative-luminance formula computed in-repo by
+  `apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NDDesignTokenContractTests.swift` — the
+  reproducible proof any reader can run (`cd apps/neondiff-desktop && swift test --filter NDDesignTokenContractTests`).
+  It fails the build below the 4.5:1 floor for textPrimary/background and accentPrimary/background in both
+  appearances, and runs in CI on every head (Swift Desktop Gate → "Swift core, AppCore, and evaluation-support
+  tests"). Rendered screenshot artifacts are held outside the repo per the evidence-retention/secret boundary and
+  are not required to verify these numbers.
 - Status is never conveyed by color alone (glyph + text always).
 - Full VoiceOver labels on all reference-screen controls; keyboard reachability preserved.
 - Respects Reduce Motion (no brand animation), Increase Contrast (borders step up to full alpha),
@@ -106,9 +109,12 @@ status glyph language — not via neon-on-black.
 ## Reference screen
 
 `OverviewView` (default landing tab) demonstrates this contract: tokenized colors/type, mono section
-labels, one bracket primary action, status rows with glyphs, corner-ticked readiness panel.
-Structural redesign of Home hierarchy remains owned by #521; onboarding by #519; the full component
-system by #520 (grounded in this document).
+labels, status rows with glyphs, and one bracket primary action as the screen's single decorative brand
+treatment (per the neon budget: the readiness panel is a plain tokenized surface, not corner-ticked, so
+it does not stack a second treatment against the bracket CTA). The corner-ticked console (`NDConsolePanel`)
+is reserved for evidence/log surfaces where it is the sole treatment. Structural redesign of Home
+hierarchy remains owned by #521; onboarding by #519; the full component system by #520 (grounded in this
+document).
 
 ## Contract enforcement
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,6 +5,14 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
+On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface:
+it drives the device-flow "Connect GitHub" authorization described below, while
+this document remains the operator/CLI reference for the App identity, permission
+set, and install path. The matching public website onboarding copy for this
+Mac-first journey lives in the website repo and is tracked in
+neon-diff-agent-website#52; it is intentionally not edited here (cross-repo
+change).
+
 ## Install URL
 
 Use the public NeonDiff GitHub App install URL from the release notes or website

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -15,9 +15,10 @@ the same local HTML dashboard used by the CLI.
 
 - No review engine runs in the desktop app.
 - No UI path posts GitHub reviews directly.
-- The Mac launcher implements native setup/status controls only where they can
-  write through existing CLI contracts. The local HTML dashboard remains the
-  deeper browser-first setup surface.
+- The native Mac app is the product surface for the Mac customer journey and
+  implements native setup/status controls that write through existing CLI
+  contracts. The local HTML dashboard is a diagnostic/operator surface for
+  CLI-first and non-Mac setups, not the product UI.
 - No signing, notarization, Sparkle appcast, downloadable artifact, TCC, Mac-control, or customer-control proof is claimed here.
 - Provider and license keys are stored in macOS Keychain under a NeonDiff-specific service and are never written to config files.
 - Native provider verification starts only from an explicit **Verify API Key** click. The stored provider key is read from Keychain for that operation and sent to the child CLI only through bounded standard input; it never enters argv, process environment, config, command previews, stdout/stderr, logs, screenshots, or evidence.
@@ -199,9 +200,9 @@ neondiff dashboard --config config.local.json --launchd-label com.electricsheeph
 neondiff dashboard --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --open true
 ```
 
-The dashboard remains the deeper browser-first setup and readiness surface for
-license status, GitHub App status, daemon status, and provider readiness. The
-Swift Providers pane now also offers the explicit, Keychain-backed verification
-action described above and retains only its redacted result metadata. Neither
-surface proves signed/notarized distribution, Sparkle/appcast delivery,
-browser/native parity, customer readiness, or v1.1 release completion.
+The dashboard is a diagnostic/operator surface for license status, GitHub App
+status, daemon status, and provider readiness; the native Swift app is the
+product surface. The Swift Providers pane now also offers the explicit,
+Keychain-backed verification action described above and retains only its
+redacted result metadata. Neither surface proves signed/notarized distribution,
+Sparkle/appcast delivery, customer readiness, or v1.1 release completion.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:watch": "vitest",
     "doctor": "tsx src/cli.ts doctor",
     "dashboard:preview-smoke": "tsx src/cli.ts dashboard --config config.example.json --preview-smoke true --output-dir runtime/dashboard-preview-smoke",
+    "check:design-source": "node scripts/check-design-source-contract.mjs",
     "check:public-claims": "node scripts/check-public-claims.mjs",
     "check:secrets": "node scripts/check-secret-scan.mjs",
     "check:secret-rule-differential": "node scripts/generate-secret-rules.mjs --check && node scripts/check-secret-rule-differential.mjs --require-swift",

--- a/scripts/check-design-source-contract.mjs
+++ b/scripts/check-design-source-contract.mjs
@@ -1,0 +1,90 @@
+import { readFileSync, existsSync } from "node:fs";
+
+// Contract guard for issue #611: the live production website
+// (https://neondiff.com) is the single approved visual source for the native
+// macOS app. This check fails the build if the design-source document is
+// missing or stripped, or if retired browser-dashboard/WebView-parity language
+// reappears in the public-facing product docs. Follows the style of
+// scripts/check-public-claims.mjs (Node, no dependencies).
+
+const designDoc = "docs/design/live-site-design-source.md";
+
+// Files that previously carried the retired "dashboard is the first-run
+// product surface" / browser-parity direction. Only these three are scanned;
+// eval and boundary docs legitimately keep parity disclaimers.
+const guardedDocs = ["README.md", "docs/SETUP.md", "docs/neondiff-desktop.md"];
+
+const requiredSubstrings = ["https://neondiff.com"];
+
+const requiredLinePatterns = [/Captured: 2026-07-15/];
+
+const requiredHeadings = [
+  "Design authority",
+  "Token table",
+  "Type system",
+  "Component translation",
+  "Neon budget",
+  "Forbidden clones",
+  "Light mode",
+  "Accessibility floors"
+];
+
+const forbiddenDocPatterns = [
+  /dashboard is the (human )?first-run/i,
+  /browser[- ]dashboard parity/i,
+  /webview/i
+];
+
+const violations = [];
+
+// (A) + (C) design-source document must exist and stay complete.
+if (!existsSync(designDoc)) {
+  violations.push(`${designDoc}: design-source document is missing`);
+} else {
+  const doc = readFileSync(designDoc, "utf8");
+  for (const needle of requiredSubstrings) {
+    if (!doc.includes(needle)) {
+      violations.push(`${designDoc}: missing required reference "${needle}"`);
+    }
+  }
+  for (const pattern of requiredLinePatterns) {
+    if (!pattern.test(doc)) {
+      violations.push(`${designDoc}: missing required line matching ${pattern}`);
+    }
+  }
+  for (const heading of requiredHeadings) {
+    if (!doc.includes(heading)) {
+      violations.push(`${designDoc}: missing required section "${heading}"`);
+    }
+  }
+  // (C) the rejected-direction statement must survive.
+  if (!doc.includes("rejected")) {
+    violations.push(`${designDoc}: missing the rejected-direction statement ("rejected")`);
+  }
+}
+
+// (B) retired-direction language must not reappear in the guarded product docs.
+for (const path of guardedDocs) {
+  if (!existsSync(path)) {
+    violations.push(`${path}: guarded doc is missing`);
+    continue;
+  }
+  const lines = readFileSync(path, "utf8").split("\n");
+  lines.forEach((line, index) => {
+    for (const pattern of forbiddenDocPatterns) {
+      if (pattern.test(line)) {
+        violations.push(`${path}:${index + 1}: retired-direction language matches ${pattern}: ${line.trim()}`);
+      }
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error("design-source contract violations:");
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log("live-site design-source contract ok");

--- a/scripts/check-design-source-contract.mjs
+++ b/scripts/check-design-source-contract.mjs
@@ -36,6 +36,14 @@ const requiredHeadings = [
   "Accessibility floors"
 ];
 
+// A required section counts only when it appears as a real Markdown heading
+// line (`^#{1,6} <text>`), not merely as a substring somewhere in prose — so a
+// section cannot be silently demoted to a sentence while keeping the gate green.
+function hasHeading(doc, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^#{1,6}[ \\t]+${escaped}[ \\t]*$`, "m").test(doc);
+}
+
 // Retired-direction language that must not reappear as an affirmative claim.
 // `exempt` (optional) matches negated/boundary phrasing on the same line that
 // is legitimate — e.g. "no WebView product UI" is a disclaimer of the rejected
@@ -69,7 +77,7 @@ export function collectViolations(root = process.cwd()) {
       }
     }
     for (const heading of requiredHeadings) {
-      if (!doc.includes(heading)) {
+      if (!hasHeading(doc, heading)) {
         violations.push(`${designDoc}: missing required section "${heading}"`);
       }
     }

--- a/scripts/check-design-source-contract.mjs
+++ b/scripts/check-design-source-contract.mjs
@@ -1,4 +1,6 @@
 import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 // Contract guard for issue #611: the live production website
 // (https://neondiff.com) is the single approved visual source for the native
@@ -6,6 +8,11 @@ import { readFileSync, existsSync } from "node:fs";
 // missing or stripped, or if retired browser-dashboard/WebView-parity language
 // reappears in the public-facing product docs. Follows the style of
 // scripts/check-public-claims.mjs (Node, no dependencies).
+//
+// `collectViolations(root)` is exported so the focused regression test
+// (tests/check-design-source-contract.test.ts) can exercise the gate against
+// fixture docs without spawning a subprocess; the CLI entrypoint below runs it
+// against the repo root and exits non-zero on any violation.
 
 const designDoc = "docs/design/live-site-design-source.md";
 
@@ -29,62 +36,81 @@ const requiredHeadings = [
   "Accessibility floors"
 ];
 
+// Retired-direction language that must not reappear as an affirmative claim.
+// `exempt` (optional) matches negated/boundary phrasing on the same line that
+// is legitimate — e.g. "no WebView product UI" is a disclaimer of the rejected
+// direction, not a reintroduction of it, so it must pass.
 const forbiddenDocPatterns = [
-  /dashboard is the (human )?first-run/i,
-  /browser[- ]dashboard parity/i,
-  /webview/i
+  { pattern: /dashboard is the (human )?first-run/i },
+  { pattern: /browser[- ]dashboard parity/i },
+  {
+    pattern: /webview/i,
+    exempt: /\b(no|not|never|without|no longer|isn'?t|aren'?t|does not|do not|don'?t|drop(?:ped|s)?|reject(?:ed|s)?|avoid)\b[^.]*\bwebview\b/i
+  }
 ];
 
-const violations = [];
+export function collectViolations(root = process.cwd()) {
+  const violations = [];
 
-// (A) + (C) design-source document must exist and stay complete.
-if (!existsSync(designDoc)) {
-  violations.push(`${designDoc}: design-source document is missing`);
-} else {
-  const doc = readFileSync(designDoc, "utf8");
-  for (const needle of requiredSubstrings) {
-    if (!doc.includes(needle)) {
-      violations.push(`${designDoc}: missing required reference "${needle}"`);
-    }
-  }
-  for (const pattern of requiredLinePatterns) {
-    if (!pattern.test(doc)) {
-      violations.push(`${designDoc}: missing required line matching ${pattern}`);
-    }
-  }
-  for (const heading of requiredHeadings) {
-    if (!doc.includes(heading)) {
-      violations.push(`${designDoc}: missing required section "${heading}"`);
-    }
-  }
-  // (C) the rejected-direction statement must survive.
-  if (!doc.includes("rejected")) {
-    violations.push(`${designDoc}: missing the rejected-direction statement ("rejected")`);
-  }
-}
-
-// (B) retired-direction language must not reappear in the guarded product docs.
-for (const path of guardedDocs) {
-  if (!existsSync(path)) {
-    violations.push(`${path}: guarded doc is missing`);
-    continue;
-  }
-  const lines = readFileSync(path, "utf8").split("\n");
-  lines.forEach((line, index) => {
-    for (const pattern of forbiddenDocPatterns) {
-      if (pattern.test(line)) {
-        violations.push(`${path}:${index + 1}: retired-direction language matches ${pattern}: ${line.trim()}`);
+  // (A) + (C) design-source document must exist and stay complete.
+  const designPath = join(root, designDoc);
+  if (!existsSync(designPath)) {
+    violations.push(`${designDoc}: design-source document is missing`);
+  } else {
+    const doc = readFileSync(designPath, "utf8");
+    for (const needle of requiredSubstrings) {
+      if (!doc.includes(needle)) {
+        violations.push(`${designDoc}: missing required reference "${needle}"`);
       }
     }
-  });
-}
-
-if (violations.length > 0) {
-  console.error("design-source contract violations:");
-  for (const violation of violations) {
-    console.error(`  - ${violation}`);
+    for (const pattern of requiredLinePatterns) {
+      if (!pattern.test(doc)) {
+        violations.push(`${designDoc}: missing required line matching ${pattern}`);
+      }
+    }
+    for (const heading of requiredHeadings) {
+      if (!doc.includes(heading)) {
+        violations.push(`${designDoc}: missing required section "${heading}"`);
+      }
+    }
+    // (C) the rejected-direction statement must survive.
+    if (!doc.includes("rejected")) {
+      violations.push(`${designDoc}: missing the rejected-direction statement ("rejected")`);
+    }
   }
-  process.exit(1);
+
+  // (B) retired-direction language must not reappear in the guarded product docs.
+  for (const path of guardedDocs) {
+    const full = join(root, path);
+    if (!existsSync(full)) {
+      violations.push(`${path}: guarded doc is missing`);
+      continue;
+    }
+    const lines = readFileSync(full, "utf8").split("\n");
+    lines.forEach((line, index) => {
+      for (const { pattern, exempt } of forbiddenDocPatterns) {
+        if (pattern.test(line) && !(exempt && exempt.test(line))) {
+          violations.push(`${path}:${index + 1}: retired-direction language matches ${pattern}: ${line.trim()}`);
+        }
+      }
+    });
+  }
+
+  return violations;
 }
 
-console.log("live-site design-source contract ok");
+function main() {
+  const violations = collectViolations();
+  if (violations.length > 0) {
+    console.error("design-source contract violations:");
+    for (const violation of violations) {
+      console.error(`  - ${violation}`);
+    }
+    process.exit(1);
+  }
+  console.log("live-site design-source contract ok");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-design-source-contract.mjs
+++ b/scripts/check-design-source-contract.mjs
@@ -49,7 +49,13 @@ function hasHeading(doc, heading) {
 // is legitimate — e.g. "no WebView product UI" is a disclaimer of the rejected
 // direction, not a reintroduction of it, so it must pass.
 const forbiddenDocPatterns = [
-  { pattern: /dashboard is the (human )?first-run/i },
+  // Retired "dashboard is the (human) first-run product surface" claim, allowing
+  // the affirmative-verb variants a rewrite might use ("remains", "serves as",
+  // "is still", …) so the exact retired direction cannot slip back with a
+  // synonym. Directional (dashboard → first-run) so the legitimate "the native
+  // app is the human first-run surface; the dashboard is an operator surface"
+  // framing does not false-positive.
+  { pattern: /dashboard\b[^.\n]{0,50}\b(is|is still|remains|serves as|stays|becomes|acts as|continues to be)\b[^.\n]{0,30}\bfirst-run\b/i },
   { pattern: /browser[- ]dashboard parity/i },
   {
     pattern: /webview/i,
@@ -81,9 +87,20 @@ export function collectViolations(root = process.cwd()) {
         violations.push(`${designDoc}: missing required section "${heading}"`);
       }
     }
-    // (C) the rejected-direction statement must survive.
-    if (!doc.includes("rejected")) {
-      violations.push(`${designDoc}: missing the rejected-direction statement ("rejected")`);
+    // (C) the SPECIFIC retired-direction rejections must survive — not merely the
+    // generic word "rejected". The unshipped-redesign line also says "rejected",
+    // so a bare includes() would pass even after the browser-dashboard/WebView
+    // boundary rejection is deleted. Each canonical rejection is checked
+    // individually so none can be stripped in isolation.
+    const requiredRejections = [
+      { label: "unshipped website redesign", pattern: /redesign is rejected/i },
+      { label: "browser-dashboard parity", pattern: /browser[- ]dashboard parity[\s\S]{0,80}\brejected\b/i },
+      { label: "WebView product UI", pattern: /webview[\s\S]{0,80}\brejected\b/i }
+    ];
+    for (const { label, pattern } of requiredRejections) {
+      if (!pattern.test(doc)) {
+        violations.push(`${designDoc}: missing the rejected-direction statement for "${label}"`);
+      }
     }
   }
 

--- a/tests/check-design-source-contract.test.ts
+++ b/tests/check-design-source-contract.test.ts
@@ -73,6 +73,18 @@ describe("design-source contract gate", () => {
     expect(violations.some((v) => v.includes('missing required section "Light mode"'))).toBe(true);
   });
 
+  it("fails when a required heading appears only as prose, not a real heading", () => {
+    // The words are present, but only as inline prose — the section was removed.
+    // A substring match would false-pass this; the gate requires a real
+    // Markdown heading line (`^#{1,6} Light mode`).
+    const demoted = validDesignDoc.replace(
+      "## Light mode\n",
+      "We also cover Light mode inside the Accessibility floors section.\n"
+    );
+    const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": demoted }));
+    expect(violations.some((v) => v.includes('missing required section "Light mode"'))).toBe(true);
+  });
+
   it("fails when the rejected-direction statement is stripped", () => {
     const stripped = validDesignDoc.replace("The unshipped redesign is rejected.", "The unshipped redesign is retired.");
     const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": stripped }));

--- a/tests/check-design-source-contract.test.ts
+++ b/tests/check-design-source-contract.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectViolations } from "../scripts/check-design-source-contract.mjs";
+
+// Focused regression coverage for the #611 design-source contract gate. Proves
+// the checker fails red on each guarded violation and stays green on a clean
+// doc set — including the negated-disclaimer case, so boundary language such as
+// "no WebView product UI" is not false-failed as a retired-direction claim.
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const validDesignDoc = [
+  "# NeonDiff design source of truth",
+  "",
+  "Captured: 2026-07-15",
+  "Source: https://neondiff.com",
+  "The unshipped redesign is rejected.",
+  "",
+  "## Design authority",
+  "## Token table",
+  "## Type system",
+  "## Component translation",
+  "## Neon budget",
+  "## Forbidden clones",
+  "## Light mode",
+  "## Accessibility floors",
+  ""
+].join("\n");
+
+const cleanGuardedDoc = "The native macOS app is the human first-run surface; the local HTML dashboard is an operator/diagnostic surface.\n";
+
+// A clean fixture: complete design doc + three guarded docs with no
+// retired-direction language. `overrides` replaces or deletes files by path.
+function writeFixture(overrides: Record<string, string | null> = {}): string {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-design-source-"));
+  roots.push(root);
+  const files: Record<string, string> = {
+    "docs/design/live-site-design-source.md": validDesignDoc,
+    "README.md": cleanGuardedDoc,
+    "docs/SETUP.md": cleanGuardedDoc,
+    "docs/neondiff-desktop.md": cleanGuardedDoc
+  };
+  for (const [path, value] of Object.entries(overrides)) {
+    if (value === null) delete files[path];
+    else files[path] = value;
+  }
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(root, path);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+describe("design-source contract gate", () => {
+  it("passes clean docs (green)", () => {
+    expect(collectViolations(writeFixture())).toEqual([]);
+  });
+
+  it("fails when the design doc is missing", () => {
+    const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": null }));
+    expect(violations.some((v) => v.includes("design-source document is missing"))).toBe(true);
+  });
+
+  it("fails when a required heading is stripped", () => {
+    const stripped = validDesignDoc.replace("## Light mode\n", "");
+    const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": stripped }));
+    expect(violations.some((v) => v.includes('missing required section "Light mode"'))).toBe(true);
+  });
+
+  it("fails when the rejected-direction statement is stripped", () => {
+    const stripped = validDesignDoc.replace("The unshipped redesign is rejected.", "The unshipped redesign is retired.");
+    const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": stripped }));
+    expect(violations.some((v) => v.includes('the rejected-direction statement'))).toBe(true);
+  });
+
+  it.each([
+    ["dashboard-as-first-run", "README.md", "The HTML dashboard is the first-run surface for everyone.\n"],
+    ["browser-dashboard parity", "docs/SETUP.md", "The native app maintains browser-dashboard parity with the web build.\n"],
+    ["affirmative WebView claim", "docs/neondiff-desktop.md", "The app embeds a WebView product surface for onboarding.\n"]
+  ])("fails on reintroduced %s language", (_label, path, content) => {
+    const violations = collectViolations(writeFixture({ [path]: content }));
+    expect(violations.some((v) => v.startsWith(`${path}:`))).toBe(true);
+  });
+
+  it("passes a negated WebView disclaimer (boundary language, not a claim)", () => {
+    const violations = collectViolations(
+      writeFixture({ "docs/neondiff-desktop.md": "There is no WebView product UI; the app is native SwiftUI.\n" })
+    );
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/check-design-source-contract.test.ts
+++ b/tests/check-design-source-contract.test.ts
@@ -19,7 +19,7 @@ const validDesignDoc = [
   "",
   "Captured: 2026-07-15",
   "Source: https://neondiff.com",
-  "The unshipped redesign is rejected.",
+  "The unshipped website redesign is rejected. Browser-dashboard parity and WebView product UI are rejected.",
   "",
   "## Design authority",
   "## Token table",
@@ -86,9 +86,27 @@ describe("design-source contract gate", () => {
   });
 
   it("fails when the rejected-direction statement is stripped", () => {
-    const stripped = validDesignDoc.replace("The unshipped redesign is rejected.", "The unshipped redesign is retired.");
+    const stripped = validDesignDoc.replace("The unshipped website redesign is rejected.", "The unshipped website redesign is retired.");
     const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": stripped }));
     expect(violations.some((v) => v.includes('the rejected-direction statement'))).toBe(true);
+  });
+
+  it("fails when the browser-dashboard/WebView rejection is deleted but a generic 'rejected' survives", () => {
+    // Keeps the unshipped-redesign rejection, drops the specific retired-direction
+    // boundary. A bare `includes("rejected")` would false-pass this.
+    const stripped = validDesignDoc.replace(
+      " Browser-dashboard parity and WebView product UI are rejected.",
+      ""
+    );
+    const violations = collectViolations(writeFixture({ "docs/design/live-site-design-source.md": stripped }));
+    expect(violations.some((v) => v.includes('the rejected-direction statement'))).toBe(true);
+  });
+
+  it("fails on a broadened dashboard-first-run verb (remains) in a guarded doc", () => {
+    const violations = collectViolations(
+      writeFixture({ "docs/SETUP.md": "The local HTML dashboard remains the first-run setup surface for everyone.\n" })
+    );
+    expect(violations.some((v) => v.startsWith("docs/SETUP.md:"))).toBe(true);
   });
 
   it.each([


### PR DESCRIPTION
Closes part of #611 (parent epic #610). Makes the live production website
(https://neondiff.com, captured 2026-07-15) the single approved visual source for
the native macOS app, adds a failing-first contract check that blocks retired
browser-dashboard/WebView parity language, and lands a tokenized Overview
reference screen in both appearances.

## What this delivers (AC 1, 4, 5, 6, 7)
- **docs/design/live-site-design-source.md** — names the live URL + capture date,
  the token table, type system, component-translation rules, neon budget,
  light-mode translation, and accessibility floors. Distinguishes brand
  translation from pixel cloning; records the rejected direction (unshipped
  redesign, browser-dashboard parity, WebView product UI).
- **scripts/check-design-source-contract.mjs** (`npm run check:design-source`,
  wired into the CI check lane) — fails if the doc is missing/stripped or if
  retired "dashboard is the first-run surface" / "browser-dashboard parity" /
  "webview" language reappears in README.md, docs/SETUP.md, docs/neondiff-desktop.md.
- **Doc corrections** — README.md, docs/SETUP.md, docs/neondiff-desktop.md now
  frame the native macOS app as the human first-run product surface and the local
  HTML dashboard as an operator/diagnostic surface; dropped browser/native parity
  framing (kept proof-boundary disclaimers).
- **NDDesignTokens + NeonDiffTheme** — ten semantic tokens (dark+light),
  appearance-resolving `NDColor`, mono `NDFont` label/console system,
  `NDBracketButtonStyle`, `NDConsolePanel`.
- **OverviewView reference screen** — tokenized surfaces for both appearances,
  mono uppercase section labels, a plain tokenized readiness panel with glyph+text
  status rows (never color alone), and one bracket primary action as the screen's
  single decorative brand treatment (one-treatment neon budget). All existing
  bindings, accessibility identifiers, and the #517 geometry sentinel
  (`neondiff-overview-start-dashboard`) preserved; no window/frame/layout
  constants changed.

## Round-2 review fixes (b9de4c3)
- **Heading gate** — `check-design-source-contract.mjs` now requires real Markdown
  heading lines (`^#{1,6} <text>$`) instead of substring matches, so a section
  cannot be demoted to prose while the gate stays green (failing-test-first;
  regression added to `tests/check-design-source-contract.test.ts`).
- **Contrast citation** — the doc's Accessibility-floors "Method" now cites the
  in-repo, runnable `NDDesignTokenContractTests` (CI-gated) instead of implying a
  committed screenshot/`contrast.txt` artifact.
- **Light-mode retokenize** — Overview-only `CommandPanel` resolves via `NDPalette`
  (was `NeonDiffTheme.accentSoft` ≈1.3:1 on the light surface); square tokenized
  rows, no geometry/sentinel change.
- **Neon budget** — the readiness panel dropped its corner-tick `NDConsolePanel`
  flourish so the bracket CTA is the single decorative treatment; `NDConsolePanel`
  is reserved for evidence/log surfaces.

## Failing-first evidence
- `check:design-source` **red** before the doc/corrections (design doc missing;
  README:126 / SETUP:223 still called the HTML dashboard the first-run surface),
  **green** after.
- Swift theme-contract test **red** (NDDesignTokens/NDColorValue absent) → **green**
  after tokens added. Measured WCAG contrast (relative-luminance computed in-test):
  textPrimary/bg 19.40:1 (dark) / 15.72:1 (light); accentPrimary/bg 15.83:1 (dark)
  / 5.19:1 (light) — all ≥ 4.5:1.

## Reference-screen evidence (public-safe, deterministic fixture; not committed)
`/Volumes/LEXAR/Codex/evidence/neondiff/customer-journey/2026-07-15/4f8e1245e816/design-reference/`
overview-dark.png, overview-light.png, ax-labels.txt, contrast.txt, red/green
check logs, README.txt.

> Note: the committed `overview-*.png` predate the round-2 Overview visual pass
> (CommandPanel retokenize + de-corner-ticked readiness panel) and were not
> re-captured — the screenshot pipeline is out-of-repo and not reproducible in the
> review-fix session. The design-token/contrast proof is CI-gated
> (`NDDesignTokenContractTests`, unchanged); the Overview changes are covered by
> `swift build` (debug+release) + that test, not by the screenshots.

**Light mode is pixel-verified rendering light.** A content-region background
pixel sampled `(0.98,0.98,0.973)` = #FAFAF8 (all channels > 0.85) before saving;
panel interiors sampled white. An earlier attempt rendered dark because `NDColor`
used an NSColor dynamic provider that ignores SwiftUI's `preferredColorScheme`;
fixed by `NDPalette`, which resolves the raw tokens from the `\.colorScheme`
environment (commit `fix(desktop): resolve NeonDiff tokens via SwiftUI colorScheme`).

**Measured platform note (large text):** NDFont roles are relative text styles
(the correct Dynamic Type implementation), but macOS SwiftUI here does not resize
standard fonts for the dynamicTypeSize value — measured: the readiness text band
spans an identical 163px with the accessibility5 hook engaged and across two
baseline dark captures. No large-text capture is shipped (it would be a duplicate);
the DEBUG hook remains for eval only and the type contract is unit-verified.

## Proof boundary
Docs + tokens + one reference screen only. **No** release/GA/notarize/parity
claims. Downstream rollout stays owned by #520 (component system, grounded in this
doc), #519 (onboarding), #521 (Home hierarchy). Does not touch the #517 geometry
harness, LogsView geometry, or existing UITest matrix files. #503's parity
requirement is superseded by this contract per the epic (not closed here).

## Content vs contract (read before evaluating the reference screen)
- **This PR styles the EXISTING Overview content.** The dashboard-launcher /
  CLI-equivalents content and the `DEV MVP` / `NO LIVE POSTING` chrome are the
  retired direction's *content* — they are owned by #521 (journey blueprint
  stage 8 replaces them with the readiness-checklist Home). Do not read this
  screen's content as the target product; this PR demonstrates the design
  *contract* (tokens, mono labels, glyph language, bracket CTA, console panel),
  not the final Home information architecture.
- **The bright mint title band in dark mode predates this PR** and violates the
  new neon budget. It is shared shell chrome (OperatorSectionHeader), flagged for
  #521, and intentionally left untouched here (no broad tab/shell rewrite).
- **Release builds pin dark today.** Light mode is contract-ready — unit-tested
  tokens (contrast.txt) and fixture-proven rendering (overview-light.png captured
  via the DEBUG evaluation fixture appearance=light path) — and release adoption
  of selectable/system appearance is a #520/#521 rollout decision, not claimed here.

