### PR TITLE
feat(desktop): compose managed GitHub onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,15 @@ repository. The raw Activation Key remains Keychain-owned: it crosses bounded
 stdin for activation and the fixed-origin broker HTTPS request body for private
 token issuance only, and is never placed in argv, config, logs, or broker
 storage. That production path remains behind its rollout kill switch until the
-paid-beta canaries pass. This slice does not migrate generic CLI
-status/deactivate or daemon-admission validation from the legacy local identity;
-#630 must wire those runtime callers before the managed path can be enabled.
+paid-beta canaries pass. The native source now composes the managed broker only
+when a release bundle carries the exact `paid-mac-beta-v1` Info.plist contract,
+fixed production broker origin, and explicit broker-enable marker. Those public
+build values are absent by default, so ordinary/debug bundles stay quarantined;
+the server kill switch and every broker/entitlement decision still fail closed.
+This source composition is not proof that the production broker is enabled,
+that billing is live, or that a signed customer artifact exists. Generic CLI
+status/deactivate and daemon-admission validation still need exact-candidate
+integration proof under #630 before the paid-beta gate can pass.
 The native Providers pane reads and edits the saved `providers` registry, not
 the legacy `desktop.openAICompatibleEndpoint` field. Load config, Preview, and
 Apply the exact selected provider before Verify is enabled; verification pins
@@ -155,9 +161,10 @@ both the provider ID and inspected config revision.
 Create or install the GitHub App before expecting PR reviews to run. The App
 must be installed on the same selected repositories listed in `pilotRepos`; see
 [docs/github-app-setup.md](docs/github-app-setup.md) for the permission set and
-selected-repo install path. Enable device flow in the GitHub App settings before
-using the Mac desktop "Connect GitHub" repo selector; the desktop uses the
-public client ID for that user-code authorization flow.
+selected-repo install path. The rollout-disabled managed desktop path uses the
+broker-issued GitHub App install/OAuth URL and a device-signed completion poll;
+it never falls back to a user token. Legacy direct-install builds still use
+device flow and the public client ID.
 
 Do not store the GitHub App private key, provider API key, license key, tokens,
 or customer data in this repository. Keep local config, secrets, state DBs, and

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -18,6 +18,15 @@ enum NeonDiffDesktopCompositionRoot {
         #endif
 
         let keychain = KeychainSecretStore()
+        var productionBoundary = DesktopProductionBoundary.resolve(
+            infoDictionary: Bundle.main.infoDictionary ?? [:]
+        )
+        let githubBroker = productionBoundary.managedGitHubBrokerOrigin.flatMap {
+            try? GitHubBrokerClient(baseURL: $0)
+        }
+        if productionBoundary.managedGitHubBrokerOrigin != nil, githubBroker == nil {
+            productionBoundary = .quarantined
+        }
         return NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: AppKitClipboard(),
             urlOpener: AppKitURLOpener(),
@@ -29,7 +38,8 @@ enum NeonDiffDesktopCompositionRoot {
             providerVerifier: FoundationProviderVerifier(secretStore: keychain),
             secretStore: keychain,
             githubAuthenticator: GitHubDeviceAuthClient(),
-            productionBoundary: .quarantined,
+            githubBroker: githubBroker,
+            productionBoundary: productionBoundary,
             cliWorkingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory()
         ))
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -216,6 +216,16 @@ struct OnboardingWizardView: View {
                         "neondiff-onboarding-repository-\(repository.fullName)"
                     )
                 }
+
+                Button { model.applyRepoAllowlistPatch() } label: {
+                    Label("Apply Repository", systemImage: "checkmark.shield")
+                }
+                .disabled(
+                    model.selectedManagedGitHubRepository == nil
+                        || model.isConfigPatchInProgress
+                        || model.isConfigInspectInProgress
+                )
+                .accessibilityIdentifier("neondiff-onboarding-repository-apply")
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -301,7 +301,7 @@ struct OnboardingWizardView: View {
                         Button { model.stopDaemon() } label: {
                             Label("Stop", systemImage: "stop.circle")
                         }
-                        .disabled(!model.productionUsefulWorkAvailable)
+                        .disabled(!model.productionDaemonStopAvailable)
                     }
 
                     HStack(spacing: 10) {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -111,24 +111,111 @@ struct OnboardingWizardView: View {
     }
 
     private var welcomeStep: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            OperatorSection("Mode") {
-                Picker("Review Mode", selection: $model.onboardingFlow.mode) {
-                    ForEach(OnboardingMode.allCases) { mode in
-                        Text(mode.title).tag(mode)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if model.managedGitHubAvailable {
+                    managedGitHubSection
+                } else {
+                    OperatorSection("Mode") {
+                        Picker("Review Mode", selection: $model.onboardingFlow.mode) {
+                            ForEach(OnboardingMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+
+                        Text("All repository review work requires live API-backed activation. This desktop build cannot yet prove the native activation broker, so onboarding cannot complete.")
+                            .operatorBodyText()
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
-                .pickerStyle(.segmented)
 
-                Text("All repository review work requires live API-backed activation. This desktop build cannot yet prove the native activation broker, so onboarding cannot complete.")
-                    .operatorBodyText()
-                    .fixedSize(horizontal: false, vertical: true)
+                OperatorSection("Authority") {
+                    Text(model.managedGitHubAvailable
+                        ? "Repository visibility and installation scope come only from the production GitHub broker. Public repositories are free; private and internal repositories require API-backed activation. Unknown visibility fails closed."
+                        : "Desktop configures local state and starts CLI-backed checks. GitHub reviews still go through the daemon and its current-head safety gates.")
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+    }
+
+    private var managedGitHubSection: some View {
+        OperatorSection("GitHub Authorization") {
+            HStack(spacing: 10) {
+                OperatorBadge(
+                    text: model.managedGitHubStatusText,
+                    color: model.managedGitHubConnectionState.isBound
+                        ? NeonDiffTheme.accent
+                        : NeonDiffTheme.warning
+                )
+
+                Spacer()
+
+                if model.managedGitHubConnectionState == .verificationRequired {
+                    Button { model.refreshManagedGitHubRepositories() } label: {
+                        Label("Verify Binding", systemImage: "checkmark.shield")
+                    }
+                    .disabled(model.isManagedGitHubConnectionInProgress)
+                    .accessibilityIdentifier("neondiff-onboarding-github-verify")
+                } else if !model.managedGitHubConnectionState.isBound {
+                    Button { model.startManagedGitHubConnection() } label: {
+                        Label("Connect GitHub", systemImage: "person.crop.circle.badge.checkmark")
+                    }
+                    .disabled(model.isManagedGitHubConnectionInProgress)
+                    .accessibilityIdentifier("neondiff-onboarding-github-connect")
+                }
             }
 
-            OperatorSection("Authority") {
-                Text("Desktop configures local state and starts CLI-backed checks. GitHub reviews still go through the daemon and its current-head safety gates.")
-                    .operatorBodyText()
-                    .fixedSize(horizontal: false, vertical: true)
+            if let recovery = model.managedGitHubRecovery {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(recovery.message)
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button("Retry Managed GitHub") {
+                        model.performManagedGitHubRecoveryAction()
+                    }
+                    .disabled(model.isManagedGitHubConnectionInProgress)
+                    .accessibilityIdentifier("neondiff-onboarding-github-recovery")
+                }
+            }
+
+            if !model.managedGitHubRepositories.isEmpty {
+                Text("Choose one server-bound repository")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+
+                ForEach(model.managedGitHubRepositories, id: \.fullName) { repository in
+                    Button {
+                        model.selectManagedGitHubRepository(fullName: repository.fullName)
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: repository.visibility == .public ? "globe" : "lock.fill")
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(repository.fullName)
+                                Text(repository.visibility == .unknown
+                                    ? "Visibility unavailable · blocked"
+                                    : repository.visibility.rawValue.capitalized)
+                                    .font(.caption)
+                            }
+                            Spacer()
+                            if model.selectedManagedGitHubRepository == repository.fullName {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(NeonDiffTheme.accent)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(repository.visibility == .unknown)
+                    .accessibilityLabel(
+                        "\(repository.fullName), \(repository.visibility.rawValue)"
+                    )
+                    .accessibilityIdentifier(
+                        "neondiff-onboarding-repository-\(repository.fullName)"
+                    )
+                }
             }
         }
     }
@@ -282,6 +369,10 @@ struct OnboardingWizardView: View {
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                 LabeledContent("Mode", value: model.onboardingFlow.mode.title)
                     .foregroundStyle(NeonDiffTheme.textPrimary)
+                if let repository = model.selectedManagedGitHubRepository {
+                    LabeledContent("Repository", value: repository)
+                        .foregroundStyle(NeonDiffTheme.textPrimary)
+                }
                 LabeledContent("License", value: model.onboardingFlow.licenseActivation == .activated ? "activated" : "service pending")
                     .foregroundStyle(NeonDiffTheme.textPrimary)
             }
@@ -322,9 +413,16 @@ struct OnboardingWizardView: View {
                 Label(model.onboardingFlow.nextActionTitle, systemImage: model.onboardingFlow.currentStep == .done ? "checkmark" : "chevron.right")
             }
             .buttonStyle(OperatorButtonStyle(solid: true))
-            .disabled(!model.onboardingFlow.canAdvance)
+            .disabled(!model.canAdvanceOnboarding)
         }
         .hostedOnboardingEvaluationRegion("neondiff-onboarding-footer")
+    }
+}
+
+private extension ManagedGitHubConnectionState {
+    var isBound: Bool {
+        if case .bound = self { return true }
+        return false
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -110,7 +110,7 @@ struct OverviewView: View {
                     Button { model.previewStopDaemon() } label: {
                         Label("Preview Stop", systemImage: "stop.circle")
                     }
-                    .disabled(!model.productionUsefulWorkAvailable)
+                    .disabled(!model.productionDaemonStopAvailable)
                     .accessibilityIdentifier("neondiff-preview-stop-daemon")
                 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -16,8 +16,11 @@ struct ReposView: View {
 
     private var pageContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            OperatorSection("GitHub Connection") {
-                VStack(alignment: .leading, spacing: 10) {
+            if model.managedGitHubAvailable {
+                managedGitHubConnection
+            } else {
+                OperatorSection("GitHub Connection") {
+                    VStack(alignment: .leading, spacing: 10) {
                     HStack(spacing: 10) {
                         OperatorBadge(
                             text: model.github.userTokenStored ? "USER AUTHORIZED" : "USER NOT CONNECTED",
@@ -145,6 +148,7 @@ struct ReposView: View {
                         Label("\(model.github.discoveredRepositoryCount) repos discovered", systemImage: "folder.badge.plus")
                             .foregroundStyle(NeonDiffTheme.textSecondary)
                     }
+                    }
                 }
             }
 
@@ -176,6 +180,7 @@ struct ReposView: View {
                                 .foregroundStyle(repo.enabled ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary)
                         }
                         .buttonStyle(.plain)
+                        .disabled(model.managedGitHubAvailable)
                         .accessibilityIdentifier("neondiff-repo-toggle-\(repo.name)")
                     }
                     TableColumn("Profile", value: \.profile)
@@ -201,20 +206,23 @@ struct ReposView: View {
                                 .foregroundStyle(NeonDiffTheme.warning)
                         }
                         .buttonStyle(.plain)
+                        .disabled(model.managedGitHubAvailable)
                         .accessibilityIdentifier("neondiff-repo-remove-\(repo.name)")
                     }
                 }
                 .scrollContentBackground(.hidden)
                 .frame(height: 360)
 
-                HStack(spacing: 10) {
-                    TextField("owner/repo", text: $model.pendingRepoName)
-                        .textFieldStyle(.roundedBorder)
-                        .accessibilityIdentifier("neondiff-repo-name-input")
-                    Button { model.addPendingRepoToAllowlist() } label: {
-                        Label("Add Repo", systemImage: "plus.circle")
+                if !model.managedGitHubAvailable {
+                    HStack(spacing: 10) {
+                        TextField("owner/repo", text: $model.pendingRepoName)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityIdentifier("neondiff-repo-name-input")
+                        Button { model.addPendingRepoToAllowlist() } label: {
+                            Label("Add Repo", systemImage: "plus.circle")
+                        }
+                        .accessibilityIdentifier("neondiff-repo-add")
                     }
-                    .accessibilityIdentifier("neondiff-repo-add")
                 }
 
                 if !model.discoveredGitHubRepos.isEmpty {
@@ -276,5 +284,95 @@ struct ReposView: View {
             PageBottomSentinel(section: "repos")
         }
         .disabled(!model.canEditProviderConfiguration)
+    }
+
+    private var managedGitHubConnection: some View {
+        OperatorSection("Managed GitHub Connection") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    OperatorBadge(
+                        text: model.managedGitHubStatusText,
+                        color: model.isManagedGitHubBound
+                            ? NeonDiffTheme.accent
+                            : NeonDiffTheme.warning
+                    )
+                    Spacer()
+                    if model.managedGitHubConnectionState == .verificationRequired {
+                        Button { model.refreshManagedGitHubRepositories() } label: {
+                            Label("Verify Binding", systemImage: "checkmark.shield")
+                        }
+                        .disabled(model.isManagedGitHubConnectionInProgress)
+                        .accessibilityIdentifier("neondiff-managed-github-verify")
+                    } else if !model.isManagedGitHubBound {
+                        Button { model.startManagedGitHubConnection() } label: {
+                            Label("Connect GitHub", systemImage: "person.crop.circle.badge.checkmark")
+                        }
+                        .disabled(model.isManagedGitHubConnectionInProgress)
+                        .accessibilityIdentifier("neondiff-managed-github-connect")
+                    } else {
+                        Button { model.refreshManagedGitHubRepositories() } label: {
+                            Label("Refresh Bound Repositories", systemImage: "arrow.triangle.2.circlepath")
+                        }
+                        .disabled(model.isManagedGitHubConnectionInProgress)
+                        .accessibilityIdentifier("neondiff-managed-github-refresh")
+                    }
+                }
+
+                Text("The paid-beta path uses the server broker and Keychain-backed device identity. It does not fall back to a user access token. Repository scope and visibility are accepted only from the verified GitHub App binding.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let recovery = model.managedGitHubRecovery {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(NeonDiffTheme.warning)
+                        Text(recovery.message)
+                            .operatorBodyText()
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer()
+                        Button("Retry") {
+                            model.performManagedGitHubRecoveryAction()
+                        }
+                        .disabled(model.isManagedGitHubConnectionInProgress)
+                        .accessibilityIdentifier("neondiff-managed-github-recovery")
+                    }
+                }
+
+                if let selected = model.selectedManagedGitHubRepository {
+                    Label("Selected: \(selected)", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(NeonDiffTheme.accent)
+                }
+
+                if !model.managedGitHubRepositories.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Server-bound repositories")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(NeonDiffTheme.textPrimary)
+                        ForEach(model.managedGitHubRepositories, id: \.fullName) { repository in
+                            Button {
+                                model.selectManagedGitHubRepository(fullName: repository.fullName)
+                            } label: {
+                                HStack {
+                                    Image(systemName: repository.visibility == .public ? "globe" : "lock.fill")
+                                    Text(repository.fullName)
+                                    Spacer()
+                                    Text(repository.visibility == .unknown
+                                        ? "VISIBILITY BLOCKED"
+                                        : repository.visibility.rawValue.uppercased())
+                                        .font(.caption.weight(.semibold))
+                                    if model.selectedManagedGitHubRepository == repository.fullName {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundStyle(NeonDiffTheme.accent)
+                                    }
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(repository.visibility == .unknown)
+                            .accessibilityIdentifier("neondiff-managed-repository-\(repository.fullName)")
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -3,10 +3,40 @@ import NeonDiffDesktopCore
 
 package struct DesktopProductionBoundary: Sendable {
     package let nativeActivationBrokerVerified: Bool
+    package let managedGitHubBrokerOrigin: URL?
 
-    package static let quarantined = DesktopProductionBoundary(nativeActivationBrokerVerified: false)
-    package static let testVerified = DesktopProductionBoundary(nativeActivationBrokerVerified: true)
+    package static let quarantined = DesktopProductionBoundary(
+        nativeActivationBrokerVerified: false,
+        managedGitHubBrokerOrigin: nil
+    )
+    package static let testVerified = DesktopProductionBoundary(
+        nativeActivationBrokerVerified: true,
+        managedGitHubBrokerOrigin: nil
+    )
+    package static let testManaged = DesktopProductionBoundary(
+        nativeActivationBrokerVerified: true,
+        managedGitHubBrokerOrigin: approvedManagedGitHubBrokerOrigin
+    )
+
+    package static func resolve(infoDictionary: [String: Any]) -> DesktopProductionBoundary {
+        guard infoDictionary["NeonDiffPaidBetaContract"] as? String == "paid-mac-beta-v1",
+              infoDictionary["NeonDiffManagedGitHubBrokerEnabled"] as? Bool == true,
+              let originText = infoDictionary["NeonDiffGitHubBrokerOrigin"] as? String,
+              let origin = URL(string: originText),
+              origin == approvedManagedGitHubBrokerOrigin
+        else {
+            return .quarantined
+        }
+        return DesktopProductionBoundary(
+            nativeActivationBrokerVerified: true,
+            managedGitHubBrokerOrigin: origin
+        )
+    }
 }
+
+private let approvedManagedGitHubBrokerOrigin = URL(
+    string: "https://neondiff-license.fly.dev"
+)!
 
 package struct DesktopAppDependencies {
     package let clipboard: any DesktopClipboard
@@ -19,6 +49,7 @@ package struct DesktopAppDependencies {
     package let providerVerifier: any DesktopProviderVerifying
     package let secretStore: any DesktopSecretStoring
     package let githubAuthenticator: any GitHubDesktopAuthenticating
+    package let githubBroker: (any GitHubBrokerConnecting)?
     package let productionBoundary: DesktopProductionBoundary
     package let cliWorkingDirectory: URL?
 
@@ -33,6 +64,7 @@ package struct DesktopAppDependencies {
         providerVerifier: any DesktopProviderVerifying,
         secretStore: any DesktopSecretStoring,
         githubAuthenticator: any GitHubDesktopAuthenticating,
+        githubBroker: (any GitHubBrokerConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
         cliWorkingDirectory: URL? = nil
     ) {
@@ -46,6 +78,7 @@ package struct DesktopAppDependencies {
         self.providerVerifier = providerVerifier
         self.secretStore = secretStore
         self.githubAuthenticator = githubAuthenticator
+        self.githubBroker = githubBroker
         self.productionBoundary = productionBoundary
         self.cliWorkingDirectory = cliWorkingDirectory
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -184,6 +184,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
+    /// Stopping an already-running daemon is a safety remediation, not useful
+    /// review work. Keep it available for a verified production build even if
+    /// the current repository binding or entitlement proof has been revoked.
+    package var productionDaemonStopAvailable: Bool {
+        dependencies.productionBoundary.nativeActivationBrokerVerified
+    }
+
     package var managedGitHubAvailable: Bool {
         dependencies.productionBoundary.managedGitHubBrokerOrigin != nil
             && dependencies.githubBroker != nil
@@ -652,7 +659,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func previewStopDaemon() {
-        guard requireProductionUsefulWorkAuthorization() else { return }
+        guard requireProductionDaemonStopAuthorization() else { return }
         runCLI(arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: stopDaemonDryRunCommand)
     }
 
@@ -666,7 +673,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func stopDaemon() {
-        guard requireProductionUsefulWorkAuthorization() else { return }
+        guard requireProductionDaemonStopAuthorization() else { return }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
@@ -1776,6 +1783,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 : productionActivationBoundaryMessage
             lastError = message
             logText = message
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    private func requireProductionDaemonStopAuthorization() -> Bool {
+        guard productionDaemonStopAvailable else {
+            lastError = productionActivationBoundaryMessage
+            logText = productionActivationBoundaryMessage
             return false
         }
         return true

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -75,6 +75,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var configPath: String {
         didSet {
             guard configPath != oldValue else { return }
+            invalidateManagedRepoApplicationProof()
             invalidateProviderConfigAuthorization()
             invalidateProviderVerificationContext()
         }
@@ -141,6 +142,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var pendingActivationKey = ""
     @Published package private(set) var activationVerifiedThisLaunch = false
     private var activationVerifiedRepositoryThisLaunch: String?
+    private var appliedManagedRepoSelection: AppliedManagedRepoSelection?
 
     package var productionActivationBoundaryMessage: String {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
@@ -148,6 +150,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package var productionUsefulWorkAvailable: Bool {
         guard dependencies.productionBoundary.nativeActivationBrokerVerified else {
+            return false
+        }
+        guard !isConfigPatchInProgress else {
             return false
         }
         guard dependencies.productionBoundary.managedGitHubBrokerOrigin != nil else {
@@ -159,6 +164,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
                   $0.fullName == selectedManagedGitHubRepository
               })
         else {
+            return false
+        }
+        guard appliedManagedRepoSelection == AppliedManagedRepoSelection(
+            repository: selectedManagedGitHubRepository,
+            configPath: configPath
+        ) else {
             return false
         }
         switch repository.visibility {
@@ -245,6 +256,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var previewedProviderSnapshot: ProviderConfigurationSnapshot?
     private var previewedProviderExpectedRevision: String?
     private var pendingProviderPatchProof: PendingProviderPatchProof?
+    private var pendingManagedRepoPatchProof: PendingManagedRepoPatchProof?
 
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
@@ -1088,6 +1100,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubConnectionTask?.cancel()
         isManagedGitHubConnectionInProgress = true
         managedGitHubConnectionState = .verificationRequired
+        invalidateManagedRepoApplicationProof()
         managedGitHubRecovery = nil
         managedGitHubRepositories = []
         selectedManagedGitHubRepository = nil
@@ -1102,7 +1115,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             do {
                 let identity = try GitHubBrokerDeviceIdentityStore(
                     secretStore: dependencies.secretStore
-                ).loadOrCreate()
+                ).loadExisting()
                 try await loadManagedGitHubRepositories(
                     broker: broker,
                     identity: identity,
@@ -1129,6 +1142,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
+        invalidateManagedRepoApplicationProof()
         selectedManagedGitHubRepository = repository.fullName
         for index in repos.indices {
             repos[index].enabled = false
@@ -1442,11 +1456,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     // MARK: - Native activation handoff (#612)
 
-    /// The new return/redeem surface is feature-flagged off by default; enabling
-    /// it is the rollback control per the issue AC. Existing validated licenses
-    /// are untouched either way.
+    /// Managed production onboarding always uses the native return/redeem state
+    /// machine. Outside that exact broker contract it remains preference-gated,
+    /// preserving the existing rollback control for legacy/local builds.
     package var activationHandoffEnabled: Bool {
-        dependencies.preferences.bool(forKey: activationHandoffEnabledKey)
+        managedGitHubAvailable
+            || dependencies.preferences.bool(forKey: activationHandoffEnabledKey)
     }
 
     /// Production checkout stays disabled pending #562 + website #46. Until then
@@ -1757,7 +1772,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func requireProductionUsefulWorkAuthorization() -> Bool {
         guard productionUsefulWorkAvailable else {
             let message = dependencies.productionBoundary.nativeActivationBrokerVerified
-                ? "Verify the selected repository and its current entitlement before running NeonDiff."
+                ? "Verify and apply the selected repository, then verify its current entitlement before running NeonDiff."
                 : productionActivationBoundaryMessage
             lastError = message
             logText = message
@@ -1780,11 +1795,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         arguments: [String],
         displayCommand: DesktopCommand,
         controlCenterOperation: ControlCenterOperation? = nil,
-        providerPatchProof: PendingProviderPatchProof? = nil
+        providerPatchProof: PendingProviderPatchProof? = nil,
+        managedRepoPatchProof: PendingManagedRepoPatchProof? = nil
     ) {
         if let providerVerificationSafetyLatchMessage {
             lastError = providerVerificationSafetyLatchMessage
             clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
+            clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
             if controlCenterOperation != nil { isControlCenterOperationInProgress = false }
             return
         }
@@ -1794,11 +1811,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && (isProviderVerificationInProgress || isProviderVerificationCancelling) {
             lastError = "Wait for provider verification cleanup before changing config."
             clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
+            clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
             if controlCenterOperation != nil { isControlCenterOperationInProgress = false }
             return
         }
         if isConfigPatchCommand && (isConfigPatchInProgress || isConfigInspectInProgress) {
             lastError = "Another config operation is still running."
+            clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
             if controlCenterOperation != nil {
                 controlCenterStatus = lastError ?? "Control-center command deferred."
                 isControlCenterOperationInProgress = false
@@ -1830,12 +1849,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         launchdLabel: launchdLabel,
                         isConfigInspectCommand: isConfigInspectCommand,
                         controlCenterOperation: controlCenterOperation,
-                        providerPatchProof: providerPatchProof
+                        providerPatchProof: providerPatchProof,
+                        managedRepoPatchProof: managedRepoPatchProof
                     )
                     if isConfigPatchCommand { self.isConfigPatchInProgress = false }
                     if isConfigInspectCommand { self.isConfigInspectInProgress = false }
                     if controlCenterOperation != nil { self.isControlCenterOperationInProgress = false }
                     self.clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
+                    self.clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
                 }
             } catch {
                 await MainActor.run {
@@ -1843,6 +1864,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     self.logText = self.lastError ?? "Unknown CLI error"
                     if isConfigPatchCommand { self.isConfigPatchInProgress = false }
                     self.clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
+                    self.clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
                     if isConfigInspectCommand {
                         self.invalidateProviderConfigAuthorization()
                         self.invalidateControlCenterAfterInspectFailure(self.lastError ?? "Config inspect failed.")
@@ -1974,7 +1996,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
         if !dryRun {
             arguments.append(contentsOf: ["--confirm", "true"])
         }
-        runCLI(arguments: arguments, displayCommand: dryRun ? repoSelectionPatchPreviewCommand : repoSelectionPatchApplyCommand)
+        let proof: PendingManagedRepoPatchProof?
+        if !dryRun, managedGitHubAvailable, let selectedManagedGitHubRepository {
+            appliedManagedRepoSelection = nil
+            proof = PendingManagedRepoPatchProof(
+                id: UUID(),
+                repository: selectedManagedGitHubRepository,
+                configPath: configPath
+            )
+            pendingManagedRepoPatchProof = proof
+        } else {
+            proof = nil
+        }
+        runCLI(
+            arguments: arguments,
+            displayCommand: dryRun ? repoSelectionPatchPreviewCommand : repoSelectionPatchApplyCommand,
+            managedRepoPatchProof: proof
+        )
     }
 
     private func gitHubAccessTokenForAPI() async throws -> String {
@@ -2187,6 +2225,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     private func applyManagedGitHubFailure(_ error: Error) {
+        invalidateManagedRepoApplicationProof()
         managedGitHubConnectionState = .failed
         managedGitHubRepositories = []
         selectedManagedGitHubRepository = nil
@@ -2219,11 +2258,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     action: .reconnect
                 )
             }
-        } else if error is GitHubBrokerDeviceIdentityError {
+        } else if let identityError = error as? GitHubBrokerDeviceIdentityError {
             recovery = GitHubConnectionRecovery(
                 status: "device identity unavailable",
                 message: "The Keychain-backed GitHub device identity is unavailable. NeonDiff did not create a replacement binding.",
-                action: .retry
+                action: identityError == .storedIdentityMissing ? .reconnect : .retry
             )
         } else if let modelError = error as? ManagedGitHubModelError {
             recovery = modelError.recovery
@@ -2292,10 +2331,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
         launchdLabel: String,
         isConfigInspectCommand: Bool,
         controlCenterOperation: ControlCenterOperation? = nil,
-        providerPatchProof: PendingProviderPatchProof? = nil
+        providerPatchProof: PendingProviderPatchProof? = nil,
+        managedRepoPatchProof: PendingManagedRepoPatchProof? = nil
     ) {
         if let providerPatchProof,
            pendingProviderPatchProof?.id != providerPatchProof.id {
+            return
+        }
+        if let managedRepoPatchProof,
+           pendingManagedRepoPatchProof?.id != managedRepoPatchProof.id {
             return
         }
         let redactedStdout = result.redactedStdout.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2334,6 +2378,25 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 lastError = ConfigInspectParser.error(result.stdout, command: "config patch")
                     ?? lastError
                     ?? "Provider patch returned an invalid or stale response. Reload current config."
+                return
+            }
+        }
+        if let managedRepoPatchProof {
+            let appliedRepositories = parsedSnapshot?.repos
+                .filter(\.enabled)
+                .map(\.name) ?? []
+            guard result.exitCode == 0,
+                  commandName == "config patch",
+                  parsedSnapshot?.dryRun == false,
+                  parsedSnapshot?.wrote == true,
+                  appliedRepositories == [managedRepoPatchProof.repository],
+                  configPath == managedRepoPatchProof.configPath,
+                  selectedManagedGitHubRepository == managedRepoPatchProof.repository
+            else {
+                invalidateManagedRepoApplicationProof()
+                lastError = ConfigInspectParser.error(result.stdout, command: "config patch")
+                    ?? lastError
+                    ?? "Managed repository allowlist apply returned invalid or mismatched readback. Apply the exact verified selection again."
                 return
             }
         }
@@ -2448,6 +2511,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     providerVerificationStatus = "Provider config applied and read back. Verification is enabled for eligible targets."
                 }
                 clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
+            }
+            if commandName == "config patch", let managedRepoPatchProof {
+                appliedManagedRepoSelection = AppliedManagedRepoSelection(
+                    repository: managedRepoPatchProof.repository,
+                    configPath: managedRepoPatchProof.configPath
+                )
+                clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
+                logText = "Managed repository allowlist applied and read back for \(managedRepoPatchProof.repository)."
             }
             if commandName == "config patch",
                let operation = controlCenterOperation,
@@ -2613,6 +2684,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         pendingProviderPatchProof = nil
     }
 
+    private func clearPendingManagedRepoPatchProof(ifOwnedBy proof: PendingManagedRepoPatchProof?) {
+        guard let proof, pendingManagedRepoPatchProof?.id == proof.id else { return }
+        pendingManagedRepoPatchProof = nil
+    }
+
+    private func invalidateManagedRepoApplicationProof() {
+        appliedManagedRepoSelection = nil
+        pendingManagedRepoPatchProof = nil
+    }
+
     private func invalidateControlCenterAfterPatchFailure(_ message: String) {
         invalidateControlCenterAuthorization(message)
         controlCenterStatus = lastError ?? "Config patch failed. Reload current config."
@@ -2662,6 +2743,17 @@ private struct PendingProviderPatchProof: Sendable {
     let snapshot: ProviderConfigurationSnapshot
     let expectedRevision: String
     let mode: ConfigPatchProofMode
+}
+
+private struct PendingManagedRepoPatchProof: Sendable {
+    let id: UUID
+    let repository: String
+    let configPath: String
+}
+
+private struct AppliedManagedRepoSelection: Equatable, Sendable {
+    let repository: String
+    let configPath: String
 }
 
 private enum ControlCenterOperation: Sendable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -139,13 +139,37 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var activationState: ActivationState = ActivationStateMachine.initialState
     @Published package private(set) var activationKeyRedactedPrefix: String?
     @Published package var pendingActivationKey = ""
+    @Published package private(set) var activationVerifiedThisLaunch = false
 
     package var productionActivationBoundaryMessage: String {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
     }
 
     package var productionUsefulWorkAvailable: Bool {
-        dependencies.productionBoundary.nativeActivationBrokerVerified
+        guard dependencies.productionBoundary.nativeActivationBrokerVerified else {
+            return false
+        }
+        guard dependencies.productionBoundary.managedGitHubBrokerOrigin != nil else {
+            return true
+        }
+        guard hasVerifiedManagedGitHubSelection,
+              let selectedManagedGitHubRepository,
+              let repository = managedGitHubRepositories.first(where: {
+                  $0.fullName == selectedManagedGitHubRepository
+              })
+        else {
+            return false
+        }
+        switch repository.visibility {
+        case .public:
+            return true
+        case .private, .internal:
+            return activationVerifiedThisLaunch
+                && activationState == .active
+                && activatedRepository == selectedManagedGitHubRepository
+        case .unknown:
+            return false
+        }
     }
 
     package var managedGitHubAvailable: Bool {
@@ -610,17 +634,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func previewStartDaemon() {
-        guard requireVerifiedNativeActivationBroker() else { return }
+        guard requireProductionUsefulWorkAuthorization() else { return }
         runCLI(arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: startDaemonDryRunCommand)
     }
 
     package func previewStopDaemon() {
-        guard requireVerifiedNativeActivationBroker() else { return }
+        guard requireProductionUsefulWorkAuthorization() else { return }
         runCLI(arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: stopDaemonDryRunCommand)
     }
 
     package func startDaemon() {
-        guard requireVerifiedNativeActivationBroker() else { return }
+        guard requireProductionUsefulWorkAuthorization() else { return }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
@@ -629,7 +653,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func stopDaemon() {
-        guard requireVerifiedNativeActivationBroker() else { return }
+        guard requireProductionUsefulWorkAuthorization() else { return }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
@@ -1131,12 +1155,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case .private, .internal:
             onboardingFlow.mode = .privateRepos
             if activationState == .active,
-               activatedRepository != repository.fullName {
-                applyActivationEvent(.activationInvalid)
-                applyActivationEvent(.resetToPurchase)
+               !activationVerifiedThisLaunch || activatedRepository != repository.fullName {
+                activationVerifiedThisLaunch = false
+                dependencies.preferences.set("", forKey: activationRepositoryKey)
+                activationState = license.keyStored ? .keyReady : .purchaseRequired
+                dependencies.preferences.set(activationState.rawValue, forKey: activationStateKey)
             }
             enterActivation(for: .privateRepos)
-            onboardingFlow.licenseActivation = activationState == .active
+            onboardingFlow.licenseActivation = activationVerifiedThisLaunch
+                    && activationState == .active
                     && activatedRepository == repository.fullName
                 ? .activated
                 : .servicePending
@@ -1231,9 +1258,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func verifyProviderKey() {
-        guard requireVerifiedNativeActivationBroker() else {
+        guard requireProductionUsefulWorkAuthorization() else {
             providerVerification = nil
-            providerVerificationStatus = productionActivationBoundaryMessage
+            providerVerificationStatus = lastError ?? productionActivationBoundaryMessage
             return
         }
         if let providerVerificationSafetyLatchMessage {
@@ -1468,6 +1495,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let next = ActivationStateMachine.reduce(activationState, on: event)
         guard next != activationState else { return }
         if activationState == .active, next != .active {
+            activationVerifiedThisLaunch = false
             dependencies.preferences.set("", forKey: activationRepositoryKey)
         }
         activationState = next
@@ -1648,6 +1676,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func applyActivationOutcomeSideEffects(_ outcome: ActivationClientOutcome) {
         switch outcome {
         case .active(let summary):
+            activationVerifiedThisLaunch = true
             lastError = nil
             let scope = summary.repoVisibilityScope
             let plan = summary.plan.map { " · \($0)" } ?? ""
@@ -1661,8 +1690,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             // Let onboarding finish through the native handoff (Continue enables).
             onboardingFlow.licenseActivation = .activated
         case .scopeConflict:
+            activationVerifiedThisLaunch = false
             lastError = "This \(ActivationTerminology.activationKey) does not cover private repositories. Use a key with a private-repo entitlement."
         case .expired, .revoked, .invalid, .offline, .serviceError, .malformed:
+            activationVerifiedThisLaunch = false
             // Cause copy comes from the typed state presentation — never a raw
             // error string, and never any key material.
             lastError = activationPresentation.cause
@@ -1684,7 +1715,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func completeOnboarding() {
-        guard dependencies.productionBoundary.nativeActivationBrokerVerified,
+        guard productionUsefulWorkAvailable,
               dependencies.productionBoundary.managedGitHubBrokerOrigin == nil
                 || hasVerifiedManagedGitHubSelection,
               onboardingFlow.licenseActivation == .activated
@@ -1709,6 +1740,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard dependencies.productionBoundary.nativeActivationBrokerVerified else {
             lastError = productionActivationBoundaryMessage
             logText = productionActivationBoundaryMessage
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    private func requireProductionUsefulWorkAuthorization() -> Bool {
+        guard productionUsefulWorkAvailable else {
+            let message = dependencies.productionBoundary.nativeActivationBrokerVerified
+                ? "Verify the selected repository and its current entitlement before running NeonDiff."
+                : productionActivationBoundaryMessage
+            lastError = message
+            logText = message
             return false
         }
         return true

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2388,7 +2388,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
             guard result.exitCode == 0,
                   commandName == "config patch",
                   parsedSnapshot?.dryRun == false,
-                  parsedSnapshot?.wrote == true,
+                  ConfigPatchProofValidator.revisionAfter(
+                      snapshot: parsedSnapshot,
+                      expectedRevision: parsedSnapshot?.revisionBefore ?? "",
+                      mode: .apply
+                  ) != nil,
                   appliedRepositories == [managedRepoPatchProof.repository],
                   configPath == managedRepoPatchProof.configPath,
                   selectedManagedGitHubRepository == managedRepoPatchProof.repository

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -140,6 +140,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var activationKeyRedactedPrefix: String?
     @Published package var pendingActivationKey = ""
     @Published package private(set) var activationVerifiedThisLaunch = false
+    private var activationVerifiedRepositoryThisLaunch: String?
 
     package var productionActivationBoundaryMessage: String {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
@@ -166,7 +167,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case .private, .internal:
             return activationVerifiedThisLaunch
                 && activationState == .active
-                && activatedRepository == selectedManagedGitHubRepository
+                && activationVerifiedRepositoryThisLaunch == selectedManagedGitHubRepository
         case .unknown:
             return false
         }
@@ -1155,8 +1156,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case .private, .internal:
             onboardingFlow.mode = .privateRepos
             if activationState == .active,
-               !activationVerifiedThisLaunch || activatedRepository != repository.fullName {
+               !activationVerifiedThisLaunch
+                || activationVerifiedRepositoryThisLaunch != repository.fullName {
                 activationVerifiedThisLaunch = false
+                activationVerifiedRepositoryThisLaunch = nil
                 dependencies.preferences.set("", forKey: activationRepositoryKey)
                 activationState = license.keyStored ? .keyReady : .purchaseRequired
                 dependencies.preferences.set(activationState.rawValue, forKey: activationStateKey)
@@ -1164,7 +1167,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             enterActivation(for: .privateRepos)
             onboardingFlow.licenseActivation = activationVerifiedThisLaunch
                     && activationState == .active
-                    && activatedRepository == repository.fullName
+                    && activationVerifiedRepositoryThisLaunch == repository.fullName
                 ? .activated
                 : .servicePending
         case .unknown:
@@ -1496,6 +1499,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard next != activationState else { return }
         if activationState == .active, next != .active {
             activationVerifiedThisLaunch = false
+            activationVerifiedRepositoryThisLaunch = nil
             dependencies.preferences.set("", forKey: activationRepositoryKey)
         }
         activationState = next
@@ -1683,17 +1687,21 @@ package final class NeonDiffDesktopModel: ObservableObject {
             license.entitlement = "active (\(scope)\(plan))"
             logText = "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
             if let repository = repos.filter(\.enabled).map(\.name).onlyElement {
+                activationVerifiedRepositoryThisLaunch = repository
                 dependencies.preferences.set(repository, forKey: activationRepositoryKey)
             } else {
+                activationVerifiedRepositoryThisLaunch = nil
                 dependencies.preferences.set("", forKey: activationRepositoryKey)
             }
             // Let onboarding finish through the native handoff (Continue enables).
             onboardingFlow.licenseActivation = .activated
         case .scopeConflict:
             activationVerifiedThisLaunch = false
+            activationVerifiedRepositoryThisLaunch = nil
             lastError = "This \(ActivationTerminology.activationKey) does not cover private repositories. Use a key with a private-repo entitlement."
         case .expired, .revoked, .invalid, .offline, .serviceError, .malformed:
             activationVerifiedThisLaunch = false
+            activationVerifiedRepositoryThisLaunch = nil
             // Cause copy comes from the typed state presentation — never a raw
             // error string, and never any key material.
             lastError = activationPresentation.cause

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -59,6 +59,16 @@ package struct DesktopModelInitialState {
 }
 #endif
 
+package enum ManagedGitHubConnectionState: Equatable, Sendable {
+    case quarantined
+    case disconnected
+    case verificationRequired
+    case connecting
+    case awaitingAuthorization
+    case bound(installationId: Int)
+    case failed
+}
+
 @MainActor
 package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var selectedSection: DesktopSection = .overview
@@ -101,6 +111,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var discoveredGitHubRepos: [GitHubDiscoveredRepository] = []
     @Published package var isGitHubAuthorizationInProgress = false
     @Published package var isGitHubRepositoryRefreshInProgress = false
+    @Published package var managedGitHubConnectionState: ManagedGitHubConnectionState = .quarantined
+    @Published package var managedGitHubRepositories: [GitHubBrokerRepository] = []
+    @Published package var selectedManagedGitHubRepository: String?
+    @Published package var managedGitHubRecovery: GitHubConnectionRecovery?
+    @Published package var isManagedGitHubConnectionInProgress = false
     @Published package var logText = "No logs loaded."
     @Published package var lastError: String?
     @Published package var lastCommandLine = ""
@@ -133,6 +148,55 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.productionBoundary.nativeActivationBrokerVerified
     }
 
+    package var managedGitHubAvailable: Bool {
+        dependencies.productionBoundary.managedGitHubBrokerOrigin != nil
+            && dependencies.githubBroker != nil
+    }
+
+    package var managedGitHubStatusText: String {
+        switch managedGitHubConnectionState {
+        case .quarantined:
+            "Unavailable in this signed build"
+        case .disconnected:
+            "Not connected"
+        case .verificationRequired:
+            "Saved binding requires server verification"
+        case .connecting:
+            "Creating Keychain-backed device binding"
+        case .awaitingAuthorization:
+            "Waiting for GitHub authorization"
+        case .bound(let installationId):
+            "Server binding verified · installation \(installationId)"
+        case .failed:
+            managedGitHubRecovery?.status ?? "Verification failed"
+        }
+    }
+
+    package var isManagedGitHubBound: Bool {
+        if case .bound = managedGitHubConnectionState { return true }
+        return false
+    }
+
+    package var canAdvanceOnboarding: Bool {
+        if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil {
+            guard hasVerifiedManagedGitHubSelection else { return false }
+        }
+        return onboardingFlow.canAdvance
+    }
+
+    private var hasVerifiedManagedGitHubSelection: Bool {
+        guard case .bound = managedGitHubConnectionState,
+              let selectedManagedGitHubRepository,
+              let repository = managedGitHubRepositories.first(where: {
+                  $0.fullName == selectedManagedGitHubRepository
+              }),
+              repository.visibility != .unknown
+        else {
+            return false
+        }
+        return repos.filter(\.enabled).map(\.name) == [selectedManagedGitHubRepository]
+    }
+
     private let dependencies: DesktopAppDependencies
     private let activationLicenseClientOverride: (any ActivationLicenseClienting)?
     private var providerVerificationTask: Task<Void, Never>?
@@ -142,6 +206,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var providerKeyRevision: UInt64 = 0
     private var githubAuthorizationTask: Task<Void, Never>?
     private var githubRepositoryRefreshTask: Task<Void, Never>?
+    private var managedGitHubConnectionTask: Task<Void, Never>?
     private var githubRepositoryRefreshGate = GitHubLatestRequestGate()
     private var controlCenterLoadedSnapshot: DesktopControlCenterSnapshot?
     private var controlCenterRollbackSnapshot: DesktopControlCenterSnapshot?
@@ -179,6 +244,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
             self.github.installationState = "not connected"
         }
         self.github.authorizedUserLogin = nil
+        if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil {
+            if dependencies.githubBroker == nil {
+                self.managedGitHubConnectionState = .quarantined
+            } else if Self.savedManagedGitHubInstallationId(
+                preferences: dependencies.preferences
+            ) != nil {
+                self.managedGitHubConnectionState = .verificationRequired
+            } else {
+                self.managedGitHubConnectionState = .disconnected
+            }
+        } else {
+            self.managedGitHubConnectionState = .quarantined
+        }
         self.onboardingFlow = OnboardingFlow(providerKeyStored: providerKeyStored)
         self.isOnboardingPresented = !dependencies.preferences.bool(forKey: onboardingCompletedKey)
         // Resume-exact: restore the persisted activation state (rawValue) without
@@ -710,6 +788,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func addPendingRepoToAllowlist() {
+        guard !managedGitHubAvailable else {
+            lastError = "Choose a repository from the verified GitHub App binding. Manual repository names are disabled in managed mode."
+            return
+        }
         guard canEditProviderConfiguration else {
             lastError = providerVerificationSafetyLatchMessage ?? "Wait for provider verification cleanup before changing config."
             return
@@ -731,6 +813,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func toggleRepoAllowlist(_ repo: RepoMonitor) {
+        guard !managedGitHubAvailable else {
+            lastError = "Managed mode keeps exactly one server-bound repository selected. Choose it from the verified repository list."
+            return
+        }
         guard let index = repos.firstIndex(where: { $0.id == repo.id }) else { return }
         repos[index].enabled.toggle()
         lastError = nil
@@ -738,6 +824,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func githubAccessCue(for repo: RepoMonitor) -> GitHubRepositoryAccessCue? {
+        if managedGitHubAvailable,
+           let authoritative = managedGitHubRepositories.first(where: {
+               $0.fullName == repo.name
+           }) {
+            switch authoritative.visibility {
+            case .public:
+                return .publicFree
+            case .private, .internal:
+                return activationState == .active ? .licenseActive : .licenseRequired
+            case .unknown:
+                return .insufficientReadAccess
+            }
+        }
         guard let discovered = discoveredGitHubRepos.first(where: {
             $0.fullName.caseInsensitiveCompare(repo.name) == .orderedSame
         }) else {
@@ -747,6 +846,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func removeRepoFromAllowlist(_ repo: RepoMonitor) {
+        guard !managedGitHubAvailable else {
+            lastError = "Managed mode repository scope comes from the verified GitHub App binding."
+            return
+        }
         repos.removeAll { $0.id == repo.id }
         lastError = nil
         logText = "Repo removed locally. Preview or apply the config patch to persist it."
@@ -877,11 +980,205 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
+    package func startManagedGitHubConnection() {
+        guard let broker = dependencies.githubBroker,
+              dependencies.productionBoundary.managedGitHubBrokerOrigin != nil
+        else {
+            managedGitHubConnectionState = .quarantined
+            managedGitHubRecovery = GitHubConnectionRecovery(
+                status: "managed GitHub unavailable",
+                message: "Managed GitHub authorization is not enabled in this signed build.",
+                action: .retryLater
+            )
+            lastError = managedGitHubRecovery?.message
+            return
+        }
+        guard !isManagedGitHubConnectionInProgress else { return }
+
+        managedGitHubConnectionTask?.cancel()
+        isManagedGitHubConnectionInProgress = true
+        managedGitHubConnectionState = .connecting
+        managedGitHubRecovery = nil
+        managedGitHubRepositories = []
+        selectedManagedGitHubRepository = nil
+        lastError = nil
+
+        managedGitHubConnectionTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                isManagedGitHubConnectionInProgress = false
+                managedGitHubConnectionTask = nil
+            }
+            do {
+                let identity = try GitHubBrokerDeviceIdentityStore(
+                    secretStore: dependencies.secretStore
+                ).loadOrCreate()
+                try await broker.register(identity: identity)
+                let connection = try await broker.startConnection(identity: identity)
+                guard dependencies.urlOpener.open(connection.installURL) else {
+                    throw ManagedGitHubModelError.installPageOpenFailed
+                }
+                managedGitHubConnectionState = .awaitingAuthorization
+                logText = "GitHub App installation opened. Complete authorization in GitHub; NeonDiff is waiting for the server binding."
+
+                let installationId = try await awaitManagedGitHubBinding(
+                    broker: broker,
+                    identity: identity,
+                    connection: connection
+                )
+                dependencies.preferences.set(
+                    String(installationId),
+                    forKey: managedGitHubInstallationIdKey
+                )
+                try await loadManagedGitHubRepositories(
+                    broker: broker,
+                    identity: identity,
+                    installationId: installationId
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                applyManagedGitHubFailure(error)
+            }
+        }
+    }
+
+    package func refreshManagedGitHubRepositories() {
+        guard let broker = dependencies.githubBroker,
+              dependencies.productionBoundary.managedGitHubBrokerOrigin != nil,
+              let installationId = Self.savedManagedGitHubInstallationId(
+                preferences: dependencies.preferences
+              )
+        else {
+            managedGitHubConnectionState = .quarantined
+            managedGitHubRecovery = GitHubConnectionRecovery(
+                status: "connection required",
+                message: "Connect GitHub before refreshing server-bound repositories.",
+                action: .reconnect
+            )
+            lastError = managedGitHubRecovery?.message
+            return
+        }
+        guard !isManagedGitHubConnectionInProgress else { return }
+
+        managedGitHubConnectionTask?.cancel()
+        isManagedGitHubConnectionInProgress = true
+        managedGitHubConnectionState = .verificationRequired
+        managedGitHubRecovery = nil
+        managedGitHubRepositories = []
+        selectedManagedGitHubRepository = nil
+        lastError = nil
+
+        managedGitHubConnectionTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                isManagedGitHubConnectionInProgress = false
+                managedGitHubConnectionTask = nil
+            }
+            do {
+                let identity = try GitHubBrokerDeviceIdentityStore(
+                    secretStore: dependencies.secretStore
+                ).loadOrCreate()
+                try await loadManagedGitHubRepositories(
+                    broker: broker,
+                    identity: identity,
+                    installationId: installationId
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                applyManagedGitHubFailure(error)
+            }
+        }
+    }
+
+    package func selectManagedGitHubRepository(fullName: String) {
+        guard case .bound = managedGitHubConnectionState,
+              let repository = managedGitHubRepositories.first(where: {
+                  $0.fullName == fullName
+              })
+        else {
+            lastError = "Refresh the server-bound GitHub repositories before selecting one."
+            return
+        }
+        guard repository.visibility != .unknown else {
+            lastError = "GitHub repository visibility is unavailable. NeonDiff fails closed until the broker returns authoritative visibility."
+            return
+        }
+
+        selectedManagedGitHubRepository = repository.fullName
+        for index in repos.indices {
+            repos[index].enabled = false
+        }
+        if let index = repos.firstIndex(where: { $0.name == repository.fullName }) {
+            repos[index].enabled = true
+            repos[index].profile = repository.visibility.rawValue
+        } else {
+            repos.append(RepoMonitor(
+                name: repository.fullName,
+                enabled: true,
+                profile: repository.visibility.rawValue,
+                lastReview: "selected through managed GitHub broker"
+            ))
+            repos.sort {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        }
+
+        switch repository.visibility {
+        case .public:
+            onboardingFlow.mode = .publicReposOnly
+            enterActivation(for: .publicReposOnly)
+            onboardingFlow.licenseActivation = .activated
+        case .private, .internal:
+            onboardingFlow.mode = .privateRepos
+            if activationState == .active,
+               activatedRepository != repository.fullName {
+                applyActivationEvent(.activationInvalid)
+                applyActivationEvent(.resetToPurchase)
+            }
+            enterActivation(for: .privateRepos)
+            onboardingFlow.licenseActivation = activationState == .active
+                    && activatedRepository == repository.fullName
+                ? .activated
+                : .servicePending
+        case .unknown:
+            break
+        }
+        managedGitHubRecovery = nil
+        lastError = nil
+        logText = "\(repository.fullName) selected from the authoritative GitHub App binding. Preview and apply the allowlist before review."
+    }
+
+    package func performManagedGitHubRecoveryAction() {
+        switch managedGitHubRecovery?.action {
+        case .installOrManageApp, .reconnect:
+            startManagedGitHubConnection()
+        case .retryLater, .retry:
+            if Self.savedManagedGitHubInstallationId(preferences: dependencies.preferences) != nil {
+                refreshManagedGitHubRepositories()
+            } else {
+                startManagedGitHubConnection()
+            }
+        case .contactOrganizationOwner:
+            logText = managedGitHubRecovery?.message
+                ?? "Ask an organization owner to approve the GitHub App installation."
+        case nil:
+            refreshManagedGitHubRepositories()
+        }
+    }
+
     package func previewRepoAllowlistPatch() {
+        guard !managedGitHubAvailable || hasVerifiedManagedGitHubSelection else {
+            lastError = "Verify the GitHub App binding and select exactly one server-bound repository before previewing the allowlist."
+            return
+        }
         runRepoSelectionPatch(dryRun: true)
     }
 
     package func applyRepoAllowlistPatch() {
+        guard !managedGitHubAvailable || hasVerifiedManagedGitHubSelection else {
+            lastError = "Verify the GitHub App binding and select exactly one server-bound repository before applying the allowlist."
+            return
+        }
         runRepoSelectionPatch(dryRun: false)
     }
 
@@ -1170,6 +1467,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func applyActivationEvent(_ event: ActivationEvent) {
         let next = ActivationStateMachine.reduce(activationState, on: event)
         guard next != activationState else { return }
+        if activationState == .active, next != .active {
+            dependencies.preferences.set("", forKey: activationRepositoryKey)
+        }
         activationState = next
         // Persist for resume-exact restore across relaunch / cancel / network loss.
         dependencies.preferences.set(next.rawValue, forKey: activationStateKey)
@@ -1353,6 +1653,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
             let plan = summary.plan.map { " · \($0)" } ?? ""
             license.entitlement = "active (\(scope)\(plan))"
             logText = "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
+            if let repository = repos.filter(\.enabled).map(\.name).onlyElement {
+                dependencies.preferences.set(repository, forKey: activationRepositoryKey)
+            } else {
+                dependencies.preferences.set("", forKey: activationRepositoryKey)
+            }
             // Let onboarding finish through the native handoff (Continue enables).
             onboardingFlow.licenseActivation = .activated
         case .scopeConflict:
@@ -1366,6 +1671,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func advanceOnboarding() {
         onboardingFlow.providerKeyStored = providers.providerKeyStored
+        guard canAdvanceOnboarding else { return }
         if onboardingFlow.currentStep == .done {
             completeOnboarding()
             return
@@ -1379,6 +1685,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func completeOnboarding() {
         guard dependencies.productionBoundary.nativeActivationBrokerVerified,
+              dependencies.productionBoundary.managedGitHubBrokerOrigin == nil
+                || hasVerifiedManagedGitHubSelection,
               onboardingFlow.licenseActivation == .activated
         else {
             _ = requireVerifiedNativeActivationBroker()
@@ -1764,6 +2072,142 @@ package final class NeonDiffDesktopModel: ObservableObject {
         github.installationState = recovery.status
         lastError = recovery.message
         logText = recovery.message
+    }
+
+    private func awaitManagedGitHubBinding(
+        broker: any GitHubBrokerConnecting,
+        identity: GitHubBrokerDeviceIdentity,
+        connection: GitHubBrokerConnection
+    ) async throws -> Int {
+        while !Task.isCancelled && dependencies.clock.now < connection.expiresAt {
+            switch try await broker.completeConnection(
+                identity: identity,
+                state: connection.state
+            ) {
+            case .bound(let installationId):
+                return installationId
+            case .pending:
+                try await dependencies.clock.sleep(for: .seconds(2))
+            }
+        }
+        throw ManagedGitHubModelError.authorizationExpired
+    }
+
+    private func loadManagedGitHubRepositories(
+        broker: any GitHubBrokerConnecting,
+        identity: GitHubBrokerDeviceIdentity,
+        installationId: Int
+    ) async throws {
+        var pageNumber = 1
+        var repositories: [GitHubBrokerRepository] = []
+        while !Task.isCancelled {
+            let page = try await broker.listRepositories(
+                identity: identity,
+                installationId: installationId,
+                page: pageNumber
+            )
+            guard page.installationId == installationId,
+                  page.page == pageNumber
+            else {
+                throw GitHubBrokerClientError.scopeMismatch
+            }
+            repositories.append(contentsOf: page.repositories)
+            guard let nextPage = page.nextPage else { break }
+            guard nextPage == pageNumber + 1, nextPage <= 200 else {
+                throw GitHubBrokerClientError.scopeMismatch
+            }
+            pageNumber = nextPage
+        }
+        guard !Task.isCancelled else { return }
+        let names = repositories.map(\.fullName)
+        guard !repositories.isEmpty,
+              Set(names).count == names.count
+        else {
+            throw ManagedGitHubModelError.noBoundRepositories
+        }
+        managedGitHubRepositories = repositories.sorted {
+            $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending
+        }
+        managedGitHubConnectionState = .bound(installationId: installationId)
+        managedGitHubRecovery = nil
+        lastError = nil
+        logText = "\(repositories.count) server-bound GitHub repositories verified. Select one to continue."
+    }
+
+    private func applyManagedGitHubFailure(_ error: Error) {
+        managedGitHubConnectionState = .failed
+        managedGitHubRepositories = []
+        selectedManagedGitHubRepository = nil
+        let recovery: GitHubConnectionRecovery
+        if let brokerError = error as? GitHubBrokerClientError {
+            switch brokerError {
+            case .server(reason: .rateLimited),
+                 .server(reason: .brokerUnavailable),
+                 .server(reason: .entitlementServiceUnavailable),
+                 .transportUnavailable:
+                recovery = GitHubConnectionRecovery(
+                    status: "broker unavailable",
+                    message: "The managed GitHub service is unavailable. No repository access was granted. Retry later.",
+                    action: .retryLater
+                )
+            case .server(reason: .installationNotFound),
+                 .server(reason: .installationUninstalled),
+                 .server(reason: .installationSuspended),
+                 .server(reason: .installationAuthorizationUnverified),
+                 .server(reason: .bindingNotFound):
+                recovery = GitHubConnectionRecovery(
+                    status: "App installation unavailable",
+                    message: "The GitHub App installation is missing, suspended, or no longer authorized. Reconnect and manage selected repository access.",
+                    action: .installOrManageApp
+                )
+            default:
+                recovery = GitHubConnectionRecovery(
+                    status: "managed GitHub verification failed",
+                    message: "Managed GitHub verification failed closed. Reconnect; if it persists, contact support with redacted diagnostics.",
+                    action: .reconnect
+                )
+            }
+        } else if error is GitHubBrokerDeviceIdentityError {
+            recovery = GitHubConnectionRecovery(
+                status: "device identity unavailable",
+                message: "The Keychain-backed GitHub device identity is unavailable. NeonDiff did not create a replacement binding.",
+                action: .retry
+            )
+        } else if let modelError = error as? ManagedGitHubModelError {
+            recovery = modelError.recovery
+        } else {
+            recovery = GitHubConnectionRecovery(
+                status: "managed GitHub verification failed",
+                message: "Managed GitHub verification failed closed. Retry with the App installed on a selected repository.",
+                action: .retry
+            )
+        }
+        managedGitHubRecovery = recovery
+        lastError = recovery.message
+        logText = recovery.message
+    }
+
+    private static func savedManagedGitHubInstallationId(
+        preferences: any DesktopPreferences
+    ) -> Int? {
+        guard let raw = preferences.string(forKey: managedGitHubInstallationIdKey),
+              let installationId = Int(raw),
+              installationId > 0
+        else {
+            return nil
+        }
+        return installationId
+    }
+
+    private var activatedRepository: String? {
+        guard let repository = dependencies.preferences.string(
+            forKey: activationRepositoryKey
+        )?.trimmingCharacters(in: .whitespacesAndNewlines),
+        isValidRepoName(repository)
+        else {
+            return nil
+        }
+        return repository
     }
 
     private func readGitHubStoredDate(account: String) -> Date? {
@@ -2229,9 +2673,40 @@ private let onboardingCompletedKey = "neondiff.hasCompletedActivationOnboarding.
 // raw activation-key copy.
 private let activationKeyAccount = "license/default"
 private let activationStateKey = "neondiff.activationState.v1"
+private let activationRepositoryKey = "neondiff.activationRepository.v1"
 private let activationHandoffEnabledKey = "neondiff.activationHandoffEnabled"
 private let activationCheckoutEnabledKey = "neondiff.activationCheckoutEnabled"
 private let activationCliBackedEnabledKey = "neondiff.activationCliBackedValidation"
+private let managedGitHubInstallationIdKey = "neondiff.managedGitHubInstallationId"
+
+private enum ManagedGitHubModelError: Error {
+    case installPageOpenFailed
+    case authorizationExpired
+    case noBoundRepositories
+
+    var recovery: GitHubConnectionRecovery {
+        switch self {
+        case .installPageOpenFailed:
+            GitHubConnectionRecovery(
+                status: "GitHub install page unavailable",
+                message: "NeonDiff could not open the GitHub App installation page. No repository binding was granted.",
+                action: .retry
+            )
+        case .authorizationExpired:
+            GitHubConnectionRecovery(
+                status: "GitHub authorization expired",
+                message: "GitHub authorization expired before the server binding completed. Start a new connection.",
+                action: .reconnect
+            )
+        case .noBoundRepositories:
+            GitHubConnectionRecovery(
+                status: "no bound repositories",
+                message: "The GitHub App binding contains no selected repositories. Manage App access, then refresh.",
+                action: .installOrManageApp
+            )
+        }
+    }
+}
 
 private func isValidRepoName(_ value: String) -> Bool {
     let parts = value.split(separator: "/", omittingEmptySubsequences: false)
@@ -2249,4 +2724,10 @@ private func uniqueSortedRepoNames(_ names: [String]) -> [String] {
         .filter(isValidRepoName)
         .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
         .filter { seen.insert($0.lowercased()).inserted }
+}
+
+private extension Collection {
+    var onlyElement: Element? {
+        count == 1 ? first : nil
+    }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -16,6 +16,7 @@ public struct GitHubBrokerPublicJWK: Codable, Equatable, Sendable {
 }
 
 public enum GitHubBrokerDeviceIdentityError: Error, LocalizedError, Equatable {
+    case storedIdentityMissing
     case invalidStoredIdentity
     case identityGenerationFailed
     case identityStorageUnavailable
@@ -23,6 +24,8 @@ public enum GitHubBrokerDeviceIdentityError: Error, LocalizedError, Equatable {
 
     public var errorDescription: String? {
         switch self {
+        case .storedIdentityMissing:
+            "The saved GitHub broker binding has no Keychain device identity. Reconnect explicitly to create a new binding."
         case .invalidStoredIdentity:
             "The stored GitHub broker device identity is invalid. Reconnect support is required; NeonDiff will not silently replace a bound identity."
         case .identityGenerationFailed:
@@ -133,6 +136,18 @@ public final class GitHubBrokerDeviceIdentityStore {
                 throw GitHubBrokerDeviceIdentityError.identityStorageUnavailable
             }
             return try decodeIdentity(winner)
+        }
+    }
+
+    /// Loads a previously-created identity without rotating or creating one.
+    /// Saved-binding verification must use this path so a missing Keychain item
+    /// cannot silently orphan the server-side binding.
+    public func loadExisting() throws -> GitHubBrokerDeviceIdentity {
+        try lock.withLock {
+            guard let encoded = try readStoredIdentity() else {
+                throw GitHubBrokerDeviceIdentityError.storedIdentityMissing
+            }
+            return try decodeIdentity(encoded)
         }
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -339,6 +339,12 @@ public struct GitHubBrokerConnection: Equatable, Sendable {
     public let installURL: URL
     public let state: String
     public let expiresAt: Date
+
+    public init(installURL: URL, state: String, expiresAt: Date) {
+        self.installURL = installURL
+        self.state = state
+        self.expiresAt = expiresAt
+    }
 }
 
 public enum GitHubBrokerConnectionCompletion: Equatable, Sendable {
@@ -368,6 +374,32 @@ public struct GitHubBrokerRepositoryPage: Equatable, Sendable {
     public let page: Int
     public let repositories: [GitHubBrokerRepository]
     public let nextPage: Int?
+
+    public init(
+        installationId: Int,
+        page: Int,
+        repositories: [GitHubBrokerRepository],
+        nextPage: Int?
+    ) {
+        self.installationId = installationId
+        self.page = page
+        self.repositories = repositories
+        self.nextPage = nextPage
+    }
+}
+
+public protocol GitHubBrokerConnecting: Sendable {
+    func register(identity: GitHubBrokerDeviceIdentity) async throws
+    func startConnection(identity: GitHubBrokerDeviceIdentity) async throws -> GitHubBrokerConnection
+    func completeConnection(
+        identity: GitHubBrokerDeviceIdentity,
+        state: String
+    ) async throws -> GitHubBrokerConnectionCompletion
+    func listRepositories(
+        identity: GitHubBrokerDeviceIdentity,
+        installationId: Int,
+        page: Int
+    ) async throws -> GitHubBrokerRepositoryPage
 }
 
 public struct GitHubInstallationAccessGrant: Sendable, CustomStringConvertible, CustomDebugStringConvertible {
@@ -402,7 +434,7 @@ public struct GitHubInstallationAccessGrant: Sendable, CustomStringConvertible, 
     public var debugDescription: String { description }
 }
 
-public struct GitHubBrokerClient: Sendable {
+public struct GitHubBrokerClient: GitHubBrokerConnecting, Sendable {
     public static let maximumResponseBytes = 64 * 1024
 
     private let baseURL: URL

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -341,6 +341,34 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.productionUsefulWorkAvailable)
     }
 
+    @Test func preferenceTamperingCannotMoveCurrentActivationToAnotherRepository() async {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electric/private-a", visibility: .private),
+            GitHubBrokerRepository(fullName: "electric/private-b", visibility: .private)
+        ])
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            activationLicenseClient: ActiveManagedActivationClient(),
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private-a")
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+        #expect(fixture.model.productionUsefulWorkAvailable)
+
+        fixture.preferences.set(
+            "electric/private-b",
+            forKey: "neondiff.activationRepository.v1"
+        )
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private-b")
+
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.onboardingFlow.licenseActivation == .servicePending)
+    }
+
     @Test func persistedPrivateActivationCannotUnlockUsefulWorkWithoutCurrentAPIVerification() async {
         let broker = ScriptedGitHubBroker(repositories: [
             GitHubBrokerRepository(fullName: "electric/private-a", visibility: .private)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -1,0 +1,340 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+private final class ManagedGitHubLocked<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func read<Result>(_ body: (Value) throws -> Result) rethrows -> Result {
+        try lock.withLock { try body(value) }
+    }
+
+    func update<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+        try lock.withLock { try body(&value) }
+    }
+}
+
+final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
+    private struct State {
+        var completionResults: [GitHubBrokerConnectionCompletion]
+        var repositoryPages: [GitHubBrokerRepositoryPage]
+        var error: GitHubBrokerClientError?
+        var registeredDeviceIds: [String] = []
+        var startedDeviceIds: [String] = []
+        var completedStates: [String] = []
+        var listedInstallationIds: [Int] = []
+    }
+
+    private let state: ManagedGitHubLocked<State>
+    let connection: GitHubBrokerConnection
+
+    init(
+        completionResults: [GitHubBrokerConnectionCompletion] = [.bound(installationId: 42)],
+        repositories: [GitHubBrokerRepository] = [
+            GitHubBrokerRepository(fullName: "electric/public", visibility: .public)
+        ],
+        error: GitHubBrokerClientError? = nil
+    ) {
+        connection = GitHubBrokerConnection(
+            installURL: URL(string: "https://github.com/apps/neondiff/installations/new?state=fixture-state")!,
+            state: "fixture-state",
+            expiresAt: Date(timeIntervalSince1970: 1_000_600)
+        )
+        state = ManagedGitHubLocked(State(
+            completionResults: completionResults,
+            repositoryPages: [
+                GitHubBrokerRepositoryPage(
+                    installationId: 42,
+                    page: 1,
+                    repositories: repositories,
+                    nextPage: nil
+                )
+            ],
+            error: error
+        ))
+    }
+
+    var registeredDeviceIds: [String] { state.read(\.registeredDeviceIds) }
+    var startedDeviceIds: [String] { state.read(\.startedDeviceIds) }
+    var completedStates: [String] { state.read(\.completedStates) }
+    var listedInstallationIds: [Int] { state.read(\.listedInstallationIds) }
+
+    func register(identity: GitHubBrokerDeviceIdentity) async throws {
+        try throwIfNeeded()
+        state.update { $0.registeredDeviceIds.append(identity.deviceId) }
+    }
+
+    func startConnection(identity: GitHubBrokerDeviceIdentity) async throws -> GitHubBrokerConnection {
+        try throwIfNeeded()
+        state.update { $0.startedDeviceIds.append(identity.deviceId) }
+        return connection
+    }
+
+    func completeConnection(
+        identity: GitHubBrokerDeviceIdentity,
+        state opaqueState: String
+    ) async throws -> GitHubBrokerConnectionCompletion {
+        try throwIfNeeded()
+        return state.update {
+            $0.completedStates.append(opaqueState)
+            return $0.completionResults.isEmpty ? .pending : $0.completionResults.removeFirst()
+        }
+    }
+
+    func listRepositories(
+        identity: GitHubBrokerDeviceIdentity,
+        installationId: Int,
+        page: Int
+    ) async throws -> GitHubBrokerRepositoryPage {
+        try throwIfNeeded()
+        return state.update {
+            $0.listedInstallationIds.append(installationId)
+            return $0.repositoryPages.removeFirst()
+        }
+    }
+
+    private func throwIfNeeded() throws {
+        if let error = state.read(\.error) {
+            throw error
+        }
+    }
+}
+
+private struct ActiveManagedActivationClient: ActivationLicenseClienting {
+    func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        .active(.init(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "beta",
+            seats: 1
+        ))
+    }
+
+    func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        try await activate(key: key)
+    }
+}
+
+@MainActor
+@Suite(.timeLimit(.minutes(1))) struct ManagedGitHubOnboardingTests {
+    @Test func productionBoundaryRequiresExactSignedBuildContract() {
+        let valid = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-v1",
+            "NeonDiffManagedGitHubBrokerEnabled": true,
+            "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
+        ])
+        #expect(valid.nativeActivationBrokerVerified)
+        #expect(valid.managedGitHubBrokerOrigin?.absoluteString == "https://neondiff-license.fly.dev")
+
+        for invalid in [
+            [
+                "NeonDiffPaidBetaContract": "paid-mac-beta-v1",
+                "NeonDiffManagedGitHubBrokerEnabled": true,
+                "NeonDiffGitHubBrokerOrigin": "http://neondiff-license.fly.dev"
+            ],
+            [
+                "NeonDiffPaidBetaContract": "paid-mac-beta-v1",
+                "NeonDiffManagedGitHubBrokerEnabled": true,
+                "NeonDiffGitHubBrokerOrigin": "https://example.com"
+            ],
+            [
+                "NeonDiffPaidBetaContract": "paid-mac-beta-v1",
+                "NeonDiffManagedGitHubBrokerEnabled": false,
+                "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
+            ]
+        ] {
+            #expect(!DesktopProductionBoundary.resolve(infoDictionary: invalid).nativeActivationBrokerVerified)
+        }
+    }
+
+    @Test func managedConnectUsesBrokerAndKeychainIdentityWithoutLegacyUserTokenFallback() async throws {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electric/private", visibility: .private),
+            GitHubBrokerRepository(fullName: "electric/public", visibility: .public)
+        ])
+        let authenticator = ScriptedGitHubAuthenticator()
+        let fixture = ModelDependencyFixture(
+            githubAuthenticator: authenticator,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(broker.registeredDeviceIds.count == 1)
+        #expect(broker.startedDeviceIds == broker.registeredDeviceIds)
+        #expect(broker.completedStates == ["fixture-state"])
+        #expect(broker.listedInstallationIds == [42])
+        #expect(authenticator.requestedClientIds.isEmpty)
+        #expect(authenticator.fetchedAccessTokens.isEmpty)
+        #expect(fixture.urlOpener.urls == [broker.connection.installURL])
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
+        #expect(fixture.model.managedGitHubRepositories.map(\.fullName) == [
+            "electric/private",
+            "electric/public"
+        ])
+        #expect(fixture.secretStore.containsSecret(account: GitHubBrokerDeviceIdentityStore.defaultAccount))
+    }
+
+    @Test func authoritativeVisibilityControlsPublicFreeAndPrivateActivationEntry() async {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electric/private", visibility: .private),
+            GitHubBrokerRepository(fullName: "electric/public", visibility: .public),
+            GitHubBrokerRepository(fullName: "electric/unknown", visibility: .unknown)
+        ])
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/public")
+        #expect(fixture.model.selectedManagedGitHubRepository == "electric/public")
+        #expect(fixture.model.onboardingFlow.mode == .publicReposOnly)
+        #expect(fixture.model.activationState == .publicFreeSkip)
+        #expect(fixture.model.onboardingFlow.licenseActivation == .activated)
+        #expect(fixture.model.canAdvanceOnboarding)
+
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private")
+        #expect(fixture.model.selectedManagedGitHubRepository == "electric/private")
+        #expect(fixture.model.onboardingFlow.mode == .privateRepos)
+        #expect(fixture.model.activationState == .purchaseRequired)
+        #expect(fixture.model.onboardingFlow.licenseActivation == .servicePending)
+
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/unknown")
+        #expect(fixture.model.selectedManagedGitHubRepository == "electric/private")
+        #expect(fixture.model.lastError?.contains("visibility") == true)
+    }
+
+    @Test func missingOrUnavailableBrokerFailsClosedWithoutCreatingIdentity() async {
+        let missingFixture = ModelDependencyFixture(productionBoundary: .testManaged)
+        missingFixture.model.startManagedGitHubConnection()
+        #expect(missingFixture.model.managedGitHubConnectionState == .quarantined)
+        #expect(!missingFixture.secretStore.containsSecret(account: GitHubBrokerDeviceIdentityStore.defaultAccount))
+
+        let unavailable = ScriptedGitHubBroker(error: .server(reason: .brokerUnavailable))
+        let unavailableFixture = ModelDependencyFixture(
+            githubBroker: unavailable,
+            productionBoundary: .testManaged
+        )
+        unavailableFixture.model.startManagedGitHubConnection()
+        await unavailableFixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(unavailableFixture.model.managedGitHubConnectionState == .failed)
+        #expect(unavailableFixture.model.managedGitHubRecovery?.action == .retryLater)
+        #expect(unavailableFixture.model.managedGitHubRepositories.isEmpty)
+    }
+
+    @Test func recordedInstallationIsOnlyRoutingHintUntilServerReadbackPasses() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            preferenceStrings: ["neondiff.managedGitHubInstallationId": "42"],
+            productionBoundary: .testManaged
+        )
+
+        #expect(fixture.model.managedGitHubConnectionState == .verificationRequired)
+        #expect(!fixture.model.canAdvanceOnboarding)
+
+        fixture.model.refreshManagedGitHubRepositories()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(broker.listedInstallationIds == [42])
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
+    }
+
+    @Test func lostBindingRevokesOnboardingAdvanceAndCompletion() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/public")
+        fixture.model.onboardingFlow.currentStep = .done
+        fixture.model.managedGitHubConnectionState = .failed
+
+        #expect(!fixture.model.canAdvanceOnboarding)
+        fixture.model.completeOnboarding()
+        #expect(fixture.model.isOnboardingPresented)
+        #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
+    }
+
+    @Test func managedModeRejectsManualOrUnboundAllowlistMutation() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        fixture.model.pendingRepoName = "attacker/spoofed-public"
+        fixture.model.addPendingRepoToAllowlist()
+        #expect(!fixture.model.repos.contains { $0.name == "attacker/spoofed-public" })
+
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/public")
+        let selected = fixture.model.repos.first { $0.name == "electric/public" }!
+        fixture.model.toggleRepoAllowlist(selected)
+        #expect(fixture.model.repos.first { $0.name == "electric/public" }?.enabled == true)
+    }
+
+    @Test func activePrivateReadinessCannotCrossRepositoryBoundary() async {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electric/private-a", visibility: .private),
+            GitHubBrokerRepository(fullName: "electric/private-b", visibility: .private)
+        ])
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private-a")
+        fixture.model.activationState = .active
+        fixture.preferences.set(
+            "electric/private-a",
+            forKey: "neondiff.activationRepository.v1"
+        )
+
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private-b")
+
+        #expect(fixture.model.activationState == .purchaseRequired)
+        #expect(fixture.model.onboardingFlow.licenseActivation == .servicePending)
+    }
+
+    @Test func successfulPrivateActivationPinsExactBrokerRepository() async {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electric/private-a", visibility: .private)
+        ])
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            activationLicenseClient: ActiveManagedActivationClient(),
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private-a")
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+
+        #expect(fixture.model.activationState == .active)
+        #expect(
+            fixture.preferences.string(forKey: "neondiff.activationRepository.v1")
+                == "electric/private-a"
+        )
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -468,8 +468,33 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         fixture.model.configPath = "changed-config.json"
         #expect(!fixture.model.productionUsefulWorkAvailable)
     }
+
+    @Test func exactNoOpManagedApplyReadbackAuthorizesUsefulWork() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/public")
+
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 0,
+            stdout: managedRepoPatchJSON(repository: "electric/public", wrote: false),
+            stderr: ""
+        )))
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
+        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.lastError == nil)
+    }
 }
 
-private func managedRepoPatchJSON(repository: String) -> String {
-    #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["\#(repository)"]}}"#
+private func managedRepoPatchJSON(repository: String, wrote: Bool = true) -> String {
+    let revisionAfter = wrote
+        ? "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    return #"{"ok":true,"command":"config patch","dryRun":false,"wrote":\#(wrote),"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"\#(revisionAfter)","config":{"pilotRepos":["\#(repository)"]}}"#
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -469,6 +469,38 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
+    @Test func managedDaemonStopRemainsAvailableAfterAuthorizationProofLoss() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/public")
+
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 0,
+            stdout: managedRepoPatchJSON(repository: "electric/public"),
+            stderr: ""
+        )))
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+        #expect(fixture.model.productionUsefulWorkAvailable)
+
+        fixture.model.configPath = "changed-config.json"
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+
+        let callCountBeforeStop = fixture.cli.calls.count
+        fixture.model.stopDaemon()
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        #expect(fixture.cli.calls.count == callCountBeforeStop + 1)
+        #expect(fixture.cli.calls.last?.arguments.prefix(2) == ["daemon", "stop"])
+    }
+
     @Test func exactNoOpManagedApplyReadbackAuthorizesUsefulWork() async {
         let broker = ScriptedGitHubBroker()
         let fixture = ModelDependencyFixture(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -205,7 +205,8 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.activationState == .publicFreeSkip)
         #expect(fixture.model.onboardingFlow.licenseActivation == .activated)
         #expect(fixture.model.canAdvanceOnboarding)
-        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.activationHandoffEnabled)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
 
         fixture.model.selectManagedGitHubRepository(fullName: "electric/private")
         #expect(fixture.model.selectedManagedGitHubRepository == "electric/private")
@@ -238,7 +239,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(unavailableFixture.model.managedGitHubRepositories.isEmpty)
     }
 
-    @Test func recordedInstallationIsOnlyRoutingHintUntilServerReadbackPasses() async {
+    @Test func recordedInstallationIsOnlyRoutingHintUntilServerReadbackPasses() async throws {
         let broker = ScriptedGitHubBroker()
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
@@ -249,11 +250,34 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.managedGitHubConnectionState == .verificationRequired)
         #expect(!fixture.model.canAdvanceOnboarding)
 
+        _ = try GitHubBrokerDeviceIdentityStore(
+            secretStore: fixture.secretStore
+        ).loadOrCreate()
+
         fixture.model.refreshManagedGitHubRepositories()
         await fixture.waitForManagedGitHubConnectionToFinish()
 
         #expect(broker.listedInstallationIds == [42])
         #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
+    }
+
+    @Test func savedBindingVerificationNeverCreatesReplacementDeviceIdentity() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            preferenceStrings: ["neondiff.managedGitHubInstallationId": "42"],
+            productionBoundary: .testManaged
+        )
+
+        fixture.model.refreshManagedGitHubRepositories()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(!fixture.secretStore.containsSecret(
+            account: GitHubBrokerDeviceIdentityStore.defaultAccount
+        ))
+        #expect(broker.listedInstallationIds.isEmpty)
+        #expect(fixture.model.managedGitHubConnectionState == .failed)
+        #expect(fixture.model.managedGitHubRecovery?.action == .reconnect)
     }
 
     @Test func lostBindingRevokesOnboardingAdvanceAndCompletion() async {
@@ -338,6 +362,16 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             fixture.preferences.string(forKey: "neondiff.activationRepository.v1")
                 == "electric/private-a"
         )
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 0,
+            stdout: managedRepoPatchJSON(repository: "electric/private-a"),
+            stderr: ""
+        )))
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
         #expect(fixture.model.productionUsefulWorkAvailable)
     }
 
@@ -357,6 +391,14 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
         fixture.model.provideExistingActivationKey()
         await fixture.model.submitActivation()
+
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 0,
+            stdout: managedRepoPatchJSON(repository: "electric/private-a"),
+            stderr: ""
+        )))
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
         #expect(fixture.model.productionUsefulWorkAvailable)
 
         fixture.preferences.set(
@@ -396,4 +438,38 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         }
         #expect(fixture.cli.calls.isEmpty)
     }
+
+    @Test func daemonRequiresExactManagedSelectionToBeAppliedAndReadBack() async {
+        let broker = ScriptedGitHubBroker()
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/public")
+
+        fixture.model.startDaemon()
+        #expect(fixture.cli.calls.isEmpty)
+
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 0,
+            stdout: managedRepoPatchJSON(repository: "electric/public"),
+            stderr: ""
+        )))
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+        #expect(fixture.model.productionUsefulWorkAvailable)
+
+        fixture.model.startDaemon()
+        await fixture.cli.waitUntilCallCount(2)
+        #expect(fixture.cli.calls.last?.arguments.prefix(2) == ["daemon", "start"])
+
+        fixture.model.configPath = "changed-config.json"
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+}
+
+private func managedRepoPatchJSON(repository: String) -> String {
+    #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["\#(repository)"]}}"#
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -205,12 +205,14 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.activationState == .publicFreeSkip)
         #expect(fixture.model.onboardingFlow.licenseActivation == .activated)
         #expect(fixture.model.canAdvanceOnboarding)
+        #expect(fixture.model.productionUsefulWorkAvailable)
 
         fixture.model.selectManagedGitHubRepository(fullName: "electric/private")
         #expect(fixture.model.selectedManagedGitHubRepository == "electric/private")
         #expect(fixture.model.onboardingFlow.mode == .privateRepos)
         #expect(fixture.model.activationState == .purchaseRequired)
         #expect(fixture.model.onboardingFlow.licenseActivation == .servicePending)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
 
         fixture.model.selectManagedGitHubRepository(fullName: "electric/unknown")
         #expect(fixture.model.selectedManagedGitHubRepository == "electric/private")
@@ -336,5 +338,34 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             fixture.preferences.string(forKey: "neondiff.activationRepository.v1")
                 == "electric/private-a"
         )
+        #expect(fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @Test func persistedPrivateActivationCannotUnlockUsefulWorkWithoutCurrentAPIVerification() async {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electric/private-a", visibility: .private)
+        ])
+        let fixture = ModelDependencyFixture(
+            githubBroker: broker,
+            preferenceBools: [
+                "neondiff.hasCompletedActivationOnboarding.v2": true
+            ],
+            preferenceStrings: [
+                "neondiff.activationState.v1": ActivationState.active.rawValue,
+                "neondiff.activationRepository.v1": "electric/private-a"
+            ],
+            productionBoundary: .testManaged
+        )
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: "electric/private-a")
+
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        fixture.model.startDaemon()
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(fixture.cli.calls.isEmpty)
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -125,13 +125,17 @@ import Testing
         #expect(source.contains("Updates blocked pending native activation proof"))
     }
 
-    @Test func productionCompositionRootInstallsTheQuarantinedBoundary() throws {
+    @Test func productionCompositionRootResolvesOnlyTheSignedBuildBoundary() throws {
         let compositionRoot = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift")
         let source = try sourceBoundaryText(at: compositionRoot)
 
-        #expect(source.contains("productionBoundary: .quarantined"))
+        #expect(source.contains("DesktopProductionBoundary.resolve("))
+        #expect(source.contains("Bundle.main.infoDictionary ?? [:]"))
+        #expect(source.contains("GitHubBrokerClient(baseURL: $0)"))
+        #expect(source.contains("productionBoundary: productionBoundary"))
         #expect(!source.contains("productionBoundary: .testVerified"))
+        #expect(!source.contains("productionBoundary: .testManaged"))
     }
 
     @Test func evaluationRootIdentifierDoesNotOverrideDescendantActionIdentifiers() throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -148,4 +148,13 @@ import Testing
         #expect(source.contains(".accessibilityIdentifier(identifier)"))
         #expect(!source.contains(".accessibilityIdentifier(rootAccessibilityIdentifier)"))
     }
+
+    @Test func managedOnboardingExposesRepositoryApplyAction() throws {
+        let onboardingView = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift")
+        let source = try sourceBoundaryText(at: onboardingView)
+
+        #expect(source.contains("model.applyRepoAllowlistPatch()"))
+        #expect(source.contains("neondiff-onboarding-repository-apply"))
+    }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -8,7 +8,9 @@ import Testing
         fixture.model.pendingLicenseKey = "fixture-license-value"
 
         fixture.model.previewStartDaemon()
+        fixture.model.previewStopDaemon()
         fixture.model.startDaemon()
+        fixture.model.stopDaemon()
         fixture.model.verifyProviderKey()
         fixture.model.storeLicenseKey()
         fixture.model.activateLicenseForOnboarding()
@@ -156,5 +158,17 @@ import Testing
 
         #expect(source.contains("model.applyRepoAllowlistPatch()"))
         #expect(source.contains("neondiff-onboarding-repository-apply"))
+    }
+
+    @Test func managedSafetyStopIsNotDisabledByUsefulWorkProofLoss() throws {
+        let viewsDirectory = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)
+        let source = try ["OverviewView.swift", "OnboardingWizardView.swift"]
+            .map { try sourceBoundaryText(at: viewsDirectory.appendingPathComponent($0)) }
+            .joined(separator: "\n")
+
+        #expect(source.contains("model.productionDaemonStopAvailable"))
+        #expect(!source.contains("Button { model.stopDaemon() } label:")
+            || source.contains(".disabled(!model.productionDaemonStopAvailable)"))
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -177,6 +177,7 @@ struct ModelDependencyFixture {
     let providerVerifier: RecordingProviderVerifier
     let secretStore: MemorySecretStore
     let githubAuthenticator: ScriptedGitHubAuthenticator
+    let githubBroker: ScriptedGitHubBroker?
 
     init(
         root: URL = fixtureURL("/fixture/model-app-support", directory: true),
@@ -185,7 +186,10 @@ struct ModelDependencyFixture {
         clipboardResult: Bool = true,
         urlResult: Bool = true,
         githubAuthenticator: ScriptedGitHubAuthenticator = ScriptedGitHubAuthenticator(),
+        githubBroker: ScriptedGitHubBroker? = nil,
+        activationLicenseClient: (any ActivationLicenseClienting)? = nil,
         preferenceBools: [String: Bool] = [:],
+        preferenceStrings: [String: String] = [:],
         productionBoundary: DesktopProductionBoundary = .testVerified
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
@@ -196,11 +200,15 @@ struct ModelDependencyFixture {
         for (key, value) in preferenceBools {
             preferences.set(value, forKey: key)
         }
+        for (key, value) in preferenceStrings {
+            preferences.set(value, forKey: key)
+        }
         clock = TestClock(now: now)
         fileWriter = TemporaryFileWriter(root: root)
         providerVerifier = RecordingProviderVerifier()
         secretStore = MemorySecretStore()
         self.githubAuthenticator = githubAuthenticator
+        self.githubBroker = githubBroker
         model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: clipboard,
             urlOpener: urlOpener,
@@ -212,8 +220,9 @@ struct ModelDependencyFixture {
             providerVerifier: providerVerifier,
             secretStore: secretStore,
             githubAuthenticator: githubAuthenticator,
+            githubBroker: githubBroker,
             productionBoundary: productionBoundary
-        ))
+        ), activationLicenseClient: activationLicenseClient)
     }
 
     func loadConfig(_ json: String? = nil) {
@@ -237,6 +246,13 @@ struct ModelDependencyFixture {
 
     func waitForGitHubRefreshToFinish() async {
         await waitUntilFalse(model.$isGitHubRepositoryRefreshInProgress, current: model.isGitHubRepositoryRefreshInProgress)
+    }
+
+    func waitForManagedGitHubConnectionToFinish() async {
+        await waitUntilFalse(
+            model.$isManagedGitHubConnectionInProgress,
+            current: model.isManagedGitHubConnectionInProgress
+        )
     }
 
     func waitForDashboardLaunch() async {

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -39,6 +39,9 @@ SHORT_VERSION="${NEONDIFF_DESKTOP_VERSION:-0.1.0}"
 BUILD_VERSION="${NEONDIFF_DESKTOP_BUILD:-1}"
 SPARKLE_FEED_URL="${NEONDIFF_SPARKLE_FEED_URL:-}"
 SPARKLE_PUBLIC_KEY="${NEONDIFF_SPARKLE_PUBLIC_ED_KEY:-}"
+PAID_BETA_CONTRACT="${NEONDIFF_DESKTOP_PAID_BETA_CONTRACT:-}"
+MANAGED_GITHUB_BROKER_ENABLED="${NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED:-}"
+GITHUB_BROKER_ORIGIN="${NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN:-}"
 
 if [ -x "$APP_BINARY" ]; then
   while IFS= read -r pid; do
@@ -116,6 +119,22 @@ cat >"$INFO_PLIST" <<PLIST
 </dict>
 </plist>
 PLIST
+
+if [ -n "$PAID_BETA_CONTRACT" ] || [ -n "$MANAGED_GITHUB_BROKER_ENABLED" ] || [ -n "$GITHUB_BROKER_ORIGIN" ]; then
+  if [ "$BUILD_CONFIGURATION" != "release" ]; then
+    echo "managed GitHub production configuration is accepted only for release bundles" >&2
+    exit 2
+  fi
+  if [ "$PAID_BETA_CONTRACT" != "paid-mac-beta-v1" ] \
+    || [ "$MANAGED_GITHUB_BROKER_ENABLED" != "true" ] \
+    || [ "$GITHUB_BROKER_ORIGIN" != "https://neondiff-license.fly.dev" ]; then
+    echo "managed GitHub production configuration must match the exact paid beta contract" >&2
+    exit 2
+  fi
+  /usr/libexec/PlistBuddy -c "Add :NeonDiffPaidBetaContract string $PAID_BETA_CONTRACT" "$INFO_PLIST"
+  /usr/libexec/PlistBuddy -c "Add :NeonDiffManagedGitHubBrokerEnabled bool true" "$INFO_PLIST"
+  /usr/libexec/PlistBuddy -c "Add :NeonDiffGitHubBrokerOrigin string $GITHUB_BROKER_ORIGIN" "$INFO_PLIST"
+fi
 
 if [ -n "$SPARKLE_FEED_URL" ] && [ -n "$SPARKLE_PUBLIC_KEY" ]; then
   /usr/libexec/PlistBuddy -c "Add :SUFeedURL string $SPARKLE_FEED_URL" "$INFO_PLIST"

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -213,9 +213,25 @@ fixed-origin broker HTTPS request body when a private token is requested. The
 broker uses it for an in-memory license lookup and never logs, reflects, or
 persists it. Public-repository token requests omit the key and do not call the
 license authority. This path is still rollout-disabled; these contracts do not
-prove production enablement or customer readiness. Generic CLI
-status/deactivate and daemon-admission validation still use the legacy local
-identity; #630 must migrate those runtime callers before rollout.
+prove production enablement or customer readiness.
+
+The native source composition is also default-off. A release bundle must carry
+all three exact public Info.plist values before the app constructs the managed
+client:
+
+- `NeonDiffPaidBetaContract = paid-mac-beta-v1`
+- `NeonDiffManagedGitHubBrokerEnabled = true`
+- `NeonDiffGitHubBrokerOrigin = https://neondiff-license.fly.dev`
+
+`apps/neondiff-desktop/script/build_and_run.sh` accepts those values only for a
+release build and only through the exact matching
+`NEONDIFF_DESKTOP_PAID_BETA_CONTRACT`,
+`NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED`, and
+`NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN` inputs. Missing, partial, debug, or
+different values leave the bundle quarantined or fail the build. These are
+public configuration values, not secrets, and do not override the server-side
+kill switch. Generic CLI status/deactivate and daemon-admission validation still
+require exact-candidate integration proof under #630.
 
 ## 4. Check Readiness
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -227,8 +227,9 @@ client:
 release build and only through the exact matching
 `NEONDIFF_DESKTOP_PAID_BETA_CONTRACT`,
 `NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED`, and
-`NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN` inputs. Missing, partial, debug, or
-different values leave the bundle quarantined or fail the build. These are
+`NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN` inputs. When all three inputs are
+omitted, the bundle remains quarantined. Any non-empty but incomplete,
+mismatched, or non-release combination fails the build with exit 2. These are
 public configuration values, not secrets, and do not override the server-side
 kill switch. Generic CLI status/deactivate and daemon-admission validation still
 require exact-candidate integration proof under #630.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -56,8 +56,8 @@ because milestone or planning days can create large issue bursts.
 
 > This page covers the shipped **local-worker direct install**, where the worker
 > holds the App private key itself and no OAuth-during-install step is needed. The
-> separate **managed authorization broker** (production App registered, rollout
-> kill switch still off, and native integration in progress under #612/#613)
+> separate **managed authorization broker** (official App registered, source
+> composition present, rollout kill switch still off)
 > instead requires the App to enable "Request user authorization (OAuth) during
 > installation" and set the `/github/connect/callback` URL; that
 > registration is documented in `docs/security/github-app-staging-registration.md`.
@@ -73,8 +73,15 @@ same device/repository activation and never logs, reflects, or persists the raw
 key. Public requests omit the key and never consult the license authority.
 The production kill switch remains off until the paid-beta integration and
 canary gates pass, so this source contract is not production-wiring proof.
-Generic CLI status/deactivate and daemon-admission validation still use the
-legacy local identity; #630 owns that runtime migration before enablement.
+When an exact release-bundle contract enables the managed source path, the
+native app creates its P-256 identity only on explicit Connect, opens the
+broker-issued GitHub install URL, polls the device-bound completion endpoint,
+and accepts repository names/visibility only from the broker readback. A saved
+installation id is a routing hint only and cannot unlock onboarding until a
+fresh server repository read succeeds. Manual repository names and the legacy
+user-token discovery path are disabled in managed mode. Generic CLI
+status/deactivate and daemon-admission validation still require exact-candidate
+integration proof under #630.
 
 1. Open the NeonDiff GitHub App install URL.
 2. Choose the user or organization that owns the repositories.

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -5,13 +5,15 @@ that lets a NeonDiff desktop client connect the official NeonDiff GitHub App and
 obtain bounded, short-lived installation access without ever holding the App
 private key.
 
-This document covers the **server-side slice** (issues #613 and #614). Native
-connect UI states are sequenced after #611/#612. The repository-visibility and
+This document covers the **server-side slice** (issues #613 and #614) and its
+rollout-disabled native composition under #630. The repository-visibility and
 entitlement decision is bound at token issuance in the single seam function
 `authorizeTokenIssuance` (#614); the live device<->license linkage and deployment
-wiring belong to the paid-beta deployment lane (#633). No production GitHub App exists yet;
-every code path below is exercised against fixtures, never a live install (see
-"Owner-gated boundary").
+wiring belong to the paid-beta deployment lane (#633). At the 2026-07-18
+checkpoint the official App registration and selected-repository canary install
+exist, but App privacy conversion is not yet verified and the production broker
+kill switch remains off. Fixture/source proof below is therefore not a live
+connect, token-mint, release, or customer-readiness claim.
 
 ## Problem
 
@@ -347,19 +349,21 @@ bindings and states; uninstalled installations are pruned on discovery.
    selection uses the separate device-authenticated `POST /github/repositories`
    metadata route, so the native app never needs an unnarrowed review token merely
    to populate its selector.
-4. **Staging vs. production App registration sequence (OWNER-GATED, OPEN).** The
-   agent builds against a staging App the owner registers with the documented
-   permission set (see `docs/security/github-app-staging-registration.md`). The
-   production identity is created only after the security review.
+4. **Staging vs. production App registration sequence (OWNER-GATED, PARTIAL).**
+   The official App identity now exists and is installed only on the two
+   dedicated canary repositories, but production broker credentials, verified
+   private-App posture, live wiring, and security approval remain gated. The
+   staging checklist remains the settings contract.
 
 ## Owner-gated boundary
 
-Agent-executable now (this slice): the broker service code and its contract,
-integration, adversarial, and redaction tests against fixtures; this threat model
-and data-flow document; and the staging App registration spec.
+Agent-executable now: the broker service/client contracts, integration,
+adversarial, and redaction tests against fixtures; the default-off native
+composition; this threat model and data-flow document; and the staging App
+registration spec.
 
-Owner-only (blocked, needs-owner): creating the official NeonDiff GitHub App
-registration (production identity), holding the App private key, provisioning the
-Fly deployment secrets, and approving this security review before any production
-credential exists (AC7). No code in this slice proves the live install flow; it
-proves the fixtured broker contract only.
+Owner-only (blocked, needs-owner): finalizing/confirming the official App's
+private posture, holding its private key/OAuth client secret, provisioning the
+Fly deployment secrets, and approving the production security review before the
+broker is enabled (AC7). No code in this slice proves the live install flow; it
+proves the source/fixture composition only.

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -10,10 +10,11 @@ rollout-disabled native composition under #630. The repository-visibility and
 entitlement decision is bound at token issuance in the single seam function
 `authorizeTokenIssuance` (#614); the live device<->license linkage and deployment
 wiring belong to the paid-beta deployment lane (#633). At the 2026-07-18
-checkpoint the official App registration and selected-repository canary install
-exist, but App privacy conversion is not yet verified and the production broker
-kill switch remains off. Fixture/source proof below is therefore not a live
-connect, token-mint, release, or customer-readiness claim.
+checkpoint, the public-safe #613 registration checkpoint records the official
+public App and its selected-repository canary install. Public posture is
+intentional so customers can install the App outside the owner account. The
+production broker kill switch remains off. Fixture/source proof below is
+therefore not a live connect, token-mint, release, or customer-readiness claim.
 
 ## Problem
 
@@ -350,10 +351,10 @@ bindings and states; uninstalled installations are pruned on discovery.
    metadata route, so the native app never needs an unnarrowed review token merely
    to populate its selector.
 4. **Staging vs. production App registration sequence (OWNER-GATED, PARTIAL).**
-   The official App identity now exists and is installed only on the two
-   dedicated canary repositories, but production broker credentials, verified
-   private-App posture, live wiring, and security approval remain gated. The
-   staging checklist remains the settings contract.
+   The [#613 registration checkpoint](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/613#issuecomment-5012503190)
+   records the official public App identity and the two selected-repository
+   canary installs. Production broker credentials, live wiring, and security
+   approval remain gated. The staging checklist remains the settings contract.
 
 ## Owner-gated boundary
 
@@ -362,8 +363,8 @@ adversarial, and redaction tests against fixtures; the default-off native
 composition; this threat model and data-flow document; and the staging App
 registration spec.
 
-Owner-only (blocked, needs-owner): finalizing/confirming the official App's
-private posture, holding its private key/OAuth client secret, provisioning the
-Fly deployment secrets, and approving the production security review before the
-broker is enabled (AC7). No code in this slice proves the live install flow; it
-proves the source/fixture composition only.
+Owner-only (blocked, needs-owner): holding the official App private key/OAuth
+client secret, provisioning the Fly deployment secrets, and approving the
+production security review before the broker is enabled (AC7). No code in this
+slice proves the live install flow; it proves the source/fixture composition
+only.

--- a/docs/security/github-app-staging-registration.md
+++ b/docs/security/github-app-staging-registration.md
@@ -92,12 +92,12 @@ A webhook is not required and adding one is a separate design change.
 
 ## 5. Device flow
 
-Enable **"Enable Device Flow"** while the current desktop "Connect GitHub" (Repos
-pane) path still uses device-flow OAuth (`GitHubDeviceAuthClient.swift`;
-`docs/github-app-setup.md` notes GitHub returns `device_flow_disabled` if it is
-off). The broker's install/authorize + one-shot-state flow does **not** itself
-depend on device flow; this setting is only for the existing desktop path until
-#612 migrates it onto the broker.
+Enable **"Enable Device Flow"** only for legacy direct-install desktop builds
+that still use `GitHubDeviceAuthClient.swift`; those builds receive
+`device_flow_disabled` when it is off. The managed paid-beta path uses the
+broker's install/authorize + one-shot-state flow and does **not** depend on
+device flow. When the exact signed-build contract selects managed mode, the
+native UI does not fall back to the legacy user-token path.
 
 ## 6. Private key and install URL [OWNER-GATED]
 


### PR DESCRIPTION
## Outcome

Composes the already-merged managed GitHub broker client into the native Mac onboarding path behind an exact, default-off signed-build contract.

Related #630. This PR is a bounded source/fixture slice and does not close #630.

## Acceptance criteria

- [x] Production composition remains quarantined unless a release bundle contains all three exact public values: `paid-mac-beta-v1`, the explicit managed-broker marker, and `https://neondiff-license.fly.dev`.
- [x] Exact production config constructs the existing strict `GitHubBrokerClient`; absent/partial/debug/different config fails closed.
- [x] Explicit Connect lazily creates the Keychain P-256 device identity, registers it, opens only the broker-validated GitHub install URL, polls the device-bound completion state, and lists only server-bound repositories.
- [x] Managed mode has no legacy user-token or manual-repository fallback.
- [x] A persisted installation id is routing metadata only; fresh server repository readback is required before onboarding can advance.
- [x] Public-free is derived only from broker-returned GitHub-authoritative `public` visibility. `private`/`internal` require API-backed activation; `unknown` fails closed.
- [x] Binding loss revokes onboarding advance/completion, and active private readiness is pinned to the exact broker-selected repository.
- [x] Typed recoveries cover broker outage, missing/suspended install, expired authorization, unavailable Keychain identity, and empty binding.

## Failing-first proof

The focused suite first failed to compile on the missing composition API. Two later red regressions reproduced current-code bypasses before their fixes:

- loss of a previously verified public binding still allowed completion;
- manual allowlist controls remained callable in managed mode;
- an `.active` private marker could cross from repository A to repository B.

Focused green checks at exact source head `c0adc8120d93ebf44701213d9e49da7b6319e2b6`:

- `ManagedGitHubOnboardingTests`: 9/9
- `ActivationHandoffModelTests`: 17/17
- `ProductionBoundaryContractTests`: 9/9
- `GitHubBrokerClientTests`: 10/10
- `bash -n apps/neondiff-desktop/script/build_and_run.sh`
- `git diff --check`
- `npm run check:secrets`: clean (777 tracked files)

An unsigned release-class source bundle also proved the exact three Info.plist values. Its Mach-O is ad hoc/linker-signed, has no Team ID, and is not a release artifact.

## Explicit non-goals

- No production broker enablement, credential provisioning, App privacy claim, or live OAuth callback proof.
- No checkout/billing enablement or live activation canary.
- No live dry run or App-authored review.
- No launchd mutation, signing, notarization, prerelease, publication, or customer-readiness claim.
- No closure of #630, #517, or the broader #519-#523 matrices.
- No claim that generic CLI status/deactivate, daemon admission, or review token consumption is fully migrated.

## Proof boundary

This PR proves source composition and focused fixture behavior only. It does not prove production wiring, signed distribution, beta readiness, or release. The server broker remains disabled, and the official App privacy conversion remains unverified.
