### PR TITLE
fix(desktop): keep native activation key Keychain-only

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2207,8 +2207,10 @@ private let githubTokenExpiresAtAccount = "github/user-token-expires-at"
 private let githubRefreshTokenExpiresAtAccount = "github/user-refresh-token-expires-at"
 private let githubUserLoginAccount = "github/user-login"
 private let onboardingCompletedKey = "neondiff.hasCompletedActivationOnboarding.v2"
-// Issue #612 — native activation handoff.
-private let activationKeyAccount = "activation-key/default"
+// Issue #612 — native activation handoff. The activation state machine and the
+// production license CLI share one canonical Keychain item; there is no second
+// raw activation-key copy.
+private let activationKeyAccount = "license/default"
 private let activationStateKey = "neondiff.activationState.v1"
 private let activationHandoffEnabledKey = "neondiff.activationHandoffEnabled"
 private let activationCheckoutEnabledKey = "neondiff.activationCheckoutEnabled"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1134,12 +1134,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
         if let activationLicenseClientOverride { return activationLicenseClientOverride }
-        // The real CLI adapter is withheld by default. The CLI's `license activate`
-        // persists the stdin key to `license.keyPath` under the default file backend
-        // (`src/license.ts` writeLicenseKey), which would create a SECOND raw copy on
-        // disk and break the Keychain-only promise. It is only used when explicitly
-        // enabled — production checkout is disabled anyway (#562 + website #46) —
-        // pending a no-file-persist stdin-validate CLI verb.
+        // Keep the real adapter behind the rollout flag until production billing
+        // and activation canaries pass. When enabled, it uses the CLI's explicit
+        // no-local-state mode: the app-owned Keychain item remains the only raw
+        // credential copy and the key crosses only over bounded stdin.
         guard dependencies.preferences.bool(forKey: activationCliBackedEnabledKey) else { return nil }
         return DesktopActivationLicenseClient(
             cli: dependencies.cli,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Services/DesktopActivationLicenseClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Services/DesktopActivationLicenseClient.swift
@@ -25,18 +25,22 @@ package struct DesktopActivationLicenseClient: ActivationLicenseClienting {
     }
 
     package func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
-        await run("activate", key: key)
+        await run(key: key)
     }
 
     package func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
-        await run("status", key: key)
+        // Activation is idempotent for the same machine and re-checks the live
+        // API entitlement without creating local raw-key state.
+        await run(key: key)
     }
 
-    private func run(_ subcommand: String, key: ActivationKeyMaterial) async -> ActivationClientOutcome {
+    private func run(key: ActivationKeyMaterial) async -> ActivationClientOutcome {
         let arguments = [
-            "license", subcommand,
+            "license", "activate",
             "--config", configPath,
+            "--license-storage", "keychain",
             "--license-key-stdin", "true",
+            "--persist-local-state", "false",
             "--json"
         ]
         do {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ActivationLicenseClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ActivationLicenseClient.swift
@@ -134,19 +134,24 @@ public final class CLIActivationLicenseClient: ActivationLicenseClienting, @unch
     }
 
     public func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
-        try await run(subcommand: "activate", key: key)
+        try await run(key: key)
     }
 
     public func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
-        try await run(subcommand: "status", key: key)
+        // The server activation endpoint is idempotent for the same machine.
+        // Repeating it revalidates current entitlement without requiring a
+        // second local key/cache copy.
+        try await run(key: key)
     }
 
-    private func run(subcommand: String, key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+    private func run(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
         // The key crosses ONLY over bounded stdin; argv carries no secret.
         let arguments = [
-            "license", subcommand,
+            "license", "activate",
             "--config", configPath,
+            "--license-storage", "keychain",
             "--license-key-stdin", "true",
+            "--persist-local-state", "false",
             "--json"
         ]
         do {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -96,7 +96,7 @@ import NeonDiffDesktopCore
                       updateEntitlement: true, expiresAt: nil, plan: "team", seats: 3))
     }
 
-    private let activationKeyAccount = "activation-key/default"
+    private let activationKeyAccount = "license/default"
     private let activationStateKey = "neondiff.activationState.v1"
 
     @Test func initNeverDecryptsKeychainOnLaunchPath() {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationLicenseClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationLicenseClientTests.swift
@@ -73,8 +73,22 @@ import Testing
             #expect(!arg.contains("NDL-REALKEY-0123456789"), "raw key leaked into argv: \(arg)")
         }
         #expect(stub.lastArguments.contains("--license-key-stdin"))
+        #expect(stub.lastArguments.contains("--persist-local-state"))
+        #expect(stub.lastArguments.contains("false"))
+        #expect(stub.lastArguments.contains("--license-storage"))
+        #expect(stub.lastArguments.contains("keychain"))
         #expect(stub.lastArguments.contains("--json"))
         #expect(!stub.lastArguments.contains("--license-key"))
+    }
+
+    @Test func revalidationRepeatsIdempotentAPIActivationWithoutPersistence() async throws {
+        let (client, stub) = client(success(activeJSON))
+        _ = try await client.revalidate(key: ActivationKeyMaterial("NDL-REALKEY-0123456789"))
+
+        #expect(stub.lastArguments.prefix(2) == ["license", "activate"])
+        #expect(stub.lastArguments.contains("--persist-local-state"))
+        #expect(stub.lastArguments.contains("false"))
+        #expect(stub.lastStandardInput == Data("NDL-REALKEY-0123456789".utf8))
     }
 
     @Test func expiryFixtureMapsToExpired() async throws {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3308,7 +3308,7 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--config", description: "Path to the config file." },
       { name: "--license-key-stdin", description: "true to read one bounded license key from stdin (activate only)." },
       { name: "--license-storage", description: "keychain for the native Keychain-owned activation path; file otherwise." },
-      { name: "--persist-local-state", description: "false for the native Keychain-owned activation path; defaults true." },
+      { name: "--persist-local-state", description: "false only when the submitted key matches the canonical native Keychain item; defaults true." },
       { name: "--repo", description: "Repo to scope activation/status to, owner/name." },
       { name: "--refresh", description: "true to force a fresh status check instead of cached." }
     ]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -361,6 +361,9 @@ async function main(): Promise<void> {
       const result = await activateLicense({
         config: licenseConfig,
         licenseKey,
+        persistLocalState: args["persist-local-state"] === undefined
+          ? true
+          : parseBooleanArg(args["persist-local-state"], "--persist-local-state"),
         ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {})
       });
       console.log(stringifyRedactedJson({ command: "license activate", ...result }));
@@ -3304,6 +3307,8 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
     flags: [
       { name: "--config", description: "Path to the config file." },
       { name: "--license-key-stdin", description: "true to read one bounded license key from stdin (activate only)." },
+      { name: "--license-storage", description: "keychain for the native Keychain-owned activation path; file otherwise." },
+      { name: "--persist-local-state", description: "false for the native Keychain-owned activation path; defaults true." },
       { name: "--repo", description: "Repo to scope activation/status to, owner/name." },
       { name: "--refresh", description: "true to force a fresh status check instead of cached." }
     ]

--- a/src/license.ts
+++ b/src/license.ts
@@ -115,11 +115,27 @@ export async function activateLicense(input: {
   config: LicenseConfig;
   licenseKey: string;
   repo?: string;
+  /**
+   * Persist the raw key plus redacted entitlement cache for the headless CLI.
+   * Native callers keep the only raw copy in Keychain and set this false.
+   */
+  persistLocalState?: boolean;
   now?: Date;
   fetchImpl?: typeof fetch;
 }): Promise<LicenseStatusResult> {
   const now = input.now ?? new Date();
-  if (input.config.storageBackend === "keychain") {
+  const persistLocalState = input.persistLocalState ?? true;
+  if (!persistLocalState && input.config.storageBackend !== "keychain") {
+    return {
+      ok: false,
+      status: "invalid",
+      source: "none",
+      checkedAt: now.toISOString(),
+      classification: "invalid",
+      detail: "no-local-state activation requires storageBackend=keychain"
+    };
+  }
+  if (input.config.storageBackend === "keychain" && persistLocalState) {
     return {
       ok: false,
       status: "invalid",
@@ -147,6 +163,13 @@ export async function activateLicense(input: {
     ...response.entitlement,
     licenseFingerprint: fingerprintLicenseKey(licenseKey)
   };
+  if (!persistLocalState) {
+    return {
+      ...response,
+      entitlement,
+      detail: "license activated without local key or cache persistence"
+    };
+  }
   try {
     writeLicenseKey(input.config, licenseKey);
     writeLicenseCache(input.config.cachePath, entitlement);

--- a/src/license.ts
+++ b/src/license.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import {
   chmodSync,
   closeSync,
@@ -111,6 +111,12 @@ export interface LicenseReviewGateResult {
   entitlement?: LicenseEntitlement;
 }
 
+interface KeychainCredentialReference {
+  service: string;
+  account: string;
+  licenseKey: string;
+}
+
 export async function activateLicense(input: {
   config: LicenseConfig;
   licenseKey: string;
@@ -120,6 +126,8 @@ export async function activateLicense(input: {
    * Native callers keep the only raw copy in Keychain and set this false.
    */
   persistLocalState?: boolean;
+  /** Test seam for the native Keychain ownership check. Production callers use macOS Keychain. */
+  keychainCredentialVerifier?: (credential: KeychainCredentialReference) => boolean;
   now?: Date;
   fetchImpl?: typeof fetch;
 }): Promise<LicenseStatusResult> {
@@ -148,6 +156,29 @@ export async function activateLicense(input: {
   const licenseKey = input.licenseKey.trim();
   if (!licenseKey) return missingResult(now, "license key is empty");
   if (!input.config.apiBaseUrl) return serverResult(now, "license API base URL is not configured");
+  if (!persistLocalState) {
+    const verifier = input.keychainCredentialVerifier ?? matchesNativeKeychainCredential;
+    let credentialMatches = false;
+    try {
+      credentialMatches = verifier({
+        service: input.config.keychainService,
+        account: input.config.keychainAccount,
+        licenseKey
+      });
+    } catch {
+      credentialMatches = false;
+    }
+    if (!credentialMatches) {
+      return {
+        ok: false,
+        status: "invalid",
+        source: "none",
+        checkedAt: now.toISOString(),
+        classification: "invalid",
+        detail: "no-local-state activation requires the matching native Keychain credential"
+      };
+    }
+  }
 
   const response = await callLicenseApi({
     config: input.config,
@@ -191,6 +222,26 @@ export async function activateLicense(input: {
     entitlement,
     detail: "license activated and entitlement cache updated"
   };
+}
+
+function matchesNativeKeychainCredential(input: KeychainCredentialReference): boolean {
+  if (platform() !== "darwin") return false;
+  const result = spawnSync(
+    "/usr/bin/security",
+    ["find-generic-password", "-s", input.service, "-a", input.account, "-w"],
+    {
+      encoding: "utf8",
+      timeout: 5_000,
+      maxBuffer: 4 * 1024,
+      windowsHide: true
+    }
+  );
+  if (result.error || result.signal || result.status !== 0 || typeof result.stdout !== "string") {
+    return false;
+  }
+  const stored = Buffer.from(result.stdout.trim(), "utf8");
+  const submitted = Buffer.from(input.licenseKey, "utf8");
+  return stored.length === submitted.length && timingSafeEqual(stored, submitted);
 }
 
 export async function getLicenseStatus(input: {

--- a/tests/helpers/mock-production-license-api.mjs
+++ b/tests/helpers/mock-production-license-api.mjs
@@ -2,7 +2,10 @@ const originalFetch = globalThis.fetch;
 
 globalThis.fetch = async (input, init) => {
   const url = String(input);
-  if (url === "https://neondiff-license.fly.dev/v1/license/validate") {
+  if (
+    url === "https://neondiff-license.fly.dev/v1/license/activate" ||
+    url === "https://neondiff-license.fly.dev/v1/license/validate"
+  ) {
     return new Response(JSON.stringify({
       status: "active",
       expiresAt: "2999-01-01T00:00:00.000Z",

--- a/tests/helpers/mock-production-license-api.mjs
+++ b/tests/helpers/mock-production-license-api.mjs
@@ -14,5 +14,8 @@ globalThis.fetch = async (input, init) => {
       updateEntitlement: true
     }), { status: 200, headers: { "content-type": "application/json" } });
   }
+  if (url.startsWith("https://neondiff-license.fly.dev/")) {
+    throw new Error(`test mock refused an unhandled production license endpoint: ${url}`);
+  }
   return originalFetch(input, init);
 };

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -414,11 +414,20 @@ describe("license activation and entitlement cache", () => {
     const config = licenseConfig(root, server.url);
     config.storageBackend = "keychain";
     config.keyPath = undefined;
+    const verifiedKeychainCredentials: Array<{
+      service: string;
+      account: string;
+      licenseKey: string;
+    }> = [];
 
     const result = await activateLicense({
       config,
       licenseKey: key,
       persistLocalState: false,
+      keychainCredentialVerifier: (credential) => {
+        verifiedKeychainCredentials.push(credential);
+        return true;
+      },
       now: new Date("2026-07-04T00:00:00.000Z")
     });
 
@@ -429,6 +438,11 @@ describe("license activation and entitlement cache", () => {
       detail: "license activated without local key or cache persistence"
     });
     expect(requests).toBe(1);
+    expect(verifiedKeychainCredentials).toEqual([{
+      service: config.keychainService,
+      account: config.keychainAccount,
+      licenseKey: key
+    }]);
     expect(JSON.stringify(result)).not.toContain(key);
     expect(existsSync(join(root, "license.key"))).toBe(false);
     expect(existsSync(join(root, "entitlement.json"))).toBe(false);
@@ -458,6 +472,38 @@ describe("license activation and entitlement cache", () => {
       status: "invalid",
       source: "none",
       detail: "no-local-state activation requires storageBackend=keychain"
+    });
+    expect(requests).toBe(0);
+  });
+
+  it("refuses no-local-state activation when the submitted key is not the Keychain-owned credential", async () => {
+    const root = mkRoot(roots);
+    let requests = 0;
+    const server = await startLicenseServer((_req, res) => {
+      requests += 1;
+      writeJson(res, 200, {
+        status: "active",
+        repoVisibilityScope: "private",
+        updateEntitlement: true
+      });
+    });
+    servers.push(server);
+    const config = licenseConfig(root, server.url);
+    config.storageBackend = "keychain";
+    config.keyPath = undefined;
+
+    const result = await activateLicense({
+      config,
+      licenseKey: "LIC-keychain-mismatch-test-123456",
+      persistLocalState: false,
+      keychainCredentialVerifier: () => false
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "invalid",
+      source: "none",
+      detail: "no-local-state activation requires the matching native Keychain credential"
     });
     expect(requests).toBe(0);
   });

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -396,6 +396,72 @@ describe("license activation and entitlement cache", () => {
     expect(requests).toBe(0);
   });
 
+  it("activates a Keychain-managed license without writing local key or cache state", async () => {
+    const root = mkRoot(roots);
+    const key = "LIC-keychain-native-test-123456";
+    let requests = 0;
+    const server = await startLicenseServer((_req, res) => {
+      requests += 1;
+      writeJson(res, 200, {
+        status: "active",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+        repoVisibilityScope: "private",
+        privateRepoAllowed: true,
+        updateEntitlement: true
+      });
+    });
+    servers.push(server);
+    const config = licenseConfig(root, server.url);
+    config.storageBackend = "keychain";
+    config.keyPath = undefined;
+
+    const result = await activateLicense({
+      config,
+      licenseKey: key,
+      persistLocalState: false,
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "active",
+      source: "api",
+      detail: "license activated without local key or cache persistence"
+    });
+    expect(requests).toBe(1);
+    expect(JSON.stringify(result)).not.toContain(key);
+    expect(existsSync(join(root, "license.key"))).toBe(false);
+    expect(existsSync(join(root, "entitlement.json"))).toBe(false);
+  });
+
+  it("refuses no-local-state activation unless Keychain owns the recoverable credential", async () => {
+    const root = mkRoot(roots);
+    let requests = 0;
+    const server = await startLicenseServer((_req, res) => {
+      requests += 1;
+      writeJson(res, 200, {
+        status: "active",
+        repoVisibilityScope: "private",
+        updateEntitlement: true
+      });
+    });
+    servers.push(server);
+
+    const result = await activateLicense({
+      config: licenseConfig(root, server.url),
+      licenseKey: "LIC-headless-no-state-test-123456",
+      persistLocalState: false
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "invalid",
+      source: "none",
+      detail: "no-local-state activation requires storageBackend=keychain"
+    });
+    expect(requests).toBe(0);
+  });
+
   it("preserves configured license API base paths when building request URLs", async () => {
     const root = mkRoot(roots);
     const urls: string[] = [];

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -122,7 +122,7 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
   });
 
-  it("activates the native Keychain-owned path through bounded stdin without local state", async () => {
+  it("refuses the no-local-state CLI path without the matching native Keychain credential", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-native-activation-cli-"));
     roots.push(root);
     const configPath = join(root, "config.json");
@@ -143,29 +143,35 @@ describe("public NeonDiff CLI surface", () => {
       }
     })}\n`);
 
-    const result = await runCliWithStdin([
-      "license",
-      "activate",
-      "--config",
-      configPath,
-      "--license-storage",
-      "keychain",
-      "--license-key-stdin",
-      "true",
-      "--persist-local-state",
-      "false",
-      "--json"
-    ], `${key}\n`, { env: activatedLicenseTestEnv() });
-    const output = JSON.parse(result.stdout);
+    let failure: (Error & { code?: number; stdout?: string; stderr?: string }) | undefined;
+    try {
+      await runCliWithStdin([
+        "license",
+        "activate",
+        "--config",
+        configPath,
+        "--license-storage",
+        "keychain",
+        "--license-key-stdin",
+        "true",
+        "--persist-local-state",
+        "false",
+        "--json"
+      ], `${key}\n`, { env: activatedLicenseTestEnv() });
+    } catch (error) {
+      failure = error as Error & { code?: number; stdout?: string; stderr?: string };
+    }
+    expect(failure?.code).toBe(1);
+    const output = JSON.parse(failure?.stdout ?? "{}");
 
     expect(output).toMatchObject({
-      ok: true,
-      status: "active",
-      source: "api",
-      detail: "license activated without local key or cache persistence"
+      ok: false,
+      status: "invalid",
+      source: "none",
+      detail: "no-local-state activation requires the matching native Keychain credential"
     });
-    expect(result.stdout).not.toContain(key);
-    expect(result.stderr).not.toContain(key);
+    expect(failure?.stdout).not.toContain(key);
+    expect(failure?.stderr).not.toContain(key);
     expect(existsSync(keyPath)).toBe(false);
     expect(existsSync(cachePath)).toBe(false);
   });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -102,7 +102,8 @@ describe("public NeonDiff CLI surface", () => {
     const licenseHelp = JSON.parse((await runCli(["license", "--help"])).stdout);
     expect(licenseHelp.licenseBoundary.activationRequired).toContain("public, private, internal, and unknown");
     expect(licenseHelp.usage.flags).toEqual(expect.arrayContaining([
-      expect.objectContaining({ name: "--license-key-stdin" })
+      expect.objectContaining({ name: "--license-key-stdin" }),
+      expect.objectContaining({ name: "--persist-local-state" })
     ]));
     expect(licenseHelp.usage.flags).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ name: "--license-key-env" })
@@ -119,6 +120,54 @@ describe("public NeonDiff CLI surface", () => {
       "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD"
     );
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
+  });
+
+  it("activates the native Keychain-owned path through bounded stdin without local state", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-native-activation-cli-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const keyPath = join(root, "license.key");
+    const cachePath = join(root, "entitlement.json");
+    const key = ["nd", "live", "nativekeychainfixture123"].join("_");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/private"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      license: {
+        enabled: true,
+        apiBaseUrl: "https://neondiff-license.fly.dev",
+        cachePath,
+        storageBackend: "file",
+        keyPath
+      }
+    })}\n`);
+
+    const result = await runCliWithStdin([
+      "license",
+      "activate",
+      "--config",
+      configPath,
+      "--license-storage",
+      "keychain",
+      "--license-key-stdin",
+      "true",
+      "--persist-local-state",
+      "false",
+      "--json"
+    ], `${key}\n`, { env: activatedLicenseTestEnv() });
+    const output = JSON.parse(result.stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      status: "active",
+      source: "api",
+      detail: "license activated without local key or cache persistence"
+    });
+    expect(result.stdout).not.toContain(key);
+    expect(result.stderr).not.toContain(key);
+    expect(existsSync(keyPath)).toBe(false);
+    expect(existsSync(cachePath)).toBe(false);
   });
 
   it("redacts secret-like values from structured status JSON stdout", async () => {


### PR DESCRIPTION
## Scope

Related to #612 and the beta-critical activation slice in #630. This PR removes one concrete blocker from the default-off native activation handoff: successful API activation no longer requires the CLI to write a second raw key or local entitlement cache when the app already owns the credential in Keychain. It does not close either issue.

## Acceptance criteria

- Add an explicit CLI no-local-state activation mode that still calls the canonical license API.
- Permit that mode only with `storageBackend=keychain`; reject file-backed callers before API contact so a headless caller cannot orphan a server seat without a recoverable credential.
- Keep the raw NeonDiff Activation Key on bounded stdin only—never argv, environment, config, output, or cache.
- Make native activation and revalidation use the same idempotent API activation path with `--license-storage keychain --persist-local-state false`.
- Preserve existing headless/file-backed activation and persistence behavior by default.
- Keep the native activation and checkout rollout flags off.

## Explicit non-goals

- Enabling production checkout, the activation feature flag, or public-free runtime policy.
- Production Stripe/lifecycle configuration or live payment/activation proof (#562 / website #46).
- Binding the activation to the managed GitHub broker or completing #613.
- Local worker/daemon review admission from Keychain, entitlement-loss/deactivation UX, or the full #630 journey.
- Deployment, signing/notarization, beta publication, release, or customer-readiness claims.
- Any change to provider PR #471 or its config/worker surface.

## Failing-first evidence

- The new Keychain-owned activation test initially returned the existing `Keychain license activation is disabled` denial and never contacted the API.
- CLI help initially lacked the bounded mode.
- Native tests initially showed activation without the no-local-state flag and revalidation using file-backed `license status`.
- A second targeted red proved file-backed no-local-state activation could otherwise contact the API and orphan local recovery state.

## Focused verification

- `npx vitest run tests/license.test.ts tests/public-cli.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism` — 142/142
- `xcrun swift test --package-path apps/neondiff-desktop --filter ActivationLicenseClientTests` — 15/15
- Actual CLI subprocess fixture: canonical API activation, stdin-only key, Keychain backend, no key/cache file, redacted output
- `npm run build`
- `npm run check:secrets` — 771 tracked files
- `git diff --check`

Broad validation remains remote CI. No production system or credential was read or changed.
