### PR TITLE
test(desktop): capture hosted onboarding geometry

### DIFF
--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -170,7 +170,7 @@ jobs:
           scripts/run-required-swift-test-suite.sh NeonDiffDesktopEvaluationSupportTests
 
       - name: Hosted XCUITest smoke
-        timeout-minutes: 15
+        timeout-minutes: 25
         env:
           PROOF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           DERIVED_DATA: ${{ runner.temp }}/neondiff-desktop-derived-data

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
@@ -12,6 +12,11 @@
 		A10000000000000000000062 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000052 /* Sparkle */; };
 		A10000000000000000000063 /* NeonDiffDesktopEvaluationSupport in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000053 /* NeonDiffDesktopEvaluationSupport */; };
 		A10000000000000000000064 /* tab-overview.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000023 /* tab-overview.json */; };
+		A10000000000000000000065 /* onboarding-welcome.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* onboarding-welcome.json */; };
+		A10000000000000000000066 /* onboarding-provider.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* onboarding-provider.json */; };
+		A10000000000000000000067 /* onboarding-daemon.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* onboarding-daemon.json */; };
+		A10000000000000000000068 /* onboarding-license.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000027 /* onboarding-license.json */; };
+		A10000000000000000000069 /* onboarding-done.json in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000028 /* onboarding-done.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,6 +34,11 @@
 		A10000000000000000000021 /* NeonDiffDesktopUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NeonDiffDesktopUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000022 /* NeonDiffDesktopFixtureResolve */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = NeonDiffDesktopFixtureResolve; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000023 /* tab-overview.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/tab-overview.json; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000024 /* onboarding-welcome.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/onboarding-welcome.json; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000025 /* onboarding-provider.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/onboarding-provider.json; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000026 /* onboarding-daemon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/onboarding-daemon.json; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000027 /* onboarding-license.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/onboarding-license.json; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000028 /* onboarding-done.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixtures/ui/onboarding-done.json; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -85,6 +95,11 @@
 				A10000000000000000000005 /* UITests */,
 				A10000000000000000000006 /* NeonDiffDesktopFixtureResolve */,
 				A10000000000000000000023 /* tab-overview.json */,
+				A10000000000000000000024 /* onboarding-welcome.json */,
+				A10000000000000000000025 /* onboarding-provider.json */,
+				A10000000000000000000026 /* onboarding-daemon.json */,
+				A10000000000000000000027 /* onboarding-license.json */,
+				A10000000000000000000028 /* onboarding-done.json */,
 				A10000000000000000000003 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -234,6 +249,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				A10000000000000000000064 /* tab-overview.json in Resources */,
+				A10000000000000000000065 /* onboarding-welcome.json in Resources */,
+				A10000000000000000000066 /* onboarding-provider.json in Resources */,
+				A10000000000000000000067 /* onboarding-daemon.json in Resources */,
+				A10000000000000000000068 /* onboarding-license.json in Resources */,
+				A10000000000000000000069 /* onboarding-done.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -34,6 +34,7 @@ struct OnboardingWizardView: View {
                     .padding(.bottom, 22)
             }
         }
+        .hostedOnboardingEvaluationRegion("neondiff-onboarding-wizard")
     }
 
     private var header: some View {
@@ -49,6 +50,9 @@ struct OnboardingWizardView: View {
                 Text(model.onboardingFlow.currentStep.title)
                     .font(NeonDiffTheme.badgeFont)
                     .foregroundStyle(NeonDiffTheme.textSecondary)
+                    .accessibilityIdentifier(
+                        "neondiff-onboarding-current-step-\(model.onboardingFlow.currentStep.rawValue)"
+                    )
             }
 
             Spacer()
@@ -59,6 +63,7 @@ struct OnboardingWizardView: View {
             )
         }
         .operatorPanel(active: true)
+        .hostedOnboardingEvaluationRegion("neondiff-onboarding-header")
     }
 
     private var stepList: some View {
@@ -83,22 +88,26 @@ struct OnboardingWizardView: View {
 
             Spacer()
         }
+        .hostedOnboardingEvaluationRegion("neondiff-onboarding-step-list")
     }
 
     @ViewBuilder
     private var stepContent: some View {
-        switch model.onboardingFlow.currentStep {
-        case .welcome:
-            welcomeStep
-        case .provider:
-            providerStep
-        case .daemon:
-            daemonStep
-        case .license:
-            licenseStep
-        case .done:
-            doneStep
+        Group {
+            switch model.onboardingFlow.currentStep {
+            case .welcome:
+                welcomeStep
+            case .provider:
+                providerStep
+            case .daemon:
+                daemonStep
+            case .license:
+                licenseStep
+            case .done:
+                doneStep
+            }
         }
+        .hostedOnboardingEvaluationRegion("neondiff-onboarding-step-content")
     }
 
     private var welcomeStep: some View {
@@ -303,5 +312,18 @@ struct OnboardingWizardView: View {
             .buttonStyle(OperatorButtonStyle(solid: true))
             .disabled(!model.onboardingFlow.canAdvance)
         }
+        .hostedOnboardingEvaluationRegion("neondiff-onboarding-footer")
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func hostedOnboardingEvaluationRegion(_ identifier: String) -> some View {
+#if DEBUG
+        accessibilityElement(children: .contain)
+            .accessibilityIdentifier(identifier)
+#else
+        self
+#endif
     }
 }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -448,6 +448,330 @@ final class NeonDiffDesktopUITests: XCTestCase {
         )
     }
 
+    func testStrictFixtureSettlesAcrossEveryOnboardingStepAtCanonicalSize() throws {
+        let requestedContentSize = HostedContentSize(width: 760, height: 560)
+        let fixtureSteps = [
+            HostedOnboardingFixtureStep(fixtureId: "onboarding-welcome", onboardingStep: "welcome", section: "overview"),
+            HostedOnboardingFixtureStep(fixtureId: "onboarding-provider", onboardingStep: "provider", section: "providers"),
+            HostedOnboardingFixtureStep(fixtureId: "onboarding-daemon", onboardingStep: "daemon", section: "overview"),
+            HostedOnboardingFixtureStep(fixtureId: "onboarding-license", onboardingStep: "license", section: "license"),
+            HostedOnboardingFixtureStep(fixtureId: "onboarding-done", onboardingStep: "done", section: "overview")
+        ]
+        var scenarios: [HostedOnboardingScenario] = []
+        for fixtureStep in fixtureSteps {
+            scenarios.append(
+                try captureOnboardingScenario(
+                    fixtureStep,
+                    requestedContentSize: requestedContentSize
+                )
+            )
+        }
+
+        XCTAssertEqual(scenarios.count, 5)
+        guard (testRun?.failureCount ?? 0) == 0 else {
+            throw HostedOnboardingTraceError.priorValidationFailure
+        }
+        try attach(
+            HostedOnboardingMatrixTrace(
+                schemaVersion: 1,
+                requestedContentSize: requestedContentSize,
+                coordinateSpace: "xcui-screen",
+                sampleIntervalMilliseconds: 100,
+                samplingDeadlineMilliseconds: 5_000,
+                tolerancePoints: 1,
+                scenarios: scenarios,
+                proofBoundary: "hosted-five-onboarding-fixtures-760x560-settled-geometry-only-actions-scroll-large-text-manual-excluded"
+            )
+        )
+    }
+
+    private func captureOnboardingScenario(
+        _ fixtureStep: HostedOnboardingFixtureStep,
+        requestedContentSize: HostedContentSize
+    ) throws -> HostedOnboardingScenario {
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(
+                forResource: fixtureStep.fixtureId,
+                withExtension: "json"
+            )
+        )
+        let app = XCUIApplication()
+        defer { app.terminate() }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "\(requestedContentSize.width)x\(requestedContentSize.height)",
+            "--disable-animations"
+        ]
+        app.launch()
+
+        guard app.windows.firstMatch.waitForExistence(timeout: 10) else {
+            throw HostedOnboardingTraceError.missingElement("window")
+        }
+        let fixtureRootIdentifier = "neondiff.fixture.\(fixtureStep.fixtureId)"
+        let fixtureRoot = app.descendants(matching: .any)[fixtureRootIdentifier]
+        guard fixtureRoot.waitForExistence(timeout: 10) else {
+            throw HostedOnboardingTraceError.missingElement(fixtureRootIdentifier)
+        }
+        guard app.state == .runningForeground else {
+            throw HostedOnboardingTraceError.appNotForeground
+        }
+
+        let markerIdentifier =
+            "neondiff.evaluation.surface.\(fixtureStep.section).0.quiescent"
+        let marker = app.descendants(matching: .any)[markerIdentifier]
+        guard marker.waitForExistence(timeout: 10) else {
+            throw HostedOnboardingTraceError.missingElement(markerIdentifier)
+        }
+        guard !marker.isHittable else {
+            throw HostedOnboardingTraceError.interactiveQuiescenceMarker(markerIdentifier)
+        }
+
+        let currentStepIdentifier =
+            "neondiff-onboarding-current-step-\(fixtureStep.onboardingStep)"
+        _ = try uniqueOnboardingElement(
+            app: app,
+            identifier: currentStepIdentifier
+        )
+        let wizard = try uniqueOnboardingElement(
+            app: app,
+            identifier: "neondiff-onboarding-wizard"
+        )
+        let regions = try [
+            "neondiff-onboarding-header",
+            "neondiff-onboarding-step-list",
+            "neondiff-onboarding-step-content",
+            "neondiff-onboarding-footer"
+        ].map {
+            ($0, try uniqueOnboardingElement(app: app, identifier: $0))
+        }
+        let samples = try captureStableOnboardingSamples(
+            app: app,
+            wizard: wizard,
+            regions: regions,
+            requestedContentSize: requestedContentSize,
+            context: fixtureStep.fixtureId
+        )
+
+        return HostedOnboardingScenario(
+            fixtureId: fixtureStep.fixtureId,
+            onboardingStep: fixtureStep.onboardingStep,
+            section: fixtureStep.section,
+            fixtureRootIdentifier: fixtureRootIdentifier,
+            currentStepIdentifier: currentStepIdentifier,
+            quiescenceMarkerIdentifier: markerIdentifier,
+            samples: samples
+        )
+    }
+
+    private func uniqueOnboardingElement(
+        app: XCUIApplication,
+        identifier: String
+    ) throws -> XCUIElement {
+        let query = app.descendants(matching: .any).matching(identifier: identifier)
+        let element = query.firstMatch
+        guard element.waitForExistence(timeout: 5) else {
+            throw HostedOnboardingTraceError.missingElement(identifier)
+        }
+        guard query.count == 1 else {
+            throw HostedOnboardingTraceError.invalidElementCount(
+                identifier: identifier,
+                count: query.count
+            )
+        }
+        return element
+    }
+
+    private func captureStableOnboardingSamples(
+        app: XCUIApplication,
+        wizard: XCUIElement,
+        regions: [(String, XCUIElement)],
+        requestedContentSize: HostedContentSize,
+        context: String
+    ) throws -> [HostedOnboardingSample] {
+        let start = ProcessInfo.processInfo.systemUptime
+        var previousSampleStart: TimeInterval?
+        var samples: [HostedOnboardingSample] = []
+        for index in 0..<3 {
+            if index > 0, let previousSampleStart {
+                let elapsedSincePrevious =
+                    ProcessInfo.processInfo.systemUptime - previousSampleStart
+                let remainingDelay = max(0, 0.1 - elapsedSincePrevious)
+                if remainingDelay > 0 {
+                    RunLoop.current.run(until: Date().addingTimeInterval(remainingDelay))
+                }
+            }
+            let sampleStart = ProcessInfo.processInfo.systemUptime
+            previousSampleStart = sampleStart
+            let wizardFrame = HostedGeometryFrame(wizard.frame)
+            guard wizardFrame.isFiniteAndNonempty else {
+                throw HostedOnboardingTraceError.invalidFrame("\(context) wizard")
+            }
+            guard wizardFrame.matches(requestedContentSize, tolerance: 1) else {
+                throw HostedOnboardingTraceError.unexpectedContentSize(
+                    context: context,
+                    requested: requestedContentSize,
+                    observed: wizardFrame
+                )
+            }
+            let windowFrame = try smallestContainingWindowFrame(
+                app: app,
+                frame: wizardFrame,
+                context: context
+            )
+            let fullyContainedInWindow = wizardFrame.isFullyContained(
+                in: windowFrame,
+                tolerance: 1
+            )
+            guard fullyContainedInWindow else {
+                throw HostedOnboardingTraceError.wizardNotContained(
+                    context: context,
+                    wizard: wizardFrame,
+                    window: windowFrame
+                )
+            }
+            let regionFrames = try regions.map { identifier, element in
+                let frame = HostedGeometryFrame(element.frame)
+                guard frame.isFiniteAndNonempty else {
+                    throw HostedOnboardingTraceError.invalidFrame(
+                        "\(context) \(identifier)"
+                    )
+                }
+                let fullyContainedInWizard = frame.isFullyContained(
+                    in: wizardFrame,
+                    tolerance: 1
+                )
+                guard fullyContainedInWizard else {
+                    throw HostedOnboardingTraceError.regionNotContained(
+                        context: context,
+                        identifier: identifier,
+                        region: frame,
+                        wizard: wizardFrame
+                    )
+                }
+                return HostedOnboardingRegionFrame(
+                    identifier: identifier,
+                    frame: frame,
+                    fullyContainedInWizard: fullyContainedInWizard
+                )
+            }
+            let sample = HostedOnboardingSample(
+                elapsedMilliseconds: Int(((sampleStart - start) * 1_000).rounded()),
+                completionElapsedMilliseconds: Int(
+                    ((ProcessInfo.processInfo.systemUptime - start) * 1_000).rounded()
+                ),
+                windowFrame: windowFrame,
+                wizardFrame: wizardFrame,
+                fullyContainedInWindow: fullyContainedInWindow,
+                regions: regionFrames
+            )
+            try validateOnboardingRegionLayout(sample, context: context)
+            samples.append(sample)
+        }
+
+        guard samples.count == 3,
+              samples[0].elapsedMilliseconds >= 0,
+              samples[0].elapsedMilliseconds <= 25,
+              let finalCompletionElapsedMilliseconds =
+                  samples.last?.completionElapsedMilliseconds,
+              finalCompletionElapsedMilliseconds <= 5_000,
+              samples.allSatisfy({
+                  $0.completionElapsedMilliseconds >= $0.elapsedMilliseconds
+              }) else {
+            throw HostedOnboardingTraceError.invalidCadence(context)
+        }
+        for (lhs, rhs) in zip(samples, samples.dropFirst()) {
+            guard rhs.elapsedMilliseconds - lhs.elapsedMilliseconds >= 90 else {
+                throw HostedOnboardingTraceError.invalidCadence(context)
+            }
+        }
+        try validateStableOnboardingSamples(samples, context: context)
+        return samples
+    }
+
+    private func smallestContainingWindowFrame(
+        app: XCUIApplication,
+        frame: HostedGeometryFrame,
+        context: String
+    ) throws -> HostedGeometryFrame {
+        let candidates = (0..<app.windows.count)
+            .map { HostedGeometryFrame(app.windows.element(boundBy: $0).frame) }
+            .filter {
+                $0.isFiniteAndNonempty
+                    && frame.isFullyContained(in: $0, tolerance: 1)
+            }
+            .sorted { $0.area < $1.area }
+        guard let windowFrame = candidates.first else {
+            throw HostedOnboardingTraceError.missingContainingWindow(context)
+        }
+        return windowFrame
+    }
+
+    private func validateStableOnboardingSamples(
+        _ samples: [HostedOnboardingSample],
+        context: String
+    ) throws {
+        guard let baseline = samples.first else {
+            throw HostedOnboardingTraceError.missingSamples(context)
+        }
+        for sample in samples.dropFirst() {
+            guard !baseline.windowFrame.differs(
+                from: sample.windowFrame,
+                byMoreThan: 1
+            ), !baseline.wizardFrame.differs(
+                from: sample.wizardFrame,
+                byMoreThan: 1
+            ), baseline.fullyContainedInWindow,
+               sample.fullyContainedInWindow,
+               baseline.regions.count == sample.regions.count else {
+                throw HostedOnboardingTraceError.unstableGeometry(context)
+            }
+            for region in baseline.regions {
+                guard let candidate = sample.regions.first(where: {
+                    $0.identifier == region.identifier
+                }), !region.frame.differs(
+                    from: candidate.frame,
+                    byMoreThan: 1
+                ), region.fullyContainedInWizard,
+                   candidate.fullyContainedInWizard else {
+                    throw HostedOnboardingTraceError.unstableGeometry(
+                        "\(context) \(region.identifier)"
+                    )
+                }
+            }
+        }
+    }
+
+    private func validateOnboardingRegionLayout(
+        _ sample: HostedOnboardingSample,
+        context: String
+    ) throws {
+        let expectedIdentifiers = Set([
+            "neondiff-onboarding-header",
+            "neondiff-onboarding-step-list",
+            "neondiff-onboarding-step-content",
+            "neondiff-onboarding-footer"
+        ])
+        guard Set(sample.regions.map(\.identifier)) == expectedIdentifiers,
+              let header = sample.regions.first(where: {
+                  $0.identifier == "neondiff-onboarding-header"
+              })?.frame,
+              let stepList = sample.regions.first(where: {
+                  $0.identifier == "neondiff-onboarding-step-list"
+              })?.frame,
+              let stepContent = sample.regions.first(where: {
+                  $0.identifier == "neondiff-onboarding-step-content"
+              })?.frame,
+              let footer = sample.regions.first(where: {
+                  $0.identifier == "neondiff-onboarding-footer"
+              })?.frame,
+              header.maxY <= min(stepList.y, stepContent.y) + 1,
+              stepList.maxX <= stepContent.x + 1,
+              max(stepList.maxY, stepContent.maxY) <= footer.y + 1 else {
+            throw HostedOnboardingTraceError.invalidRegionLayout(context)
+        }
+    }
+
     private func captureRenderedTextScaleScenario(
         requestedContentSize: HostedContentSize,
         textSizeMode: String,
@@ -1315,6 +1639,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
         add(attachment)
     }
 
+    private func attach(_ trace: HostedOnboardingMatrixTrace) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let attachment = XCTAttachment(
+            data: try encoder.encode(trace),
+            uniformTypeIdentifier: "public.json"
+        )
+        attachment.name = "neondiff-hosted-onboarding-matrix.json"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func attachTransportDiagnostic(_ diagnostic: HostedTransportDiagnostic) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -1350,6 +1686,12 @@ private struct HostedPageBottomRouteStep {
 private struct HostedCanonicalSizeRequest {
     let requestedContentSize: HostedContentSize
     let contentSizeArgument: String
+}
+
+private struct HostedOnboardingFixtureStep {
+    let fixtureId: String
+    let onboardingStep: String
+    let section: String
 }
 
 private struct HostedGeometryFrame: Codable, Equatable {
@@ -1391,6 +1733,15 @@ private struct HostedGeometryFrame: Codable, Equatable {
             && x + width <= container.x + container.width + tolerance
             && y + height <= container.y + container.height + tolerance
     }
+
+    func matches(_ size: HostedContentSize, tolerance: Double) -> Bool {
+        abs(width - Double(size.width)) <= tolerance
+            && abs(height - Double(size.height)) <= tolerance
+    }
+
+    var maxX: Double { x + width }
+    var maxY: Double { y + height }
+    var area: Double { width * height }
 }
 
 private struct HostedGeometryRegionFrame: Codable, Equatable {
@@ -1602,6 +1953,42 @@ private struct HostedRenderedTextScaleTrace: Codable {
     let proofBoundary: String
 }
 
+private struct HostedOnboardingRegionFrame: Codable, Equatable {
+    let identifier: String
+    let frame: HostedGeometryFrame
+    let fullyContainedInWizard: Bool
+}
+
+private struct HostedOnboardingSample: Codable, Equatable {
+    let elapsedMilliseconds: Int
+    let completionElapsedMilliseconds: Int
+    let windowFrame: HostedGeometryFrame
+    let wizardFrame: HostedGeometryFrame
+    let fullyContainedInWindow: Bool
+    let regions: [HostedOnboardingRegionFrame]
+}
+
+private struct HostedOnboardingScenario: Codable {
+    let fixtureId: String
+    let onboardingStep: String
+    let section: String
+    let fixtureRootIdentifier: String
+    let currentStepIdentifier: String
+    let quiescenceMarkerIdentifier: String
+    let samples: [HostedOnboardingSample]
+}
+
+private struct HostedOnboardingMatrixTrace: Codable {
+    let schemaVersion: Int
+    let requestedContentSize: HostedContentSize
+    let coordinateSpace: String
+    let sampleIntervalMilliseconds: Int
+    let samplingDeadlineMilliseconds: Int
+    let tolerancePoints: Double
+    let scenarios: [HostedOnboardingScenario]
+    let proofBoundary: String
+}
+
 private struct HostedGeometryCoordinateSpaces: Codable {
     let windowAndContent: String
     let regions: String
@@ -1706,6 +2093,75 @@ private enum HostedRenderedTextScaleError: LocalizedError {
             "Accessibility3 did not increase visible production text height by more than "
                 + "one point in the worst case: defaultMaximum=\(defaultMaximumFrame) "
                 + "accessibility3Minimum=\(accessibility3MinimumFrame)"
+        }
+    }
+}
+
+private enum HostedOnboardingTraceError: LocalizedError {
+    case priorValidationFailure
+    case appNotForeground
+    case missingElement(String)
+    case invalidElementCount(identifier: String, count: Int)
+    case interactiveQuiescenceMarker(String)
+    case invalidFrame(String)
+    case unexpectedContentSize(
+        context: String,
+        requested: HostedContentSize,
+        observed: HostedGeometryFrame
+    )
+    case missingContainingWindow(String)
+    case wizardNotContained(
+        context: String,
+        wizard: HostedGeometryFrame,
+        window: HostedGeometryFrame
+    )
+    case regionNotContained(
+        context: String,
+        identifier: String,
+        region: HostedGeometryFrame,
+        wizard: HostedGeometryFrame
+    )
+    case missingSamples(String)
+    case invalidCadence(String)
+    case unstableGeometry(String)
+    case invalidRegionLayout(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .priorValidationFailure:
+            "Hosted onboarding trace withheld after an earlier validation failure"
+        case .appNotForeground:
+            "Hosted onboarding fixture is not running in the foreground"
+        case .missingElement(let identifier):
+            "Missing hosted onboarding element: \(identifier)"
+        case let .invalidElementCount(identifier, count):
+            "Hosted onboarding element count is not exactly one: "
+                + "identifier=\(identifier) count=\(count)"
+        case .interactiveQuiescenceMarker(let identifier):
+            "Hosted onboarding quiescence marker is unexpectedly interactive: \(identifier)"
+        case .invalidFrame(let context):
+            "Invalid hosted onboarding frame: \(context)"
+        case let .unexpectedContentSize(context, requested, observed):
+            "Hosted onboarding content size does not match the request: "
+                + "context=\(context) requested=\(requested.width)x\(requested.height) "
+                + "observed=\(observed)"
+        case .missingContainingWindow(let context):
+            "Hosted onboarding wizard has no containing app window: \(context)"
+        case let .wizardNotContained(context, wizard, window):
+            "Hosted onboarding wizard is not fully contained: "
+                + "context=\(context) wizard=\(wizard) window=\(window)"
+        case let .regionNotContained(context, identifier, region, wizard):
+            "Hosted onboarding region is not fully contained: "
+                + "context=\(context) identifier=\(identifier) "
+                + "region=\(region) wizard=\(wizard)"
+        case .missingSamples(let context):
+            "Missing hosted onboarding samples: \(context)"
+        case .invalidCadence(let context):
+            "Invalid hosted onboarding sample cadence: \(context)"
+        case .unstableGeometry(let context):
+            "Hosted onboarding geometry drift exceeded one point: \(context)"
+        case .invalidRegionLayout(let context):
+            "Hosted onboarding regions overlap or are ordered incorrectly: \(context)"
         }
     }
 }

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -237,6 +237,16 @@ private func target() {
     expect(project).toContain("alwaysOutOfDate = 1;");
     expect(project.match(/SKIP_INSTALL = YES;/g)).toHaveLength(2);
     expect(project).toContain("tab-overview.json in Resources");
+    for (const fixture of [
+      "onboarding-welcome",
+      "onboarding-provider",
+      "onboarding-daemon",
+      "onboarding-license",
+      "onboarding-done"
+    ]) {
+      expect(project).toContain(`${fixture}.json in Resources`);
+      expect(project).toContain(`path = fixtures/ui/${fixture}.json`);
+    }
     expect(source).toContain('"--ui-testing"');
     expect(source).toContain('"--ui-fixture"');
     expect(source).toContain('"--content-size"');
@@ -517,6 +527,100 @@ private func target() {
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain(
       String.raw`neondiff.fixture.\(fixtureId).text-size.accessibility3`
+    );
+  });
+
+  it("pins the canonical five-step onboarding geometry matrix", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+    const onboarding = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift",
+      "utf8"
+    );
+    const workflow = readFileSync(workflowPath, "utf8");
+
+    expect(source).toContain(
+      "testStrictFixtureSettlesAcrossEveryOnboardingStepAtCanonicalSize"
+    );
+    expect(source).toContain("HostedContentSize(width: 760, height: 560)");
+    expect(source).toContain(
+      'HostedOnboardingFixtureStep(fixtureId: "onboarding-welcome", onboardingStep: "welcome", section: "overview")'
+    );
+    expect(source).toContain(
+      'HostedOnboardingFixtureStep(fixtureId: "onboarding-provider", onboardingStep: "provider", section: "providers")'
+    );
+    expect(source).toContain(
+      'HostedOnboardingFixtureStep(fixtureId: "onboarding-daemon", onboardingStep: "daemon", section: "overview")'
+    );
+    expect(source).toContain(
+      'HostedOnboardingFixtureStep(fixtureId: "onboarding-license", onboardingStep: "license", section: "license")'
+    );
+    expect(source).toContain(
+      'HostedOnboardingFixtureStep(fixtureId: "onboarding-done", onboardingStep: "done", section: "overview")'
+    );
+    expect(source).toContain(
+      '"--content-size", "\\(requestedContentSize.width)x\\(requestedContentSize.height)"'
+    );
+    expect(source).toContain("wizardFrame.matches(requestedContentSize");
+    expect(source).toContain('"neondiff-onboarding-wizard"');
+    expect(source).toContain('"neondiff-onboarding-header"');
+    expect(source).toContain('"neondiff-onboarding-step-list"');
+    expect(source).toContain('"neondiff-onboarding-step-content"');
+    expect(source).toContain('"neondiff-onboarding-footer"');
+    expect(source).toContain(
+      '"neondiff-onboarding-current-step-\\(fixtureStep.onboardingStep)"'
+    );
+    expect(source).toContain("captureStableOnboardingSamples");
+    expect(source).toContain("samples.count == 3");
+    expect(source).toContain("finalCompletionElapsedMilliseconds <= 5_000");
+    expect(source).toContain("completionElapsedMilliseconds");
+    expect(source).toContain("validateStableOnboardingSamples");
+    expect(source).toContain("validateOnboardingRegionLayout");
+    expect(source).toContain("fullyContainedInWizard");
+    expect(source).toContain("fullyContainedInWindow");
+    expect(source).toContain("testRun?.failureCount");
+    expect(source).toContain("priorValidationFailure");
+    expect(source).toContain("HostedOnboardingMatrixTrace(");
+    expect(source).toContain("neondiff-hosted-onboarding-matrix.json");
+    expect(source).toContain(
+      'proofBoundary: "hosted-five-onboarding-fixtures-760x560-settled-geometry-only-actions-scroll-large-text-manual-excluded"'
+    );
+    const onboardingImplementationStart = source.indexOf(
+      "func testStrictFixtureSettlesAcrossEveryOnboardingStepAtCanonicalSize"
+    );
+    const onboardingImplementationEnd = source.indexOf(
+      "private func captureRenderedTextScaleScenario",
+      onboardingImplementationStart
+    );
+    expect(onboardingImplementationStart).toBeGreaterThanOrEqual(0);
+    expect(onboardingImplementationEnd).toBeGreaterThan(
+      onboardingImplementationStart
+    );
+    const onboardingImplementation = source.slice(
+      onboardingImplementationStart,
+      onboardingImplementationEnd
+    );
+    expect(onboardingImplementation).not.toMatch(
+      /\.(?:click|doubleClick|rightClick|hover|tap|twoFingerTap|press|typeKey|typeText|scroll|swipe\w*|drag|coordinate|perform|pinch|rotate)\s*\(/
+    );
+
+    for (const identifier of [
+      "neondiff-onboarding-wizard",
+      "neondiff-onboarding-header",
+      "neondiff-onboarding-step-list",
+      "neondiff-onboarding-step-content",
+      "neondiff-onboarding-footer"
+    ]) {
+      expect(onboarding).toContain(
+        `.hostedOnboardingEvaluationRegion("${identifier}")`
+      );
+    }
+    expect(onboarding).toContain(
+      '"neondiff-onboarding-current-step-\\(model.onboardingFlow.currentStep.rawValue)"'
+    );
+    expect(onboarding).toContain("#if DEBUG");
+    expect(onboarding).toContain("hostedOnboardingEvaluationRegion");
+    expect(workflow).toMatch(
+      /name: Hosted XCUITest smoke\s+timeout-minutes: 25/
     );
   });
 


### PR DESCRIPTION
## Summary

- add a hosted, read-only five-fixture onboarding geometry matrix at requested and observed 760x560
- require exact fixture root, generation-0 quiescence marker, current-step semantics, unique wizard regions, full containment, non-overlap/order, and three settled samples per fixture
- package all five onboarding fixtures in the UI-test bundle and emit a proof-last JSON attachment only after validation
- keep diagnostic AX grouping DEBUG-only so release accessibility hierarchy is unchanged
- extend the hosted job timeout from 15 to 25 minutes for the five additional app launches

## Exact candidate

- head: `8fbd40534d650fce3951b1dafbdb429ee835d7b3`
- base: `e17dabb596563485b8f5d2a3bad161f8a2e629e4`

## Failing-first and focused validation

- valid RED: focused hosted-XCTest contract failed because the onboarding matrix was absent
- focused Vitest: 11/11 passed
- Xcode 26.6 `build-for-testing`: passed; all five onboarding JSON resources are present in the built UI-test bundle
- public-claims scan: passed
- secret scan: passed
- diff check: passed
- independent correctness, security/spec, and accessibility/design reviews: clean after fixes

## Exact-head remote proof

- full CI run `29433869189`: passed
- CodeQL run `29433867413`: actions, JavaScript/TypeScript, and Python passed
- Swift Desktop Gate run `29433869274`: passed
- hosted XCTest on macOS 15.7.7 arm64: 7/7 passed, 0 failed, 0 skipped
- artifact id: `8350988774`
- artifact wrapper digest: `sha256:ec0310e5ef000cd2db60865159adb4894ef5a78eca64aa7996c9247efa7d5ac7`
- downloaded xcresult zip SHA-256: `3ce9e8d7e04dfd3cf51ac2f5caefceb3a8e506449f68747ca451b065b0fba061`
- onboarding attachment SHA-256: `77ecfbc0dcda1b1321c971874f1ba08c4a083d1d9fadd096072c627b69906a77`
- attachment manifest SHA-256: `4e21ad7253869b7e34beb603f0b565463930e6fe6c436f6ce68ce3940a4daf6d`
- five scenarios x three samples; every observed wizard is 760x560 and every required region is fully contained
- final completion time by scenario: welcome 1335 ms, provider 1529 ms, daemon 1714 ms, license 1102 ms, done 1268 ms
- exact-head evaOS re-review: completed, advisory COMMENT, no validated inline findings, no high-severity findings

No release-status, launchd-heartbeat, signed-artifact, or live-runtime proof applies to this test-only PR. It does not promote or mutate any live runtime. The workflow change is timeout-only; rollback is restoring the hosted step timeout from 25 to 15 minutes.

## Proof boundary

This PR proves only that five deterministic DEBUG onboarding fixtures (`welcome`, `provider`, `daemon`, `license`, `done`) settle at observed 760x560 with the recorded regions contained, ordered, stable, and sampled without UI interaction.

It does not prove onboarding actions, scroll exhaustion, large text, actual API-backed activation, system accessibility settings, keyboard/trackpad/VoiceOver behavior, installed or signed artifacts, release, GA, runtime, or customer readiness.

Related to #517 and #503; both acceptance matrices remain open.
