### PR TITLE
fix(license): bind backfill proof to full tuple

### DIFF
--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -110,9 +110,10 @@ maximum period, USD currency, scope, and one-seat authority.
 
 Legacy checkout binding uses the admin
 `bind-checkout-subscription` command. Run `--dry-run` first, review the opaque
-issuance fingerprint and exact tuple, and require explicit production owner
-approval before the write form. Never accept or print a raw key, and do not
-mint a replacement key during reconciliation.
+issuance fingerprint plus the full provider/checkout/lookup-key tuple
+fingerprint, and require explicit production owner approval before the write
+form. Never accept or print a raw key, and do not mint a replacement key during
+reconciliation.
 
 The complete matrix, result mapping, rollout steps, and redaction contract live
 in

--- a/services/license-api/docs/admin-runbook.md
+++ b/services/license-api/docs/admin-runbook.md
@@ -87,10 +87,13 @@ LICENSE_DB_PATH=/data/license.sqlite npm run admin -- \
   --dry-run
 ```
 
-`would_bind` plus the opaque issuance fingerprint is evidence for review, not
-permission to write. Stop on `not_found`, `wrong_source`, `conflict`, or
-`unavailable`. A production write requires explicit owner approval of the
-fingerprint, database, provider account, mode, subscription, and checkout tuple.
+`would_bind` plus both opaque fingerprints is evidence for review, not
+permission to write. The `iss_...` fingerprint identifies the checkout
+issuance; the `bnd_...` fingerprint covers that issuance, the exact provider
+account/mode/subscription/checkout tuple, and the server-derived checkout lookup
+key. Stop on `not_found`, `wrong_source`, `conflict`, or `unavailable`. A
+production write requires explicit owner approval of both fingerprints,
+database, provider account, mode, subscription, checkout, and lookup-key tuple.
 Only then repeat the exact command without `--dry-run`; expect `bound`, or
 `already_bound` for an identical replay.
 

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -171,8 +171,9 @@ cache is diagnostic only; it does not authorize review during an outage.
 
 Run `bind-checkout-subscription ... --dry-run` first for every verified legacy
 `source=checkout` issuance. A production write needs explicit owner approval of
-the opaque fingerprint and exact provider tuple. Do not recover a raw key or
-mint a replacement during reconciliation. See
+the opaque issuance and full-tuple fingerprints plus the exact provider and
+server-derived lookup-key tuple. Do not recover a raw key or mint a replacement
+during reconciliation. See
 [`admin-runbook.md`](admin-runbook.md).
 
 Then hand the redacted source/contract evidence to #559. This runbook does not

--- a/services/license-api/docs/subscription-lifecycle.md
+++ b/services/license-api/docs/subscription-lifecycle.md
@@ -161,10 +161,12 @@ accept a raw key, plan, expiry, scope, ownership, update access, or seat count.
    ```
 
 2. Verify the redacted result is `would_bind` with an opaque `iss_...`
-   fingerprint. `not_found`, `wrong_source`, `conflict`, or `unavailable` is a
-   stop condition.
-3. Record explicit production owner approval against that fingerprint and
-   tuple. Dry-run success is not authorization to write production.
+   issuance fingerprint and a `bnd_...` fingerprint covering the exact
+   provider account/mode/subscription/checkout tuple plus the server-derived
+   checkout lookup key. `not_found`, `wrong_source`, `conflict`, or
+   `unavailable` is a stop condition.
+3. Record explicit production owner approval against both fingerprints and the
+   exact tuple. Dry-run success is not authorization to write production.
 4. Repeat the same command without `--dry-run` only inside the approved
    production maintenance procedure. Expect `bound`; an exact retry returns
    `already_bound`.

--- a/services/license-api/src/checkout-policy.ts
+++ b/services/license-api/src/checkout-policy.ts
@@ -54,6 +54,10 @@ export function checkoutPolicyFor(key: CheckoutLookupKey): CheckoutPolicy {
   return CHECKOUT_POLICIES[key];
 }
 
+export function checkoutLookupKeyForPlan(plan: string): CheckoutLookupKey | undefined {
+  return CHECKOUT_LOOKUP_KEYS.find((key) => CHECKOUT_POLICIES[key].plan === plan);
+}
+
 export function isCheckoutLookupKey(value: string): value is CheckoutLookupKey {
   return Object.prototype.hasOwnProperty.call(CHECKOUT_POLICIES, value);
 }

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -4,6 +4,7 @@ import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
   CHECKOUT_LOOKUP_KEYS,
+  checkoutLookupKeyForPlan,
   checkoutPolicyFor,
   isCheckoutLookupKey,
   type CheckoutLookupKey,
@@ -295,12 +296,32 @@ export interface BindCheckoutSubscriptionInput extends CheckoutSubscriptionBindi
 export interface BindCheckoutSubscriptionResult {
   result: "bound" | "already_bound" | "would_bind";
   issuanceFingerprint: string;
+  bindingFingerprint: string;
 }
 
 export function checkoutIssuanceFingerprint(issuanceIdempotencyKey: string): string {
   return `iss_${createHash("sha256")
     .update("neondiff:checkout-binding-backfill:issuance:v1\0")
     .update(issuanceIdempotencyKey.trim())
+    .digest("hex")
+    .slice(0, 32)}`;
+}
+
+export function checkoutBindingFingerprint(
+  input: BindCheckoutSubscriptionInput & { checkoutLookupKey: CheckoutLookupKey }
+): string {
+  const canonicalTuple = JSON.stringify([
+    input.issuanceIdempotencyKey,
+    input.provider,
+    input.providerAccountId,
+    input.providerMode,
+    input.externalSubscriptionId,
+    input.externalCheckoutId,
+    input.checkoutLookupKey
+  ]);
+  return `bnd_${createHash("sha256")
+    .update("neondiff:checkout-binding-backfill:tuple:v1\0")
+    .update(canonicalTuple)
     .digest("hex")
     .slice(0, 32)}`;
 }
@@ -621,6 +642,16 @@ export class LicenseStore {
           "checkout issuance entitlement is incompatible with subscription lifecycle"
         );
       }
+      const checkoutLookupKey = checkoutLookupKeyForPlan(record.plan);
+      if (!checkoutLookupKey) {
+        throw new CheckoutBindingConflictError(
+          "checkout issuance plan has no authoritative lookup key"
+        );
+      }
+      const bindingFingerprint = checkoutBindingFingerprint({
+        ...validated,
+        checkoutLookupKey
+      });
 
       const requestedBinding: CheckoutSubscriptionBindingInput = {
         provider: validated.provider,
@@ -641,13 +672,13 @@ export class LicenseStore {
         }
         this.db.exec("commit");
         transactionStarted = false;
-        return { result: "already_bound", issuanceFingerprint };
+        return { result: "already_bound", issuanceFingerprint, bindingFingerprint };
       }
 
       if (options.dryRun) {
         this.db.exec("rollback");
         transactionStarted = false;
-        return { result: "would_bind", issuanceFingerprint };
+        return { result: "would_bind", issuanceFingerprint, bindingFingerprint };
       }
 
       this.db
@@ -668,7 +699,7 @@ export class LicenseStore {
         );
       this.db.exec("commit");
       transactionStarted = false;
-      return { result: "bound", issuanceFingerprint };
+      return { result: "bound", issuanceFingerprint, bindingFingerprint };
     } catch (error) {
       if (transactionStarted) this.db.exec("rollback");
       if (isSqliteBusy(error)) {

--- a/services/license-api/test/admin.test.ts
+++ b/services/license-api/test/admin.test.ts
@@ -135,16 +135,21 @@ describe("admin issuance CLI", () => {
     assert.doesNotMatch(output, /\u001b|forged-admin-line|cus_/);
   });
 
-  it("bind-checkout-subscription dry-run writes nothing and emits only result plus fingerprint", () => {
+  it("bind-checkout-subscription dry-run writes nothing and emits only redacted tuple proof", () => {
     issueLegacyCheckout();
     lines = [];
 
     assert.equal(runAdmin(bindArgs(["--dry-run"]), store, out), 0);
     assert.equal(lines.length, 1);
     const output = JSON.parse(lines[0]) as Record<string, unknown>;
-    assert.deepEqual(Object.keys(output).sort(), ["issuanceFingerprint", "result"]);
+    assert.deepEqual(Object.keys(output).sort(), [
+      "bindingFingerprint",
+      "issuanceFingerprint",
+      "result"
+    ]);
     assert.equal(output.result, "would_bind");
     assert.match(String(output.issuanceFingerprint), /^iss_[a-f0-9]{32}$/);
+    assert.match(String(output.bindingFingerprint), /^bnd_[a-f0-9]{32}$/);
 
     lines = [];
     assert.equal(runAdmin(bindArgs(), store, out), 0);
@@ -164,6 +169,7 @@ describe("admin issuance CLI", () => {
 
     assert.equal(replay.result, "already_bound");
     assert.equal(replay.issuanceFingerprint, first.issuanceFingerprint);
+    assert.equal(replay.bindingFingerprint, first.bindingFingerprint);
     const output = JSON.stringify([first, replay]);
     for (const secret of [
       rawKey,

--- a/services/license-api/test/checkout-binding-backfill.test.ts
+++ b/services/license-api/test/checkout-binding-backfill.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, it } from "node:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { LicenseStore } from "../src/store.ts";
+import { LicenseStore, checkoutBindingFingerprint } from "../src/store.ts";
 
 const tempDirectories: string[] = [];
 
@@ -222,6 +222,39 @@ async function concurrentBindings(
 }
 
 describe("checkout subscription binding backfill store", () => {
+  it("fingerprints the issuance, full provider tuple, and authoritative lookup key", () => {
+    assert.equal(
+      checkoutBindingFingerprint({
+        issuanceIdempotencyKey: "checkout-session:cs_fixture",
+        provider: "stripe",
+        providerAccountId: "acct_live_fixture",
+        providerMode: "live",
+        externalSubscriptionId: "sub_fixture",
+        externalCheckoutId: "cs_fixture",
+        checkoutLookupKey: "neondiff_monthly"
+      }),
+      "bnd_7efb5b35c12691630054ec82364dc9d6"
+    );
+
+    const input = {
+      ...binding(),
+      checkoutLookupKey: "neondiff_monthly"
+    } as Parameters<typeof checkoutBindingFingerprint>[0];
+    const baseline = checkoutBindingFingerprint(input);
+    assert.match(baseline, /^bnd_[a-f0-9]{32}$/);
+
+    for (const changed of [
+      { issuanceIdempotencyKey: "checkout-session:other" },
+      { providerAccountId: "acct_other" },
+      { providerMode: "test" as const },
+      { externalSubscriptionId: "sub_other" },
+      { externalCheckoutId: "cs_other" },
+      { checkoutLookupKey: "neondiff_yearly" as const }
+    ]) {
+      assert.notEqual(checkoutBindingFingerprint({ ...input, ...changed }), baseline);
+    }
+  });
+
   it("dry-runs an existing checkout issuance with zero writes", () => {
     const path = databasePath();
     const store = new LicenseStore(path);
@@ -231,6 +264,7 @@ describe("checkout subscription binding backfill store", () => {
 
       assert.equal(result.result, "would_bind");
       assert.match(String(result.issuanceFingerprint), /^iss_[a-f0-9]{32}$/);
+      assert.match(String(result.bindingFingerprint), /^bnd_[a-f0-9]{32}$/);
       assert.equal(bindingCount(path), 0);
     } finally {
       store.close();
@@ -288,6 +322,7 @@ describe("checkout subscription binding backfill store", () => {
       assert.equal(created.result, "bound");
       assert.equal(replayed.result, "already_bound");
       assert.equal(replayed.issuanceFingerprint, created.issuanceFingerprint);
+      assert.equal(replayed.bindingFingerprint, created.bindingFingerprint);
       assert.equal(bindingCount(path), 1);
     } finally {
       second.close();


### PR DESCRIPTION
## Outcome

Closes the exact cross-repository safety gap found on website PR #55: legacy checkout-binding proof now covers the complete authoritative tuple consumed by website #46. Related to #562; does not close its production rollout.

## Bounded acceptance criteria

- keep the existing `iss_...` issuance fingerprint
- add a domain-separated `bnd_...` fingerprint covering issuance reference, provider, provider account, provider mode, subscription, checkout, and server-derived checkout lookup key
- derive lookup key from the stored server-owned entitlement plan, never caller authority
- emit both fingerprints only for `would_bind`, `bound`, and `already_bound` success
- preserve zero-write dry run, idempotent replay, conflict handling, redaction, and raw-key prohibition
- publish one exact known vector for the website consumer and prove every tuple field changes the fingerprint

## Explicit non-goals

- no production database/backfill, deploy, Stripe, checkout, lifecycle enablement, or license mutation
- no raw-key recovery or replacement issuance
- no website merge, billing rollout, beta, package, tag, GitHub Release, or customer-readiness claim
- no unrelated lifecycle/API/desktop refactor

## Failing-first and focused proof at `7ea81cbc123debe4f81953f14b8cf758169180d1`

- RED: admin/store tests failed because `bindingFingerprint` was absent
- focused admin + checkout-binding/concurrency tests: 23/23 passed
- license-service TypeScript build: passed
- tracked-file secret scan: 773 files passed
- `git diff --check`: passed

## Proof boundary

This is a source contract only. It enables website PR #55 to reject a proof copied from a different account/mode/subscription/checkout/lookup tuple. It does not prove any production binding, webhook, migration, entitlement, checkout, deploy, or paid flow.