### PR TITLE
fix(license): migrate Litestream-backed production schema

### DIFF
--- a/services/license-api/src/schema-signature.ts
+++ b/services/license-api/src/schema-signature.ts
@@ -1,0 +1,43 @@
+export interface SchemaObjectSignature {
+  type: string;
+  name: string;
+  tableName: string;
+  sql: string;
+}
+
+const LITESTREAM_INTERNAL_SCHEMA_SIGNATURE: readonly SchemaObjectSignature[] = [
+  {
+    type: "table",
+    name: "_litestream_lock",
+    tableName: "_litestream_lock",
+    sql: "create table _litestream_lock(id integer)"
+  },
+  {
+    type: "table",
+    name: "_litestream_seq",
+    tableName: "_litestream_seq",
+    sql: "create table _litestream_seq(id integer primary key,seq integer)"
+  }
+];
+
+const LITESTREAM_INTERNAL_NAMES = new Set(
+  LITESTREAM_INTERNAL_SCHEMA_SIGNATURE.map(({ name }) => name)
+);
+
+/**
+ * Litestream 0.5 creates two bookkeeping tables in the replicated database.
+ * They are not part of the application schema, but ignoring an arbitrary
+ * prefix would weaken the exact-schema gate. Strip them only when the complete
+ * pair matches Litestream's exact normalized signature; partial or modified
+ * lookalikes remain visible and fail the caller's schema comparison.
+ */
+export function stripVerifiedLitestreamInternalSchema(
+  signature: readonly SchemaObjectSignature[]
+): SchemaObjectSignature[] {
+  const internal = signature.filter(({ name }) => LITESTREAM_INTERNAL_NAMES.has(name));
+  if (internal.length === 0) return [...signature];
+  if (JSON.stringify(internal) !== JSON.stringify(LITESTREAM_INTERNAL_SCHEMA_SIGNATURE)) {
+    return [...signature];
+  }
+  return signature.filter(({ name }) => !LITESTREAM_INTERNAL_NAMES.has(name));
+}

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -15,6 +15,10 @@ import {
   type ParsedSubscriptionLifecycleRequest,
   type RenewPaidSubscriptionLifecycleRequest
 } from "./subscription-lifecycle.js";
+import {
+  stripVerifiedLitestreamInternalSchema,
+  type SchemaObjectSignature
+} from "./schema-signature.js";
 
 const SCHEMA_VERSION = 2;
 const DEFAULT_BUSY_TIMEOUT_MS = 250;
@@ -53,13 +57,6 @@ export interface LicenseStoreOptions {
   /** Server-owned clock. Checkout callers cannot override it per issuance. */
   now?: () => Date;
   busyTimeoutMs?: number;
-}
-
-interface SchemaObjectSignature {
-  type: string;
-  name: string;
-  tableName: string;
-  sql: string;
 }
 
 const CORE_SCHEMA = `
@@ -1395,12 +1392,14 @@ function readSchemaSignature(db: DatabaseSync): SchemaObjectSignature[] {
        order by type, name`
     )
     .all() as unknown as Array<{ type: string; name: string; tbl_name: string; sql: string }>;
-  return rows.map((row) => ({
-    type: row.type,
-    name: row.name,
-    tableName: row.tbl_name,
-    sql: normalizeSchemaSql(row.sql)
-  }));
+  return stripVerifiedLitestreamInternalSchema(
+    rows.map((row) => ({
+      type: row.type,
+      name: row.name,
+      tableName: row.tbl_name,
+      sql: normalizeSchemaSql(row.sql)
+    }))
+  );
 }
 
 function normalizeSchemaSql(sql: string): string {

--- a/services/license-api/src/verify-legacy-restore.ts
+++ b/services/license-api/src/verify-legacy-restore.ts
@@ -1,12 +1,9 @@
 import { statSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
-
-interface SchemaObjectSignature {
-  type: string;
-  name: string;
-  tableName: string;
-  sql: string;
-}
+import {
+  stripVerifiedLitestreamInternalSchema,
+  type SchemaObjectSignature
+} from "./schema-signature.js";
 
 const LEGACY_SCHEMA = `
   create table licenses (
@@ -52,12 +49,14 @@ function readSchemaSignature(db: DatabaseSync): SchemaObjectSignature[] {
     tbl_name: string;
     sql: string;
   }>;
-  return rows.map((row) => ({
-    type: row.type,
-    name: row.name,
-    tableName: row.tbl_name,
-    sql: normalizeSchemaSql(row.sql)
-  }));
+  return stripVerifiedLitestreamInternalSchema(
+    rows.map((row) => ({
+      type: row.type,
+      name: row.name,
+      tableName: row.tbl_name,
+      sql: normalizeSchemaSql(row.sql)
+    }))
+  );
 }
 
 function normalizeSchemaSql(sql: string): string {

--- a/services/license-api/test/store-migration.test.ts
+++ b/services/license-api/test/store-migration.test.ts
@@ -42,6 +42,11 @@ const LEGACY_SCHEMA = `
   );
 `;
 
+const LITESTREAM_INTERNAL_SCHEMA = `
+  create table _litestream_lock (id integer);
+  create table _litestream_seq (id integer primary key, seq integer);
+`;
+
 const tempDirectories: string[] = [];
 
 afterEach(() => {
@@ -362,6 +367,48 @@ describe("license store schema v2 migration", () => {
     assert.ok(objectNames(db, "table").includes("checkout_subscription_bindings"));
     assert.ok(objectNames(db, "table").includes("license_subscription_lifecycle_events"));
     db.close();
+  });
+
+  it("migrates the exact legacy schema when Litestream 0.5 metadata tables are present", () => {
+    const path = databasePath();
+    createLegacyDatabase(path);
+    const before = open(path);
+    before.exec(LITESTREAM_INTERNAL_SCHEMA);
+    before.prepare("insert into _litestream_lock (id) values (?)").run(1);
+    before.prepare("insert into _litestream_seq (id, seq) values (?, ?)").run(1, 3170);
+    before.close();
+
+    const store = new LicenseStore(path);
+    store.close();
+
+    const db = open(path);
+    assert.equal(userVersion(db), 2);
+    assertLegacyRowsPreserved(db);
+    assert.deepEqual({ ...db.prepare("select * from _litestream_lock").get() }, { id: 1 });
+    assert.deepEqual({ ...db.prepare("select * from _litestream_seq").get() }, { id: 1, seq: 3170 });
+    assert.ok(objectNames(db, "table").includes("checkout_subscription_bindings"));
+    assert.ok(objectNames(db, "table").includes("license_subscription_lifecycle_events"));
+    db.close();
+  });
+
+  it("rejects a Litestream metadata lookalike before migration", () => {
+    const path = databasePath();
+    createLegacyDatabase(path);
+    const db = open(path);
+    db.exec(`
+      create table _litestream_lock (id text);
+      create table _litestream_seq (id integer primary key, seq integer);
+    `);
+    const before = schemaRows(db);
+    db.close();
+
+    assert.throws(() => new LicenseStore(path), /unknown non-empty schema at user_version 0/);
+
+    const inspected = open(path);
+    assert.equal(userVersion(inspected), 0);
+    assert.deepEqual(schemaRows(inspected), before);
+    assertLegacyRowsPreserved(inspected);
+    inspected.close();
   });
 
   it("reopens schema v2 without changing its schema or data", () => {

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -64,6 +64,11 @@ const legacySchema = `
   );
 `;
 
+const litestreamInternalSchema = `
+  create table _litestream_lock (id integer);
+  create table _litestream_seq (id integer primary key, seq integer);
+`;
+
 function readServiceFile(relativePath: string): string {
   return readFileSync(join(licenseApiDir, relativePath), "utf8");
 }
@@ -410,6 +415,9 @@ fi
       const legacyPath = join(root, "legacy.sqlite");
       const legacyDb = new DatabaseSync(legacyPath);
       legacyDb.exec(legacySchema);
+      legacyDb.exec(litestreamInternalSchema);
+      legacyDb.prepare("insert into _litestream_lock (id) values (?)").run(1);
+      legacyDb.prepare("insert into _litestream_seq (id, seq) values (?, ?)").run(1, 3170);
       legacyDb.close();
 
       const verified = execFileSync(
@@ -418,6 +426,20 @@ fi
         { cwd: alternateCwd, encoding: "utf8" }
       );
       expect(verified.trim()).toBe("legacy restore verification ok");
+
+      const lookalikePath = join(root, "litestream-lookalike.sqlite");
+      const lookalikeDb = new DatabaseSync(lookalikePath);
+      lookalikeDb.exec(legacySchema);
+      lookalikeDb.exec(`
+        create table _litestream_lock (id text);
+        create table _litestream_seq (id integer primary key, seq integer);
+      `);
+      lookalikeDb.close();
+      expect(() => execFileSync(
+        process.execPath,
+        [legacyRestoreVerifier, lookalikePath],
+        { cwd: alternateCwd, encoding: "utf8", stdio: "pipe" }
+      )).toThrow();
 
       const v2Path = join(root, "v2.sqlite");
       const v2Store = new LicenseStore(v2Path);


### PR DESCRIPTION
Related: #562
Parent: #610

## Customer/release failure

A protected deploy of exact `origin/main` `c9167699868cec9e6cdfa5ed10a9d1a3fb3278e5` reached the live Fly machine but failed before HTTP startup with `unknown non-empty schema at user_version 0`. The production DB remained `user_version=0`; the previous immutable image was restored immediately and `/healthz`, Fly checks, `pragma quick_check`, and fresh Litestream LTX replication were reverified.

Schema-only inspection found the reviewed legacy application schema plus Litestream 0.5's exact `_litestream_lock` and `_litestream_seq` bookkeeping tables. No rows, keys, customer data, or secret values were read or copied.

## Bounded acceptance criteria

- The v2 migrator accepts the exact legacy NeonDiff schema when the complete, exact normalized Litestream 0.5 metadata pair is present.
- The shipped point-in-time restore verifier accepts the same exact pair.
- Litestream rows and all legacy license/activation/issuance rows remain unchanged through migration.
- A partial, altered, or extra lookalike remains visible to the strict schema comparison and fails closed before mutation.
- Current-head focused tests, service build, remote CI, CodeQL, and review surfaces pass before merge.

## Explicit non-goals

- No production database write, backfill, checkout enablement, Stripe event change, broker/App credential work, native wiring, signing, publication, or customer-readiness claim.
- No broad schema relaxation and no prefix-based ignore rule.
- This PR does not close #562 or its live lifecycle/canary matrix.

## Failing-first proof

Before the implementation:

- `node --import tsx --test services/license-api/test/store-migration.test.ts` — 19 passed, 1 failed on the exact Litestream-backed legacy fixture.
- focused `tests/license-service-dr.test.ts` verifier case — failed because the exact Litestream metadata pair was treated as product schema.

After the implementation (Node 26):

- migration suite: 20/20 passed;
- focused shipped restore-verifier case: passed, including altered-lookalike rejection;
- `npm run build --prefix services/license-api` passed;
- `git diff --check` passed.

Agent-authored. Public-safe evidence only; no secret values or production data are included.
