### PR TITLE
feat(desktop): add managed GitHub broker client

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -18,6 +18,7 @@ public struct GitHubBrokerPublicJWK: Codable, Equatable, Sendable {
 public enum GitHubBrokerDeviceIdentityError: Error, LocalizedError, Equatable {
     case invalidStoredIdentity
     case identityGenerationFailed
+    case identityStorageUnavailable
     case credentialSigningFailed
 
     public var errorDescription: String? {
@@ -26,6 +27,8 @@ public enum GitHubBrokerDeviceIdentityError: Error, LocalizedError, Equatable {
             "The stored GitHub broker device identity is invalid. Reconnect support is required; NeonDiff will not silently replace a bound identity."
         case .identityGenerationFailed:
             "NeonDiff could not create the GitHub broker device identity."
+        case .identityStorageUnavailable:
+            "NeonDiff could not access the stored GitHub broker device identity."
         case .credentialSigningFailed:
             "NeonDiff could not sign the GitHub broker device credential."
         }
@@ -110,27 +113,46 @@ public final class GitHubBrokerDeviceIdentityStore {
     /// connect action. Never call this on the app launch path.
     public func loadOrCreate() throws -> GitHubBrokerDeviceIdentity {
         try lock.withLock {
-            if let encoded = try secretStore.readSecret(account: account) {
-                guard let raw = Data(base64Encoded: encoded),
-                      let key = try? P256.Signing.PrivateKey(rawRepresentation: raw)
-                else {
-                    // A silently replaced identity would orphan or cross-bind the
-                    // server-side installation record, so corrupt state fails closed.
-                    throw GitHubBrokerDeviceIdentityError.invalidStoredIdentity
-                }
-                return GitHubBrokerDeviceIdentity(privateKey: key)
+            if let encoded = try readStoredIdentity() {
+                return try decodeIdentity(encoded)
             }
 
+            let key = P256.Signing.PrivateKey()
+            let encoded = key.rawRepresentation.base64EncodedString()
             do {
-                let key = P256.Signing.PrivateKey()
-                try secretStore.setSecret(key.rawRepresentation.base64EncodedString(), account: account)
-                return GitHubBrokerDeviceIdentity(privateKey: key)
-            } catch let error as GitHubBrokerDeviceIdentityError {
-                throw error
+                if try secretStore.createSecretIfAbsent(encoded, account: account) {
+                    return GitHubBrokerDeviceIdentity(privateKey: key)
+                }
             } catch {
-                throw GitHubBrokerDeviceIdentityError.identityGenerationFailed
+                throw GitHubBrokerDeviceIdentityError.identityStorageUnavailable
             }
+
+            // Another store instance won the atomic Keychain add. Discard this
+            // generated key and rebind to the persisted winner.
+            guard let winner = try readStoredIdentity() else {
+                throw GitHubBrokerDeviceIdentityError.identityStorageUnavailable
+            }
+            return try decodeIdentity(winner)
         }
+    }
+
+    private func readStoredIdentity() throws -> String? {
+        do {
+            return try secretStore.readSecret(account: account)
+        } catch {
+            throw GitHubBrokerDeviceIdentityError.identityStorageUnavailable
+        }
+    }
+
+    private func decodeIdentity(_ encoded: String) throws -> GitHubBrokerDeviceIdentity {
+        guard let raw = Data(base64Encoded: encoded),
+              let key = try? P256.Signing.PrivateKey(rawRepresentation: raw)
+        else {
+            // A silently replaced identity would orphan or cross-bind the
+            // server-side installation record, so corrupt state fails closed.
+            throw GitHubBrokerDeviceIdentityError.invalidStoredIdentity
+        }
+        return GitHubBrokerDeviceIdentity(privateKey: key)
     }
 }
 
@@ -531,9 +553,14 @@ public struct GitHubBrokerClient: Sendable {
         guard response.body.count <= Self.maximumResponseBytes else {
             throw GitHubBrokerClientError.responseTooLarge
         }
-        let normalizedHeaders = Dictionary(uniqueKeysWithValues: response.headers.map {
-            ($0.key.lowercased(), $0.value.lowercased())
-        })
+        var normalizedHeaders: [String: String] = [:]
+        for (name, value) in response.headers {
+            let normalizedName = name.lowercased()
+            guard normalizedHeaders[normalizedName] == nil else {
+                throw GitHubBrokerClientError.invalidResponse
+            }
+            normalizedHeaders[normalizedName] = value.lowercased()
+        }
         guard normalizedHeaders["content-type"]?.hasPrefix("application/json") == true else {
             throw GitHubBrokerClientError.invalidResponse
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -1,0 +1,663 @@
+import CryptoKit
+import Foundation
+
+public struct GitHubBrokerPublicJWK: Codable, Equatable, Sendable {
+    public let kty: String
+    public let crv: String
+    public let x: String
+    public let y: String
+
+    public init(kty: String = "EC", crv: String = "P-256", x: String, y: String) {
+        self.kty = kty
+        self.crv = crv
+        self.x = x
+        self.y = y
+    }
+}
+
+public enum GitHubBrokerDeviceIdentityError: Error, LocalizedError, Equatable {
+    case invalidStoredIdentity
+    case identityGenerationFailed
+    case credentialSigningFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidStoredIdentity:
+            "The stored GitHub broker device identity is invalid. Reconnect support is required; NeonDiff will not silently replace a bound identity."
+        case .identityGenerationFailed:
+            "NeonDiff could not create the GitHub broker device identity."
+        case .credentialSigningFailed:
+            "NeonDiff could not sign the GitHub broker device credential."
+        }
+    }
+}
+
+public struct GitHubBrokerDeviceCredential: Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    fileprivate let token: String
+
+    public var description: String { "GitHub broker device credential [REDACTED]" }
+    public var debugDescription: String { description }
+
+    @_spi(Testing) public var tokenForTesting: String { token }
+}
+
+public struct GitHubBrokerDeviceIdentity: @unchecked Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    public let deviceId: String
+    public let publicKeyJWK: GitHubBrokerPublicJWK
+    private let privateKey: P256.Signing.PrivateKey
+
+    fileprivate init(privateKey: P256.Signing.PrivateKey) {
+        self.privateKey = privateKey
+        let raw = [UInt8](privateKey.publicKey.rawRepresentation)
+        precondition(raw.count == 64)
+        publicKeyJWK = GitHubBrokerPublicJWK(
+            x: base64URL(raw[0..<32]),
+            y: base64URL(raw[32..<64])
+        )
+        deviceId = Self.deviceId(for: publicKeyJWK)
+    }
+
+    public var description: String { "GitHub broker device \(deviceId)" }
+    public var debugDescription: String { description }
+
+    public func makeCredential(now: Date = Date()) throws -> GitHubBrokerDeviceCredential {
+        let issuedAt = Int(now.timeIntervalSince1970)
+        let header = try canonicalJSON([
+            "alg": "ES256",
+            "typ": "JWT"
+        ])
+        let payload = try canonicalJSON([
+            "exp": issuedAt + 300,
+            "iat": issuedAt,
+            "sub": deviceId
+        ])
+        let encodedHeader = base64URL(header)
+        let encodedPayload = base64URL(payload)
+        let signingInput = Data("\(encodedHeader).\(encodedPayload)".utf8)
+        do {
+            let signature = try privateKey.signature(for: signingInput)
+            return GitHubBrokerDeviceCredential(
+                token: "\(encodedHeader).\(encodedPayload).\(base64URL(signature.rawRepresentation))"
+            )
+        } catch {
+            throw GitHubBrokerDeviceIdentityError.credentialSigningFailed
+        }
+    }
+
+    private static func deviceId(for jwk: GitHubBrokerPublicJWK) -> String {
+        // RFC 7638 requires the lexicographically ordered required members.
+        let canonical = #"{"crv":"\#(jwk.crv)","kty":"\#(jwk.kty)","x":"\#(jwk.x)","y":"\#(jwk.y)"}"#
+        return base64URL(Data(SHA256.hash(data: Data(canonical.utf8))))
+    }
+}
+
+public final class GitHubBrokerDeviceIdentityStore {
+    public static let defaultAccount = "github-broker-device-p256"
+
+    private let secretStore: any DesktopSecretStoring
+    private let account: String
+    private let lock = NSLock()
+
+    public init(
+        secretStore: any DesktopSecretStoring,
+        account: String = GitHubBrokerDeviceIdentityStore.defaultAccount
+    ) {
+        self.secretStore = secretStore
+        self.account = account
+    }
+
+    /// Loads lazily from Keychain or creates the device identity on an explicit
+    /// connect action. Never call this on the app launch path.
+    public func loadOrCreate() throws -> GitHubBrokerDeviceIdentity {
+        try lock.withLock {
+            if let encoded = try secretStore.readSecret(account: account) {
+                guard let raw = Data(base64Encoded: encoded),
+                      let key = try? P256.Signing.PrivateKey(rawRepresentation: raw)
+                else {
+                    // A silently replaced identity would orphan or cross-bind the
+                    // server-side installation record, so corrupt state fails closed.
+                    throw GitHubBrokerDeviceIdentityError.invalidStoredIdentity
+                }
+                return GitHubBrokerDeviceIdentity(privateKey: key)
+            }
+
+            do {
+                let key = P256.Signing.PrivateKey()
+                try secretStore.setSecret(key.rawRepresentation.base64EncodedString(), account: account)
+                return GitHubBrokerDeviceIdentity(privateKey: key)
+            } catch let error as GitHubBrokerDeviceIdentityError {
+                throw error
+            } catch {
+                throw GitHubBrokerDeviceIdentityError.identityGenerationFailed
+            }
+        }
+    }
+}
+
+public struct GitHubBrokerHTTPRequest: Sendable {
+    public let method: String
+    public let url: URL
+    public let headers: [String: String]
+    public let body: Data
+    public let maximumResponseBytes: Int
+
+    public init(
+        method: String,
+        url: URL,
+        headers: [String: String],
+        body: Data,
+        maximumResponseBytes: Int
+    ) {
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+        self.maximumResponseBytes = maximumResponseBytes
+    }
+}
+
+public struct GitHubBrokerHTTPResponse: Sendable {
+    public let statusCode: Int
+    public let url: URL
+    public let headers: [String: String]
+    public let body: Data
+
+    public init(statusCode: Int, url: URL, headers: [String: String], body: Data) {
+        self.statusCode = statusCode
+        self.url = url
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public protocol GitHubBrokerTransporting: Sendable {
+    func send(_ request: GitHubBrokerHTTPRequest) async throws -> GitHubBrokerHTTPResponse
+}
+
+/// Production transport. Redirects are refused and both declared and received
+/// response sizes are checked before any body reaches the broker decoder.
+public final class URLSessionGitHubBrokerTransport: GitHubBrokerTransporting, @unchecked Sendable {
+    private let session: URLSession
+
+    public init(configuration: URLSessionConfiguration = .ephemeral) {
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieStorage = nil
+        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForResource = 20
+        configuration.waitsForConnectivity = false
+        session = URLSession(
+            configuration: configuration,
+            delegate: GitHubBrokerRedirectRejectingDelegate(),
+            delegateQueue: nil
+        )
+    }
+
+    public func send(_ request: GitHubBrokerHTTPRequest) async throws -> GitHubBrokerHTTPResponse {
+        var urlRequest = URLRequest(url: request.url)
+        urlRequest.httpMethod = request.method
+        urlRequest.httpBody = request.body
+        request.headers.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
+
+        let (bytes, response) = try await session.bytes(for: urlRequest)
+        guard let http = response as? HTTPURLResponse, let responseURL = http.url else {
+            throw GitHubBrokerClientError.invalidResponse
+        }
+        if http.expectedContentLength > Int64(request.maximumResponseBytes) {
+            throw GitHubBrokerClientError.responseTooLarge
+        }
+        var data = Data()
+        if http.expectedContentLength > 0 {
+            data.reserveCapacity(min(Int(http.expectedContentLength), request.maximumResponseBytes))
+        }
+        for try await byte in bytes {
+            guard data.count < request.maximumResponseBytes else {
+                throw GitHubBrokerClientError.responseTooLarge
+            }
+            data.append(byte)
+        }
+        let headers = Dictionary(uniqueKeysWithValues: http.allHeaderFields.map {
+            (String(describing: $0.key).lowercased(), String(describing: $0.value))
+        })
+        return GitHubBrokerHTTPResponse(
+            statusCode: http.statusCode,
+            url: responseURL,
+            headers: headers,
+            body: data
+        )
+    }
+}
+
+private final class GitHubBrokerRedirectRejectingDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+public enum GitHubBrokerReason: String, Sendable {
+    case invalidRequest = "invalid_request"
+    case deviceNotRegistered = "device_not_registered"
+    case invalidDeviceCredential = "invalid_device_credential"
+    case stateNotFound = "state_not_found"
+    case stateExpired = "state_expired"
+    case stateReplayed = "state_replayed"
+    case bindingNotFound = "binding_not_found"
+    case installationNotFound = "installation_not_found"
+    case installationUninstalled = "installation_uninstalled"
+    case installationSuspended = "installation_suspended"
+    case installationAuthorizationUnverified = "installation_authorization_unverified"
+    case repoOutsideInstallation = "repo_outside_installation"
+    case repoOutsideAuthorization = "repo_outside_authorization"
+    case repoRenamedOrTransferred = "repo_renamed_or_transferred"
+    case visibilityUnknown = "visibility_unknown"
+    case entitlementMissing = "entitlement_missing"
+    case entitlementExpired = "entitlement_expired"
+    case entitlementRevoked = "entitlement_revoked"
+    case entitlementInvalid = "entitlement_invalid"
+    case entitlementScopeInsufficient = "entitlement_scope_insufficient"
+    case entitlementSeatExhausted = "entitlement_seat_exhausted"
+    case entitlementReplayConflict = "entitlement_replay_conflict"
+    case entitlementServiceUnavailable = "entitlement_service_unavailable"
+    case rateLimited = "rate_limited"
+    case brokerUnavailable = "broker_unavailable"
+}
+
+public enum GitHubBrokerClientError: Error, LocalizedError, Equatable, Sendable {
+    case invalidBaseURL
+    case invalidRequest
+    case transportUnavailable
+    case invalidResponse
+    case responseTooLarge
+    case originMismatch
+    case identityMismatch
+    case scopeMismatch
+    case permissionMismatch
+    case server(reason: GitHubBrokerReason)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidBaseURL: "The GitHub broker URL is invalid."
+        case .invalidRequest: "The GitHub broker request is invalid."
+        case .transportUnavailable: "The GitHub broker is unavailable."
+        case .invalidResponse: "The GitHub broker returned an invalid response."
+        case .responseTooLarge: "The GitHub broker response exceeded the safety limit."
+        case .originMismatch: "The GitHub broker response came from an unexpected origin."
+        case .identityMismatch: "The GitHub broker registered a different device identity."
+        case .scopeMismatch: "The GitHub broker returned a repository outside the requested scope."
+        case .permissionMismatch: "The GitHub broker returned an unexpected permission set."
+        case .server(let reason): "The GitHub broker refused the request: \(reason.rawValue)."
+        }
+    }
+}
+
+public struct GitHubBrokerPermissions: Equatable, Sendable {
+    public let values: [String: String]
+
+    public init(values: [String: String]) {
+        self.values = values
+    }
+
+    public static let minimumReview = GitHubBrokerPermissions(values: [
+        "actions": "read",
+        "checks": "read",
+        "contents": "read",
+        "metadata": "read",
+        "pull_requests": "write"
+    ])
+}
+
+public struct GitHubBrokerConnection: Equatable, Sendable {
+    public let installURL: URL
+    public let state: String
+    public let expiresAt: Date
+}
+
+public enum GitHubBrokerConnectionCompletion: Equatable, Sendable {
+    case pending
+    case bound(installationId: Int)
+}
+
+public struct GitHubInstallationAccessGrant: Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    public let expiresAt: Date
+    public let repositories: [String]
+    public let permissions: GitHubBrokerPermissions
+    private let token: String
+    private let expiresAtText: String
+
+    fileprivate init(
+        token: String,
+        expiresAt: Date,
+        expiresAtText: String,
+        repositories: [String],
+        permissions: GitHubBrokerPermissions
+    ) {
+        self.token = token
+        self.expiresAt = expiresAt
+        self.expiresAtText = expiresAtText
+        self.repositories = repositories
+        self.permissions = permissions
+    }
+
+    public func withToken<T>(_ body: (String) throws -> T) rethrows -> T {
+        try body(token)
+    }
+
+    public var description: String {
+        "GitHub installation grant for \(repositories.joined(separator: ", ")) (expires \(expiresAtText))"
+    }
+
+    public var debugDescription: String { description }
+}
+
+public struct GitHubBrokerClient: Sendable {
+    public static let maximumResponseBytes = 64 * 1024
+
+    private let baseURL: URL
+    private let transport: any GitHubBrokerTransporting
+    private let now: @Sendable () -> Date
+
+    public init(
+        baseURL: URL,
+        transport: any GitHubBrokerTransporting = URLSessionGitHubBrokerTransport(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) throws {
+        guard Self.isValidBaseURL(baseURL) else {
+            throw GitHubBrokerClientError.invalidBaseURL
+        }
+        self.baseURL = baseURL
+        self.transport = transport
+        self.now = now
+    }
+
+    public func register(identity: GitHubBrokerDeviceIdentity) async throws {
+        let response: RegisterResponse = try await post(
+            path: "/device/register",
+            body: [
+                "publicKeyJwk": [
+                    "kty": identity.publicKeyJWK.kty,
+                    "crv": identity.publicKeyJWK.crv,
+                    "x": identity.publicKeyJWK.x,
+                    "y": identity.publicKeyJWK.y
+                ]
+            ],
+            credential: nil
+        )
+        guard response.status == "registered", response.deviceId == identity.deviceId else {
+            throw GitHubBrokerClientError.identityMismatch
+        }
+    }
+
+    public func startConnection(identity: GitHubBrokerDeviceIdentity) async throws -> GitHubBrokerConnection {
+        let response: StartResponse = try await post(
+            path: "/github/connect/start",
+            body: [:],
+            credential: try identity.makeCredential(now: now())
+        )
+        guard response.status == "connect_started",
+              let installURL = URL(string: response.installUrl),
+              Self.isValidInstallURL(installURL, state: response.state),
+              let expiresAt = parseBrokerDate(response.expiresAt),
+              expiresAt > now(),
+              expiresAt.timeIntervalSince(now()) <= 10 * 60 + 5
+        else {
+            throw GitHubBrokerClientError.invalidResponse
+        }
+        return GitHubBrokerConnection(installURL: installURL, state: response.state, expiresAt: expiresAt)
+    }
+
+    public func completeConnection(
+        identity: GitHubBrokerDeviceIdentity,
+        state: String
+    ) async throws -> GitHubBrokerConnectionCompletion {
+        guard Self.isOpaqueState(state) else {
+            throw GitHubBrokerClientError.invalidRequest
+        }
+        let response: CompleteResponse = try await post(
+            path: "/github/connect/complete",
+            body: ["state": state],
+            credential: try identity.makeCredential(now: now())
+        )
+        switch response.status {
+        case "pending":
+            guard response.installationId == nil else {
+                throw GitHubBrokerClientError.invalidResponse
+            }
+            return .pending
+        case "bound":
+            guard let installationId = response.installationId, installationId > 0 else {
+                throw GitHubBrokerClientError.invalidResponse
+            }
+            return .bound(installationId: installationId)
+        default:
+            throw GitHubBrokerClientError.invalidResponse
+        }
+    }
+
+    public func issueToken(
+        identity: GitHubBrokerDeviceIdentity,
+        installationId: Int,
+        repositories: [String]
+    ) async throws -> GitHubInstallationAccessGrant {
+        guard installationId > 0,
+              repositories.isEmpty == false,
+              repositories.count <= 50,
+              Set(repositories).count == repositories.count,
+              repositories.allSatisfy(Self.isCanonicalRepository)
+        else {
+            throw GitHubBrokerClientError.invalidRequest
+        }
+        let response: TokenResponse = try await post(
+            path: "/github/token",
+            body: [
+                "installationId": installationId,
+                "repositories": repositories
+            ],
+            credential: try identity.makeCredential(now: now())
+        )
+        guard response.status == "issued",
+              response.token.isEmpty == false,
+              response.repositories == repositories
+        else {
+            throw GitHubBrokerClientError.scopeMismatch
+        }
+        let permissions = GitHubBrokerPermissions(values: response.permissions)
+        guard permissions == .minimumReview else {
+            throw GitHubBrokerClientError.permissionMismatch
+        }
+        guard let expiresAt = parseBrokerDate(response.expiresAt),
+              expiresAt > now(),
+              expiresAt.timeIntervalSince(now()) <= 3_700
+        else {
+            throw GitHubBrokerClientError.invalidResponse
+        }
+        return GitHubInstallationAccessGrant(
+            token: response.token,
+            expiresAt: expiresAt,
+            expiresAtText: response.expiresAt,
+            repositories: response.repositories,
+            permissions: permissions
+        )
+    }
+
+    private func post<T: Decodable>(
+        path: String,
+        body: [String: Any],
+        credential: GitHubBrokerDeviceCredential?
+    ) async throws -> T {
+        guard let url = URL(string: path, relativeTo: baseURL)?.absoluteURL,
+              Self.sameOrigin(url, baseURL),
+              url.path == path
+        else {
+            throw GitHubBrokerClientError.invalidRequest
+        }
+        let encodedBody: Data
+        do {
+            encodedBody = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        } catch {
+            throw GitHubBrokerClientError.invalidRequest
+        }
+        var headers = [
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        ]
+        if let credential {
+            headers["Authorization"] = "Bearer \(credential.token)"
+        }
+        let request = GitHubBrokerHTTPRequest(
+            method: "POST",
+            url: url,
+            headers: headers,
+            body: encodedBody,
+            maximumResponseBytes: Self.maximumResponseBytes
+        )
+        let response: GitHubBrokerHTTPResponse
+        do {
+            response = try await transport.send(request)
+        } catch let error as GitHubBrokerClientError {
+            throw error
+        } catch {
+            throw GitHubBrokerClientError.transportUnavailable
+        }
+        guard response.url == request.url else {
+            throw GitHubBrokerClientError.originMismatch
+        }
+        guard response.body.count <= Self.maximumResponseBytes else {
+            throw GitHubBrokerClientError.responseTooLarge
+        }
+        let normalizedHeaders = Dictionary(uniqueKeysWithValues: response.headers.map {
+            ($0.key.lowercased(), $0.value.lowercased())
+        })
+        guard normalizedHeaders["content-type"]?.hasPrefix("application/json") == true else {
+            throw GitHubBrokerClientError.invalidResponse
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            throw Self.serverError(from: response.body)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: response.body)
+        } catch {
+            throw GitHubBrokerClientError.invalidResponse
+        }
+    }
+
+    private static func serverError(from body: Data) -> GitHubBrokerClientError {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              object["status"] as? String == "error",
+              let rawReason = object["reason"] as? String,
+              let reason = GitHubBrokerReason(rawValue: rawReason)
+        else {
+            return .invalidResponse
+        }
+        // Deliberately ignore server `detail`; only the typed reason crosses the
+        // native public/error boundary.
+        return .server(reason: reason)
+    }
+
+    private static func isValidBaseURL(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "https"
+            && url.host?.isEmpty == false
+            && url.user == nil
+            && url.password == nil
+            && url.query == nil
+            && url.fragment == nil
+            && (url.path.isEmpty || url.path == "/")
+    }
+
+    private static func sameOrigin(_ left: URL, _ right: URL) -> Bool {
+        left.scheme?.lowercased() == right.scheme?.lowercased()
+            && left.host?.lowercased() == right.host?.lowercased()
+            && effectivePort(left) == effectivePort(right)
+    }
+
+    private static func isValidInstallURL(_ url: URL, state: String) -> Bool {
+        guard url.scheme?.lowercased() == "https",
+              url.host?.lowercased() == "github.com",
+              url.user == nil,
+              url.password == nil,
+              url.fragment == nil,
+              url.path.hasPrefix("/apps/"),
+              url.path.hasSuffix("/installations/new"),
+              isOpaqueState(state)
+        else {
+            return false
+        }
+        return URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .filter { $0.name == "state" }
+            .map(\.value) == [state]
+    }
+
+    private static func isOpaqueState(_ value: String) -> Bool {
+        value.range(of: #"^[A-Za-z0-9_-]{8,256}$"#, options: .regularExpression) != nil
+    }
+
+    private static func isCanonicalRepository(_ value: String) -> Bool {
+        value.range(
+            of: #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"#,
+            options: .regularExpression
+        ) != nil
+    }
+}
+
+private struct RegisterResponse: Decodable {
+    let status: String
+    let deviceId: String
+}
+
+private struct StartResponse: Decodable {
+    let status: String
+    let installUrl: String
+    let state: String
+    let expiresAt: String
+}
+
+private struct CompleteResponse: Decodable {
+    let status: String
+    let installationId: Int?
+}
+
+private struct TokenResponse: Decodable {
+    let status: String
+    let token: String
+    let expiresAt: String
+    let repositories: [String]
+    let permissions: [String: String]
+}
+
+private func canonicalJSON(_ object: [String: Any]) throws -> Data {
+    do {
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    } catch {
+        throw GitHubBrokerDeviceIdentityError.credentialSigningFailed
+    }
+}
+
+private func base64URL<S: DataProtocol>(_ bytes: S) -> String {
+    Data(bytes).base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+private func parseBrokerDate(_ value: String) -> Date? {
+    let fractional = ISO8601DateFormatter()
+    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = fractional.date(from: value) { return date }
+    return ISO8601DateFormatter().date(from: value)
+}
+
+private func effectivePort(_ url: URL) -> Int? {
+    if let port = url.port { return port }
+    switch url.scheme?.lowercased() {
+    case "https": return 443
+    case "http": return 80
+    default: return nil
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
@@ -3,6 +3,7 @@ import Security
 
 public protocol DesktopSecretStoring {
     func setSecret(_ secret: String, account: String) throws
+    func createSecretIfAbsent(_ secret: String, account: String) throws -> Bool
     func readSecret(account: String) throws -> String?
     func readSecret(account: String, allowUserInteraction: Bool) throws -> String?
     func containsSecret(account: String) -> Bool
@@ -10,6 +11,12 @@ public protocol DesktopSecretStoring {
 }
 
 public extension DesktopSecretStoring {
+    func createSecretIfAbsent(_ secret: String, account: String) throws -> Bool {
+        guard try readSecret(account: account) == nil else { return false }
+        try setSecret(secret, account: account)
+        return true
+    }
+
     func readSecret(account: String, allowUserInteraction: Bool) throws -> String? {
         guard allowUserInteraction else { return nil }
         return try readSecret(account: account)
@@ -55,6 +62,21 @@ public final class KeychainSecretStore: DesktopSecretStoring {
         addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         let status = SecItemAdd(addQuery as CFDictionary, nil)
         guard status == errSecSuccess else { throw KeychainSecretError.unexpectedStatus(status) }
+    }
+
+    /// Atomically creates a generic-password item without replacing an existing
+    /// value. Keychain uniqueness on class/service/account coordinates separate
+    /// store instances and prevents concurrent identity creation from orphaning
+    /// a server binding.
+    public func createSecretIfAbsent(_ secret: String, account: String) throws -> Bool {
+        let data = Data(secret.utf8)
+        var addQuery = baseQuery(account: account)
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status == errSecSuccess { return true }
+        if status == errSecDuplicateItem { return false }
+        throw KeychainSecretError.unexpectedStatus(status)
     }
 
     public func readSecret(account: String) throws -> String? {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
@@ -1,0 +1,393 @@
+import CryptoKit
+import Foundation
+import Testing
+@_spi(Testing) import NeonDiffDesktopCore
+
+private let brokerCredentialResponseField = ["to", "ken"].joined()
+
+@Suite struct GitHubBrokerClientTests {
+    @Test func keychainIdentityIsStableAndSignsVerifiableShortLivedCredentials() throws {
+        let secrets = BrokerMemorySecretStore()
+        let store = GitHubBrokerDeviceIdentityStore(
+            secretStore: secrets,
+            account: "broker-device-fixture"
+        )
+
+        let first = try store.loadOrCreate()
+        let second = try store.loadOrCreate()
+
+        #expect(first.deviceId == second.deviceId)
+        #expect(first.publicKeyJWK == second.publicKeyJWK)
+        #expect(first.publicKeyJWK.kty == "EC")
+        #expect(first.publicKeyJWK.crv == "P-256")
+        #expect(first.publicKeyJWK.x.isEmpty == false)
+        #expect(first.publicKeyJWK.y.isEmpty == false)
+        #expect(Array(secrets.values.keys) == ["broker-device-fixture"])
+        #expect(String(describing: first) == "GitHub broker device \(first.deviceId)")
+        #expect(String(describing: first).contains(secrets.values["broker-device-fixture"] ?? "") == false)
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let credential = try first.makeCredential(now: now)
+        let compactCredential = credential.tokenForTesting
+        let segments = compactCredential.split(separator: ".", omittingEmptySubsequences: false)
+        #expect(segments.count == 3)
+        #expect(String(describing: credential) == "GitHub broker device credential [REDACTED]")
+
+        let header = try #require(decodeBase64URLJSON(String(segments[0])))
+        let payload = try #require(decodeBase64URLJSON(String(segments[1])))
+        #expect(header["alg"] as? String == "ES256")
+        #expect(header["typ"] as? String == "JWT")
+        #expect(payload["sub"] as? String == first.deviceId)
+        #expect(payload["iat"] as? Int == Int(now.timeIntervalSince1970))
+        #expect(payload["exp"] as? Int == Int(now.timeIntervalSince1970) + 300)
+
+        let publicKey = try P256.Signing.PublicKey(
+            rawRepresentation: jwkRawRepresentation(first.publicKeyJWK)
+        )
+        let signature = try P256.Signing.ECDSASignature(
+            rawRepresentation: try #require(decodeBase64URL(String(segments[2])))
+        )
+        let signingInput = Data("\(segments[0]).\(segments[1])".utf8)
+        #expect(publicKey.isValidSignature(signature, for: signingInput))
+    }
+
+    @Test func corruptStoredIdentityFailsClosedWithoutSilentRotation() throws {
+        let secrets = BrokerMemorySecretStore()
+        try secrets.setSecret("not-valid-private-key-material", account: "broker-device-fixture")
+        let store = GitHubBrokerDeviceIdentityStore(
+            secretStore: secrets,
+            account: "broker-device-fixture"
+        )
+
+        #expect(throws: GitHubBrokerDeviceIdentityError.invalidStoredIdentity) {
+            _ = try store.loadOrCreate()
+        }
+        #expect(secrets.values["broker-device-fixture"] == "not-valid-private-key-material")
+    }
+
+    @Test func brokerClientUsesExactOriginAndPreservesRepositoryScope() async throws {
+        let secrets = BrokerMemorySecretStore()
+        let identity = try GitHubBrokerDeviceIdentityStore(secretStore: secrets).loadOrCreate()
+        let transport = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/device/register",
+                body: ["status": "registered", "deviceId": identity.deviceId]
+            ),
+            .json(
+                url: "https://broker.example/github/connect/start",
+                body: [
+                    "status": "connect_started",
+                    "installUrl": "https://github.com/apps/neondiff/installations/new?state=opaque-state",
+                    "state": "opaque-state",
+                    "expiresAt": "2027-01-15T08:05:00Z"
+                ]
+            ),
+            .json(
+                url: "https://broker.example/github/connect/complete",
+                body: ["status": "pending"]
+            ),
+            .json(
+                url: "https://broker.example/github/connect/complete",
+                body: ["status": "bound", "installationId": 4242]
+            ),
+            .json(
+                url: "https://broker.example/github/token",
+                body: [
+                    "status": "issued",
+                    brokerCredentialResponseField: "fixture-installation-value",
+                    "expiresAt": "2027-01-15T08:50:00Z",
+                    "repositories": ["octo/private"],
+                    "permissions": [
+                        "actions": "read",
+                        "checks": "read",
+                        "contents": "read",
+                        "metadata": "read",
+                        "pull_requests": "write"
+                    ]
+                ]
+            )
+        ])
+        let client = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: transport,
+            now: { Date(timeIntervalSince1970: 1_800_000_000) }
+        )
+
+        try await client.register(identity: identity)
+        let connect = try await client.startConnection(identity: identity)
+        #expect(connect.installURL.host == "github.com")
+        #expect(connect.state == "opaque-state")
+        #expect(try await client.completeConnection(identity: identity, state: connect.state) == .pending)
+        #expect(try await client.completeConnection(identity: identity, state: connect.state) == .bound(installationId: 4242))
+
+        let grant = try await client.issueToken(
+            identity: identity,
+            installationId: 4242,
+            repositories: ["octo/private"]
+        )
+        #expect(grant.repositories == ["octo/private"])
+        #expect(grant.permissions == GitHubBrokerPermissions.minimumReview)
+        #expect(String(describing: grant) == "GitHub installation grant for octo/private (expires 2027-01-15T08:50:00Z)")
+        #expect(String(describing: grant).contains("fixture-installation-value") == false)
+        #expect(grant.withToken { $0 } == "fixture-installation-value")
+
+        let requests = await transport.requests
+        #expect(requests.count == 5)
+        #expect(requests.allSatisfy { $0.url.scheme == "https" && $0.url.host == "broker.example" })
+        #expect(requests[0].headers["Authorization"] == nil)
+        #expect(requests.dropFirst().allSatisfy { request in
+            request.headers["Authorization"]?.hasPrefix("Bearer ey") == true
+        })
+        let registration = try #require(
+            JSONSerialization.jsonObject(with: requests[0].body) as? [String: Any]
+        )
+        let publicJWK = try #require(registration["publicKeyJwk"] as? [String: Any])
+        #expect(publicJWK["d"] == nil)
+        let tokenRequest = try #require(
+            JSONSerialization.jsonObject(with: requests[4].body) as? [String: Any]
+        )
+        #expect(tokenRequest["repositories"] as? [String] == ["octo/private"])
+        #expect(tokenRequest["permissions"] == nil)
+    }
+
+    @Test func brokerClientFailsClosedOnIdentityOriginBudgetAndScopeMismatch() async throws {
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerMemorySecretStore()
+        ).loadOrCreate()
+
+        let wrongIdentity = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/device/register",
+                body: ["status": "registered", "deviceId": "different-device"]
+            )
+        ])
+        let wrongIdentityClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: wrongIdentity
+        )
+        await expectBrokerError(.identityMismatch) {
+            try await wrongIdentityClient.register(identity: identity)
+        }
+
+        let wrongOrigin = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://evil.example/github/connect/start",
+                body: [
+                    "status": "connect_started",
+                    "installUrl": "https://github.com/apps/neondiff/installations/new?state=opaque-state",
+                    "state": "opaque-state",
+                    "expiresAt": "2027-01-15T08:05:00Z"
+                ]
+            )
+        ])
+        let wrongOriginClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: wrongOrigin
+        )
+        await expectBrokerError(.originMismatch) {
+            _ = try await wrongOriginClient.startConnection(identity: identity)
+        }
+
+        let oversized = ScriptedBrokerTransport(responses: [
+            GitHubBrokerHTTPResponse(
+                statusCode: 200,
+                url: URL(string: "https://broker.example/github/connect/start")!,
+                headers: ["content-type": "application/json"],
+                body: Data(repeating: 0x41, count: GitHubBrokerClient.maximumResponseBytes + 1)
+            )
+        ])
+        let oversizedClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: oversized
+        )
+        await expectBrokerError(.responseTooLarge) {
+            _ = try await oversizedClient.startConnection(identity: identity)
+        }
+
+        let widenedScope = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/github/token",
+                body: [
+                    "status": "issued",
+                    brokerCredentialResponseField: "fixture-installation-value",
+                    "expiresAt": "2027-01-15T08:50:00Z",
+                    "repositories": ["octo/private", "octo/not-requested"],
+                    "permissions": [
+                        "actions": "read",
+                        "checks": "read",
+                        "contents": "read",
+                        "metadata": "read",
+                        "pull_requests": "write"
+                    ]
+                ]
+            )
+        ])
+        let widenedScopeClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: widenedScope
+        )
+        await expectBrokerError(.scopeMismatch) {
+            _ = try await widenedScopeClient.issueToken(
+                identity: identity,
+                installationId: 4242,
+                repositories: ["octo/private"]
+            )
+        }
+
+        let widenedPermissions = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/github/token",
+                body: [
+                    "status": "issued",
+                    brokerCredentialResponseField: "fixture-installation-value",
+                    "expiresAt": "2027-01-15T08:50:00Z",
+                    "repositories": ["octo/private"],
+                    "permissions": [
+                        "actions": "read",
+                        "checks": "read",
+                        "contents": "read",
+                        "issues": "write",
+                        "metadata": "read",
+                        "pull_requests": "write"
+                    ]
+                ]
+            )
+        ])
+        let widenedPermissionsClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: widenedPermissions
+        )
+        await expectBrokerError(.permissionMismatch) {
+            _ = try await widenedPermissionsClient.issueToken(
+                identity: identity,
+                installationId: 4242,
+                repositories: ["octo/private"]
+            )
+        }
+    }
+
+    @Test func brokerClientMapsServerReasonsWithoutReflectingDetail() async throws {
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerMemorySecretStore()
+        ).loadOrCreate()
+        let transport = ScriptedBrokerTransport(responses: [
+            .json(
+                statusCode: 403,
+                url: "https://broker.example/github/token",
+                body: [
+                    "status": "error",
+                    "reason": "entitlement_missing",
+                    "detail": "sensitive upstream detail must not escape"
+                ]
+            )
+        ])
+        let client = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: transport
+        )
+
+        do {
+            _ = try await client.issueToken(
+                identity: identity,
+                installationId: 4242,
+                repositories: ["octo/private"]
+            )
+            Issue.record("expected a typed server refusal")
+        } catch let error as GitHubBrokerClientError {
+            #expect(error == .server(reason: .entitlementMissing))
+            #expect(error.localizedDescription.contains("sensitive upstream") == false)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
+    }
+}
+
+private final class BrokerMemorySecretStore: DesktopSecretStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: String] = [:]
+
+    var values: [String: String] {
+        lock.withLock { storage }
+    }
+
+    func setSecret(_ secret: String, account: String) throws {
+        lock.withLock { storage[account] = secret }
+    }
+
+    func readSecret(account: String) throws -> String? {
+        lock.withLock { storage[account] }
+    }
+
+    func containsSecret(account: String) -> Bool {
+        lock.withLock { storage[account] != nil }
+    }
+
+    func deleteSecret(account: String) throws {
+        _ = lock.withLock { storage.removeValue(forKey: account) }
+    }
+}
+
+private actor ScriptedBrokerTransport: GitHubBrokerTransporting {
+    private var scripted: [GitHubBrokerHTTPResponse]
+    private(set) var requests: [GitHubBrokerHTTPRequest] = []
+
+    init(responses: [GitHubBrokerHTTPResponse]) {
+        scripted = responses
+    }
+
+    func send(_ request: GitHubBrokerHTTPRequest) async throws -> GitHubBrokerHTTPResponse {
+        requests.append(request)
+        guard scripted.isEmpty == false else {
+            throw GitHubBrokerClientError.transportUnavailable
+        }
+        return scripted.removeFirst()
+    }
+}
+
+private extension GitHubBrokerHTTPResponse {
+    static func json(
+        statusCode: Int = 200,
+        url: String,
+        body: [String: Any]
+    ) -> GitHubBrokerHTTPResponse {
+        GitHubBrokerHTTPResponse(
+            statusCode: statusCode,
+            url: URL(string: url)!,
+            headers: ["content-type": "application/json"],
+            body: try! JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        )
+    }
+}
+
+private func decodeBase64URLJSON(_ value: String) -> [String: Any]? {
+    guard let data = decodeBase64URL(value) else { return nil }
+    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+}
+
+private func decodeBase64URL(_ value: String) -> Data? {
+    var base64 = value.replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+    return Data(base64Encoded: base64)
+}
+
+private func jwkRawRepresentation(_ jwk: GitHubBrokerPublicJWK) throws -> Data {
+    var result = Data()
+    result.append(try #require(decodeBase64URL(jwk.x)))
+    result.append(try #require(decodeBase64URL(jwk.y)))
+    return result
+}
+
+private func expectBrokerError<T>(
+    _ expected: GitHubBrokerClientError,
+    operation: () async throws -> T
+) async {
+    do {
+        _ = try await operation()
+        Issue.record("expected \(expected)")
+    } catch let error as GitHubBrokerClientError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("unexpected error type: \(error)")
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
@@ -65,6 +65,53 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         #expect(secrets.values["broker-device-fixture"] == "not-valid-private-key-material")
     }
 
+    @Test func secretStoreFailuresStayInsidePublicErrorBoundary() {
+        let readFailure = GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerFailingSecretStore(failRead: true)
+        )
+        #expect(throws: GitHubBrokerDeviceIdentityError.identityStorageUnavailable) {
+            _ = try readFailure.loadOrCreate()
+        }
+
+        let createFailure = GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerFailingSecretStore(failCreate: true)
+        )
+        #expect(throws: GitHubBrokerDeviceIdentityError.identityStorageUnavailable) {
+            _ = try createFailure.loadOrCreate()
+        }
+    }
+
+    @Test func concurrentStoreInstancesConvergeOnOnePersistedIdentity() throws {
+        let secrets = RacingBrokerSecretStore()
+        let first = ConcurrentIdentityLoader(
+            store: GitHubBrokerDeviceIdentityStore(secretStore: secrets)
+        )
+        let second = ConcurrentIdentityLoader(
+            store: GitHubBrokerDeviceIdentityStore(secretStore: secrets)
+        )
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "GitHubBrokerClientTests.identity-race", attributes: .concurrent)
+
+        group.enter()
+        queue.async {
+            first.run()
+            group.leave()
+        }
+        group.enter()
+        queue.async {
+            second.run()
+            group.leave()
+        }
+        group.wait()
+
+        let firstLoaded = try first.result.get()
+        let secondLoaded = try second.result.get()
+        let firstIdentity = try #require(firstLoaded)
+        let secondIdentity = try #require(secondLoaded)
+        #expect(firstIdentity.deviceId == secondIdentity.deviceId)
+        #expect(secrets.createCount == 1)
+    }
+
     @Test func brokerClientUsesExactOriginAndPreservesRepositoryScope() async throws {
         let secrets = BrokerMemorySecretStore()
         let identity = try GitHubBrokerDeviceIdentityStore(secretStore: secrets).loadOrCreate()
@@ -300,6 +347,31 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
             Issue.record("unexpected error type: \(error)")
         }
     }
+
+    @Test func brokerClientRejectsDuplicateCaseInsensitiveResponseHeaders() async throws {
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerMemorySecretStore()
+        ).loadOrCreate()
+        let transport = ScriptedBrokerTransport(responses: [
+            GitHubBrokerHTTPResponse(
+                statusCode: 200,
+                url: URL(string: "https://broker.example/github/connect/start")!,
+                headers: [
+                    "Content-Type": "application/json",
+                    "content-type": "application/json"
+                ],
+                body: Data(#"{"status":"connect_started"}"#.utf8)
+            )
+        ])
+        let client = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: transport
+        )
+
+        await expectBrokerError(.invalidResponse) {
+            _ = try await client.startConnection(identity: identity)
+        }
+    }
 }
 
 private final class BrokerMemorySecretStore: DesktopSecretStoring, @unchecked Sendable {
@@ -324,6 +396,120 @@ private final class BrokerMemorySecretStore: DesktopSecretStoring, @unchecked Se
 
     func deleteSecret(account: String) throws {
         _ = lock.withLock { storage.removeValue(forKey: account) }
+    }
+}
+
+private struct BrokerSecretStoreFixtureError: Error {}
+
+private final class BrokerFailingSecretStore: DesktopSecretStoring, @unchecked Sendable {
+    private let failRead: Bool
+    private let failCreate: Bool
+
+    init(failRead: Bool = false, failCreate: Bool = false) {
+        self.failRead = failRead
+        self.failCreate = failCreate
+    }
+
+    func setSecret(_ secret: String, account: String) throws {
+        if failCreate { throw BrokerSecretStoreFixtureError() }
+    }
+
+    func readSecret(account: String) throws -> String? {
+        if failRead { throw BrokerSecretStoreFixtureError() }
+        return nil
+    }
+
+    func containsSecret(account: String) -> Bool { false }
+    func deleteSecret(account: String) throws {}
+}
+
+private final class RacingBrokerSecretStore: DesktopSecretStoring, @unchecked Sendable {
+    private let condition = NSCondition()
+    private var storage: [String: String] = [:]
+    private var initialReads = 0
+    private var creations = 0
+
+    var createCount: Int {
+        condition.withLock { creations }
+    }
+
+    func setSecret(_ secret: String, account: String) throws {
+        condition.withLock {
+            storage[account] = secret
+            creations += 1
+        }
+    }
+
+    func createSecretIfAbsent(_ secret: String, account: String) throws -> Bool {
+        condition.withLock {
+            guard storage[account] == nil else { return false }
+            storage[account] = secret
+            creations += 1
+            return true
+        }
+    }
+
+    func readSecret(account: String) throws -> String? {
+        condition.lock()
+        let snapshot = storage[account]
+        if initialReads < 2 {
+            initialReads += 1
+            if initialReads == 2 {
+                condition.broadcast()
+            } else {
+                while initialReads < 2 {
+                    condition.wait()
+                }
+            }
+        }
+        condition.unlock()
+        return snapshot
+    }
+
+    func containsSecret(account: String) -> Bool {
+        condition.withLock { storage[account] != nil }
+    }
+
+    func deleteSecret(account: String) throws {
+        _ = condition.withLock { storage.removeValue(forKey: account) }
+    }
+}
+
+private final class ConcurrentIdentityLoader: @unchecked Sendable {
+    let result = LockedBrokerIdentityResult()
+    private let store: GitHubBrokerDeviceIdentityStore
+
+    init(store: GitHubBrokerDeviceIdentityStore) {
+        self.store = store
+    }
+
+    func run() {
+        do {
+            result.set(try store.loadOrCreate())
+        } catch {
+            result.set(error)
+        }
+    }
+}
+
+private final class LockedBrokerIdentityResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var identity: GitHubBrokerDeviceIdentity?
+    private var error: Error?
+
+    func set(_ identity: GitHubBrokerDeviceIdentity) {
+        lock.withLock { self.identity = identity }
+    }
+
+    func set(_ error: Error) {
+        lock.withLock { self.error = error }
+    }
+
+    func get() throws -> GitHubBrokerDeviceIdentity? {
+        try lock.withLock {
+            if let error { throw error }
+            return identity
+        }
     }
 }
 


### PR DESCRIPTION
## Outcome

Adds the bounded native custody and transport seam required for the managed GitHub App broker. This is source-only, default-uncomposed infrastructure related to #613 and #630; it does not wire production or close either issue.

## Acceptance criteria

- [x] P-256 device identity is generated lazily and stored only through the existing Keychain-owned `DesktopSecretStoring` boundary.
- [x] Device identity uses the RFC 7638 JWK thumbprint and signs 300-second ES256 credentials.
- [x] Native register, connect-start, connect-complete, and token calls use a fixed HTTPS origin, reject redirects, bound response sizes, and expose typed public-safe errors.
- [x] Installation grants remain memory-only, require exact requested repository scope, and require the server-defined minimal review permission set.
- [x] Corrupt identity state, origin drift, oversized responses, widened scope, widened permissions, and server refusals fail closed.
- [x] Behavioral coverage was written failing-first and now passes.

## Explicit non-goals

- No production GitHub App registration, OAuth configuration, broker credentials, protected-environment deployment, or security approval.
- No AppCore/UI composition, feature-flag enablement, repository picker, provider setup, dry run, or live review.
- No production activation, beta artifact, signing/notarization, deployment, publication, or customer-readiness claim.
- No closure of #613, #630, #612, or broader #517 work.

## Validation

- `swift test --filter GitHubBrokerClientTests` — 5 passed.
- `swift test --filter GitHubDeviceAuthTests` — 3 passed.
- `node scripts/check-secret-scan.mjs` — 773 tracked files clean.
- Node/Foundation secret-rule differential — 203 expected cases across 20 rules passed.
- `git diff --check` — passed.

A single bounded local review pass was attempted; the runner recursively invoked itself and was stopped without a terminal report. Its one reproducible finding was synthetic test values matching the repository secret scanner. Those values were corrected and the focused secret gates above passed. No second review wave was launched. Broad TypeScript, Swift, Xcode, CodeQL, and hosted checks remain canonical remote CI gates.

Related to #613.
Related to #630.