### PR TITLE
fix(desktop): fit and prove separate Settings scene

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -112,11 +112,11 @@ struct NeonDiffDesktopApp: App {
 #if DEBUG
         if evaluationContext?.textSizeMode == .accessibility3 {
             settingsScene
-                .dynamicTypeSize(.accessibility3)
                 .hostedSettingsEvaluationContent(
                     enabled: true,
                     status: settingsEvaluationStatus
                 )
+                .dynamicTypeSize(.accessibility3)
         } else if evaluationContext != nil {
             settingsScene
                 .hostedSettingsEvaluationContent(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -375,6 +375,7 @@ private struct SettingsWindowFitView: NSViewRepresentable {
         private weak var window: NSWindow?
         private var contentHeight: Binding<CGFloat>?
         private var pendingHeight: CGFloat?
+        private var pendingOriginContainment = false
         private var attachmentGeneration = 0
 
         func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>) {
@@ -385,6 +386,7 @@ private struct SettingsWindowFitView: NSViewRepresentable {
             detachObservers()
             attachmentGeneration += 1
             pendingHeight = nil
+            pendingOriginContainment = false
             self.window = window
             guard let window else { return }
             let center = NotificationCenter.default
@@ -409,6 +411,7 @@ private struct SettingsWindowFitView: NSViewRepresentable {
             window = nil
             contentHeight = nil
             pendingHeight = nil
+            pendingOriginContainment = false
         }
 
         @objc private func windowScreenDidChange(_ notification: Notification) {
@@ -443,8 +446,12 @@ private struct SettingsWindowFitView: NSViewRepresentable {
                 return
             }
             if abs(currentContentHeight - targetHeight) > 0.5 {
-                guard pendingHeight != targetHeight else { return }
+                if pendingHeight == targetHeight {
+                    pendingOriginContainment = pendingOriginContainment || containOrigin
+                    return
+                }
                 pendingHeight = targetHeight
+                pendingOriginContainment = containOrigin
                 let generation = attachmentGeneration
                 DispatchQueue.main.async { [weak self] in
                     guard let self,
@@ -454,20 +461,23 @@ private struct SettingsWindowFitView: NSViewRepresentable {
                           let contentHeight = self.contentHeight else {
                         return
                     }
+                    let shouldContainOrigin = self.pendingOriginContainment
                     contentHeight.wrappedValue = targetHeight
                     self.pendingHeight = nil
+                    self.pendingOriginContainment = false
                     DispatchQueue.main.async { [weak self] in
                         guard let self,
                               self.window === window,
                               self.attachmentGeneration == generation else {
                             return
                         }
-                        self.fitWindow(containOrigin: containOrigin)
+                        self.fitWindow(containOrigin: shouldContainOrigin)
                     }
                 }
                 return
             }
             pendingHeight = nil
+            pendingOriginContainment = false
             guard containOrigin else { return }
             var origin = windowFrame.origin
             origin.x = min(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -139,7 +139,12 @@ struct NeonDiffDesktopApp: App {
         .buttonStyle(OperatorButtonStyle())
         .tint(NeonDiffTheme.accent)
         .preferredColorScheme(preferredColorScheme)
-        .frame(width: 560, height: 700)
+        .frame(
+            width: SettingsWindowLayout.preferredContentWidth,
+            height: SettingsWindowLayout.fittedContentHeight(
+                visibleScreenHeight: NSScreen.main?.visibleFrame.height
+            )
+        )
     }
 
     @ViewBuilder
@@ -304,6 +309,34 @@ struct NeonDiffDesktopApp: App {
 #else
         nil
 #endif
+    }
+}
+
+private enum SettingsWindowLayout {
+    static let preferredContentWidth: CGFloat = 560
+    static let preferredContentHeight: CGFloat = 700
+
+    static func fittedContentHeight(visibleScreenHeight: CGFloat?) -> CGFloat {
+        guard let visibleScreenHeight,
+              visibleScreenHeight.isFinite,
+              visibleScreenHeight > 0 else {
+            return preferredContentHeight
+        }
+        let contentRect = NSRect(
+            x: 0,
+            y: 0,
+            width: preferredContentWidth,
+            height: preferredContentHeight
+        )
+        let frameRect = NSWindow.frameRect(
+            forContentRect: contentRect,
+            styleMask: [.titled, .closable]
+        )
+        let chromeHeight = max(0, frameRect.height - contentRect.height)
+        return max(
+            1,
+            min(preferredContentHeight, floor(visibleScreenHeight - chromeHeight))
+        )
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -412,14 +412,14 @@ private struct SettingsWindowFitView: NSViewRepresentable {
         }
 
         @objc private func windowScreenDidChange(_ notification: Notification) {
-            fitWindow()
+            fitWindow(containOrigin: false)
         }
 
         @objc private func screenParametersDidChange(_ notification: Notification) {
             fitWindow()
         }
 
-        private func fitWindow() {
+        private func fitWindow(containOrigin: Bool = true) {
             guard let window,
                   let contentHeight,
                   let visibleFrame = window.screen?.visibleFrame else {
@@ -462,12 +462,13 @@ private struct SettingsWindowFitView: NSViewRepresentable {
                               self.attachmentGeneration == generation else {
                             return
                         }
-                        self.fitWindow()
+                        self.fitWindow(containOrigin: containOrigin)
                     }
                 }
                 return
             }
             pendingHeight = nil
+            guard containOrigin else { return }
             var origin = windowFrame.origin
             origin.x = min(
                 max(origin.x, visibleFrame.minX),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -8,6 +8,8 @@ struct NeonDiffDesktopApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var model: NeonDiffDesktopModel
     @StateObject private var updateController: NeonUpdateController
+    @State private var settingsContentHeight =
+        SettingsWindowLayout.preferredContentHeight
 #if DEBUG
     private let evaluationContext: DesktopResolvedEvaluationLaunchContext?
     private let evaluationReadinessRequest: DesktopEvaluationReadinessRequest?
@@ -141,9 +143,11 @@ struct NeonDiffDesktopApp: App {
         .preferredColorScheme(preferredColorScheme)
         .frame(
             width: SettingsWindowLayout.preferredContentWidth,
-            height: SettingsWindowLayout.fittedContentHeight(
-                visibleScreenHeight: NSScreen.main?.visibleFrame.height
-            )
+            height: settingsContentHeight
+        )
+        .background(
+            SettingsWindowFitView(contentHeight: $settingsContentHeight)
+                .allowsHitTesting(false)
         )
     }
 
@@ -316,27 +320,155 @@ private enum SettingsWindowLayout {
     static let preferredContentWidth: CGFloat = 560
     static let preferredContentHeight: CGFloat = 700
 
-    static func fittedContentHeight(visibleScreenHeight: CGFloat?) -> CGFloat {
-        guard let visibleScreenHeight,
-              visibleScreenHeight.isFinite,
-              visibleScreenHeight > 0 else {
-            return preferredContentHeight
+    static func fittedContentHeight(
+        visibleScreenHeight: CGFloat,
+        chromeHeight: CGFloat
+    ) -> CGFloat? {
+        guard visibleScreenHeight.isFinite,
+              visibleScreenHeight > 0,
+              chromeHeight.isFinite,
+              chromeHeight >= 0,
+              visibleScreenHeight > chromeHeight else {
+            return nil
         }
-        let contentRect = NSRect(
-            x: 0,
-            y: 0,
-            width: preferredContentWidth,
-            height: preferredContentHeight
-        )
-        let frameRect = NSWindow.frameRect(
-            forContentRect: contentRect,
-            styleMask: [.titled, .closable]
-        )
-        let chromeHeight = max(0, frameRect.height - contentRect.height)
         return max(
             1,
             min(preferredContentHeight, floor(visibleScreenHeight - chromeHeight))
         )
+    }
+}
+
+private struct SettingsWindowFitView: NSViewRepresentable {
+    @Binding var contentHeight: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.isHidden = true
+        DispatchQueue.main.async {
+            context.coordinator.attach(
+                to: view.window,
+                contentHeight: $contentHeight
+            )
+        }
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        DispatchQueue.main.async {
+            context.coordinator.attach(
+                to: view.window,
+                contentHeight: $contentHeight
+            )
+        }
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private weak var window: NSWindow?
+        private var contentHeight: Binding<CGFloat>?
+        private var pendingHeight: CGFloat?
+
+        func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>) {
+            self.contentHeight = contentHeight
+            guard self.window !== window else {
+                fitWindow()
+                return
+            }
+            detachObservers()
+            self.window = window
+            guard let window else { return }
+            let center = NotificationCenter.default
+            center.addObserver(
+                self,
+                selector: #selector(windowGeometryDidChange),
+                name: NSWindow.didChangeScreenNotification,
+                object: window
+            )
+            center.addObserver(
+                self,
+                selector: #selector(windowGeometryDidChange),
+                name: NSWindow.didMoveNotification,
+                object: window
+            )
+            center.addObserver(
+                self,
+                selector: #selector(windowGeometryDidChange),
+                name: NSApplication.didChangeScreenParametersNotification,
+                object: nil
+            )
+            fitWindow()
+        }
+
+        func detach() {
+            detachObservers()
+            window = nil
+            contentHeight = nil
+            pendingHeight = nil
+        }
+
+        @objc private func windowGeometryDidChange(_ notification: Notification) {
+            fitWindow()
+        }
+
+        private func fitWindow() {
+            guard let window,
+                  let contentHeight,
+                  let visibleFrame = window.screen?.visibleFrame else {
+                return
+            }
+            let chromeHeight = max(
+                0,
+                window.frame.height - window.contentLayoutRect.height
+            )
+            guard let targetHeight = SettingsWindowLayout.fittedContentHeight(
+                visibleScreenHeight: visibleFrame.height,
+                chromeHeight: chromeHeight
+            ) else {
+                return
+            }
+            if abs(contentHeight.wrappedValue - targetHeight) > 0.5 {
+                guard pendingHeight != targetHeight else { return }
+                pendingHeight = targetHeight
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, let contentHeight = self.contentHeight else { return }
+                    contentHeight.wrappedValue = targetHeight
+                    self.pendingHeight = nil
+                    DispatchQueue.main.async { [weak self] in
+                        self?.fitWindow()
+                    }
+                }
+                return
+            }
+            var origin = window.frame.origin
+            origin.x = min(
+                max(origin.x, visibleFrame.minX),
+                max(visibleFrame.minX, visibleFrame.maxX - window.frame.width)
+            )
+            origin.y = min(
+                max(origin.y, visibleFrame.minY),
+                max(visibleFrame.minY, visibleFrame.maxY - window.frame.height)
+            )
+            if abs(origin.x - window.frame.origin.x) > 0.5
+                || abs(origin.y - window.frame.origin.y) > 0.5 {
+                window.setFrameOrigin(origin)
+            }
+        }
+
+        private func detachObservers() {
+            NotificationCenter.default.removeObserver(self)
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -13,6 +13,7 @@ struct NeonDiffDesktopApp: App {
     private let evaluationReadinessRequest: DesktopEvaluationReadinessRequest?
     private let evaluationRenderLatch: DesktopEvaluationRenderLatch?
     private let evaluationSurfaceStatus: DesktopEvaluationSurfaceStatus?
+    @StateObject private var settingsEvaluationStatus = HostedSettingsEvaluationStatus()
 #endif
 
     init() {
@@ -102,15 +103,43 @@ struct NeonDiffDesktopApp: App {
         }
 
         Settings {
-            ZStack {
-                OperatorBackdrop()
-                SettingsPane(model: model, updateController: updateController)
-            }
-            .buttonStyle(OperatorButtonStyle())
-            .tint(NeonDiffTheme.accent)
-            .preferredColorScheme(preferredColorScheme)
-            .frame(width: 560)
+            evaluationTextSizedSettingsScene
         }
+    }
+
+    @ViewBuilder
+    private var evaluationTextSizedSettingsScene: some View {
+#if DEBUG
+        if evaluationContext?.textSizeMode == .accessibility3 {
+            settingsScene
+                .dynamicTypeSize(.accessibility3)
+                .hostedSettingsEvaluationContent(
+                    enabled: true,
+                    status: settingsEvaluationStatus
+                )
+        } else if evaluationContext != nil {
+            settingsScene
+                .hostedSettingsEvaluationContent(
+                    enabled: true,
+                    status: settingsEvaluationStatus
+                )
+        } else {
+            settingsScene
+        }
+#else
+        settingsScene
+#endif
+    }
+
+    private var settingsScene: some View {
+        ZStack {
+            OperatorBackdrop()
+            SettingsPane(model: model, updateController: updateController)
+        }
+        .buttonStyle(OperatorButtonStyle())
+        .tint(NeonDiffTheme.accent)
+        .preferredColorScheme(preferredColorScheme)
+        .frame(width: 560, height: 700)
     }
 
     @ViewBuilder

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -380,11 +380,11 @@ private struct SettingsWindowFitView: NSViewRepresentable {
         func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>) {
             self.contentHeight = contentHeight
             guard self.window !== window else {
-                fitWindow(clampOrigin: true)
                 return
             }
             detachObservers()
             attachmentGeneration += 1
+            pendingHeight = nil
             self.window = window
             guard let window else { return }
             let center = NotificationCenter.default
@@ -396,17 +396,11 @@ private struct SettingsWindowFitView: NSViewRepresentable {
             )
             center.addObserver(
                 self,
-                selector: #selector(windowDidMove),
-                name: NSWindow.didMoveNotification,
-                object: window
-            )
-            center.addObserver(
-                self,
                 selector: #selector(screenParametersDidChange),
                 name: NSApplication.didChangeScreenParametersNotification,
                 object: nil
             )
-            fitWindow(clampOrigin: true)
+            fitWindow()
         }
 
         func detach() {
@@ -418,20 +412,14 @@ private struct SettingsWindowFitView: NSViewRepresentable {
         }
 
         @objc private func windowScreenDidChange(_ notification: Notification) {
-            fitWindow(clampOrigin: true)
-        }
-
-        @objc private func windowDidMove(_ notification: Notification) {
-            // Do not clamp during a live drag: the window must be allowed to cross
-            // the boundary far enough for AppKit to select its destination screen.
-            fitWindow(clampOrigin: false)
+            fitWindow()
         }
 
         @objc private func screenParametersDidChange(_ notification: Notification) {
-            fitWindow(clampOrigin: true)
+            fitWindow()
         }
 
-        private func fitWindow(clampOrigin: Bool) {
+        private func fitWindow() {
             guard let window,
                   let contentHeight,
                   let visibleFrame = window.screen?.visibleFrame else {
@@ -474,12 +462,12 @@ private struct SettingsWindowFitView: NSViewRepresentable {
                               self.attachmentGeneration == generation else {
                             return
                         }
-                        self.fitWindow(clampOrigin: clampOrigin)
+                        self.fitWindow()
                     }
                 }
                 return
             }
-            guard clampOrigin else { return }
+            pendingHeight = nil
             var origin = windowFrame.origin
             origin.x = min(
                 max(origin.x, visibleFrame.minX),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -375,91 +375,133 @@ private struct SettingsWindowFitView: NSViewRepresentable {
         private weak var window: NSWindow?
         private var contentHeight: Binding<CGFloat>?
         private var pendingHeight: CGFloat?
+        private var attachmentGeneration = 0
 
         func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>) {
             self.contentHeight = contentHeight
             guard self.window !== window else {
-                fitWindow()
+                fitWindow(clampOrigin: true)
                 return
             }
             detachObservers()
+            attachmentGeneration += 1
             self.window = window
             guard let window else { return }
             let center = NotificationCenter.default
             center.addObserver(
                 self,
-                selector: #selector(windowGeometryDidChange),
+                selector: #selector(windowScreenDidChange),
                 name: NSWindow.didChangeScreenNotification,
                 object: window
             )
             center.addObserver(
                 self,
-                selector: #selector(windowGeometryDidChange),
+                selector: #selector(windowDidMove),
                 name: NSWindow.didMoveNotification,
                 object: window
             )
             center.addObserver(
                 self,
-                selector: #selector(windowGeometryDidChange),
+                selector: #selector(screenParametersDidChange),
                 name: NSApplication.didChangeScreenParametersNotification,
                 object: nil
             )
-            fitWindow()
+            fitWindow(clampOrigin: true)
         }
 
         func detach() {
             detachObservers()
+            attachmentGeneration += 1
             window = nil
             contentHeight = nil
             pendingHeight = nil
         }
 
-        @objc private func windowGeometryDidChange(_ notification: Notification) {
-            fitWindow()
+        @objc private func windowScreenDidChange(_ notification: Notification) {
+            fitWindow(clampOrigin: true)
         }
 
-        private func fitWindow() {
+        @objc private func windowDidMove(_ notification: Notification) {
+            // Do not clamp during a live drag: the window must be allowed to cross
+            // the boundary far enough for AppKit to select its destination screen.
+            fitWindow(clampOrigin: false)
+        }
+
+        @objc private func screenParametersDidChange(_ notification: Notification) {
+            fitWindow(clampOrigin: true)
+        }
+
+        private func fitWindow(clampOrigin: Bool) {
             guard let window,
                   let contentHeight,
                   let visibleFrame = window.screen?.visibleFrame else {
                 return
             }
-            let chromeHeight = max(
-                0,
-                window.frame.height - window.contentLayoutRect.height
-            )
+            let windowFrame = window.frame
+            let contentLayoutRect = window.contentLayoutRect
+            let currentContentHeight = contentHeight.wrappedValue
+            guard Self.isFiniteNonempty(windowFrame),
+                  Self.isFiniteNonempty(contentLayoutRect),
+                  Self.isFiniteNonempty(visibleFrame),
+                  currentContentHeight.isFinite,
+                  currentContentHeight > 0 else {
+                return
+            }
+            let chromeHeight = windowFrame.height - contentLayoutRect.height
             guard let targetHeight = SettingsWindowLayout.fittedContentHeight(
                 visibleScreenHeight: visibleFrame.height,
                 chromeHeight: chromeHeight
             ) else {
                 return
             }
-            if abs(contentHeight.wrappedValue - targetHeight) > 0.5 {
+            if abs(currentContentHeight - targetHeight) > 0.5 {
                 guard pendingHeight != targetHeight else { return }
                 pendingHeight = targetHeight
+                let generation = attachmentGeneration
                 DispatchQueue.main.async { [weak self] in
-                    guard let self, let contentHeight = self.contentHeight else { return }
+                    guard let self,
+                          self.window === window,
+                          self.attachmentGeneration == generation,
+                          self.pendingHeight == targetHeight,
+                          let contentHeight = self.contentHeight else {
+                        return
+                    }
                     contentHeight.wrappedValue = targetHeight
                     self.pendingHeight = nil
                     DispatchQueue.main.async { [weak self] in
-                        self?.fitWindow()
+                        guard let self,
+                              self.window === window,
+                              self.attachmentGeneration == generation else {
+                            return
+                        }
+                        self.fitWindow(clampOrigin: clampOrigin)
                     }
                 }
                 return
             }
-            var origin = window.frame.origin
+            guard clampOrigin else { return }
+            var origin = windowFrame.origin
             origin.x = min(
                 max(origin.x, visibleFrame.minX),
-                max(visibleFrame.minX, visibleFrame.maxX - window.frame.width)
+                max(visibleFrame.minX, visibleFrame.maxX - windowFrame.width)
             )
             origin.y = min(
                 max(origin.y, visibleFrame.minY),
-                max(visibleFrame.minY, visibleFrame.maxY - window.frame.height)
+                max(visibleFrame.minY, visibleFrame.maxY - windowFrame.height)
             )
-            if abs(origin.x - window.frame.origin.x) > 0.5
-                || abs(origin.y - window.frame.origin.y) > 0.5 {
+            if abs(origin.x - windowFrame.origin.x) > 0.5
+                || abs(origin.y - windowFrame.origin.y) > 0.5 {
                 window.setFrameOrigin(origin)
             }
+        }
+
+        private static func isFiniteNonempty(_ rect: CGRect) -> Bool {
+            rect.origin.x.isFinite
+                && rect.origin.y.isFinite
+                && rect.width.isFinite
+                && rect.height.isFinite
+                && rect.width > 0
+                && rect.height > 0
         }
 
         private func detachObservers() {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -212,6 +212,9 @@ struct HostedSettingsWindowConfigurator: NSViewRepresentable {
                     let sample = HostedSettingsWindowSample(
                         windowFrame: window.frame,
                         contentLayoutRect: window.contentLayoutRect,
+                        contentLayoutScreenRect: window.convertToScreen(
+                            window.contentLayoutRect
+                        ),
                         visibleScreenFrame: visibleScreenFrame
                     )
                     if let previous = stableSamples.last,
@@ -248,11 +251,20 @@ fileprivate struct HostedSettingsWindowGeometryEnvelope: Codable {
 fileprivate struct HostedSettingsWindowSample: Codable {
     let windowFrame: HostedSettingsAppKitFrame
     let contentLayoutRect: HostedSettingsAppKitFrame
+    let contentLayoutScreenRect: HostedSettingsAppKitFrame
     let visibleScreenFrame: HostedSettingsAppKitFrame
 
-    init(windowFrame: CGRect, contentLayoutRect: CGRect, visibleScreenFrame: CGRect) {
+    init(
+        windowFrame: CGRect,
+        contentLayoutRect: CGRect,
+        contentLayoutScreenRect: CGRect,
+        visibleScreenFrame: CGRect
+    ) {
         self.windowFrame = HostedSettingsAppKitFrame(windowFrame)
         self.contentLayoutRect = HostedSettingsAppKitFrame(contentLayoutRect)
+        self.contentLayoutScreenRect = HostedSettingsAppKitFrame(
+            contentLayoutScreenRect
+        )
         self.visibleScreenFrame = HostedSettingsAppKitFrame(visibleScreenFrame)
     }
 
@@ -260,6 +272,10 @@ fileprivate struct HostedSettingsWindowSample: Codable {
         windowFrame.differs(from: other.windowFrame, byMoreThan: tolerance)
             || contentLayoutRect.differs(
                 from: other.contentLayoutRect,
+                byMoreThan: tolerance
+            )
+            || contentLayoutScreenRect.differs(
+                from: other.contentLayoutScreenRect,
                 byMoreThan: tolerance
             )
             || visibleScreenFrame.differs(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -237,8 +237,8 @@ struct HostedSettingsWindowConfigurator: NSViewRepresentable {
                         ),
                         visibleScreenFrame: visibleScreenFrame
                     )
-                    if let previous = stableSamples.last,
-                       previous.differs(from: sample, byMoreThan: 1) {
+                    if let baseline = stableSamples.first,
+                       baseline.differs(from: sample, byMoreThan: 1) {
                         stableSamples = [sample]
                     } else {
                         stableSamples.append(sample)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -84,12 +84,24 @@ struct SettingsPane: View {
 final class HostedSettingsEvaluationStatus: ObservableObject {
     @Published private(set) var accessibilityIdentifier =
         "neondiff.evaluation.settings.rendering"
+    @Published private(set) var geometryPayload = "unavailable"
 
     func reset() {
         accessibilityIdentifier = "neondiff.evaluation.settings.rendering"
+        geometryPayload = "unavailable"
     }
 
-    func markQuiescent() {
+    fileprivate func markQuiescent(samples: [HostedSettingsWindowSample]) {
+        let envelope = HostedSettingsWindowGeometryEnvelope(
+            schemaVersion: 1,
+            coordinateSpace: "appkit-screen",
+            samples: samples
+        )
+        guard let data = try? JSONEncoder().encode(envelope) else {
+            geometryPayload = "encoding-failed"
+            return
+        }
+        geometryPayload = data.base64EncodedString()
         accessibilityIdentifier = "neondiff.evaluation.settings.quiescent"
     }
 }
@@ -118,14 +130,31 @@ extension View {
 
 private struct HostedSettingsEvaluationMarker: View {
     @ObservedObject var status: HostedSettingsEvaluationStatus
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
-        Color.clear
-            .frame(width: 1, height: 1)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("NeonDiff Settings evaluation state")
-            .accessibilityIdentifier(status.accessibilityIdentifier)
-            .allowsHitTesting(false)
+        ZStack {
+            Color.clear
+                .frame(width: 1, height: 1)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("NeonDiff Settings evaluation state")
+                .accessibilityIdentifier(status.accessibilityIdentifier)
+
+            Color.clear
+                .frame(width: 1, height: 1)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("NeonDiff Settings observed text size")
+                .accessibilityIdentifier("neondiff.evaluation.settings.text-size")
+                .accessibilityValue(dynamicTypeSize.evaluationIdentifier)
+
+            Color.clear
+                .frame(width: 1, height: 1)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("NeonDiff Settings AppKit geometry")
+                .accessibilityIdentifier("neondiff.evaluation.settings.appkit-geometry")
+                .accessibilityValue(status.geometryPayload)
+        }
+        .allowsHitTesting(false)
     }
 }
 
@@ -174,14 +203,16 @@ struct HostedSettingsWindowConfigurator: NSViewRepresentable {
                 var stableSamples: [HostedSettingsWindowSample] = []
                 while !Task.isCancelled,
                       ProcessInfo.processInfo.systemUptime <= deadline {
-                    guard let window = view?.window else {
+                    guard let window = view?.window,
+                          let visibleScreenFrame = window.screen?.visibleFrame else {
                         try? await Task.sleep(for: .milliseconds(20))
                         continue
                     }
                     window.contentView?.layoutSubtreeIfNeeded()
                     let sample = HostedSettingsWindowSample(
                         windowFrame: window.frame,
-                        contentLayoutRect: window.contentLayoutRect
+                        contentLayoutRect: window.contentLayoutRect,
+                        visibleScreenFrame: visibleScreenFrame
                     )
                     if let previous = stableSamples.last,
                        previous.differs(from: sample, byMoreThan: 1) {
@@ -191,7 +222,7 @@ struct HostedSettingsWindowConfigurator: NSViewRepresentable {
                     }
                     if stableSamples.count == 3 {
                         completed = true
-                        status.markQuiescent()
+                        status.markQuiescent(samples: stableSamples)
                         monitorTask = nil
                         return
                     }
@@ -208,9 +239,22 @@ struct HostedSettingsWindowConfigurator: NSViewRepresentable {
     }
 }
 
-private struct HostedSettingsWindowSample {
-    let windowFrame: CGRect
-    let contentLayoutRect: CGRect
+fileprivate struct HostedSettingsWindowGeometryEnvelope: Codable {
+    let schemaVersion: Int
+    let coordinateSpace: String
+    let samples: [HostedSettingsWindowSample]
+}
+
+fileprivate struct HostedSettingsWindowSample: Codable {
+    let windowFrame: HostedSettingsAppKitFrame
+    let contentLayoutRect: HostedSettingsAppKitFrame
+    let visibleScreenFrame: HostedSettingsAppKitFrame
+
+    init(windowFrame: CGRect, contentLayoutRect: CGRect, visibleScreenFrame: CGRect) {
+        self.windowFrame = HostedSettingsAppKitFrame(windowFrame)
+        self.contentLayoutRect = HostedSettingsAppKitFrame(contentLayoutRect)
+        self.visibleScreenFrame = HostedSettingsAppKitFrame(visibleScreenFrame)
+    }
 
     func differs(from other: Self, byMoreThan tolerance: CGFloat) -> Bool {
         windowFrame.differs(from: other.windowFrame, byMoreThan: tolerance)
@@ -218,15 +262,51 @@ private struct HostedSettingsWindowSample {
                 from: other.contentLayoutRect,
                 byMoreThan: tolerance
             )
+            || visibleScreenFrame.differs(
+                from: other.visibleScreenFrame,
+                byMoreThan: tolerance
+            )
     }
 }
 
-private extension CGRect {
-    func differs(from other: CGRect, byMoreThan tolerance: CGFloat) -> Bool {
-        abs(origin.x - other.origin.x) > tolerance
-            || abs(origin.y - other.origin.y) > tolerance
+fileprivate struct HostedSettingsAppKitFrame: Codable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ rect: CGRect) {
+        x = rect.origin.x
+        y = rect.origin.y
+        width = rect.width
+        height = rect.height
+    }
+
+    func differs(from other: Self, byMoreThan tolerance: CGFloat) -> Bool {
+        abs(x - other.x) > tolerance
+            || abs(y - other.y) > tolerance
             || abs(width - other.width) > tolerance
             || abs(height - other.height) > tolerance
+    }
+}
+
+private extension DynamicTypeSize {
+    var evaluationIdentifier: String {
+        switch self {
+        case .xSmall: "x-small"
+        case .small: "small"
+        case .medium: "medium"
+        case .large: "large"
+        case .xLarge: "x-large"
+        case .xxLarge: "xx-large"
+        case .xxxLarge: "xxx-large"
+        case .accessibility1: "accessibility1"
+        case .accessibility2: "accessibility2"
+        case .accessibility3: "accessibility3"
+        case .accessibility4: "accessibility4"
+        case .accessibility5: "accessibility5"
+        @unknown default: "unknown"
+        }
     }
 }
 #endif

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -84,11 +84,16 @@ struct SettingsPane: View {
 final class HostedSettingsEvaluationStatus: ObservableObject {
     @Published private(set) var accessibilityIdentifier =
         "neondiff.evaluation.settings.rendering"
-    @Published private(set) var geometryPayload = "unavailable"
+    @Published private(set) var geometryAccessibilityManifest =
+        "neondiff-settings-appkit-geometry-unavailable"
+    @Published private(set) var geometryAccessibilityChunks:
+        [HostedSettingsGeometryAccessibilityChunk] = []
 
     func reset() {
         accessibilityIdentifier = "neondiff.evaluation.settings.rendering"
-        geometryPayload = "unavailable"
+        geometryAccessibilityManifest =
+            "neondiff-settings-appkit-geometry-unavailable"
+        geometryAccessibilityChunks = []
     }
 
     fileprivate func markQuiescent(samples: [HostedSettingsWindowSample]) {
@@ -103,10 +108,12 @@ final class HostedSettingsEvaluationStatus: ObservableObject {
             samples: samples
         )
         guard let data = try? JSONEncoder().encode(envelope) else {
-            geometryPayload = "encoding-failed"
             return
         }
-        geometryPayload = data.base64EncodedString()
+        let chunks = HostedSettingsGeometryAccessibilityChunk.chunks(data)
+        guard !chunks.isEmpty else { return }
+        geometryAccessibilityChunks = chunks
+        geometryAccessibilityManifest = "ndsg1-chunks:\(chunks.count)"
         accessibilityIdentifier = "neondiff.evaluation.settings.quiescent"
     }
 }
@@ -148,16 +155,24 @@ private struct HostedSettingsEvaluationMarker: View {
             Color.clear
                 .frame(width: 1, height: 1)
                 .accessibilityElement(children: .ignore)
-                .accessibilityLabel("NeonDiff Settings observed text size")
+                .accessibilityLabel(
+                    "ndst1:\(dynamicTypeSize.evaluationIdentifier)"
+                )
                 .accessibilityIdentifier("neondiff.evaluation.settings.text-size")
-                .accessibilityValue(dynamicTypeSize.evaluationIdentifier)
 
             Color.clear
                 .frame(width: 1, height: 1)
                 .accessibilityElement(children: .ignore)
-                .accessibilityLabel("NeonDiff Settings AppKit geometry")
+                .accessibilityLabel(status.geometryAccessibilityManifest)
                 .accessibilityIdentifier("neondiff.evaluation.settings.appkit-geometry")
-                .accessibilityValue(status.geometryPayload)
+
+            ForEach(status.geometryAccessibilityChunks) { chunk in
+                Color.clear
+                    .frame(width: 1, height: 1)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(chunk.label)
+                    .accessibilityIdentifier(chunk.identifier)
+            }
         }
         .allowsHitTesting(false)
     }
@@ -258,6 +273,33 @@ fileprivate struct HostedSettingsWindowCoordinateSpaces: Codable {
     let contentLayoutRect: String
     let contentLayoutScreenRect: String
     let visibleScreenFrame: String
+}
+
+struct HostedSettingsGeometryAccessibilityChunk: Identifiable, Equatable {
+    let identifier: String
+    let label: String
+
+    var id: String { identifier }
+
+    static func chunks(_ data: Data) -> [Self] {
+        let chunkByteCount = 64
+        let chunkCount = (data.count + chunkByteCount - 1) / chunkByteCount
+        guard chunkCount > 0 else { return [] }
+        let chunks = (0..<chunkCount).compactMap { index -> Self? in
+            let lowerBound = index * chunkByteCount
+            let upperBound = min(lowerBound + chunkByteCount, data.count)
+            guard lowerBound < upperBound else { return nil }
+            let encoded = data.subdata(in: lowerBound..<upperBound)
+                .base64EncodedString()
+            let label = "ndsg1:\(index):\(chunkCount):\(encoded)"
+            guard label.utf8.count <= 128 else { return nil }
+            return Self(
+                identifier: "neondiff.evaluation.settings.appkit-geometry.\(index)",
+                label: label
+            )
+        }
+        return chunks.count == chunkCount ? chunks : []
+    }
 }
 
 fileprivate struct HostedSettingsWindowSample: Codable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -126,7 +126,7 @@ extension View {
     ) -> some View {
         if enabled {
             accessibilityElement(children: .contain)
-                .accessibilityIdentifier("neondiff-settings-window-content")
+                .accessibilityIdentifier("neondiff-settings-evaluation-container")
                 .overlay(alignment: .topLeading) {
                     HostedSettingsEvaluationMarker(status: status)
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import NeonDiffDesktopAppCore
 
@@ -77,3 +78,155 @@ struct SettingsPane: View {
         .scrollContentBackground(.hidden)
     }
 }
+
+#if DEBUG
+@MainActor
+final class HostedSettingsEvaluationStatus: ObservableObject {
+    @Published private(set) var accessibilityIdentifier =
+        "neondiff.evaluation.settings.rendering"
+
+    func reset() {
+        accessibilityIdentifier = "neondiff.evaluation.settings.rendering"
+    }
+
+    func markQuiescent() {
+        accessibilityIdentifier = "neondiff.evaluation.settings.quiescent"
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func hostedSettingsEvaluationContent(
+        enabled: Bool,
+        status: HostedSettingsEvaluationStatus
+    ) -> some View {
+        if enabled {
+            accessibilityElement(children: .contain)
+                .accessibilityIdentifier("neondiff-settings-window-content")
+                .overlay(alignment: .topLeading) {
+                    HostedSettingsEvaluationMarker(status: status)
+                }
+                .background(
+                    HostedSettingsWindowConfigurator(status: status)
+                        .allowsHitTesting(false)
+                )
+        } else {
+            self
+        }
+    }
+}
+
+private struct HostedSettingsEvaluationMarker: View {
+    @ObservedObject var status: HostedSettingsEvaluationStatus
+
+    var body: some View {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("NeonDiff Settings evaluation state")
+            .accessibilityIdentifier(status.accessibilityIdentifier)
+            .allowsHitTesting(false)
+    }
+}
+
+struct HostedSettingsWindowConfigurator: NSViewRepresentable {
+    @ObservedObject var status: HostedSettingsEvaluationStatus
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(status: status)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        NSView(frame: .zero)
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        context.coordinator.monitor(view: view)
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: Coordinator) {
+        coordinator.cancel()
+    }
+
+    @MainActor
+    final class Coordinator {
+        private let status: HostedSettingsEvaluationStatus
+        private weak var monitoredView: NSView?
+        private var monitorTask: Task<Void, Never>?
+        private var completed = false
+
+        init(status: HostedSettingsEvaluationStatus) {
+            self.status = status
+        }
+
+        func monitor(view: NSView) {
+            if monitoredView !== view {
+                monitoredView = view
+                monitorTask?.cancel()
+                monitorTask = nil
+                completed = false
+                status.reset()
+            }
+            guard !completed, monitorTask == nil else { return }
+            monitorTask = Task { @MainActor [weak self, weak view] in
+                guard let self else { return }
+                let deadline = ProcessInfo.processInfo.systemUptime + 5
+                var stableSamples: [HostedSettingsWindowSample] = []
+                while !Task.isCancelled,
+                      ProcessInfo.processInfo.systemUptime <= deadline {
+                    guard let window = view?.window else {
+                        try? await Task.sleep(for: .milliseconds(20))
+                        continue
+                    }
+                    window.contentView?.layoutSubtreeIfNeeded()
+                    let sample = HostedSettingsWindowSample(
+                        windowFrame: window.frame,
+                        contentLayoutRect: window.contentLayoutRect
+                    )
+                    if let previous = stableSamples.last,
+                       previous.differs(from: sample, byMoreThan: 1) {
+                        stableSamples = [sample]
+                    } else {
+                        stableSamples.append(sample)
+                    }
+                    if stableSamples.count == 3 {
+                        completed = true
+                        status.markQuiescent()
+                        monitorTask = nil
+                        return
+                    }
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+                monitorTask = nil
+            }
+        }
+
+        func cancel() {
+            monitorTask?.cancel()
+            monitorTask = nil
+        }
+    }
+}
+
+private struct HostedSettingsWindowSample {
+    let windowFrame: CGRect
+    let contentLayoutRect: CGRect
+
+    func differs(from other: Self, byMoreThan tolerance: CGFloat) -> Bool {
+        windowFrame.differs(from: other.windowFrame, byMoreThan: tolerance)
+            || contentLayoutRect.differs(
+                from: other.contentLayoutRect,
+                byMoreThan: tolerance
+            )
+    }
+}
+
+private extension CGRect {
+    func differs(from other: CGRect, byMoreThan tolerance: CGFloat) -> Bool {
+        abs(origin.x - other.origin.x) > tolerance
+            || abs(origin.y - other.origin.y) > tolerance
+            || abs(width - other.width) > tolerance
+            || abs(height - other.height) > tolerance
+    }
+}
+#endif

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -94,7 +94,12 @@ final class HostedSettingsEvaluationStatus: ObservableObject {
     fileprivate func markQuiescent(samples: [HostedSettingsWindowSample]) {
         let envelope = HostedSettingsWindowGeometryEnvelope(
             schemaVersion: 1,
-            coordinateSpace: "appkit-screen",
+            coordinateSpaces: HostedSettingsWindowCoordinateSpaces(
+                windowFrame: "appkit-screen",
+                contentLayoutRect: "appkit-window",
+                contentLayoutScreenRect: "appkit-screen",
+                visibleScreenFrame: "appkit-screen"
+            ),
             samples: samples
         )
         guard let data = try? JSONEncoder().encode(envelope) else {
@@ -244,8 +249,15 @@ struct HostedSettingsWindowConfigurator: NSViewRepresentable {
 
 fileprivate struct HostedSettingsWindowGeometryEnvelope: Codable {
     let schemaVersion: Int
-    let coordinateSpace: String
+    let coordinateSpaces: HostedSettingsWindowCoordinateSpaces
     let samples: [HostedSettingsWindowSample]
+}
+
+fileprivate struct HostedSettingsWindowCoordinateSpaces: Codable {
+    let windowFrame: String
+    let contentLayoutRect: String
+    let contentLayoutScreenRect: String
+    let visibleScreenFrame: String
 }
 
 fileprivate struct HostedSettingsWindowSample: Codable {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -554,9 +554,20 @@ final class NeonDiffDesktopUITests: XCTestCase {
         let textSizeMarker = app.descendants(matching: .any)[
             "neondiff.evaluation.settings.text-size"
         ]
-        guard textSizeMarker.waitForExistence(timeout: 2),
-              let observedTextSize = textSizeMarker.value as? String,
-              !observedTextSize.isEmpty,
+        let textSizePrefix = "ndst1:"
+        guard textSizeMarker.waitForExistence(timeout: 2) else {
+            throw HostedSettingsSceneTraceError.missingElement(
+                "neondiff.evaluation.settings.text-size"
+            )
+        }
+        let textSizeLabel = textSizeMarker.label
+        guard textSizeLabel.hasPrefix(textSizePrefix) else {
+            throw HostedSettingsSceneTraceError.invalidObservedTextSize(
+                request.textSizeMode
+            )
+        }
+        let observedTextSize = String(textSizeLabel.dropFirst(textSizePrefix.count))
+        guard !observedTextSize.isEmpty,
               observedTextSize != "unknown" else {
             throw HostedSettingsSceneTraceError.invalidObservedTextSize(
                 request.textSizeMode
@@ -578,6 +589,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
             )
         }
         let appKitGeometry = try decodeAndValidateSettingsAppKitGeometry(
+            app: app,
             marker: geometryMarker,
             requestedContentSize: requestedContentSize,
             context: request.textSizeMode
@@ -660,15 +672,44 @@ final class NeonDiffDesktopUITests: XCTestCase {
     }
 
     private func decodeAndValidateSettingsAppKitGeometry(
+        app: XCUIApplication,
         marker: XCUIElement,
         requestedContentSize: HostedContentSize,
         context: String
     ) throws -> HostedSettingsAppKitGeometryEnvelope {
-        guard let encodedPayload = marker.value as? String,
-              encodedPayload != "unavailable",
-              encodedPayload != "encoding-failed",
-              let data = Data(base64Encoded: encodedPayload),
-              let envelope = try? JSONDecoder().decode(
+        let manifestPrefix = "ndsg1-chunks:"
+        let manifest = marker.label
+        guard manifest.hasPrefix(manifestPrefix),
+              let chunkCount = Int(manifest.dropFirst(manifestPrefix.count)),
+              chunkCount > 0,
+              chunkCount <= 64 else {
+            throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
+        }
+        var data = Data()
+        for index in 0..<chunkCount {
+            let chunk = app.descendants(matching: .any)[
+                "neondiff.evaluation.settings.appkit-geometry.\(index)"
+            ]
+            guard chunk.waitForExistence(timeout: 2) else {
+                throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
+            }
+            guard !chunk.isHittable else {
+                throw HostedSettingsSceneTraceError.interactiveGeometryChunk(index)
+            }
+            let prefix = "ndsg1:\(index):\(chunkCount):"
+            let label = chunk.label
+            guard label.hasPrefix(prefix),
+                  let decoded = Data(
+                      base64Encoded: String(label.dropFirst(prefix.count))
+                  ),
+                  !decoded.isEmpty,
+                  decoded.count <= 64,
+                  (index == chunkCount - 1 || decoded.count == 64) else {
+                throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
+            }
+            data.append(decoded)
+        }
+        guard let envelope = try? JSONDecoder().decode(
                   HostedSettingsAppKitGeometryEnvelope.self,
                   from: data
               ) else {
@@ -686,6 +727,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
         for sample in envelope.samples {
             guard sample.windowFrame.isFiniteAndNonempty,
                   sample.contentLayoutRect.isFiniteAndNonempty,
+                  sample.contentLayoutScreenRect.isFiniteAndNonempty,
                   sample.visibleScreenFrame.isFiniteAndNonempty,
                   sample.contentLayoutRect.matches(
                       requestedContentSize,
@@ -2717,6 +2759,7 @@ private enum HostedSettingsSceneTraceError: LocalizedError {
     case invalidObservedTextSize(String)
     case unexpectedObservedTextSize(expected: String, observed: String)
     case invalidAppKitGeometryPayload(String)
+    case interactiveGeometryChunk(Int)
     case invalidAppKitGeometry(String)
     case unstableAppKitGeometry(String)
     case unexpectedWindowCount(before: Int, after: Int)
@@ -2749,6 +2792,8 @@ private enum HostedSettingsSceneTraceError: LocalizedError {
                 + "expected=\(expected) observed=\(observed)"
         case .invalidAppKitGeometryPayload(let context):
             "Hosted Settings AppKit geometry payload is invalid: \(context)"
+        case .interactiveGeometryChunk(let index):
+            "Hosted Settings AppKit geometry chunk is interactive: \(index)"
         case .invalidAppKitGeometry(let context):
             "Hosted Settings AppKit geometry is invalid or not contained: \(context)"
         case .unstableAppKitGeometry(let context):

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -478,7 +478,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 samplingDeadlineMilliseconds: 5_000,
                 tolerancePoints: 1,
                 scenarios: scenarios,
-                proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-visible-screen-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"
+                proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-title-edge-and-outer-page-bottom-only-host-visible-screen-full-containment-system-preference-inner-scroll-manual-excluded"
             )
         )
     }
@@ -745,7 +745,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                       in: sample.windowFrame,
                       tolerance: 1
                   ),
-                  sample.windowFrame.isFullyContained(
+                  sample.windowFrame.hasAccessibleTopEdge(
                       in: sample.visibleScreenFrame,
                       tolerance: 1
                   ) else {
@@ -2552,6 +2552,16 @@ private struct HostedSettingsAppKitFrame: Codable {
             && y >= -tolerance
             && x + width <= windowFrame.width + tolerance
             && y + height <= windowFrame.height + tolerance
+    }
+
+    func hasAccessibleTopEdge(in visibleScreen: Self, tolerance: Double) -> Bool {
+        // Canonical fixture sizes intentionally remain independent of the
+        // hosted runner's Dock-reduced visible height. Keep the title edge and
+        // full window width accessible without claiming whole-screen fit.
+        x >= visibleScreen.x - tolerance
+            && x + width <= visibleScreen.x + visibleScreen.width + tolerance
+            && y + height >= visibleScreen.y - tolerance
+            && y + height <= visibleScreen.y + visibleScreen.height + tolerance
     }
 
     func differs(from other: Self, byMoreThan tolerance: Double) -> Bool {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -478,7 +478,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 samplingDeadlineMilliseconds: 5_000,
                 tolerancePoints: 1,
                 scenarios: scenarios,
-                proofBoundary: "hosted-separate-settings-scene-560x700-default-and-accessibility3-outer-geometry-and-page-bottom-only-system-preference-inner-scroll-manual-excluded"
+                proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-visible-screen-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"
             )
         )
     }
@@ -551,6 +551,37 @@ final class NeonDiffDesktopUITests: XCTestCase {
         guard !marker.isHittable else {
             throw HostedSettingsSceneTraceError.interactiveQuiescenceMarker
         }
+        let textSizeMarker = app.descendants(matching: .any)[
+            "neondiff.evaluation.settings.text-size"
+        ]
+        guard textSizeMarker.waitForExistence(timeout: 2),
+              let observedTextSize = textSizeMarker.value as? String,
+              !observedTextSize.isEmpty,
+              observedTextSize != "unknown" else {
+            throw HostedSettingsSceneTraceError.invalidObservedTextSize(
+                request.textSizeMode
+            )
+        }
+        if request.textSizeArgument == "accessibility3",
+           observedTextSize != "accessibility3" {
+            throw HostedSettingsSceneTraceError.unexpectedObservedTextSize(
+                expected: "accessibility3",
+                observed: observedTextSize
+            )
+        }
+        let geometryMarker = app.descendants(matching: .any)[
+            "neondiff.evaluation.settings.appkit-geometry"
+        ]
+        guard geometryMarker.waitForExistence(timeout: 2) else {
+            throw HostedSettingsSceneTraceError.missingElement(
+                "neondiff.evaluation.settings.appkit-geometry"
+            )
+        }
+        let appKitGeometry = try decodeAndValidateSettingsAppKitGeometry(
+            marker: geometryMarker,
+            requestedContentSize: requestedContentSize,
+            context: request.textSizeMode
+        )
         let outerScroll = app.descendants(matching: .any)[
             "neondiff-settings-outer-scroll"
         ]
@@ -617,13 +648,74 @@ final class NeonDiffDesktopUITests: XCTestCase {
         return HostedSettingsSceneScenario(
             textSizeMode: request.textSizeMode,
             launchTextSizeArgument: request.textSizeArgument,
+            observedSettingsTextSize: observedTextSize,
             fixtureRootIdentifier: rootIdentifier,
             quiescenceMarkerIdentifier: markerIdentifier,
             openAction: openAction,
+            appKitGeometry: appKitGeometry,
             preActionSamples: preActionSamples,
             scrollAction: scrollAction,
             postActionSamples: postActionSamples
         )
+    }
+
+    private func decodeAndValidateSettingsAppKitGeometry(
+        marker: XCUIElement,
+        requestedContentSize: HostedContentSize,
+        context: String
+    ) throws -> HostedSettingsAppKitGeometryEnvelope {
+        guard let encodedPayload = marker.value as? String,
+              encodedPayload != "unavailable",
+              encodedPayload != "encoding-failed",
+              let data = Data(base64Encoded: encodedPayload),
+              let envelope = try? JSONDecoder().decode(
+                  HostedSettingsAppKitGeometryEnvelope.self,
+                  from: data
+              ) else {
+            throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
+        }
+        guard envelope.schemaVersion == 1,
+              envelope.coordinateSpace == "appkit-screen",
+              envelope.samples.count == 3,
+              let baseline = envelope.samples.first else {
+            throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
+        }
+        for sample in envelope.samples {
+            guard sample.windowFrame.isFiniteAndNonempty,
+                  sample.contentLayoutRect.isFiniteAndNonempty,
+                  sample.visibleScreenFrame.isFiniteAndNonempty,
+                  sample.contentLayoutRect.matches(
+                      requestedContentSize,
+                      tolerance: 1
+                  ),
+                  sample.contentLayoutRect.isFullyContained(
+                      in: sample.windowFrame,
+                      tolerance: 1
+                  ),
+                  sample.windowFrame.isFullyContained(
+                      in: sample.visibleScreenFrame,
+                      tolerance: 1
+                  ) else {
+                throw HostedSettingsSceneTraceError.invalidAppKitGeometry(context)
+            }
+        }
+        for sample in envelope.samples.dropFirst() {
+            guard !baseline.windowFrame.differs(
+                      from: sample.windowFrame,
+                      byMoreThan: 1
+                  ),
+                  !baseline.contentLayoutRect.differs(
+                      from: sample.contentLayoutRect,
+                      byMoreThan: 1
+                  ),
+                  !baseline.visibleScreenFrame.differs(
+                      from: sample.visibleScreenFrame,
+                      byMoreThan: 1
+                  ) else {
+                throw HostedSettingsSceneTraceError.unstableAppKitGeometry(context)
+            }
+        }
+        return envelope
     }
 
     private func captureStableSettingsSceneSamples(
@@ -2342,12 +2434,57 @@ private struct HostedSettingsSceneSample: Codable, Equatable {
 private struct HostedSettingsSceneScenario: Codable {
     let textSizeMode: String
     let launchTextSizeArgument: String?
+    let observedSettingsTextSize: String
     let fixtureRootIdentifier: String
     let quiescenceMarkerIdentifier: String
     let openAction: HostedSettingsOpenAction
+    let appKitGeometry: HostedSettingsAppKitGeometryEnvelope
     let preActionSamples: [HostedSettingsSceneSample]
     let scrollAction: HostedSettingsScrollAction?
     let postActionSamples: [HostedSettingsSceneSample]
+}
+
+private struct HostedSettingsAppKitGeometryEnvelope: Codable {
+    let schemaVersion: Int
+    let coordinateSpace: String
+    let samples: [HostedSettingsAppKitSample]
+}
+
+private struct HostedSettingsAppKitSample: Codable {
+    let windowFrame: HostedSettingsAppKitFrame
+    let contentLayoutRect: HostedSettingsAppKitFrame
+    let visibleScreenFrame: HostedSettingsAppKitFrame
+}
+
+private struct HostedSettingsAppKitFrame: Codable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    var isFiniteAndNonempty: Bool {
+        x.isFinite && y.isFinite && width.isFinite && height.isFinite
+            && width > 0 && height > 0
+    }
+
+    func matches(_ size: HostedContentSize, tolerance: Double) -> Bool {
+        abs(width - Double(size.width)) <= tolerance
+            && abs(height - Double(size.height)) <= tolerance
+    }
+
+    func isFullyContained(in container: Self, tolerance: Double) -> Bool {
+        x >= container.x - tolerance
+            && y >= container.y - tolerance
+            && x + width <= container.x + container.width + tolerance
+            && y + height <= container.y + container.height + tolerance
+    }
+
+    func differs(from other: Self, byMoreThan tolerance: Double) -> Bool {
+        abs(x - other.x) > tolerance
+            || abs(y - other.y) > tolerance
+            || abs(width - other.width) > tolerance
+            || abs(height - other.height) > tolerance
+    }
 }
 
 private struct HostedSettingsSceneTrace: Codable {
@@ -2544,6 +2681,11 @@ private enum HostedSettingsSceneTraceError: LocalizedError {
     case appNotForeground
     case missingElement(String)
     case interactiveQuiescenceMarker
+    case invalidObservedTextSize(String)
+    case unexpectedObservedTextSize(expected: String, observed: String)
+    case invalidAppKitGeometryPayload(String)
+    case invalidAppKitGeometry(String)
+    case unstableAppKitGeometry(String)
     case unexpectedWindowCount(before: Int, after: Int)
     case invalidFrame(String)
     case unexpectedContentSize(
@@ -2567,6 +2709,17 @@ private enum HostedSettingsSceneTraceError: LocalizedError {
             "Missing hosted Settings element: \(identifier)"
         case .interactiveQuiescenceMarker:
             "Hosted Settings quiescence marker is unexpectedly interactive"
+        case .invalidObservedTextSize(let context):
+            "Hosted Settings did not expose its observed text size: \(context)"
+        case let .unexpectedObservedTextSize(expected, observed):
+            "Hosted Settings observed text size does not match the override: "
+                + "expected=\(expected) observed=\(observed)"
+        case .invalidAppKitGeometryPayload(let context):
+            "Hosted Settings AppKit geometry payload is invalid: \(context)"
+        case .invalidAppKitGeometry(let context):
+            "Hosted Settings AppKit geometry is invalid or not contained: \(context)"
+        case .unstableAppKitGeometry(let context):
+            "Hosted Settings AppKit geometry drift exceeded one point: \(context)"
         case let .unexpectedWindowCount(before, after):
             "Hosted Settings command did not create exactly one window: "
                 + "before=\(before) after=\(after)"

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -448,6 +448,309 @@ final class NeonDiffDesktopUITests: XCTestCase {
         )
     }
 
+    func testSeparateSettingsSceneSettlesAtCanonicalSizeAndReachesPageBottom() throws {
+        let requestedContentSize = HostedContentSize(width: 560, height: 700)
+        let requests = [
+            HostedSettingsTextSizeRequest(textSizeMode: "runner-default-no-test-override", textSizeArgument: nil),
+            HostedSettingsTextSizeRequest(textSizeMode: "swiftui-dynamic-type-accessibility3-test-override", textSizeArgument: "accessibility3")
+        ]
+        var scenarios: [HostedSettingsSceneScenario] = []
+        for request in requests {
+            scenarios.append(
+                try captureSettingsSceneScenario(
+                    request,
+                    requestedContentSize: requestedContentSize
+                )
+            )
+        }
+
+        XCTAssertEqual(scenarios.count, 2)
+        guard (testRun?.failureCount ?? 0) == 0 else {
+            throw HostedSettingsSceneTraceError.priorValidationFailure
+        }
+        try attach(
+            HostedSettingsSceneTrace(
+                schemaVersion: 1,
+                fixtureId: "tab-overview",
+                requestedContentSize: requestedContentSize,
+                coordinateSpace: "xcui-screen",
+                sampleIntervalMilliseconds: 100,
+                samplingDeadlineMilliseconds: 5_000,
+                tolerancePoints: 1,
+                scenarios: scenarios,
+                proofBoundary: "hosted-separate-settings-scene-560x700-default-and-accessibility3-outer-geometry-and-page-bottom-only-system-preference-inner-scroll-manual-excluded"
+            )
+        )
+    }
+
+    private func captureSettingsSceneScenario(
+        _ request: HostedSettingsTextSizeRequest,
+        requestedContentSize: HostedContentSize
+    ) throws -> HostedSettingsSceneScenario {
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "tab-overview", withExtension: "json")
+        )
+        let app = XCUIApplication()
+        defer { app.terminate() }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "1040x680",
+            "--disable-animations"
+        ]
+        if let textSizeArgument = request.textSizeArgument {
+            app.launchArguments.append(contentsOf: ["--text-size", textSizeArgument])
+        }
+        app.launch()
+
+        let rootIdentifier = request.textSizeArgument == nil
+            ? "neondiff.fixture.tab-overview"
+            : "neondiff.fixture.tab-overview.text-size.accessibility3"
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            app.descendants(matching: .any)[rootIdentifier]
+                .waitForExistence(timeout: 10)
+        )
+        guard app.state == .runningForeground else {
+            throw HostedSettingsSceneTraceError.appNotForeground
+        }
+
+        let windowCountBeforeAction = app.windows.count
+        let openActionStart = ProcessInfo.processInfo.systemUptime
+        app.typeKey(",", modifierFlags: [.command])
+        let settingsContent = app.descendants(matching: .any)[
+            "neondiff-settings-window-content"
+        ]
+        guard settingsContent.waitForExistence(timeout: 10) else {
+            throw HostedSettingsSceneTraceError.missingElement(
+                "neondiff-settings-window-content"
+            )
+        }
+        let openAction = HostedSettingsOpenAction(
+            method: "automated-command-comma",
+            attemptCount: 1,
+            result: "settings-window-content-observed",
+            elapsedMilliseconds: Int(
+                ((ProcessInfo.processInfo.systemUptime - openActionStart) * 1_000).rounded()
+            ),
+            windowCountBefore: windowCountBeforeAction,
+            windowCountAfter: app.windows.count
+        )
+        guard openAction.windowCountAfter == openAction.windowCountBefore + 1 else {
+            throw HostedSettingsSceneTraceError.unexpectedWindowCount(
+                before: openAction.windowCountBefore,
+                after: openAction.windowCountAfter
+            )
+        }
+
+        let markerIdentifier = "neondiff.evaluation.settings.quiescent"
+        let marker = app.descendants(matching: .any)[markerIdentifier]
+        guard marker.waitForExistence(timeout: 10) else {
+            throw HostedSettingsSceneTraceError.missingElement(markerIdentifier)
+        }
+        guard !marker.isHittable else {
+            throw HostedSettingsSceneTraceError.interactiveQuiescenceMarker
+        }
+        let outerScroll = app.descendants(matching: .any)[
+            "neondiff-settings-outer-scroll"
+        ]
+        let bottomSentinel = app.descendants(matching: .any)[
+            "neondiff-settings-page-bottom"
+        ]
+        guard outerScroll.waitForExistence(timeout: 2) else {
+            throw HostedSettingsSceneTraceError.missingElement(
+                "neondiff-settings-outer-scroll"
+            )
+        }
+        guard bottomSentinel.waitForExistence(timeout: 2) else {
+            throw HostedSettingsSceneTraceError.missingElement(
+                "neondiff-settings-page-bottom"
+            )
+        }
+
+        let preActionSamples = try captureStableSettingsSceneSamples(
+            app: app,
+            settingsContent: settingsContent,
+            outerScroll: outerScroll,
+            bottomSentinel: bottomSentinel,
+            requestedContentSize: requestedContentSize,
+            context: "\(request.textSizeMode)-pre"
+        )
+        let scrollAction: HostedSettingsScrollAction?
+        let postActionSamples: [HostedSettingsSceneSample]
+        if preActionSamples.allSatisfy(\.sentinelFullyContainedInOuterScroll) {
+            scrollAction = nil
+            postActionSamples = preActionSamples
+        } else {
+            outerScroll.scroll(byDeltaX: 0, deltaY: -10_000)
+            postActionSamples = try captureStableSettingsSceneSamples(
+                app: app,
+                settingsContent: settingsContent,
+                outerScroll: outerScroll,
+                bottomSentinel: bottomSentinel,
+                requestedContentSize: requestedContentSize,
+                context: "\(request.textSizeMode)-post"
+            )
+            guard let preActionSentinelFrame = preActionSamples.last?.sentinelFrame,
+                  let postActionSentinelFrame = postActionSamples.first?.sentinelFrame,
+                  preActionSentinelFrame.differs(
+                      from: postActionSentinelFrame,
+                      byMoreThan: 1
+                  ) else {
+                throw HostedSettingsSceneTraceError.scrollHadNoEffect(
+                    request.textSizeMode
+                )
+            }
+            scrollAction = HostedSettingsScrollAction(
+                controlIdentifier: "neondiff-settings-outer-scroll",
+                deltaX: 0,
+                deltaY: -10_000,
+                attemptCount: 1,
+                result: "returned",
+                effectProven: true
+            )
+        }
+        guard postActionSamples.allSatisfy(\.sentinelFullyContainedInOuterScroll) else {
+            throw HostedSettingsSceneTraceError.sentinelNotContained(request.textSizeMode)
+        }
+
+        return HostedSettingsSceneScenario(
+            textSizeMode: request.textSizeMode,
+            launchTextSizeArgument: request.textSizeArgument,
+            fixtureRootIdentifier: rootIdentifier,
+            quiescenceMarkerIdentifier: markerIdentifier,
+            openAction: openAction,
+            preActionSamples: preActionSamples,
+            scrollAction: scrollAction,
+            postActionSamples: postActionSamples
+        )
+    }
+
+    private func captureStableSettingsSceneSamples(
+        app: XCUIApplication,
+        settingsContent: XCUIElement,
+        outerScroll: XCUIElement,
+        bottomSentinel: XCUIElement,
+        requestedContentSize: HostedContentSize,
+        context: String
+    ) throws -> [HostedSettingsSceneSample] {
+        let start = ProcessInfo.processInfo.systemUptime
+        var samples: [HostedSettingsSceneSample] = []
+        var previousSampleStart: TimeInterval?
+        for index in 0..<3 {
+            if index > 0, let previousSampleStart {
+                let elapsedSincePrevious =
+                    ProcessInfo.processInfo.systemUptime - previousSampleStart
+                let remainingDelay = max(0, 0.1 - elapsedSincePrevious)
+                if remainingDelay > 0 {
+                    RunLoop.current.run(until: Date().addingTimeInterval(remainingDelay))
+                }
+            }
+            let sampleStart = ProcessInfo.processInfo.systemUptime
+            previousSampleStart = sampleStart
+            let settingsContentFrame = HostedGeometryFrame(settingsContent.frame)
+            let windowFrame = try settingsContainingWindowFrame(
+                app: app,
+                settingsContentFrame: settingsContentFrame,
+                context: context
+            )
+            let outerScrollFrame = HostedGeometryFrame(outerScroll.frame)
+            let sentinelFrame = HostedGeometryFrame(bottomSentinel.frame)
+            guard settingsContentFrame.isFiniteAndNonempty,
+                  windowFrame.isFiniteAndNonempty,
+                  outerScrollFrame.isFiniteAndNonempty,
+                  sentinelFrame.isFiniteAndNonempty else {
+                throw HostedSettingsSceneTraceError.invalidFrame(context)
+            }
+            guard settingsContentFrame.matches(requestedContentSize, tolerance: 1) else {
+                throw HostedSettingsSceneTraceError.unexpectedContentSize(
+                    requested: requestedContentSize,
+                    observed: settingsContentFrame
+                )
+            }
+            let sample = HostedSettingsSceneSample(
+                elapsedMilliseconds: Int(((sampleStart - start) * 1_000).rounded()),
+                completionElapsedMilliseconds: Int(
+                    ((ProcessInfo.processInfo.systemUptime - start) * 1_000).rounded()
+                ),
+                windowFrame: windowFrame,
+                settingsContentFrame: settingsContentFrame,
+                outerScrollFrame: outerScrollFrame,
+                sentinelFrame: sentinelFrame,
+                settingsContentFullyContainedInWindow: settingsContentFrame.isFullyContained(
+                    in: windowFrame,
+                    tolerance: 1
+                ),
+                outerScrollFullyContainedInSettingsContent: outerScrollFrame.isFullyContained(
+                    in: settingsContentFrame,
+                    tolerance: 1
+                ),
+                sentinelFullyContainedInOuterScroll: sentinelFrame.isFullyContained(
+                    in: outerScrollFrame,
+                    tolerance: 1
+                )
+            )
+            guard sample.settingsContentFullyContainedInWindow,
+                  sample.outerScrollFullyContainedInSettingsContent else {
+                throw HostedSettingsSceneTraceError.invalidContainment(context)
+            }
+            samples.append(sample)
+        }
+
+        guard samples.count == 3,
+              samples[0].elapsedMilliseconds >= 0,
+              samples[0].elapsedMilliseconds <= 25,
+              let finalCompletionElapsedMilliseconds =
+                  samples.last?.completionElapsedMilliseconds,
+              finalCompletionElapsedMilliseconds <= 5_000 else {
+            throw HostedSettingsSceneTraceError.invalidCadence(context)
+        }
+        for (lhs, rhs) in zip(samples, samples.dropFirst()) {
+            guard rhs.elapsedMilliseconds - lhs.elapsedMilliseconds >= 90 else {
+                throw HostedSettingsSceneTraceError.invalidCadence(context)
+            }
+        }
+        guard let baseline = samples.first else {
+            throw HostedSettingsSceneTraceError.invalidCadence(context)
+        }
+        for sample in samples.dropFirst() {
+            guard !baseline.windowFrame.differs(from: sample.windowFrame, byMoreThan: 1),
+                  !baseline.settingsContentFrame.differs(
+                      from: sample.settingsContentFrame,
+                      byMoreThan: 1
+                  ),
+                  !baseline.outerScrollFrame.differs(
+                      from: sample.outerScrollFrame,
+                      byMoreThan: 1
+                  ),
+                  !baseline.sentinelFrame.differs(
+                      from: sample.sentinelFrame,
+                      byMoreThan: 1
+                  ) else {
+                throw HostedSettingsSceneTraceError.unstableGeometry(context)
+            }
+        }
+        return samples
+    }
+
+    private func settingsContainingWindowFrame(
+        app: XCUIApplication,
+        settingsContentFrame: HostedGeometryFrame,
+        context: String
+    ) throws -> HostedGeometryFrame {
+        let candidates = (0..<app.windows.count)
+            .map { HostedGeometryFrame(app.windows.element(boundBy: $0).frame) }
+            .filter {
+                $0.isFiniteAndNonempty
+                    && settingsContentFrame.isFullyContained(in: $0, tolerance: 1)
+            }
+            .sorted { $0.area < $1.area }
+        guard let windowFrame = candidates.first else {
+            throw HostedSettingsSceneTraceError.missingContainingWindow(context)
+        }
+        return windowFrame
+    }
+
     func testStrictFixtureSettlesAcrossEveryOnboardingStepAtCanonicalSize() throws {
         let requestedContentSize = HostedContentSize(width: 760, height: 560)
         let fixtureSteps = [
@@ -1651,6 +1954,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
         add(attachment)
     }
 
+    private func attach(_ trace: HostedSettingsSceneTrace) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let attachment = XCTAttachment(
+            data: try encoder.encode(trace),
+            uniformTypeIdentifier: "public.json"
+        )
+        attachment.name = "neondiff-hosted-settings-scene.json"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func attachTransportDiagnostic(_ diagnostic: HostedTransportDiagnostic) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -1989,6 +2304,64 @@ private struct HostedOnboardingMatrixTrace: Codable {
     let proofBoundary: String
 }
 
+private struct HostedSettingsTextSizeRequest {
+    let textSizeMode: String
+    let textSizeArgument: String?
+}
+
+private struct HostedSettingsOpenAction: Codable {
+    let method: String
+    let attemptCount: Int
+    let result: String
+    let elapsedMilliseconds: Int
+    let windowCountBefore: Int
+    let windowCountAfter: Int
+}
+
+private struct HostedSettingsScrollAction: Codable {
+    let controlIdentifier: String
+    let deltaX: Double
+    let deltaY: Double
+    let attemptCount: Int
+    let result: String
+    let effectProven: Bool
+}
+
+private struct HostedSettingsSceneSample: Codable, Equatable {
+    let elapsedMilliseconds: Int
+    let completionElapsedMilliseconds: Int
+    let windowFrame: HostedGeometryFrame
+    let settingsContentFrame: HostedGeometryFrame
+    let outerScrollFrame: HostedGeometryFrame
+    let sentinelFrame: HostedGeometryFrame
+    let settingsContentFullyContainedInWindow: Bool
+    let outerScrollFullyContainedInSettingsContent: Bool
+    let sentinelFullyContainedInOuterScroll: Bool
+}
+
+private struct HostedSettingsSceneScenario: Codable {
+    let textSizeMode: String
+    let launchTextSizeArgument: String?
+    let fixtureRootIdentifier: String
+    let quiescenceMarkerIdentifier: String
+    let openAction: HostedSettingsOpenAction
+    let preActionSamples: [HostedSettingsSceneSample]
+    let scrollAction: HostedSettingsScrollAction?
+    let postActionSamples: [HostedSettingsSceneSample]
+}
+
+private struct HostedSettingsSceneTrace: Codable {
+    let schemaVersion: Int
+    let fixtureId: String
+    let requestedContentSize: HostedContentSize
+    let coordinateSpace: String
+    let sampleIntervalMilliseconds: Int
+    let samplingDeadlineMilliseconds: Int
+    let tolerancePoints: Double
+    let scenarios: [HostedSettingsSceneScenario]
+    let proofBoundary: String
+}
+
 private struct HostedGeometryCoordinateSpaces: Codable {
     let windowAndContent: String
     let regions: String
@@ -2162,6 +2535,58 @@ private enum HostedOnboardingTraceError: LocalizedError {
             "Hosted onboarding geometry drift exceeded one point: \(context)"
         case .invalidRegionLayout(let context):
             "Hosted onboarding regions overlap or are ordered incorrectly: \(context)"
+        }
+    }
+}
+
+private enum HostedSettingsSceneTraceError: LocalizedError {
+    case priorValidationFailure
+    case appNotForeground
+    case missingElement(String)
+    case interactiveQuiescenceMarker
+    case unexpectedWindowCount(before: Int, after: Int)
+    case invalidFrame(String)
+    case unexpectedContentSize(
+        requested: HostedContentSize,
+        observed: HostedGeometryFrame
+    )
+    case missingContainingWindow(String)
+    case invalidContainment(String)
+    case invalidCadence(String)
+    case unstableGeometry(String)
+    case scrollHadNoEffect(String)
+    case sentinelNotContained(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .priorValidationFailure:
+            "Hosted Settings trace withheld after an earlier validation failure"
+        case .appNotForeground:
+            "Hosted Settings fixture is not running in the foreground"
+        case .missingElement(let identifier):
+            "Missing hosted Settings element: \(identifier)"
+        case .interactiveQuiescenceMarker:
+            "Hosted Settings quiescence marker is unexpectedly interactive"
+        case let .unexpectedWindowCount(before, after):
+            "Hosted Settings command did not create exactly one window: "
+                + "before=\(before) after=\(after)"
+        case .invalidFrame(let context):
+            "Invalid hosted Settings frame: \(context)"
+        case let .unexpectedContentSize(requested, observed):
+            "Hosted Settings content size does not match the request: "
+                + "requested=\(requested.width)x\(requested.height) observed=\(observed)"
+        case .missingContainingWindow(let context):
+            "Hosted Settings content has no containing app window: \(context)"
+        case .invalidContainment(let context):
+            "Hosted Settings containment failed: \(context)"
+        case .invalidCadence(let context):
+            "Hosted Settings sample cadence is invalid: \(context)"
+        case .unstableGeometry(let context):
+            "Hosted Settings geometry drift exceeded one point: \(context)"
+        case .scrollHadNoEffect(let context):
+            "Hosted Settings outer scroll did not move the bottom sentinel: \(context)"
+        case .sentinelNotContained(let context):
+            "Hosted Settings bottom sentinel is not reachable: \(context)"
         }
     }
 }

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -688,7 +688,15 @@ final class NeonDiffDesktopUITests: XCTestCase {
                       requestedContentSize,
                       tolerance: 1
                   ),
-                  sample.contentLayoutRect.isFullyContained(
+                  sample.contentLayoutScreenRect.matches(
+                      requestedContentSize,
+                      tolerance: 1
+                  ),
+                  sample.contentLayoutRect.isFullyContainedInWindowBounds(
+                      windowFrame: sample.windowFrame,
+                      tolerance: 1
+                  ),
+                  sample.contentLayoutScreenRect.isFullyContained(
                       in: sample.windowFrame,
                       tolerance: 1
                   ),
@@ -706,6 +714,10 @@ final class NeonDiffDesktopUITests: XCTestCase {
                   ),
                   !baseline.contentLayoutRect.differs(
                       from: sample.contentLayoutRect,
+                      byMoreThan: 1
+                  ),
+                  !baseline.contentLayoutScreenRect.differs(
+                      from: sample.contentLayoutScreenRect,
                       byMoreThan: 1
                   ),
                   !baseline.visibleScreenFrame.differs(
@@ -2453,6 +2465,7 @@ private struct HostedSettingsAppKitGeometryEnvelope: Codable {
 private struct HostedSettingsAppKitSample: Codable {
     let windowFrame: HostedSettingsAppKitFrame
     let contentLayoutRect: HostedSettingsAppKitFrame
+    let contentLayoutScreenRect: HostedSettingsAppKitFrame
     let visibleScreenFrame: HostedSettingsAppKitFrame
 }
 
@@ -2477,6 +2490,16 @@ private struct HostedSettingsAppKitFrame: Codable {
             && y >= container.y - tolerance
             && x + width <= container.x + container.width + tolerance
             && y + height <= container.y + container.height + tolerance
+    }
+
+    func isFullyContainedInWindowBounds(
+        windowFrame: Self,
+        tolerance: Double
+    ) -> Bool {
+        x >= -tolerance
+            && y >= -tolerance
+            && x + width <= windowFrame.width + tolerance
+            && y + height <= windowFrame.height + tolerance
     }
 
     func differs(from other: Self, byMoreThan tolerance: Double) -> Bool {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -470,7 +470,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
         }
         try attach(
             HostedSettingsSceneTrace(
-                schemaVersion: 1,
+                schemaVersion: 2,
                 fixtureId: "tab-overview",
                 requestedContentSize: requestedContentSize,
                 coordinateSpace: "xcui-screen",
@@ -478,7 +478,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 samplingDeadlineMilliseconds: 5_000,
                 tolerancePoints: 1,
                 scenarios: scenarios,
-                proofBoundary: "hosted-separate-settings-preferred-560x700-visible-screen-fitted-root-and-appkit-content-layout-default-and-observed-accessibility3-window-contained-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"
+                proofBoundary: "hosted-separate-settings-preferred-560x700-appkit-window-and-content-layout-fitted-to-observed-visible-screen-xcui-window-dimension-bridge-outer-scroll-contained-and-page-bottom-reachable-runner-default-and-swiftui-accessibility3-test-override-only-system-text-preference-inner-scroll-manual-voiceover-focus-control-hittability-localization-multidisplay-relocation-installed-release-excluded"
             )
         )
     }
@@ -518,18 +518,18 @@ final class NeonDiffDesktopUITests: XCTestCase {
         let windowCountBeforeAction = app.windows.count
         let openActionStart = ProcessInfo.processInfo.systemUptime
         app.typeKey(",", modifierFlags: [.command])
-        let settingsContent = app.descendants(matching: .any)[
-            "neondiff-settings-window-content"
+        let settingsEvaluationContainer = app.descendants(matching: .any)[
+            "neondiff-settings-evaluation-container"
         ]
-        guard settingsContent.waitForExistence(timeout: 10) else {
+        guard settingsEvaluationContainer.waitForExistence(timeout: 10) else {
             throw HostedSettingsSceneTraceError.missingElement(
-                "neondiff-settings-window-content"
+                "neondiff-settings-evaluation-container"
             )
         }
         let openAction = HostedSettingsOpenAction(
             method: "automated-command-comma",
             attemptCount: 1,
-            result: "settings-window-content-observed",
+            result: "settings-evaluation-container-observed",
             elapsedMilliseconds: Int(
                 ((ProcessInfo.processInfo.systemUptime - openActionStart) * 1_000).rounded()
             ),
@@ -594,9 +594,10 @@ final class NeonDiffDesktopUITests: XCTestCase {
             requestedContentSize: requestedContentSize,
             context: request.textSizeMode
         )
-        let observedContentSize = try XCTUnwrap(
-            appKitGeometry.samples.first?.contentLayoutScreenRect.roundedContentSize
-        )
+        let appKitBaseline = try XCTUnwrap(appKitGeometry.samples.first)
+        let observedAppKitContentLayoutSize =
+            appKitBaseline.contentLayoutScreenRect.roundedContentSize
+        let observedAppKitWindowSize = appKitBaseline.windowFrame.roundedContentSize
         let outerScroll = app.descendants(matching: .any)[
             "neondiff-settings-outer-scroll"
         ]
@@ -616,10 +617,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
 
         let preActionSamples = try captureStableSettingsSceneSamples(
             app: app,
-            settingsContent: settingsContent,
+            settingsEvaluationContainer: settingsEvaluationContainer,
             outerScroll: outerScroll,
             bottomSentinel: bottomSentinel,
-            requestedContentSize: observedContentSize,
+            expectedAppKitWindowSize: observedAppKitWindowSize,
+            appKitWindowFrame: appKitBaseline.windowFrame,
+            appKitContentLayoutScreenRect: appKitBaseline.contentLayoutScreenRect,
             context: "\(request.textSizeMode)-pre"
         )
         let scrollAction: HostedSettingsScrollAction?
@@ -631,10 +634,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
             outerScroll.scroll(byDeltaX: 0, deltaY: -10_000)
             postActionSamples = try captureStableSettingsSceneSamples(
                 app: app,
-                settingsContent: settingsContent,
+                settingsEvaluationContainer: settingsEvaluationContainer,
                 outerScroll: outerScroll,
                 bottomSentinel: bottomSentinel,
-                requestedContentSize: observedContentSize,
+                expectedAppKitWindowSize: observedAppKitWindowSize,
+                appKitWindowFrame: appKitBaseline.windowFrame,
+                appKitContentLayoutScreenRect: appKitBaseline.contentLayoutScreenRect,
                 context: "\(request.textSizeMode)-post"
             )
             guard let preActionSentinelFrame = preActionSamples.last?.sentinelFrame,
@@ -664,7 +669,8 @@ final class NeonDiffDesktopUITests: XCTestCase {
             textSizeMode: request.textSizeMode,
             launchTextSizeArgument: request.textSizeArgument,
             observedSettingsTextSize: observedTextSize,
-            observedContentSize: observedContentSize,
+            observedAppKitContentLayoutSize: observedAppKitContentLayoutSize,
+            observedAppKitWindowSize: observedAppKitWindowSize,
             fixtureRootIdentifier: rootIdentifier,
             quiescenceMarkerIdentifier: markerIdentifier,
             openAction: openAction,
@@ -785,10 +791,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
 
     private func captureStableSettingsSceneSamples(
         app: XCUIApplication,
-        settingsContent: XCUIElement,
+        settingsEvaluationContainer: XCUIElement,
         outerScroll: XCUIElement,
         bottomSentinel: XCUIElement,
-        requestedContentSize: HostedContentSize,
+        expectedAppKitWindowSize: HostedContentSize,
+        appKitWindowFrame: HostedSettingsAppKitFrame,
+        appKitContentLayoutScreenRect: HostedSettingsAppKitFrame,
         context: String
     ) throws -> [HostedSettingsSceneSample] {
         let start = ProcessInfo.processInfo.systemUptime
@@ -805,41 +813,69 @@ final class NeonDiffDesktopUITests: XCTestCase {
             }
             let sampleStart = ProcessInfo.processInfo.systemUptime
             previousSampleStart = sampleStart
-            let settingsContentFrame = HostedGeometryFrame(settingsContent.frame)
+            let accessibilityContainerFrame = HostedGeometryFrame(
+                settingsEvaluationContainer.frame
+            )
             let windowFrame = try settingsContainingWindowFrame(
                 app: app,
-                settingsContentFrame: settingsContentFrame,
+                accessibilityContainerFrame: accessibilityContainerFrame,
                 context: context
+            )
+            let projectedAppKitContentLayoutFrame = HostedGeometryFrame(
+                appKitContentLayoutScreenRect,
+                relativeTo: appKitWindowFrame,
+                in: windowFrame
             )
             let outerScrollFrame = HostedGeometryFrame(outerScroll.frame)
             let sentinelFrame = HostedGeometryFrame(bottomSentinel.frame)
-            guard settingsContentFrame.isFiniteAndNonempty,
+            guard accessibilityContainerFrame.isFiniteAndNonempty,
                   windowFrame.isFiniteAndNonempty,
+                  projectedAppKitContentLayoutFrame.isFiniteAndNonempty,
                   outerScrollFrame.isFiniteAndNonempty,
                   sentinelFrame.isFiniteAndNonempty else {
                 throw HostedSettingsSceneTraceError.invalidFrame(context)
             }
-            guard settingsContentFrame.matches(requestedContentSize, tolerance: 1) else {
-                throw HostedSettingsSceneTraceError.unexpectedContentSize(
-                    requested: requestedContentSize,
-                    observed: settingsContentFrame
+            guard windowFrame.matches(expectedAppKitWindowSize, tolerance: 1),
+                  accessibilityContainerFrame.matches(
+                      expectedAppKitWindowSize,
+                      tolerance: 1
+                  ) else {
+                throw HostedSettingsSceneTraceError.unexpectedWindowSize(
+                    expected: expectedAppKitWindowSize,
+                    observedWindow: windowFrame,
+                    observedAccessibilityContainer: accessibilityContainerFrame
                 )
             }
+            let accessibilityContainerMatchesWindowFrame =
+                !accessibilityContainerFrame.differs(
+                from: windowFrame,
+                byMoreThan: 1
+            )
             let sample = HostedSettingsSceneSample(
                 elapsedMilliseconds: Int(((sampleStart - start) * 1_000).rounded()),
                 completionElapsedMilliseconds: Int(
                     ((ProcessInfo.processInfo.systemUptime - start) * 1_000).rounded()
                 ),
                 windowFrame: windowFrame,
-                settingsContentFrame: settingsContentFrame,
+                accessibilityContainerFrame: accessibilityContainerFrame,
+                projectedAppKitContentLayoutFrame: projectedAppKitContentLayoutFrame,
                 outerScrollFrame: outerScrollFrame,
                 sentinelFrame: sentinelFrame,
-                settingsContentFullyContainedInWindow: settingsContentFrame.isFullyContained(
+                accessibilityContainerMatchesWindowFrame:
+                    accessibilityContainerMatchesWindowFrame,
+                accessibilityContainerFullyContainedInWindow:
+                    accessibilityContainerFrame.isFullyContained(
                     in: windowFrame,
                     tolerance: 1
                 ),
-                outerScrollFullyContainedInSettingsContent: outerScrollFrame.isFullyContained(
-                    in: settingsContentFrame,
+                projectedAppKitContentLayoutFullyContainedInWindow:
+                    projectedAppKitContentLayoutFrame.isFullyContained(
+                    in: windowFrame,
+                    tolerance: 1
+                ),
+                outerScrollFullyContainedInProjectedAppKitContentLayout:
+                    outerScrollFrame.isFullyContained(
+                    in: projectedAppKitContentLayoutFrame,
                     tolerance: 1
                 ),
                 sentinelFullyContainedInOuterScroll: sentinelFrame.isFullyContained(
@@ -847,8 +883,10 @@ final class NeonDiffDesktopUITests: XCTestCase {
                     tolerance: 1
                 )
             )
-            guard sample.settingsContentFullyContainedInWindow,
-                  sample.outerScrollFullyContainedInSettingsContent else {
+            guard sample.accessibilityContainerMatchesWindowFrame,
+                  sample.accessibilityContainerFullyContainedInWindow,
+                  sample.projectedAppKitContentLayoutFullyContainedInWindow,
+                  sample.outerScrollFullyContainedInProjectedAppKitContentLayout else {
                 throw HostedSettingsSceneTraceError.invalidContainment(context)
             }
             samples.append(sample)
@@ -872,8 +910,12 @@ final class NeonDiffDesktopUITests: XCTestCase {
         }
         for sample in samples.dropFirst() {
             guard !baseline.windowFrame.differs(from: sample.windowFrame, byMoreThan: 1),
-                  !baseline.settingsContentFrame.differs(
-                      from: sample.settingsContentFrame,
+                  !baseline.accessibilityContainerFrame.differs(
+                      from: sample.accessibilityContainerFrame,
+                      byMoreThan: 1
+                  ),
+                  !baseline.projectedAppKitContentLayoutFrame.differs(
+                      from: sample.projectedAppKitContentLayoutFrame,
                       byMoreThan: 1
                   ),
                   !baseline.outerScrollFrame.differs(
@@ -892,14 +934,17 @@ final class NeonDiffDesktopUITests: XCTestCase {
 
     private func settingsContainingWindowFrame(
         app: XCUIApplication,
-        settingsContentFrame: HostedGeometryFrame,
+        accessibilityContainerFrame: HostedGeometryFrame,
         context: String
     ) throws -> HostedGeometryFrame {
         let candidates = (0..<app.windows.count)
             .map { HostedGeometryFrame(app.windows.element(boundBy: $0).frame) }
             .filter {
                 $0.isFiniteAndNonempty
-                    && settingsContentFrame.isFullyContained(in: $0, tolerance: 1)
+                    && accessibilityContainerFrame.isFullyContained(
+                        in: $0,
+                        tolerance: 1
+                    )
             }
             .sorted { $0.area < $1.area }
         guard let windowFrame = candidates.first else {
@@ -2186,6 +2231,19 @@ private struct HostedGeometryFrame: Codable, Equatable {
         self.height = height
     }
 
+    init(
+        _ appKitContentLayoutScreenRect: HostedSettingsAppKitFrame,
+        relativeTo appKitWindowFrame: HostedSettingsAppKitFrame,
+        in xcuiWindowFrame: Self
+    ) {
+        x = xcuiWindowFrame.x
+            + (appKitContentLayoutScreenRect.x - appKitWindowFrame.x)
+        y = xcuiWindowFrame.y
+            + (appKitWindowFrame.maxY - appKitContentLayoutScreenRect.maxY)
+        width = appKitContentLayoutScreenRect.width
+        height = appKitContentLayoutScreenRect.height
+    }
+
     var isFiniteAndNonempty: Bool {
         [x, y, width, height, x + width, y + height].allSatisfy(\.isFinite)
             && width > 0
@@ -2488,11 +2546,14 @@ private struct HostedSettingsSceneSample: Codable, Equatable {
     let elapsedMilliseconds: Int
     let completionElapsedMilliseconds: Int
     let windowFrame: HostedGeometryFrame
-    let settingsContentFrame: HostedGeometryFrame
+    let accessibilityContainerFrame: HostedGeometryFrame
+    let projectedAppKitContentLayoutFrame: HostedGeometryFrame
     let outerScrollFrame: HostedGeometryFrame
     let sentinelFrame: HostedGeometryFrame
-    let settingsContentFullyContainedInWindow: Bool
-    let outerScrollFullyContainedInSettingsContent: Bool
+    let accessibilityContainerMatchesWindowFrame: Bool
+    let accessibilityContainerFullyContainedInWindow: Bool
+    let projectedAppKitContentLayoutFullyContainedInWindow: Bool
+    let outerScrollFullyContainedInProjectedAppKitContentLayout: Bool
     let sentinelFullyContainedInOuterScroll: Bool
 }
 
@@ -2500,7 +2561,8 @@ private struct HostedSettingsSceneScenario: Codable {
     let textSizeMode: String
     let launchTextSizeArgument: String?
     let observedSettingsTextSize: String
-    let observedContentSize: HostedContentSize
+    let observedAppKitContentLayoutSize: HostedContentSize
+    let observedAppKitWindowSize: HostedContentSize
     let fixtureRootIdentifier: String
     let quiescenceMarkerIdentifier: String
     let openAction: HostedSettingsOpenAction
@@ -2552,6 +2614,8 @@ private struct HostedSettingsAppKitFrame: Codable {
             height: Int(height.rounded())
         )
     }
+
+    var maxY: Double { y + height }
 
     func matchesFittedSettingsContent(
         preferredContentSize: HostedContentSize,
@@ -2802,9 +2866,10 @@ private enum HostedSettingsSceneTraceError: LocalizedError {
     case unstableAppKitGeometry(String)
     case unexpectedWindowCount(before: Int, after: Int)
     case invalidFrame(String)
-    case unexpectedContentSize(
-        requested: HostedContentSize,
-        observed: HostedGeometryFrame
+    case unexpectedWindowSize(
+        expected: HostedContentSize,
+        observedWindow: HostedGeometryFrame,
+        observedAccessibilityContainer: HostedGeometryFrame
     )
     case missingContainingWindow(String)
     case invalidContainment(String)
@@ -2841,11 +2906,17 @@ private enum HostedSettingsSceneTraceError: LocalizedError {
                 + "before=\(before) after=\(after)"
         case .invalidFrame(let context):
             "Invalid hosted Settings frame: \(context)"
-        case let .unexpectedContentSize(requested, observed):
-            "Hosted Settings content size does not match the request: "
-                + "requested=\(requested.width)x\(requested.height) observed=\(observed)"
+        case let .unexpectedWindowSize(
+            expected,
+            observedWindow,
+            observedAccessibilityContainer
+        ):
+            "Hosted Settings AppKit/XCUI window dimensions do not match: "
+                + "expected=\(expected.width)x\(expected.height) "
+                + "window=\(observedWindow) "
+                + "accessibilityContainer=\(observedAccessibilityContainer)"
         case .missingContainingWindow(let context):
-            "Hosted Settings content has no containing app window: \(context)"
+            "Hosted Settings evaluation container has no containing app window: \(context)"
         case .invalidContainment(let context):
             "Hosted Settings containment failed: \(context)"
         case .invalidCadence(let context):

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -448,7 +448,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
         )
     }
 
-    func testSeparateSettingsSceneSettlesAtCanonicalSizeAndReachesPageBottom() throws {
+    func testSeparateSettingsSceneFitsVisibleScreenAndReachesPageBottom() throws {
         let requestedContentSize = HostedContentSize(width: 560, height: 700)
         let requests = [
             HostedSettingsTextSizeRequest(textSizeMode: "runner-default-no-test-override", textSizeArgument: nil),
@@ -478,7 +478,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 samplingDeadlineMilliseconds: 5_000,
                 tolerancePoints: 1,
                 scenarios: scenarios,
-                proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-title-edge-and-outer-page-bottom-only-host-visible-screen-full-containment-system-preference-inner-scroll-manual-excluded"
+                proofBoundary: "hosted-separate-settings-preferred-560x700-visible-screen-fitted-root-and-appkit-content-layout-default-and-observed-accessibility3-window-contained-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"
             )
         )
     }
@@ -594,6 +594,9 @@ final class NeonDiffDesktopUITests: XCTestCase {
             requestedContentSize: requestedContentSize,
             context: request.textSizeMode
         )
+        let observedContentSize = try XCTUnwrap(
+            appKitGeometry.samples.first?.contentLayoutScreenRect.roundedContentSize
+        )
         let outerScroll = app.descendants(matching: .any)[
             "neondiff-settings-outer-scroll"
         ]
@@ -616,7 +619,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
             settingsContent: settingsContent,
             outerScroll: outerScroll,
             bottomSentinel: bottomSentinel,
-            requestedContentSize: requestedContentSize,
+            requestedContentSize: observedContentSize,
             context: "\(request.textSizeMode)-pre"
         )
         let scrollAction: HostedSettingsScrollAction?
@@ -631,7 +634,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 settingsContent: settingsContent,
                 outerScroll: outerScroll,
                 bottomSentinel: bottomSentinel,
-                requestedContentSize: requestedContentSize,
+                requestedContentSize: observedContentSize,
                 context: "\(request.textSizeMode)-post"
             )
             guard let preActionSentinelFrame = preActionSamples.last?.sentinelFrame,
@@ -661,6 +664,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
             textSizeMode: request.textSizeMode,
             launchTextSizeArgument: request.textSizeArgument,
             observedSettingsTextSize: observedTextSize,
+            observedContentSize: observedContentSize,
             fixtureRootIdentifier: rootIdentifier,
             quiescenceMarkerIdentifier: markerIdentifier,
             openAction: openAction,
@@ -729,12 +733,16 @@ final class NeonDiffDesktopUITests: XCTestCase {
                   sample.contentLayoutRect.isFiniteAndNonempty,
                   sample.contentLayoutScreenRect.isFiniteAndNonempty,
                   sample.visibleScreenFrame.isFiniteAndNonempty,
-                  sample.contentLayoutRect.matches(
-                      requestedContentSize,
+                  sample.contentLayoutRect.matchesFittedSettingsContent(
+                      preferredContentSize: requestedContentSize,
+                      windowFrame: sample.windowFrame,
+                      visibleScreenFrame: sample.visibleScreenFrame,
                       tolerance: 1
                   ),
-                  sample.contentLayoutScreenRect.matches(
-                      requestedContentSize,
+                  sample.contentLayoutScreenRect.matchesFittedSettingsContent(
+                      preferredContentSize: requestedContentSize,
+                      windowFrame: sample.windowFrame,
+                      visibleScreenFrame: sample.visibleScreenFrame,
                       tolerance: 1
                   ),
                   sample.contentLayoutRect.isFullyContainedInWindowBounds(
@@ -745,7 +753,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                       in: sample.windowFrame,
                       tolerance: 1
                   ),
-                  sample.windowFrame.hasAccessibleTopEdge(
+                  sample.windowFrame.isFullyContained(
                       in: sample.visibleScreenFrame,
                       tolerance: 1
                   ) else {
@@ -2492,6 +2500,7 @@ private struct HostedSettingsSceneScenario: Codable {
     let textSizeMode: String
     let launchTextSizeArgument: String?
     let observedSettingsTextSize: String
+    let observedContentSize: HostedContentSize
     let fixtureRootIdentifier: String
     let quiescenceMarkerIdentifier: String
     let openAction: HostedSettingsOpenAction
@@ -2537,6 +2546,35 @@ private struct HostedSettingsAppKitFrame: Codable {
             && abs(height - Double(size.height)) <= tolerance
     }
 
+    var roundedContentSize: HostedContentSize {
+        HostedContentSize(
+            width: Int(width.rounded()),
+            height: Int(height.rounded())
+        )
+    }
+
+    func matchesFittedSettingsContent(
+        preferredContentSize: HostedContentSize,
+        windowFrame: Self,
+        visibleScreenFrame: Self,
+        tolerance: Double
+    ) -> Bool {
+        let chromeHeight = windowFrame.height - height
+        let availableContentHeight = visibleScreenFrame.height - chromeHeight
+        guard chromeHeight.isFinite,
+              chromeHeight >= -tolerance,
+              availableContentHeight.isFinite,
+              availableContentHeight > 0 else {
+            return false
+        }
+        let expectedHeight = min(
+            Double(preferredContentSize.height),
+            floor(availableContentHeight)
+        )
+        return abs(width - Double(preferredContentSize.width)) <= tolerance
+            && abs(height - expectedHeight) <= tolerance
+    }
+
     func isFullyContained(in container: Self, tolerance: Double) -> Bool {
         x >= container.x - tolerance
             && y >= container.y - tolerance
@@ -2552,16 +2590,6 @@ private struct HostedSettingsAppKitFrame: Codable {
             && y >= -tolerance
             && x + width <= windowFrame.width + tolerance
             && y + height <= windowFrame.height + tolerance
-    }
-
-    func hasAccessibleTopEdge(in visibleScreen: Self, tolerance: Double) -> Bool {
-        // Canonical fixture sizes intentionally remain independent of the
-        // hosted runner's Dock-reduced visible height. Keep the title edge and
-        // full window width accessible without claiming whole-screen fit.
-        x >= visibleScreen.x - tolerance
-            && x + width <= visibleScreen.x + visibleScreen.width + tolerance
-            && y + height >= visibleScreen.y - tolerance
-            && y + height <= visibleScreen.y + visibleScreen.height + tolerance
     }
 
     func differs(from other: Self, byMoreThan tolerance: Double) -> Bool {

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -675,7 +675,10 @@ final class NeonDiffDesktopUITests: XCTestCase {
             throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
         }
         guard envelope.schemaVersion == 1,
-              envelope.coordinateSpace == "appkit-screen",
+              envelope.coordinateSpaces.windowFrame == "appkit-screen",
+              envelope.coordinateSpaces.contentLayoutRect == "appkit-window",
+              envelope.coordinateSpaces.contentLayoutScreenRect == "appkit-screen",
+              envelope.coordinateSpaces.visibleScreenFrame == "appkit-screen",
               envelope.samples.count == 3,
               let baseline = envelope.samples.first else {
             throw HostedSettingsSceneTraceError.invalidAppKitGeometryPayload(context)
@@ -2458,8 +2461,15 @@ private struct HostedSettingsSceneScenario: Codable {
 
 private struct HostedSettingsAppKitGeometryEnvelope: Codable {
     let schemaVersion: Int
-    let coordinateSpace: String
+    let coordinateSpaces: HostedSettingsAppKitCoordinateSpaces
     let samples: [HostedSettingsAppKitSample]
+}
+
+private struct HostedSettingsAppKitCoordinateSpaces: Codable {
+    let windowFrame: String
+    let contentLayoutRect: String
+    let contentLayoutScreenRect: String
+    let visibleScreenFrame: String
 }
 
 private struct HostedSettingsAppKitSample: Codable {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -46,6 +46,73 @@ function extractBalancedSwiftDeclaration(
   throw new Error(`Unbalanced Swift declaration body: ${declaration}`);
 }
 
+function projectSwiftReleaseSource(source: string): string {
+  const lines = source.match(/.*(?:\n|$)/g)?.filter(Boolean) ?? [];
+  const frames: Array<{
+    kind: "debug" | "other";
+    parentIncluded: boolean;
+    debugBranchIncluded?: boolean;
+  }> = [];
+  const projected: string[] = [];
+  let included = true;
+
+  for (const line of lines) {
+    const directive = line.trim();
+    if (directive === "#if DEBUG" || directive === "#if !DEBUG") {
+      const debugBranchIncluded = directive === "#if !DEBUG";
+      frames.push({
+        kind: "debug",
+        parentIncluded: included,
+        debugBranchIncluded,
+      });
+      included = included && debugBranchIncluded;
+      continue;
+    }
+    if (directive.startsWith("#if ")) {
+      frames.push({ kind: "other", parentIncluded: included });
+      if (included) projected.push(line);
+      continue;
+    }
+    if (directive === "#else") {
+      const frame = frames.at(-1);
+      if (!frame) throw new Error("Unmatched Swift #else");
+      if (frame.kind === "debug") {
+        frame.debugBranchIncluded = !frame.debugBranchIncluded;
+        included = frame.parentIncluded && frame.debugBranchIncluded;
+      } else {
+        included = frame.parentIncluded;
+        if (included) projected.push(line);
+      }
+      continue;
+    }
+    if (directive.startsWith("#elseif ")) {
+      const frame = frames.at(-1);
+      if (!frame) throw new Error("Unmatched Swift #elseif");
+      if (frame.kind === "debug") {
+        const releaseBranch = directive === "#elseif !DEBUG";
+        frame.debugBranchIncluded = releaseBranch;
+        included = frame.parentIncluded && releaseBranch;
+      } else if (included) {
+        projected.push(line);
+      }
+      continue;
+    }
+    if (directive === "#endif") {
+      const frame = frames.pop();
+      if (!frame) throw new Error("Unmatched Swift #endif");
+      included = frame.parentIncluded;
+      if (frame.kind === "other" && included) projected.push(line);
+      continue;
+    }
+    if (included) projected.push(line);
+  }
+
+  if (frames.length !== 0) {
+    throw new Error("Unterminated Swift conditional compilation block");
+  }
+  return projected.join("");
+}
+
 function maskSwiftCommentsAndLiterals(source: string): string {
   const masked = [...source];
   let index = 0;
@@ -833,7 +900,26 @@ private func target() {
     expect(settings).toContain("visibleScreenFrame: visibleScreenFrame");
     expect(settings).toContain("window.convertToScreen(");
     expect(settings).toContain("status.markQuiescent(samples: stableSamples)");
-    expect(settings).toContain("#if DEBUG");
+    expect(settings).toContain("if let baseline = stableSamples.first");
+    expect(settings).not.toContain("if let previous = stableSamples.last");
+    const releaseSettings = projectSwiftReleaseSource(settings);
+    for (const debugOnlySetting of [
+      "HostedSettingsWindowConfigurator",
+      "HostedSettingsEvaluationStatus",
+      "HostedSettingsGeometryAccessibilityChunk",
+      "neondiff.evaluation.settings.quiescent",
+      "neondiff-settings-evaluation-container",
+      "neondiff.evaluation.settings.text-size",
+      "neondiff.evaluation.settings.appkit-geometry",
+      "geometryAccessibilityManifest",
+      "geometryAccessibilityChunks",
+    ]) {
+      expect(releaseSettings).not.toContain(debugOnlySetting);
+    }
+    const releaseApp = projectSwiftReleaseSource(app);
+    expect(releaseApp).not.toContain("HostedSettingsEvaluationStatus");
+    expect(releaseApp).not.toContain("settingsEvaluationStatus");
+    expect(releaseApp).not.toContain(".hostedSettingsEvaluationContent(");
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -9,6 +9,10 @@ const testPlanPath = "apps/neondiff-desktop/NeonDiffDesktop.xctestplan";
 const uiTestPath = "apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift";
 const themePath =
   "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift";
+const appPath =
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift";
+const settingsPath =
+  "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift";
 const workflowPath = ".github/workflows/swift-desktop-gate.yml";
 
 function extractBalancedSwiftDeclaration(
@@ -415,7 +419,6 @@ private func target() {
     expect(
       source.match(/outerPageScroll\.scroll\(byDeltaX: 0, deltaY: -10_000\)/g)
     ).toHaveLength(1);
-    expect(source.match(/\.scroll\s*\(/g)).toHaveLength(1);
     const checkpointSource = extractBalancedSwiftDeclaration(
       source,
       "private func capturePageBottomCheckpoint("
@@ -667,6 +670,58 @@ private func target() {
     expect(theme).toContain(
       ".font(.system(size: sectionTitleSize, weight: .bold, design: .monospaced))"
     );
+  });
+
+  it("pins the separate Settings scene canonical geometry contract", () => {
+    const source = readFileSync(uiTestPath, "utf8");
+    const app = readFileSync(appPath, "utf8");
+    const settings = readFileSync(settingsPath, "utf8");
+
+    expect(source).toContain(
+      "testSeparateSettingsSceneSettlesAtCanonicalSizeAndReachesPageBottom"
+    );
+    expect(source).toContain("HostedContentSize(width: 560, height: 700)");
+    expect(source).toContain(
+      'HostedSettingsTextSizeRequest(textSizeMode: "runner-default-no-test-override", textSizeArgument: nil)'
+    );
+    expect(source).toContain(
+      'HostedSettingsTextSizeRequest(textSizeMode: "swiftui-dynamic-type-accessibility3-test-override", textSizeArgument: "accessibility3")'
+    );
+    expect(source).toContain('app.typeKey(",", modifierFlags: [.command])');
+    expect(source).toContain('"neondiff-settings-window-content"');
+    expect(source).toContain('"neondiff.evaluation.settings.quiescent"');
+    expect(source).toContain('"neondiff-settings-outer-scroll"');
+    expect(source).toContain('"neondiff-settings-page-bottom"');
+    expect(source).toContain("captureStableSettingsSceneSamples");
+    expect(source).toContain("samples.count == 3");
+    expect(source).toContain("finalCompletionElapsedMilliseconds <= 5_000");
+    expect(source).toContain("settingsContentFrame.matches(requestedContentSize");
+    expect(source).toContain("sentinelFullyContainedInOuterScroll");
+    expect(source).toContain("effectProven: true");
+    expect(source).toContain("scrollHadNoEffect");
+    expect(source).toContain("HostedSettingsSceneTrace(");
+    expect(source).toContain("neondiff-hosted-settings-scene.json");
+    expect(source).toContain(
+      'proofBoundary: "hosted-separate-settings-scene-560x700-default-and-accessibility3-outer-geometry-and-page-bottom-only-system-preference-inner-scroll-manual-excluded"'
+    );
+    const settingsScenarioSource = extractBalancedSwiftDeclaration(
+      source,
+      "private func captureSettingsSceneScenario("
+    );
+    expect(settingsScenarioSource.match(/\.scroll\s*\(/g)).toHaveLength(1);
+    expect(settingsScenarioSource).not.toMatch(
+      /AXUIElement|CGEvent|NSEvent|XCUIRemote|performAction|setAttributeValue/
+    );
+
+    expect(app).toContain("evaluationTextSizedSettingsScene");
+    expect(app).toContain(".frame(width: 560, height: 700)");
+    expect(app).toContain(".dynamicTypeSize(.accessibility3)");
+    expect(app).toContain("hostedSettingsEvaluationContent");
+    expect(settings).toContain("HostedSettingsWindowConfigurator");
+    expect(settings).toContain("HostedSettingsEvaluationStatus");
+    expect(settings).toContain('"neondiff.evaluation.settings.quiescent"');
+    expect(settings).toContain('"neondiff-settings-window-content"');
+    expect(settings).toContain("#if DEBUG");
   });
 
   it("runs xcodebuild at the exact head and always uploads the immutable xcresult", () => {

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -48,6 +48,11 @@ function extractBalancedSwiftDeclaration(
 
 function projectSwiftReleaseSource(source: string): string {
   const lines = source.match(/.*(?:\n|$)/g)?.filter(Boolean) ?? [];
+  const maskedLines =
+    maskSwiftCommentsAndLiterals(source).match(/.*(?:\n|$)/g)?.filter(Boolean) ?? [];
+  if (maskedLines.length !== lines.length) {
+    throw new Error("Swift release projection line mismatch");
+  }
   const frames: Array<{
     kind: "debug" | "other";
     parentIncluded: boolean;
@@ -56,8 +61,8 @@ function projectSwiftReleaseSource(source: string): string {
   const projected: string[] = [];
   let included = true;
 
-  for (const line of lines) {
-    const directive = line.trim();
+  for (const [index, line] of lines.entries()) {
+    const directive = maskedLines[index].trim();
     if (directive === "#if DEBUG" || directive === "#if !DEBUG") {
       const debugBranchIncluded = directive === "#if !DEBUG";
       frames.push({
@@ -69,6 +74,9 @@ function projectSwiftReleaseSource(source: string): string {
       continue;
     }
     if (directive.startsWith("#if ")) {
+      if (/\bDEBUG\b/.test(directive)) {
+        throw new Error(`Unsupported Swift DEBUG condition: ${directive}`);
+      }
       frames.push({ kind: "other", parentIncluded: included });
       if (included) projected.push(line);
       continue;
@@ -88,11 +96,19 @@ function projectSwiftReleaseSource(source: string): string {
     if (directive.startsWith("#elseif ")) {
       const frame = frames.at(-1);
       if (!frame) throw new Error("Unmatched Swift #elseif");
-      if (frame.kind === "debug") {
-        const releaseBranch = directive === "#elseif !DEBUG";
-        frame.debugBranchIncluded = releaseBranch;
-        included = frame.parentIncluded && releaseBranch;
-      } else if (included) {
+      if (directive === "#elseif DEBUG") {
+        included = false;
+      } else if (directive === "#elseif !DEBUG") {
+        included = frame.parentIncluded;
+      } else {
+        if (/\bDEBUG\b/.test(directive)) {
+          throw new Error(`Unsupported Swift DEBUG condition: ${directive}`);
+        }
+        // Preserve every non-DEBUG alternative conservatively. This can make
+        // the contract false-fail, but cannot hide release-reachable symbols.
+        included = frame.parentIncluded;
+      }
+      if (frame.kind === "other" && included) {
         projected.push(line);
       }
       continue;
@@ -265,6 +281,38 @@ private func target() {
         "private func target()"
       )
     ).toThrow(/Ambiguous Swift declaration/);
+  });
+
+  it("projects DEBUG branches out of release source without directive decoys", () => {
+    const source = `
+let literalDecoy = """
+#if DEBUG
+#endif
+"""
+/*
+#if DEBUG
+#endif
+*/
+releaseBeforeConditional()
+#if DEBUG
+debugOnly()
+#elseif os(macOS)
+releaseAlternative()
+#else
+releaseFallback()
+#endif
+releaseAfterConditional()
+`;
+
+    const projected = projectSwiftReleaseSource(source);
+    expect(projected).toContain("releaseBeforeConditional()");
+    expect(projected).toContain("releaseAlternative()");
+    expect(projected).toContain("releaseFallback()");
+    expect(projected).toContain("releaseAfterConditional()");
+    expect(projected).not.toContain("debugOnly()");
+    expect(() =>
+      projectSwiftReleaseSource("#if DEBUG && os(macOS)\ndebugOnly()\n#endif\n")
+    ).toThrow(/Unsupported Swift DEBUG condition/);
   });
 
   it("checks in a shared app/UI-test project and test plan", () => {
@@ -841,6 +889,11 @@ private func target() {
     expect(app).toContain("NSWindow.didChangeScreenNotification");
     expect(app).toContain("NSApplication.didChangeScreenParametersNotification");
     expect(app).not.toContain("NSWindow.didMoveNotification");
+    const screenChangeSource = extractBalancedSwiftDeclaration(
+      app,
+      "private func windowScreenDidChange("
+    );
+    expect(screenChangeSource).toContain("fitWindow(containOrigin: false)");
     expect(app).toContain("static let preferredContentWidth: CGFloat = 560");
     expect(app).toContain("static let preferredContentHeight: CGFloat = 700");
     expect(app).toContain("floor(visibleScreenHeight - chromeHeight)");
@@ -854,7 +907,7 @@ private func target() {
     expect(fittedHeightSource).toContain("visibleScreenHeight > chromeHeight");
     const fitWindowSource = extractBalancedSwiftDeclaration(
       app,
-      "private func fitWindow()"
+      "private func fitWindow(containOrigin: Bool = true)"
     );
     expect(fitWindowSource).toContain(
       "let chromeHeight = windowFrame.height - contentLayoutRect.height"
@@ -863,6 +916,8 @@ private func target() {
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(contentLayoutRect)");
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(visibleFrame)");
     expect(fitWindowSource.match(/pendingHeight = nil/g)).toHaveLength(2);
+    expect(fitWindowSource).toContain("self.fitWindow(containOrigin: containOrigin)");
+    expect(fitWindowSource).toContain("guard containOrigin else { return }");
     const attachSource = extractBalancedSwiftDeclaration(
       app,
       "func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>)"

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -746,15 +746,30 @@ private func target() {
     expect(app).toContain("SettingsWindowLayout.fittedContentHeight(");
     expect(app).toContain("SettingsWindowFitView(contentHeight:");
     expect(app).toContain("window.screen?.visibleFrame");
-    expect(app).toContain(
-      "window.frame.height - window.contentLayoutRect.height"
-    );
     expect(app).toContain("NSWindow.didChangeScreenNotification");
+    expect(app).toContain("NSWindow.didMoveNotification");
     expect(app).toContain("NSApplication.didChangeScreenParametersNotification");
     expect(app).toContain("static let preferredContentWidth: CGFloat = 560");
     expect(app).toContain("static let preferredContentHeight: CGFloat = 700");
     expect(app).toContain("floor(visibleScreenHeight - chromeHeight)");
     expect(app).not.toContain("NSScreen.main?.visibleFrame.height");
+    const fitWindowSource = extractBalancedSwiftDeclaration(
+      app,
+      "private func fitWindow(clampOrigin: Bool)"
+    );
+    expect(fitWindowSource).toContain(
+      "let chromeHeight = windowFrame.height - contentLayoutRect.height"
+    );
+    expect(fitWindowSource).toContain("Self.isFiniteNonempty(windowFrame)");
+    expect(fitWindowSource).toContain("Self.isFiniteNonempty(contentLayoutRect)");
+    expect(fitWindowSource).toContain("Self.isFiniteNonempty(visibleFrame)");
+    expect(fitWindowSource).toContain("guard clampOrigin else { return }");
+    expect(fitWindowSource).not.toMatch(/let chromeHeight\s*=\s*max\s*\(/);
+    const moveHandlerSource = extractBalancedSwiftDeclaration(
+      app,
+      "@objc private func windowDidMove(_ notification: Notification)"
+    );
+    expect(moveHandlerSource).toContain("fitWindow(clampOrigin: false)");
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain("hostedSettingsEvaluationContent");
     const settingsSceneSource = extractBalancedSwiftDeclaration(

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -678,7 +678,7 @@ private func target() {
     const settings = readFileSync(settingsPath, "utf8");
 
     expect(source).toContain(
-      "testSeparateSettingsSceneSettlesAtCanonicalSizeAndReachesPageBottom"
+      "testSeparateSettingsSceneFitsVisibleScreenAndReachesPageBottom"
     );
     expect(source).toContain("HostedContentSize(width: 560, height: 700)");
     expect(source).toContain(
@@ -708,11 +708,16 @@ private func target() {
       'envelope.coordinateSpaces.contentLayoutScreenRect == "appkit-screen"'
     );
     expect(source).toContain("envelope.samples.count == 3");
-    expect(source).toContain("sample.contentLayoutRect.matches(");
-    expect(source).toContain("sample.contentLayoutScreenRect.matches(");
+    expect(source).toContain(
+      "sample.contentLayoutRect.matchesFittedSettingsContent("
+    );
+    expect(source).toContain(
+      "sample.contentLayoutScreenRect.matchesFittedSettingsContent("
+    );
     expect(source).toContain("isFullyContainedInWindowBounds(");
     expect(source).toContain("sample.contentLayoutScreenRect.isFullyContained(");
-    expect(source).toContain("sample.windowFrame.hasAccessibleTopEdge(");
+    expect(source).toContain("sample.windowFrame.isFullyContained(");
+    expect(source).toContain("observedContentSize: observedContentSize");
     expect(source).toContain('"neondiff-settings-outer-scroll"');
     expect(source).toContain('"neondiff-settings-page-bottom"');
     expect(source).toContain("captureStableSettingsSceneSamples");
@@ -725,7 +730,7 @@ private func target() {
     expect(source).toContain("HostedSettingsSceneTrace(");
     expect(source).toContain("neondiff-hosted-settings-scene.json");
     expect(source).toContain(
-      'proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-title-edge-and-outer-page-bottom-only-host-visible-screen-full-containment-system-preference-inner-scroll-manual-excluded"'
+      'proofBoundary: "hosted-separate-settings-preferred-560x700-visible-screen-fitted-root-and-appkit-content-layout-default-and-observed-accessibility3-window-contained-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"'
     );
     const settingsScenarioSource = extractBalancedSwiftDeclaration(
       source,
@@ -737,7 +742,12 @@ private func target() {
     );
 
     expect(app).toContain("evaluationTextSizedSettingsScene");
-    expect(app).toContain(".frame(width: 560, height: 700)");
+    expect(app).toContain("SettingsWindowLayout.preferredContentWidth");
+    expect(app).toContain("SettingsWindowLayout.fittedContentHeight(");
+    expect(app).toContain("NSScreen.main?.visibleFrame.height");
+    expect(app).toContain("static let preferredContentWidth: CGFloat = 560");
+    expect(app).toContain("static let preferredContentHeight: CGFloat = 700");
+    expect(app).toContain("floor(visibleScreenHeight - chromeHeight)");
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain("hostedSettingsEvaluationContent");
     const settingsSceneSource = extractBalancedSwiftDeclaration(

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -735,6 +735,18 @@ private func target() {
     expect(app).toContain(".frame(width: 560, height: 700)");
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain("hostedSettingsEvaluationContent");
+    const settingsSceneSource = extractBalancedSwiftDeclaration(
+      app,
+      "private var evaluationTextSizedSettingsScene"
+    );
+    const hostedWrapperIndex = settingsSceneSource.indexOf(
+      ".hostedSettingsEvaluationContent("
+    );
+    const accessibilityOverrideIndex = settingsSceneSource.indexOf(
+      ".dynamicTypeSize(.accessibility3)"
+    );
+    expect(hostedWrapperIndex).toBeGreaterThan(-1);
+    expect(accessibilityOverrideIndex).toBeGreaterThan(hostedWrapperIndex);
     expect(settings).toContain("HostedSettingsWindowConfigurator");
     expect(settings).toContain("HostedSettingsEvaluationStatus");
     expect(settings).toContain('"neondiff.evaluation.settings.quiescent"');

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -744,10 +744,17 @@ private func target() {
     expect(app).toContain("evaluationTextSizedSettingsScene");
     expect(app).toContain("SettingsWindowLayout.preferredContentWidth");
     expect(app).toContain("SettingsWindowLayout.fittedContentHeight(");
-    expect(app).toContain("NSScreen.main?.visibleFrame.height");
+    expect(app).toContain("SettingsWindowFitView(contentHeight:");
+    expect(app).toContain("window.screen?.visibleFrame");
+    expect(app).toContain(
+      "window.frame.height - window.contentLayoutRect.height"
+    );
+    expect(app).toContain("NSWindow.didChangeScreenNotification");
+    expect(app).toContain("NSApplication.didChangeScreenParametersNotification");
     expect(app).toContain("static let preferredContentWidth: CGFloat = 560");
     expect(app).toContain("static let preferredContentHeight: CGFloat = 700");
     expect(app).toContain("floor(visibleScreenHeight - chromeHeight)");
+    expect(app).not.toContain("NSScreen.main?.visibleFrame.height");
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain("hostedSettingsEvaluationContent");
     const settingsSceneSource = extractBalancedSwiftDeclaration(

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -763,6 +763,7 @@ private func target() {
     expect(settings).toContain("geometryAccessibilityChunks");
     expect(settings).toContain('let chunkByteCount = 64');
     expect(settings).toContain('let label = "ndsg1:');
+    expect(settings).toContain("guard label.utf8.count <= 128");
     expect(settings).not.toContain(".accessibilityValue(");
     expect(settings).toContain("visibleScreenFrame: visibleScreenFrame");
     expect(settings).toContain("window.convertToScreen(");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -63,23 +63,28 @@ function projectSwiftReleaseSource(source: string): string {
 
   for (const [index, line] of lines.entries()) {
     const directive = maskedLines[index].trim();
-    if (directive === "#if DEBUG" || directive === "#if !DEBUG") {
-      const debugBranchIncluded = directive === "#if !DEBUG";
-      frames.push({
-        kind: "debug",
-        parentIncluded: included,
-        debugBranchIncluded,
-      });
-      included = included && debugBranchIncluded;
-      continue;
-    }
-    if (directive.startsWith("#if ")) {
-      if (/\bDEBUG\b/.test(directive)) {
+    const ifMatch = directive.match(/^#if\s+(.+)$/);
+    if (ifMatch) {
+      const condition = ifMatch[1].trim();
+      if (condition === "DEBUG" || condition === "!DEBUG") {
+        const debugBranchIncluded = condition === "!DEBUG";
+        frames.push({
+          kind: "debug",
+          parentIncluded: included,
+          debugBranchIncluded,
+        });
+        included = included && debugBranchIncluded;
+        continue;
+      }
+      if (/\bDEBUG\b/.test(condition)) {
         throw new Error(`Unsupported Swift DEBUG condition: ${directive}`);
       }
       frames.push({ kind: "other", parentIncluded: included });
       if (included) projected.push(line);
       continue;
+    }
+    if (directive.startsWith("#if")) {
+      throw new Error(`Unsupported Swift conditional directive: ${directive}`);
     }
     if (directive === "#else") {
       const frame = frames.at(-1);
@@ -93,15 +98,17 @@ function projectSwiftReleaseSource(source: string): string {
       }
       continue;
     }
-    if (directive.startsWith("#elseif ")) {
+    const elseifMatch = directive.match(/^#elseif\s+(.+)$/);
+    if (elseifMatch) {
       const frame = frames.at(-1);
       if (!frame) throw new Error("Unmatched Swift #elseif");
-      if (directive === "#elseif DEBUG") {
+      const condition = elseifMatch[1].trim();
+      if (condition === "DEBUG") {
         included = false;
-      } else if (directive === "#elseif !DEBUG") {
+      } else if (condition === "!DEBUG") {
         included = frame.parentIncluded;
       } else {
-        if (/\bDEBUG\b/.test(directive)) {
+        if (/\bDEBUG\b/.test(condition)) {
           throw new Error(`Unsupported Swift DEBUG condition: ${directive}`);
         }
         // Preserve every non-DEBUG alternative conservatively. This can make
@@ -112,6 +119,9 @@ function projectSwiftReleaseSource(source: string): string {
         projected.push(line);
       }
       continue;
+    }
+    if (directive.startsWith("#elseif")) {
+      throw new Error(`Unsupported Swift conditional directive: ${directive}`);
     }
     if (directive === "#endif") {
       const frame = frames.pop();
@@ -302,6 +312,11 @@ releaseAlternative()
 releaseFallback()
 #endif
 releaseAfterConditional()
+#if DEBUG
+debugTabOnly()
+#elseif\tos(macOS)
+releaseTabbedAlternative()
+#endif
 `;
 
     const projected = projectSwiftReleaseSource(source);
@@ -309,7 +324,9 @@ releaseAfterConditional()
     expect(projected).toContain("releaseAlternative()");
     expect(projected).toContain("releaseFallback()");
     expect(projected).toContain("releaseAfterConditional()");
+    expect(projected).toContain("releaseTabbedAlternative()");
     expect(projected).not.toContain("debugOnly()");
+    expect(projected).not.toContain("debugTabOnly()");
     expect(() =>
       projectSwiftReleaseSource("#if DEBUG && os(macOS)\ndebugOnly()\n#endif\n")
     ).toThrow(/Unsupported Swift DEBUG condition/);
@@ -916,15 +933,26 @@ releaseAfterConditional()
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(contentLayoutRect)");
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(visibleFrame)");
     expect(fitWindowSource.match(/pendingHeight = nil/g)).toHaveLength(2);
-    expect(fitWindowSource).toContain("self.fitWindow(containOrigin: containOrigin)");
     expect(fitWindowSource).toContain("guard containOrigin else { return }");
+    expect(fitWindowSource).toContain(
+      "pendingOriginContainment = pendingOriginContainment || containOrigin"
+    );
+    expect(fitWindowSource).toContain(
+      "let shouldContainOrigin = self.pendingOriginContainment"
+    );
+    expect(fitWindowSource).toContain(
+      "self.fitWindow(containOrigin: shouldContainOrigin)"
+    );
     const attachSource = extractBalancedSwiftDeclaration(
       app,
       "func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>)"
     );
     expect(attachSource).toMatch(
-      /attachmentGeneration \+= 1\s+pendingHeight = nil\s+self\.window = window/
+      /attachmentGeneration \+= 1\s+pendingHeight = nil\s+pendingOriginContainment = false\s+self\.window = window/
     );
+    expect(attachSource).toContain("pendingOriginContainment = false");
+    const detachSource = extractBalancedSwiftDeclaration(app, "func detach()");
+    expect(detachSource).toContain("pendingOriginContainment = false");
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain("hostedSettingsEvaluationContent");
     const settingsSceneSource = extractBalancedSwiftDeclaration(

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -690,6 +690,16 @@ private func target() {
     expect(source).toContain('app.typeKey(",", modifierFlags: [.command])');
     expect(source).toContain('"neondiff-settings-window-content"');
     expect(source).toContain('"neondiff.evaluation.settings.quiescent"');
+    expect(source).toContain('"neondiff.evaluation.settings.text-size"');
+    expect(source).toContain('observedTextSize != "accessibility3"');
+    expect(source).toContain(
+      '"neondiff.evaluation.settings.appkit-geometry"'
+    );
+    expect(source).toContain("decodeAndValidateSettingsAppKitGeometry");
+    expect(source).toContain('envelope.coordinateSpace == "appkit-screen"');
+    expect(source).toContain("envelope.samples.count == 3");
+    expect(source).toContain("sample.contentLayoutRect.matches(");
+    expect(source).toContain("sample.windowFrame.isFullyContained(");
     expect(source).toContain('"neondiff-settings-outer-scroll"');
     expect(source).toContain('"neondiff-settings-page-bottom"');
     expect(source).toContain("captureStableSettingsSceneSamples");
@@ -702,7 +712,7 @@ private func target() {
     expect(source).toContain("HostedSettingsSceneTrace(");
     expect(source).toContain("neondiff-hosted-settings-scene.json");
     expect(source).toContain(
-      'proofBoundary: "hosted-separate-settings-scene-560x700-default-and-accessibility3-outer-geometry-and-page-bottom-only-system-preference-inner-scroll-manual-excluded"'
+      'proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-visible-screen-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"'
     );
     const settingsScenarioSource = extractBalancedSwiftDeclaration(
       source,
@@ -721,6 +731,10 @@ private func target() {
     expect(settings).toContain("HostedSettingsEvaluationStatus");
     expect(settings).toContain('"neondiff.evaluation.settings.quiescent"');
     expect(settings).toContain('"neondiff-settings-window-content"');
+    expect(settings).toContain('"neondiff.evaluation.settings.text-size"');
+    expect(settings).toContain('"neondiff.evaluation.settings.appkit-geometry"');
+    expect(settings).toContain("visibleScreenFrame: visibleScreenFrame");
+    expect(settings).toContain("status.markQuiescent(samples: stableSamples)");
     expect(settings).toContain("#if DEBUG");
   });
 

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -712,7 +712,7 @@ private func target() {
     expect(source).toContain("sample.contentLayoutScreenRect.matches(");
     expect(source).toContain("isFullyContainedInWindowBounds(");
     expect(source).toContain("sample.contentLayoutScreenRect.isFullyContained(");
-    expect(source).toContain("sample.windowFrame.isFullyContained(");
+    expect(source).toContain("sample.windowFrame.hasAccessibleTopEdge(");
     expect(source).toContain('"neondiff-settings-outer-scroll"');
     expect(source).toContain('"neondiff-settings-page-bottom"');
     expect(source).toContain("captureStableSettingsSceneSamples");
@@ -725,7 +725,7 @@ private func target() {
     expect(source).toContain("HostedSettingsSceneTrace(");
     expect(source).toContain("neondiff-hosted-settings-scene.json");
     expect(source).toContain(
-      'proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-visible-screen-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"'
+      'proofBoundary: "hosted-separate-settings-root-and-appkit-content-layout-560x700-default-and-observed-accessibility3-title-edge-and-outer-page-bottom-only-host-visible-screen-full-containment-system-preference-inner-scroll-manual-excluded"'
     );
     const settingsScenarioSource = extractBalancedSwiftDeclaration(
       source,

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -681,6 +681,11 @@ private func target() {
     expect(source).toContain(
       "testSeparateSettingsSceneFitsVisibleScreenAndReachesPageBottom"
     );
+    const settingsTestSource = extractBalancedSwiftDeclaration(
+      source,
+      "func testSeparateSettingsSceneFitsVisibleScreenAndReachesPageBottom()"
+    );
+    expect(settingsTestSource).toContain("schemaVersion: 2");
     expect(source).toContain("HostedContentSize(width: 560, height: 700)");
     expect(source).toContain(
       'HostedSettingsTextSizeRequest(textSizeMode: "runner-default-no-test-override", textSizeArgument: nil)'
@@ -689,7 +694,7 @@ private func target() {
       'HostedSettingsTextSizeRequest(textSizeMode: "swiftui-dynamic-type-accessibility3-test-override", textSizeArgument: "accessibility3")'
     );
     expect(source).toContain('app.typeKey(",", modifierFlags: [.command])');
-    expect(source).toContain('"neondiff-settings-window-content"');
+    expect(source).toContain('"neondiff-settings-evaluation-container"');
     expect(source).toContain('"neondiff.evaluation.settings.quiescent"');
     expect(source).toContain('"neondiff.evaluation.settings.text-size"');
     expect(source).toContain('let textSizePrefix = "ndst1:"');
@@ -718,20 +723,39 @@ private func target() {
     expect(source).toContain("isFullyContainedInWindowBounds(");
     expect(source).toContain("sample.contentLayoutScreenRect.isFullyContained(");
     expect(source).toContain("sample.windowFrame.isFullyContained(");
-    expect(source).toContain("observedContentSize: observedContentSize");
+    expect(source).toContain(
+      "observedAppKitContentLayoutSize: observedAppKitContentLayoutSize"
+    );
+    expect(source).toContain(
+      "observedAppKitWindowSize: observedAppKitWindowSize"
+    );
     expect(source).toContain('"neondiff-settings-outer-scroll"');
     expect(source).toContain('"neondiff-settings-page-bottom"');
     expect(source).toContain("captureStableSettingsSceneSamples");
     expect(source).toContain("samples.count == 3");
     expect(source).toContain("finalCompletionElapsedMilliseconds <= 5_000");
-    expect(source).toContain("settingsContentFrame.matches(requestedContentSize");
+    expect(source).toContain("windowFrame.matches(expectedAppKitWindowSize");
+    expect(source).toContain("accessibilityContainerMatchesWindowFrame");
+    expect(source).toContain("projectedAppKitContentLayoutFrame");
+    expect(source).toContain(
+      "appKitContentLayoutScreenRect.x - appKitWindowFrame.x"
+    );
+    expect(source).toContain(
+      "appKitWindowFrame.maxY - appKitContentLayoutScreenRect.maxY"
+    );
+    expect(source).toContain(
+      "projectedAppKitContentLayoutFullyContainedInWindow"
+    );
+    expect(source).toContain(
+      "outerScrollFullyContainedInProjectedAppKitContentLayout"
+    );
     expect(source).toContain("sentinelFullyContainedInOuterScroll");
     expect(source).toContain("effectProven: true");
     expect(source).toContain("scrollHadNoEffect");
     expect(source).toContain("HostedSettingsSceneTrace(");
     expect(source).toContain("neondiff-hosted-settings-scene.json");
     expect(source).toContain(
-      'proofBoundary: "hosted-separate-settings-preferred-560x700-visible-screen-fitted-root-and-appkit-content-layout-default-and-observed-accessibility3-window-contained-outer-page-bottom-only-system-preference-inner-scroll-manual-excluded"'
+      'proofBoundary: "hosted-separate-settings-preferred-560x700-appkit-window-and-content-layout-fitted-to-observed-visible-screen-xcui-window-dimension-bridge-outer-scroll-contained-and-page-bottom-reachable-runner-default-and-swiftui-accessibility3-test-override-only-system-text-preference-inner-scroll-manual-voiceover-focus-control-hittability-localization-multidisplay-relocation-installed-release-excluded"'
     );
     const settingsScenarioSource = extractBalancedSwiftDeclaration(
       source,
@@ -796,7 +820,7 @@ private func target() {
     expect(settings).toContain("HostedSettingsWindowConfigurator");
     expect(settings).toContain("HostedSettingsEvaluationStatus");
     expect(settings).toContain('"neondiff.evaluation.settings.quiescent"');
-    expect(settings).toContain('"neondiff-settings-window-content"');
+    expect(settings).toContain('"neondiff-settings-evaluation-container"');
     expect(settings).toContain('"neondiff.evaluation.settings.text-size"');
     expect(settings).toContain('"neondiff.evaluation.settings.appkit-geometry"');
     expect(settings).toContain("HostedSettingsGeometryAccessibilityChunk");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -696,7 +696,12 @@ private func target() {
       '"neondiff.evaluation.settings.appkit-geometry"'
     );
     expect(source).toContain("decodeAndValidateSettingsAppKitGeometry");
-    expect(source).toContain('envelope.coordinateSpace == "appkit-screen"');
+    expect(source).toContain(
+      'envelope.coordinateSpaces.contentLayoutRect == "appkit-window"'
+    );
+    expect(source).toContain(
+      'envelope.coordinateSpaces.contentLayoutScreenRect == "appkit-screen"'
+    );
     expect(source).toContain("envelope.samples.count == 3");
     expect(source).toContain("sample.contentLayoutRect.matches(");
     expect(source).toContain("sample.contentLayoutScreenRect.matches(");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -419,6 +419,7 @@ private func target() {
     expect(
       source.match(/outerPageScroll\.scroll\(byDeltaX: 0, deltaY: -10_000\)/g)
     ).toHaveLength(1);
+    expect(source.match(/\.scroll\s*\(/g)).toHaveLength(2);
     const checkpointSource = extractBalancedSwiftDeclaration(
       source,
       "private func capturePageBottomCheckpoint("
@@ -753,6 +754,13 @@ private func target() {
     expect(app).toContain("static let preferredContentHeight: CGFloat = 700");
     expect(app).toContain("floor(visibleScreenHeight - chromeHeight)");
     expect(app).not.toContain("NSScreen.main?.visibleFrame.height");
+    const fittedHeightSource = extractBalancedSwiftDeclaration(
+      app,
+      "static func fittedContentHeight("
+    );
+    expect(fittedHeightSource).toContain("chromeHeight.isFinite");
+    expect(fittedHeightSource).toContain("chromeHeight >= 0");
+    expect(fittedHeightSource).toContain("visibleScreenHeight > chromeHeight");
     const fitWindowSource = extractBalancedSwiftDeclaration(
       app,
       "private func fitWindow()"
@@ -763,7 +771,6 @@ private func target() {
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(windowFrame)");
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(contentLayoutRect)");
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(visibleFrame)");
-    expect(fitWindowSource).not.toMatch(/let chromeHeight\s*=\s*max\s*\(/);
     expect(fitWindowSource.match(/pendingHeight = nil/g)).toHaveLength(2);
     const attachSource = extractBalancedSwiftDeclaration(
       app,

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -691,11 +691,16 @@ private func target() {
     expect(source).toContain('"neondiff-settings-window-content"');
     expect(source).toContain('"neondiff.evaluation.settings.quiescent"');
     expect(source).toContain('"neondiff.evaluation.settings.text-size"');
+    expect(source).toContain('let textSizePrefix = "ndst1:"');
+    expect(source).toContain("let textSizeLabel = textSizeMarker.label");
     expect(source).toContain('observedTextSize != "accessibility3"');
     expect(source).toContain(
       '"neondiff.evaluation.settings.appkit-geometry"'
     );
     expect(source).toContain("decodeAndValidateSettingsAppKitGeometry");
+    expect(source).toContain('let manifestPrefix = "ndsg1-chunks:"');
+    expect(source).toContain('let prefix = "ndsg1:\\(index):\\(chunkCount):"');
+    expect(source).toContain("let label = chunk.label");
     expect(source).toContain(
       'envelope.coordinateSpaces.contentLayoutRect == "appkit-window"'
     );
@@ -753,6 +758,12 @@ private func target() {
     expect(settings).toContain('"neondiff-settings-window-content"');
     expect(settings).toContain('"neondiff.evaluation.settings.text-size"');
     expect(settings).toContain('"neondiff.evaluation.settings.appkit-geometry"');
+    expect(settings).toContain("HostedSettingsGeometryAccessibilityChunk");
+    expect(settings).toContain("geometryAccessibilityManifest");
+    expect(settings).toContain("geometryAccessibilityChunks");
+    expect(settings).toContain('let chunkByteCount = 64');
+    expect(settings).toContain('let label = "ndsg1:');
+    expect(settings).not.toContain(".accessibilityValue(");
     expect(settings).toContain("visibleScreenFrame: visibleScreenFrame");
     expect(settings).toContain("window.convertToScreen(");
     expect(settings).toContain("status.markQuiescent(samples: stableSamples)");

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -747,15 +747,15 @@ private func target() {
     expect(app).toContain("SettingsWindowFitView(contentHeight:");
     expect(app).toContain("window.screen?.visibleFrame");
     expect(app).toContain("NSWindow.didChangeScreenNotification");
-    expect(app).toContain("NSWindow.didMoveNotification");
     expect(app).toContain("NSApplication.didChangeScreenParametersNotification");
+    expect(app).not.toContain("NSWindow.didMoveNotification");
     expect(app).toContain("static let preferredContentWidth: CGFloat = 560");
     expect(app).toContain("static let preferredContentHeight: CGFloat = 700");
     expect(app).toContain("floor(visibleScreenHeight - chromeHeight)");
     expect(app).not.toContain("NSScreen.main?.visibleFrame.height");
     const fitWindowSource = extractBalancedSwiftDeclaration(
       app,
-      "private func fitWindow(clampOrigin: Bool)"
+      "private func fitWindow()"
     );
     expect(fitWindowSource).toContain(
       "let chromeHeight = windowFrame.height - contentLayoutRect.height"
@@ -763,13 +763,15 @@ private func target() {
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(windowFrame)");
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(contentLayoutRect)");
     expect(fitWindowSource).toContain("Self.isFiniteNonempty(visibleFrame)");
-    expect(fitWindowSource).toContain("guard clampOrigin else { return }");
     expect(fitWindowSource).not.toMatch(/let chromeHeight\s*=\s*max\s*\(/);
-    const moveHandlerSource = extractBalancedSwiftDeclaration(
+    expect(fitWindowSource.match(/pendingHeight = nil/g)).toHaveLength(2);
+    const attachSource = extractBalancedSwiftDeclaration(
       app,
-      "@objc private func windowDidMove(_ notification: Notification)"
+      "func attach(to window: NSWindow?, contentHeight: Binding<CGFloat>)"
     );
-    expect(moveHandlerSource).toContain("fitWindow(clampOrigin: false)");
+    expect(attachSource).toMatch(
+      /attachmentGeneration \+= 1\s+pendingHeight = nil\s+self\.window = window/
+    );
     expect(app).toContain(".dynamicTypeSize(.accessibility3)");
     expect(app).toContain("hostedSettingsEvaluationContent");
     const settingsSceneSource = extractBalancedSwiftDeclaration(

--- a/tests/desktop-hosted-xcuitest.test.ts
+++ b/tests/desktop-hosted-xcuitest.test.ts
@@ -699,6 +699,9 @@ private func target() {
     expect(source).toContain('envelope.coordinateSpace == "appkit-screen"');
     expect(source).toContain("envelope.samples.count == 3");
     expect(source).toContain("sample.contentLayoutRect.matches(");
+    expect(source).toContain("sample.contentLayoutScreenRect.matches(");
+    expect(source).toContain("isFullyContainedInWindowBounds(");
+    expect(source).toContain("sample.contentLayoutScreenRect.isFullyContained(");
     expect(source).toContain("sample.windowFrame.isFullyContained(");
     expect(source).toContain('"neondiff-settings-outer-scroll"');
     expect(source).toContain('"neondiff-settings-page-bottom"');
@@ -734,6 +737,7 @@ private func target() {
     expect(settings).toContain('"neondiff.evaluation.settings.text-size"');
     expect(settings).toContain('"neondiff.evaluation.settings.appkit-geometry"');
     expect(settings).toContain("visibleScreenFrame: visibleScreenFrame");
+    expect(settings).toContain("window.convertToScreen(");
     expect(settings).toContain("status.markQuiescent(samples: stableSamples)");
     expect(settings).toContain("#if DEBUG");
   });


### PR DESCRIPTION
## Summary

- make the native SwiftUI Settings scene prefer the canonical 560x700 content size and fit its height to its attached AppKit window's actual screen visible frame minus measured native window chrome when the preferred size cannot fit
- refit and contain on actual destination-screen and display-parameter changes without observing ordinary move notifications, so cross-display dragging is not intercepted
- add a fresh-launch hosted Settings matrix for runner-default and Settings-local observed `.accessibility3`
- require one automated Command-comma attempt per scenario, exactly one additional app window, and a non-interactive quiescence marker
- retain three settled AppKit samples for `window.frame`, raw window-local `contentLayoutRect`, explicitly converted screen-space content layout, and `screen.visibleFrame`
- validate per-field coordinate-space metadata, preferred and observed fitted content sizes, window-local/screen-space containment, stable visible-screen metadata, whole-window visible-screen containment, outer-scroll containment, and bottom-sentinel reachability
- keep all markers, geometry transport, and evaluation status DEBUG-only; ordinary and release accessibility hierarchy is unchanged

## Exact candidate

- head: `0e485a89e63394afc05605a6ce8497428a77290c`
- base: `1a523474da1f24ce7f3bb751e70034bef3d10f17`

## Failing-first and focused validation

- dependency bootstrap before collection was not counted as RED
- valid RED after dependency install: focused hosted-XCTest contract had 1 failure / 11 passes because the Settings-scene contract was absent
- final review-hardening RED at `c87c750887eac807c284f9e4c55199c2d51aad63`: 2 failures / 11 passes, proving legal tab-separated `#elseif` release projection and pending containment-request coalescing were not yet enforced
- focused Vitest at exact head: 13/13 passed
- Xcode 26.6 hosted target `build-for-testing` at exact head: passed; no app or UI test was launched; the package cache and result bundle were explicitly routed to Lexar after the local system volume rejected an earlier dependency-resolution attempt for insufficient space
- public-claims scan: passed
- secret scan: passed over 768 tracked files
- diff check: passed
- independent exact-head correctness review: clean delta; no P0-P3 findings at the 95% confidence gate
- independent exact-head security/proof-integrity review: clean delta at 97% confidence
- independent exact-head accessibility/design review: clean delta; no P0-P3 findings at the 95% confidence gate

## Authoritative remote failing run and correction

- superseded head `9d2d70d4ba359c37673b149d8a6c3e698ecbcaa7`: CI and CodeQL passed; Swift Desktop Gate run `29467836959` failed the new Settings test
- immutable failed artifact `8363880207`; GitHub wrapper digest `sha256:5c06fb8a56b3c9b1f44702982908e1080300b478fc9b4d52c83075fdab539e6a`; independently downloaded xcresult ZIP SHA-256 `868a1be181cb384f4d25fe0f19286084df01e2c96962d6231c0358cfea0787af`
- independent xcresult readback: 10 total, 7 passed, 1 failed, 2 skipped on macOS 15.7.7 arm64
- precise failure: the new test stopped in the first fresh-launch runner-default scenario because the clear SwiftUI marker's `accessibilityValue` was not exposed as a String; all seven pre-existing hosted tests passed
- correction: transport the typed text-size value through a versioned AX label and transport geometry through ordered 64-byte Base64 chunks with unique identifiers, versioned labels, a 128-byte label ceiling, bounded count, strict decoding, and no retry
- the final source-contract assertion also pins the runtime 128-byte ceiling
- superseded head `e444580bbb21944735319c0fe78f84a66c81fc22`: CI run `29468913275` and CodeQL run `29468911360` passed; Swift Desktop Gate run `29468913276` failed only the new Settings test
- immutable failed artifact `8364283997`; GitHub wrapper digest `sha256:bfff6e7aacf70d2e550b27d2ddb38fb91c463d694abc886f3d9c0cef1e39ff1a`; independently downloaded xcresult ZIP SHA-256 `9ebdc09e006fe5fd3bd1fcd0cfd4b2573683db30ef11b7ac41b2ba6c09ca6e3c`
- independent xcresult readback: 10 total, 7 passed, 1 failed, 2 skipped on macOS 15.7.7 arm64; failure was `invalidAppKitGeometry("runner-default-no-test-override")`
- the immutable screen recording shows the 1024x768 hosted runner with a visible Dock: canonical 560x700 Settings content plus native title bar cannot be wholly contained in the Dock-reduced visible frame, although the top/title edge and full width remain accessible; all seven pre-existing hosted tests passed
- independent accessibility/design review rejected the intermediate top-edge-only boundary because a bottom sentinel could remain inside the scroll view while still sitting behind the Dock
- correction: keep 560x700 as the preferred production Settings size, fit the actual content height to `screen.visibleFrame` minus native frame chrome when needed, record the observed fitted size, restore whole-window visible-screen containment, and retain all AppKit coordinate-space, window-local, screen-space, stability, cadence, outer-scroll, and sentinel checks
- independent current-head review then rejected `NSScreen.main` because it could fit and reposition a Settings window against the wrong display; correction binds fitting to the actual attached Settings `NSWindow`, its `screen`, and its measured frame chrome
- the next current-head review found that immediate `didMove` clamping could trap the window on its current display and that zero-normalizing a negative chrome measurement bypassed the fail-closed guard
- correction: ordinary move notifications do not participate in fitting; actual destination-screen/display-parameter changes fit and contain against the attached window's actual screen; raw finite/nonempty AppKit geometry and raw chrome must pass guards before any state or frame mutation; attachment generation, target, window identity, and pending-height checks reject stale or suppressed deferred writes
- exact-head evaOS review then raised two P3 source-contract gaps: the old file-global single-scroll invariant had no updated two-helper equivalent, and the contract forbade one implementation form without directly pinning the finite/nonnegative chrome guard
- correction: require exactly two `.scroll(` calls file-wide while retaining one-call scoped checks for the page-bottom and Settings helpers, and explicitly require the production `chromeHeight.isFinite`, `chromeHeight >= 0`, and `visibleScreenHeight > chromeHeight` guards
- superseded head `1a662b8b7e7b09402973f11d5eacb32210c18bed`: CI run `29471094787` and CodeQL run `29471092752` passed; Swift Desktop Gate run `29471094795` failed only the new Settings test
- immutable failed artifact `8365043603`; GitHub wrapper digest `sha256:c5552ce82923604b237340a4f224e04115b795bee73b326024b6e300b36a1c07`; independently downloaded xcresult ZIP SHA-256 `648f85b680bcf5a069dc0545171b4761c8e429b1cf7a087eb8770ff3091c72e7`
- independent xcresult readback: 10 total, 7 passed, 1 failed, 2 skipped on macOS 15.7.7 arm64; all seven pre-existing hosted tests passed
- precise failure: the validated AppKit content layout was 560x656 while the SwiftUI accessibility evaluation container exposed the complete 560x684 titled Settings window; the 28-point difference was native title-bar chrome, and the test incorrectly compared content-layout dimensions to window-root dimensions
- the immutable screenshot and recording show the complete Settings window contained between the menu bar and Dock; the failure occurred after all three AppKit fit/containment samples passed and before a Settings trace could be attached, so this is diagnostic failure evidence rather than a passing sample packet
- correction: emit Settings trace schema 2; name the DEBUG accessibility surface as an evaluation container; retain AppKit as the authority for fitted window, content-layout, and visible-screen geometry; separately require the XCUI window and evaluation container to match the AppKit window dimensions and each other; project the AppKit content-layout rectangle into XCUI coordinates by window-relative left and top insets; and require the outer scroll to remain inside that projected content rectangle before proving the page-bottom sentinel reachable

## Post-pass review hardening

- superseded passing head `a68237f48cfd6004339e18eb70047a9c52c4d800` first established the hosted Settings proof; its evidence remains bound only to that head
- CodeRabbit then found that the three-sample stability check compared against the previous sample instead of the first and that the DEBUG source contract could over-remove release-reachable alternatives; `c96f66b3b524469bc9f5beaca7ef571ba6fd5592` corrected both with failing-first contracts
- exact-head correctness/security/design review at `c96f66b3b524469bc9f5beaca7ef571ba6fd5592` found remaining non-DEBUG alternative/comment-literal projection gaps and destination-screen origin snapping; `c87c750887eac807c284f9e4c55199c2d51aad63` added masked, fail-closed release projection and preserved cross-display dragging
- exact-head review at `c87c750887eac807c284f9e4c55199c2d51aad63` found legal tab-separated conditional directives could still false-pass and same-height asynchronous requests could lose a stronger containment requirement; final head `0e485a89e63394afc05605a6ce8497428a77290c` accepts legal directive whitespace, fails closed on unsupported DEBUG conditions, and monotonically upgrades pending containment requests

## Current-head remote proof

- exact remote head: `0e485a89e63394afc05605a6ce8497428a77290c`
- CI run `29480146401`: passed
- CodeQL run `29480143564`: actions, JavaScript/TypeScript, and Python analyses passed; wrapper check passed
- Swift Desktop Gate run `29480146332`: passed; independent xcresult readback is 10 total, 8 passed, 0 failed, 2 known activation-handoff skips on macOS 15.7.7 arm64
- immutable artifact `8368575779`; GitHub wrapper digest `sha256:f7ecf4309adc78b01b5ad76dd8d5eea5a416e2698584439caf9044205c23e0ac`; independently downloaded contained xcresult ZIP SHA-256 `3988ff7d52caf5af174aadb5ab4a834c685dda1b0acad3fdd0b349c2e96fad76`
- independently exported Settings trace SHA-256 `1d27217ffa868032feedd9406a675c2c628e6e7022ed2cb6d70418f84c837252`
- Settings trace schema 2 contains two fresh-launch scenarios: observed runner-default `large` and test-overridden `accessibility3`; both record preferred 560x700, fitted AppKit content 560x656, AppKit/XCUI window 560x684, three stable AppKit samples, one Command-comma attempt, exact projected-content/outer-scroll alignment, one effective outer-scroll action, and settled post-action bottom-sentinel containment
- all code/test check annotations are empty; two warning-only annotations report GitHub forcing pinned Node-20 actions onto Node 24 and do not identify a source or test failure
- review-thread pagination is complete: 6 total, 6 resolved, 0 current actionable, 0 outdated unresolved
- exact-head evaOS review completed with no validated findings; three independent exact-head correctness, security/proof-integrity, and accessibility/design reviews also returned no findings

No local UI result is used as proof. CodeRabbit full review run `1fee599d-3434-404c-8283-2c4b1cddc616` evaluated the exact base-to-head range and approved exact head `0e485a89e63394afc05605a6ce8497428a77290c`; final merge-state readback remains required before merge.

## Proof boundary

This PR proves only the deterministic DEBUG `tab-overview` fixture opening one separate Settings scene from each fresh launch via one automated Command-comma attempt, with Settings-local observed runner-default/accessibility3 state, preferred 560x700 content, observed visible-screen-fitted AppKit content-layout and window sizes, three settled AppKit geometry samples, a dimension-matched XCUI Settings window/evaluation-container bridge, outer-scroll containment inside the projected AppKit content rectangle, whole-window visible-screen containment, and outer Settings page-bottom reachability.

It excludes manual keyboard behavior, Settings close/reopen, moving the Settings window between screens after opening, the real macOS system text-size preference, host/system-preference scrolling, inner-scroll exhaustion, individual-control hittability, VoiceOver/focus order, localization, signed/notarized or installed artifacts, release, GA, runtime, billing, broker production wiring, and customer readiness.

No live checkout, launchd, runtime, TCC, global npm configuration, secret store, or customer surface is changed.

Related: #517. The broader acceptance matrix remains open.
