### PR TITLE
feat(policy): enforce public-free/private-paid at the authorization boundary (#614)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,13 @@ If you are a coding agent working in this repository:
 ## Source-Available Product Boundary
 
 - NeonDiff is source-available beta software.
-- API-backed activation is required for supported public, private, internal, and unknown repository work.
+- Public open-source repositories are free and require no NeonDiff Activation Key
+  (owner ruling; the #532 "activate every repository" pivot is reversed).
+- API-backed activation is required for supported private, internal, and
+  commercial repository work; unknown visibility fails closed. GitHub-authoritative
+  visibility decides the tier, and provider verification is still required for all
+  tiers. Enforced at the #614 authorization boundary; public-facing website copy
+  migration is owned by website #52.
 - Active individual, organization, trial, or legacy entitlements govern supported use and update access.
 - License keys support paid/private usage and update entitlement.
 - Exact license text, public/private grants, and commercial terms are governed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,13 @@ Agents should read [AGENTS.md](AGENTS.md) before editing this repository.
 ## Pull Request Expectations
 
 - Preserve source-available beta wording unless #104 is updated with approved license text.
-- Preserve mandatory API-backed activation for public, private, internal, and
-  unknown repository work; do not reintroduce a free-use bypass.
+- Preserve mandatory API-backed activation for private, internal, and commercial
+  repository work, and fail closed on unknown visibility; the "no free-use bypass"
+  rule protects the PRIVATE-entitlement boundary. Public open-source repositories
+  are intentionally free (owner ruling — policy, not a bypass). Keep
+  GitHub-authoritative visibility with unknown failing closed; provider
+  verification remains required for all tiers. Public-facing website copy migration
+  is owned by website #52.
 - Preserve dry-run before live posting.
 - Preserve current-head duplicate suppression and stale-head checks.
 - Preserve secret-looking finding suppression.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Use it when you want a GitHub App to review pull requests from a local worker,
 with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
-API-backed activation is required for supported review work on every repository
-visibility. NeonDiff support licenses cost $1/month or $10/year for individuals,
+Public open-source repositories are free and require no NeonDiff Activation Key.
+API-backed activation is required for private, internal, and commercial repository
+work, and unknown visibility fails closed; GitHub-authoritative visibility decides
+the tier, and provider verification is still required for all tiers. NeonDiff
+support licenses cost $1/month or $10/year for individuals,
 or $100/year for organizations. Individual plans include a 7-day trial,
 organization plans include a 30-day trial, and legacy lifetime licenses remain
 honored but are no longer sold. NeonDiff is source-available commercial

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -22,10 +22,14 @@ for the support-tier pricing contract.
 - npm
 - GitHub App credentials for the repos you want to review
 - a provider/model path available on the machine running the worker
-- NeonDiff license key for API-backed activation before supported review work
+- NeonDiff license key for private, internal, or commercial review (public
+  open-source review is free)
 
-API-backed activation is required for supported public, private, internal, and
-unknown repository review. Support licenses cost $1/month or $10/year for
+Public open-source repositories are free and require no NeonDiff Activation Key.
+API-backed activation is required for private, internal, and commercial
+repository work; unknown visibility fails closed, and GitHub-authoritative
+visibility (public, private, internal, and unknown) decides the tier. Support
+licenses cost $1/month or $10/year for
 individuals, or $100/year for organizations. Individual plans include a 7-day
 trial, organization plans include a 30-day trial, and legacy lifetime licenses
 remain honored for existing holders but are no longer sold. Provider/model costs

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -54,6 +54,14 @@ because milestone or planning days can create large issue bursts.
 
 ## Selected-Repo Install Path
 
+> This page covers the shipped **local-worker direct install**, where the worker
+> holds the App private key itself and no OAuth-during-install step is needed. The
+> separate **managed authorization broker** (owner-gated, not yet wired to the
+> desktop — #612) instead requires the App to enable "Request user authorization
+> (OAuth) during installation" and set the `/github/connect/callback` URL; that
+> registration is documented in `docs/security/github-app-staging-registration.md`.
+> Do not enable OAuth-during-install for the local direct-install path below.
+
 1. Open the NeonDiff GitHub App install URL.
 2. Choose the user or organization that owns the repositories.
 3. Select `Only select repositories`.

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -5,12 +5,13 @@ that lets a NeonDiff desktop client connect the official NeonDiff GitHub App and
 obtain bounded, short-lived installation access without ever holding the App
 private key.
 
-This document covers the **server-side slice only** (issue #613). Native connect
-UI states are sequenced after #611/#612; the repository-visibility and
-entitlement decision that #614 binds at token issuance is present here only as a
-single seam function (`authorizeTokenIssuance`) with a fail-closed pre-#614
-default. No production GitHub App exists yet; every code path below is exercised
-against fixtures, never a live install (see "Owner-gated boundary").
+This document covers the **server-side slice** (issues #613 and #614). Native
+connect UI states are sequenced after #611/#612. The repository-visibility and
+entitlement decision is bound at token issuance in the single seam function
+`authorizeTokenIssuance` (#614); the live device<->license linkage and deployment
+wiring belong to the deploy lane (#559). No production GitHub App exists yet;
+every code path below is exercised against fixtures, never a live install (see
+"Owner-gated boundary").
 
 ## Problem
 
@@ -140,12 +141,22 @@ embedded key (see Rollback in issue #613).
 - `repo_renamed_or_transferred` — the installation repository list is re-fetched at
   issuance; a stale repository reference is a typed error, never a silent pass.
 - `visibility_unknown` — a requested repo's visibility could not be determined;
-  fail closed rather than assume public.
-- `entitlement_gate_not_implemented` — the pre-#614 default: a requested repo is
-  private or internal and the entitlement gate that would authorize it is not yet
-  implemented. Fail closed.
-- `entitlement_missing` — reserved for #614 (private repo without active
-  entitlement).
+  fail closed rather than assume public (HTTP 403).
+- Entitlement decisions for a private/internal request (#614), each a distinct
+  fail-closed reason code so native/CLI consumers can key their locked/free
+  explanation and recovery action off the exact state:
+  - `entitlement_missing` — no active entitlement was resolved (HTTP 403).
+  - `entitlement_expired` — the entitlement has lapsed (HTTP 403).
+  - `entitlement_revoked` — the entitlement was revoked (HTTP 403).
+  - `entitlement_invalid` — the entitlement is not recognized (HTTP 403).
+  - `entitlement_scope_insufficient` — an active license whose scope covers only
+    public repositories (HTTP 403).
+  - `entitlement_seat_exhausted` — the license seat allocation is exhausted for
+    this device (HTTP 409).
+  - `entitlement_replay_conflict` — an entitlement event-order/replay conflict
+    (HTTP 409).
+  - `entitlement_service_unavailable` — the license authority could not be
+    reached; fail closed, never allow (HTTP 503).
 - `rate_limited` — per-device and per-installation budgets on the broker; GitHub
   secondary limits are surfaced distinctly.
 - `broker_unavailable` — the broker or its GitHub dependency is unreachable; the
@@ -154,17 +165,47 @@ embedded key (see Rollback in issue #613).
 ## The issuance seam (`authorizeTokenIssuance`)
 
 There is exactly one code path that can mint an installation token, and it flows
-through `authorizeTokenIssuance`. The function receives the requested repositories
-already resolved against the installation's repository list (each with its
-visibility) and returns either `allow` (with the exact repositories to narrow to)
-or `deny` with a typed reason code.
-
-Pre-#614 policy: `allow` only when **every** requested repository is verified
-`public`; any `private`, `internal`, or `unknown` visibility denies with
-`entitlement_gate_not_implemented` (or `visibility_unknown`). #614 replaces the
-body of this one function to add the entitlement decision; no caller can skip it
-because minting is unreachable except through its `allow` result (the
+through `authorizeTokenIssuance`. The function is pure: it receives the requested
+repositories already resolved against the installation's repository list (each
+with its GitHub-authoritative visibility) plus the entitlement snapshot the
+service resolved from the license authority, and returns either `allow` (with the
+exact repositories to narrow to) or `deny` with a typed reason code. No caller can
+skip it because minting is unreachable except through its `allow` result (the
 gate-every-caller rule).
+
+#614 policy, evaluated in order:
+
+1. An empty request is `invalid_request`.
+2. Any repository whose visibility could not be authoritatively determined denies
+   with `visibility_unknown` — never assume public.
+3. An **all-public** request is authorized with **no NeonDiff Activation Key**
+   (the public-free tier); the entitlement snapshot is not consulted, so the free
+   tier does not depend on the license authority being reachable.
+4. Otherwise (at least one `private`/`internal` repository) an **active,
+   private-covering entitlement** is required. Every other entitlement state
+   denies with its own distinct reason code (see "Failure and abuse states").
+
+**Ordering and egress.** The service resolves entitlement for the non-public
+repositories *before* calling the seam and *before* any mint, using only the
+license authority (no GitHub content API, no provider/model call). A blocked
+private request therefore mints no usable installation token — zero content
+egress. Reading the installation's repository list to determine visibility uses a
+separate **metadata:read-only** token, so no broad token exists before the seam
+authorizes.
+
+**Server-authoritative visibility (AC1/AC6).** The token request body carries no
+visibility field; the broker derives visibility from GitHub. A modified client
+that believes a private repo is public gains nothing — the server's fresh read
+wins, and a private repo without an active entitlement is denied.
+
+**A provider key never unlocks private (AC5).** The seam has no provider-key
+input by construction; the only snapshot that authorizes a private request is an
+active, private-covering entitlement.
+
+The entitlement snapshot is resolved through an injected authority (contract
+shape: the license-api `Entitlement`, merged #574). Its default is fail-closed
+(deny all private work) until the deploy lane (#559) wires the live device<->
+license linkage; the broker slice proves the binding against fixtures only.
 
 ## Threat model (STRIDE)
 

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -99,11 +99,20 @@ device id (the digest of the registered public key). The broker verifies the
 signature against the stored public key and rejects expired or wrong-subject
 tokens.
 
-The GitHub installation flow itself is the proof of repository authority: a device
-can only ever obtain tokens for installations whose callback it completed, because
-the one-shot state nonce binds the browser session GitHub authorized to the device
-that initiated the connect. Private-tier binding to an activation/entitlement
-record at the license service is #612/#614 work, layered at the same seam.
+The GitHub installation flow is the proof of repository authority, but the
+one-shot state nonce alone is NOT sufficient: it binds the returning browser
+session to the initiating device, yet it does not prove the returning identity
+actually owns the installation id in the callback. So the callback additionally
+requires an **install-time OAuth authorization code** and verifies, via the
+exchanged user identity (`GET /user/installations`), that the user can access the
+requested installation before recording any binding (#614, P1). A device
+therefore obtains tokens only for installations whose ownership it proved at
+callback time — a valid state plus an arbitrary victim installation id binds
+nothing. Enabling OAuth-during-install and provisioning the OAuth client
+credentials is OWNER-GATED (see the staging-registration spec); until then the
+callback fails closed with `installation_authorization_unverified`. Private-tier
+binding to an activation/entitlement record at the license service is #612/#614
+work, layered at the same seam.
 
 ## Return path (resolves design open question #1)
 
@@ -136,6 +145,10 @@ embedded key (see Rollback in issue #613).
   (discovered at issuance time; there are no webhooks in v1, so uninstall surfaces
   at the next token request or poll failure).
 - `installation_suspended` — the installation is suspended.
+- `installation_authorization_unverified` — the callback did not prove the
+  returning identity owns the installation (missing/invalid install-time OAuth
+  code, or OAuth-during-install not yet provisioned); fail closed, no binding
+  (HTTP 403, #614 P1).
 - `repo_outside_installation` — a requested repo is not in the installation's
   current selection (AC4).
 - `repo_renamed_or_transferred` — the installation repository list is re-fetched at
@@ -211,7 +224,10 @@ license linkage; the broker slice proves the binding against fixtures only.
 
 - **Spoofing.** Unauthenticated token minting is prevented by device-signed
   requests plus callback-time binding; the state nonce is one-shot with a 10-minute
-  expiry, so a stolen or replayed callback cannot bind a foreign device.
+  expiry, and the callback additionally requires proof (the install-time OAuth
+  code) that the returning identity owns the installation, so neither a stolen or
+  replayed callback nor a valid state paired with a guessed victim installation id
+  can bind a foreign installation (#614 P1).
 - **Tampering.** Minted tokens are narrowed by the `repositories` and `permissions`
   parameters, so a leaked token bounds blast radius to the user's own selected
   repos for <= 1 h.
@@ -249,8 +265,15 @@ bindings and states; uninstalled installations are pruned on discovery.
    redirect in #612 if desired.
 2. **Device-registration abuse economics (OPEN).** Bot farms registering devices
    on the free tier. Initial posture: registration rate limits plus GitHub-side
-   installation authority is the real gate (a device with no completed callback
-   can mint nothing). Revisit with abuse telemetry.
+   installation authority is the real gate — a device can mint nothing without a
+   binding, and a binding now requires proven installation ownership at callback
+   time (the install-time OAuth code exchange, #614 P1), not merely a completed
+   callback. This closes the install-binding forgery where a valid state plus a
+   guessed victim installation id could bind a foreign installation. **Blocking
+   owner-gated dependency:** the App must enable "Request user authorization
+   (OAuth) during installation" and provision its OAuth client id/secret (see
+   `docs/security/github-app-staging-registration.md`); until then the callback
+   fails closed. Revisit registration abuse with telemetry.
 3. **Token-response repo snapshot (RESOLVED).** `POST /github/token` returns only
    the token, its expiry, and the granted repositories/permissions. The app lists
    repositories client-side with the brokered token, keeping broker surfaces

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -245,6 +245,18 @@ license linkage; the broker slice proves the binding against fixtures only.
   bound to the requesting device, and refuses repositories outside the
   installation's selection (AC4). #614 refuses private repos without entitlement —
   all at the same seam, so no caller path can skip a gate.
+  - **Known limitation — installation-level, not per-repo, identity (OPEN, owner/#559).**
+    The callback proves the OAuth identity can access the *installation*
+    (`GET /user/installations`), not each *repository* in it. In an org
+    installation whose selection spans repos the OAuth user can only partially
+    access, the device binds to the whole installation, and token issuance is then
+    gated by entitlement + installation selection but not by that user's per-repo
+    GitHub access. The installation's repo selection (org-admin-controlled at
+    install) is the v1 access boundary GitHub itself enforces on installation
+    tokens; tightening to per-repo OAuth-user access requires storing the user's
+    accessible-repo set per binding (or re-checking with a user token at mint
+    time), which the device-bound v1 model does not carry. Deferred to the
+    OAuth-wiring lane (#559) where the live identity model is finalized.
 
 ## Retention
 

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -282,18 +282,22 @@ license linkage; the broker slice proves the binding against fixtures only.
   bound to the requesting device, and refuses repositories outside the
   installation's selection (AC4). #614 refuses private repos without entitlement —
   all at the same seam, so no caller path can skip a gate.
-  - **Known limitation — installation-level, not per-repo, identity (OPEN, owner/#559).**
-    The callback proves the OAuth identity can access the *installation*
-    (`GET /user/installations`), not each *repository* in it. In an org
-    installation whose selection spans repos the OAuth user can only partially
-    access, the device binds to the whole installation, and token issuance is then
-    gated by entitlement + installation selection but not by that user's per-repo
-    GitHub access. The installation's repo selection (org-admin-controlled at
-    install) is the v1 access boundary GitHub itself enforces on installation
-    tokens; tightening to per-repo OAuth-user access requires storing the user's
-    accessible-repo set per binding (or re-checking with a user token at mint
-    time), which the device-bound v1 model does not carry. Deferred to the
-    OAuth-wiring lane (#559) where the live identity model is finalized.
+  - **Per-repo access is enforced at bind time (#614 P1).** The callback proves the
+    OAuth identity can access the installation AND enumerates the exact repositories
+    that user can reach (`GET /user/installations/{id}/repositories`); the binding is
+    scoped to that set, and token issuance refuses any repo outside it
+    (`repo_outside_authorization`). So in an org installation whose selection spans
+    repos the OAuth user can only partially access, the device can mint only for the
+    repos that user could actually reach — not the whole installation.
+  - **Known limitation — the authorized set is a bind-time snapshot (OPEN, future).**
+    The user OAuth token is deliberately not persisted, so the per-repo set is
+    captured once at connect and not re-verified on every `POST /github/token`. A
+    repository-access revocation on GitHub therefore takes effect for the broker on
+    the user's *next* connect/bind, not mid-session — acceptable because minted
+    installation tokens are short-lived (<= 1 h) and re-connecting refreshes the set
+    atomically. A periodic bind-refresh (re-running the user-token repo check on a
+    cadence or at token renewal) is a possible future tightening if near-real-time
+    revocation is required.
 
 ## Retention
 
@@ -313,12 +317,15 @@ bindings and states; uninstalled installations are pruned on discovery.
    uses the device-poll `complete` endpoint. See "Return path". Layer a scheme
    redirect in #612 if desired.
 2. **Device-registration abuse economics (OPEN).** Bot farms registering devices
-   on the free tier. Initial posture: registration rate limits plus GitHub-side
-   installation authority is the real gate — a device can mint nothing without a
-   binding, and a binding now requires proven installation ownership at callback
-   time (the install-time OAuth code exchange, #614 P1), not merely a completed
-   callback. This closes the install-binding forgery where a valid state plus a
-   guessed victim installation id could bind a foreign installation. **Blocking
+   on the free tier. Initial posture: the real gate is **proven per-repo GitHub
+   access at callback time** — a binding now requires the install-time OAuth code
+   exchange (#614 P1) and is scoped to the exact repositories that user can reach
+   (`GET /user/installations/{id}/repositories`), so a device can mint nothing
+   without it; installation membership + registration rate limits are the base
+   layer beneath that proof, not the primary control. This closes the
+   install-binding forgery where a valid state plus a guessed victim installation
+   id could bind a foreign installation, and prevents an entitled-but-unauthorized
+   user from reaching a private repo they cannot access. **Blocking
    owner-gated dependency:** the App must enable "Request user authorization
    (OAuth) during installation" and provision its OAuth client id/secret (see
    `docs/security/github-app-staging-registration.md`); until then the callback

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -57,14 +57,27 @@ the license store's strict schema verification is unaffected.
    choice, repository selection, and permission display. NeonDiff never proxies
    or skins this step, so the user sees the official App identity and exact
    permissions on github.com (AC2).
-4. **Callback (GitHub to broker).** `GET /github/connect/callback?installation_id&state`.
-   Because OAuth-during-install is disabled, this route is registered as the App's
-   **Setup URL** (GitHub's post-install redirect), not the user authorization
-   callback URL. The broker verifies the one-shot state (unconsumed, unexpired, CSRF-proof —
-   mirrors website PR #48: one-shot fulfillment tokens + explicit owned return
-   origins + framework CSRF), verifies the installation exists and belongs to the
-   App (`GET /app/installations/{id}` with an App JWT), records the binding
-   (device id <-> installation id), and marks the state consumed.
+4. **Callback (GitHub to broker).** `GET /github/connect/callback?installation_id&state&code`.
+   OAuth-during-install is **enabled**, so this route is the App's **user
+   authorization callback URL** (with OAuth-during-install on, GitHub makes the
+   Setup URL unavailable and sends the post-install browser return here), carrying
+   an install-time OAuth `code` alongside `installation_id` and `state`. The broker
+   verifies the one-shot state (unconsumed, unexpired, CSRF-proof — mirrors website
+   PR #48: one-shot fulfillment tokens + explicit owned return origins + framework
+   CSRF), then — **before** resolving the installation (decide before side effects,
+   so a forged callback cannot use App-JWT 403-vs-404 to probe arbitrary victim
+   installation ids) — exchanges the `code` for the returning user identity and
+   confirms via `GET /user/installations/{id}/repositories` that the user can
+   access the installation, capturing the exact repositories they can access (the
+   authorized set the binding is scoped to). Only then does it verify the
+   installation exists and belongs to the App (`GET /app/installations/{id}` with an
+   App JWT), record the binding (device id <-> installation id, scoped to that
+   authorized repo set), and mark the state consumed. A **code-less** return — a
+   bare install/reconfigure **update** redirect that carries `setup_action` but no
+   `code` (GitHub sends these to the same callback URL and they prove no new
+   authorization) — is acknowledged with the neutral return page and binds nothing,
+   so legitimate updates are never locked out; any *other* code-less callback fails
+   closed with `installation_authorization_unverified`.
 5. **Return (native to broker).** The app confirms the binding at
    `POST /github/connect/complete` with its device credential and the original
    `state`. See "Return path" for why this is a device poll rather than a
@@ -73,7 +86,10 @@ the license store's strict schema verification is unaffected.
    device credential, `installation_id`, and the requested `repositories` /
    `permissions`. The broker checks, in order: the binding exists; the
    installation is live and not suspended; every requested repository is present
-   in the installation's current selection; **then** the seam decision
+   in the installation's current selection; every requested repository is within
+   the connecting user's authorized set captured at bind time (else
+   `repo_outside_authorization`, so an entitled but GitHub-unauthorized user cannot
+   reach a private repo they cannot access); **then** the seam decision
    (`authorizeTokenIssuance`, the #614 gate); and only on `allow` mints an
    installation access token via App JWT, narrowed by the canonical
    `repository_ids` (GitHub rejects `owner/name` here) and a **server-clamped**
@@ -104,10 +120,17 @@ one-shot state nonce alone is NOT sufficient: it binds the returning browser
 session to the initiating device, yet it does not prove the returning identity
 actually owns the installation id in the callback. So the callback additionally
 requires an **install-time OAuth authorization code** and verifies, via the
-exchanged user identity (`GET /user/installations`), that the user can access the
-requested installation before recording any binding (#614, P1). A device
-therefore obtains tokens only for installations whose ownership it proved at
-callback time — a valid state plus an arbitrary victim installation id binds
+exchanged user identity, that the user can access the requested installation
+before recording any binding (#614, P1). Membership alone
+(`GET /user/installations`) does **not** prove access to every repository in an
+installation — an org install can list for a user who can reach only some of its
+repos. The broker therefore uses `GET /user/installations/{id}/repositories` to
+capture the **exact repository set** the returning user can access and scopes the
+binding to it; a later `POST /github/token` for any repo outside that set fails
+closed with `repo_outside_authorization`, so an entitled but GitHub-unauthorized
+user can never mint a token for a private repo they cannot access on GitHub. A
+device therefore obtains tokens only for installations — and repositories — whose
+access it proved at callback time — a valid state plus an arbitrary victim installation id binds
 nothing. Enabling OAuth-during-install and provisioning the OAuth client
 credentials is OWNER-GATED (see the staging-registration spec); until then the
 callback fails closed with `installation_authorization_unverified`. Private-tier
@@ -151,6 +174,11 @@ embedded key (see Rollback in issue #613).
   (HTTP 403, #614 P1).
 - `repo_outside_installation` — a requested repo is not in the installation's
   current selection (AC4).
+- `repo_outside_authorization` — a requested repo is in the installation but
+  outside the set the connecting OAuth user could access at bind time; fail closed
+  (HTTP 403, #614 P1). Installation membership alone (`GET /user/installations`)
+  does not prove per-repo access, so the binding is scoped to the exact repository
+  set from `GET /user/installations/{id}/repositories`.
 - `repo_renamed_or_transferred` — the installation repository list is re-fetched at
   issuance; a stale repository reference is a typed error, never a silent pass.
 - `visibility_unknown` — a requested repo's visibility could not be determined;
@@ -186,7 +214,7 @@ exact repositories to narrow to) or `deny` with a typed reason code. No caller c
 skip it because minting is unreachable except through its `allow` result (the
 gate-every-caller rule).
 
-#614 policy, evaluated in order:
+**#614 policy, evaluated in order:**
 
 1. An empty request is `invalid_request`.
 2. Any repository whose visibility could not be authoritatively determined denies

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -133,7 +133,16 @@ device therefore obtains tokens only for installations — and repositories — 
 access it proved at callback time — a valid state plus an arbitrary victim installation id binds
 nothing. Enabling OAuth-during-install and provisioning the OAuth client
 credentials is OWNER-GATED (see the staging-registration spec); until then the
-callback fails closed with `installation_authorization_unverified`. Private-tier
+callback fails closed with `installation_authorization_unverified`.
+
+The authorized repository set is a **bind-time snapshot** — the short-lived user
+OAuth token is deliberately not persisted, so the set is not re-verified on every
+`POST /github/token`. A repository-access revocation on GitHub therefore takes
+effect for the broker on the user's **next connect/bind**, not mid-session; this
+is acceptable because the minted installation tokens are short-lived (GitHub TTL
+<= 1 h) and re-connecting refreshes the set atomically. A periodic bind-refresh
+(re-running the user-token repository check on a cadence, or on token renewal) is
+a possible future tightening if near-real-time revocation is required. Private-tier
 binding to an activation/entitlement record at the license service is #612/#614
 work, layered at the same seam.
 

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -48,23 +48,30 @@ Issues merely because the App reviews PRs.
 
 Organization permissions: none. Account permissions: none.
 
-## 3. Setup URL (post-install redirect)
+## 3. Callback and Setup URLs (post-install redirect)
 
-Because OAuth-during-install is disabled (step 1), GitHub sends the post-install
-browser return to the App's **Setup URL**, not the user authorization callback URL
-(see https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-setup-url).
-Get this wrong and the broker never receives the install return, so the desktop
-poll pends until the state expires.
+Because OAuth-during-install is **enabled** (step 1), the post-install browser
+return carries an OAuth **`code`** in addition to `installation_id`, `state`, and
+`setup_action`; the broker exchanges that code to prove the returning identity
+owns the installation before it records any binding (the #614 P1 requirement). Get
+these URLs wrong and the broker never receives the install return (or receives it
+without a `code` and fails closed with `installation_authorization_unverified`),
+so the desktop poll pends until the state expires.
 
-- **Setup URL (required):** the broker return route on the license-service host:
+- **User authorization callback URL (required):** the broker return route on the
+  license-service host:
   `https://<license-service-host>/github/connect/callback`
-  After install, GitHub redirects here with `installation_id`, `setup_action`, and
-  the `state` the broker placed on the install link — exactly what
-  `GET /github/connect/callback` consumes.
-- **"Redirect on update":** enabled, so reconfiguring the installation returns
-  through the same route.
-- **User authorization callback URL:** unused in this flow (OAuth-on-install is
-  off); leave it blank or matching the Setup URL.
+  With OAuth-during-install enabled, GitHub redirects here after install with
+  `installation_id`, `setup_action`, the `state` the broker placed on the install
+  link, and the OAuth `code` — exactly what `GET /github/connect/callback`
+  consumes and verifies.
+- **Setup URL:** set to the **same** route
+  (`https://<license-service-host>/github/connect/callback`) so a plain install or
+  reconfigure still returns through the broker; with "Redirect on update" enabled,
+  reconfiguring the installation returns through the same route.
+- Both URLs point at the one broker route; it tolerates the `code`-bearing OAuth
+  return and the code-less update return (the latter fails closed with no binding,
+  by design).
 
 ## 4. Webhook
 
@@ -96,9 +103,10 @@ depend on device flow; this setting is only for the existing desktop path until
 ## 7. Deployment secrets [OWNER-GATED]
 
 Place the following in the license-service deployment environment (Fly secrets for
-the shared `services/license-api` deployment). The broker reads the private key
-from this secret store at runtime and never persists, logs, or returns it. These
-names are the contract for the future production-wiring step in `server.ts`.
+the shared `services/license-api` deployment). The broker reads the private key and
+the OAuth client secret from this secret store at runtime and never persists, logs,
+or returns them. These names are the contract for the future production-wiring step
+in `server.ts`.
 Until it provides `githubBroker`, the shared license request listener matches every
 broker path and returns a typed `{ "reason": "broker_unavailable" }` 503 — a
 deliberate fail-closed status, not an unrouted 404:
@@ -107,9 +115,12 @@ deliberate fail-closed status, not an unrouted 404:
 |---------------------------------|---------|
 | `GITHUB_BROKER_APP_ID`          | Numeric staging App id. |
 | `GITHUB_BROKER_PRIVATE_KEY`     | Staging App private key PEM contents. |
+| `GITHUB_BROKER_OAUTH_CLIENT_ID`     | Staging App OAuth **client id** ("Request user authorization (OAuth) during installation", step 1). Wires to `githubBroker.oauthClientId`. Required for callback identity verification (#614 P1). |
+| `GITHUB_BROKER_OAUTH_CLIENT_SECRET` | Staging App OAuth **client secret**. Wires to `githubBroker.oauthClientSecret`. Used only to exchange the callback `code` for a short-lived user token to confirm installation ownership; never persisted, logged, or returned. |
 | `GITHUB_BROKER_INSTALL_BASE_URL`| `https://github.com/apps/<staging-app-slug>/installations/new`. |
 | `GITHUB_BROKER_DB_PATH`         | Path for the broker SQLite DB on the mounted volume (separate from `LICENSE_DB_PATH`). |
 | `GITHUB_BROKER_API_BASE_URL`    | Optional; defaults to `https://api.github.com`. |
+| `GITHUB_BROKER_OAUTH_BASE_URL`  | Optional; OAuth authorization host, defaults to `https://github.com`. Wires to `githubBroker.oauthBaseUrl`. |
 
 Do not reuse the production `LICENSE_ISSUANCE_SECRET` or any production credential
 for staging.

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -19,15 +19,22 @@ production identity is created only after the committed security review
    GitHub App named distinctly for staging, e.g. `NeonDiff (Staging)`.
 2. Homepage URL: the NeonDiff website or repository URL.
 3. **[OWNER-GATED — BLOCKING for #614]** **Enable** "Request user authorization
-   (OAuth) during installation", set the callback/Setup URL to the broker's
-   `/github/connect/callback`, and provision the App's OAuth **client id** and
-   **client secret** as deployment secrets (`githubBroker.oauthClientId` /
-   `oauthClientSecret`). The broker binds a device to an installation ONLY after
-   exchanging the install-time authorization `code` and confirming the
-   authorizing user can access that installation (`GET /user/installations`).
-   Without this, a valid one-shot state alone lets a caller bind to an arbitrary
-   (victim) installation id — the install-binding forgery the #614 security
-   review flagged (P1). Until it is enabled, `connectCallback` fails closed with
+   (OAuth) during installation", set the **User authorization callback URL** to
+   the broker's `/github/connect/callback`, and provision the App's OAuth
+   **client id** and **client secret** as deployment secrets
+   (`githubBroker.oauthClientId` / `oauthClientSecret`). Note that with
+   OAuth-during-install enabled GitHub makes the separate **Setup URL** field
+   **unavailable** (the two are mutually exclusive) and routes the post-install
+   return to this callback URL instead — so there is no Setup URL to set. The
+   broker binds a device to an installation ONLY after exchanging the install-time
+   authorization `code` and confirming the authorizing user can access it; because
+   installation membership alone (`GET /user/installations`) does not prove access
+   to every repository in an org installation, the broker enumerates the user's
+   accessible repositories with `GET /user/installations/{id}/repositories` and
+   scopes the binding to that exact set (per-repo, #614 P1). Without this, a valid
+   one-shot state alone lets a caller bind to an arbitrary (victim) installation id
+   — the install-binding forgery the #614 security review flagged (P1). Until it is
+   enabled, `connectCallback` fails closed with
    `installation_authorization_unverified` and no binding is recorded.
 
 ## 2. Repository permissions
@@ -48,30 +55,33 @@ Issues merely because the App reviews PRs.
 
 Organization permissions: none. Account permissions: none.
 
-## 3. Callback and Setup URLs (post-install redirect)
+## 3. Callback URL (post-install redirect)
 
 Because OAuth-during-install is **enabled** (step 1), the post-install browser
 return carries an OAuth **`code`** in addition to `installation_id`, `state`, and
 `setup_action`; the broker exchanges that code to prove the returning identity
-owns the installation before it records any binding (the #614 P1 requirement). Get
-these URLs wrong and the broker never receives the install return (or receives it
-without a `code` and fails closed with `installation_authorization_unverified`),
-so the desktop poll pends until the state expires.
+owns the installation before it records any binding (the #614 P1 requirement).
+With OAuth-during-install on, GitHub makes the separate **Setup URL** field
+**unavailable** — there is exactly one URL to set, and every install/reconfigure
+return comes through it. Get it wrong and the broker never receives the install
+return (or receives it without a `code` and fails closed with
+`installation_authorization_unverified`), so the desktop poll pends until the
+state expires.
 
-- **User authorization callback URL (required):** the broker return route on the
-  license-service host:
+- **User authorization callback URL (the only URL to set):** the broker return
+  route on the license-service host:
   `https://<license-service-host>/github/connect/callback`
   With OAuth-during-install enabled, GitHub redirects here after install with
   `installation_id`, `setup_action`, the `state` the broker placed on the install
   link, and the OAuth `code` — exactly what `GET /github/connect/callback`
   consumes and verifies.
-- **Setup URL:** set to the **same** route
-  (`https://<license-service-host>/github/connect/callback`) so a plain install or
-  reconfigure still returns through the broker; with "Redirect on update" enabled,
-  reconfiguring the installation returns through the same route.
-- Both URLs point at the one broker route; it tolerates the `code`-bearing OAuth
-  return and the code-less update return (the latter fails closed with no binding,
-  by design).
+- **Redirect on update (reconfigure):** a reconfigure/update return arrives at the
+  same callback URL but is **code-less** (it carries `setup_action` and
+  `installation_id`, not a new authorization `code`). The broker acknowledges it
+  with the neutral return page and binds nothing, so a legitimate installation
+  update is **never locked out** — the existing binding is untouched and the device
+  simply keeps polling. Only a code-less return that is *not* a `setup_action`
+  update fails closed with `installation_authorization_unverified`.
 
 ## 4. Webhook
 

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -18,9 +18,17 @@ production identity is created only after the committed security review
 1. Under the owning org (or a personal account for early staging), create a new
    GitHub App named distinctly for staging, e.g. `NeonDiff (Staging)`.
 2. Homepage URL: the NeonDiff website or repository URL.
-3. Leave "Request user authorization (OAuth) during installation" unchecked for
-   the install/authorize broker flow (the broker binds via installation id +
-   one-shot state, not a user OAuth token).
+3. **[OWNER-GATED — BLOCKING for #614]** **Enable** "Request user authorization
+   (OAuth) during installation", set the callback/Setup URL to the broker's
+   `/github/connect/callback`, and provision the App's OAuth **client id** and
+   **client secret** as deployment secrets (`githubBroker.oauthClientId` /
+   `oauthClientSecret`). The broker binds a device to an installation ONLY after
+   exchanging the install-time authorization `code` and confirming the
+   authorizing user can access that installation (`GET /user/installations`).
+   Without this, a valid one-shot state alone lets a caller bind to an arbitrary
+   (victim) installation id — the install-binding forgery the #614 security
+   review flagged (P1). Until it is enabled, `connectCallback` fails closed with
+   `installation_authorization_unverified` and no binding is recorded.
 
 ## 2. Repository permissions
 

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -106,10 +106,13 @@ Place the following in the license-service deployment environment (Fly secrets f
 the shared `services/license-api` deployment). The broker reads the private key and
 the OAuth client secret from this secret store at runtime and never persists, logs,
 or returns them. These names are the contract for the future production-wiring step
-in `server.ts`.
-Until it provides `githubBroker`, the shared license request listener matches every
-broker path and returns a typed `{ "reason": "broker_unavailable" }` 503 — a
-deliberate fail-closed status, not an unrouted 404:
+in `services/license-api/src/http.ts` (`HttpHandlerOptions.githubBroker` →
+`createGitHubBrokerService`), read there from the deployment environment; `server.ts`
+only starts the listener and today passes no `githubBroker` option and reads no
+`GITHUB_BROKER_*` env vars. Until `http.ts` is given `githubBroker`, the shared
+license request listener matches every broker path (`isGitHubBrokerPath`) and
+returns a typed `{ "reason": "broker_unavailable" }` 503 — a deliberate fail-closed
+status, not an unrouted 404:
 
 | Secret                          | Purpose |
 |---------------------------------|---------|

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -15,9 +15,16 @@ const paths = [
   "docs/releases/v1.0.0.md"
 ];
 
+// Layer-3 licensing policy (owner ruling, reversing the #532 "activate every
+// repository" pivot; enforced at the #614 authorization boundary): public
+// open-source repositories are FREE with no Activation Key; private, internal,
+// commercial, and unknown-visibility work require active API-backed entitlement
+// (unknown fails closed). Public-facing website copy migration is owned by
+// website issue #52. These required claims now guard the CORRECT policy.
 const required = [
   /source-available/i,
-  /API-backed activation is required/i,
+  /public open-source repositor(?:y|ies) (?:are|is) free/i,
+  /API-backed activation is required for (?:supported )?private/i,
   /private.*commercial.*paid|paid.*private.*commercial/i,
   /\$100\/(?:year|yr)/i,
   /7-day trial/i,
@@ -38,13 +45,6 @@ const forbiddenClaims = [
   /\benterprise-ready\b/i,
   /\bCodeRabbit parity\b/i,
   /\bpublic launch is complete\b/i
-];
-
-const retiredFreeClaims = [
-  /public(?: open-source)? repositor(?:y|ies) (?:are|is) free/i,
-  /free (?:for|on) public repositor(?:y|ies)/i,
-  /public repos? with no license (?:may )?(?:pass|run|review)/i,
-  /PUBLIC · FREE/
 ];
 
 let failed = false;
@@ -70,16 +70,6 @@ for (const path of paths) {
         console.error(`${path}: forbidden public claims phrase outside boundary language: ${match}`);
         failed = true;
       }
-    }
-  }
-}
-
-for (const path of paths.filter((path) => !path.startsWith("docs/releases/"))) {
-  const text = readFileSync(path, "utf8");
-  for (const pattern of retiredFreeClaims) {
-    if (pattern.test(text)) {
-      console.error(`${path}: retired public-free claim remains: ${pattern}`);
-      failed = true;
     }
   }
 }

--- a/services/license-api/src/github-broker/authorization.ts
+++ b/services/license-api/src/github-broker/authorization.ts
@@ -12,14 +12,19 @@ export interface RequestedRepository {
  * The entitlement snapshot the seam binds a private/internal request against.
  * It is derived from the production entitlement contract (the license-api
  * `Entitlement`, merged #574) BEFORE the seam runs, so the decision function
- * stays pure and table-testable. `active` carries whether the live license
- * covers private repositories; every terminal state maps to a distinct
- * fail-closed reason code. `none` is the public-free default — no NeonDiff
+ * stays pure and table-testable. `none` is the public-free default — no NeonDiff
  * Activation Key was presented. The broker never derives entitlement from a
- * provider key; only an active, private-covering entitlement unlocks private.
+ * provider key; only an active entitlement whose coverage names a repository
+ * unlocks that repository.
+ *
+ * `active` authorizes ONLY the repositories in `coveredPrivateRepositories`
+ * (matched by `owner/name`). This is per-repository, not a single global
+ * boolean: a request spanning several private repos is authorized only when
+ * every one of them is covered (the resolver enumerates the covered set from the
+ * account/license scope). A public-only license covers none (empty set).
  */
 export type EntitlementSnapshot =
-  | { status: "active"; privateRepoAllowed: boolean }
+  | { status: "active"; coveredPrivateRepositories: string[] }
   | { status: "expired" }
   | { status: "revoked" }
   | { status: "invalid" }
@@ -45,11 +50,17 @@ export type IssuanceAuthorizationDecision =
  *      determine denies with `visibility_unknown` — never assume public (AC1/AC3).
  *   3. an all-public request is authorized with NO Activation Key required
  *      (the public-free layer-3 policy); the entitlement snapshot is not consulted.
- *   4. otherwise (at least one private/internal repository) an active,
- *      private-covering entitlement is required; every other entitlement state
- *      denies with its own distinct fail-closed reason code (AC3/AC4/AC5). The
- *      snapshot is resolved from the license authority before this runs, so the
- *      decision function stays pure; an omitted snapshot fails closed as `none`.
+ *   4. otherwise (at least one private/internal repository) an active entitlement
+ *      that covers EVERY requested private repository is required; any other
+ *      state — or any private repo the active entitlement does not cover — denies
+ *      with a distinct fail-closed reason code (AC3/AC4/AC5). The snapshot is
+ *      resolved from the license authority before this runs, so the decision
+ *      function stays pure; an omitted snapshot fails closed as `none`.
+ *
+ * The ONLY path that returns `allow` for a non-public request is an explicit,
+ * per-repository coverage match; every other input — including an entitlement
+ * status outside the known union (contract drift) — falls through to a
+ * fail-closed deny (never an implicit allow).
  */
 export function authorizeTokenIssuance(input: {
   requestedRepositories: RequestedRepository[];
@@ -66,23 +77,34 @@ export function authorizeTokenIssuance(input: {
     decision: "allow",
     repositories: repositories.map((repository) => repository.fullName)
   };
-  if (repositories.every((repository) => repository.visibility === "public")) {
+  const nonPublic = repositories.filter((repository) => repository.visibility !== "public");
+  if (nonPublic.length === 0) {
     return allow;
   }
-  const denial = entitlementDenialReason(input.entitlement ?? { status: "none" });
-  return denial ? { decision: "deny", reason: denial } : allow;
+  const entitlement = input.entitlement ?? { status: "none" };
+  // Fail closed by construction: the sole authorizing branch is an active
+  // entitlement whose covered set names every requested private repository.
+  if (entitlement.status === "active" && Array.isArray(entitlement.coveredPrivateRepositories)) {
+    const covered = new Set(entitlement.coveredPrivateRepositories);
+    if (nonPublic.every((repository) => covered.has(repository.fullName))) {
+      return allow;
+    }
+    return { decision: "deny", reason: "entitlement_scope_insufficient" };
+  }
+  return { decision: "deny", reason: entitlementDenialReason(entitlement) };
 }
 
 /**
- * Map a non-public request's entitlement snapshot to its fail-closed reason code,
- * or `undefined` when the entitlement authorizes private/internal work. The only
- * authorizing state is an active license whose scope covers private repositories;
- * a provider key is never an input here, so it can never unlock private (AC5).
+ * Map a non-authorizing entitlement snapshot to its fail-closed reason code. The
+ * `default` is load-bearing: any status outside the known union (contract drift,
+ * a future license state, a malformed snapshot) denies as `entitlement_invalid`
+ * rather than falling through — the seam never mints on an unrecognized state.
  */
-function entitlementDenialReason(entitlement: EntitlementSnapshot): BrokerReason | undefined {
+function entitlementDenialReason(entitlement: EntitlementSnapshot): BrokerReason {
   switch (entitlement.status) {
     case "active":
-      return entitlement.privateRepoAllowed ? undefined : "entitlement_scope_insufficient";
+      // An active snapshot without a usable covered set covers nothing.
+      return "entitlement_scope_insufficient";
     case "expired":
       return "entitlement_expired";
     case "revoked":
@@ -97,5 +119,7 @@ function entitlementDenialReason(entitlement: EntitlementSnapshot): BrokerReason
       return "entitlement_service_unavailable";
     case "none":
       return "entitlement_missing";
+    default:
+      return "entitlement_invalid";
   }
 }

--- a/services/license-api/src/github-broker/authorization.ts
+++ b/services/license-api/src/github-broker/authorization.ts
@@ -35,34 +35,67 @@ export type IssuanceAuthorizationDecision =
 /**
  * THE single token-issuance decision point. Every mint path in the broker flows
  * through this function; there is no other code path that can authorize an
- * installation token (the gate-every-caller rule). #614 replaces the body of this
- * ONE function to add the repository-visibility + entitlement binding — callers
- * and the surrounding issuance flow do not change.
- *
- * Pre-#614 policy (fail closed): authorize ONLY when every requested repository is
- * verified public. Any private/internal repository denies with
- * `entitlement_gate_not_implemented`; unknown visibility denies with
- * `visibility_unknown` (never assume public). Callers resolve each requested
+ * installation token (the gate-every-caller rule). Callers resolve each requested
  * repository against the installation's current selection before calling this, so
  * a repo outside the installation never reaches the seam.
+ *
+ * #614 policy (fail closed), evaluated in order:
+ *   1. an empty request is `invalid_request`.
+ *   2. any repository whose visibility the App could not authoritatively
+ *      determine denies with `visibility_unknown` — never assume public (AC1/AC3).
+ *   3. an all-public request is authorized with NO Activation Key required
+ *      (the public-free layer-3 policy); the entitlement snapshot is not consulted.
+ *   4. otherwise (at least one private/internal repository) an active,
+ *      private-covering entitlement is required; every other entitlement state
+ *      denies with its own distinct fail-closed reason code (AC3/AC4/AC5). The
+ *      snapshot is resolved from the license authority before this runs, so the
+ *      decision function stays pure; an omitted snapshot fails closed as `none`.
  */
 export function authorizeTokenIssuance(input: {
   requestedRepositories: RequestedRepository[];
   entitlement?: EntitlementSnapshot;
 }): IssuanceAuthorizationDecision {
-  if (input.requestedRepositories.length === 0) {
+  const repositories = input.requestedRepositories;
+  if (repositories.length === 0) {
     return { decision: "deny", reason: "invalid_request" };
   }
-  for (const repository of input.requestedRepositories) {
-    if (repository.visibility === "unknown") {
-      return { decision: "deny", reason: "visibility_unknown" };
-    }
-    if (repository.visibility !== "public") {
-      return { decision: "deny", reason: "entitlement_gate_not_implemented" };
-    }
+  if (repositories.some((repository) => repository.visibility === "unknown")) {
+    return { decision: "deny", reason: "visibility_unknown" };
   }
-  return {
+  const allow: IssuanceAuthorizationDecision = {
     decision: "allow",
-    repositories: input.requestedRepositories.map((repository) => repository.fullName)
+    repositories: repositories.map((repository) => repository.fullName)
   };
+  if (repositories.every((repository) => repository.visibility === "public")) {
+    return allow;
+  }
+  const denial = entitlementDenialReason(input.entitlement ?? { status: "none" });
+  return denial ? { decision: "deny", reason: denial } : allow;
+}
+
+/**
+ * Map a non-public request's entitlement snapshot to its fail-closed reason code,
+ * or `undefined` when the entitlement authorizes private/internal work. The only
+ * authorizing state is an active license whose scope covers private repositories;
+ * a provider key is never an input here, so it can never unlock private (AC5).
+ */
+function entitlementDenialReason(entitlement: EntitlementSnapshot): BrokerReason | undefined {
+  switch (entitlement.status) {
+    case "active":
+      return entitlement.privateRepoAllowed ? undefined : "entitlement_scope_insufficient";
+    case "expired":
+      return "entitlement_expired";
+    case "revoked":
+      return "entitlement_revoked";
+    case "invalid":
+      return "entitlement_invalid";
+    case "seat_exhausted":
+      return "entitlement_seat_exhausted";
+    case "replay_conflict":
+      return "entitlement_replay_conflict";
+    case "service_unavailable":
+      return "entitlement_service_unavailable";
+    case "none":
+      return "entitlement_missing";
+  }
 }

--- a/services/license-api/src/github-broker/authorization.ts
+++ b/services/license-api/src/github-broker/authorization.ts
@@ -8,6 +8,26 @@ export interface RequestedRepository {
   visibility: GitHubRepositoryVisibility;
 }
 
+/**
+ * The entitlement snapshot the seam binds a private/internal request against.
+ * It is derived from the production entitlement contract (the license-api
+ * `Entitlement`, merged #574) BEFORE the seam runs, so the decision function
+ * stays pure and table-testable. `active` carries whether the live license
+ * covers private repositories; every terminal state maps to a distinct
+ * fail-closed reason code. `none` is the public-free default — no NeonDiff
+ * Activation Key was presented. The broker never derives entitlement from a
+ * provider key; only an active, private-covering entitlement unlocks private.
+ */
+export type EntitlementSnapshot =
+  | { status: "active"; privateRepoAllowed: boolean }
+  | { status: "expired" }
+  | { status: "revoked" }
+  | { status: "invalid" }
+  | { status: "seat_exhausted" }
+  | { status: "replay_conflict" }
+  | { status: "service_unavailable" }
+  | { status: "none" };
+
 export type IssuanceAuthorizationDecision =
   | { decision: "allow"; repositories: string[] }
   | { decision: "deny"; reason: BrokerReason };
@@ -28,6 +48,7 @@ export type IssuanceAuthorizationDecision =
  */
 export function authorizeTokenIssuance(input: {
   requestedRepositories: RequestedRepository[];
+  entitlement?: EntitlementSnapshot;
 }): IssuanceAuthorizationDecision {
   if (input.requestedRepositories.length === 0) {
     return { decision: "deny", reason: "invalid_request" };

--- a/services/license-api/src/github-broker/errors.ts
+++ b/services/license-api/src/github-broker/errors.ts
@@ -17,6 +17,7 @@ export type BrokerReason =
   | "installation_suspended"
   | "installation_authorization_unverified"
   | "repo_outside_installation"
+  | "repo_outside_authorization"
   | "repo_renamed_or_transferred"
   | "visibility_unknown"
   | "entitlement_missing"
@@ -43,6 +44,7 @@ const REASON_STATUS: Record<BrokerReason, number> = {
   installation_suspended: 409,
   installation_authorization_unverified: 403,
   repo_outside_installation: 403,
+  repo_outside_authorization: 403,
   repo_renamed_or_transferred: 409,
   visibility_unknown: 403,
   entitlement_missing: 403,

--- a/services/license-api/src/github-broker/errors.ts
+++ b/services/license-api/src/github-broker/errors.ts
@@ -20,6 +20,13 @@ export type BrokerReason =
   | "visibility_unknown"
   | "entitlement_gate_not_implemented"
   | "entitlement_missing"
+  | "entitlement_expired"
+  | "entitlement_revoked"
+  | "entitlement_invalid"
+  | "entitlement_scope_insufficient"
+  | "entitlement_seat_exhausted"
+  | "entitlement_replay_conflict"
+  | "entitlement_service_unavailable"
   | "rate_limited"
   | "broker_unavailable";
 
@@ -39,6 +46,13 @@ const REASON_STATUS: Record<BrokerReason, number> = {
   visibility_unknown: 403,
   entitlement_gate_not_implemented: 403,
   entitlement_missing: 403,
+  entitlement_expired: 403,
+  entitlement_revoked: 403,
+  entitlement_invalid: 403,
+  entitlement_scope_insufficient: 403,
+  entitlement_seat_exhausted: 409,
+  entitlement_replay_conflict: 409,
+  entitlement_service_unavailable: 503,
   rate_limited: 429,
   broker_unavailable: 503
 };

--- a/services/license-api/src/github-broker/errors.ts
+++ b/services/license-api/src/github-broker/errors.ts
@@ -15,6 +15,7 @@ export type BrokerReason =
   | "installation_not_found"
   | "installation_uninstalled"
   | "installation_suspended"
+  | "installation_authorization_unverified"
   | "repo_outside_installation"
   | "repo_renamed_or_transferred"
   | "visibility_unknown"
@@ -40,6 +41,7 @@ const REASON_STATUS: Record<BrokerReason, number> = {
   installation_not_found: 404,
   installation_uninstalled: 409,
   installation_suspended: 409,
+  installation_authorization_unverified: 403,
   repo_outside_installation: 403,
   repo_renamed_or_transferred: 409,
   visibility_unknown: 403,

--- a/services/license-api/src/github-broker/errors.ts
+++ b/services/license-api/src/github-broker/errors.ts
@@ -18,7 +18,6 @@ export type BrokerReason =
   | "repo_outside_installation"
   | "repo_renamed_or_transferred"
   | "visibility_unknown"
-  | "entitlement_gate_not_implemented"
   | "entitlement_missing"
   | "entitlement_expired"
   | "entitlement_revoked"
@@ -44,7 +43,6 @@ const REASON_STATUS: Record<BrokerReason, number> = {
   repo_outside_installation: 403,
   repo_renamed_or_transferred: 409,
   visibility_unknown: 403,
-  entitlement_gate_not_implemented: 403,
   entitlement_missing: 403,
   entitlement_expired: 403,
   entitlement_revoked: 403,

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -47,16 +47,24 @@ export interface GitHubInstallationClient {
    * Verify that the identity behind an install-time OAuth authorization code is
    * actually authorized for `installationId` — i.e. the user who completed the
    * GitHub "Request user authorization (OAuth) during installation" flow can
-   * access this installation. Returns true only when the exchanged user identity
-   * lists the installation; false denies the binding. Transient failures throw a
-   * typed client error so the caller fails closed. This closes the callback
-   * install-binding forgery: a valid connect-state alone can no longer bind a
-   * device to an arbitrary (victim) installation id.
+   * access this installation — AND return the exact set of repositories that user
+   * can access within it (the authorized set the binding is scoped to). Returns
+   * the repository `owner/name` list (possibly empty) when the exchanged user
+   * identity can access the installation; returns `null` to DENY the binding when
+   * the identity cannot be proven for this installation (no OAuth credentials, a
+   * bad/absent code, or the installation is not among the user's accessible ones).
+   * Transient failures throw a typed client error so the caller fails closed.
+   *
+   * This closes two callback forgeries: (1) a valid connect-state alone can no
+   * longer bind a device to an arbitrary (victim) installation id; and (2) an
+   * entitled but GitHub-unauthorized user can no longer mint a token for a private
+   * repo they cannot access — the binding, and every later token, is confined to
+   * the user's authorized repository set, not the whole installation selection.
    */
   verifyInstallationForAuthorizationCode(
     installationId: number,
     authorizationCode: string
-  ): Promise<boolean>;
+  ): Promise<string[] | null>;
   /** The installation's current repository selection, with each repo's visibility. */
   listInstallationRepositories(installationId: number): Promise<InstallationRepository[]>;
   /** Mint a narrowed installation access token. This is the RETURNED token; it is
@@ -181,16 +189,27 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
     async verifyInstallationForAuthorizationCode(
       installationId: number,
       authorizationCode: string
-    ): Promise<boolean> {
+    ): Promise<string[] | null> {
       // Owner-gated: without the OAuth-during-install client credentials the
       // broker cannot prove installation ownership, so identity is UNVERIFIED.
-      // Return false (not a transient error) so the callback surfaces the
+      // Return null (not a transient error) so the callback surfaces the
       // documented pre-provisioning reason `installation_authorization_unverified`
       // (403), not a broker outage (503).
       if (!config.oauthClientId || !config.oauthClientSecret) {
-        return false;
+        return null;
       }
       const oauthBaseUrl = normalizeHttpApiBaseUrl(config.oauthBaseUrl, "githubBroker.oauthBaseUrl", "https://github.com");
+      // Build the endpoint with the URL resolver so a base with (or without) a
+      // trailing slash never produces a `//login/...` double slash that a strict
+      // OAuth host/proxy would 404.
+      const tokenUrl = new URL("/login/oauth/access_token", oauthBaseUrl).toString();
+      // GitHub's App web flow expects form-encoded parameters (not JSON) at this
+      // endpoint; keep `Accept: application/json` so the response is parseable.
+      const tokenForm = new URLSearchParams({
+        client_id: config.oauthClientId,
+        client_secret: config.oauthClientSecret,
+        code: authorizationCode
+      });
       // Honor the configured request timeout so a stalled token exchange fails
       // closed as a typed broker outage instead of holding the listener open.
       let tokenResponse: Response;
@@ -199,15 +218,11 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
         ? setTimeout(() => controller.abort(new Error("OAuth token exchange timed out")), config.requestTimeoutMs)
         : undefined;
       try {
-        tokenResponse = await fetch(`${oauthBaseUrl}/login/oauth/access_token`, {
+        tokenResponse = await fetch(tokenUrl, {
           method: "POST",
           signal: controller?.signal,
-          headers: { Accept: "application/json", "Content-Type": "application/json" },
-          body: JSON.stringify({
-            client_id: config.oauthClientId,
-            client_secret: config.oauthClientSecret,
-            code: authorizationCode
-          })
+          headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+          body: tokenForm.toString()
         });
       } catch {
         throw new GitHubBrokerClientError("unavailable", "OAuth token exchange failed");
@@ -221,17 +236,27 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
       const userToken = tokenBody?.access_token;
       // A bad/expired/forged code yields no user token: deny the binding (not a
       // transient error — the identity was not proven).
-      if (!userToken) return false;
-      // List the installations the authenticated user can access; the binding is
-      // authorized only when the requested installation is among them.
+      if (!userToken) return null;
+      // Enumerate the repositories the authenticated user can access WITHIN this
+      // installation (not just installation membership). The binding is scoped to
+      // this authorized set, so a later token can never reach a private repo the
+      // connecting user cannot access on GitHub. A 404 means the user cannot access
+      // the installation at all -> identity unverified for it (null, fail closed).
+      const authorized: string[] = [];
       for (let page = 1; ; page += 1) {
-        const result = await request<{ installations?: Array<{ id: number }> }>(
-          `/user/installations?per_page=100&page=${page}`,
-          { token: userToken }
-        );
-        const chunk = result.json?.installations ?? [];
-        if (chunk.some((installation) => installation.id === installationId)) return true;
-        if (chunk.length < 100) return false;
+        let result;
+        try {
+          result = await request<{ repositories?: Array<{ full_name: string }> }>(
+            `/user/installations/${installationId}/repositories?per_page=100&page=${page}`,
+            { token: userToken }
+          );
+        } catch (error) {
+          if (error instanceof GitHubApiStatusError && (error.status === 404 || error.status === 403)) return null;
+          throw error;
+        }
+        const chunk = result.json?.repositories ?? [];
+        for (const repository of chunk) authorized.push(repository.full_name);
+        if (chunk.length < 100) return authorized;
       }
     },
     async listInstallationRepositories(installationId: number): Promise<InstallationRepository[]> {

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -43,6 +43,20 @@ export class GitHubBrokerClientError extends Error {
 export interface GitHubInstallationClient {
   /** Resolve an installation by id; returns null when it does not exist (uninstalled). */
   getInstallation(installationId: number): Promise<InstallationSummary | null>;
+  /**
+   * Verify that the identity behind an install-time OAuth authorization code is
+   * actually authorized for `installationId` — i.e. the user who completed the
+   * GitHub "Request user authorization (OAuth) during installation" flow can
+   * access this installation. Returns true only when the exchanged user identity
+   * lists the installation; false denies the binding. Transient failures throw a
+   * typed client error so the caller fails closed. This closes the callback
+   * install-binding forgery: a valid connect-state alone can no longer bind a
+   * device to an arbitrary (victim) installation id.
+   */
+  verifyInstallationForAuthorizationCode(
+    installationId: number,
+    authorizationCode: string
+  ): Promise<boolean>;
   /** The installation's current repository selection, with each repo's visibility. */
   listInstallationRepositories(installationId: number): Promise<InstallationRepository[]>;
   /** Mint a narrowed installation access token. This is the RETURNED token; it is
@@ -60,6 +74,17 @@ export interface GitHubAppConfig {
   privateKey: string;
   apiBaseUrl?: string;
   requestTimeoutMs?: number;
+  /**
+   * OAuth client credentials for the App's "Request user authorization (OAuth)
+   * during installation" flow, used only to exchange the callback authorization
+   * code for a short-lived user token when verifying installation ownership. Both
+   * are OWNER-GATED deployment secrets (see docs/security/github-app-staging-registration.md);
+   * when either is absent, callback identity verification fails closed.
+   */
+  oauthClientId?: string;
+  oauthClientSecret?: string;
+  /** OAuth authorization host; defaults to https://github.com. */
+  oauthBaseUrl?: string;
 }
 
 /**
@@ -151,6 +176,51 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
         if (error instanceof GitHubBrokerClientError) throw error;
         if (isNotFound(error)) return null;
         throw error;
+      }
+    },
+    async verifyInstallationForAuthorizationCode(
+      installationId: number,
+      authorizationCode: string
+    ): Promise<boolean> {
+      // Owner-gated: without the OAuth-during-install client credentials the
+      // broker cannot prove installation ownership, so it fails closed (throws a
+      // typed transient error the callback maps to a fail-closed refusal).
+      if (!config.oauthClientId || !config.oauthClientSecret) {
+        throw new GitHubBrokerClientError("unavailable", "OAuth-during-install is not configured");
+      }
+      const oauthBaseUrl = normalizeHttpApiBaseUrl(config.oauthBaseUrl, "githubBroker.oauthBaseUrl", "https://github.com");
+      let tokenResponse: Response;
+      try {
+        tokenResponse = await fetch(`${oauthBaseUrl}/login/oauth/access_token`, {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_id: config.oauthClientId,
+            client_secret: config.oauthClientSecret,
+            code: authorizationCode
+          })
+        });
+      } catch {
+        throw new GitHubBrokerClientError("unavailable", "OAuth token exchange failed");
+      }
+      if (!tokenResponse.ok) {
+        throw new GitHubBrokerClientError("unavailable", `OAuth token exchange ${tokenResponse.status}`);
+      }
+      const tokenBody = (await tokenResponse.json().catch(() => undefined)) as { access_token?: string } | undefined;
+      const userToken = tokenBody?.access_token;
+      // A bad/expired/forged code yields no user token: deny the binding (not a
+      // transient error — the identity was not proven).
+      if (!userToken) return false;
+      // List the installations the authenticated user can access; the binding is
+      // authorized only when the requested installation is among them.
+      for (let page = 1; ; page += 1) {
+        const result = await request<{ installations?: Array<{ id: number }> }>(
+          `/user/installations?per_page=100&page=${page}`,
+          { token: userToken }
+        );
+        const chunk = result.json?.installations ?? [];
+        if (chunk.some((installation) => installation.id === installationId)) return true;
+        if (chunk.length < 100) return false;
       }
     },
     async listInstallationRepositories(installationId: number): Promise<InstallationRepository[]> {

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -183,16 +183,25 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
       authorizationCode: string
     ): Promise<boolean> {
       // Owner-gated: without the OAuth-during-install client credentials the
-      // broker cannot prove installation ownership, so it fails closed (throws a
-      // typed transient error the callback maps to a fail-closed refusal).
+      // broker cannot prove installation ownership, so identity is UNVERIFIED.
+      // Return false (not a transient error) so the callback surfaces the
+      // documented pre-provisioning reason `installation_authorization_unverified`
+      // (403), not a broker outage (503).
       if (!config.oauthClientId || !config.oauthClientSecret) {
-        throw new GitHubBrokerClientError("unavailable", "OAuth-during-install is not configured");
+        return false;
       }
       const oauthBaseUrl = normalizeHttpApiBaseUrl(config.oauthBaseUrl, "githubBroker.oauthBaseUrl", "https://github.com");
+      // Honor the configured request timeout so a stalled token exchange fails
+      // closed as a typed broker outage instead of holding the listener open.
       let tokenResponse: Response;
+      const controller = config.requestTimeoutMs ? new AbortController() : undefined;
+      const timeout = controller
+        ? setTimeout(() => controller.abort(new Error("OAuth token exchange timed out")), config.requestTimeoutMs)
+        : undefined;
       try {
         tokenResponse = await fetch(`${oauthBaseUrl}/login/oauth/access_token`, {
           method: "POST",
+          signal: controller?.signal,
           headers: { Accept: "application/json", "Content-Type": "application/json" },
           body: JSON.stringify({
             client_id: config.oauthClientId,
@@ -202,6 +211,8 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
         });
       } catch {
         throw new GitHubBrokerClientError("unavailable", "OAuth token exchange failed");
+      } finally {
+        if (timeout) clearTimeout(timeout);
       }
       if (!tokenResponse.ok) {
         throw new GitHubBrokerClientError("unavailable", `OAuth token exchange ${tokenResponse.status}`);

--- a/services/license-api/src/github-broker/index.ts
+++ b/services/license-api/src/github-broker/index.ts
@@ -19,7 +19,9 @@ export {
 export {
   GitHubBrokerService,
   MINIMAL_REVIEW_PERMISSIONS,
-  type GitHubBrokerServiceOptions
+  type GitHubBrokerServiceOptions,
+  type EntitlementResolver,
+  type EntitlementResolutionContext
 } from "./service.js";
 export { GitHubBrokerStore } from "./store.js";
 export {

--- a/services/license-api/src/github-broker/index.ts
+++ b/services/license-api/src/github-broker/index.ts
@@ -1,4 +1,9 @@
-export { authorizeTokenIssuance, type RequestedRepository, type IssuanceAuthorizationDecision } from "./authorization.js";
+export {
+  authorizeTokenIssuance,
+  type RequestedRepository,
+  type EntitlementSnapshot,
+  type IssuanceAuthorizationDecision
+} from "./authorization.js";
 export { BrokerError, type BrokerReason } from "./errors.js";
 export {
   createGitHubInstallationClient,

--- a/services/license-api/src/github-broker/routes.ts
+++ b/services/license-api/src/github-broker/routes.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RateLimiter } from "../service.js";
 import { BrokerError } from "./errors.js";
 import type { GitHubInstallationClient } from "./github-app.js";
-import { GitHubBrokerService } from "./service.js";
+import { GitHubBrokerService, type EntitlementResolver } from "./service.js";
 import { GitHubBrokerStore } from "./store.js";
 
 const MAX_BODY_BYTES = 16 * 1024;
@@ -26,6 +26,7 @@ export interface GitHubBrokerDeps {
   dbPath?: string;
   githubClient: GitHubInstallationClient;
   installBaseUrl: string;
+  resolveEntitlement?: EntitlementResolver;
   now?: () => Date;
   deviceRegisterRateLimiter?: RateLimiter;
   connectRateLimiter?: RateLimiter;
@@ -43,6 +44,7 @@ export function createGitHubBrokerService(deps: GitHubBrokerDeps): GitHubBrokerS
     store,
     githubClient: deps.githubClient,
     installBaseUrl: deps.installBaseUrl,
+    resolveEntitlement: deps.resolveEntitlement,
     now: deps.now,
     deviceRegisterRateLimiter: deps.deviceRegisterRateLimiter,
     connectRateLimiter: deps.connectRateLimiter,

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -185,8 +185,10 @@ export class GitHubBrokerService {
 
     // Verify the identity proof BEFORE resolving the installation (decide before
     // side effects): a forged callback is rejected without any App-JWT GitHub call
-    // for the supplied installation id, closing the 403-vs-404 probing oracle.
-    await this.verifyInstallationAuthorization(installationId, code);
+    // for the supplied installation id, closing the 403-vs-404 probing oracle. The
+    // proof also yields the repository set the connecting user can access in this
+    // installation — the binding is scoped to that authorized set.
+    const authorizedRepositories = await this.verifyInstallationAuthorization(installationId, code);
 
     const installation = await this.resolveInstallation(installationId);
 
@@ -194,34 +196,42 @@ export class GitHubBrokerService {
     if (!this.store.consumeConnectState(state, installationId, at.toISOString())) {
       throw new BrokerError("state_replayed", "connect state was already used");
     }
-    this.store.upsertBinding(stored.device_id, installationId, installation.account_login, at.toISOString());
+    this.store.upsertBinding(
+      stored.device_id,
+      installationId,
+      installation.account_login,
+      authorizedRepositories,
+      at.toISOString()
+    );
     return { html: connectReturnPage() };
   }
 
   /**
    * Fail closed unless the install-time OAuth authorization `code` proves the
-   * identity is authorized for `installationId`. An unproven identity — including
-   * the owner-gated pre-provisioning state where OAuth-during-install is not
-   * configured (the client returns `false`) — is `installation_authorization_unverified`
-   * (403, no binding); a transient verification failure maps to a typed broker
-   * outage (503, also no binding).
+   * identity is authorized for `installationId`. Returns the repository set the
+   * connecting user can access in the installation (the authorized set the binding
+   * is scoped to). An unproven identity — including the owner-gated
+   * pre-provisioning state where OAuth-during-install is not configured (the client
+   * returns `null`) — is `installation_authorization_unverified` (403, no binding);
+   * a transient verification failure maps to a typed broker outage (503, no binding).
    */
   private async verifyInstallationAuthorization(
     installationId: number,
     authorizationCode: string
-  ): Promise<void> {
-    let authorized: boolean;
+  ): Promise<string[]> {
+    let authorized: string[] | null;
     try {
       authorized = await this.githubClient.verifyInstallationForAuthorizationCode(installationId, authorizationCode);
     } catch (error) {
       throw mapClientError(error);
     }
-    if (!authorized) {
+    if (authorized === null) {
       throw new BrokerError(
         "installation_authorization_unverified",
         "installation authorization could not be verified for this identity"
       );
     }
+    return authorized;
   }
 
   /** POST /github/connect/complete — device polls to confirm the binding landed. */
@@ -283,6 +293,21 @@ export class GitHubBrokerService {
       if (installation.suspended) throw new BrokerError("installation_suspended", "installation is suspended");
 
       const requested = await this.resolveRequestedRepositories(installationId, repositories);
+
+      // Confine issuance to the repositories the connecting OAuth user was
+      // authorized for at bind time (a subset of the installation selection). This
+      // runs BEFORE entitlement resolution, so a repo outside the user's authorized
+      // set egresses nothing to the license authority — an entitled-but-GitHub-
+      // unauthorized user can never reach a private repo they cannot access (#620 P1).
+      const authorizedRepositories = new Set(this.store.listBindingRepositories(deviceId, installationId));
+      for (const repository of requested) {
+        if (!authorizedRepositories.has(repository.fullName)) {
+          throw new BrokerError(
+            "repo_outside_authorization",
+            "a requested repository is outside the connecting user's authorized set"
+          );
+        }
+      }
 
       // Bind entitlement for any non-public repository BEFORE the seam and BEFORE
       // any mint. Resolution is a license-authority lookup (no GitHub content, no

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -139,9 +139,15 @@ export class GitHubBrokerService {
 
   /**
    * GET /github/connect/callback — the browser return from GitHub. Verifies the
-   * one-shot state, confirms the installation belongs to the App, and records the
-   * (device, installation) binding. Returns a small HTML page telling the user to
-   * return to the app (no URL scheme is registered in v1; see the design doc).
+   * one-shot state, confirms the installation belongs to the App, PROVES the
+   * install-time identity is authorized for this installation (via the OAuth
+   * authorization code), and only then records the (device, installation)
+   * binding. Returns a small HTML page telling the user to return to the app (no
+   * URL scheme is registered in v1; see the design doc).
+   *
+   * The identity proof is what stops a valid connect-state from binding a device
+   * to an arbitrary (victim) installation id: a forged direct callback carrying a
+   * state but no proof of installation ownership fails closed with no binding.
    */
   async connectCallback(query: URLSearchParams): Promise<{ html: string }> {
     const at = this.now();
@@ -161,12 +167,47 @@ export class GitHubBrokerService {
 
     const installation = await this.resolveInstallation(installationId);
 
+    // Prove the identity completing the flow is authorized for THIS installation
+    // BEFORE any binding is recorded (closes the install-binding forgery).
+    await this.verifyInstallationAuthorization(installationId, query.get("code"));
+
     // One-shot: only the first caller flips consumed_at; a race loses as a replay.
     if (!this.store.consumeConnectState(state, installationId, at.toISOString())) {
       throw new BrokerError("state_replayed", "connect state was already used");
     }
     this.store.upsertBinding(stored.device_id, installationId, installation.account_login, at.toISOString());
     return { html: connectReturnPage() };
+  }
+
+  /**
+   * Fail closed unless the install-time OAuth authorization code proves the
+   * identity is authorized for `installationId`. A missing code or an unproven
+   * identity is `installation_authorization_unverified` (403, no binding);
+   * transient/unconfigured verification is mapped to a typed transient error
+   * (also no binding).
+   */
+  private async verifyInstallationAuthorization(
+    installationId: number,
+    authorizationCode: string | null
+  ): Promise<void> {
+    if (!authorizationCode) {
+      throw new BrokerError(
+        "installation_authorization_unverified",
+        "installation authorization was not proven for this identity"
+      );
+    }
+    let authorized: boolean;
+    try {
+      authorized = await this.githubClient.verifyInstallationForAuthorizationCode(installationId, authorizationCode);
+    } catch (error) {
+      throw mapClientError(error);
+    }
+    if (!authorized) {
+      throw new BrokerError(
+        "installation_authorization_unverified",
+        "installation authorization could not be verified for this identity"
+      );
+    }
   }
 
   /** POST /github/connect/complete — device polls to confirm the binding landed. */

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -353,6 +353,11 @@ export class GitHubBrokerService {
    * Returns the public-free default (`none`) without touching the authority when
    * every requested repository is public. A resolver throw is a service outage and
    * fails closed as `service_unavailable` (never an allow).
+   *
+   * Decide before side effects: if ANY requested repo has unknown visibility, the
+   * seam denies (`visibility_unknown`) regardless of entitlement, so no
+   * license-service lookup is performed for it — an undecidable request egresses
+   * nothing, not even to the license authority.
    */
   private async resolveEntitlementForRequest(
     deviceId: string,
@@ -360,6 +365,9 @@ export class GitHubBrokerService {
     accountLogin: string | undefined,
     requested: RequestedRepository[]
   ): Promise<EntitlementSnapshot> {
+    if (requested.some((repository) => repository.visibility === "unknown")) {
+      return { status: "none" };
+    }
     const privateRepositories = requested
       .filter((repository) => repository.visibility !== "public")
       .map((repository) => repository.fullName);

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from "node:crypto";
 import { createHash } from "node:crypto";
 import { RateLimiter } from "../service.js";
-import { authorizeTokenIssuance, type RequestedRepository } from "./authorization.js";
+import {
+  authorizeTokenIssuance,
+  type EntitlementSnapshot,
+  type RequestedRepository
+} from "./authorization.js";
 import { authenticateDevice, deviceIdFromPublicJwk } from "./device-auth.js";
 import { BrokerError } from "./errors.js";
 import {
@@ -30,11 +34,46 @@ export const MINIMAL_REVIEW_PERMISSIONS: Record<string, string> = {
 
 const PERMISSION_SCOPE_RANK: Record<string, number> = { read: 1, write: 2, admin: 3 };
 
+/**
+ * Context handed to the entitlement resolver for a private/internal token
+ * request. Only the ids and the private repository names are exposed — never a
+ * license key or provider secret — so a resolver stays public-safe.
+ */
+export interface EntitlementResolutionContext {
+  deviceId: string;
+  installationId: number;
+  accountLogin?: string;
+  /** The requested repositories whose visibility is private or internal. */
+  privateRepositories: string[];
+}
+
+/**
+ * Resolves the production entitlement for a private/internal token request,
+ * bound to the license authority (contract shape: license-api `Entitlement`,
+ * merged #574). The live device<->license linkage and deployment wiring are the
+ * deploy lane's (#559); the broker only depends on this narrow snapshot function,
+ * proven here with fixtures. It is called ONLY when a request includes a
+ * non-public repository, so the public-free tier never depends on the license
+ * service. Any throw is treated as a service outage and fails closed.
+ */
+export type EntitlementResolver = (
+  context: EntitlementResolutionContext
+) => EntitlementSnapshot | Promise<EntitlementSnapshot>;
+
+/** The fail-closed default: no entitlement authority wired -> private denied. */
+const denyPrivateEntitlementResolver: EntitlementResolver = () => ({ status: "none" });
+
 export interface GitHubBrokerServiceOptions {
   store: GitHubBrokerStore;
   githubClient: GitHubInstallationClient;
   /** Official App install URL, e.g. https://github.com/apps/<app>/installations/new. */
   installBaseUrl: string;
+  /**
+   * Entitlement authority for private/internal issuance. Defaults to a fail-closed
+   * resolver (denies all private work) until the deploy lane wires the license
+   * linkage; public/free issuance never calls it.
+   */
+  resolveEntitlement?: EntitlementResolver;
   now?: () => Date;
   deviceRegisterRateLimiter?: RateLimiter;
   connectRateLimiter?: RateLimiter;
@@ -52,6 +91,7 @@ export class GitHubBrokerService {
   private readonly store: GitHubBrokerStore;
   private readonly githubClient: GitHubInstallationClient;
   private readonly installBaseUrl: string;
+  private readonly resolveEntitlement: EntitlementResolver;
   private readonly now: () => Date;
   private readonly deviceRegisterRateLimiter: RateLimiter;
   private readonly connectRateLimiter: RateLimiter;
@@ -61,6 +101,7 @@ export class GitHubBrokerService {
     this.store = options.store;
     this.githubClient = options.githubClient;
     this.installBaseUrl = options.installBaseUrl;
+    this.resolveEntitlement = options.resolveEntitlement ?? denyPrivateEntitlementResolver;
     this.now = options.now ?? (() => new Date());
     this.deviceRegisterRateLimiter =
       options.deviceRegisterRateLimiter ?? new RateLimiter({ maxPerWindow: 20, windowMs: 60_000 });
@@ -188,8 +229,20 @@ export class GitHubBrokerService {
 
       const requested = await this.resolveRequestedRepositories(installationId, repositories);
 
-      // The issuance seam: the ONLY path to minting. #614 replaces its body.
-      const decision = authorizeTokenIssuance({ requestedRepositories: requested });
+      // Bind entitlement for any non-public repository BEFORE the seam and BEFORE
+      // any mint. Resolution is a license-authority lookup (no GitHub content, no
+      // provider call), so a blocked private path egresses nothing. The all-public
+      // path never calls the authority, so the free tier does not depend on the
+      // license service being reachable (AC2).
+      const entitlement = await this.resolveEntitlementForRequest(
+        deviceId,
+        installationId,
+        installation.account_login,
+        requested
+      );
+
+      // The issuance seam: the ONLY path to minting.
+      const decision = authorizeTokenIssuance({ requestedRepositories: requested, entitlement });
       if (decision.decision === "deny") {
         throw new BrokerError(decision.reason, "token issuance is not authorized for the requested repositories");
       }
@@ -252,6 +305,34 @@ export class GitHubBrokerService {
       if (!match) throw new BrokerError("repo_outside_installation", "a requested repository is not in the installation selection");
       return { fullName, id: match.id, visibility: match.visibility };
     });
+  }
+
+  /**
+   * Resolve the entitlement snapshot the seam binds a non-public request against.
+   * Returns the public-free default (`none`) without touching the authority when
+   * every requested repository is public. A resolver throw is a service outage and
+   * fails closed as `service_unavailable` (never an allow).
+   */
+  private async resolveEntitlementForRequest(
+    deviceId: string,
+    installationId: number,
+    accountLogin: string | undefined,
+    requested: RequestedRepository[]
+  ): Promise<EntitlementSnapshot> {
+    const privateRepositories = requested
+      .filter((repository) => repository.visibility !== "public")
+      .map((repository) => repository.fullName);
+    if (privateRepositories.length === 0) return { status: "none" };
+    try {
+      return await this.resolveEntitlement({
+        deviceId,
+        installationId,
+        ...(accountLogin ? { accountLogin } : {}),
+        privateRepositories
+      });
+    } catch {
+      return { status: "service_unavailable" };
+    }
   }
 
   private async mintToken(

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -138,16 +138,21 @@ export class GitHubBrokerService {
   }
 
   /**
-   * GET /github/connect/callback — the browser return from GitHub. Verifies the
-   * one-shot state, confirms the installation belongs to the App, PROVES the
-   * install-time identity is authorized for this installation (via the OAuth
-   * authorization code), and only then records the (device, installation)
-   * binding. Returns a small HTML page telling the user to return to the app (no
-   * URL scheme is registered in v1; see the design doc).
+   * GET /github/connect/callback — the browser return from GitHub. Two distinct
+   * redirects can hit this one route (both configured to it per the staging spec):
    *
-   * The identity proof is what stops a valid connect-state from binding a device
-   * to an arbitrary (victim) installation id: a forged direct callback carrying a
-   * state but no proof of installation ownership fails closed with no binding.
+   *  - the **OAuth callback** (OAuth-during-install), which carries the user
+   *    authorization `code` alongside `installation_id` and `state`; and
+   *  - a bare **Setup-URL redirect** (install/reconfigure acknowledgment), which
+   *    carries `setup_action` but NO `code`.
+   *
+   * Only the OAuth callback can PROVE the returning identity owns the installation,
+   * so only it records a (device, installation) binding — and the proof is verified
+   * BEFORE the installation is resolved, so a forged callback cannot use this route
+   * to probe (App-JWT calls / 403-vs-404) arbitrary victim installation ids. A bare
+   * setup redirect is acknowledged with the neutral page and binds nothing (the
+   * device keeps polling until a real OAuth callback binds). Returns a small HTML
+   * page telling the user to return to the app (no URL scheme is registered in v1).
    */
   async connectCallback(query: URLSearchParams): Promise<{ html: string }> {
     const at = this.now();
@@ -165,11 +170,25 @@ export class GitHubBrokerService {
       throw new BrokerError("state_expired", "connect state has expired");
     }
 
-    const installation = await this.resolveInstallation(installationId);
+    const code = query.get("code");
+    if (!code) {
+      // No OAuth code ⇒ identity is unproven, so we never bind. A benign setup
+      // redirect is acknowledged; any other code-less callback is a typed refusal.
+      if (query.get("setup_action")) {
+        return { html: connectReturnPage() };
+      }
+      throw new BrokerError(
+        "installation_authorization_unverified",
+        "installation authorization was not proven for this identity"
+      );
+    }
 
-    // Prove the identity completing the flow is authorized for THIS installation
-    // BEFORE any binding is recorded (closes the install-binding forgery).
-    await this.verifyInstallationAuthorization(installationId, query.get("code"));
+    // Verify the identity proof BEFORE resolving the installation (decide before
+    // side effects): a forged callback is rejected without any App-JWT GitHub call
+    // for the supplied installation id, closing the 403-vs-404 probing oracle.
+    await this.verifyInstallationAuthorization(installationId, code);
+
+    const installation = await this.resolveInstallation(installationId);
 
     // One-shot: only the first caller flips consumed_at; a race loses as a replay.
     if (!this.store.consumeConnectState(state, installationId, at.toISOString())) {
@@ -180,22 +199,17 @@ export class GitHubBrokerService {
   }
 
   /**
-   * Fail closed unless the install-time OAuth authorization code proves the
-   * identity is authorized for `installationId`. A missing code or an unproven
-   * identity is `installation_authorization_unverified` (403, no binding);
-   * transient/unconfigured verification is mapped to a typed transient error
-   * (also no binding).
+   * Fail closed unless the install-time OAuth authorization `code` proves the
+   * identity is authorized for `installationId`. An unproven identity — including
+   * the owner-gated pre-provisioning state where OAuth-during-install is not
+   * configured (the client returns `false`) — is `installation_authorization_unverified`
+   * (403, no binding); a transient verification failure maps to a typed broker
+   * outage (503, also no binding).
    */
   private async verifyInstallationAuthorization(
     installationId: number,
-    authorizationCode: string | null
+    authorizationCode: string
   ): Promise<void> {
-    if (!authorizationCode) {
-      throw new BrokerError(
-        "installation_authorization_unverified",
-        "installation authorization was not proven for this identity"
-      );
-    }
     let authorized: boolean;
     try {
       authorized = await this.githubClient.verifyInstallationForAuthorizationCode(installationId, authorizationCode);

--- a/services/license-api/src/github-broker/store.ts
+++ b/services/license-api/src/github-broker/store.ts
@@ -43,6 +43,15 @@ const SCHEMA = `
     foreign key (device_id) references devices(device_id)
   );
 
+  create table binding_repositories (
+    device_id text not null,
+    installation_id integer not null,
+    full_name text not null,
+    primary key (device_id, installation_id, full_name),
+    foreign key (device_id, installation_id)
+      references installation_bindings(device_id, installation_id) on delete cascade
+  );
+
   create table decision_ledger (
     id integer primary key autoincrement,
     device_id text not null,
@@ -177,21 +186,57 @@ export class GitHubBrokerStore {
     return Number(info.changes) > 0;
   }
 
-  upsertBinding(deviceId: string, installationId: number, accountLogin: string | undefined, now: string): void {
-    this.db
-      .prepare(
-        `insert into installation_bindings (device_id, installation_id, account_login, created_at)
-         values (?, ?, ?, ?)
-         on conflict (device_id, installation_id)
-         do update set account_login = excluded.account_login`
-      )
-      .run(deviceId, installationId, accountLogin ?? null, now);
+  /**
+   * Record (or refresh) a binding and REPLACE its authorized-repository set in one
+   * transaction. `authorizedRepositories` is the exact `owner/name` set the
+   * connecting OAuth user can access in the installation; token issuance is later
+   * confined to it, so an entitled-but-GitHub-unauthorized user cannot reach a
+   * private repo outside their access. Re-connecting refreshes the set atomically.
+   */
+  upsertBinding(
+    deviceId: string,
+    installationId: number,
+    accountLogin: string | undefined,
+    authorizedRepositories: string[],
+    now: string
+  ): void {
+    this.db.exec("begin immediate");
+    try {
+      this.db
+        .prepare(
+          `insert into installation_bindings (device_id, installation_id, account_login, created_at)
+           values (?, ?, ?, ?)
+           on conflict (device_id, installation_id)
+           do update set account_login = excluded.account_login`
+        )
+        .run(deviceId, installationId, accountLogin ?? null, now);
+      this.db
+        .prepare("delete from binding_repositories where device_id = ? and installation_id = ?")
+        .run(deviceId, installationId);
+      const insert = this.db.prepare(
+        `insert or ignore into binding_repositories (device_id, installation_id, full_name)
+         values (?, ?, ?)`
+      );
+      for (const fullName of authorizedRepositories) insert.run(deviceId, installationId, fullName);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
   }
 
   getBinding(deviceId: string, installationId: number): InstallationBindingRow | undefined {
     return this.db
       .prepare("select * from installation_bindings where device_id = ? and installation_id = ?")
       .get(deviceId, installationId) as InstallationBindingRow | undefined;
+  }
+
+  /** The `owner/name` set the connecting OAuth user was authorized for at bind time. */
+  listBindingRepositories(deviceId: string, installationId: number): string[] {
+    const rows = this.db
+      .prepare("select full_name from binding_repositories where device_id = ? and installation_id = ?")
+      .all(deviceId, installationId) as Array<{ full_name: string }>;
+    return rows.map((row) => row.full_name);
   }
 
   /** Append a public-safe decision row. Never carries repo content or key material. */

--- a/services/license-api/src/github-broker/store.ts
+++ b/services/license-api/src/github-broker/store.ts
@@ -13,8 +13,24 @@ import { DatabaseSync } from "node:sqlite";
  * states, installation bindings, and an append-only decision ledger. No tokens,
  * private keys, source, or diffs are ever stored.
  */
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const DEFAULT_BUSY_TIMEOUT_MS = 250;
+
+/**
+ * The per-repo authorized-set table. Extracted so a fresh bootstrap and the
+ * v1 -> v2 upgrade create the exact same table (base v1 shipped
+ * `installation_bindings` without it, so an existing broker DB must gain it).
+ */
+const BINDING_REPOSITORIES_TABLE = `
+  create table binding_repositories (
+    device_id text not null,
+    installation_id integer not null,
+    full_name text not null,
+    primary key (device_id, installation_id, full_name),
+    foreign key (device_id, installation_id)
+      references installation_bindings(device_id, installation_id) on delete cascade
+  );
+`;
 
 const SCHEMA = `
   create table devices (
@@ -43,14 +59,7 @@ const SCHEMA = `
     foreign key (device_id) references devices(device_id)
   );
 
-  create table binding_repositories (
-    device_id text not null,
-    installation_id integer not null,
-    full_name text not null,
-    primary key (device_id, installation_id, full_name),
-    foreign key (device_id, installation_id)
-      references installation_bindings(device_id, installation_id) on delete cascade
-  );
+  ${BINDING_REPOSITORIES_TABLE.trim()}
 
   create table decision_ledger (
     id integer primary key autoincrement,
@@ -112,15 +121,27 @@ export class GitHubBrokerStore {
   private ensureSchema(): void {
     const version = this.readUserVersion();
     if (version === SCHEMA_VERSION) return;
-    if (version !== 0) throw new Error(`unsupported github broker schema version ${version}`);
+    if (version !== 0 && version !== 1) {
+      throw new Error(`unsupported github broker schema version ${version}`);
+    }
     this.db.exec("begin immediate");
     try {
       // Re-check under the writer lock in case a peer migrated first.
-      if (this.readUserVersion() === SCHEMA_VERSION) {
+      const current = this.readUserVersion();
+      if (current === SCHEMA_VERSION) {
         this.db.exec("commit");
         return;
       }
-      this.db.exec(SCHEMA);
+      if (current === 0) {
+        // Fresh bootstrap: the full schema (already includes binding_repositories).
+        this.db.exec(SCHEMA);
+      } else {
+        // v1 -> v2 upgrade: base v1 shipped installation_bindings WITHOUT the
+        // per-repo authorized-set table, so an existing broker DB must gain it in
+        // place — otherwise upsertBinding/listBindingRepositories hit "no such
+        // table". Idempotent and crash-safe under the same writer transaction.
+        this.db.exec(BINDING_REPOSITORIES_TABLE);
+      }
       this.db.exec(`pragma user_version = ${SCHEMA_VERSION}`);
       this.db.exec("commit");
     } catch (error) {

--- a/services/license-api/test/github-broker-adversarial.test.ts
+++ b/services/license-api/test/github-broker-adversarial.test.ts
@@ -286,7 +286,7 @@ describe("github broker adversarial and lifecycle coverage", () => {
       await registerDevice(denyHarness.url, device);
       await connectInstallation(denyHarness.url, device, PUBLIC_INSTALL.id);
       const deny = await post(denyHarness.url, "/github/token", { installationId: PUBLIC_INSTALL.id, repositories: ["octo/private"] }, bearer(await device.sign()));
-      assert.equal(deny.json.reason, "entitlement_gate_not_implemented");
+      assert.equal(deny.json.reason, "entitlement_missing");
       // A denied request must never reach the mint call.
       assert.equal(denyFake.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
     } finally {
@@ -324,7 +324,7 @@ describe("github broker adversarial and lifecycle coverage", () => {
 
       const rows = store.listDecisions(device.deviceId);
       const reasons = rows.map((row) => `${row.decision}:${row.reason_code}`);
-      assert.ok(reasons.includes("deny:entitlement_gate_not_implemented"), JSON.stringify(reasons));
+      assert.ok(reasons.includes("deny:entitlement_missing"), JSON.stringify(reasons));
       assert.ok(reasons.includes("allow:issued"), JSON.stringify(reasons));
       const serialized = JSON.stringify(rows);
       assert.ok(!serialized.includes(harness.mintedToken), "no minted token in the ledger");

--- a/services/license-api/test/github-broker-adversarial.test.ts
+++ b/services/license-api/test/github-broker-adversarial.test.ts
@@ -52,7 +52,8 @@ function mutableFake(config: {
       return { token: "broker-test-mutable-token", expires_at: new Date(Date.now() + 3_600_000).toISOString() };
     },
     async verifyInstallationForAuthorizationCode(installationId: number, code: string) {
-      return code === `oauth-code-${installationId}`;
+      if (code !== `oauth-code-${installationId}`) return null;
+      return (config.repositories ?? []).map((repository) => repository.full_name);
     }
   };
   return { client, calls, state };

--- a/services/license-api/test/github-broker-adversarial.test.ts
+++ b/services/license-api/test/github-broker-adversarial.test.ts
@@ -50,6 +50,9 @@ function mutableFake(config: {
     async createInstallationAccessToken(installationId: number, params: unknown) {
       calls.push({ op: "createInstallationAccessToken", installationId, params });
       return { token: "broker-test-mutable-token", expires_at: new Date(Date.now() + 3_600_000).toISOString() };
+    },
+    async verifyInstallationForAuthorizationCode(installationId: number, code: string) {
+      return code === `oauth-code-${installationId}`;
     }
   };
   return { client, calls, state };
@@ -237,7 +240,7 @@ describe("github broker adversarial and lifecycle coverage", () => {
       const pending = await post(harness.url, "/github/connect/complete", { state }, bearer(await device.sign()));
       assert.equal(pending.json.status, "pending");
 
-      await fetch(`${harness.url}/github/connect/callback?installation_id=${PUBLIC_INSTALL.id}&state=${encodeURIComponent(state)}`, { redirect: "manual" });
+      await fetch(`${harness.url}/github/connect/callback?installation_id=${PUBLIC_INSTALL.id}&state=${encodeURIComponent(state)}&code=oauth-code-${PUBLIC_INSTALL.id}`, { redirect: "manual" });
 
       const bound = await post(harness.url, "/github/connect/complete", { state }, bearer(await device.sign()));
       assert.equal(bound.status, 200, bound.text);

--- a/services/license-api/test/github-broker-binding-identity.test.ts
+++ b/services/license-api/test/github-broker-binding-identity.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  authorizationCodeFor,
+  bearer,
+  connectInstallation,
+  makeDevice,
+  post,
+  registerDevice,
+  startBroker,
+  type FakeInstallation
+} from "./github-broker-support.ts";
+
+/**
+ * Install-binding identity coverage (PR #620 AC8, P1). The callback must prove
+ * the identity completing the flow is authorized for the installation before it
+ * records any (device, installation) binding. Without that proof a valid
+ * connect-state alone could bind a device to an arbitrary VICTIM installation id
+ * (small enumerable int), then mint a contents:read + pull_requests:write token
+ * on the victim's repos. These tests prove the forgery is refused with zero
+ * binding, and that a legitimate identity-proving callback still binds.
+ */
+
+const VICTIM: FakeInstallation = {
+  id: 9002,
+  account_login: "victim-org",
+  repositories: [{ id: 61, full_name: "victim-org/site", visibility: "public" }]
+};
+const ATTACKER: FakeInstallation = {
+  id: 9001,
+  account_login: "attacker",
+  repositories: []
+};
+
+describe("github broker callback install-binding identity (#620 P1)", () => {
+  it("refuses a forged callback that carries a valid state but no installation-ownership proof", async () => {
+    const harness = await startBroker({ installations: [VICTIM, ATTACKER] });
+    try {
+      const attacker = await makeDevice();
+      await registerDevice(harness.url, attacker);
+      // Attacker gets a legitimate state for their OWN device via connect/start...
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await attacker.sign()));
+      const state = start.json.state as string;
+
+      // ...then hits the callback directly with the VICTIM installation id and no
+      // OAuth code (no GitHub round-trip proving they own installation 9002).
+      const forged = await fetch(
+        `${harness.url}/github/connect/callback?installation_id=${VICTIM.id}&state=${encodeURIComponent(state)}`,
+        { redirect: "manual" }
+      );
+      const forgedText = await forged.text();
+      assert.equal(forged.status, 403, forgedText);
+      assert.equal(JSON.parse(forgedText).reason, "installation_authorization_unverified");
+
+      // No binding was recorded: a token request for the victim installation fails
+      // closed with binding_not_found, and nothing was minted.
+      const token = await post(
+        harness.url,
+        "/github/token",
+        { installationId: VICTIM.id, repositories: ["victim-org/site"] },
+        bearer(await attacker.sign())
+      );
+      assert.equal(token.status, 404, token.text);
+      assert.equal(token.json.reason, "binding_not_found");
+      assert.equal(harness.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("refuses a callback whose OAuth code authorizes a different installation than requested", async () => {
+    const harness = await startBroker({ installations: [VICTIM, ATTACKER] });
+    try {
+      const attacker = await makeDevice();
+      await registerDevice(harness.url, attacker);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await attacker.sign()));
+      const state = start.json.state as string;
+
+      // The attacker holds a code proving ownership of their OWN installation
+      // (9001) but targets the victim's installation (9002).
+      const crossed = await fetch(
+        `${harness.url}/github/connect/callback?installation_id=${VICTIM.id}&state=${encodeURIComponent(state)}&code=${encodeURIComponent(authorizationCodeFor(ATTACKER.id))}`,
+        { redirect: "manual" }
+      );
+      const crossedText = await crossed.text();
+      assert.equal(crossed.status, 403, crossedText);
+      assert.equal(JSON.parse(crossedText).reason, "installation_authorization_unverified");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("binds and issues when the callback proves installation ownership (legitimate flow)", async () => {
+    const harness = await startBroker({ installations: [VICTIM] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const result = await connectInstallation(harness.url, device, VICTIM.id);
+      assert.ok(result.callbackStatus < 400 || result.callbackStatus === 302, `callback ok: ${result.callbackStatus}`);
+
+      const token = await post(
+        harness.url,
+        "/github/token",
+        { installationId: VICTIM.id, repositories: ["victim-org/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(token.status, 200, token.text);
+      assert.equal(token.json.token, harness.mintedToken);
+    } finally {
+      harness.close();
+    }
+  });
+});

--- a/services/license-api/test/github-broker-binding-identity.test.ts
+++ b/services/license-api/test/github-broker-binding-identity.test.ts
@@ -110,4 +110,54 @@ describe("github broker callback install-binding identity (#620 P1)", () => {
       harness.close();
     }
   });
+
+  it("acknowledges a bare Setup-URL redirect (setup_action, no code) without binding or resolving", async () => {
+    const harness = await startBroker({ installations: [VICTIM] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await device.sign()));
+      const state = start.json.state as string;
+      harness.calls.length = 0;
+      const setup = await fetch(
+        `${harness.url}/github/connect/callback?installation_id=${VICTIM.id}&state=${encodeURIComponent(state)}&setup_action=install`,
+        { redirect: "manual" }
+      );
+      assert.equal(setup.status, 200, await setup.text());
+      // A code-less setup redirect never resolves the installation or binds.
+      assert.equal(harness.calls.filter((call) => call.op === "getInstallation").length, 0);
+      const token = await post(
+        harness.url,
+        "/github/token",
+        { installationId: VICTIM.id, repositories: ["victim-org/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(token.status, 404, token.text);
+      assert.equal(token.json.reason, "binding_not_found");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("rejects a forged OAuth callback BEFORE resolving the installation (no App-JWT probe oracle)", async () => {
+    const harness = await startBroker({ installations: [VICTIM, ATTACKER] });
+    try {
+      const attacker = await makeDevice();
+      await registerDevice(harness.url, attacker);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await attacker.sign()));
+      const state = start.json.state as string;
+      harness.calls.length = 0;
+      // A code proving the attacker's OWN installation, aimed at the victim id.
+      const forged = await fetch(
+        `${harness.url}/github/connect/callback?installation_id=${VICTIM.id}&state=${encodeURIComponent(state)}&code=${encodeURIComponent(authorizationCodeFor(ATTACKER.id))}`,
+        { redirect: "manual" }
+      );
+      assert.equal(forged.status, 403, await forged.text());
+      // Identity is verified before resolution, so the supplied victim id is never
+      // resolved via an App JWT — no 403-vs-404 existence oracle.
+      assert.equal(harness.calls.filter((call) => call.op === "getInstallation").length, 0);
+    } finally {
+      harness.close();
+    }
+  });
 });

--- a/services/license-api/test/github-broker-binding-identity.test.ts
+++ b/services/license-api/test/github-broker-binding-identity.test.ts
@@ -160,4 +160,55 @@ describe("github broker callback install-binding identity (#620 P1)", () => {
       harness.close();
     }
   });
+
+  it("confines the binding to the user's accessible repos: an unauthorized repo in the SAME installation is refused with zero mint (#620 P1)", async () => {
+    // An org installation with two private repos where the connecting OAuth user
+    // can access repo-a but NOT repo-b. /user/installations proves installation
+    // membership; only /user/installations/{id}/repositories proves per-repo access.
+    const ORG: FakeInstallation = {
+      id: 9100,
+      account_login: "org",
+      repositories: [
+        { id: 71, full_name: "org/repo-a", visibility: "private" },
+        { id: 72, full_name: "org/repo-b", visibility: "private" }
+      ],
+      userRepositories: ["org/repo-a"]
+    };
+    // Entitlement COVERS both private repos, isolating the per-repo access gate as
+    // the sole reason repo-b is refused (proving it is not merely an entitlement miss).
+    const harness = await startBroker({
+      installations: [ORG],
+      resolveEntitlement: () => ({ status: "active", coveredPrivateRepositories: ["org/repo-a", "org/repo-b"] })
+    });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, ORG.id);
+      harness.calls.length = 0;
+
+      // repo-b is inside the installation and entitlement-covered, but OUTSIDE the
+      // connecting user's authorized set -> refused before the seam, zero mint.
+      const denied = await post(
+        harness.url,
+        "/github/token",
+        { installationId: ORG.id, repositories: ["org/repo-b"] },
+        bearer(await device.sign())
+      );
+      assert.equal(denied.status, 403, denied.text);
+      assert.equal(denied.json.reason, "repo_outside_authorization");
+      assert.equal(harness.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+
+      // repo-a (authorized AND covered) still mints normally through the same binding.
+      const allowed = await post(
+        harness.url,
+        "/github/token",
+        { installationId: ORG.id, repositories: ["org/repo-a"] },
+        bearer(await device.sign())
+      );
+      assert.equal(allowed.status, 200, allowed.text);
+      assert.equal(allowed.json.token, harness.mintedToken);
+    } finally {
+      harness.close();
+    }
+  });
 });

--- a/services/license-api/test/github-broker-binding-identity.test.ts
+++ b/services/license-api/test/github-broker-binding-identity.test.ts
@@ -175,16 +175,23 @@ describe("github broker callback install-binding identity (#620 P1)", () => {
       userRepositories: ["org/repo-a"]
     };
     // Entitlement COVERS both private repos, isolating the per-repo access gate as
-    // the sole reason repo-b is refused (proving it is not merely an entitlement miss).
+    // the sole reason repo-b is refused (proving it is not merely an entitlement
+    // miss). A COUNTING SPY records every resolver call so we can assert the
+    // per-repo denial happens BEFORE entitlement resolution.
+    let entitlementCalls = 0;
     const harness = await startBroker({
       installations: [ORG],
-      resolveEntitlement: () => ({ status: "active", coveredPrivateRepositories: ["org/repo-a", "org/repo-b"] })
+      resolveEntitlement: () => {
+        entitlementCalls += 1;
+        return { status: "active", coveredPrivateRepositories: ["org/repo-a", "org/repo-b"] };
+      }
     });
     try {
       const device = await makeDevice();
       await registerDevice(harness.url, device);
       await connectInstallation(harness.url, device, ORG.id);
       harness.calls.length = 0;
+      entitlementCalls = 0;
 
       // repo-b is inside the installation and entitlement-covered, but OUTSIDE the
       // connecting user's authorized set -> refused before the seam, zero mint.
@@ -197,6 +204,10 @@ describe("github broker callback install-binding identity (#620 P1)", () => {
       assert.equal(denied.status, 403, denied.text);
       assert.equal(denied.json.reason, "repo_outside_authorization");
       assert.equal(harness.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+      // Ordering pin: the per-repo denial precedes entitlement resolution, so the
+      // license authority is never consulted for an unauthorized repo (a reorder
+      // that moved the gate after entitlement resolution would fail here).
+      assert.equal(entitlementCalls, 0, "entitlement authority must not be consulted for an unauthorized repo");
 
       // repo-a (authorized AND covered) still mints normally through the same binding.
       const allowed = await post(

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -119,6 +119,33 @@ describe("production github installation client wire contract", () => {
     assert.ok(!exchange?.url.includes("//login/oauth"), exchange?.url);
   });
 
+  it("paginates /user/installations/{id}/repositories so the authorized set spans every page", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ full_name: `octo/repo-${i}` }));
+    const captured = stubFetch((request) => {
+      if (request.url.includes("/login/oauth/access_token")) return { json: { access_token: "user-tok" } };
+      if (request.url.includes("/user/installations/6001/repositories")) {
+        const page = new URL(request.url).searchParams.get("page");
+        if (page === "1") return { json: { repositories: page1 } };
+        if (page === "2") return { json: { repositories: [{ full_name: "octo/on-page-2" }] } };
+        return { json: { repositories: [] } };
+      }
+      return { json: {} };
+    });
+    const client = createGitHubInstallationClient({
+      appId: "123",
+      privateKey: appPrivateKey,
+      oauthClientId: "cid",
+      oauthClientSecret: "csec"
+    });
+    const authorized = await client.verifyInstallationForAuthorizationCode(6001, "good-code");
+    // A repo on the SECOND page must be in the authorized set — a broken-pagination
+    // regression that dropped later pages would silently shrink the set and fail here.
+    assert.ok(Array.isArray(authorized) && authorized.includes("octo/on-page-2"), JSON.stringify(authorized));
+    assert.equal(authorized.length, 101);
+    const listCalls = captured.filter((request) => request.url.includes("/repositories"));
+    assert.equal(listCalls.length, 2, "both pages were fetched");
+  });
+
   it("aborts a stalled OAuth exchange as a typed broker outage under the configured timeout", async () => {
     globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
       if (String(input).includes("/login/oauth/access_token")) {

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -28,10 +28,20 @@ afterEach(() => {
 function stubFetch(handler: (request: CapturedRequest) => { status?: number; json: unknown }): CapturedRequest[] {
   const captured: CapturedRequest[] = [];
   globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+    const rawBody = init?.body ? String(init.body) : undefined;
+    let parsedBody: unknown = rawBody;
+    if (rawBody !== undefined) {
+      // JSON for App-JWT calls; form-encoded for the OAuth token exchange.
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        parsedBody = rawBody;
+      }
+    }
     const request: CapturedRequest = {
       url: String(input),
       method: init?.method ?? "GET",
-      body: init?.body ? JSON.parse(String(init.body)) : undefined
+      body: parsedBody
     };
     captured.push(request);
     const { status = 200, json } = handler(request);
@@ -69,19 +79,22 @@ describe("production github installation client wire contract", () => {
     });
   });
 
-  it("returns unverified (false) with no network call when OAuth-during-install is unconfigured", async () => {
+  it("returns unverified (null) with no network call when OAuth-during-install is unconfigured", async () => {
     const captured = stubFetch(() => ({ json: {} }));
     const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
-    // No oauthClientId/Secret -> identity is unverified (the callback maps false to
+    // No oauthClientId/Secret -> identity is unverified (the callback maps null to
     // installation_authorization_unverified, 403), and no OAuth exchange is attempted.
-    assert.equal(await client.verifyInstallationForAuthorizationCode(6001, "any-code"), false);
+    assert.equal(await client.verifyInstallationForAuthorizationCode(6001, "any-code"), null);
     assert.equal(captured.length, 0);
   });
 
-  it("verifies installation ownership via the OAuth code exchange and /user/installations", async () => {
+  it("verifies ownership and returns the user's accessible repositories for the installation", async () => {
     const captured = stubFetch((request) => {
       if (request.url.includes("/login/oauth/access_token")) return { json: { access_token: "user-tok" } };
-      if (request.url.includes("/user/installations")) return { json: { installations: [{ id: 6001 }] } };
+      if (request.url.includes("/user/installations/6001/repositories")) {
+        return { json: { repositories: [{ full_name: "octo/site" }, { full_name: "octo/private" }] } };
+      }
+      if (request.url.includes("/user/installations/9999/repositories")) return { status: 404, json: { message: "Not Found" } };
       return { json: {} };
     });
     const client = createGitHubInstallationClient({
@@ -90,12 +103,20 @@ describe("production github installation client wire contract", () => {
       oauthClientId: "cid",
       oauthClientSecret: "csec"
     });
-    assert.equal(await client.verifyInstallationForAuthorizationCode(6001, "good-code"), true);
-    // An installation the OAuth user cannot access is not in the list -> unverified.
-    assert.equal(await client.verifyInstallationForAuthorizationCode(9999, "good-code"), false);
+    // A proven identity yields the EXACT repos the user can access in the
+    // installation (the per-repo authorized set), not mere installation membership.
+    assert.deepEqual(await client.verifyInstallationForAuthorizationCode(6001, "good-code"), ["octo/site", "octo/private"]);
+    // An installation the OAuth user cannot access returns 404 -> unverified (null).
+    assert.equal(await client.verifyInstallationForAuthorizationCode(9999, "good-code"), null);
     const exchange = captured.find((request) => request.url.includes("/login/oauth/access_token"));
     assert.equal(exchange?.method, "POST");
-    assert.deepEqual(exchange?.body, { client_id: "cid", client_secret: "csec", code: "good-code" });
+    // GitHub's web flow requires form-encoded parameters, not JSON.
+    const params = new URLSearchParams(String(exchange?.body));
+    assert.equal(params.get("client_id"), "cid");
+    assert.equal(params.get("client_secret"), "csec");
+    assert.equal(params.get("code"), "good-code");
+    // The endpoint is joined without a double slash.
+    assert.ok(!exchange?.url.includes("//login/oauth"), exchange?.url);
   });
 
   it("aborts a stalled OAuth exchange as a typed broker outage under the configured timeout", async () => {

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -68,4 +68,56 @@ describe("production github installation client wire contract", () => {
       permissions: { contents: "read", pull_requests: "write" }
     });
   });
+
+  it("returns unverified (false) with no network call when OAuth-during-install is unconfigured", async () => {
+    const captured = stubFetch(() => ({ json: {} }));
+    const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
+    // No oauthClientId/Secret -> identity is unverified (the callback maps false to
+    // installation_authorization_unverified, 403), and no OAuth exchange is attempted.
+    assert.equal(await client.verifyInstallationForAuthorizationCode(6001, "any-code"), false);
+    assert.equal(captured.length, 0);
+  });
+
+  it("verifies installation ownership via the OAuth code exchange and /user/installations", async () => {
+    const captured = stubFetch((request) => {
+      if (request.url.includes("/login/oauth/access_token")) return { json: { access_token: "user-tok" } };
+      if (request.url.includes("/user/installations")) return { json: { installations: [{ id: 6001 }] } };
+      return { json: {} };
+    });
+    const client = createGitHubInstallationClient({
+      appId: "123",
+      privateKey: appPrivateKey,
+      oauthClientId: "cid",
+      oauthClientSecret: "csec"
+    });
+    assert.equal(await client.verifyInstallationForAuthorizationCode(6001, "good-code"), true);
+    // An installation the OAuth user cannot access is not in the list -> unverified.
+    assert.equal(await client.verifyInstallationForAuthorizationCode(9999, "good-code"), false);
+    const exchange = captured.find((request) => request.url.includes("/login/oauth/access_token"));
+    assert.equal(exchange?.method, "POST");
+    assert.deepEqual(exchange?.body, { client_id: "cid", client_secret: "csec", code: "good-code" });
+  });
+
+  it("aborts a stalled OAuth exchange as a typed broker outage under the configured timeout", async () => {
+    globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+      if (String(input).includes("/login/oauth/access_token")) {
+        // Hang until the timeout controller aborts the request.
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        });
+      }
+      return new Response(JSON.stringify({ installations: [{ id: 6001 }] }), { status: 200 });
+    }) as typeof fetch;
+    const client = createGitHubInstallationClient({
+      appId: "123",
+      privateKey: appPrivateKey,
+      oauthClientId: "cid",
+      oauthClientSecret: "csec",
+      requestTimeoutMs: 30
+    });
+    await assert.rejects(
+      () => client.verifyInstallationForAuthorizationCode(6001, "good-code"),
+      (error: unknown) => error instanceof Error && /OAuth token exchange failed/.test(error.message)
+    );
+  });
 });

--- a/services/license-api/test/github-broker-contract.test.ts
+++ b/services/license-api/test/github-broker-contract.test.ts
@@ -98,7 +98,7 @@ describe("github broker token-issuance contract", () => {
     assert.ok(state, "connect start returns a state nonce");
 
     const first = await fetch(
-      `${harness.url}/github/connect/callback?installation_id=4001&state=${encodeURIComponent(state)}`,
+      `${harness.url}/github/connect/callback?installation_id=4001&state=${encodeURIComponent(state)}&code=oauth-code-4001`,
       { redirect: "manual" }
     );
     assert.ok(first.status < 400 || first.status === 302, `first callback consumed: ${first.status}`);

--- a/services/license-api/test/github-broker-contract.test.ts
+++ b/services/license-api/test/github-broker-contract.test.ts
@@ -71,7 +71,7 @@ describe("github broker token-issuance contract", () => {
     assert.doesNotMatch(response.text, /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
   });
 
-  it("(c) refuses issuance for a private repo with entitlement_gate_not_implemented", async () => {
+  it("(c) refuses issuance for a private repo without entitlement (entitlement_missing)", async () => {
     const fresh = await makeDevice();
     await registerDevice(harness.url, fresh);
     await connectInstallation(harness.url, fresh, 4001);
@@ -83,7 +83,9 @@ describe("github broker token-issuance contract", () => {
       bearer(await fresh.sign())
     );
     assert.equal(response.status, 403);
-    assert.equal(response.json.reason, "entitlement_gate_not_implemented");
+    // No entitlement resolver is configured here, so the fail-closed default
+    // denies the private request as entitlement_missing (never as public).
+    assert.equal(response.json.reason, "entitlement_missing");
     // Fail closed: no token minted for the denied request.
     assert.equal(response.json.token, undefined);
   });

--- a/services/license-api/test/github-broker-decision-matrix.test.ts
+++ b/services/license-api/test/github-broker-decision-matrix.test.ts
@@ -26,8 +26,11 @@ const PRIVATE = repo("octo/secret", "private", 12);
 const INTERNAL = repo("octo/internal", "internal", 13);
 const UNKNOWN = repo("octo/mystery", "unknown", 14);
 
-const ACTIVE_PRIVATE: EntitlementSnapshot = { status: "active", privateRepoAllowed: true };
-const ACTIVE_PUBLIC_ONLY: EntitlementSnapshot = { status: "active", privateRepoAllowed: false };
+const ACTIVE_PRIVATE: EntitlementSnapshot = {
+  status: "active",
+  coveredPrivateRepositories: ["octo/secret", "octo/internal"]
+};
+const ACTIVE_PUBLIC_ONLY: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: [] };
 
 interface Row {
   name: string;

--- a/services/license-api/test/github-broker-decision-matrix.test.ts
+++ b/services/license-api/test/github-broker-decision-matrix.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  authorizeTokenIssuance,
+  type EntitlementSnapshot,
+  type RequestedRepository
+} from "../src/github-broker/index.ts";
+
+/**
+ * Unit decision-matrix for the #614 authorization boundary. This drives the pure
+ * seam function directly across visibility × installation-binding × entitlement ×
+ * seat × service-state, so the whole policy is table-provable without the HTTP
+ * stack. Red first against the #613 placeholder (which denies every private repo
+ * with a single `entitlement_gate_not_implemented`); green once the seam binds the
+ * full matrix. The public/no-key row and the unknown-fails-closed row are the two
+ * load-bearing anchors: public work must succeed with no Activation Key, and any
+ * visibility the App could not authoritatively determine must fail closed.
+ */
+
+function repo(fullName: string, visibility: RequestedRepository["visibility"], id = 1): RequestedRepository {
+  return { fullName, id, visibility };
+}
+
+const PUBLIC = repo("octo/site", "public", 11);
+const PRIVATE = repo("octo/secret", "private", 12);
+const INTERNAL = repo("octo/internal", "internal", 13);
+const UNKNOWN = repo("octo/mystery", "unknown", 14);
+
+const ACTIVE_PRIVATE: EntitlementSnapshot = { status: "active", privateRepoAllowed: true };
+const ACTIVE_PUBLIC_ONLY: EntitlementSnapshot = { status: "active", privateRepoAllowed: false };
+
+interface Row {
+  name: string;
+  repositories: RequestedRepository[];
+  entitlement?: EntitlementSnapshot;
+  expect:
+    | { decision: "allow"; repositories: string[] }
+    | { decision: "deny"; reason: string };
+}
+
+const MATRIX: Row[] = [
+  // Public tier — no Activation Key required (layer-3 policy). Entitlement is not
+  // consulted at all on the all-public path.
+  {
+    name: "public repo, no entitlement (public-free)",
+    repositories: [PUBLIC],
+    entitlement: { status: "none" },
+    expect: { decision: "allow", repositories: ["octo/site"] }
+  },
+  {
+    name: "public repo, entitlement omitted entirely (public-free)",
+    repositories: [PUBLIC],
+    expect: { decision: "allow", repositories: ["octo/site"] }
+  },
+  {
+    name: "multiple public repos, no entitlement",
+    repositories: [PUBLIC, repo("octo/docs", "public", 15)],
+    entitlement: { status: "none" },
+    expect: { decision: "allow", repositories: ["octo/site", "octo/docs"] }
+  },
+  // Unknown / ambiguous visibility — fail closed, never assume public. Wins even
+  // over a present entitlement and even when mixed with a public repo.
+  {
+    name: "unknown visibility fails closed",
+    repositories: [UNKNOWN],
+    entitlement: ACTIVE_PRIVATE,
+    expect: { decision: "deny", reason: "visibility_unknown" }
+  },
+  {
+    name: "public + unknown fails closed on the unknown",
+    repositories: [PUBLIC, UNKNOWN],
+    entitlement: ACTIVE_PRIVATE,
+    expect: { decision: "deny", reason: "visibility_unknown" }
+  },
+  // Private / internal — an active, private-covering entitlement is required.
+  {
+    name: "private repo with active private-covering entitlement",
+    repositories: [PRIVATE],
+    entitlement: ACTIVE_PRIVATE,
+    expect: { decision: "allow", repositories: ["octo/secret"] }
+  },
+  {
+    name: "internal repo with active private-covering entitlement",
+    repositories: [INTERNAL],
+    entitlement: ACTIVE_PRIVATE,
+    expect: { decision: "allow", repositories: ["octo/internal"] }
+  },
+  {
+    name: "public + private with active private-covering entitlement",
+    repositories: [PUBLIC, PRIVATE],
+    entitlement: ACTIVE_PRIVATE,
+    expect: { decision: "allow", repositories: ["octo/site", "octo/secret"] }
+  },
+  {
+    name: "private repo with a public-only active license (scope insufficient)",
+    repositories: [PRIVATE],
+    entitlement: ACTIVE_PUBLIC_ONLY,
+    expect: { decision: "deny", reason: "entitlement_scope_insufficient" }
+  },
+  {
+    name: "private repo with no entitlement (missing)",
+    repositories: [PRIVATE],
+    entitlement: { status: "none" },
+    expect: { decision: "deny", reason: "entitlement_missing" }
+  },
+  {
+    name: "private repo, entitlement omitted (fail-closed default = missing)",
+    repositories: [PRIVATE],
+    expect: { decision: "deny", reason: "entitlement_missing" }
+  },
+  {
+    name: "private repo with expired entitlement",
+    repositories: [PRIVATE],
+    entitlement: { status: "expired" },
+    expect: { decision: "deny", reason: "entitlement_expired" }
+  },
+  {
+    name: "private repo with revoked entitlement",
+    repositories: [PRIVATE],
+    entitlement: { status: "revoked" },
+    expect: { decision: "deny", reason: "entitlement_revoked" }
+  },
+  {
+    name: "private repo with invalid entitlement",
+    repositories: [PRIVATE],
+    entitlement: { status: "invalid" },
+    expect: { decision: "deny", reason: "entitlement_invalid" }
+  },
+  {
+    name: "private repo over seat allocation",
+    repositories: [PRIVATE],
+    entitlement: { status: "seat_exhausted" },
+    expect: { decision: "deny", reason: "entitlement_seat_exhausted" }
+  },
+  {
+    name: "private repo with an event-order (replay) conflict",
+    repositories: [PRIVATE],
+    entitlement: { status: "replay_conflict" },
+    expect: { decision: "deny", reason: "entitlement_replay_conflict" }
+  },
+  {
+    name: "private repo when the license service is unavailable",
+    repositories: [PRIVATE],
+    entitlement: { status: "service_unavailable" },
+    expect: { decision: "deny", reason: "entitlement_service_unavailable" }
+  },
+  // Empty request is a malformed request, independent of entitlement.
+  {
+    name: "empty repository set is invalid",
+    repositories: [],
+    entitlement: ACTIVE_PRIVATE,
+    expect: { decision: "deny", reason: "invalid_request" }
+  }
+];
+
+describe("github broker issuance decision matrix (#614)", () => {
+  for (const row of MATRIX) {
+    it(row.name, () => {
+      const decision = authorizeTokenIssuance({
+        requestedRepositories: row.repositories,
+        ...(row.entitlement ? { entitlement: row.entitlement } : {})
+      });
+      if (row.expect.decision === "allow") {
+        assert.equal(decision.decision, "allow", JSON.stringify(decision));
+        assert.deepEqual(
+          decision.decision === "allow" ? decision.repositories : undefined,
+          row.expect.repositories
+        );
+      } else {
+        assert.equal(decision.decision, "deny", JSON.stringify(decision));
+        assert.equal(decision.decision === "deny" ? decision.reason : undefined, row.expect.reason);
+      }
+    });
+  }
+
+  it("a provider key never substitutes for entitlement: only an active private-covering license unlocks private", () => {
+    // The seam has no provider-key input by construction; the ONLY snapshot that
+    // flips a private request to allow is an active, private-covering entitlement.
+    const flips = (["active-private", "active-public", "expired", "revoked", "invalid", "seat_exhausted", "replay_conflict", "service_unavailable", "none"] as const).filter((label) => {
+      const entitlement: EntitlementSnapshot =
+        label === "active-private"
+          ? ACTIVE_PRIVATE
+          : label === "active-public"
+            ? ACTIVE_PUBLIC_ONLY
+            : { status: label as Exclude<EntitlementSnapshot["status"], "active"> };
+      return authorizeTokenIssuance({ requestedRepositories: [PRIVATE], entitlement }).decision === "allow";
+    });
+    assert.deepEqual(flips, ["active-private"]);
+  });
+});

--- a/services/license-api/test/github-broker-entitlement-adversarial.test.ts
+++ b/services/license-api/test/github-broker-entitlement-adversarial.test.ts
@@ -149,7 +149,7 @@ describe("github broker #614 adversarial entitlement boundary", () => {
 
   it("mints for the same server-private repo once an active private-covering entitlement exists", async () => {
     const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
-    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const resolver = countingResolver({ status: "active", coveredPrivateRepositories: ["octo/private"] });
     const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
     try {
       const device = await makeDevice();
@@ -172,7 +172,7 @@ describe("github broker #614 adversarial entitlement boundary", () => {
 
   it("repo rename/transfer at issuance fails typed and never reaches the entitlement authority or a mint", async () => {
     const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
-    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const resolver = countingResolver({ status: "active", coveredPrivateRepositories: ["octo/private"] });
     const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
     try {
       const device = await makeDevice();
@@ -197,7 +197,7 @@ describe("github broker #614 adversarial entitlement boundary", () => {
 
   it("install swap: a private repo outside the installation selection is refused before the seam", async () => {
     const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
-    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const resolver = countingResolver({ status: "active", coveredPrivateRepositories: ["octo/private"] });
     const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
     try {
       const device = await makeDevice();
@@ -221,7 +221,7 @@ describe("github broker #614 adversarial entitlement boundary", () => {
 
   it("direct call skipping the connect/binding flow cannot reach the entitlement seam or a mint", async () => {
     const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
-    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const resolver = countingResolver({ status: "active", coveredPrivateRepositories: ["octo/private"] });
     const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
     try {
       const device = await makeDevice();

--- a/services/license-api/test/github-broker-entitlement-adversarial.test.ts
+++ b/services/license-api/test/github-broker-entitlement-adversarial.test.ts
@@ -66,6 +66,9 @@ function mutableFake(config: {
       async createInstallationAccessToken(installationId: number, params: unknown) {
         calls.push({ op: "createInstallationAccessToken", installationId, params });
         return { token: "broker-test-adversarial-token", expires_at: new Date(Date.now() + 3_600_000).toISOString() };
+      },
+      async verifyInstallationForAuthorizationCode(installationId: number, code: string) {
+        return code === `oauth-code-${installationId}`;
       }
     }
   };

--- a/services/license-api/test/github-broker-entitlement-adversarial.test.ts
+++ b/services/license-api/test/github-broker-entitlement-adversarial.test.ts
@@ -56,6 +56,9 @@ function mutableFake(config: {
     client: {
       async getInstallation(installationId: number) {
         calls.push({ op: "getInstallation", installationId });
+        // Tighten the fixture boundary: only the configured installation exists; an
+        // unknown id (an install swap) resolves to null, exactly like GitHub's 404.
+        if (installationId !== config.installationId) return null;
         return { id: installationId, account_login: "octo", suspended: false };
       },
       async listInstallationRepositories(installationId: number) {
@@ -68,7 +71,8 @@ function mutableFake(config: {
         return { token: "broker-test-adversarial-token", expires_at: new Date(Date.now() + 3_600_000).toISOString() };
       },
       async verifyInstallationForAuthorizationCode(installationId: number, code: string) {
-        return code === `oauth-code-${installationId}`;
+        if (code !== `oauth-code-${installationId}`) return null;
+        return repositories.map((repository) => repository.full_name);
       }
     }
   };
@@ -198,7 +202,7 @@ describe("github broker #614 adversarial entitlement boundary", () => {
     }
   });
 
-  it("install swap: a private repo outside the installation selection is refused before the seam", async () => {
+  it("a private repo outside the installation selection is refused before the seam", async () => {
     const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
     const resolver = countingResolver({ status: "active", coveredPrivateRepositories: ["octo/private"] });
     const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
@@ -215,6 +219,34 @@ describe("github broker #614 adversarial entitlement boundary", () => {
       );
       assert.equal(response.status, 403, response.text);
       assert.equal(response.json.reason, "repo_outside_installation");
+      assert.equal(resolver.contexts.length, 0);
+      assert.equal(mints(fake.calls), 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("install swap: a token request for a DIFFERENT installation than the device bound is refused with zero seam/mint", async () => {
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "active", coveredPrivateRepositories: ["octo/private"] });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      fake.calls.length = 0;
+      // The device is bound to INSTALL_ID; it now targets a different installation id
+      // it never connected. The per-(device, installation) binding check fails closed
+      // before any installation resolution, entitlement lookup, or mint.
+      const OTHER_INSTALL_ID = INSTALL_ID + 1;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: OTHER_INSTALL_ID, repositories: ["octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 404, response.text);
+      assert.equal(response.json.reason, "binding_not_found");
       assert.equal(resolver.contexts.length, 0);
       assert.equal(mints(fake.calls), 0);
     } finally {

--- a/services/license-api/test/github-broker-entitlement-adversarial.test.ts
+++ b/services/license-api/test/github-broker-entitlement-adversarial.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { GitHubBrokerStore } from "../src/github-broker/index.ts";
+import type {
+  EntitlementResolutionContext,
+  EntitlementSnapshot
+} from "../src/github-broker/index.ts";
+import {
+  bearer,
+  connectInstallation,
+  makeDevice,
+  post,
+  registerDevice,
+  startBroker,
+  type FakeGitHubCall
+} from "./github-broker-support.ts";
+
+/**
+ * Adversarial fixtures for the #614 authorization boundary (issue "Testing Plan",
+ * Adversarial row): the server's GitHub-authoritative visibility must win over any
+ * client belief, and no attempt — stale visibility, a modified client asserting
+ * public, repo rename/transfer, install swap, entitlement replay, or a
+ * binding-skipping direct call — may mint a usable token for a private repo
+ * without an active entitlement. Denials that precede the seam must never even
+ * consult the entitlement authority.
+ */
+
+type Visibility = "public" | "private" | "internal" | "unknown";
+
+/**
+ * A mutable installation client whose repository visibility can be flipped
+ * between the connect and token phases, and which can be made to throw a
+ * rename/transfer client error at token time. Records call order.
+ */
+function mutableFake(config: {
+  installationId: number;
+  repositories: Array<{ id: number; full_name: string; visibility: Visibility }>;
+}): {
+  client: Record<string, unknown>;
+  calls: FakeGitHubCall[];
+  setVisibility(fullName: string, visibility: Visibility): void;
+  failListWith(brokerClientErrorClass: string): void;
+} {
+  const calls: FakeGitHubCall[] = [];
+  const repositories = config.repositories.map((repository) => ({ ...repository }));
+  let listFailure: { brokerClientErrorClass: string } | undefined;
+  return {
+    calls,
+    setVisibility(fullName, visibility) {
+      const repository = repositories.find((candidate) => candidate.full_name === fullName);
+      if (repository) repository.visibility = visibility;
+    },
+    failListWith(brokerClientErrorClass) {
+      listFailure = { brokerClientErrorClass };
+    },
+    client: {
+      async getInstallation(installationId: number) {
+        calls.push({ op: "getInstallation", installationId });
+        return { id: installationId, account_login: "octo", suspended: false };
+      },
+      async listInstallationRepositories(installationId: number) {
+        calls.push({ op: "listInstallationRepositories", installationId });
+        if (listFailure) throw Object.assign(new Error("client error"), listFailure);
+        return repositories.map((repository) => ({ ...repository }));
+      },
+      async createInstallationAccessToken(installationId: number, params: unknown) {
+        calls.push({ op: "createInstallationAccessToken", installationId, params });
+        return { token: "broker-test-adversarial-token", expires_at: new Date(Date.now() + 3_600_000).toISOString() };
+      }
+    }
+  };
+}
+
+function countingResolver(snapshot: EntitlementSnapshot): {
+  resolveEntitlement: (context: EntitlementResolutionContext) => EntitlementSnapshot;
+  contexts: EntitlementResolutionContext[];
+} {
+  const contexts: EntitlementResolutionContext[] = [];
+  return {
+    contexts,
+    resolveEntitlement(context) {
+      contexts.push(context);
+      return snapshot;
+    }
+  };
+}
+
+const INSTALL_ID = 8001;
+const baseRepositories = [
+  { id: 91, full_name: "octo/site", visibility: "public" as Visibility },
+  { id: 92, full_name: "octo/private", visibility: "private" as Visibility }
+];
+
+function mints(calls: FakeGitHubCall[]): number {
+  return calls.filter((call) => call.op === "createInstallationAccessToken").length;
+}
+
+describe("github broker #614 adversarial entitlement boundary", () => {
+  it("stale visibility: a repo public at connect but private at token requires entitlement (server wins)", async () => {
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "none" });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      // The repo the client saw as public is now private on GitHub's side.
+      fake.setVisibility("octo/site", "private");
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL_ID, repositories: ["octo/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "entitlement_missing");
+      assert.equal(mints(fake.calls), 0, "no token minted on the freshly-private repo");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("modified client asserting public cannot unlock a server-private repo without entitlement", async () => {
+    // The token request body carries no visibility field; the broker derives it
+    // from GitHub. A tampered client believing octo/private is public gains nothing.
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "none" });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        // A modified client even tries to smuggle a visibility hint; the broker ignores it.
+        { installationId: INSTALL_ID, repositories: ["octo/private"], visibility: "public" },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "entitlement_missing");
+      assert.equal(mints(fake.calls), 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("mints for the same server-private repo once an active private-covering entitlement exists", async () => {
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL_ID, repositories: ["octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 200, response.text);
+      assert.equal(mints(fake.calls), 1);
+      assert.deepEqual(resolver.contexts[0].privateRepositories, ["octo/private"]);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("repo rename/transfer at issuance fails typed and never reaches the entitlement authority or a mint", async () => {
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      fake.calls.length = 0;
+      fake.failListWith("renamed_or_transferred");
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL_ID, repositories: ["octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 409, response.text);
+      assert.equal(response.json.reason, "repo_renamed_or_transferred");
+      assert.equal(resolver.contexts.length, 0, "a pre-seam failure never consults the license authority");
+      assert.equal(mints(fake.calls), 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("install swap: a private repo outside the installation selection is refused before the seam", async () => {
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL_ID, repositories: ["octo/not-in-selection"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "repo_outside_installation");
+      assert.equal(resolver.contexts.length, 0);
+      assert.equal(mints(fake.calls), 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("direct call skipping the connect/binding flow cannot reach the entitlement seam or a mint", async () => {
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "active", privateRepoAllowed: true });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device); // registered but never connected/bound
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL_ID, repositories: ["octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 404, response.text);
+      assert.equal(response.json.reason, "binding_not_found");
+      assert.equal(resolver.contexts.length, 0);
+      assert.equal(mints(fake.calls), 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("entitlement replay/event-order conflict fails closed and is recorded in the public-safe ledger", async () => {
+    const store = new GitHubBrokerStore(":memory:");
+    const fake = mutableFake({ installationId: INSTALL_ID, repositories: baseRepositories });
+    const resolver = countingResolver({ status: "replay_conflict" });
+    const harness = await startBroker({ fake: { client: fake.client, calls: fake.calls, mintedToken: "x" } as never, store, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      await connectInstallation(harness.url, device, INSTALL_ID);
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL_ID, repositories: ["octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 409, response.text);
+      assert.equal(response.json.reason, "entitlement_replay_conflict");
+
+      const rows = store.listDecisions(device.deviceId);
+      const reasons = rows.map((row) => `${row.decision}:${row.reason_code}`);
+      assert.ok(reasons.includes("deny:entitlement_replay_conflict"), JSON.stringify(reasons));
+      // Ledger stays public-safe: fixed columns, no repo names or key material.
+      const serialized = JSON.stringify(rows);
+      assert.doesNotMatch(serialized, /octo\/private/);
+      assert.doesNotMatch(serialized, /-----BEGIN/);
+    } finally {
+      harness.close();
+      store.close();
+    }
+  });
+});

--- a/services/license-api/test/github-broker-entitlement.test.ts
+++ b/services/license-api/test/github-broker-entitlement.test.ts
@@ -31,7 +31,10 @@ const INSTALL: FakeInstallation = {
   ]
 };
 
-const ACTIVE_PRIVATE: EntitlementSnapshot = { status: "active", privateRepoAllowed: true };
+const ACTIVE_PRIVATE: EntitlementSnapshot = {
+  status: "active",
+  coveredPrivateRepositories: ["octo/private", "octo/internal"]
+};
 
 interface RecordingResolver {
   resolveEntitlement: (context: EntitlementResolutionContext) => EntitlementSnapshot;
@@ -145,7 +148,7 @@ describe("github broker entitlement binding at the mint path (#614)", () => {
   });
 
   const denyCases: Array<{ name: string; snapshot: EntitlementSnapshot | "throws"; status: number; reason: string }> = [
-    { name: "public-only active license", snapshot: { status: "active", privateRepoAllowed: false }, status: 403, reason: "entitlement_scope_insufficient" },
+    { name: "public-only active license", snapshot: { status: "active", coveredPrivateRepositories: [] }, status: 403, reason: "entitlement_scope_insufficient" },
     { name: "expired", snapshot: { status: "expired" }, status: 403, reason: "entitlement_expired" },
     { name: "revoked", snapshot: { status: "revoked" }, status: 403, reason: "entitlement_revoked" },
     { name: "invalid", snapshot: { status: "invalid" }, status: 403, reason: "entitlement_invalid" },

--- a/services/license-api/test/github-broker-entitlement.test.ts
+++ b/services/license-api/test/github-broker-entitlement.test.ts
@@ -27,7 +27,8 @@ const INSTALL: FakeInstallation = {
   repositories: [
     { id: 81, full_name: "octo/site", visibility: "public" },
     { id: 82, full_name: "octo/private", visibility: "private" },
-    { id: 83, full_name: "octo/internal", visibility: "internal" }
+    { id: 83, full_name: "octo/internal", visibility: "internal" },
+    { id: 84, full_name: "octo/mystery", visibility: "unknown" }
   ]
 };
 
@@ -125,6 +126,53 @@ describe("github broker entitlement binding at the mint path (#614)", () => {
     }
   });
 
+  it("does NOT consult the entitlement authority when a requested repo has unknown visibility", async () => {
+    // The seam denies unknown visibility (visibility_unknown) before entitlement
+    // matters; performing a license-service lookup for such a request would violate
+    // decide-before-side-effects. Assert zero resolver calls and zero mint.
+    const fake = fakeGitHubClient([INSTALL]);
+    const resolver = recordingResolver(ACTIVE_PRIVATE, fake.calls);
+    const harness = await startBroker({ fake, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await boundDevice(harness.url);
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL.id, repositories: ["octo/mystery"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "visibility_unknown");
+      assert.equal(resolver.contexts.length, 0, "no license-service lookup for an unknown-visibility request");
+      assert.equal(fake.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("does NOT consult the authority for a mixed private+unknown request (unknown short-circuits)", async () => {
+    const fake = fakeGitHubClient([INSTALL]);
+    const resolver = recordingResolver(ACTIVE_PRIVATE, fake.calls);
+    const harness = await startBroker({ fake, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await boundDevice(harness.url);
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL.id, repositories: ["octo/private", "octo/mystery"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "visibility_unknown");
+      assert.equal(resolver.contexts.length, 0, "an unknown repo short-circuits the license-service lookup");
+      assert.equal(fake.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+    } finally {
+      harness.close();
+    }
+  });
+
   it("resolves entitlement for the mixed public+private set and mints both on allow", async () => {
     const fake = fakeGitHubClient([INSTALL]);
     const resolver = recordingResolver(ACTIVE_PRIVATE, fake.calls);
@@ -154,7 +202,11 @@ describe("github broker entitlement binding at the mint path (#614)", () => {
     { name: "invalid", snapshot: { status: "invalid" }, status: 403, reason: "entitlement_invalid" },
     { name: "over seat", snapshot: { status: "seat_exhausted" }, status: 409, reason: "entitlement_seat_exhausted" },
     { name: "replay conflict", snapshot: { status: "replay_conflict" }, status: 409, reason: "entitlement_replay_conflict" },
-    { name: "license service outage (resolver throws)", snapshot: "throws", status: 503, reason: "entitlement_service_unavailable" }
+    { name: "license service outage (resolver throws)", snapshot: "throws", status: 503, reason: "entitlement_service_unavailable" },
+    // Fail-closed coverage of unexpected snapshots reaching the mint path.
+    { name: "active snapshot missing its covered array (drift)", snapshot: { status: "active" } as unknown as EntitlementSnapshot, status: 403, reason: "entitlement_scope_insufficient" },
+    { name: "active snapshot with an empty covered set", snapshot: { status: "active", coveredPrivateRepositories: [] }, status: 403, reason: "entitlement_scope_insufficient" },
+    { name: "unrecognized entitlement status (drift)", snapshot: { status: "some_future_state" } as unknown as EntitlementSnapshot, status: 403, reason: "entitlement_invalid" }
   ];
 
   for (const testCase of denyCases) {

--- a/services/license-api/test/github-broker-entitlement.test.ts
+++ b/services/license-api/test/github-broker-entitlement.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { EntitlementResolutionContext, EntitlementSnapshot } from "../src/github-broker/index.ts";
+import {
+  bearer,
+  connectInstallation,
+  fakeGitHubClient,
+  makeDevice,
+  post,
+  registerDevice,
+  startBroker,
+  type FakeInstallation
+} from "./github-broker-support.ts";
+
+/**
+ * Call-order and zero-egress coverage for the #614 entitlement binding at the
+ * single mint path (the broker's one caller of the issuance seam). Every private
+ * request must have its entitlement decided BEFORE any usable installation token
+ * is minted, and every denied path must produce zero token mints (no content
+ * egress). The entitlement authority is fixture-injected; the public/free tier
+ * must never touch it.
+ */
+
+const INSTALL: FakeInstallation = {
+  id: 7001,
+  account_login: "octo",
+  repositories: [
+    { id: 81, full_name: "octo/site", visibility: "public" },
+    { id: 82, full_name: "octo/private", visibility: "private" },
+    { id: 83, full_name: "octo/internal", visibility: "internal" }
+  ]
+};
+
+const ACTIVE_PRIVATE: EntitlementSnapshot = { status: "active", privateRepoAllowed: true };
+
+interface RecordingResolver {
+  resolveEntitlement: (context: EntitlementResolutionContext) => EntitlementSnapshot;
+  contexts: EntitlementResolutionContext[];
+  /** Count of minted installation tokens observed at each resolver invocation. */
+  mintCountsAtResolve: number[];
+}
+
+/**
+ * A resolver returning a fixed snapshot (or throwing to model a license-service
+ * outage) that records, at call time, how many installation tokens have already
+ * been minted — proving the entitlement decision precedes the mint.
+ */
+function recordingResolver(
+  snapshot: EntitlementSnapshot | "throws",
+  calls: { op: string }[]
+): RecordingResolver {
+  const contexts: EntitlementResolutionContext[] = [];
+  const mintCountsAtResolve: number[] = [];
+  return {
+    contexts,
+    mintCountsAtResolve,
+    resolveEntitlement(context: EntitlementResolutionContext): EntitlementSnapshot {
+      contexts.push(context);
+      mintCountsAtResolve.push(calls.filter((call) => call.op === "createInstallationAccessToken").length);
+      if (snapshot === "throws") throw new Error("license service unreachable");
+      return snapshot;
+    }
+  };
+}
+
+async function boundDevice(url: string) {
+  const device = await makeDevice();
+  await registerDevice(url, device);
+  await connectInstallation(url, device, INSTALL.id);
+  return device;
+}
+
+describe("github broker entitlement binding at the mint path (#614)", () => {
+  it("mints a private token only after an active private-covering entitlement is resolved", async () => {
+    const fake = fakeGitHubClient([INSTALL]);
+    const resolver = recordingResolver(ACTIVE_PRIVATE, fake.calls);
+    const harness = await startBroker({ fake, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await boundDevice(harness.url);
+      fake.calls.length = 0; // isolate the issuance sequence
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL.id, repositories: ["octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 200, response.text);
+      assert.equal(response.json.token, harness.mintedToken);
+
+      // Entitlement was resolved for the private repo, before the mint.
+      assert.equal(resolver.contexts.length, 1);
+      assert.deepEqual(resolver.contexts[0].privateRepositories, ["octo/private"]);
+      assert.equal(resolver.contexts[0].accountLogin, "octo");
+      assert.deepEqual(resolver.mintCountsAtResolve, [0], "no token minted before entitlement decided");
+
+      const listIndex = fake.calls.findIndex((call) => call.op === "listInstallationRepositories");
+      const mintIndex = fake.calls.findIndex((call) => call.op === "createInstallationAccessToken");
+      assert.ok(listIndex >= 0 && mintIndex > listIndex, "mint follows the visibility read");
+      const mint = fake.calls.find((call) => call.op === "createInstallationAccessToken");
+      assert.deepEqual((mint?.params as { repositoryIds?: number[] }).repositoryIds, [82]);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("does NOT consult the entitlement authority for an all-public request (public-free)", async () => {
+    const fake = fakeGitHubClient([INSTALL]);
+    const resolver = recordingResolver(ACTIVE_PRIVATE, fake.calls);
+    const harness = await startBroker({ fake, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await boundDevice(harness.url);
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL.id, repositories: ["octo/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 200, response.text);
+      assert.equal(resolver.contexts.length, 0, "public-free issuance never calls the license service");
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("resolves entitlement for the mixed public+private set and mints both on allow", async () => {
+    const fake = fakeGitHubClient([INSTALL]);
+    const resolver = recordingResolver(ACTIVE_PRIVATE, fake.calls);
+    const harness = await startBroker({ fake, resolveEntitlement: resolver.resolveEntitlement });
+    try {
+      const device = await boundDevice(harness.url);
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL.id, repositories: ["octo/site", "octo/private"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 200, response.text);
+      // Only the non-public repositories are handed to the entitlement authority.
+      assert.deepEqual(resolver.contexts[0].privateRepositories, ["octo/private"]);
+      const mint = fake.calls.find((call) => call.op === "createInstallationAccessToken");
+      assert.deepEqual((mint?.params as { repositoryIds?: number[] }).repositoryIds, [81, 82]);
+    } finally {
+      harness.close();
+    }
+  });
+
+  const denyCases: Array<{ name: string; snapshot: EntitlementSnapshot | "throws"; status: number; reason: string }> = [
+    { name: "public-only active license", snapshot: { status: "active", privateRepoAllowed: false }, status: 403, reason: "entitlement_scope_insufficient" },
+    { name: "expired", snapshot: { status: "expired" }, status: 403, reason: "entitlement_expired" },
+    { name: "revoked", snapshot: { status: "revoked" }, status: 403, reason: "entitlement_revoked" },
+    { name: "invalid", snapshot: { status: "invalid" }, status: 403, reason: "entitlement_invalid" },
+    { name: "over seat", snapshot: { status: "seat_exhausted" }, status: 409, reason: "entitlement_seat_exhausted" },
+    { name: "replay conflict", snapshot: { status: "replay_conflict" }, status: 409, reason: "entitlement_replay_conflict" },
+    { name: "license service outage (resolver throws)", snapshot: "throws", status: 503, reason: "entitlement_service_unavailable" }
+  ];
+
+  for (const testCase of denyCases) {
+    it(`fails closed with ${testCase.reason} and zero content egress: ${testCase.name}`, async () => {
+      const fake = fakeGitHubClient([INSTALL]);
+      const resolver = recordingResolver(testCase.snapshot, fake.calls);
+      const harness = await startBroker({ fake, resolveEntitlement: resolver.resolveEntitlement });
+      try {
+        const device = await boundDevice(harness.url);
+        fake.calls.length = 0;
+        const response = await post(
+          harness.url,
+          "/github/token",
+          { installationId: INSTALL.id, repositories: ["octo/private"] },
+          bearer(await device.sign())
+        );
+        assert.equal(response.status, testCase.status, response.text);
+        assert.equal(response.json.reason, testCase.reason);
+        assert.equal(response.json.token, undefined);
+        // Zero content egress: no usable installation token minted on a blocked path.
+        assert.equal(fake.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+      } finally {
+        harness.close();
+      }
+    });
+  }
+
+  it("a provider key never substitutes for entitlement: the default authority denies private as entitlement_missing", async () => {
+    // No resolver configured -> the fail-closed default. A device could hold any
+    // provider key locally; the broker has no provider-key input, so private stays
+    // denied until an active private-covering entitlement is resolved.
+    const fake = fakeGitHubClient([INSTALL]);
+    const harness = await startBroker({ fake });
+    try {
+      const device = await boundDevice(harness.url);
+      fake.calls.length = 0;
+      const response = await post(
+        harness.url,
+        "/github/token",
+        { installationId: INSTALL.id, repositories: ["octo/internal"] },
+        bearer(await device.sign())
+      );
+      assert.equal(response.status, 403, response.text);
+      assert.equal(response.json.reason, "entitlement_missing");
+      assert.equal(fake.calls.filter((call) => call.op === "createInstallationAccessToken").length, 0);
+    } finally {
+      harness.close();
+    }
+  });
+});

--- a/services/license-api/test/github-broker-reason-contract.test.ts
+++ b/services/license-api/test/github-broker-reason-contract.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { BrokerError, type BrokerReason } from "../src/github-broker/index.ts";
+
+/**
+ * The client-facing typed error contract for the #614 entitlement decisions.
+ * Native and CLI consumers key their locked/free explanations and recovery
+ * actions off these reason codes and HTTP statuses; this pins the contract so a
+ * status change is a deliberate, reviewed break. Bodies stay public-safe: a fixed
+ * shape carrying only the reason and a redaction-safe detail phrase.
+ */
+
+const ENTITLEMENT_REASON_STATUS: Array<[BrokerReason, number]> = [
+  ["entitlement_missing", 403],
+  ["entitlement_expired", 403],
+  ["entitlement_revoked", 403],
+  ["entitlement_invalid", 403],
+  ["entitlement_scope_insufficient", 403],
+  ["entitlement_seat_exhausted", 409],
+  ["entitlement_replay_conflict", 409],
+  ["entitlement_service_unavailable", 503],
+  ["visibility_unknown", 403]
+];
+
+describe("github broker #614 typed reason-code contract", () => {
+  for (const [reason, status] of ENTITLEMENT_REASON_STATUS) {
+    it(`${reason} surfaces HTTP ${status} with a public-safe body`, () => {
+      const error = new BrokerError(reason, "a fixed public-safe phrase");
+      assert.equal(error.httpStatus, status);
+      const body = error.body();
+      assert.deepEqual(Object.keys(body).sort(), ["detail", "reason", "status"]);
+      assert.equal(body.status, "error");
+      assert.equal(body.reason, reason);
+      assert.equal(body.detail, "a fixed public-safe phrase");
+    });
+  }
+
+  it("the retired pre-#614 placeholder reason is no longer part of the contract", () => {
+    // entitlement_gate_not_implemented was the #613 fail-closed default; #614
+    // replaces it with the concrete entitlement reason codes above, so it no
+    // longer maps to a status.
+    const retired = "entitlement_gate_not_implemented" as BrokerReason;
+    assert.equal(new BrokerError(retired).httpStatus, undefined);
+  });
+});

--- a/services/license-api/test/github-broker-seam-hardening.test.ts
+++ b/services/license-api/test/github-broker-seam-hardening.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  authorizeTokenIssuance,
+  type EntitlementSnapshot,
+  type RequestedRepository
+} from "../src/github-broker/index.ts";
+
+/**
+ * Security-review hardening of the pure issuance seam (PR #620 AC8 findings):
+ *  - P2 (fail-OPEN): an entitlement status outside the known union (contract
+ *    drift, a future license state, malformed/undefined) must FAIL CLOSED, never
+ *    fall through to an allow+mint.
+ *  - P3 (coarse collapse): a request spanning several private repositories must
+ *    be authorized PER REPOSITORY — the whole request is denied unless every
+ *    requested private repo is covered by the active entitlement.
+ */
+
+function repo(fullName: string, visibility: RequestedRepository["visibility"], id: number): RequestedRepository {
+  return { fullName, id, visibility };
+}
+
+const PUB = repo("octo/site", "public", 1);
+const PRIV_A = repo("octo/a", "private", 2);
+const PRIV_B = repo("octo/b", "private", 3);
+
+describe("issuance seam hardening (#620 security review)", () => {
+  // ---- P2: out-of-union / undefined entitlement status fails closed ----
+  it("denies a private request when the entitlement status is outside the known union (drift)", () => {
+    const drifted = { status: "some_future_state" } as unknown as EntitlementSnapshot;
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A], entitlement: drifted });
+    assert.equal(decision.decision, "deny", JSON.stringify(decision));
+    assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_invalid");
+  });
+
+  it("denies a private request when the entitlement snapshot has no status (malformed)", () => {
+    const malformed = {} as unknown as EntitlementSnapshot;
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A], entitlement: malformed });
+    assert.equal(decision.decision, "deny", JSON.stringify(decision));
+    assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_invalid");
+  });
+
+  it("denies a private request when the active snapshot omits its covered set (drift)", () => {
+    const noCoverage = { status: "active" } as unknown as EntitlementSnapshot;
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A], entitlement: noCoverage });
+    assert.equal(decision.decision, "deny", JSON.stringify(decision));
+    // An active license that names no covered private repos covers none.
+    assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_scope_insufficient");
+  });
+
+  // ---- P3: per-repository coverage ----
+  it("allows only when every requested private repo is covered by the active entitlement", () => {
+    const covered: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: ["octo/a", "octo/b"] };
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A, PRIV_B], entitlement: covered });
+    assert.equal(decision.decision, "allow", JSON.stringify(decision));
+    assert.deepEqual(decision.decision === "allow" ? decision.repositories : undefined, ["octo/a", "octo/b"]);
+  });
+
+  it("denies the whole request when a private repo in a mixed set is uncovered", () => {
+    const partial: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: ["octo/a"] };
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A, PRIV_B], entitlement: partial });
+    assert.equal(decision.decision, "deny", JSON.stringify(decision));
+    assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_scope_insufficient");
+  });
+
+  it("allows a single covered private repo, and ignores public repos when checking coverage", () => {
+    const covered: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: ["octo/a"] };
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PUB, PRIV_A], entitlement: covered });
+    assert.equal(decision.decision, "allow", JSON.stringify(decision));
+    assert.deepEqual(decision.decision === "allow" ? decision.repositories : undefined, ["octo/site", "octo/a"]);
+  });
+
+  it("denies when the active entitlement covers a different repo than the one requested", () => {
+    const covered: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: ["octo/other"] };
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A], entitlement: covered });
+    assert.equal(decision.decision, "deny", JSON.stringify(decision));
+    assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_scope_insufficient");
+  });
+});

--- a/services/license-api/test/github-broker-seam-hardening.test.ts
+++ b/services/license-api/test/github-broker-seam-hardening.test.ts
@@ -48,6 +48,13 @@ describe("issuance seam hardening (#620 security review)", () => {
     assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_scope_insufficient");
   });
 
+  it("denies a private request when the active entitlement covers an empty set", () => {
+    const empty: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: [] };
+    const decision = authorizeTokenIssuance({ requestedRepositories: [PRIV_A], entitlement: empty });
+    assert.equal(decision.decision, "deny", JSON.stringify(decision));
+    assert.equal(decision.decision === "deny" ? decision.reason : undefined, "entitlement_scope_insufficient");
+  });
+
   // ---- P3: per-repository coverage ----
   it("allows only when every requested private repo is covered by the active entitlement", () => {
     const covered: EntitlementSnapshot = { status: "active", coveredPrivateRepositories: ["octo/a", "octo/b"] };

--- a/services/license-api/test/github-broker-store-migration.test.ts
+++ b/services/license-api/test/github-broker-store-migration.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { GitHubBrokerStore } from "../src/github-broker/index.ts";
+
+/**
+ * The broker store must upgrade an EXISTING v1 database in place. Base f9f52d2
+ * shipped `user_version = 1` with `installation_bindings` and NO
+ * `binding_repositories`; the per-repo authorized-set work (v2) adds that table.
+ * Without a migration, `ensureSchema` returned early on a v1 DB and
+ * `upsertBinding` / `listBindingRepositories` threw "no such table" — bricking
+ * every existing deployment on upgrade (it fails closed, but the broker 500s on
+ * every connect/token). These tests pin the v1 -> v2 migration: the table is
+ * created in place, a bind/list round-trips, and re-opening is idempotent.
+ */
+
+const V1_SCHEMA = `
+  create table devices (
+    device_id text primary key,
+    public_jwk text not null,
+    created_at text not null,
+    last_seen_at text not null
+  );
+  create table connect_states (
+    state text primary key,
+    device_id text not null,
+    installation_id integer,
+    created_at text not null,
+    expires_at text not null,
+    consumed_at text,
+    foreign key (device_id) references devices(device_id)
+  );
+  create table installation_bindings (
+    device_id text not null,
+    installation_id integer not null,
+    account_login text,
+    created_at text not null,
+    primary key (device_id, installation_id),
+    foreign key (device_id) references devices(device_id)
+  );
+  create table decision_ledger (
+    id integer primary key autoincrement,
+    device_id text not null,
+    installation_id integer,
+    decision text not null,
+    reason_code text not null,
+    created_at text not null
+  );
+`;
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Materialize a DB at the pre-upgrade v1 schema with a device + binding already present. */
+function seedV1Database(): string {
+  const dir = mkdtempSync(join(tmpdir(), "broker-mig-"));
+  dirs.push(dir);
+  const path = join(dir, "broker.db");
+  const db = new DatabaseSync(path);
+  db.exec("pragma foreign_keys = on");
+  db.exec(V1_SCHEMA);
+  const now = new Date().toISOString();
+  db.prepare("insert into devices (device_id, public_jwk, created_at, last_seen_at) values (?, ?, ?, ?)").run("dev-1", "{}", now, now);
+  db.prepare("insert into installation_bindings (device_id, installation_id, account_login, created_at) values (?, ?, ?, ?)").run("dev-1", 4242, "octo", now);
+  db.exec("pragma user_version = 1");
+  db.close();
+  return path;
+}
+
+describe("github broker store v1 -> v2 migration", () => {
+  it("adds binding_repositories on an existing v1 DB and a bind/list round-trips", () => {
+    const path = seedV1Database();
+    // Opening the store runs ensureSchema, which must migrate v1 -> v2 in place.
+    const store = new GitHubBrokerStore(path);
+    try {
+      // The migrated table now exists (this threw "no such table" before the fix),
+      // and the pre-existing binding simply has an empty authorized set.
+      assert.deepEqual(store.listBindingRepositories("dev-1", 4242), []);
+      // A fresh bind writes the per-repo authorized set and it round-trips.
+      store.upsertBinding("dev-1", 4242, "octo", ["octo/a", "octo/b"], new Date().toISOString());
+      assert.deepEqual(store.listBindingRepositories("dev-1", 4242).sort(), ["octo/a", "octo/b"]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("re-opening the migrated DB is idempotent (stays at v2, data intact)", () => {
+    const path = seedV1Database();
+    const first = new GitHubBrokerStore(path);
+    first.upsertBinding("dev-1", 4242, "octo", ["octo/a"], new Date().toISOString());
+    first.close();
+    // A second open must not re-run the migration or lose the authorized set.
+    const second = new GitHubBrokerStore(path);
+    try {
+      assert.deepEqual(second.listBindingRepositories("dev-1", 4242), ["octo/a"]);
+    } finally {
+      second.close();
+    }
+  });
+});

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -144,6 +144,8 @@ export async function startBroker(
     fake?: ReturnType<typeof fakeGitHubClient>;
     /** A pre-built broker store so a test can inspect the decision ledger. */
     store?: unknown;
+    /** Entitlement authority for private/internal issuance (#614 fixtures). */
+    resolveEntitlement?: unknown;
     deviceRegisterRateLimiter?: RateLimiter;
     tokenRateLimiter?: RateLimiter;
     connectRateLimiter?: RateLimiter;
@@ -161,6 +163,7 @@ export async function startBroker(
       ...(options.store ? { store: options.store } : { dbPath: ":memory:" }),
       githubClient: fake.client,
       installBaseUrl: INSTALL_BASE_URL,
+      ...(options.resolveEntitlement ? { resolveEntitlement: options.resolveEntitlement } : {}),
       now: nowFn,
       deviceRegisterRateLimiter: options.deviceRegisterRateLimiter,
       tokenRateLimiter: options.tokenRateLimiter,

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -76,6 +76,13 @@ export interface FakeInstallation {
   /** null models an uninstalled/missing installation (GitHub 404). */
   missing?: boolean;
   repositories: FakeRepository[];
+  /**
+   * The `owner/name` set the connecting OAuth user can access in this installation
+   * (what `/user/installations/{id}/repositories` returns). Defaults to every
+   * installation repository; set a narrower list to model a user with partial
+   * access to an org installation.
+   */
+  userRepositories?: string[];
 }
 
 export interface FakeGitHubCall {
@@ -134,8 +141,13 @@ export function fakeGitHubClient(
     },
     async verifyInstallationForAuthorizationCode(installationId: number, code: string) {
       // The code proves ownership of exactly this installation; a mismatched or
-      // absent code (a forged callback) is not authorized.
-      return code === authorizationCodeFor(installationId);
+      // absent code (a forged callback) is not authorized (null). A proven identity
+      // yields the repositories the user can access in the installation (the
+      // authorized set the binding is scoped to) — all installation repos by default.
+      if (code !== authorizationCodeFor(installationId)) return null;
+      const installation = byId.get(installationId);
+      if (!installation || installation.missing) return null;
+      return installation.userRepositories ?? installation.repositories.map((repository) => repository.full_name);
     }
   };
   return { client, calls, mintedToken };

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -22,6 +22,16 @@ import { RateLimiter } from "../src/service.ts";
 export const INSTALL_BASE_URL = "https://github.com/apps/neondiff-staging/installations/new";
 export const FIXED_NOW = new Date("2026-07-15T00:00:00.000Z");
 
+/**
+ * The install-time OAuth authorization code a legitimate identity would return
+ * for `installationId`. The fake treats this as proof of installation ownership;
+ * any other (or absent) code fails the callback identity check. Mirrors the real
+ * "OAuth-during-install code proves the user can access this installation".
+ */
+export function authorizationCodeFor(installationId: number): string {
+  return `oauth-code-${installationId}`;
+}
+
 /** A device identity mirroring the client: keypair + RFC 7638 thumbprint id. */
 export interface TestDevice {
   deviceId: string;
@@ -121,6 +131,11 @@ export function fakeGitHubClient(
         token: mintedToken,
         expires_at: new Date((overrides.mintedToken ? Date.now() : FIXED_NOW.getTime()) + 3_600_000).toISOString()
       };
+    },
+    async verifyInstallationForAuthorizationCode(installationId: number, code: string) {
+      // The code proves ownership of exactly this installation; a mismatched or
+      // absent code (a forged callback) is not authorized.
+      return code === authorizationCodeFor(installationId);
     }
   };
   return { client, calls, mintedToken };
@@ -222,7 +237,7 @@ export async function connectInstallation(
   const start = await post(url, "/github/connect/start", {}, bearer(await device.sign()));
   const state = start.json.state as string;
   const callback = await fetch(
-    `${url}/github/connect/callback?installation_id=${installationId}&state=${encodeURIComponent(state)}`,
+    `${url}/github/connect/callback?installation_id=${installationId}&state=${encodeURIComponent(state)}&code=${encodeURIComponent(authorizationCodeFor(installationId))}`,
     { redirect: "manual" }
   );
   const complete = await post(url, "/github/connect/complete", { state }, bearer(await device.sign()));

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -99,8 +99,12 @@ describe("NeonDiff public community funnel", () => {
     ].map(read).join("\n");
     // No public surface may reintroduce the retired #532 "activation required for
     // public repositories" claim (owner ruling: public open-source repos are FREE).
-    expect(currentPublicSurfaces).not.toMatch(
-      /API-backed activation is required for (?:supported )?(?:public|every|all)[^.\n]*(?:repositor|repo)/i
+    // Normalize whitespace first so a line-WRAPPED occurrence cannot slip past the
+    // guard: the raw blob let `docs/SETUP.md` evade this by wrapping "...public,
+    // private, internal, and\nunknown repository review" across a newline.
+    const normalizedPublicSurfaces = currentPublicSurfaces.replace(/\s+/g, " ");
+    expect(normalizedPublicSurfaces).not.toMatch(
+      /API-backed activation is required for (?:supported )?(?:public|every|all)[^.]*(?:repositor|repo)/i
     );
     // Guard the correct layer-3 claim on the SPECIFIC canonical surfaces that carry
     // it (not the joined blob) so reverting either file's policy line fails here:

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -23,7 +23,8 @@ describe("NeonDiff public community funnel", () => {
       /docs\/pricing\.md/i,
       /docs\/providers\.md/i,
       /docs\/known-limitations-and-provider-status\.md/i,
-      /API-backed activation is required.*every repository/i,
+      /public open-source repositor(?:y|ies) (?:are|is) free/i,
+      /API-backed activation is required for private, internal, and commercial/i,
       /v1\.0\.4 verification notice/i,
       /v1\.0\.4 is the first package intended to enforce\s*>?\s*mandatory API-backed activation/i,
       /v1\.0\.3 and\s*>?\s*earlier do not enforce this boundary/i,
@@ -96,13 +97,13 @@ describe("NeonDiff public community funnel", () => {
       "docs/neondiff-config.md",
       "docs/teams-marketplace-plan.md"
     ].map(read).join("\n");
-    for (const retiredClaim of [
-      /public(?: open-source)? repositor(?:y|ies) (?:are|is) free/i,
-      /free (?:for|on) public repositor(?:y|ies)/i,
-      /public repos? with no license (?:may )?(?:pass|run|review)/i
-    ]) {
-      expect(currentPublicSurfaces).not.toMatch(retiredClaim);
-    }
+    // Owner ruling (reversing the #532 "activate every repository" pivot): public
+    // open-source repositories are FREE with no Activation Key, so the former
+    // "retired free-use claim" guards are removed. The correct layer-3 claim is now
+    // asserted positively (README required-claims above + check-public-claims.mjs):
+    // public free; private/internal/commercial require active API-backed entitlement.
+    expect(currentPublicSurfaces).toMatch(/public open-source repositor(?:y|ies) (?:are|is) free/i);
+    expect(currentPublicSurfaces).toMatch(/API-backed activation is required for private, internal, and commercial/i);
   });
 
   it("pricing doc records support tiers, BYOK costs, and no hosted model credit bundle", () => {

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -97,13 +97,20 @@ describe("NeonDiff public community funnel", () => {
       "docs/neondiff-config.md",
       "docs/teams-marketplace-plan.md"
     ].map(read).join("\n");
-    // Owner ruling (reversing the #532 "activate every repository" pivot): public
-    // open-source repositories are FREE with no Activation Key, so the former
-    // "retired free-use claim" guards are removed. The correct layer-3 claim is now
-    // asserted positively (README required-claims above + check-public-claims.mjs):
+    // No public surface may reintroduce the retired #532 "activation required for
+    // public repositories" claim (owner ruling: public open-source repos are FREE).
+    expect(currentPublicSurfaces).not.toMatch(
+      /API-backed activation is required for (?:supported )?(?:public|every|all)[^.\n]*(?:repositor|repo)/i
+    );
+    // Guard the correct layer-3 claim on the SPECIFIC canonical surfaces that carry
+    // it (not the joined blob) so reverting either file's policy line fails here:
     // public free; private/internal/commercial require active API-backed entitlement.
-    expect(currentPublicSurfaces).toMatch(/public open-source repositor(?:y|ies) (?:are|is) free/i);
-    expect(currentPublicSurfaces).toMatch(/API-backed activation is required for private, internal, and commercial/i);
+    const readmePolicy = read("README.md");
+    const contributingPolicy = read("CONTRIBUTING.md");
+    expect(readmePolicy).toMatch(/public open-source repositor(?:y|ies) (?:are|is) free/i);
+    expect(readmePolicy).toMatch(/API-backed activation is required for private, internal, and commercial/i);
+    expect(contributingPolicy).toMatch(/public open-source repositor(?:y|ies)\s+are (?:intentionally )?free/i);
+    expect(contributingPolicy).toMatch(/API-backed activation for private, internal, and commercial/i);
   });
 
   it("pricing doc records support tiers, BYOK costs, and no hosted model credit bundle", () => {


### PR DESCRIPTION
Closes #614. Parent: #610.

## What this does
Replaces the #613 fail-closed placeholder in the managed GitHub App broker's single token-issuance seam (`authorizeTokenIssuance`) with the full **public-free / private-paid** decision matrix, at the authorization boundary — the one place that can mint a usable installation token.

Decision order (fail closed):
1. empty request → `invalid_request`
2. any repo whose visibility could not be authoritatively determined → `visibility_unknown` (never assume public)
3. **all-public → allow with NO NeonDiff Activation Key** (public-free layer‑3 policy); the entitlement authority is not consulted, so the free tier does not depend on the license service being reachable
4. otherwise (≥1 private/internal repo) → an **active, private-covering entitlement** is required; every other entitlement state denies with a distinct reason code

New typed reason codes (client-facing contract): `entitlement_missing` (403), `entitlement_expired` (403), `entitlement_revoked` (403), `entitlement_invalid` (403), `entitlement_scope_insufficient` (403), `entitlement_seat_exhausted` (409), `entitlement_replay_conflict` (409), `entitlement_service_unavailable` (503). The retired `entitlement_gate_not_implemented` is removed.

## Acceptance criteria
- **AC1** visibility is GitHub-authoritative (from the installation repo list), never a client/user setting — server-wins test included.
- **AC2** public/free succeeds with no Activation Key (provider verification stays a separate, unchanged requirement).
- **AC3** private/internal/unknown block before any usable repo authorization or mint without an active entitlement.
- **AC4** expired / revoked / invalid / replay-conflict / over-seat / service-unavailable each fail closed with a distinct reason code.
- **AC5** a provider key alone never unlocks private — the seam has no provider-key input; only an active private-covering entitlement authorizes private (explicit test).
- **AC6** direct client calls cannot bypass the binding — a modified client asserting public gains nothing; binding-skipping direct calls → `binding_not_found`.
- **AC7** *(owner-gated)* exact-head CodeQL + security review before merge — not done here (no production App exists yet).
- **AC8** call-order + zero-egress asserted: entitlement decided before any mint; blocked paths mint zero usable tokens.

## Gate-every-caller (single mint path)
There is exactly one code path that mints an installation token, and it crosses `authorizeTokenIssuance`:
- `GitHubBrokerService.issueToken` → (binding check → live/suspended check → installation repo resolution → **entitlement resolution for non-public repos** → seam → mint). Enforced in `services/license-api/src/github-broker/service.ts`.
- The visibility read uses a separate **metadata:read-only** token (the #618 P1 fix), so no broad token exists before the seam authorizes.
- Client surfaces that reach diff retrieval / provider calls (worker scheduler admission, CLI `review-pr`, desktop dry-run, future MCP/agent surfaces) obtain usable repo authorization only via this broker seam; the live device↔license linkage and their wiring belong to the deploy lane (**#559**).

## Scope / proof boundary
Enforcement is **fixture-proven**. The entitlement snapshot is bound to the production contract shape (license-api `Entitlement`, merged #574) via an injected resolver whose default is fail-closed (deny private) until #559 wires the live linkage. **Production/live proof belongs to the deploy lane #559 and the #615 canaries; checkout stays disabled.** No client `src/` changes here (the client-side license-admission public-free flip is downstream of the boundary).

## Tests (services/license-api)
- `github-broker-decision-matrix.test.ts` — 19-row pure-seam matrix (public-free + unknown-fail-closed anchors)
- `github-broker-entitlement.test.ts` — per-request call-order + zero-egress at the mint path, public-free never calls the authority
- `github-broker-entitlement-adversarial.test.ts` — stale visibility (server wins), modified client, rename/transfer, install swap, replay/event-order (+ledger), direct-endpoint bypass
- `github-broker-reason-contract.test.ts` — typed reason-code → HTTP status + public-safe body
- Updated: `github-broker-contract.test.ts`, `github-broker-adversarial.test.ts` (placeholder code → `entitlement_missing`)

`cd services/license-api && npm test` → 257/257 green (Node 26). Root `npm run check:secrets` → ok.

**Do not merge** — pending exact-head CodeQL + security review (AC7/AC8) and the #559 deploy proof.
