### PR TITLE
test(desktop): prove visible dynamic type scaling

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -312,7 +312,6 @@ struct OperatorSectionHeader: View {
                     .font(NeonDiffTheme.headlineFont)
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                     .accessibilityIdentifier("neondiff-section-title")
-                    .accessibilityLabel(title)
             }
 
             Spacer(minLength: 16)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -115,6 +115,7 @@ struct OperatorSectionHeader: View {
                     .font(NeonDiffTheme.headlineFont)
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                     .accessibilityIdentifier("neondiff-section-title")
+                    .accessibilityLabel(title)
             }
 
             Spacer(minLength: 16)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -114,6 +114,7 @@ struct OperatorSectionHeader: View {
                 Text(title)
                     .font(NeonDiffTheme.headlineFont)
                     .foregroundStyle(NeonDiffTheme.textPrimary)
+                    .accessibilityIdentifier("neondiff-section-title")
             }
 
             Spacer(minLength: 16)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -297,9 +297,28 @@ struct OperatorBackdrop: View {
 }
 
 struct OperatorSectionHeader: View {
-    @ScaledMetric(relativeTo: .headline) private var sectionTitleSize: CGFloat = 13
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     var title: String
     var status: String
+
+    /// macOS does not scale `@ScaledMetric` from SwiftUI's dynamic-type override,
+    /// so resolve the shared title size directly from the environment.
+    private var sectionTitleSize: CGFloat {
+        switch dynamicTypeSize {
+        case .xSmall: 11
+        case .small: 12
+        case .medium, .large: 13
+        case .xLarge: 14
+        case .xxLarge: 15
+        case .xxxLarge: 16
+        case .accessibility1: 18
+        case .accessibility2: 20
+        case .accessibility3: 23
+        case .accessibility4: 26
+        case .accessibility5: 30
+        default: 13
+        }
+    }
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -297,6 +297,7 @@ struct OperatorBackdrop: View {
 }
 
 struct OperatorSectionHeader: View {
+    @ScaledMetric(relativeTo: .headline) private var sectionTitleSize: CGFloat = 13
     var title: String
     var status: String
 
@@ -309,7 +310,7 @@ struct OperatorSectionHeader: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
                 Text(title)
-                    .font(NeonDiffTheme.headlineFont)
+                    .font(.system(size: sectionTitleSize, weight: .bold, design: .monospaced))
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                     .accessibilityIdentifier("neondiff-section-title")
             }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -5,6 +5,54 @@ final class NeonDiffDesktopUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    func testAccessibility3OverrideScalesVisibleProductionSectionTitle() throws {
+        let requestedContentSize = HostedContentSize(width: 1040, height: 680)
+        let defaultScenario = try captureRenderedTextScaleScenario(
+            requestedContentSize: requestedContentSize,
+            textSizeMode: "runner-default-no-test-override",
+            textSizeArgument: nil,
+            rootIdentifier: "neondiff.fixture.tab-overview"
+        )
+        let accessibility3Scenario = try captureRenderedTextScaleScenario(
+            requestedContentSize: requestedContentSize,
+            textSizeMode: "swiftui-dynamic-type-accessibility3-test-override",
+            textSizeArgument: "accessibility3",
+            rootIdentifier: "neondiff.fixture.tab-overview.text-size.accessibility3"
+        )
+        let defaultFrame = try XCTUnwrap(defaultScenario.samples.last?.frame)
+        let accessibility3Frame = try XCTUnwrap(
+            accessibility3Scenario.samples.last?.frame
+        )
+        let renderedHeightGrowthPoints = accessibility3Frame.height - defaultFrame.height
+        guard renderedHeightGrowthPoints > 1 else {
+            throw HostedRenderedTextScaleError.insufficientRenderedScale(
+                defaultFrame: defaultFrame,
+                accessibility3Frame: accessibility3Frame
+            )
+        }
+        guard (testRun?.failureCount ?? 0) == 0 else {
+            throw HostedRenderedTextScaleError.priorValidationFailure
+        }
+
+        try attach(
+            HostedRenderedTextScaleTrace(
+                schemaVersion: 1,
+                fixtureId: "tab-overview",
+                requestedContentSize: requestedContentSize,
+                semanticTextIdentifier: "neondiff-section-title",
+                expectedLabel: "Overview",
+                coordinateSpace: "xcui-screen",
+                sampleIntervalMilliseconds: 100,
+                tolerancePoints: 1,
+                minimumRequiredHeightGrowthPoints: 1,
+                renderedHeightGrowthPoints: renderedHeightGrowthPoints,
+                defaultScenario: defaultScenario,
+                accessibility3Scenario: accessibility3Scenario,
+                proofBoundary: "hosted-visible-production-section-title-rendered-scale-comparison-only-system-preference-excluded"
+            )
+        )
+    }
+
     func testStrictFixtureSettlesAcrossOverviewReposOverview() throws {
         let requestedContentSize = HostedContentSize(width: 1040, height: 680)
         let fixtureURL = try XCTUnwrap(
@@ -393,6 +441,135 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 proofBoundary: "hosted-accessibility3-minimum-size-outer-geometry-and-page-bottom-only-inner-scroll-exhaustion-excluded"
             )
         )
+    }
+
+    private func captureRenderedTextScaleScenario(
+        requestedContentSize: HostedContentSize,
+        textSizeMode: String,
+        textSizeArgument: String?,
+        rootIdentifier: String
+    ) throws -> HostedRenderedTextScaleScenario {
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
+        )
+        let app = XCUIApplication()
+        defer { app.terminate() }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--disable-animations"
+        ]
+        if let textSizeArgument {
+            app.launchArguments.append(contentsOf: ["--text-size", textSizeArgument])
+        }
+        app.launch()
+
+        guard app.windows.firstMatch.waitForExistence(timeout: 10) else {
+            throw HostedRenderedTextScaleError.missingElement("window")
+        }
+        let root = app.descendants(matching: .any)[rootIdentifier]
+        guard root.waitForExistence(timeout: 10) else {
+            throw HostedRenderedTextScaleError.missingElement(rootIdentifier)
+        }
+        guard app.state == .runningForeground else {
+            throw HostedRenderedTextScaleError.appNotForeground
+        }
+
+        let markerIdentifier = "neondiff.evaluation.surface.overview.0.quiescent"
+        _ = try captureCheckpoint(
+            app: app,
+            section: "overview",
+            generation: 0,
+            markerIdentifier: markerIdentifier,
+            requestedContentSize: requestedContentSize
+        )
+
+        let titleQuery = app.staticTexts.matching(identifier: "neondiff-section-title")
+        guard titleQuery.count == 1 else {
+            throw HostedRenderedTextScaleError.invalidElementCount(
+                identifier: "neondiff-section-title",
+                count: titleQuery.count
+            )
+        }
+        let title = titleQuery.element(boundBy: 0)
+        guard title.waitForExistence(timeout: 2) else {
+            throw HostedRenderedTextScaleError.missingElement("neondiff-section-title")
+        }
+        guard title.label == "Overview" else {
+            throw HostedRenderedTextScaleError.unexpectedLabel(title.label)
+        }
+        let samples = try captureStableVisibleTextSamples(
+            title,
+            context: textSizeMode
+        )
+
+        return HostedRenderedTextScaleScenario(
+            textSizeMode: textSizeMode,
+            launchTextSizeArgument: textSizeArgument,
+            rootIdentifier: rootIdentifier,
+            quiescenceMarkerIdentifier: markerIdentifier,
+            samples: samples
+        )
+    }
+
+    private func captureStableVisibleTextSamples(
+        _ element: XCUIElement,
+        context: String
+    ) throws -> [HostedRenderedTextSample] {
+        let start = ProcessInfo.processInfo.systemUptime
+        var previousSampleStart: TimeInterval?
+        var samples: [HostedRenderedTextSample] = []
+        for index in 0..<3 {
+            if index > 0, let previousSampleStart {
+                let elapsedSincePrevious =
+                    ProcessInfo.processInfo.systemUptime - previousSampleStart
+                let remainingDelay = max(0, 0.1 - elapsedSincePrevious)
+                if remainingDelay > 0 {
+                    RunLoop.current.run(until: Date().addingTimeInterval(remainingDelay))
+                }
+            }
+            let sampleStart = ProcessInfo.processInfo.systemUptime
+            previousSampleStart = sampleStart
+            let frame = HostedGeometryFrame(element.frame)
+            guard frame.isFiniteAndNonempty else {
+                throw HostedRenderedTextScaleError.invalidFrame(context)
+            }
+            let label = element.label
+            guard label == "Overview" else {
+                throw HostedRenderedTextScaleError.unexpectedLabel(label)
+            }
+            samples.append(
+                HostedRenderedTextSample(
+                    elapsedMilliseconds: Int(((sampleStart - start) * 1_000).rounded()),
+                    frame: frame,
+                    label: label
+                )
+            )
+        }
+
+        guard samples.count == 3,
+              samples[0].elapsedMilliseconds >= 0,
+              samples[0].elapsedMilliseconds <= 25,
+              let finalElapsedMilliseconds = samples.last?.elapsedMilliseconds,
+              finalElapsedMilliseconds <= 5_000 else {
+            throw HostedRenderedTextScaleError.invalidCadence(context)
+        }
+        for (lhs, rhs) in zip(samples, samples.dropFirst()) {
+            guard rhs.elapsedMilliseconds - lhs.elapsedMilliseconds >= 90 else {
+                throw HostedRenderedTextScaleError.invalidCadence(context)
+            }
+        }
+        guard let baseline = samples.first else {
+            throw HostedRenderedTextScaleError.missingSamples(context)
+        }
+        for sample in samples.dropFirst() {
+            guard !baseline.frame.differs(from: sample.frame, byMoreThan: 1),
+                  baseline.label == sample.label else {
+                throw HostedRenderedTextScaleError.unstableGeometry(context)
+            }
+        }
+        return samples
     }
 
     private func captureCanonicalSizeScenario(
@@ -1091,6 +1268,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
         add(attachment)
     }
 
+    private func attach(_ trace: HostedRenderedTextScaleTrace) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let attachment = XCTAttachment(
+            data: try encoder.encode(trace),
+            uniformTypeIdentifier: "public.json"
+        )
+        attachment.name = "neondiff-hosted-rendered-text-scale.json"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func attachTransportDiagnostic(_ diagnostic: HostedTransportDiagnostic) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -1344,6 +1533,36 @@ private struct HostedLargeTextMatrixTrace: Codable {
     let proofBoundary: String
 }
 
+private struct HostedRenderedTextSample: Codable, Equatable {
+    let elapsedMilliseconds: Int
+    let frame: HostedGeometryFrame
+    let label: String
+}
+
+private struct HostedRenderedTextScaleScenario: Codable {
+    let textSizeMode: String
+    let launchTextSizeArgument: String?
+    let rootIdentifier: String
+    let quiescenceMarkerIdentifier: String
+    let samples: [HostedRenderedTextSample]
+}
+
+private struct HostedRenderedTextScaleTrace: Codable {
+    let schemaVersion: Int
+    let fixtureId: String
+    let requestedContentSize: HostedContentSize
+    let semanticTextIdentifier: String
+    let expectedLabel: String
+    let coordinateSpace: String
+    let sampleIntervalMilliseconds: Int
+    let tolerancePoints: Double
+    let minimumRequiredHeightGrowthPoints: Double
+    let renderedHeightGrowthPoints: Double
+    let defaultScenario: HostedRenderedTextScaleScenario
+    let accessibility3Scenario: HostedRenderedTextScaleScenario
+    let proofBoundary: String
+}
+
 private struct HostedGeometryCoordinateSpaces: Codable {
     let windowAndContent: String
     let regions: String
@@ -1389,6 +1608,49 @@ private enum HostedPageBottomTraceError: LocalizedError {
         case let .sentinelNotContained(context, sentinel, container):
             "Hosted page-bottom sentinel is not fully contained in \(context): "
                 + "sentinel=\(sentinel) container=\(container)"
+        }
+    }
+}
+
+private enum HostedRenderedTextScaleError: LocalizedError {
+    case priorValidationFailure
+    case appNotForeground
+    case missingElement(String)
+    case invalidElementCount(identifier: String, count: Int)
+    case unexpectedLabel(String)
+    case invalidFrame(String)
+    case missingSamples(String)
+    case invalidCadence(String)
+    case unstableGeometry(String)
+    case insufficientRenderedScale(
+        defaultFrame: HostedGeometryFrame,
+        accessibility3Frame: HostedGeometryFrame
+    )
+
+    var errorDescription: String? {
+        switch self {
+        case .priorValidationFailure:
+            "Hosted rendered-text trace withheld after an earlier validation failure"
+        case .appNotForeground:
+            "Hosted rendered-text fixture is not running in the foreground"
+        case .missingElement(let identifier):
+            "Missing hosted rendered-text element: \(identifier)"
+        case let .invalidElementCount(identifier, count):
+            "Hosted rendered-text element count is not exactly one: "
+                + "identifier=\(identifier) count=\(count)"
+        case .unexpectedLabel(let label):
+            "Hosted rendered-text element has an unexpected label: \(label)"
+        case .invalidFrame(let context):
+            "Hosted rendered-text frame is invalid: \(context)"
+        case .missingSamples(let context):
+            "Hosted rendered-text samples are missing: \(context)"
+        case .invalidCadence(let context):
+            "Hosted rendered-text sample cadence is invalid: \(context)"
+        case .unstableGeometry(let context):
+            "Hosted rendered-text geometry drift exceeded one point: \(context)"
+        case let .insufficientRenderedScale(defaultFrame, accessibility3Frame):
+            "Accessibility3 did not increase visible production text height by more than "
+                + "one point: default=\(defaultFrame) accessibility3=\(accessibility3Frame)"
         }
     }
 }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -43,7 +43,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 fixtureId: "tab-overview",
                 requestedContentSize: requestedContentSize,
                 semanticTextIdentifier: "neondiff-section-title",
-                expectedLabel: "Overview",
+                expectedSemanticValue: "Overview",
                 coordinateSpace: "xcui-screen",
                 sampleIntervalMilliseconds: 100,
                 tolerancePoints: 1,
@@ -501,9 +501,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
         guard title.waitForExistence(timeout: 2) else {
             throw HostedRenderedTextScaleError.missingElement("neondiff-section-title")
         }
-        guard title.label == "Overview" else {
-            throw HostedRenderedTextScaleError.unexpectedLabel(title.label)
-        }
+        _ = try semanticStaticTextValue(title)
         let samples = try captureStableVisibleTextSamples(
             title,
             visibleContainer: app.windows.firstMatch,
@@ -546,10 +544,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
             guard visibleContainerFrame.isFiniteAndNonempty else {
                 throw HostedRenderedTextScaleError.invalidVisibleContainerFrame(context)
             }
-            let label = element.label
-            guard label == "Overview" else {
-                throw HostedRenderedTextScaleError.unexpectedLabel(label)
-            }
+            let semanticValue = try semanticStaticTextValue(element)
             let fullyContainedInVisibleContainer = frame.isFullyContained(
                 in: visibleContainerFrame,
                 tolerance: 1
@@ -565,7 +560,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 HostedRenderedTextSample(
                     elapsedMilliseconds: Int(((sampleStart - start) * 1_000).rounded()),
                     frame: frame,
-                    label: label,
+                    semanticValue: semanticValue,
                     visibleContainerFrame: visibleContainerFrame,
                     fullyContainedInVisibleContainer: fullyContainedInVisibleContainer
                 )
@@ -595,11 +590,21 @@ final class NeonDiffDesktopUITests: XCTestCase {
                   ),
                   baseline.fullyContainedInVisibleContainer,
                   sample.fullyContainedInVisibleContainer,
-                  baseline.label == sample.label else {
+                  baseline.semanticValue == sample.semanticValue else {
                 throw HostedRenderedTextScaleError.unstableGeometry(context)
             }
         }
         return samples
+    }
+
+    private func semanticStaticTextValue(_ element: XCUIElement) throws -> String {
+        guard let semanticValue = element.value as? String,
+              semanticValue == "Overview" else {
+            throw HostedRenderedTextScaleError.unexpectedSemanticValue(
+                String(describing: element.value)
+            )
+        }
+        return semanticValue
     }
 
     private func captureCanonicalSizeScenario(
@@ -1566,7 +1571,7 @@ private struct HostedLargeTextMatrixTrace: Codable {
 private struct HostedRenderedTextSample: Codable, Equatable {
     let elapsedMilliseconds: Int
     let frame: HostedGeometryFrame
-    let label: String
+    let semanticValue: String
     let visibleContainerFrame: HostedGeometryFrame
     let fullyContainedInVisibleContainer: Bool
 }
@@ -1584,7 +1589,7 @@ private struct HostedRenderedTextScaleTrace: Codable {
     let fixtureId: String
     let requestedContentSize: HostedContentSize
     let semanticTextIdentifier: String
-    let expectedLabel: String
+    let expectedSemanticValue: String
     let coordinateSpace: String
     let sampleIntervalMilliseconds: Int
     let tolerancePoints: Double
@@ -1651,7 +1656,7 @@ private enum HostedRenderedTextScaleError: LocalizedError {
     case appNotForeground
     case missingElement(String)
     case invalidElementCount(identifier: String, count: Int)
-    case unexpectedLabel(String)
+    case unexpectedSemanticValue(String)
     case invalidFrame(String)
     case invalidVisibleContainerFrame(String)
     case textNotVisible(
@@ -1678,8 +1683,8 @@ private enum HostedRenderedTextScaleError: LocalizedError {
         case let .invalidElementCount(identifier, count):
             "Hosted rendered-text element count is not exactly one: "
                 + "identifier=\(identifier) count=\(count)"
-        case .unexpectedLabel(let label):
-            "Hosted rendered-text element has an unexpected label: \(label)"
+        case .unexpectedSemanticValue(let value):
+            "Hosted rendered-text element has an unexpected semantic value: \(value)"
         case .invalidFrame(let context):
             "Hosted rendered-text frame is invalid: \(context)"
         case .invalidVisibleContainerFrame(let context):

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -19,15 +19,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
             textSizeArgument: "accessibility3",
             rootIdentifier: "neondiff.fixture.tab-overview.text-size.accessibility3"
         )
-        let defaultFrame = try XCTUnwrap(defaultScenario.samples.last?.frame)
-        let accessibility3Frame = try XCTUnwrap(
-            accessibility3Scenario.samples.last?.frame
+        let defaultMaximumSample = try XCTUnwrap(
+            defaultScenario.samples.max { $0.frame.height < $1.frame.height }
         )
-        let renderedHeightGrowthPoints = accessibility3Frame.height - defaultFrame.height
-        guard renderedHeightGrowthPoints > 1 else {
+        let accessibility3MinimumSample = try XCTUnwrap(
+            accessibility3Scenario.samples.min { $0.frame.height < $1.frame.height }
+        )
+        let robustRenderedHeightGrowthPoints =
+            accessibility3MinimumSample.frame.height - defaultMaximumSample.frame.height
+        guard robustRenderedHeightGrowthPoints > 1 else {
             throw HostedRenderedTextScaleError.insufficientRenderedScale(
-                defaultFrame: defaultFrame,
-                accessibility3Frame: accessibility3Frame
+                defaultMaximumFrame: defaultMaximumSample.frame,
+                accessibility3MinimumFrame: accessibility3MinimumSample.frame
             )
         }
         guard (testRun?.failureCount ?? 0) == 0 else {
@@ -45,7 +48,9 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 sampleIntervalMilliseconds: 100,
                 tolerancePoints: 1,
                 minimumRequiredHeightGrowthPoints: 1,
-                renderedHeightGrowthPoints: renderedHeightGrowthPoints,
+                defaultMaximumHeightPoints: defaultMaximumSample.frame.height,
+                accessibility3MinimumHeightPoints: accessibility3MinimumSample.frame.height,
+                robustRenderedHeightGrowthPoints: robustRenderedHeightGrowthPoints,
                 defaultScenario: defaultScenario,
                 accessibility3Scenario: accessibility3Scenario,
                 proofBoundary: "hosted-visible-production-section-title-rendered-scale-comparison-only-system-preference-excluded"
@@ -501,6 +506,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
         }
         let samples = try captureStableVisibleTextSamples(
             title,
+            visibleContainer: app.windows.firstMatch,
             context: textSizeMode
         )
 
@@ -515,6 +521,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
 
     private func captureStableVisibleTextSamples(
         _ element: XCUIElement,
+        visibleContainer: XCUIElement,
         context: String
     ) throws -> [HostedRenderedTextSample] {
         let start = ProcessInfo.processInfo.systemUptime
@@ -532,18 +539,35 @@ final class NeonDiffDesktopUITests: XCTestCase {
             let sampleStart = ProcessInfo.processInfo.systemUptime
             previousSampleStart = sampleStart
             let frame = HostedGeometryFrame(element.frame)
+            let visibleContainerFrame = HostedGeometryFrame(visibleContainer.frame)
             guard frame.isFiniteAndNonempty else {
                 throw HostedRenderedTextScaleError.invalidFrame(context)
+            }
+            guard visibleContainerFrame.isFiniteAndNonempty else {
+                throw HostedRenderedTextScaleError.invalidVisibleContainerFrame(context)
             }
             let label = element.label
             guard label == "Overview" else {
                 throw HostedRenderedTextScaleError.unexpectedLabel(label)
             }
+            let fullyContainedInVisibleContainer = frame.isFullyContained(
+                in: visibleContainerFrame,
+                tolerance: 1
+            )
+            guard fullyContainedInVisibleContainer else {
+                throw HostedRenderedTextScaleError.textNotVisible(
+                    context: context,
+                    textFrame: frame,
+                    visibleContainerFrame: visibleContainerFrame
+                )
+            }
             samples.append(
                 HostedRenderedTextSample(
                     elapsedMilliseconds: Int(((sampleStart - start) * 1_000).rounded()),
                     frame: frame,
-                    label: label
+                    label: label,
+                    visibleContainerFrame: visibleContainerFrame,
+                    fullyContainedInVisibleContainer: fullyContainedInVisibleContainer
                 )
             )
         }
@@ -565,6 +589,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
         }
         for sample in samples.dropFirst() {
             guard !baseline.frame.differs(from: sample.frame, byMoreThan: 1),
+                  !baseline.visibleContainerFrame.differs(
+                      from: sample.visibleContainerFrame,
+                      byMoreThan: 1
+                  ),
+                  baseline.fullyContainedInVisibleContainer,
+                  sample.fullyContainedInVisibleContainer,
                   baseline.label == sample.label else {
                 throw HostedRenderedTextScaleError.unstableGeometry(context)
             }
@@ -1537,6 +1567,8 @@ private struct HostedRenderedTextSample: Codable, Equatable {
     let elapsedMilliseconds: Int
     let frame: HostedGeometryFrame
     let label: String
+    let visibleContainerFrame: HostedGeometryFrame
+    let fullyContainedInVisibleContainer: Bool
 }
 
 private struct HostedRenderedTextScaleScenario: Codable {
@@ -1557,7 +1589,9 @@ private struct HostedRenderedTextScaleTrace: Codable {
     let sampleIntervalMilliseconds: Int
     let tolerancePoints: Double
     let minimumRequiredHeightGrowthPoints: Double
-    let renderedHeightGrowthPoints: Double
+    let defaultMaximumHeightPoints: Double
+    let accessibility3MinimumHeightPoints: Double
+    let robustRenderedHeightGrowthPoints: Double
     let defaultScenario: HostedRenderedTextScaleScenario
     let accessibility3Scenario: HostedRenderedTextScaleScenario
     let proofBoundary: String
@@ -1619,12 +1653,18 @@ private enum HostedRenderedTextScaleError: LocalizedError {
     case invalidElementCount(identifier: String, count: Int)
     case unexpectedLabel(String)
     case invalidFrame(String)
+    case invalidVisibleContainerFrame(String)
+    case textNotVisible(
+        context: String,
+        textFrame: HostedGeometryFrame,
+        visibleContainerFrame: HostedGeometryFrame
+    )
     case missingSamples(String)
     case invalidCadence(String)
     case unstableGeometry(String)
     case insufficientRenderedScale(
-        defaultFrame: HostedGeometryFrame,
-        accessibility3Frame: HostedGeometryFrame
+        defaultMaximumFrame: HostedGeometryFrame,
+        accessibility3MinimumFrame: HostedGeometryFrame
     )
 
     var errorDescription: String? {
@@ -1642,15 +1682,25 @@ private enum HostedRenderedTextScaleError: LocalizedError {
             "Hosted rendered-text element has an unexpected label: \(label)"
         case .invalidFrame(let context):
             "Hosted rendered-text frame is invalid: \(context)"
+        case .invalidVisibleContainerFrame(let context):
+            "Hosted rendered-text visible-container frame is invalid: \(context)"
+        case let .textNotVisible(context, textFrame, visibleContainerFrame):
+            "Hosted rendered-text frame is not fully contained in the visible container: "
+                + "context=\(context) text=\(textFrame) "
+                + "container=\(visibleContainerFrame)"
         case .missingSamples(let context):
             "Hosted rendered-text samples are missing: \(context)"
         case .invalidCadence(let context):
             "Hosted rendered-text sample cadence is invalid: \(context)"
         case .unstableGeometry(let context):
             "Hosted rendered-text geometry drift exceeded one point: \(context)"
-        case let .insufficientRenderedScale(defaultFrame, accessibility3Frame):
+        case let .insufficientRenderedScale(
+            defaultMaximumFrame,
+            accessibility3MinimumFrame
+        ):
             "Accessibility3 did not increase visible production text height by more than "
-                + "one point: default=\(defaultFrame) accessibility3=\(accessibility3Frame)"
+                + "one point in the worst case: defaultMaximum=\(defaultMaximumFrame) "
+                + "accessibility3Minimum=\(accessibility3MinimumFrame)"
         }
     }
 }

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -554,6 +554,11 @@ private func target() {
     expect(theme).toContain(
       '.accessibilityIdentifier("neondiff-section-title")'
     );
+    expect(theme).toContain("@ScaledMetric(relativeTo: .headline)");
+    expect(theme).toContain("private var sectionTitleSize: CGFloat = 13");
+    expect(theme).toContain(
+      ".font(.system(size: sectionTitleSize, weight: .bold, design: .monospaced))"
+    );
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -7,6 +7,8 @@ const schemePath =
   "apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/xcshareddata/xcschemes/NeonDiffDesktopHosted.xcscheme";
 const testPlanPath = "apps/neondiff-desktop/NeonDiffDesktop.xctestplan";
 const uiTestPath = "apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift";
+const themePath =
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift";
 const workflowPath = ".github/workflows/swift-desktop-gate.yml";
 
 function extractBalancedSwiftDeclaration(
@@ -515,6 +517,34 @@ private func target() {
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain(
       String.raw`neondiff.fixture.\(fixtureId).text-size.accessibility3`
+    );
+  });
+
+  it("requires settled rendered scaling for visible production text", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+    const theme = readFileSync(themePath, "utf8");
+
+    expect(source).toContain(
+      "testAccessibility3OverrideScalesVisibleProductionSectionTitle"
+    );
+    expect(source).toContain("captureStableVisibleTextSamples");
+    expect(source).toContain("HostedRenderedTextScaleTrace(");
+    expect(source).toContain("renderedHeightGrowthPoints > 1");
+    expect(source).toContain("case insufficientRenderedScale(");
+    expect(source).toContain("samples.count == 3");
+    expect(source).toContain("finalElapsedMilliseconds <= 5_000");
+    expect(source).toContain(
+      'proofBoundary: "hosted-visible-production-section-title-rendered-scale-comparison-only-system-preference-excluded"'
+    );
+    expect(source).toContain("neondiff-hosted-rendered-text-scale.json");
+    expect(source).toContain(
+      'textSizeMode: "runner-default-no-test-override"'
+    );
+    expect(source).toContain(
+      'textSizeMode: "swiftui-dynamic-type-accessibility3-test-override"'
+    );
+    expect(theme).toContain(
+      '.accessibilityIdentifier("neondiff-section-title")'
     );
   });
 

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -529,10 +529,15 @@ private func target() {
     );
     expect(source).toContain("captureStableVisibleTextSamples");
     expect(source).toContain("HostedRenderedTextScaleTrace(");
-    expect(source).toContain("renderedHeightGrowthPoints > 1");
+    expect(source).toContain("robustRenderedHeightGrowthPoints > 1");
+    expect(source).toContain("defaultScenario.samples.max");
+    expect(source).toContain("accessibility3Scenario.samples.min");
     expect(source).toContain("case insufficientRenderedScale(");
     expect(source).toContain("samples.count == 3");
     expect(source).toContain("finalElapsedMilliseconds <= 5_000");
+    expect(source).toContain("visibleContainer: app.windows.firstMatch");
+    expect(source).toContain("fullyContainedInVisibleContainer");
+    expect(source).toContain("case textNotVisible(");
     expect(source).toContain(
       'proofBoundary: "hosted-visible-production-section-title-rendered-scale-comparison-only-system-preference-excluded"'
     );

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -554,8 +554,12 @@ private func target() {
     expect(theme).toContain(
       '.accessibilityIdentifier("neondiff-section-title")'
     );
-    expect(theme).toContain("@ScaledMetric(relativeTo: .headline)");
-    expect(theme).toContain("private var sectionTitleSize: CGFloat = 13");
+    expect(theme).toContain(
+      "@Environment(\\.dynamicTypeSize) private var dynamicTypeSize"
+    );
+    expect(theme).toContain("private var sectionTitleSize: CGFloat");
+    expect(theme).toContain("case .accessibility3: 23");
+    expect(theme).toContain("case .accessibility5: 30");
     expect(theme).toContain(
       ".font(.system(size: sectionTitleSize, weight: .bold, design: .monospaced))"
     );

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -551,6 +551,7 @@ private func target() {
     expect(theme).toContain(
       '.accessibilityIdentifier("neondiff-section-title")'
     );
+    expect(theme).toContain(".accessibilityLabel(title)");
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -538,6 +538,9 @@ private func target() {
     expect(source).toContain("visibleContainer: app.windows.firstMatch");
     expect(source).toContain("fullyContainedInVisibleContainer");
     expect(source).toContain("case textNotVisible(");
+    expect(source).toContain("element.value as? String");
+    expect(source).toContain("case unexpectedSemanticValue(String)");
+    expect(source).toContain('expectedSemanticValue: "Overview"');
     expect(source).toContain(
       'proofBoundary: "hosted-visible-production-section-title-rendered-scale-comparison-only-system-preference-excluded"'
     );
@@ -551,7 +554,6 @@ private func target() {
     expect(theme).toContain(
       '.accessibilityIdentifier("neondiff-section-title")'
     );
-    expect(theme).toContain(".accessibilityLabel(title)");
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {


### PR DESCRIPTION
Related to #517.

## Scope

- Add one accessibility identifier to the existing visible production section title.
- Launch the strict hosted DEBUG fixture twice at 1040x680: runner-default text and the existing SwiftUI `.accessibility3` test override.
- Bind both launches to the expected root and app-authored Overview generation-0 quiescence marker.
- Capture exactly three XCUI title-frame samples per mode at a minimum 100 ms cadence, require one unique `Overview` title, finite/stable geometry within one point, and a five-second sampling deadline.
- Emit an immutable JSON attachment only if the accessibility3 title height exceeds the default title height by more than one point.

## Failing first

Focused hosted contract: 1 failed / 9 passed because the visible rendered-scale test and production title identifier were absent.

## Local candidate checks

- Focused hosted Vitest: 10/10.
- Xcode 26.6 hosted `build-for-testing`: succeeded without launching UI.
- Public-claims scan: passed.
- Secret scan: passed over 747 tracked files.
- Diff check: passed.

## Proof boundary

The candidate does not yet prove rendered scaling; remote current-head macOS XCUITest and immutable attachment readback are required. A passing packet would prove only that one visible production semantic section title renders taller under the DEBUG SwiftUI `.accessibility3` override than under runner-default text. It would not prove the real macOS system large-text preference, all page-internal text, conditional states, onboarding, the separate Settings scene, inner native-scroll exhaustion, manual/keyboard/VoiceOver behavior, signed or installed artifacts, release, GA, parity, runtime, or customer readiness. #517 remains open.
