### PR TITLE
feat(license-api): add default-off GitHub broker runtime wiring

### DIFF
--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -117,21 +117,23 @@ the shared `services/license-api` deployment). The broker reads the private key 
 the OAuth client secret from this secret store at runtime and never persists, logs,
 or returns them. These names are the contract for the future production-wiring step
 in `services/license-api/src/http.ts` (`HttpHandlerOptions.githubBroker` →
-`createGitHubBrokerService`), read there from the deployment environment; `server.ts`
-only starts the listener and today passes no `githubBroker` option and reads no
-`GITHUB_BROKER_*` env vars. Until `http.ts` is given `githubBroker`, the shared
-license request listener matches every broker path (`isGitHubBrokerPath`) and
-returns a typed `{ "reason": "broker_unavailable" }` 503 — a deliberate fail-closed
-status, not an unrouted 404:
+`createGitHubBrokerService`), read there from the deployment environment.
+`server.ts` constructs the existing broker seam only when
+`GITHUB_BROKER_ENABLED=true` and every required value below validates. Missing
+or invalid enabled configuration leaves the license API available while every
+broker path returns typed `{ "reason": "broker_unavailable" }` 503. Setting
+`GITHUB_BROKER_ENABLED=false` is the production kill switch; the remaining
+secrets may stay provisioned without activating the broker:
 
 | Secret                          | Purpose |
 |---------------------------------|---------|
+| `GITHUB_BROKER_ENABLED`         | Exact `true` enables construction; unset/`false` keeps every broker route unavailable. |
 | `GITHUB_BROKER_APP_ID`          | Numeric staging App id. |
 | `GITHUB_BROKER_PRIVATE_KEY`     | Staging App private key PEM contents. |
 | `GITHUB_BROKER_OAUTH_CLIENT_ID`     | Staging App OAuth **client id** ("Request user authorization (OAuth) during installation", step 1). Wires to `githubBroker.oauthClientId`. Required for callback identity verification (#614 P1). |
 | `GITHUB_BROKER_OAUTH_CLIENT_SECRET` | Staging App OAuth **client secret**. Wires to `githubBroker.oauthClientSecret`. Used only to exchange the callback `code` for a short-lived user token to confirm installation ownership; never persisted, logged, or returned. |
 | `GITHUB_BROKER_INSTALL_BASE_URL`| `https://github.com/apps/<staging-app-slug>/installations/new`. |
-| `GITHUB_BROKER_DB_PATH`         | Path for the broker SQLite DB on the mounted volume (separate from `LICENSE_DB_PATH`). |
+| `GITHUB_BROKER_DB_PATH`         | Absolute path for the broker SQLite DB on the mounted volume (must differ from `LICENSE_DB_PATH`). |
 | `GITHUB_BROKER_API_BASE_URL`    | Optional; defaults to `https://api.github.com`. |
 | `GITHUB_BROKER_OAUTH_BASE_URL`  | Optional; OAuth authorization host, defaults to `https://github.com`. Wires to `githubBroker.oauthBaseUrl`. |
 

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -115,9 +115,9 @@ depend on device flow; this setting is only for the existing desktop path until
 Place the following in the license-service deployment environment (Fly secrets for
 the shared `services/license-api` deployment). The broker reads the private key and
 the OAuth client secret from this secret store at runtime and never persists, logs,
-or returns them. These names are the contract for the future production-wiring step
-in `services/license-api/src/http.ts` (`HttpHandlerOptions.githubBroker` →
-`createGitHubBrokerService`), read there from the deployment environment.
+or returns them. These names are the runtime contract read by
+`services/license-api/src/server.ts`, which passes validated dependencies through
+`HttpHandlerOptions.githubBroker` to `createGitHubBrokerService`.
 `server.ts` constructs the existing broker seam only when
 `GITHUB_BROKER_ENABLED=true` and every required value below validates. Missing
 or invalid enabled configuration leaves the license API available while every

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -147,6 +147,22 @@ Environment:
   lifecycle route also requires it for deterministic key derivation, but never
   accepts it as request authorization. Keep it only on Fly and the checkout
   webhook server; do not expose it to browsers, clients, workflows, or logs.
+- `GITHUB_BROKER_ENABLED` — exact `true` constructs the managed GitHub App
+  broker; unset/`false` is the kill switch and keeps its routes at typed
+  `broker_unavailable`.
+- `GITHUB_BROKER_APP_ID`, `GITHUB_BROKER_PRIVATE_KEY`,
+  `GITHUB_BROKER_OAUTH_CLIENT_ID`, `GITHUB_BROKER_OAUTH_CLIENT_SECRET`,
+  `GITHUB_BROKER_INSTALL_BASE_URL`, and `GITHUB_BROKER_DB_PATH` — required
+  together when the broker is enabled. The DB path must be absolute and separate
+  from `LICENSE_DB_PATH`. Optional `GITHUB_BROKER_API_BASE_URL` and
+  `GITHUB_BROKER_OAUTH_BASE_URL` default to GitHub's public HTTPS hosts.
+  Configuration errors are reported by setting name/reason only; values are
+  never logged.
+
+This runtime wiring does not supply the production App registration, secrets,
+private-repository entitlement resolver, native client adoption, or live install
+proof. Until those owner-gated and #612 integration steps pass, keep the broker
+disabled in production.
 
 ## Admin issuance CLI
 

--- a/services/license-api/src/github-broker/runtime-config.ts
+++ b/services/license-api/src/github-broker/runtime-config.ts
@@ -1,0 +1,175 @@
+import { createPrivateKey } from "node:crypto";
+import { isAbsolute, resolve } from "node:path";
+import { createGitHubInstallationClient } from "./github-app.js";
+import type { GitHubBrokerDeps } from "./routes.js";
+import { normalizeHttpApiBaseUrl } from "./url.js";
+
+const REQUIRED_SETTINGS = [
+  "GITHUB_BROKER_APP_ID",
+  "GITHUB_BROKER_PRIVATE_KEY",
+  "GITHUB_BROKER_OAUTH_CLIENT_ID",
+  "GITHUB_BROKER_OAUTH_CLIENT_SECRET",
+  "GITHUB_BROKER_INSTALL_BASE_URL",
+  "GITHUB_BROKER_DB_PATH"
+] as const;
+
+type RequiredSetting = (typeof REQUIRED_SETTINGS)[number];
+type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type GitHubBrokerRuntimeConfig =
+  | { status: "disabled" }
+  | { status: "invalid"; setting: string; reason: string }
+  | { status: "ready"; deps: GitHubBrokerDeps };
+
+/**
+ * Translate the owner-provisioned Fly environment into the already-reviewed
+ * broker dependency seam. The explicit enable flag is both rollout gate and kill
+ * switch: secrets may remain provisioned while the public routes keep returning
+ * typed `broker_unavailable`.
+ *
+ * Invalid enabled configuration never includes a submitted value in its result.
+ * The production entrypoint can therefore report a setting/reason without
+ * logging private key or OAuth material.
+ */
+export function loadGitHubBrokerRuntimeConfig(
+  environment: RuntimeEnvironment,
+  licenseDbPath: string
+): GitHubBrokerRuntimeConfig {
+  const enabled = normalized(environment.GITHUB_BROKER_ENABLED);
+  if (enabled === undefined || enabled === "false") return { status: "disabled" };
+  if (enabled !== "true") {
+    return invalid("GITHUB_BROKER_ENABLED", "must_be_true_or_false");
+  }
+
+  const values = new Map<RequiredSetting, string>();
+  for (const setting of REQUIRED_SETTINGS) {
+    const value = normalized(environment[setting]);
+    if (value === undefined) return invalid(setting, "missing");
+    values.set(setting, value);
+  }
+
+  const appId = required(values, "GITHUB_BROKER_APP_ID");
+  if (!/^[1-9]\d{0,19}$/.test(appId)) {
+    return invalid("GITHUB_BROKER_APP_ID", "invalid");
+  }
+
+  const privateKey = required(values, "GITHUB_BROKER_PRIVATE_KEY");
+  try {
+    const parsed = createPrivateKey(privateKey);
+    if (parsed.asymmetricKeyType !== "rsa") {
+      return invalid("GITHUB_BROKER_PRIVATE_KEY", "invalid");
+    }
+  } catch {
+    return invalid("GITHUB_BROKER_PRIVATE_KEY", "invalid");
+  }
+
+  const oauthClientId = required(values, "GITHUB_BROKER_OAUTH_CLIENT_ID");
+  const oauthClientSecret = required(
+    values,
+    "GITHUB_BROKER_OAUTH_CLIENT_SECRET"
+  );
+  if (oauthClientId.length > 512) {
+    return invalid("GITHUB_BROKER_OAUTH_CLIENT_ID", "invalid");
+  }
+  if (oauthClientSecret.length > 2048) {
+    return invalid("GITHUB_BROKER_OAUTH_CLIENT_SECRET", "invalid");
+  }
+
+  const installBaseUrl = normalizeInstallBaseUrl(
+    required(values, "GITHUB_BROKER_INSTALL_BASE_URL")
+  );
+  if (!installBaseUrl) {
+    return invalid("GITHUB_BROKER_INSTALL_BASE_URL", "invalid");
+  }
+
+  const dbPath = required(values, "GITHUB_BROKER_DB_PATH");
+  if (!isAbsolute(dbPath)) {
+    return invalid("GITHUB_BROKER_DB_PATH", "must_be_absolute");
+  }
+  if (resolve(dbPath) === resolve(licenseDbPath)) {
+    return invalid("GITHUB_BROKER_DB_PATH", "must_differ_from_license_db");
+  }
+
+  let apiBaseUrl: string | undefined;
+  let oauthBaseUrl: string | undefined;
+  try {
+    if (normalized(environment.GITHUB_BROKER_API_BASE_URL)) {
+      apiBaseUrl = normalizeHttpApiBaseUrl(
+        environment.GITHUB_BROKER_API_BASE_URL,
+        "GITHUB_BROKER_API_BASE_URL",
+        "https://api.github.com"
+      ).toString();
+    }
+  } catch {
+    return invalid("GITHUB_BROKER_API_BASE_URL", "invalid");
+  }
+  try {
+    if (normalized(environment.GITHUB_BROKER_OAUTH_BASE_URL)) {
+      oauthBaseUrl = normalizeHttpApiBaseUrl(
+        environment.GITHUB_BROKER_OAUTH_BASE_URL,
+        "GITHUB_BROKER_OAUTH_BASE_URL",
+        "https://github.com"
+      ).toString();
+    }
+  } catch {
+    return invalid("GITHUB_BROKER_OAUTH_BASE_URL", "invalid");
+  }
+
+  const githubClient = createGitHubInstallationClient({
+    appId,
+    privateKey,
+    oauthClientId,
+    oauthClientSecret,
+    requestTimeoutMs: 8_000,
+    ...(apiBaseUrl ? { apiBaseUrl } : {}),
+    ...(oauthBaseUrl ? { oauthBaseUrl } : {})
+  });
+  return {
+    status: "ready",
+    deps: {
+      dbPath,
+      githubClient,
+      installBaseUrl
+    }
+  };
+}
+
+function normalized(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function required(
+  values: ReadonlyMap<RequiredSetting, string>,
+  setting: RequiredSetting
+): string {
+  const value = values.get(setting);
+  if (!value) throw new Error(`missing validated setting: ${setting}`);
+  return value;
+}
+
+function normalizeInstallBaseUrl(value: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "github.com" ||
+    url.port ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    !/^\/apps\/[a-z0-9-]+\/installations\/new$/.test(url.pathname)
+  ) {
+    return undefined;
+  }
+  return url.toString();
+}
+
+function invalid(setting: string, reason: string): GitHubBrokerRuntimeConfig {
+  return { status: "invalid", setting, reason };
+}

--- a/services/license-api/src/github-broker/runtime-config.ts
+++ b/services/license-api/src/github-broker/runtime-config.ts
@@ -2,6 +2,7 @@ import { createPrivateKey } from "node:crypto";
 import { isAbsolute, resolve } from "node:path";
 import { createGitHubInstallationClient } from "./github-app.js";
 import type { GitHubBrokerDeps } from "./routes.js";
+import { GitHubBrokerStore } from "./store.js";
 import { normalizeHttpApiBaseUrl } from "./url.js";
 
 const REQUIRED_SETTINGS = [
@@ -115,6 +116,16 @@ export function loadGitHubBrokerRuntimeConfig(
     return invalid("GITHUB_BROKER_OAUTH_BASE_URL", "invalid");
   }
 
+  let store: GitHubBrokerStore;
+  try {
+    // Open and migrate inside the fail-closed configuration boundary. Passing
+    // the ready store onward prevents a later constructor failure from taking
+    // down unrelated license and health routes.
+    store = new GitHubBrokerStore(dbPath);
+  } catch {
+    return invalid("GITHUB_BROKER_DB_PATH", "open_failed");
+  }
+
   const githubClient = createGitHubInstallationClient({
     appId,
     privateKey,
@@ -128,6 +139,7 @@ export function loadGitHubBrokerRuntimeConfig(
     status: "ready",
     deps: {
       dbPath,
+      store,
       githubClient,
       installBaseUrl
     }

--- a/services/license-api/src/server.ts
+++ b/services/license-api/src/server.ts
@@ -2,6 +2,7 @@ import { LicenseStore } from "./store.js";
 import { startLicenseServer } from "./http.js";
 import { createGitHubActionsOidcVerifier } from "./oidc-lifecycle.js";
 import { RateLimiter } from "./service.js";
+import { loadGitHubBrokerRuntimeConfig } from "./github-broker/runtime-config.js";
 
 /**
  * Production entrypoint. SQLite lives on a mounted volume in deploy
@@ -15,6 +16,16 @@ async function main(): Promise<void> {
   // Fly injects FLY_APP_NAME into Machines. Outside that operator-controlled
   // runtime, request-supplied Fly headers are untrusted and ignored.
   const trustFlyProxyHeaders = Boolean(process.env.FLY_APP_NAME?.trim());
+  const githubBrokerRuntime = loadGitHubBrokerRuntimeConfig(process.env, dbPath);
+  if (githubBrokerRuntime.status === "invalid") {
+    // Setting name + fixed reason are public-safe. Never log the submitted value.
+    // The license API remains available while every broker route fails closed
+    // with the existing typed `broker_unavailable` response.
+    // eslint-disable-next-line no-console
+    console.error(
+      `github broker unavailable: ${githubBrokerRuntime.setting} ${githubBrokerRuntime.reason}`
+    );
+  }
   const store = new LicenseStore(dbPath);
   const { url } = await startLicenseServer({
     store,
@@ -26,7 +37,10 @@ async function main(): Promise<void> {
       maxPerWindow: 60,
       windowMs: 60_000
     }),
-    lifecycleOidcVerifier: createGitHubActionsOidcVerifier()
+    lifecycleOidcVerifier: createGitHubActionsOidcVerifier(),
+    ...(githubBrokerRuntime.status === "ready"
+      ? { githubBroker: githubBrokerRuntime.deps }
+      : {})
   });
   // eslint-disable-next-line no-console
   console.log(`license-api listening on ${url} (db=${dbPath})`);

--- a/services/license-api/test/github-broker-runtime-config.test.ts
+++ b/services/license-api/test/github-broker-runtime-config.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { loadGitHubBrokerRuntimeConfig } from "../src/github-broker/runtime-config.ts";
 
 const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const appPrivateKey = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+const brokerDbRoot = mkdtempSync(join(tmpdir(), "neondiff-broker-runtime-"));
+const brokerDbPath = join(brokerDbRoot, "github-broker.sqlite");
 
 function completeEnvironment(): Record<string, string> {
   return {
@@ -15,7 +20,7 @@ function completeEnvironment(): Record<string, string> {
     GITHUB_BROKER_OAUTH_CLIENT_SECRET: "fixture-oauth-secret",
     GITHUB_BROKER_INSTALL_BASE_URL:
       "https://github.com/apps/neondiff-staging/installations/new",
-    GITHUB_BROKER_DB_PATH: "/data/github-broker.sqlite"
+    GITHUB_BROKER_DB_PATH: brokerDbPath
   };
 }
 
@@ -38,7 +43,7 @@ describe("production GitHub broker runtime configuration", () => {
     );
     assert.equal(result.status, "ready");
     if (result.status !== "ready") return;
-    assert.equal(result.deps.dbPath, "/data/github-broker.sqlite");
+    assert.equal(result.deps.dbPath, brokerDbPath);
     assert.equal(
       result.deps.installBaseUrl,
       "https://github.com/apps/neondiff-staging/installations/new"
@@ -47,6 +52,21 @@ describe("production GitHub broker runtime configuration", () => {
     const serialized = JSON.stringify(result);
     assert.equal(serialized.includes(appPrivateKey), false);
     assert.equal(serialized.includes("fixture-oauth-secret"), false);
+    result.deps.store?.close();
+  });
+
+  it("keeps the license API available when broker storage cannot open", () => {
+    assert.deepEqual(
+      loadGitHubBrokerRuntimeConfig(
+        { ...completeEnvironment(), GITHUB_BROKER_DB_PATH: brokerDbRoot },
+        "/data/license.sqlite"
+      ),
+      {
+        status: "invalid",
+        setting: "GITHUB_BROKER_DB_PATH",
+        reason: "open_failed"
+      }
+    );
   });
 
   it("fails closed with a public-safe setting name for every missing required value", () => {

--- a/services/license-api/test/github-broker-runtime-config.test.ts
+++ b/services/license-api/test/github-broker-runtime-config.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { describe, it } from "node:test";
+import { loadGitHubBrokerRuntimeConfig } from "../src/github-broker/runtime-config.ts";
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const appPrivateKey = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+
+function completeEnvironment(): Record<string, string> {
+  return {
+    GITHUB_BROKER_ENABLED: "true",
+    GITHUB_BROKER_APP_ID: "123456",
+    GITHUB_BROKER_PRIVATE_KEY: appPrivateKey,
+    GITHUB_BROKER_OAUTH_CLIENT_ID: "Iv1.fixture-client-id",
+    GITHUB_BROKER_OAUTH_CLIENT_SECRET: "fixture-oauth-secret",
+    GITHUB_BROKER_INSTALL_BASE_URL:
+      "https://github.com/apps/neondiff-staging/installations/new",
+    GITHUB_BROKER_DB_PATH: "/data/github-broker.sqlite"
+  };
+}
+
+describe("production GitHub broker runtime configuration", () => {
+  it("defaults off and remains an explicit kill switch even when credentials stay provisioned", () => {
+    const unset = loadGitHubBrokerRuntimeConfig({}, "/data/license.sqlite");
+    assert.deepEqual(unset, { status: "disabled" });
+
+    const disabled = loadGitHubBrokerRuntimeConfig(
+      { ...completeEnvironment(), GITHUB_BROKER_ENABLED: "false" },
+      "/data/license.sqlite"
+    );
+    assert.deepEqual(disabled, { status: "disabled" });
+  });
+
+  it("constructs the existing broker dependencies only from a complete enabled contract", () => {
+    const result = loadGitHubBrokerRuntimeConfig(
+      completeEnvironment(),
+      "/data/license.sqlite"
+    );
+    assert.equal(result.status, "ready");
+    if (result.status !== "ready") return;
+    assert.equal(result.deps.dbPath, "/data/github-broker.sqlite");
+    assert.equal(
+      result.deps.installBaseUrl,
+      "https://github.com/apps/neondiff-staging/installations/new"
+    );
+    assert.equal(typeof result.deps.githubClient.getInstallation, "function");
+    const serialized = JSON.stringify(result);
+    assert.equal(serialized.includes(appPrivateKey), false);
+    assert.equal(serialized.includes("fixture-oauth-secret"), false);
+  });
+
+  it("fails closed with a public-safe setting name for every missing required value", () => {
+    for (const setting of [
+      "GITHUB_BROKER_APP_ID",
+      "GITHUB_BROKER_PRIVATE_KEY",
+      "GITHUB_BROKER_OAUTH_CLIENT_ID",
+      "GITHUB_BROKER_OAUTH_CLIENT_SECRET",
+      "GITHUB_BROKER_INSTALL_BASE_URL",
+      "GITHUB_BROKER_DB_PATH"
+    ]) {
+      const environment = completeEnvironment();
+      delete environment[setting];
+      assert.deepEqual(
+        loadGitHubBrokerRuntimeConfig(environment, "/data/license.sqlite"),
+        { status: "invalid", setting, reason: "missing" }
+      );
+    }
+  });
+
+  it("rejects ambiguous flags, invalid identities, unsafe URLs, and storage collisions", () => {
+    const cases: Array<{
+      patch: Record<string, string>;
+      setting: string;
+      reason: string;
+      licenseDbPath?: string;
+    }> = [
+      {
+        patch: { GITHUB_BROKER_ENABLED: "1" },
+        setting: "GITHUB_BROKER_ENABLED",
+        reason: "must_be_true_or_false"
+      },
+      {
+        patch: { GITHUB_BROKER_APP_ID: "not-an-id" },
+        setting: "GITHUB_BROKER_APP_ID",
+        reason: "invalid"
+      },
+      {
+        patch: { GITHUB_BROKER_PRIVATE_KEY: "not a private key" },
+        setting: "GITHUB_BROKER_PRIVATE_KEY",
+        reason: "invalid"
+      },
+      {
+        patch: { GITHUB_BROKER_INSTALL_BASE_URL: "https://example.com/install" },
+        setting: "GITHUB_BROKER_INSTALL_BASE_URL",
+        reason: "invalid"
+      },
+      {
+        patch: { GITHUB_BROKER_API_BASE_URL: "http://api.github.test" },
+        setting: "GITHUB_BROKER_API_BASE_URL",
+        reason: "invalid"
+      },
+      {
+        patch: { GITHUB_BROKER_OAUTH_BASE_URL: "http://github.test" },
+        setting: "GITHUB_BROKER_OAUTH_BASE_URL",
+        reason: "invalid"
+      },
+      {
+        patch: { GITHUB_BROKER_DB_PATH: "runtime/github-broker.sqlite" },
+        setting: "GITHUB_BROKER_DB_PATH",
+        reason: "must_be_absolute"
+      },
+      {
+        patch: { GITHUB_BROKER_DB_PATH: "/data/license.sqlite" },
+        setting: "GITHUB_BROKER_DB_PATH",
+        reason: "must_differ_from_license_db",
+        licenseDbPath: "/data/license.sqlite"
+      }
+    ];
+
+    for (const testCase of cases) {
+      const result = loadGitHubBrokerRuntimeConfig(
+        { ...completeEnvironment(), ...testCase.patch },
+        testCase.licenseDbPath ?? "/data/license.sqlite"
+      );
+      assert.deepEqual(result, {
+        status: "invalid",
+        setting: testCase.setting,
+        reason: testCase.reason
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This is a bounded source slice for #613. It wires the already-reviewed managed GitHub broker into the production license-service entrypoint behind an explicit, default-off configuration contract.

- construct the existing broker only when `GITHUB_BROKER_ENABLED=true` and every required setting validates
- preserve the existing typed `broker_unavailable` response when disabled or invalid, while keeping the license API available
- validate the App identity, RSA key shape, official install URL, HTTPS endpoints, and separate absolute broker database path
- open/migrate broker storage inside the fail-closed boundary so store failures cannot terminate unrelated license or health routes
- report only fixed setting names/reasons; never serialize or log key or OAuth-secret values
- preserve fail-closed private/internal behavior by intentionally leaving the authoritative entitlement resolver for #612

## Bounded acceptance criteria

- [x] Unset/`false` is an explicit rollout kill switch even when credentials remain provisioned.
- [x] Exact `true` requires a complete validated environment before the existing broker seam is constructed.
- [x] Missing/invalid configuration or broker-store open failure does not expose submitted values and leaves broker routes typed unavailable.
- [x] Broker storage must use an absolute path distinct from `LICENSE_DB_PATH`.
- [x] Existing repository-binding, minimal-permission, and fail-closed entitlement invariants remain unchanged.
- [x] Failing-first evidence exists for both the missing runtime module and the broker-store startup isolation defect.

## Non-goals

- production GitHub App registration or OAuth/install setting changes
- credential creation, secret provisioning, rotation, or revocation
- Fly deployment, rollout, or enabling `GITHUB_BROKER_ENABLED`
- broker-database DR/replication proof (recorded as a hard pre-enable gate on #613)
- authoritative private-repository entitlement resolver (#612)
- native authorization/repository-selection wiring or live token issuance
- public-free runtime flip, beta publication, release, or customer-readiness proof

## Focused local evidence

At current head:

- broker runtime/client/wire tests: 17 passed, 0 failed
- `services/license-api` TypeScript build: passed
- repository secret scan: passed
- `git diff --check`: passed

Broad validation remains remote CI.

Related: #613
Parent tracker: #610
