### PR TITLE
test(desktop): add strict large-text geometry matrix

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -57,7 +57,7 @@ struct NeonDiffDesktopApp: App {
 
     var body: some Scene {
         WindowGroup("NeonDiff Desktop") {
-            contentView
+            evaluationTextSizedContentView
                 .frame(
                     minWidth: CGFloat(minimumContentSize.width),
                     minHeight: CGFloat(minimumContentSize.height)
@@ -110,6 +110,19 @@ struct NeonDiffDesktopApp: App {
             .preferredColorScheme(preferredColorScheme)
             .frame(width: 560)
         }
+    }
+
+    @ViewBuilder
+    private var evaluationTextSizedContentView: some View {
+#if DEBUG
+        if evaluationContext?.textSizeMode == .accessibility3 {
+            contentView.dynamicTypeSize(.accessibility3)
+        } else {
+            contentView
+        }
+#else
+        contentView
+#endif
     }
 
     private var contentView: ContentView {
@@ -204,8 +217,14 @@ struct NeonDiffDesktopApp: App {
 
     private var rootAccessibilityIdentifier: String {
 #if DEBUG
-        evaluationContext.map { "neondiff.fixture.\($0.fixture.id)" }
-            ?? "neondiff.desktop.root"
+        guard let evaluationContext else { return "neondiff.desktop.root" }
+        let fixtureId = evaluationContext.fixture.id
+        switch evaluationContext.textSizeMode {
+        case .runnerDefault:
+            return "neondiff.fixture.\(fixtureId)"
+        case .accessibility3:
+            return "neondiff.fixture.\(fixtureId).text-size.accessibility3"
+        }
 #else
         "neondiff.desktop.root"
 #endif

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift
@@ -73,14 +73,23 @@ struct DesktopResolvedEvaluationFixture: Codable {
 struct DesktopResolvedEvaluationLaunchContext {
     let fixture: DesktopResolvedEvaluationFixture
     let contentSize: NSSize
+    let textSizeMode: DesktopResolvedEvaluationTextSizeMode
     let disableAnimations: Bool
+}
+
+enum DesktopResolvedEvaluationTextSizeMode: String {
+    case runnerDefault = "runner-default"
+    case accessibility3
 }
 
 enum DesktopResolvedEvaluationLaunch {
     static func load(arguments: [String]) throws -> DesktopResolvedEvaluationLaunchContext? {
-        let flags = ["--ui-testing", "--ui-fixture", "--content-size", "--disable-animations"]
-        guard arguments.contains(where: flags.contains) else { return nil }
-        guard flags.allSatisfy({ flag in arguments.filter({ $0 == flag }).count == 1 }) else {
+        let requiredFlags = ["--ui-testing", "--ui-fixture", "--content-size", "--disable-animations"]
+        let optionalFlags = ["--text-size"]
+        let evaluationFlags = requiredFlags + optionalFlags
+        guard arguments.contains(where: evaluationFlags.contains) else { return nil }
+        guard requiredFlags.allSatisfy({ flag in arguments.filter({ $0 == flag }).count == 1 }),
+              optionalFlags.allSatisfy({ flag in arguments.filter({ $0 == flag }).count <= 1 }) else {
             throw DesktopResolvedEvaluationLaunchError.invalidArguments
         }
         guard let fixturePath = value(after: "--ui-fixture", in: arguments),
@@ -97,6 +106,15 @@ enum DesktopResolvedEvaluationLaunch {
                 .contains(where: { $0 == (width, height) }) else {
             throw DesktopResolvedEvaluationLaunchError.invalidArguments
         }
+        let textSizeValue = value(after: "--text-size", in: arguments)
+        if arguments.contains("--text-size"), textSizeValue == nil {
+            throw DesktopResolvedEvaluationLaunchError.invalidArguments
+        }
+        guard let textSizeMode = DesktopResolvedEvaluationTextSizeMode(
+            rawValue: textSizeValue ?? DesktopResolvedEvaluationTextSizeMode.runnerDefault.rawValue
+        ) else {
+            throw DesktopResolvedEvaluationLaunchError.invalidArguments
+        }
         let fixture = try resolveFixture(arguments: arguments)
         guard fixture.schemaVersion == 1, fixture.environment.disableAnimations else {
             throw DesktopResolvedEvaluationLaunchError.invalidFixture
@@ -104,6 +122,7 @@ enum DesktopResolvedEvaluationLaunch {
         return DesktopResolvedEvaluationLaunchContext(
             fixture: fixture,
             contentSize: NSSize(width: width, height: height),
+            textSizeMode: textSizeMode,
             disableAnimations: true
         )
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationLaunchOptions.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationLaunchOptions.swift
@@ -5,6 +5,7 @@ public enum DesktopEvaluationLaunchOptionsError: LocalizedError, Equatable {
     case duplicate(String)
     case relativeFixturePath
     case unsupportedContentSize
+    case unsupportedTextSize
     case fixtureFlagWithoutUITesting
 
     public var errorDescription: String? {
@@ -13,18 +14,28 @@ public enum DesktopEvaluationLaunchOptionsError: LocalizedError, Equatable {
         case .duplicate(let flag): "Duplicate UI-testing launch argument: \(flag)."
         case .relativeFixturePath: "UI fixture path must be absolute."
         case .unsupportedContentSize: "UI-testing content size is not canonical."
+        case .unsupportedTextSize: "UI-testing text size is not supported."
         case .fixtureFlagWithoutUITesting: "UI fixture flags require --ui-testing."
         }
     }
 }
 
+public enum DesktopEvaluationTextSizeMode: String, Equatable, Sendable {
+    case runnerDefault = "runner-default"
+    case accessibility3
+}
+
 public struct DesktopEvaluationLaunchOptions: Equatable, Sendable {
     public let fixtureURL: URL
     public let contentSize: DesktopEvaluationContentSize
+    public let textSizeMode: DesktopEvaluationTextSizeMode
     public let disableAnimations: Bool
 
     public static func parse(arguments: [String]) throws -> DesktopEvaluationLaunchOptions? {
-        let evaluationFlags: Set<String> = ["--ui-testing", "--ui-fixture", "--content-size", "--disable-animations"]
+        let evaluationFlags: Set<String> = [
+            "--ui-testing", "--ui-fixture", "--content-size", "--text-size",
+            "--disable-animations"
+        ]
         let suppliedEvaluationFlags = arguments.filter(evaluationFlags.contains)
         guard !suppliedEvaluationFlags.isEmpty else { return nil }
         guard arguments.contains("--ui-testing") else {
@@ -51,9 +62,19 @@ public struct DesktopEvaluationLaunchOptions: Equatable, Sendable {
         guard DesktopEvaluationContentSize.canonical.contains(contentSize) else {
             throw DesktopEvaluationLaunchOptionsError.unsupportedContentSize
         }
+        let textSizeValue = value(after: "--text-size", in: arguments)
+        if arguments.contains("--text-size"), textSizeValue == nil {
+            throw DesktopEvaluationLaunchOptionsError.incomplete
+        }
+        guard let textSizeMode = DesktopEvaluationTextSizeMode(
+            rawValue: textSizeValue ?? DesktopEvaluationTextSizeMode.runnerDefault.rawValue
+        ) else {
+            throw DesktopEvaluationLaunchOptionsError.unsupportedTextSize
+        }
         return DesktopEvaluationLaunchOptions(
             fixtureURL: URL(fileURLWithPath: fixturePath),
             contentSize: contentSize,
+            textSizeMode: textSizeMode,
             disableAnimations: true
         )
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopEvaluationLaunchContextTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopEvaluationSupportTests/DesktopEvaluationLaunchContextTests.swift
@@ -17,6 +17,7 @@ struct DesktopEvaluationLaunchContextTests {
 
         #expect(context?.fixture.id == "tab-overview")
         #expect(context?.options.contentSize == DesktopEvaluationContentSize(width: 1280, height: 800))
+        #expect(context?.options.textSizeMode == .runnerDefault)
     }
 
     @Test func rejectsSymlinkedFixtureFiles() throws {
@@ -46,6 +47,71 @@ struct DesktopEvaluationLaunchContextTests {
                 "--ui-testing",
                 "--ui-fixture", fixtureURL.path,
                 "--content-size", "1280x800",
+                "--disable-animations"
+            ])
+        }
+    }
+
+    @Test func rejectsUnsupportedTextSizeOverride() throws {
+        let fixtureURL = try temporaryFixture()
+        defer { removeTemporaryFixture(fixtureURL) }
+
+        #expect(throws: DesktopEvaluationLaunchOptionsError.unsupportedTextSize) {
+            try DesktopEvaluationLaunchContext.load(arguments: [
+                "NeonDiffDesktop",
+                "--ui-testing",
+                "--ui-fixture", fixtureURL.path,
+                "--content-size", "1040x680",
+                "--text-size", "unsupported",
+                "--disable-animations"
+            ])
+        }
+    }
+
+    @Test func loadsAccessibility3TextSizeOverride() throws {
+        let fixtureURL = try temporaryFixture()
+        defer { removeTemporaryFixture(fixtureURL) }
+
+        let context = try DesktopEvaluationLaunchContext.load(arguments: [
+            "NeonDiffDesktop",
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--text-size", "accessibility3",
+            "--disable-animations"
+        ])
+
+        #expect(context?.options.textSizeMode == .accessibility3)
+    }
+
+    @Test func rejectsDuplicateTextSizeOverride() throws {
+        let fixtureURL = try temporaryFixture()
+        defer { removeTemporaryFixture(fixtureURL) }
+
+        #expect(throws: DesktopEvaluationLaunchOptionsError.duplicate("--text-size")) {
+            try DesktopEvaluationLaunchContext.load(arguments: [
+                "NeonDiffDesktop",
+                "--ui-testing",
+                "--ui-fixture", fixtureURL.path,
+                "--content-size", "1040x680",
+                "--text-size", "accessibility3",
+                "--text-size", "accessibility3",
+                "--disable-animations"
+            ])
+        }
+    }
+
+    @Test func rejectsMissingTextSizeOverrideValue() throws {
+        let fixtureURL = try temporaryFixture()
+        defer { removeTemporaryFixture(fixtureURL) }
+
+        #expect(throws: DesktopEvaluationLaunchOptionsError.incomplete) {
+            try DesktopEvaluationLaunchContext.load(arguments: [
+                "NeonDiffDesktop",
+                "--ui-testing",
+                "--ui-fixture", fixtureURL.path,
+                "--content-size", "1040x680",
+                "--text-size",
                 "--disable-animations"
             ])
         }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -280,6 +280,121 @@ final class NeonDiffDesktopUITests: XCTestCase {
         )
     }
 
+    func testStrictFixtureSettlesAndReachesEverySidebarPageBottomAtMinimumSizeWithAccessibility3Text() throws {
+        let requestedContentSize = HostedContentSize(width: 1040, height: 680)
+        let textSizeMode = "swiftui-dynamic-type-accessibility3-test-override"
+        let route = everySidebarPageBottomRoute
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
+        )
+        let app = XCUIApplication()
+        defer { app.terminate() }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--text-size", "accessibility3",
+            "--disable-animations"
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            app.descendants(matching: .any)[
+                "neondiff.fixture.tab-overview.text-size.accessibility3"
+            ].waitForExistence(timeout: 10)
+        )
+        XCTAssertEqual(app.state, .runningForeground)
+
+        var geometryCheckpoints: [HostedGeometryCheckpoint] = []
+        var pageBottomCheckpoints: [HostedPageBottomCheckpoint] = []
+        var navigationActions: [HostedNavigationAction] = []
+        for (routeIndex, step) in route.enumerated() {
+            if routeIndex > 0 {
+                let previous = route[routeIndex - 1]
+                navigationActions.append(
+                    try clickNavigation(
+                        app: app,
+                        index: routeIndex - 1,
+                        fromSection: previous.section,
+                        toSection: step.section,
+                        identifier: "neondiff-sidebar-section-\(step.section)"
+                    )
+                )
+            }
+
+            let markerIdentifier =
+                "neondiff.evaluation.surface.\(step.section).\(step.generation).quiescent"
+            geometryCheckpoints.append(
+                try captureCheckpoint(
+                    app: app,
+                    section: step.section,
+                    generation: step.generation,
+                    markerIdentifier: markerIdentifier,
+                    requestedContentSize: requestedContentSize
+                )
+            )
+            pageBottomCheckpoints.append(
+                try capturePageBottomCheckpoint(
+                    app: app,
+                    section: step.section,
+                    generation: step.generation,
+                    markerIdentifier: markerIdentifier,
+                    outerScrollIdentifier: step.outerScrollIdentifier,
+                    sentinelIdentifier: step.sentinelIdentifier
+                )
+            )
+        }
+
+        XCTAssertEqual(geometryCheckpoints.count, 7)
+        XCTAssertEqual(pageBottomCheckpoints.count, 7)
+        XCTAssertEqual(navigationActions.count, 6)
+        assertStableAcrossTransitions(geometryCheckpoints)
+        guard (testRun?.failureCount ?? 0) == 0 else {
+            throw HostedPageBottomTraceError.priorValidationFailure
+        }
+
+        try attach(
+            HostedLargeTextMatrixTrace(
+                schemaVersion: 1,
+                fixtureId: "tab-overview",
+                requestedContentSize: requestedContentSize,
+                textSizeMode: textSizeMode,
+                settledGeometry: HostedSettledGeometryTrace(
+                    schemaVersion: 2,
+                    scenario: "every-sidebar-destination-1040x680-accessibility3",
+                    fixtureId: "tab-overview",
+                    requestedContentSize: requestedContentSize,
+                    textSizeMode: textSizeMode,
+                    coordinateSpaces: HostedGeometryCoordinateSpaces(
+                        windowAndContent: "appkit-screen",
+                        regions: "swiftui-global"
+                    ),
+                    sampleIntervalMilliseconds: 100,
+                    tolerancePoints: 1,
+                    navigationActions: navigationActions,
+                    checkpoints: geometryCheckpoints,
+                    proofBoundary: "hosted-every-sidebar-destination-1040x680-accessibility3-geometry-only"
+                ),
+                pageBottomReachability: HostedPageBottomReachabilityTrace(
+                    schemaVersion: 1,
+                    scenario: "every-sidebar-page-bottom-1040x680-accessibility3",
+                    fixtureId: "tab-overview",
+                    requestedContentSize: requestedContentSize,
+                    textSizeMode: textSizeMode,
+                    coordinateSpace: "xcui-screen",
+                    minimumSampleIntervalMilliseconds: 100,
+                    samplingDeadlineMilliseconds: 5_000,
+                    tolerancePoints: 1,
+                    navigationActions: navigationActions,
+                    checkpoints: pageBottomCheckpoints,
+                    proofBoundary: "hosted-outer-page-bottom-1040x680-accessibility3-reachability-only-inner-scroll-exhaustion-excluded"
+                ),
+                proofBoundary: "hosted-accessibility3-minimum-size-outer-geometry-and-page-bottom-only-inner-scroll-exhaustion-excluded"
+            )
+        )
+    }
+
     private func captureCanonicalSizeScenario(
         _ request: HostedCanonicalSizeRequest
     ) throws -> HostedCanonicalSizeScenario {
@@ -964,6 +1079,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
         add(attachment)
     }
 
+    private func attach(_ trace: HostedLargeTextMatrixTrace) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let attachment = XCTAttachment(
+            data: try encoder.encode(trace),
+            uniformTypeIdentifier: "public.json"
+        )
+        attachment.name = "neondiff-hosted-large-text-matrix.json"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func attachTransportDiagnostic(_ diagnostic: HostedTransportDiagnostic) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -1204,6 +1331,16 @@ private struct HostedCanonicalSizeMatrixTrace: Codable {
     let fixtureId: String
     let textSizeMode: String
     let scenarios: [HostedCanonicalSizeScenario]
+    let proofBoundary: String
+}
+
+private struct HostedLargeTextMatrixTrace: Codable {
+    let schemaVersion: Int
+    let fixtureId: String
+    let requestedContentSize: HostedContentSize
+    let textSizeMode: String
+    let settledGeometry: HostedSettledGeometryTrace
+    let pageBottomReachability: HostedPageBottomReachabilityTrace
     let proofBoundary: String
 }
 

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -482,6 +482,42 @@ private func target() {
     expect(source).toContain("neondiff-hosted-canonical-size-matrix.json");
   });
 
+  it("pins the strict accessibility3 large-text hosted matrix", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+    const launchOptions = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationLaunchOptions.swift",
+      "utf8"
+    );
+    const resolvedLaunch = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/DesktopResolvedEvaluationFixture.swift",
+      "utf8"
+    );
+    const app = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift",
+      "utf8"
+    );
+
+    expect(source).toContain(
+      "testStrictFixtureSettlesAndReachesEverySidebarPageBottomAtMinimumSizeWithAccessibility3Text"
+    );
+    expect(source).toContain('"--text-size", "accessibility3"');
+    expect(source).toContain(
+      'let textSizeMode = "swiftui-dynamic-type-accessibility3-test-override"'
+    );
+    expect(source).toContain(
+      'proofBoundary: "hosted-accessibility3-minimum-size-outer-geometry-and-page-bottom-only-inner-scroll-exhaustion-excluded"'
+    );
+    expect(source).toContain("neondiff-hosted-large-text-matrix.json");
+    expect(launchOptions).toContain('"--text-size"');
+    expect(launchOptions).toContain("case accessibility3");
+    expect(resolvedLaunch).toContain('"--text-size"');
+    expect(resolvedLaunch).toContain("textSizeMode: DesktopResolvedEvaluationTextSizeMode");
+    expect(app).toContain(".dynamicTypeSize(.accessibility3)");
+    expect(app).toContain(
+      String.raw`neondiff.fixture.\(fixtureId).text-size.accessibility3`
+    );
+  });
+
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow).toContain("Hosted XCUITest smoke");


### PR DESCRIPTION
## Summary

- add a strict DEBUG-only `--text-size` launch contract with only `runner-default` and `accessibility3`
- apply SwiftUI `.dynamicTypeSize(.accessibility3)` only for the hosted evaluation context and expose the accepted mode through the fixture root identifier
- add one hosted 1040x680 matrix covering all seven sidebar destinations for settled outer geometry and page-bottom reachability, with an immutable JSON attachment

## Failing-first evidence

Before the implementation:

- `tests/desktop-hosted-xcuitest.test.ts`: 1 failed / 8 passed because the large-text matrix was absent
- `DesktopEvaluationLaunchContextTests`: 1 failed / 3 passed because unsupported `--text-size` was silently ignored

## Focused local validation

- hosted/evaluation/release-boundary Vitest: 39/39 passed
- launch-context Swift tests: 7/7 passed
- Repos/layout source contracts: 7/7 passed
- Xcode 26.6 `NeonDiffDesktopHosted` build-for-testing: succeeded
- secret scan: 747 tracked files, passed
- forbidden public-claims scan: passed
- `git diff --check`: passed

No local UI test was launched. Hosted runtime behavior and the JSON attachment require current-head remote macOS CI.

## Proof boundary

This PR targets only the hosted DEBUG `tab-overview` fixture at 1040x680 with a SwiftUI `.accessibility3` test override. It covers settled outer geometry and page-bottom reachability for the seven current sidebar destinations.

It does not prove native Table or TextEditor inner-scroll exhaustion, real system-preference/manual accessibility behavior, conditional recovery/result states, onboarding, the separate Settings scene, a signed or notarized installed app, release, GA, parity, runtime, or customer readiness. #517 remains open.

Related to #517.