### PR TITLE
feat: add bound repository discovery for native onboarding

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -346,6 +346,30 @@ public enum GitHubBrokerConnectionCompletion: Equatable, Sendable {
     case bound(installationId: Int)
 }
 
+public enum GitHubBrokerRepositoryVisibility: String, Codable, Equatable, Sendable {
+    case `public`
+    case `private`
+    case `internal`
+    case unknown
+}
+
+public struct GitHubBrokerRepository: Codable, Equatable, Sendable {
+    public let fullName: String
+    public let visibility: GitHubBrokerRepositoryVisibility
+
+    public init(fullName: String, visibility: GitHubBrokerRepositoryVisibility) {
+        self.fullName = fullName
+        self.visibility = visibility
+    }
+}
+
+public struct GitHubBrokerRepositoryPage: Equatable, Sendable {
+    public let installationId: Int
+    public let page: Int
+    public let repositories: [GitHubBrokerRepository]
+    public let nextPage: Int?
+}
+
 public struct GitHubInstallationAccessGrant: Sendable, CustomStringConvertible, CustomDebugStringConvertible {
     public let expiresAt: Date
     public let repositories: [String]
@@ -460,6 +484,44 @@ public struct GitHubBrokerClient: Sendable {
         default:
             throw GitHubBrokerClientError.invalidResponse
         }
+    }
+
+    public func listRepositories(
+        identity: GitHubBrokerDeviceIdentity,
+        installationId: Int,
+        page: Int = 1
+    ) async throws -> GitHubBrokerRepositoryPage {
+        guard installationId > 0, (1...200).contains(page) else {
+            throw GitHubBrokerClientError.invalidRequest
+        }
+        let response: RepositoryPageResponse = try await post(
+            path: "/github/repositories",
+            body: [
+                "installationId": installationId,
+                "page": page
+            ],
+            credential: try identity.makeCredential(now: now())
+        )
+        let repositoryNames = response.repositories.map(\.fullName)
+        guard response.status == "listed",
+              response.installationId == installationId,
+              response.page == page,
+              response.repositories.count <= 50,
+              Set(repositoryNames).count == repositoryNames.count,
+              repositoryNames.allSatisfy(Self.isCanonicalRepository),
+              repositoryNames == repositoryNames.sorted(),
+              response.nextPage == nil || response.nextPage == page + 1,
+              response.nextPage.map({ (1...200).contains($0) }) ?? true,
+              response.nextPage == nil || response.repositories.count == 50
+        else {
+            throw GitHubBrokerClientError.scopeMismatch
+        }
+        return GitHubBrokerRepositoryPage(
+            installationId: response.installationId,
+            page: response.page,
+            repositories: response.repositories,
+            nextPage: response.nextPage
+        )
     }
 
     public func issueToken(
@@ -648,6 +710,14 @@ private struct StartResponse: Decodable {
 private struct CompleteResponse: Decodable {
     let status: String
     let installationId: Int?
+}
+
+private struct RepositoryPageResponse: Decodable {
+    let status: String
+    let installationId: Int
+    let page: Int
+    let repositories: [GitHubBrokerRepository]
+    let nextPage: Int?
 }
 
 private struct TokenResponse: Decodable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -511,8 +511,7 @@ public struct GitHubBrokerClient: Sendable {
               repositoryNames.allSatisfy(Self.isCanonicalRepository),
               repositoryNames == repositoryNames.sorted(),
               response.nextPage == nil || response.nextPage == page + 1,
-              response.nextPage.map({ (1...200).contains($0) }) ?? true,
-              response.nextPage == nil || response.repositories.count == 50
+              response.nextPage.map({ (1...200).contains($0) }) ?? true
         else {
             throw GitHubBrokerClientError.scopeMismatch
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
@@ -138,6 +138,19 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
                 body: ["status": "bound", "installationId": 4242]
             ),
             .json(
+                url: "https://broker.example/github/repositories",
+                body: [
+                    "status": "listed",
+                    "installationId": 4242,
+                    "page": 1,
+                    "repositories": [
+                        ["fullName": "octo/private", "visibility": "private"],
+                        ["fullName": "octo/public", "visibility": "public"]
+                    ],
+                    "nextPage": NSNull()
+                ]
+            ),
+            .json(
                 url: "https://broker.example/github/token",
                 body: [
                     "status": "issued",
@@ -167,6 +180,18 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         #expect(try await client.completeConnection(identity: identity, state: connect.state) == .pending)
         #expect(try await client.completeConnection(identity: identity, state: connect.state) == .bound(installationId: 4242))
 
+        let repositories = try await client.listRepositories(
+            identity: identity,
+            installationId: 4242
+        )
+        #expect(repositories.installationId == 4242)
+        #expect(repositories.page == 1)
+        #expect(repositories.nextPage == nil)
+        #expect(repositories.repositories == [
+            GitHubBrokerRepository(fullName: "octo/private", visibility: .private),
+            GitHubBrokerRepository(fullName: "octo/public", visibility: .public)
+        ])
+
         let grant = try await client.issueToken(
             identity: identity,
             installationId: 4242,
@@ -179,7 +204,7 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         #expect(grant.withToken { $0 } == "fixture-installation-value")
 
         let requests = await transport.requests
-        #expect(requests.count == 5)
+        #expect(requests.count == 6)
         #expect(requests.allSatisfy { $0.url.scheme == "https" && $0.url.host == "broker.example" })
         #expect(requests[0].headers["Authorization"] == nil)
         #expect(requests.dropFirst().allSatisfy { request in
@@ -191,10 +216,86 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         let publicJWK = try #require(registration["publicKeyJwk"] as? [String: Any])
         #expect(publicJWK["d"] == nil)
         let tokenRequest = try #require(
-            JSONSerialization.jsonObject(with: requests[4].body) as? [String: Any]
+            JSONSerialization.jsonObject(with: requests[5].body) as? [String: Any]
         )
         #expect(tokenRequest["repositories"] as? [String] == ["octo/private"])
         #expect(tokenRequest["permissions"] == nil)
+        let repositoryRequest = try #require(
+            JSONSerialization.jsonObject(with: requests[4].body) as? [String: Any]
+        )
+        #expect(repositoryRequest["installationId"] as? Int == 4242)
+        #expect(repositoryRequest["page"] as? Int == 1)
+    }
+
+    @Test func brokerClientRejectsMalformedRepositoryPages() async throws {
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerMemorySecretStore()
+        ).loadOrCreate()
+
+        let noRequestTransport = ScriptedBrokerTransport(responses: [])
+        let noRequestClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: noRequestTransport
+        )
+        await expectBrokerError(.invalidRequest) {
+            try await noRequestClient.listRepositories(
+                identity: identity,
+                installationId: 4242,
+                page: 0
+            )
+        }
+        #expect(await noRequestTransport.requests.isEmpty)
+
+        let duplicateTransport = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/github/repositories",
+                body: [
+                    "status": "listed",
+                    "installationId": 4242,
+                    "page": 1,
+                    "repositories": [
+                        ["fullName": "octo/repo", "visibility": "private"],
+                        ["fullName": "octo/repo", "visibility": "private"]
+                    ],
+                    "nextPage": NSNull()
+                ]
+            )
+        ])
+        let duplicateClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: duplicateTransport
+        )
+        await expectBrokerError(.scopeMismatch) {
+            try await duplicateClient.listRepositories(
+                identity: identity,
+                installationId: 4242
+            )
+        }
+
+        let unknownVisibilityTransport = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/github/repositories",
+                body: [
+                    "status": "listed",
+                    "installationId": 4242,
+                    "page": 1,
+                    "repositories": [
+                        ["fullName": "octo/repo", "visibility": "secret"]
+                    ],
+                    "nextPage": NSNull()
+                ]
+            )
+        ])
+        let unknownVisibilityClient = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: unknownVisibilityTransport
+        )
+        await expectBrokerError(.invalidResponse) {
+            try await unknownVisibilityClient.listRepositories(
+                identity: identity,
+                installationId: 4242
+            )
+        }
     }
 
     @Test func brokerClientFailsClosedOnIdentityOriginBudgetAndScopeMismatch() async throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
@@ -298,6 +298,39 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         }
     }
 
+    @Test func brokerClientAcceptsSparseAuthorizedPageWithContinuation() async throws {
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerMemorySecretStore()
+        ).loadOrCreate()
+        let transport = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/github/repositories",
+                body: [
+                    "status": "listed",
+                    "installationId": 4242,
+                    "page": 1,
+                    "repositories": [
+                        ["fullName": "octo/authorized", "visibility": "private"]
+                    ],
+                    "nextPage": 2
+                ]
+            )
+        ])
+        let client = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: transport
+        )
+
+        let page = try await client.listRepositories(
+            identity: identity,
+            installationId: 4242
+        )
+        #expect(page.repositories == [
+            GitHubBrokerRepository(fullName: "octo/authorized", visibility: .private)
+        ])
+        #expect(page.nextPage == 2)
+    }
+
     @Test func brokerClientFailsClosedOnIdentityOriginBudgetAndScopeMismatch() async throws {
         let identity = try GitHubBrokerDeviceIdentityStore(
             secretStore: BrokerMemorySecretStore()

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -9,7 +9,7 @@ This document covers the **server-side slice** (issues #613 and #614). Native
 connect UI states are sequenced after #611/#612. The repository-visibility and
 entitlement decision is bound at token issuance in the single seam function
 `authorizeTokenIssuance` (#614); the live device<->license linkage and deployment
-wiring belong to the deploy lane (#559). No production GitHub App exists yet;
+wiring belong to the paid-beta deployment lane (#633). No production GitHub App exists yet;
 every code path below is exercised against fixtures, never a live install (see
 "Owner-gated boundary").
 
@@ -82,7 +82,17 @@ the license store's strict schema verification is unaffected.
    `POST /github/connect/complete` with its device credential and the original
    `state`. See "Return path" for why this is a device poll rather than a
    browser-to-app URL-scheme redirect in v1.
-6. **Token issuance (native to broker, recurring).** `POST /github/token` with the
+6. **Repository discovery (native to broker).** The app calls
+   `POST /github/repositories` with the device credential, installation id, and
+   page. The broker requires the exact device/installation binding, rechecks that
+   the installation is live and not suspended, then returns only the intersection
+   of the OAuth-authorized bind-time repository set and the installation's current
+   selected repositories. The response contains canonical repository names and
+   GitHub-authoritative visibility metadata in deterministic pages of 50. The
+   broker may use a metadata:read-only installation token internally to enumerate
+   the current selection, but no token is returned and the review-token mint seam
+   is never called.
+7. **Token issuance (native to broker, recurring).** `POST /github/token` with the
    device credential, `installation_id`, and the requested `repositories` /
    `permissions`. The broker checks, in order: the binding exists; the
    installation is live and not suspended; every requested repository is present
@@ -101,7 +111,7 @@ the license store's strict schema verification is unaffected.
    artifact. Reading the installation's repository list to make the visibility
    decision uses a separate **metadata:read-only** installation token, so no
    broad token is ever minted before the seam authorizes.
-7. **Local operation.** The local worker polls GitHub with the brokered token
+8. **Local operation.** The local worker polls GitHub with the brokered token
    exactly as it does today with a locally minted one, and renews via step 6
    before expiry. Reviews post as the NeonDiff App installation identity (AC6),
    because installation tokens author as the App.
@@ -254,8 +264,9 @@ active, private-covering entitlement.
 
 The entitlement snapshot is resolved through an injected authority (contract
 shape: the license-api `Entitlement`, merged #574). Its default is fail-closed
-(deny all private work) until the deploy lane (#559) wires the live device<->
-license linkage; the broker slice proves the binding against fixtures only.
+(deny all private work) until the paid-beta deployment lane (#633) wires the live
+device<->license linkage; the broker slice proves the binding against fixtures
+only.
 
 ## Threat model (STRIDE)
 

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -88,10 +88,11 @@ the license store's strict schema verification is unaffected.
    the installation is live and not suspended, then returns only the intersection
    of the OAuth-authorized bind-time repository set and the installation's current
    selected repositories. The response contains canonical repository names and
-   GitHub-authoritative visibility metadata in deterministic pages of 50. The
-   broker may use a metadata:read-only installation token internally to enumerate
-   the current selection, but no token is returned and the review-token mint seam
-   is never called.
+   GitHub-authoritative visibility metadata in deterministic pages of at most 50.
+   Each native page maps to exactly one bounded upstream repository-list page; the
+   broker does not drain the full installation selection for every request. It may
+   use a metadata:read-only installation token internally, but no token is returned
+   and the review-token mint seam is never called.
 7. **Token issuance (native to broker, recurring).** `POST /github/token` with the
    device credential, `installation_id`, and the requested `repositories` /
    `permissions`. The broker checks, in order: the binding exists; the
@@ -342,9 +343,10 @@ bindings and states; uninstalled installations are pruned on discovery.
    `docs/security/github-app-staging-registration.md`); until then the callback
    fails closed. Revisit registration abuse with telemetry.
 3. **Token-response repo snapshot (RESOLVED).** `POST /github/token` returns only
-   the token, its expiry, and the granted repositories/permissions. The app lists
-   repositories client-side with the brokered token, keeping broker surfaces
-   minimal.
+   the token, its expiry, and the granted repositories/permissions. Repository
+   selection uses the separate device-authenticated `POST /github/repositories`
+   metadata route, so the native app never needs an unnarrowed review token merely
+   to populate its selector.
 4. **Staging vs. production App registration sequence (OWNER-GATED, OPEN).** The
    agent builds against a staging App the owner registers with the documented
    permission set (see `docs/security/github-app-staging-registration.md`). The

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -112,7 +112,7 @@ the license store's strict schema verification is unaffected.
    decision uses a separate **metadata:read-only** installation token, so no
    broad token is ever minted before the seam authorizes.
 8. **Local operation.** The local worker polls GitHub with the brokered token
-   exactly as it does today with a locally minted one, and renews via step 6
+   exactly as it does today with a locally minted one, and renews via step 7
    before expiry. Reviews post as the NeonDiff App installation identity (AC6),
    because installation tokens author as the App.
 

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -23,6 +23,12 @@ export interface InstallationRepository {
   visibility: GitHubRepositoryVisibility;
 }
 
+export interface InstallationRepositoryPage {
+  repositories: InstallationRepository[];
+  totalCount: number;
+  hasNextPage: boolean;
+}
+
 export interface InstallationAccessToken {
   token: string;
   expires_at: string;
@@ -67,6 +73,16 @@ export interface GitHubInstallationClient {
   ): Promise<string[] | null>;
   /** The installation's current repository selection, with each repo's visibility. */
   listInstallationRepositories(installationId: number): Promise<InstallationRepository[]>;
+  /**
+   * One bounded page of the installation's current repository selection. Native
+   * discovery uses this seam so each customer-visible page consumes exactly one
+   * upstream list request rather than draining the full installation repeatedly.
+   */
+  listInstallationRepositoriesPage(
+    installationId: number,
+    page: number,
+    perPage: number
+  ): Promise<InstallationRepositoryPage>;
   /** Mint a narrowed installation access token. This is the RETURNED token; it is
    * reached only after the issuance seam authorizes the request. Narrowing uses
    * `repositoryIds` (GitHub's canonical `repository_ids`), never `owner/name`. */
@@ -281,6 +297,41 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
         }
         if (chunk.length < 100) return repositories;
       }
+    },
+    async listInstallationRepositoriesPage(
+      installationId: number,
+      page: number,
+      perPage: number
+    ): Promise<InstallationRepositoryPage> {
+      // Discovery needs only one bounded upstream page. The internal token stays
+      // metadata:read-only and is never returned to the device.
+      const token = (await installationToken(installationId, { permissions: { metadata: "read" } })).token;
+      const result = await request<{
+        total_count?: number;
+        repositories?: Array<{
+          id: number;
+          full_name: string;
+          visibility?: string;
+          private?: boolean;
+        }>;
+      }>(
+        `/installation/repositories?per_page=${perPage}&page=${page}`,
+        { token }
+      );
+      const totalCount = result.json?.total_count;
+      if (typeof totalCount !== "number" || !Number.isSafeInteger(totalCount) || totalCount < 0) {
+        throw new GitHubBrokerClientError("unavailable", "installation repository count was invalid");
+      }
+      const repositories = (result.json?.repositories ?? []).map((repository) => ({
+        id: repository.id,
+        full_name: repository.full_name,
+        visibility: normalizeVisibility(repository.visibility, repository.private)
+      }));
+      return {
+        repositories,
+        totalCount,
+        hasNextPage: page * perPage < totalCount
+      };
     },
     createInstallationAccessToken(installationId, params) {
       return installationToken(installationId, {

--- a/services/license-api/src/github-broker/index.ts
+++ b/services/license-api/src/github-broker/index.ts
@@ -12,6 +12,7 @@ export {
   type GitHubInstallationClient,
   type InstallationSummary,
   type InstallationRepository,
+  type InstallationRepositoryPage,
   type InstallationAccessToken,
   type GitHubRepositoryVisibility,
   type GitHubAppConfig

--- a/services/license-api/src/github-broker/routes.ts
+++ b/services/license-api/src/github-broker/routes.ts
@@ -11,6 +11,7 @@ const BROKER_PATHS = new Set([
   "/github/connect/start",
   "/github/connect/callback",
   "/github/connect/complete",
+  "/github/repositories",
   "/github/token"
 ]);
 
@@ -72,6 +73,9 @@ export async function handleGitHubBrokerRequest(
     }
     if (req.method === "POST" && path === "/github/connect/complete") {
       return writeJson(res, 200, await service.connectComplete(req.headers.authorization, await readBody(req)));
+    }
+    if (req.method === "POST" && path === "/github/repositories") {
+      return writeJson(res, 200, await service.listRepositories(req.headers.authorization, await readBody(req)));
     }
     if (req.method === "POST" && path === "/github/token") {
       return writeJson(res, 200, await service.issueToken(req.headers.authorization, await readBody(req)));

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -11,7 +11,7 @@ import { BrokerError } from "./errors.js";
 import {
   GitHubBrokerClientError,
   type GitHubInstallationClient,
-  type InstallationRepository,
+  type InstallationRepositoryPage,
   type InstallationSummary
 } from "./github-app.js";
 import { GitHubBrokerStore } from "./store.js";
@@ -276,10 +276,10 @@ export class GitHubBrokerService {
    *  2. the installation's current selected repositories.
    *
    * The broker returns metadata only. Its GitHub client may use a broker-internal
-   * metadata:read token to enumerate the installation, but this path never calls
-   * the review-token mint seam or returns any token. Fixed-size pagination keeps
-   * the native response budget bounded even for large selected-repository
-   * installations.
+   * metadata:read token to enumerate one upstream page, but this path never calls
+   * the review-token mint seam or returns any token. Each native page maps to one
+   * upstream page of at most 50 repositories, keeping request and response work
+   * bounded even for large selected-repository installations.
    */
   async listRepositories(
     authorization: string | string[] | undefined,
@@ -302,37 +302,39 @@ export class GitHubBrokerService {
     const installation = await this.resolveInstallation(installationId, { uninstalledIsGone: true });
     if (installation.suspended) throw new BrokerError("installation_suspended", "installation is suspended");
 
-    let selectedRepositories: InstallationRepository[];
+    let selectedPage: InstallationRepositoryPage;
     try {
-      selectedRepositories = await this.githubClient.listInstallationRepositories(installationId);
+      selectedPage = await this.githubClient.listInstallationRepositoriesPage(
+        installationId,
+        page,
+        REPOSITORY_PAGE_SIZE
+      );
     } catch (error) {
       throw mapClientError(error);
+    }
+    if (selectedPage.totalCount > MAX_DISCOVERABLE_REPOSITORIES) {
+      throw new BrokerError(
+        "invalid_request",
+        "installation repository selection exceeds the supported discovery limit"
+      );
     }
     const authorizedRepositories = new Set(
       this.store.listBindingRepositories(deviceId, installationId)
     );
-    const repositories = selectedRepositories
+    const repositories = selectedPage.repositories
       .filter((repository) => authorizedRepositories.has(repository.full_name))
       .sort((left, right) => {
         if (left.full_name < right.full_name) return -1;
         if (left.full_name > right.full_name) return 1;
         return 0;
       });
-    if (repositories.length > MAX_DISCOVERABLE_REPOSITORIES) {
-      throw new BrokerError(
-        "invalid_request",
-        "installation repository selection exceeds the supported discovery limit"
-      );
-    }
-    const offset = (page - 1) * REPOSITORY_PAGE_SIZE;
-    const currentPage = repositories.slice(offset, offset + REPOSITORY_PAGE_SIZE);
-    const nextPage = offset + currentPage.length < repositories.length ? page + 1 : null;
+    const nextPage = selectedPage.hasNextPage ? page + 1 : null;
 
     return {
       status: "listed",
       installationId,
       page,
-      repositories: currentPage.map((repository) => ({
+      repositories: repositories.map((repository) => ({
         fullName: repository.full_name,
         visibility: repository.visibility
       })),

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -11,12 +11,16 @@ import { BrokerError } from "./errors.js";
 import {
   GitHubBrokerClientError,
   type GitHubInstallationClient,
+  type InstallationRepository,
   type InstallationSummary
 } from "./github-app.js";
 import { GitHubBrokerStore } from "./store.js";
 
 const STATE_TTL_MS = 10 * 60 * 1_000;
 const MAX_REPOSITORIES_PER_REQUEST = 50;
+const REPOSITORY_PAGE_SIZE = 50;
+const MAX_REPOSITORY_PAGE = 200;
+const MAX_DISCOVERABLE_REPOSITORIES = REPOSITORY_PAGE_SIZE * MAX_REPOSITORY_PAGE;
 
 /**
  * The server-defined minimal review permission set (matches
@@ -51,10 +55,10 @@ export interface EntitlementResolutionContext {
  * Resolves the production entitlement for a private/internal token request,
  * bound to the license authority (contract shape: license-api `Entitlement`,
  * merged #574). The live device<->license linkage and deployment wiring are the
- * deploy lane's (#559); the broker only depends on this narrow snapshot function,
- * proven here with fixtures. It is called ONLY when a request includes a
- * non-public repository, so the public-free tier never depends on the license
- * service. Any throw is treated as a service outage and fails closed.
+ * paid-beta deployment lane's (#633); the broker only depends on this narrow
+ * snapshot function, proven here with fixtures. It is called ONLY when a request
+ * includes a non-public repository, so the public-free tier never depends on the
+ * license service. Any throw is treated as a service outage and fails closed.
  */
 export type EntitlementResolver = (
   context: EntitlementResolutionContext
@@ -261,6 +265,79 @@ export class GitHubBrokerService {
     const binding = this.store.getBinding(deviceId, stored.installation_id);
     if (!binding) throw new BrokerError("binding_not_found", "installation binding was not found");
     return { status: "bound", installationId: stored.installation_id };
+  }
+
+  /**
+   * POST /github/repositories — device-authenticated discovery for the native
+   * repository selector. The response is the intersection of:
+   *
+   *  1. the repositories the OAuth identity could access when it established
+   *     this exact device/installation binding; and
+   *  2. the installation's current selected repositories.
+   *
+   * The broker returns metadata only. Its GitHub client may use a broker-internal
+   * metadata:read token to enumerate the installation, but this path never calls
+   * the review-token mint seam or returns any token. Fixed-size pagination keeps
+   * the native response budget bounded even for large selected-repository
+   * installations.
+   */
+  async listRepositories(
+    authorization: string | string[] | undefined,
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    const { installationId, page } = parseRepositoryListRequest(body);
+
+    if (!this.tokenRateLimiter.allow(hashKey(`repos:${deviceId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many repository discovery requests for this device");
+    }
+    if (!this.tokenRateLimiter.allow(hashKey(`repos-inst:${installationId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many repository discovery requests for this installation");
+    }
+
+    const binding = this.store.getBinding(deviceId, installationId);
+    if (!binding) throw new BrokerError("binding_not_found", "no binding for this device and installation");
+
+    const installation = await this.resolveInstallation(installationId, { uninstalledIsGone: true });
+    if (installation.suspended) throw new BrokerError("installation_suspended", "installation is suspended");
+
+    let selectedRepositories: InstallationRepository[];
+    try {
+      selectedRepositories = await this.githubClient.listInstallationRepositories(installationId);
+    } catch (error) {
+      throw mapClientError(error);
+    }
+    const authorizedRepositories = new Set(
+      this.store.listBindingRepositories(deviceId, installationId)
+    );
+    const repositories = selectedRepositories
+      .filter((repository) => authorizedRepositories.has(repository.full_name))
+      .sort((left, right) => {
+        if (left.full_name < right.full_name) return -1;
+        if (left.full_name > right.full_name) return 1;
+        return 0;
+      });
+    if (repositories.length > MAX_DISCOVERABLE_REPOSITORIES) {
+      throw new BrokerError(
+        "invalid_request",
+        "installation repository selection exceeds the supported discovery limit"
+      );
+    }
+    const offset = (page - 1) * REPOSITORY_PAGE_SIZE;
+    const currentPage = repositories.slice(offset, offset + REPOSITORY_PAGE_SIZE);
+    const nextPage = offset + currentPage.length < repositories.length ? page + 1 : null;
+
+    return {
+      status: "listed",
+      installationId,
+      page,
+      repositories: currentPage.map((repository) => ({
+        fullName: repository.full_name,
+        visibility: repository.visibility
+      })),
+      nextPage
+    };
   }
 
   /**
@@ -480,6 +557,27 @@ function parseTokenRequest(body: unknown): {
   });
   const permissions = parsePermissions(record.permissions);
   return { installationId, repositories, ...(permissions ? { permissions } : {}) };
+}
+
+function parseRepositoryListRequest(body: unknown): {
+  installationId: number;
+  page: number;
+} {
+  const record = asObject(body);
+  const installationId = parseInstallationId(record.installationId);
+  const page = record.page ?? 1;
+  if (
+    typeof page !== "number"
+    || !Number.isInteger(page)
+    || page <= 0
+    || page > MAX_REPOSITORY_PAGE
+  ) {
+    throw new BrokerError(
+      "invalid_request",
+      `page must be an integer between 1 and ${MAX_REPOSITORY_PAGE}`
+    );
+  }
+  return { installationId, page };
 }
 
 function parsePermissions(value: unknown): Record<string, string> | undefined {

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -64,6 +64,33 @@ describe("production github installation client wire contract", () => {
     assert.deepEqual(tokenMint?.body, { permissions: { metadata: "read" } });
   });
 
+  it("lists exactly one bounded installation repository page for native discovery", async () => {
+    const captured = stubFetch((request) => {
+      if (request.url.includes("/access_tokens")) {
+        return { json: { token: "t", expires_at: new Date().toISOString() } };
+      }
+      return {
+        json: {
+          total_count: 73,
+          repositories: [{ id: 72, full_name: "octo/page-two", visibility: "private" }]
+        }
+      };
+    });
+    const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
+    const result = await client.listInstallationRepositoriesPage(6001, 2, 50);
+    assert.deepEqual(result, {
+      repositories: [{ id: 72, full_name: "octo/page-two", visibility: "private" }],
+      totalCount: 73,
+      hasNextPage: false
+    });
+    const listCalls = captured.filter((request) => request.url.includes("/installation/repositories"));
+    assert.equal(listCalls.length, 1);
+    assert.equal(new URL(listCalls[0].url).searchParams.get("page"), "2");
+    assert.equal(new URL(listCalls[0].url).searchParams.get("per_page"), "50");
+    const tokenMint = captured.find((request) => request.url.includes("/access_tokens"));
+    assert.deepEqual(tokenMint?.body, { permissions: { metadata: "read" } });
+  });
+
   it("mints the returned token with repository_ids and a permissions object", async () => {
     const captured = stubFetch(() => ({ json: { token: "t", expires_at: new Date().toISOString() } }));
     const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });

--- a/services/license-api/test/github-broker-contract.test.ts
+++ b/services/license-api/test/github-broker-contract.test.ts
@@ -156,6 +156,13 @@ describe("github broker token-issuance contract", () => {
       assert.equal(first.json.repositories.length, 50);
       assert.equal(first.json.nextPage, 2);
       assert.equal(first.text.includes("octo-page/not-authorized"), false);
+      assert.deepEqual(
+        pagedHarness.calls
+          .filter((call) => call.op === "listInstallationRepositories")
+          .map((call) => call.params),
+        [{ page: 1, perPage: 50 }],
+        "page 1 must issue one bounded upstream repository-list request"
+      );
 
       const second = await post(
         pagedHarness.url,
@@ -167,6 +174,13 @@ describe("github broker token-issuance contract", () => {
       assert.equal(second.json.page, 2);
       assert.equal(second.json.repositories.length, 3);
       assert.equal(second.json.nextPage, null);
+      assert.deepEqual(
+        pagedHarness.calls
+          .filter((call) => call.op === "listInstallationRepositories")
+          .map((call) => call.params),
+        [{ page: 1, perPage: 50 }, { page: 2, perPage: 50 }],
+        "each native page must add exactly one bounded upstream request"
+      );
       assert.equal(
         pagedHarness.calls.some((call) => call.op === "createInstallationAccessToken"),
         false,

--- a/services/license-api/test/github-broker-contract.test.ts
+++ b/services/license-api/test/github-broker-contract.test.ts
@@ -111,4 +111,114 @@ describe("github broker token-issuance contract", () => {
     assert.equal(replay.status, 409, replayText);
     assert.equal(JSON.parse(replayText).reason, "state_replayed");
   });
+
+  it("(e) paginates only the bound user's current installation repositories without review-token minting", async () => {
+    const repositories = Array.from({ length: 53 }, (_, index) => ({
+      id: 1_000 + index,
+      full_name: `octo-page/repo-${String(index).padStart(2, "0")}`,
+      visibility: index % 2 === 0 ? ("public" as const) : ("private" as const)
+    }));
+    repositories.push({ id: 9_999, full_name: "octo-page/not-authorized", visibility: "private" });
+    const pagedHarness = await startBroker({
+      installations: [{
+        id: 4002,
+        account_login: "octo-page",
+        repositories,
+        userRepositories: repositories
+          .map((repository) => repository.full_name)
+          .filter((fullName) => fullName !== "octo-page/not-authorized")
+      }]
+    });
+    try {
+      const fresh = await makeDevice();
+      await registerDevice(pagedHarness.url, fresh);
+
+      const unbound = await post(
+        pagedHarness.url,
+        "/github/repositories",
+        { installationId: 4002, page: 1 },
+        bearer(await fresh.sign())
+      );
+      assert.equal(unbound.status, 404, unbound.text);
+      assert.equal(unbound.json.reason, "binding_not_found");
+
+      await connectInstallation(pagedHarness.url, fresh, 4002);
+      const first = await post(
+        pagedHarness.url,
+        "/github/repositories",
+        { installationId: 4002, page: 1 },
+        bearer(await fresh.sign())
+      );
+      assert.equal(first.status, 200, first.text);
+      assert.equal(first.json.status, "listed");
+      assert.equal(first.json.installationId, 4002);
+      assert.equal(first.json.page, 1);
+      assert.equal(first.json.repositories.length, 50);
+      assert.equal(first.json.nextPage, 2);
+      assert.equal(first.text.includes("octo-page/not-authorized"), false);
+
+      const second = await post(
+        pagedHarness.url,
+        "/github/repositories",
+        { installationId: 4002, page: 2 },
+        bearer(await fresh.sign())
+      );
+      assert.equal(second.status, 200, second.text);
+      assert.equal(second.json.page, 2);
+      assert.equal(second.json.repositories.length, 3);
+      assert.equal(second.json.nextPage, null);
+      assert.equal(
+        pagedHarness.calls.some((call) => call.op === "createInstallationAccessToken"),
+        false,
+        "repository discovery never calls the returned review-token mint seam"
+      );
+      assert.doesNotMatch(`${first.text}${second.text}`, /-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+      assert.doesNotMatch(`${first.text}${second.text}`, /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
+    } finally {
+      pagedHarness.close();
+    }
+  });
+
+  it("(f) rejects malformed pages and suspended installations before repository metadata egress", async () => {
+    const suspendedHarness = await startBroker({
+      installations: [{
+        id: 4003,
+        account_login: "octo-suspended",
+        suspended: true,
+        repositories: [
+          { id: 20_001, full_name: "octo-suspended/site", visibility: "public" }
+        ]
+      }]
+    });
+    try {
+      const fresh = await makeDevice();
+      await registerDevice(suspendedHarness.url, fresh);
+      await connectInstallation(suspendedHarness.url, fresh, 4003);
+
+      const invalidPage = await post(
+        suspendedHarness.url,
+        "/github/repositories",
+        { installationId: 4003, page: 0 },
+        bearer(await fresh.sign())
+      );
+      assert.equal(invalidPage.status, 400, invalidPage.text);
+      assert.equal(invalidPage.json.reason, "invalid_request");
+
+      const suspended = await post(
+        suspendedHarness.url,
+        "/github/repositories",
+        { installationId: 4003, page: 1 },
+        bearer(await fresh.sign())
+      );
+      assert.equal(suspended.status, 409, suspended.text);
+      assert.equal(suspended.json.reason, "installation_suspended");
+      assert.equal(
+        suspendedHarness.calls.some((call) => call.op === "listInstallationRepositories"),
+        false,
+        "suspended installation is refused before listing repository metadata"
+      );
+    } finally {
+      suspendedHarness.close();
+    }
+  });
 });

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -128,6 +128,25 @@ export function fakeGitHubClient(
       if (!installation || installation.missing) return [];
       return installation.repositories.map((repository) => ({ ...repository }));
     },
+    async listInstallationRepositoriesPage(installationId: number, page: number, perPage: number) {
+      calls.push({
+        op: "listInstallationRepositories",
+        installationId,
+        params: { page, perPage }
+      });
+      const installation = byId.get(installationId);
+      if (!installation || installation.missing) {
+        return { repositories: [], totalCount: 0, hasNextPage: false };
+      }
+      const offset = (page - 1) * perPage;
+      return {
+        repositories: installation.repositories
+          .slice(offset, offset + perPage)
+          .map((repository) => ({ ...repository })),
+        totalCount: installation.repositories.length,
+        hasNextPage: offset + perPage < installation.repositories.length
+      };
+    },
     async createInstallationAccessToken(
       installationId: number,
       params: { repositories?: string[]; permissions?: Record<string, string> }

--- a/services/license-api/test/github-broker-wire.test.ts
+++ b/services/license-api/test/github-broker-wire.test.ts
@@ -135,9 +135,14 @@ describe("github broker token wire contract", () => {
     try {
       const started = await startLicenseServer({ store });
       server = started.server;
-      const response = await post(started.url, "/github/token", { installationId: 1, repositories: ["octo/site"] });
-      assert.equal(response.status, 503, response.text);
-      assert.equal(response.json.reason, "broker_unavailable");
+      for (const [path, body] of [
+        ["/github/token", { installationId: 1, repositories: ["octo/site"] }],
+        ["/github/repositories", { installationId: 1, page: 1 }]
+      ] as const) {
+        const response = await post(started.url, path, body);
+        assert.equal(response.status, 503, response.text);
+        assert.equal(response.json.reason, "broker_unavailable");
+      }
     } finally {
       server?.close();
       store.close();


### PR DESCRIPTION
## Summary

Adds the bounded repository-discovery seam needed after a native customer completes the managed GitHub App authorization flow:

- `POST /github/repositories` requires a device credential and the exact device/installation binding
- server output is the intersection of the OAuth-authorized bind-time set and GitHub's current installation selection
- deterministic pages of up to 50 carry canonical repository names plus authoritative visibility metadata
- the native client validates installation, page, ordering, uniqueness, pagination, repository shape, and visibility before accepting the response
- the security/data-flow contract now distinguishes the broker-internal metadata-only token from the review-token mint seam and routes paid-beta deployment truth to #633

Related to #613. This does not close the broader production-registration issue.

## Bounded acceptance criteria

- [x] unbound, suspended, invalid-page, and unconfigured-broker paths fail with typed reasons
- [x] repository metadata is restricted to the current-selection / OAuth-authorized intersection
- [x] discovery never invokes the returned review-token mint seam or returns token/key material
- [x] upstream paging is fixed-size, deterministic, bounded, and strictly validated by the native client
- [x] behavior is covered by failing-first server and native-client tests
- [x] production remains default-off
- [x] exact-head remote CI and review surfaces pass

## Explicit non-goals

- production GitHub App registration, OAuth credentials, or broker secrets
- deployment, kill-switch enablement, or live GitHub calls
- entitlement-policy or public-free runtime changes
- AppCore/UI composition, onboarding redesign, signing, notarization, publication, or release claims

## Failing-first evidence

Before the implementation, the server contract failed because `/github/repositories` was not a recognized broker route, and the native tests did not compile because the repository page API/types did not exist.

## Focused validation

- `PATH=/opt/homebrew/bin:$PATH node --import tsx --test test/github-broker-*.test.ts` — 107/107 passed
- `xcrun swift test --filter GitHubBrokerClientTests` — 10/10 passed
- `npm run check:public-claims` — passed
- `npm run check:secrets` — passed (773 tracked files)
- `git diff --check` — passed

Broad build/test validation is intentionally delegated to canonical GitHub Actions. The nested service build cannot run in this fresh worktree without the root dependency install that CI performs first; the focused TypeScript execution above used Node 26 and passed.



