### PR TITLE
fix(license-api): replicate managed broker state

### DIFF
--- a/services/license-api/Dockerfile
+++ b/services/license-api/Dockerfile
@@ -61,6 +61,7 @@ COPY --from=litestream /usr/local/bin/litestream /usr/local/bin/litestream
 COPY services/license-api/package.json services/license-api/package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 COPY services/license-api/litestream.yml /etc/litestream.yml
+COPY services/license-api/litestream-broker.yml /etc/litestream-broker.yml
 COPY services/license-api/docker-entrypoint.sh /usr/local/bin/license-api-entrypoint
 
 # SQLite lives on a mounted volume; the app creates the file itself on startup.
@@ -73,6 +74,8 @@ ENV LICENSE_DB_PATH=/data/license.sqlite
 ENV LITESTREAM_CONFIG=/etc/litestream.yml
 ENV LITESTREAM_SYNC_INTERVAL=1s
 ENV LICENSE_LITESTREAM_REQUIRED=true
+ENV GITHUB_BROKER_DB_PATH=/data/github-broker.sqlite
+ENV GITHUB_BROKER_LITESTREAM_CONFIG=/etc/litestream-broker.yml
 ENV PORT=8080
 ENV HOST=0.0.0.0
 EXPOSE 8080

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -158,6 +158,12 @@ Environment:
   `GITHUB_BROKER_OAUTH_BASE_URL` default to GitHub's public HTTPS hosts.
   Configuration errors are reported by setting name/reason only; values are
   never logged.
+- `GITHUB_BROKER_REPLICA_URL` — owner-held offsite Litestream destination for
+  broker device/binding/decision state. It must be distinct from
+  `LICENSE_REPLICA_URL`. Broker-enabled container startup refuses to proceed
+  without it. Once provisioned it selects `/etc/litestream-broker.yml` to
+  restore/replicate both SQLite databases even while the broker route-level
+  kill switch is off.
 
 This runtime wiring does not supply the production App registration, secrets,
 private-repository entitlement resolver, native client adoption, or live install

--- a/services/license-api/docker-entrypoint.sh
+++ b/services/license-api/docker-entrypoint.sh
@@ -5,12 +5,37 @@ set -eu
 : "${LITESTREAM_CONFIG:=/etc/litestream.yml}"
 : "${LITESTREAM_SYNC_INTERVAL:=1s}"
 : "${LICENSE_LITESTREAM_REQUIRED:=true}"
+: "${GITHUB_BROKER_ENABLED:=false}"
+: "${GITHUB_BROKER_DB_PATH:=/data/github-broker.sqlite}"
+: "${GITHUB_BROKER_LITESTREAM_CONFIG:=/etc/litestream-broker.yml}"
 export LICENSE_DB_PATH LITESTREAM_CONFIG LITESTREAM_SYNC_INTERVAL LICENSE_LITESTREAM_REQUIRED
+export GITHUB_BROKER_ENABLED GITHUB_BROKER_DB_PATH GITHUB_BROKER_LITESTREAM_CONFIG
 
 mkdir -p "$(dirname "$LICENSE_DB_PATH")"
 
+broker_replication_configured=false
+if [ -n "${GITHUB_BROKER_REPLICA_URL:-}" ]; then
+  if [ "$GITHUB_BROKER_DB_PATH" = "$LICENSE_DB_PATH" ]; then
+    echo "GITHUB_BROKER_DB_PATH must differ from LICENSE_DB_PATH; refusing to start." >&2
+    exit 1
+  fi
+  if [ "${LICENSE_REPLICA_URL:-}" = "$GITHUB_BROKER_REPLICA_URL" ]; then
+    echo "GITHUB_BROKER_REPLICA_URL must differ from LICENSE_REPLICA_URL; refusing to start." >&2
+    exit 1
+  fi
+  LITESTREAM_CONFIG="$GITHUB_BROKER_LITESTREAM_CONFIG"
+  export LITESTREAM_CONFIG GITHUB_BROKER_REPLICA_URL
+  mkdir -p "$(dirname "$GITHUB_BROKER_DB_PATH")"
+  broker_replication_configured=true
+elif [ "$GITHUB_BROKER_ENABLED" = "true" ]; then
+  echo "GITHUB_BROKER_REPLICA_URL is unset; refusing to enable the managed GitHub broker without independent Litestream DR replication." >&2
+  exit 1
+fi
+
 if [ -z "${LICENSE_REPLICA_URL:-}" ]; then
-  if [ "$LICENSE_LITESTREAM_REQUIRED" = "true" ]; then
+  if [ "$LICENSE_LITESTREAM_REQUIRED" = "true" ] ||
+    [ "$GITHUB_BROKER_ENABLED" = "true" ] ||
+    [ "$broker_replication_configured" = "true" ]; then
     echo "LICENSE_REPLICA_URL is unset; refusing to start production license-api without Litestream DR replication. Set LICENSE_REPLICA_URL via Fly secrets, or set LICENSE_LITESTREAM_REQUIRED=false for local/dev only." >&2
     exit 1
   fi
@@ -23,6 +48,15 @@ if [ ! -f "$LICENSE_DB_PATH" ]; then
   litestream restore -if-replica-exists -config "$LITESTREAM_CONFIG" "$LICENSE_DB_PATH"
 else
   echo "license-api database exists at $LICENSE_DB_PATH; skipping restore." >&2
+fi
+
+if [ "$broker_replication_configured" = "true" ]; then
+  if [ ! -f "$GITHUB_BROKER_DB_PATH" ]; then
+    echo "GitHub broker database is missing at $GITHUB_BROKER_DB_PATH; attempting Litestream restore." >&2
+    litestream restore -if-replica-exists -config "$LITESTREAM_CONFIG" "$GITHUB_BROKER_DB_PATH"
+  else
+    echo "GitHub broker database exists at $GITHUB_BROKER_DB_PATH; skipping restore." >&2
+  fi
 fi
 
 exec litestream replicate -config "$LITESTREAM_CONFIG" -exec "node dist/server.js"

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -60,7 +60,7 @@ flyctl volumes create license_data --region iad --size 1 \
 
 ## 3. Secrets
 
-Production DR now requires an owner-held Litestream replica URL, provider
+Production DR now requires an owner-held Litestream license replica URL, provider
 credentials, production `LICENSE_LITESTREAM_REQUIRED=true`, and checkout
 issuance requires `LICENSE_ISSUANCE_SECRET`. Do not commit secret values. Set
 the replica URL, provider credentials, and issuance secret through Fly secrets
@@ -68,10 +68,18 @@ before deploying with the required flag enabled; otherwise the container
 refuses to start or checkout issuance stays disabled. `LICENSE_DB_PATH` / `PORT` / `HOST` /
 `LITESTREAM_CONFIG` / `LITESTREAM_SYNC_INTERVAL` /
 `LICENSE_LITESTREAM_REQUIRED` are plain config in `fly.toml`, not secrets.
+The managed GitHub broker remains default-off. Before separately provisioning
+`GITHUB_BROKER_ENABLED=true`, the owner must also provision a distinct
+`GITHUB_BROKER_REPLICA_URL`; the entrypoint then selects
+`/etc/litestream-broker.yml`, restores both databases, and supervises both
+replicas. A missing broker replica URL refuses broker-enabled startup. Once the
+replica URL is provisioned, the combined replication config remains active when
+the broker flag is turned back off, preserving backup freshness during rollback.
 
 ```sh
 flyctl secrets set \
   LICENSE_REPLICA_URL="<object-store-url-for-license.sqlite>" \
+  GITHUB_BROKER_REPLICA_URL="<distinct-object-store-url-for-github-broker.sqlite>" \
   AWS_ACCESS_KEY_ID="<provider-access-key-id>" \
   AWS_SECRET_ACCESS_KEY="<provider-secret-access-key>" \
   LICENSE_ISSUANCE_SECRET="<shared-secret-used-by-website-webhook>" \
@@ -81,6 +89,11 @@ flyctl secrets set \
 Use the provider-specific variables for non-S3-compatible storage. See
 [`disaster-recovery.md`](disaster-recovery.md) for the owner-only setup and
 restore drill proof boundary.
+
+Do not set `GITHUB_BROKER_ENABLED=true` from this runbook alone. Production App
+registration, OAuth/install configuration, approved broker credentials,
+security approval, authoritative #612 entitlement wiring, and the two-database
+restore/rollback drill remain separate #613 gates.
 
 `LICENSE_ISSUANCE_SECRET` enables `POST /v1/admin/licenses/issue` for the
 website payment webhook. Keep the same value configured only on the license API

--- a/services/license-api/docs/disaster-recovery.md
+++ b/services/license-api/docs/disaster-recovery.md
@@ -1,10 +1,12 @@
 # License API disaster recovery runbook
 
 This runbook covers disaster recovery for the NeonDiff license API SQLite
-database at `/data/license.sqlite`.
+database at `/data/license.sqlite` and, only when the managed GitHub broker is
+enabled, its separate state database at `/data/github-broker.sqlite`.
 
 Issue scope: [#423](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/423)
-and [#562](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/562).
+[#562](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/562),
+and [#613](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/613).
 This source-only PR does not prove live replication; it only adds the buildable
 Litestream wiring, owner runbook, static assertions, and local client outage
 fail-closed verification. Live object storage, Fly secrets, deploy, and timed restore
@@ -14,7 +16,9 @@ evidence remain Owner-gated.
 
 - RPO target: <= 5 minutes. Litestream is configured to sync from
   `/data/license.sqlite` to the object-store replica every `1s`; the <= 5 minute
-  target leaves room for transient platform or object-store latency.
+  target leaves room for transient platform or object-store latency. When the
+  broker is enabled, the same cadence applies independently to
+  `/data/github-broker.sqlite`.
 - RTO target: <= 30 minutes. A trained owner should be able to provision or
   restart a staging/replacement Fly app, restore the missing DB, pass `/healthz`,
   and validate admin readback inside this window.
@@ -26,10 +30,16 @@ evidence remain Owner-gated.
 ## Architecture
 
 - Primary database: `/data/license.sqlite` on the Fly volume `license_data`.
+- Managed-broker database: `/data/github-broker.sqlite` on the same single-writer
+  volume, with a distinct offsite replica URL. It contains device registrations,
+  authoritative installation/repository bindings, and the decision ledger.
 - Runtime supervisor: `docker-entrypoint.sh`.
-- Replication config: `/etc/litestream.yml`, copied from `litestream.yml`.
-- Replica URL: `LICENSE_REPLICA_URL`, set only through Fly secrets or an
-  equivalent platform secret store.
+- Replication config: `/etc/litestream.yml` before broker DR is provisioned;
+  `/etc/litestream-broker.yml` whenever `GITHUB_BROKER_REPLICA_URL` is present.
+  This keeps broker-state backups fresh while the route-level kill switch is off.
+- Replica URLs: `LICENSE_REPLICA_URL` and, before broker enablement,
+  `GITHUB_BROKER_REPLICA_URL`, set only through Fly secrets or an equivalent
+  platform secret store. The destinations must be distinct.
 - Provider credentials: set through provider-native environment variables or
   Fly secrets. Do not commit values. For S3-compatible storage, use the
   provider's recommended key variables.
@@ -37,7 +47,8 @@ evidence remain Owner-gated.
 The container fails closed by default when `LICENSE_REPLICA_URL` is absent
 because this service is release-required for supported review entitlements. Local
 development may set `LICENSE_LITESTREAM_REQUIRED=false` to run without
-replication.
+replication. Broker enablement always requires both replica URLs and distinct
+database paths; the local/dev bypass never waives broker DR.
 
 ## Schema v2 recovery invariant
 
@@ -95,14 +106,17 @@ chat.
 ```sh
 flyctl secrets set \
   LICENSE_REPLICA_URL="<object-store-url-for-license.sqlite>" \
+  GITHUB_BROKER_REPLICA_URL="<distinct-object-store-url-for-github-broker.sqlite>" \
   AWS_ACCESS_KEY_ID="<provider-access-key-id>" \
   AWS_SECRET_ACCESS_KEY="<provider-secret-access-key>" \
   --app neondiff-license
 ```
 
 Use provider-specific variable names when not using S3-compatible storage. Keep
-the replica path dedicated to this service, for example a `license-api/prod`
-prefix, so restore drills do not collide with unrelated databases.
+both replica paths dedicated and distinct, for example
+`license-api/prod/license` and `license-api/prod/github-broker`, so restore
+drills do not collide with each other or unrelated databases. Provisioning the
+broker replica URL does not enable the broker.
 
 ## Deploy verification
 
@@ -119,6 +133,8 @@ Expected evidence:
 
 - the boot logs show either an existing DB or a missing-file restore attempt;
 - Litestream logs show replication started for `/data/license.sqlite`;
+- when the broker is enabled, logs also show restore/replication for
+  `/data/github-broker.sqlite` through `/etc/litestream-broker.yml`;
 - `/healthz` returns `{"status":"ok"}`;
 - admin readback against `LICENSE_DB_PATH=/data/license.sqlite` lists issued
   license hashes and never raw keys.
@@ -131,7 +147,7 @@ volume; never destroy the production volume as a drill.
 1. Record start time, source commit SHA, app name, volume id, and replica URL
    prefix in the evidence packet.
 2. Create or reset a staging Fly app with a fresh `license_data` volume and no
-   `/data/license.sqlite` file.
+   `/data/license.sqlite` or `/data/github-broker.sqlite` file.
 3. Give the drill read-only credentials to the source replica and a dedicated,
    non-writing replica destination/prefix. Never run `litestream replicate`
    against the production replica from the drill.
@@ -141,8 +157,9 @@ volume; never destroy the production volume as a drill.
    latest-state `-if-replica-exists` startup behavior as rollback proof.
 5. Wait for `/healthz` to pass and run admin `list` against the restored DB.
 6. Record end time and calculate restore duration. The drill passes only if
-   duration is <= 30 minutes and the restored DB contains the expected license
-   hashes/activation rows.
+   duration is <= 30 minutes, the restored license DB contains the expected
+   license hashes/activation rows, and an enabled broker restore contains the
+   expected device, binding, selected-repository, and decision-ledger rows.
 7. Revoke or delete any throwaway keys created solely for the drill, then
    destroy the staging app/volume if it is not reused.
 
@@ -161,6 +178,8 @@ and do not let staging write back into the production replica prefix.
 - Daily: monitor `/healthz` and Fly machine health.
 - Daily: alert on Litestream replication errors, repeated restart loops, or a
   missing `LICENSE_REPLICA_URL` in production.
+- Daily while the broker is enabled: alert on a missing
+  `GITHUB_BROKER_REPLICA_URL` or stale broker replica generation.
 - Weekly: inspect replica freshness using Litestream object-store metadata or a
   provider inventory command; save a compact evidence note.
 - Monthly until GA, then quarterly: run a timed staging restore drill and store
@@ -178,6 +197,8 @@ Minimum alert set:
 - Litestream process exit or repeated replication error in logs.
 - Object-store replica has no recent generation/snapshot evidence within the
   RPO window.
+- License and broker replicas unexpectedly share a destination or only one
+  database restores on a broker-enabled drill.
 - Volume snapshot or object-store lifecycle policy disabled unexpectedly.
 
 Treat healthz-only green as insufficient for DR. Healthz proves the HTTP

--- a/services/license-api/fly.toml
+++ b/services/license-api/fly.toml
@@ -20,9 +20,13 @@ primary_region = "iad"  # placeholder — set to wherever the fleet/owner is clo
   LITESTREAM_CONFIG = "/etc/litestream.yml"
   LITESTREAM_SYNC_INTERVAL = "1s"
   LICENSE_LITESTREAM_REQUIRED = "true"
+  GITHUB_BROKER_DB_PATH = "/data/github-broker.sqlite"
+  GITHUB_BROKER_LITESTREAM_CONFIG = "/etc/litestream-broker.yml"
   # LICENSE_REPLICA_URL is intentionally not committed here. The owner sets
   # the object-store replica URL and provider credentials via `flyctl secrets`
   # before production deploy; see docs/disaster-recovery.md.
+  # GITHUB_BROKER_REPLICA_URL is also owner-provisioned and is required before
+  # the separately provisioned GITHUB_BROKER_ENABLED flag may be set to true.
 
 # --- Storage -----------------------------------------------------------------
 # SQLite (node:sqlite, see src/store.ts) is a single-writer embedded file DB.

--- a/services/license-api/litestream-broker.yml
+++ b/services/license-api/litestream-broker.yml
@@ -1,0 +1,21 @@
+# Litestream v0.5 config for NeonDiff license + managed GitHub broker DR.
+#
+# Selected whenever GITHUB_BROKER_REPLICA_URL is provisioned so the server-side
+# kill switch can disable broker routes without stopping backup freshness.
+# Litestream expands ${VAR} from the process environment before parsing this
+# file. Keep replica URLs and provider credentials in Fly secrets / platform
+# env, never in this file.
+logging:
+  type: text
+  level: info
+  stderr: true
+
+dbs:
+  - path: ${LICENSE_DB_PATH}
+    replica:
+      url: ${LICENSE_REPLICA_URL}
+      sync-interval: ${LITESTREAM_SYNC_INTERVAL}
+  - path: ${GITHUB_BROKER_DB_PATH}
+    replica:
+      url: ${GITHUB_BROKER_REPLICA_URL}
+      sync-interval: ${LITESTREAM_SYNC_INTERVAL}

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -1,5 +1,13 @@
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -58,6 +66,11 @@ const legacySchema = `
 
 function readServiceFile(relativePath: string): string {
   return readFileSync(join(licenseApiDir, relativePath), "utf8");
+}
+
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
 }
 
 function licenseConfig(root: string, apiBaseUrl: string): LicenseConfig {
@@ -128,6 +141,7 @@ describe("license service disaster recovery wiring", () => {
   it("pins Litestream install, config, and entrypoint to the mounted license database without secrets", () => {
     const dockerfile = readServiceFile("Dockerfile");
     const litestreamConfig = readServiceFile("litestream.yml");
+    const brokerLitestreamConfig = readServiceFile("litestream-broker.yml");
     const entrypoint = readServiceFile("docker-entrypoint.sh");
     const flyConfig = readServiceFile("fly.toml");
 
@@ -135,6 +149,9 @@ describe("license service disaster recovery wiring", () => {
     expect(dockerfile).toContain(litestreamLinuxX64Sha);
     expect(dockerfile).toContain(litestreamLinuxArm64Sha);
     expect(dockerfile).toContain("COPY services/license-api/litestream.yml /etc/litestream.yml");
+    expect(dockerfile).toContain(
+      "COPY services/license-api/litestream-broker.yml /etc/litestream-broker.yml"
+    );
     expect(dockerfile).toContain("COPY services/license-api/docker-entrypoint.sh /usr/local/bin/license-api-entrypoint");
     expect(dockerfile).toContain("chown node:node /data");
     expect(dockerfile).toContain('ENTRYPOINT ["license-api-entrypoint"]');
@@ -145,20 +162,171 @@ describe("license service disaster recovery wiring", () => {
     expect(litestreamConfig).not.toMatch(/^\s*url:\s+(?!\$\{LICENSE_REPLICA_URL\}\s*$).+/m);
     expect(litestreamConfig).not.toMatch(/AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key:\s+\S|account-key:\s+\S/i);
 
+    expect(brokerLitestreamConfig).toContain(`path: \${LICENSE_DB_PATH}`);
+    expect(brokerLitestreamConfig).toContain("url: ${LICENSE_REPLICA_URL}");
+    expect(brokerLitestreamConfig).toContain(`path: \${GITHUB_BROKER_DB_PATH}`);
+    expect(brokerLitestreamConfig).toContain("url: ${GITHUB_BROKER_REPLICA_URL}");
+    expect(brokerLitestreamConfig).not.toMatch(
+      /^\s*url:\s+(?!\$\{(?:LICENSE|GITHUB_BROKER)_REPLICA_URL\}\s*$).+/m
+    );
+    expect(brokerLitestreamConfig).not.toMatch(
+      /AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key:\s+\S|account-key:\s+\S/i
+    );
+
     expect(entrypoint).toContain(`LICENSE_DB_PATH:=/data/license.sqlite`);
+    expect(entrypoint).toContain(`GITHUB_BROKER_DB_PATH:=/data/github-broker.sqlite`);
+    expect(entrypoint).toContain(
+      `GITHUB_BROKER_LITESTREAM_CONFIG:=/etc/litestream-broker.yml`
+    );
     expect(entrypoint).toContain('if [ ! -f "$LICENSE_DB_PATH" ]');
     expect(entrypoint).toContain('litestream restore -if-replica-exists -config "$LITESTREAM_CONFIG" "$LICENSE_DB_PATH"');
+    expect(entrypoint).toContain(
+      'litestream restore -if-replica-exists -config "$LITESTREAM_CONFIG" "$GITHUB_BROKER_DB_PATH"'
+    );
     expect(entrypoint).toContain('exec litestream replicate -config "$LITESTREAM_CONFIG" -exec "node dist/server.js"');
     expect(entrypoint).toContain("LICENSE_LITESTREAM_REQUIRED");
     expect(entrypoint).not.toMatch(/AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key:\s+\S|account-key:\s+\S|password\s*=/i);
 
     expect(flyConfig).toContain(`LICENSE_DB_PATH = "${dbPath}"`);
+    expect(flyConfig).toContain(`GITHUB_BROKER_DB_PATH = "/data/github-broker.sqlite"`);
+    expect(flyConfig).toContain(
+      `GITHUB_BROKER_LITESTREAM_CONFIG = "/etc/litestream-broker.yml"`
+    );
     expect(flyConfig).toContain('LICENSE_REPLICA_URL');
+    expect(flyConfig).toContain('GITHUB_BROKER_REPLICA_URL');
     expect(flyConfig).not.toMatch(/^\s*LICENSE_REPLICA_URL\s*=/m);
+    expect(flyConfig).not.toMatch(/^\s*GITHUB_BROKER_REPLICA_URL\s*=/m);
     expect(flyConfig).toContain('LICENSE_LITESTREAM_REQUIRED = "true"');
     expect(flyConfig).toContain('source = "license_data"');
     expect(flyConfig).toContain('destination = "/data"');
     expect(flyConfig).not.toMatch(/AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key|account-key|password\s*=/i);
+  });
+
+  it("preserves two-database DR under the broker kill switch and refuses enablement without it", () => {
+    const root = mkdtempSync(join(tmpdir(), "nd-broker-dr-entrypoint-"));
+    try {
+      const binDir = join(root, "bin");
+      const tracePath = join(root, "trace.log");
+      const licensePath = join(root, "data", "license.sqlite");
+      const brokerPath = join(root, "data", "github-broker.sqlite");
+      mkdirSync(binDir, { recursive: true });
+      writeExecutable(
+        join(binDir, "litestream"),
+        `#!/bin/sh
+printf 'litestream' >> "$TRACE_LOG"
+for arg in "$@"; do printf ' <%s>' "$arg" >> "$TRACE_LOG"; done
+printf '\\n' >> "$TRACE_LOG"
+if [ "$1" = "restore" ]; then
+  for target in "$@"; do :; done
+  mkdir -p "$(dirname "$target")"
+  : > "$target"
+fi
+`
+      );
+
+      const baseEnv = {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        TRACE_LOG: tracePath,
+        LICENSE_DB_PATH: licensePath,
+        LICENSE_REPLICA_URL: "s3://fixture/license",
+        LICENSE_LITESTREAM_REQUIRED: "true",
+        LITESTREAM_CONFIG: join(licenseApiDir, "litestream.yml"),
+        GITHUB_BROKER_ENABLED: "true",
+        GITHUB_BROKER_DB_PATH: brokerPath,
+        GITHUB_BROKER_REPLICA_URL: "s3://fixture/broker",
+        GITHUB_BROKER_LITESTREAM_CONFIG: join(
+          licenseApiDir,
+          "litestream-broker.yml"
+        )
+      };
+
+      execFileSync("sh", [join(licenseApiDir, "docker-entrypoint.sh")], {
+        env: baseEnv,
+        stdio: "pipe"
+      });
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace).toContain(`<${licensePath}>`);
+      expect(trace).toContain(`<${brokerPath}>`);
+      expect(trace.match(/litestream <restore>/g)).toHaveLength(2);
+      expect(trace).toContain(
+        `<${join(licenseApiDir, "litestream-broker.yml")}>`
+      );
+      expect(trace).toContain("litestream <replicate>");
+
+      rmSync(licensePath, { force: true });
+      rmSync(brokerPath, { force: true });
+      rmSync(tracePath, { force: true });
+      execFileSync("sh", [join(licenseApiDir, "docker-entrypoint.sh")], {
+        env: { ...baseEnv, GITHUB_BROKER_ENABLED: "false" },
+        stdio: "pipe"
+      });
+      const killedTrace = readFileSync(tracePath, "utf8");
+      expect(killedTrace.match(/litestream <restore>/g)).toHaveLength(2);
+      expect(killedTrace).toContain(`<${brokerPath}>`);
+      expect(killedTrace).toContain(
+        `<${join(licenseApiDir, "litestream-broker.yml")}>`
+      );
+
+      rmSync(licensePath, { force: true });
+      rmSync(brokerPath, { force: true });
+      rmSync(tracePath, { force: true });
+      execFileSync("sh", [join(licenseApiDir, "docker-entrypoint.sh")], {
+        env: {
+          ...baseEnv,
+          GITHUB_BROKER_ENABLED: "false",
+          GITHUB_BROKER_REPLICA_URL: ""
+        },
+        stdio: "pipe"
+      });
+      const licenseOnlyTrace = readFileSync(tracePath, "utf8");
+      expect(licenseOnlyTrace.match(/litestream <restore>/g)).toHaveLength(1);
+      expect(licenseOnlyTrace).toContain(`<${licensePath}>`);
+      expect(licenseOnlyTrace).not.toContain(`<${brokerPath}>`);
+      expect(licenseOnlyTrace).toContain(`<${join(licenseApiDir, "litestream.yml")}>`);
+
+      rmSync(tracePath, { force: true });
+      expect(() =>
+        execFileSync("sh", [join(licenseApiDir, "docker-entrypoint.sh")], {
+          env: { ...baseEnv, GITHUB_BROKER_REPLICA_URL: "" },
+          stdio: "pipe"
+        })
+      ).toThrow();
+      expect(existsSync(tracePath)).toBe(false);
+
+      expect(() =>
+        execFileSync("sh", [join(licenseApiDir, "docker-entrypoint.sh")], {
+          env: {
+            ...baseEnv,
+            GITHUB_BROKER_REPLICA_URL: baseEnv.LICENSE_REPLICA_URL
+          },
+          stdio: "pipe"
+        })
+      ).toThrow();
+      expect(existsSync(tracePath)).toBe(false);
+
+      const missingLicenseReplica = spawnSync(
+        "sh",
+        [join(licenseApiDir, "docker-entrypoint.sh")],
+        {
+          env: {
+            ...baseEnv,
+            GITHUB_BROKER_ENABLED: "false",
+            LICENSE_LITESTREAM_REQUIRED: "false",
+            LICENSE_REPLICA_URL: ""
+          },
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      );
+      expect(missingLicenseReplica.status).not.toBe(0);
+      expect(missingLicenseReplica.stderr).toContain(
+        "LICENSE_REPLICA_URL is unset; refusing to start production"
+      );
+      expect(existsSync(tracePath)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("documents owner-gated DR proof without claiming live replication from this source-only slice", () => {


### PR DESCRIPTION
## Scope

Related to #613. This is a bounded, default-off source slice for managed GitHub broker disaster recovery. It does not close #613.

## Acceptance criteria

- Keep the existing license-only restore/replication path unchanged while broker DR is unprovisioned and disabled.
- When a distinct broker replica is provisioned, restore and replicate both the license and broker SQLite databases through one supervised Litestream process.
- Keep both backups fresh when the broker route-level kill switch is off.
- Refuse startup before Litestream or Node when broker enablement lacks an independent broker replica, when replica destinations collide, or when the combined configuration lacks the license replica.
- Keep replica URLs and provider credentials out of committed configuration.
- Document the two-database restore, freshness, rollback, and proof boundary without claiming live DR.

## Explicit non-goals

- Creating the production GitHub App or changing OAuth/install settings.
- Provisioning credentials, replica URLs, Fly secrets, volumes, or object storage.
- Deploying or enabling the broker, or running a live restore/rollback drill.
- Authoritative #612 entitlement resolution, native wiring, or public-free activation.
- Signed distribution, paid beta, release, or customer-readiness claims.

## Failing-first evidence

The entrypoint behavior test was added before implementation. It initially failed because the broker config did not exist and only the license database was restored. Final inspection added a separate failing assertion proving a provisioned combined config with a missing license replica could otherwise reach process startup; startup now rejects that state before Litestream or Node.

## Focused verification

- `sh -n services/license-api/docker-entrypoint.sh`
- `npx vitest run tests/license-service-dr.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism` — 5/5
- Parsed `litestream.yml` (1 DB) and `litestream-broker.yml` (2 DBs) with the repository YAML parser
- `npm run check:secrets` — 770 tracked files
- `git diff --check`

Broad validation remains remote CI. No production mutation occurred.
