### PR TITLE
fix(github): authorize existing App installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,14 @@ Create or install the GitHub App before expecting PR reviews to run. The App
 must be installed on the same selected repositories listed in `pilotRepos`; see
 [docs/github-app-setup.md](docs/github-app-setup.md) for the permission set and
 selected-repo install path. The rollout-disabled managed desktop path uses the
-broker-issued GitHub App install/OAuth URL and a device-signed completion poll;
-it never falls back to a user token. Legacy direct-install builds still use
-device flow and the public client ID.
+broker-issued GitHub App install/OAuth URL and keeps polling its device-bound
+completion state while authorization is pending. A fresh installation callback
+wins without asking the customer to authorize twice. If the official App was
+already installed and GitHub therefore sends no install callback, the verified
+managed build uses its compiled public App client ID to show Device Flow as a
+transient installation-access proof. That user token stays in process memory
+only for the authorization window and is never a review credential. Legacy
+direct-install builds still read their public client ID from local config.
 
 Do not store the GitHub App private key, provider API key, license key, tokens,
 or customer data in this repository. Keep local config, secrets, state DBs, and

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -182,6 +182,51 @@ struct OnboardingWizardView: View {
                 }
             }
 
+            if let code = model.githubAuthorizationCode,
+               model.managedGitHubConnectionState == .awaitingAuthorization {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Authorize the existing App installation")
+                        .font(.subheadline.weight(.semibold))
+                    Text(code.userCode)
+                        .font(NeonDiffTheme.commandFont)
+                        .textSelection(.enabled)
+                        .accessibilityIdentifier("neondiff-onboarding-github-device-code")
+                    HStack(spacing: 10) {
+                        Button("Copy Code") { model.copyGitHubUserCode() }
+                        Button("Open GitHub") { model.openGitHubDeviceVerification() }
+                    }
+                    Text("This user authorization proves installation access only. NeonDiff never stores it or uses it to post reviews; review credentials remain GitHub App installation tokens.")
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            if !model.managedGitHubInstallationCandidates.isEmpty {
+                Text("Choose the App installation to bind")
+                    .font(.subheadline.weight(.semibold))
+                ForEach(model.managedGitHubInstallationCandidates) { candidate in
+                    Button {
+                        model.selectManagedGitHubInstallation(
+                            installationId: candidate.installationId
+                        )
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(candidate.account)
+                                Text("Installation \(candidate.installationId) · \(candidate.repositoryCount) accessible repositories")
+                                    .font(.caption)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier(
+                        "neondiff-onboarding-github-installation-\(candidate.installationId)"
+                    )
+                }
+            }
+
             if !model.managedGitHubRepositories.isEmpty {
                 Text("Choose one server-bound repository")
                     .font(.subheadline.weight(.semibold))

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -318,7 +318,7 @@ struct ReposView: View {
                     }
                 }
 
-                Text("The paid-beta path uses the server broker and Keychain-backed device identity. It does not fall back to a user access token. Repository scope and visibility are accepted only from the verified GitHub App binding.")
+                Text("The paid-beta path uses the server broker and Keychain-backed device identity. Existing installations may use a transient GitHub user authorization only to prove the selected installation; it is never stored or used to post reviews. Repository scope, visibility, and review credentials come only from the verified GitHub App binding.")
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -335,6 +335,50 @@ struct ReposView: View {
                         }
                         .disabled(model.isManagedGitHubConnectionInProgress)
                         .accessibilityIdentifier("neondiff-managed-github-recovery")
+                    }
+                }
+
+                if let code = model.githubAuthorizationCode,
+                   model.managedGitHubConnectionState == .awaitingAuthorization {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Authorize existing installation")
+                            .font(.subheadline.weight(.semibold))
+                        Text(code.userCode)
+                            .font(NeonDiffTheme.commandFont)
+                            .textSelection(.enabled)
+                            .accessibilityIdentifier("neondiff-managed-github-device-code")
+                        HStack(spacing: 10) {
+                            Button("Copy Code") { model.copyGitHubUserCode() }
+                            Button("Open GitHub") { model.openGitHubDeviceVerification() }
+                        }
+                    }
+                }
+
+                if !model.managedGitHubInstallationCandidates.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Choose the App installation to bind")
+                            .font(.subheadline.weight(.semibold))
+                        ForEach(model.managedGitHubInstallationCandidates) { candidate in
+                            Button {
+                                model.selectManagedGitHubInstallation(
+                                    installationId: candidate.installationId
+                                )
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(candidate.account)
+                                        Text("Installation \(candidate.installationId) · \(candidate.repositoryCount) repositories")
+                                            .font(.caption)
+                                    }
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier(
+                                "neondiff-managed-github-installation-\(candidate.installationId)"
+                            )
+                        }
                     }
                 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -4,18 +4,22 @@ import NeonDiffDesktopCore
 package struct DesktopProductionBoundary: Sendable {
     package let nativeActivationBrokerVerified: Bool
     package let managedGitHubBrokerOrigin: URL?
+    package let managedGitHubAppClientID: String?
 
     package static let quarantined = DesktopProductionBoundary(
         nativeActivationBrokerVerified: false,
-        managedGitHubBrokerOrigin: nil
+        managedGitHubBrokerOrigin: nil,
+        managedGitHubAppClientID: nil
     )
     package static let testVerified = DesktopProductionBoundary(
         nativeActivationBrokerVerified: true,
-        managedGitHubBrokerOrigin: nil
+        managedGitHubBrokerOrigin: nil,
+        managedGitHubAppClientID: nil
     )
     package static let testManaged = DesktopProductionBoundary(
         nativeActivationBrokerVerified: true,
-        managedGitHubBrokerOrigin: approvedManagedGitHubBrokerOrigin
+        managedGitHubBrokerOrigin: approvedManagedGitHubBrokerOrigin,
+        managedGitHubAppClientID: "fixture-client-id"
     )
 
     package static func resolve(infoDictionary: [String: Any]) -> DesktopProductionBoundary {
@@ -29,7 +33,8 @@ package struct DesktopProductionBoundary: Sendable {
         }
         return DesktopProductionBoundary(
             nativeActivationBrokerVerified: true,
-            managedGitHubBrokerOrigin: origin
+            managedGitHubBrokerOrigin: origin,
+            managedGitHubAppClientID: approvedManagedGitHubAppClientID
         )
     }
 }
@@ -37,6 +42,7 @@ package struct DesktopProductionBoundary: Sendable {
 private let approvedManagedGitHubBrokerOrigin = URL(
     string: "https://neondiff-license.fly.dev"
 )!
+private let approvedManagedGitHubAppClientID = "Iv23liNr6jOVuCFC7DkN"
 
 package struct DesktopAppDependencies {
     package let clipboard: any DesktopClipboard

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1144,9 +1144,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 case .bound(let callbackInstallationId):
                     boundInstallationId = callbackInstallationId
                 case .pending:
-                    boundInstallationId = try await broker.authorizeExistingInstallation(
+                    boundInstallationId = try await authorizeExistingInstallationWithReplayReadback(
+                        broker: broker,
                         identity: pending.identity,
-                        state: pending.connection.state,
+                        connection: pending.connection,
                         installationId: installationId,
                         userAccessToken: pending.userAccessToken
                     )
@@ -2326,9 +2327,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     case .bound(let callbackInstallationId):
                         return callbackInstallationId
                     case .pending:
-                        return try await broker.authorizeExistingInstallation(
+                        return try await authorizeExistingInstallationWithReplayReadback(
+                            broker: broker,
                             identity: identity,
-                            state: connection.state,
+                            connection: connection,
                             installationId: candidate.installationId,
                             userAccessToken: token.accessToken
                         )
@@ -2347,6 +2349,38 @@ package final class NeonDiffDesktopModel: ObservableObject {
             }
         }
         throw ManagedGitHubModelError.authorizationExpired
+    }
+
+    private func authorizeExistingInstallationWithReplayReadback(
+        broker: any GitHubBrokerConnecting,
+        identity: GitHubBrokerDeviceIdentity,
+        connection: GitHubBrokerConnection,
+        installationId: Int,
+        userAccessToken: String
+    ) async throws -> Int {
+        do {
+            return try await broker.authorizeExistingInstallation(
+                identity: identity,
+                state: connection.state,
+                installationId: installationId,
+                userAccessToken: userAccessToken
+            )
+        } catch let error as GitHubBrokerClientError
+            where error == .server(reason: .stateReplayed) {
+            // The browser callback can consume the one-shot state after the
+            // pre-submit completion poll but before this request wins its store
+            // race. Resolve that one exact ambiguity with one authoritative,
+            // device-authenticated readback; never retry or resubmit the token.
+            switch try await broker.completeConnection(
+                identity: identity,
+                state: connection.state
+            ) {
+            case .bound(let callbackInstallationId):
+                return callbackInstallationId
+            case .pending:
+                throw error
+            }
+        }
     }
 
     private func loadManagedGitHubRepositories(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -65,8 +65,16 @@ package enum ManagedGitHubConnectionState: Equatable, Sendable {
     case verificationRequired
     case connecting
     case awaitingAuthorization
+    case installationSelectionRequired
     case bound(installationId: Int)
     case failed
+}
+
+package struct ManagedGitHubInstallationCandidate: Identifiable, Equatable, Sendable {
+    package var id: Int { installationId }
+    package let installationId: Int
+    package let account: String
+    package let repositoryCount: Int
 }
 
 @MainActor
@@ -114,6 +122,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var isGitHubRepositoryRefreshInProgress = false
     @Published package var managedGitHubConnectionState: ManagedGitHubConnectionState = .quarantined
     @Published package var managedGitHubRepositories: [GitHubBrokerRepository] = []
+    @Published package var managedGitHubInstallationCandidates: [ManagedGitHubInstallationCandidate] = []
     @Published package var selectedManagedGitHubRepository: String?
     @Published package var managedGitHubRecovery: GitHubConnectionRecovery?
     @Published package var isManagedGitHubConnectionInProgress = false
@@ -208,6 +217,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "Creating Keychain-backed device binding"
         case .awaitingAuthorization:
             "Waiting for GitHub authorization"
+        case .installationSelectionRequired:
+            "Choose an authorized App installation"
         case .bound(let installationId):
             "Server binding verified · installation \(installationId)"
         case .failed:
@@ -250,6 +261,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var githubAuthorizationTask: Task<Void, Never>?
     private var githubRepositoryRefreshTask: Task<Void, Never>?
     private var managedGitHubConnectionTask: Task<Void, Never>?
+    private var pendingManagedGitHubAuthorization: PendingManagedGitHubAuthorization?
     private var githubRepositoryRefreshGate = GitHubLatestRequestGate()
     private var controlCenterLoadedSnapshot: DesktopControlCenterSnapshot?
     private var controlCenterRollbackSnapshot: DesktopControlCenterSnapshot?
@@ -1044,6 +1056,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubConnectionState = .connecting
         managedGitHubRecovery = nil
         managedGitHubRepositories = []
+        managedGitHubInstallationCandidates = []
+        pendingManagedGitHubAuthorization = nil
+        githubAuthorizationCode = nil
         selectedManagedGitHubRepository = nil
         lastError = nil
 
@@ -1064,12 +1079,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 }
                 managedGitHubConnectionState = .awaitingAuthorization
                 logText = "GitHub App installation opened. Complete authorization in GitHub; NeonDiff is waiting for the server binding."
-
-                let installationId = try await awaitManagedGitHubBinding(
-                    broker: broker,
+                let installationId: Int
+                switch try await broker.completeConnection(
                     identity: identity,
-                    connection: connection
-                )
+                    state: connection.state
+                ) {
+                case .bound(let callbackInstallationId):
+                    installationId = callbackInstallationId
+                case .pending:
+                    guard let existingInstallationId = try await authorizeExistingManagedGitHubInstallation(
+                        broker: broker,
+                        identity: identity,
+                        connection: connection
+                    ) else {
+                        return
+                    }
+                    installationId = existingInstallationId
+                }
                 dependencies.preferences.set(
                     String(installationId),
                     forKey: managedGitHubInstallationIdKey
@@ -1081,6 +1107,63 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 )
             } catch {
                 guard !Task.isCancelled else { return }
+                applyManagedGitHubFailure(error)
+            }
+        }
+    }
+
+    package func selectManagedGitHubInstallation(installationId: Int) {
+        guard managedGitHubConnectionState == .installationSelectionRequired,
+              !isManagedGitHubConnectionInProgress,
+              let broker = dependencies.githubBroker,
+              let pending = pendingManagedGitHubAuthorization,
+              pending.candidates.contains(where: { $0.installationId == installationId })
+        else {
+            lastError = "Choose one of the GitHub App installations verified for this authorization."
+            return
+        }
+
+        isManagedGitHubConnectionInProgress = true
+        managedGitHubConnectionState = .connecting
+        managedGitHubRecovery = nil
+        lastError = nil
+        managedGitHubConnectionTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                pendingManagedGitHubAuthorization = nil
+                githubAuthorizationCode = nil
+                isManagedGitHubConnectionInProgress = false
+                managedGitHubConnectionTask = nil
+            }
+            do {
+                let boundInstallationId: Int
+                switch try await broker.completeConnection(
+                    identity: pending.identity,
+                    state: pending.connection.state
+                ) {
+                case .bound(let callbackInstallationId):
+                    boundInstallationId = callbackInstallationId
+                case .pending:
+                    boundInstallationId = try await broker.authorizeExistingInstallation(
+                        identity: pending.identity,
+                        state: pending.connection.state,
+                        installationId: installationId,
+                        userAccessToken: pending.userAccessToken
+                    )
+                }
+                managedGitHubInstallationCandidates = []
+                dependencies.preferences.set(
+                    String(boundInstallationId),
+                    forKey: managedGitHubInstallationIdKey
+                )
+                try await loadManagedGitHubRepositories(
+                    broker: broker,
+                    identity: pending.identity,
+                    installationId: boundInstallationId
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                managedGitHubInstallationCandidates = []
                 applyManagedGitHubFailure(error)
             }
         }
@@ -2181,20 +2264,86 @@ package final class NeonDiffDesktopModel: ObservableObject {
         logText = recovery.message
     }
 
-    private func awaitManagedGitHubBinding(
+    private func authorizeExistingManagedGitHubInstallation(
         broker: any GitHubBrokerConnecting,
         identity: GitHubBrokerDeviceIdentity,
         connection: GitHubBrokerConnection
-    ) async throws -> Int {
-        while !Task.isCancelled && dependencies.clock.now < connection.expiresAt {
-            switch try await broker.completeConnection(
-                identity: identity,
-                state: connection.state
+    ) async throws -> Int? {
+        guard let clientId = github.clientId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !clientId.isEmpty
+        else {
+            throw ManagedGitHubModelError.clientIdMissing
+        }
+        let code = try await dependencies.githubAuthenticator.requestDeviceCode(clientId: clientId)
+        guard !Task.isCancelled else { return nil }
+        githubAuthorizationCode = code
+        managedGitHubConnectionState = .awaitingAuthorization
+        logText = "Authorize NeonDiff at \(code.verificationURI.absoluteString) with code \(code.userCode). The user token is transient proof only; reviews use the GitHub App."
+
+        var intervalSeconds = code.intervalSeconds
+        while !Task.isCancelled,
+              dependencies.clock.now < code.expiresAt,
+              dependencies.clock.now < connection.expiresAt {
+            try await dependencies.clock.sleep(for: .seconds(max(1, intervalSeconds)))
+            switch try await dependencies.githubAuthenticator.pollDeviceAuthorization(
+                clientId: clientId,
+                deviceCode: code.deviceCode
             ) {
-            case .bound(let installationId):
-                return installationId
-            case .pending:
-                try await dependencies.clock.sleep(for: .seconds(2))
+            case .pending(let nextInterval):
+                intervalSeconds = max(1, nextInterval)
+                managedGitHubConnectionState = .awaitingAuthorization
+            case .failed(let error, let description):
+                throw GitHubDeviceAuthClientError.actionable(
+                    GitHubConnectionRecoveryClassifier.deviceAuthorizationFailure(
+                        error,
+                        description: description
+                    )
+                )
+            case .authorized(let token):
+                let discovered = try await dependencies.githubAuthenticator.listAccessibleRepositories(
+                    accessToken: token.accessToken
+                )
+                let grouped = Dictionary(grouping: discovered, by: \.installationId)
+                let candidates: [ManagedGitHubInstallationCandidate] = grouped.compactMap { element -> ManagedGitHubInstallationCandidate? in
+                    let installationId = element.key
+                    let repositories = element.value
+                    guard let first = repositories.first else { return nil }
+                    return ManagedGitHubInstallationCandidate(
+                        installationId: installationId,
+                        account: first.installationAccount,
+                        repositoryCount: Set(repositories.map(\.fullName)).count
+                    )
+                }.sorted { $0.installationId < $1.installationId }
+                guard !candidates.isEmpty else {
+                    throw ManagedGitHubModelError.noAuthorizedInstallations
+                }
+                githubAuthorizationCode = nil
+                if candidates.count == 1, let candidate = candidates.first {
+                    switch try await broker.completeConnection(
+                        identity: identity,
+                        state: connection.state
+                    ) {
+                    case .bound(let callbackInstallationId):
+                        return callbackInstallationId
+                    case .pending:
+                        return try await broker.authorizeExistingInstallation(
+                            identity: identity,
+                            state: connection.state,
+                            installationId: candidate.installationId,
+                            userAccessToken: token.accessToken
+                        )
+                    }
+                }
+                pendingManagedGitHubAuthorization = PendingManagedGitHubAuthorization(
+                    identity: identity,
+                    connection: connection,
+                    userAccessToken: token.accessToken,
+                    candidates: candidates
+                )
+                managedGitHubInstallationCandidates = candidates
+                managedGitHubConnectionState = .installationSelectionRequired
+                logText = "Choose the GitHub App installation to bind. NeonDiff will send the transient authorization proof only after that explicit choice."
+                return nil
             }
         }
         throw ManagedGitHubModelError.authorizationExpired
@@ -2243,6 +2392,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func applyManagedGitHubFailure(_ error: Error) {
         invalidateManagedRepoApplicationProof()
+        pendingManagedGitHubAuthorization = nil
+        managedGitHubInstallationCandidates = []
+        githubAuthorizationCode = nil
         managedGitHubConnectionState = .failed
         managedGitHubRepositories = []
         selectedManagedGitHubRepository = nil
@@ -2846,7 +2998,9 @@ private let managedGitHubInstallationIdKey = "neondiff.managedGitHubInstallation
 
 private enum ManagedGitHubModelError: Error {
     case installPageOpenFailed
+    case clientIdMissing
     case authorizationExpired
+    case noAuthorizedInstallations
     case noBoundRepositories
 
     var recovery: GitHubConnectionRecovery {
@@ -2857,11 +3011,23 @@ private enum ManagedGitHubModelError: Error {
                 message: "NeonDiff could not open the GitHub App installation page. No repository binding was granted.",
                 action: .retry
             )
+        case .clientIdMissing:
+            GitHubConnectionRecovery(
+                status: "GitHub client ID missing",
+                message: "Load a configuration containing the official public GitHub App client ID before connecting.",
+                action: .retry
+            )
         case .authorizationExpired:
             GitHubConnectionRecovery(
                 status: "GitHub authorization expired",
                 message: "GitHub authorization expired before the server binding completed. Start a new connection.",
                 action: .reconnect
+            )
+        case .noAuthorizedInstallations:
+            GitHubConnectionRecovery(
+                status: "no authorized App installation",
+                message: "GitHub authorization succeeded, but no selected NeonDiff App repositories are accessible. Install or manage the App, then reconnect.",
+                action: .installOrManageApp
             )
         case .noBoundRepositories:
             GitHubConnectionRecovery(
@@ -2871,6 +3037,13 @@ private enum ManagedGitHubModelError: Error {
             )
         }
     }
+}
+
+private struct PendingManagedGitHubAuthorization {
+    let identity: GitHubBrokerDeviceIdentity
+    let connection: GitHubBrokerConnection
+    let userAccessToken: String
+    let candidates: [ManagedGitHubInstallationCandidate]
 }
 
 private func isValidRepoName(_ value: String) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2270,7 +2270,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         identity: GitHubBrokerDeviceIdentity,
         connection: GitHubBrokerConnection
     ) async throws -> Int? {
-        guard let clientId = github.clientId?.trimmingCharacters(in: .whitespacesAndNewlines),
+        guard let clientId = dependencies.productionBoundary.managedGitHubAppClientID?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
               !clientId.isEmpty
         else {
             throw ManagedGitHubModelError.clientIdMissing
@@ -2286,6 +2287,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
               dependencies.clock.now < code.expiresAt,
               dependencies.clock.now < connection.expiresAt {
             try await dependencies.clock.sleep(for: .seconds(max(1, intervalSeconds)))
+            switch try await broker.completeConnection(
+                identity: identity,
+                state: connection.state
+            ) {
+            case .bound(let callbackInstallationId):
+                return callbackInstallationId
+            case .pending:
+                break
+            }
             switch try await dependencies.githubAuthenticator.pollDeviceAuthorization(
                 clientId: clientId,
                 deviceCode: code.deviceCode
@@ -3047,8 +3057,8 @@ private enum ManagedGitHubModelError: Error {
             )
         case .clientIdMissing:
             GitHubConnectionRecovery(
-                status: "GitHub client ID missing",
-                message: "Load a configuration containing the official public GitHub App client ID before connecting.",
+                status: "GitHub App client ID unavailable",
+                message: "This build is missing the official public GitHub App client ID required for managed authorization. Install a verified NeonDiff beta build before reconnecting.",
                 action: .retry
             )
         case .authorizationExpired:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -410,6 +410,12 @@ public protocol GitHubBrokerConnecting: Sendable {
         identity: GitHubBrokerDeviceIdentity,
         state: String
     ) async throws -> GitHubBrokerConnectionCompletion
+    func authorizeExistingInstallation(
+        identity: GitHubBrokerDeviceIdentity,
+        state: String,
+        installationId: Int,
+        userAccessToken: String
+    ) async throws -> Int
     func listRepositories(
         identity: GitHubBrokerDeviceIdentity,
         installationId: Int,
@@ -531,6 +537,35 @@ public struct GitHubBrokerClient: GitHubBrokerConnecting, Sendable {
         default:
             throw GitHubBrokerClientError.invalidResponse
         }
+    }
+
+    public func authorizeExistingInstallation(
+        identity: GitHubBrokerDeviceIdentity,
+        state: String,
+        installationId: Int,
+        userAccessToken: String
+    ) async throws -> Int {
+        guard Self.isOpaqueState(state),
+              installationId > 0,
+              userAccessToken.isEmpty == false,
+              userAccessToken.utf8.count <= 4_096,
+              userAccessToken.rangeOfCharacter(from: .whitespacesAndNewlines) == nil
+        else {
+            throw GitHubBrokerClientError.invalidRequest
+        }
+        let response: AuthorizeExistingResponse = try await post(
+            path: "/github/connect/authorize-existing",
+            body: [
+                "state": state,
+                "installationId": installationId,
+                "userAccessToken": userAccessToken
+            ],
+            credential: try identity.makeCredential(now: now())
+        )
+        guard response.status == "bound", response.installationId == installationId else {
+            throw GitHubBrokerClientError.identityMismatch
+        }
+        return response.installationId
     }
 
     public func listRepositories(
@@ -761,6 +796,11 @@ private struct StartResponse: Decodable {
 private struct CompleteResponse: Decodable {
     let status: String
     let installationId: Int?
+}
+
+private struct AuthorizeExistingResponse: Decodable {
+    let status: String
+    let installationId: Int
 }
 
 private struct RepositoryPageResponse: Decodable {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -167,6 +167,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         ])
         #expect(valid.nativeActivationBrokerVerified)
         #expect(valid.managedGitHubBrokerOrigin?.absoluteString == "https://neondiff-license.fly.dev")
+        #expect(valid.managedGitHubAppClientID == "Iv23liNr6jOVuCFC7DkN")
 
         for invalid in [
             [
@@ -245,8 +246,6 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             githubBroker: broker,
             productionBoundary: .testManaged
         )
-        fixture.loadConfig()
-
         fixture.model.startManagedGitHubConnection()
         await fixture.waitForManagedGitHubConnectionToFinish()
 
@@ -264,18 +263,10 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let broker = ScriptedGitHubBroker(
             completionResults: [.pending, .bound(installationId: 42)]
         )
-        let transientToken = "fixture-raced-callback-user-proof"
         let authenticator = ScriptedGitHubAuthenticator(
             pollResults: [
-                .authorized(GitHubUserToken(accessToken: transientToken))
-            ],
-            repositories: [
-                GitHubDiscoveredRepository(
-                    fullName: "electric/public",
-                    visibility: "public",
-                    installationId: 42,
-                    installationAccount: "electric"
-                )
+                .pending(intervalSeconds: 2),
+                .failed(error: .accessDenied, description: "device authorization should not be required")
             ]
         )
         let fixture = ModelDependencyFixture(
@@ -290,13 +281,13 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
 
         #expect(broker.completedStates == ["fixture-state", "fixture-state"])
         #expect(broker.authorizedInstallationIds.isEmpty)
+        #expect(authenticator.pollDeviceCodes.isEmpty)
         #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
-        #expect(fixture.secretStore.values.values.contains(transientToken) == false)
     }
 
     @Test func callbackThatConsumesStateDuringSingleInstallSubmitConvergesByOneReadback() async throws {
         let broker = ScriptedGitHubBroker(
-            completionResults: [.pending, .pending, .bound(installationId: 42)],
+            completionResults: [.pending, .pending, .pending, .bound(installationId: 42)],
             authorizationError: .server(reason: .stateReplayed)
         )
         let authenticator = ScriptedGitHubAuthenticator(
@@ -322,7 +313,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         fixture.model.startManagedGitHubConnection()
         await fixture.waitForManagedGitHubConnectionToFinish()
 
-        #expect(broker.completedStates == ["fixture-state", "fixture-state", "fixture-state"])
+        #expect(broker.completedStates == ["fixture-state", "fixture-state", "fixture-state", "fixture-state"])
         #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
     }
 
@@ -374,7 +365,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
 
     @Test func callbackThatConsumesStateDuringExplicitSelectionSubmitConvergesByOneReadback() async throws {
         let broker = ScriptedGitHubBroker(
-            completionResults: [.pending, .pending, .bound(installationId: 43)],
+            completionResults: [.pending, .pending, .pending, .bound(installationId: 43)],
             authorizationError: .server(reason: .stateReplayed)
         )
         let authenticator = ScriptedGitHubAuthenticator(
@@ -410,7 +401,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         fixture.model.selectManagedGitHubInstallation(installationId: 43)
         await fixture.waitForManagedGitHubConnectionToFinish()
 
-        #expect(broker.completedStates == ["fixture-state", "fixture-state", "fixture-state"])
+        #expect(broker.completedStates == ["fixture-state", "fixture-state", "fixture-state", "fixture-state"])
         #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 43))
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -28,6 +28,9 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
         var registeredDeviceIds: [String] = []
         var startedDeviceIds: [String] = []
         var completedStates: [String] = []
+        var authorizedStates: [String] = []
+        var authorizedInstallationIds: [Int] = []
+        var authorizationTokens: [String] = []
         var listedInstallationIds: [Int] = []
     }
 
@@ -63,6 +66,9 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
     var registeredDeviceIds: [String] { state.read(\.registeredDeviceIds) }
     var startedDeviceIds: [String] { state.read(\.startedDeviceIds) }
     var completedStates: [String] { state.read(\.completedStates) }
+    var authorizedStates: [String] { state.read(\.authorizedStates) }
+    var authorizedInstallationIds: [Int] { state.read(\.authorizedInstallationIds) }
+    var authorizationTokens: [String] { state.read(\.authorizationTokens) }
     var listedInstallationIds: [Int] { state.read(\.listedInstallationIds) }
 
     func register(identity: GitHubBrokerDeviceIdentity) async throws {
@@ -87,6 +93,21 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
         }
     }
 
+    func authorizeExistingInstallation(
+        identity: GitHubBrokerDeviceIdentity,
+        state opaqueState: String,
+        installationId: Int,
+        userAccessToken: String
+    ) async throws -> Int {
+        try throwIfNeeded()
+        return state.update {
+            $0.authorizedStates.append(opaqueState)
+            $0.authorizedInstallationIds.append(installationId)
+            $0.authorizationTokens.append(userAccessToken)
+            return installationId
+        }
+    }
+
     func listRepositories(
         identity: GitHubBrokerDeviceIdentity,
         installationId: Int,
@@ -95,7 +116,13 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
         try throwIfNeeded()
         return state.update {
             $0.listedInstallationIds.append(installationId)
-            return $0.repositoryPages.removeFirst()
+            let page = $0.repositoryPages.removeFirst()
+            return GitHubBrokerRepositoryPage(
+                installationId: installationId,
+                page: page.page,
+                repositories: page.repositories,
+                nextPage: page.nextPage
+            )
         }
     }
 
@@ -184,6 +211,127 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             "electric/public"
         ])
         #expect(fixture.secretStore.containsSecret(account: GitHubBrokerDeviceIdentityStore.defaultAccount))
+    }
+
+    @Test func alreadyInstalledAppUsesTransientDeviceFlowProofWithoutStoringUserToken() async throws {
+        let broker = ScriptedGitHubBroker(
+            completionResults: [.pending],
+            repositories: [
+                GitHubBrokerRepository(fullName: "electric/public", visibility: .public)
+            ]
+        )
+        let transientToken = "fixture-managed-transient-user-proof"
+        let authenticator = ScriptedGitHubAuthenticator(
+            pollResults: [
+                .authorized(GitHubUserToken(accessToken: transientToken))
+            ],
+            repositories: [
+                GitHubDiscoveredRepository(
+                    fullName: "electric/public",
+                    visibility: "public",
+                    installationId: 42,
+                    installationAccount: "electric"
+                )
+            ]
+        )
+        let fixture = ModelDependencyFixture(
+            githubAuthenticator: authenticator,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.loadConfig()
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(authenticator.requestedClientIds == ["fixture-client-id"])
+        #expect(authenticator.listedAccessTokens == [transientToken])
+        #expect(broker.authorizedStates == ["fixture-state"])
+        #expect(broker.authorizedInstallationIds == [42])
+        #expect(broker.authorizationTokens == [transientToken])
+        #expect(broker.listedInstallationIds == [42])
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
+        #expect(fixture.secretStore.values.values.contains(transientToken) == false)
+    }
+
+    @Test func installCallbackThatLandsDuringDeviceFlowWinsWithoutReplayFailure() async throws {
+        let broker = ScriptedGitHubBroker(
+            completionResults: [.pending, .bound(installationId: 42)]
+        )
+        let transientToken = "fixture-raced-callback-user-proof"
+        let authenticator = ScriptedGitHubAuthenticator(
+            pollResults: [
+                .authorized(GitHubUserToken(accessToken: transientToken))
+            ],
+            repositories: [
+                GitHubDiscoveredRepository(
+                    fullName: "electric/public",
+                    visibility: "public",
+                    installationId: 42,
+                    installationAccount: "electric"
+                )
+            ]
+        )
+        let fixture = ModelDependencyFixture(
+            githubAuthenticator: authenticator,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.loadConfig()
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(broker.completedStates == ["fixture-state", "fixture-state"])
+        #expect(broker.authorizedInstallationIds.isEmpty)
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
+        #expect(fixture.secretStore.values.values.contains(transientToken) == false)
+    }
+
+    @Test func multipleExistingInstallationsRequireExplicitSelectionBeforeBinding() async throws {
+        let broker = ScriptedGitHubBroker(completionResults: [.pending])
+        let transientToken = "fixture-multi-install-user-proof"
+        let authenticator = ScriptedGitHubAuthenticator(
+            pollResults: [
+                .authorized(GitHubUserToken(accessToken: transientToken))
+            ],
+            repositories: [
+                GitHubDiscoveredRepository(
+                    fullName: "electric/public",
+                    visibility: "public",
+                    installationId: 42,
+                    installationAccount: "electric"
+                ),
+                GitHubDiscoveredRepository(
+                    fullName: "other/private",
+                    visibility: "private",
+                    installationId: 43,
+                    installationAccount: "other"
+                )
+            ]
+        )
+        let fixture = ModelDependencyFixture(
+            githubAuthenticator: authenticator,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.loadConfig()
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(fixture.model.managedGitHubConnectionState == .installationSelectionRequired)
+        #expect(fixture.model.managedGitHubInstallationCandidates.map(\.installationId) == [42, 43])
+        #expect(broker.authorizedInstallationIds.isEmpty)
+        #expect(fixture.secretStore.values.values.contains(transientToken) == false)
+
+        fixture.model.selectManagedGitHubInstallation(installationId: 43)
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(broker.authorizedInstallationIds == [43])
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 43))
+        #expect(fixture.model.managedGitHubInstallationCandidates.isEmpty)
+        #expect(fixture.secretStore.values.values.contains(transientToken) == false)
     }
 
     @Test func authoritativeVisibilityControlsPublicFreeAndPrivateActivationEntry() async {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -25,6 +25,7 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
         var completionResults: [GitHubBrokerConnectionCompletion]
         var repositoryPages: [GitHubBrokerRepositoryPage]
         var error: GitHubBrokerClientError?
+        var authorizationError: GitHubBrokerClientError?
         var registeredDeviceIds: [String] = []
         var startedDeviceIds: [String] = []
         var completedStates: [String] = []
@@ -42,7 +43,8 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
         repositories: [GitHubBrokerRepository] = [
             GitHubBrokerRepository(fullName: "electric/public", visibility: .public)
         ],
-        error: GitHubBrokerClientError? = nil
+        error: GitHubBrokerClientError? = nil,
+        authorizationError: GitHubBrokerClientError? = nil
     ) {
         connection = GitHubBrokerConnection(
             installURL: URL(string: "https://github.com/apps/neondiff/installations/new?state=fixture-state")!,
@@ -59,7 +61,8 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
                     nextPage: nil
                 )
             ],
-            error: error
+            error: error,
+            authorizationError: authorizationError
         ))
     }
 
@@ -100,6 +103,9 @@ final class ScriptedGitHubBroker: GitHubBrokerConnecting, @unchecked Sendable {
         userAccessToken: String
     ) async throws -> Int {
         try throwIfNeeded()
+        if let error = state.read(\.authorizationError) {
+            throw error
+        }
         return state.update {
             $0.authorizedStates.append(opaqueState)
             $0.authorizedInstallationIds.append(installationId)
@@ -288,6 +294,38 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.secretStore.values.values.contains(transientToken) == false)
     }
 
+    @Test func callbackThatConsumesStateDuringSingleInstallSubmitConvergesByOneReadback() async throws {
+        let broker = ScriptedGitHubBroker(
+            completionResults: [.pending, .pending, .bound(installationId: 42)],
+            authorizationError: .server(reason: .stateReplayed)
+        )
+        let authenticator = ScriptedGitHubAuthenticator(
+            pollResults: [
+                .authorized(GitHubUserToken(accessToken: "fixture-submit-race-proof"))
+            ],
+            repositories: [
+                GitHubDiscoveredRepository(
+                    fullName: "electric/public",
+                    visibility: "public",
+                    installationId: 42,
+                    installationAccount: "electric"
+                )
+            ]
+        )
+        let fixture = ModelDependencyFixture(
+            githubAuthenticator: authenticator,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.loadConfig()
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(broker.completedStates == ["fixture-state", "fixture-state", "fixture-state"])
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 42))
+    }
+
     @Test func multipleExistingInstallationsRequireExplicitSelectionBeforeBinding() async throws {
         let broker = ScriptedGitHubBroker(completionResults: [.pending])
         let transientToken = "fixture-multi-install-user-proof"
@@ -332,6 +370,48 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 43))
         #expect(fixture.model.managedGitHubInstallationCandidates.isEmpty)
         #expect(fixture.secretStore.values.values.contains(transientToken) == false)
+    }
+
+    @Test func callbackThatConsumesStateDuringExplicitSelectionSubmitConvergesByOneReadback() async throws {
+        let broker = ScriptedGitHubBroker(
+            completionResults: [.pending, .pending, .bound(installationId: 43)],
+            authorizationError: .server(reason: .stateReplayed)
+        )
+        let authenticator = ScriptedGitHubAuthenticator(
+            pollResults: [
+                .authorized(GitHubUserToken(accessToken: "fixture-selection-race-proof"))
+            ],
+            repositories: [
+                GitHubDiscoveredRepository(
+                    fullName: "electric/public",
+                    visibility: "public",
+                    installationId: 42,
+                    installationAccount: "electric"
+                ),
+                GitHubDiscoveredRepository(
+                    fullName: "other/private",
+                    visibility: "private",
+                    installationId: 43,
+                    installationAccount: "other"
+                )
+            ]
+        )
+        let fixture = ModelDependencyFixture(
+            githubAuthenticator: authenticator,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        fixture.loadConfig()
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        #expect(fixture.model.managedGitHubConnectionState == .installationSelectionRequired)
+
+        fixture.model.selectManagedGitHubInstallation(installationId: 43)
+        await fixture.waitForManagedGitHubConnectionToFinish()
+
+        #expect(broker.completedStates == ["fixture-state", "fixture-state", "fixture-state"])
+        #expect(fixture.model.managedGitHubConnectionState == .bound(installationId: 43))
     }
 
     @Test func authoritativeVisibilityControlsPublicFreeAndPrivateActivationEntry() async {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
@@ -229,6 +229,41 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         #expect(repositoryRequest["page"] as? Int == 1)
     }
 
+    @Test func brokerClientAuthorizesAnExistingInstallationWithDeviceBoundState() async throws {
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: BrokerMemorySecretStore()
+        ).loadOrCreate()
+        let transport = ScriptedBrokerTransport(responses: [
+            .json(
+                url: "https://broker.example/github/connect/authorize-existing",
+                body: ["status": "bound", "installationId": 4242]
+            )
+        ])
+        let client = try GitHubBrokerClient(
+            baseURL: URL(string: "https://broker.example")!,
+            transport: transport,
+            now: { Date(timeIntervalSince1970: 1_800_000_000) }
+        )
+
+        let installationId = try await client.authorizeExistingInstallation(
+            identity: identity,
+            state: "opaque-device-state",
+            installationId: 4242,
+            userAccessToken: "fixture-transient-user-proof"
+        )
+        #expect(installationId == 4242)
+
+        let request = try #require(await transport.requests.first)
+        #expect(request.url.absoluteString == "https://broker.example/github/connect/authorize-existing")
+        #expect(request.headers["Authorization"]?.hasPrefix("Bearer ey") == true)
+        let body = try #require(
+            JSONSerialization.jsonObject(with: request.body) as? [String: Any]
+        )
+        #expect(body["state"] as? String == "opaque-device-state")
+        #expect(body["installationId"] as? Int == 4242)
+        #expect(body["userAccessToken"] as? String == "fixture-transient-user-proof")
+    }
+
     @Test func brokerClientRejectsMalformedRepositoryPages() async throws {
         let identity = try GitHubBrokerDeviceIdentityStore(
             secretStore: BrokerMemorySecretStore()

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -112,10 +112,16 @@ export NEONDIFF_GITHUB_APP_CLIENT_ID="<github-app-client-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
 
-For the Mac desktop Repos pane, copy the GitHub App client ID into
-`github.clientId` or `NEONDIFF_GITHUB_APP_CLIENT_ID`, and enable device flow in
-the GitHub App settings. Without that optional feature, GitHub will return
-`device_flow_disabled` when the desktop tries to show a user authorization code.
+For legacy/direct Mac desktop builds, copy the GitHub App client ID into
+`github.clientId` or `NEONDIFF_GITHUB_APP_CLIENT_ID`. A verified managed beta
+build instead carries the official App's public client ID in its production
+boundary, so first-run does not depend on loading CLI config. Enable Device Flow
+in the official App settings: when GitHub does not rerun OAuth-during-install
+for an existing installation, the native app uses Device Flow only as transient
+installation-access proof. It continues polling the broker during that window,
+so a fresh-install callback wins without a second authorization. If Device Flow
+is disabled, GitHub returns `device_flow_disabled` and the existing-install path
+fails closed.
 
 ## 3. Configure Provider And License
 
@@ -222,6 +228,12 @@ client:
 - `NeonDiffPaidBetaContract = paid-mac-beta-v1`
 - `NeonDiffManagedGitHubBrokerEnabled = true`
 - `NeonDiffGitHubBrokerOrigin = https://neondiff-license.fly.dev`
+
+After that exact bundle contract passes, the managed production boundary also
+supplies the compiled official GitHub App public client ID. It is public
+metadata, not a secret, and it is unavailable to quarantined/debug composition.
+This lets native first-run authorize an already-installed App without requiring
+a prior CLI `config inspect`; it does not enable the server kill switch.
 
 `apps/neondiff-desktop/script/build_and_run.sh` accepts those values only for a
 release build and only through the exact matching

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -76,9 +76,16 @@ canary gates pass, so this source contract is not production-wiring proof.
 When an exact release-bundle contract enables the managed source path, the
 native app creates its P-256 identity only on explicit Connect, opens the
 broker-issued GitHub install URL, polls the device-bound completion endpoint,
-and accepts repository names/visibility only from the broker readback. A saved
-installation id is a routing hint only and cannot unlock onboarding until a
-fresh server repository read succeeds. Manual repository names and the legacy
+and accepts repository names/visibility only from the broker readback. The app
+continues polling completion while any existing-install Device Flow prompt is
+pending, so a fresh OAuth-during-install callback wins without a second user
+authorization. If GitHub routes a pre-existing installation to configuration
+without a callback, the verified build uses its compiled official public App
+client ID for Device Flow. The resulting user token is transient proof for the
+exact selected installation only; it stays in process memory until an explicit
+installation choice, is then cleared, and is never used to post a review. A
+saved installation id is a routing hint only and cannot unlock onboarding until
+a fresh server repository read succeeds. Manual repository names and the legacy
 user-token discovery path are disabled in managed mode. Generic CLI
 status/deactivate and daemon-admission validation still require exact-candidate
 integration proof under #630.
@@ -230,6 +237,12 @@ To remove NeonDiff from a user or organization:
   treating the repo as install-proven.
 - `activeRepoChecks` is zero: the config has no enabled repo to prove; add a
   selected installed repo to `pilotRepos`.
+- A managed first run shows `GitHub App client ID unavailable`: the bundle is
+  missing the verified paid-beta production boundary. Install the exact signed
+  beta artifact; do not paste a user token or private key into the app.
+- A pre-existing App installation remains pending: confirm Device Flow is
+  enabled on the official App, then use the native code prompt. Fresh installs
+  should complete through the broker callback without a second authorization.
 - Private repo review fails before provider calls: check license status before
   widening GitHub permissions or changing provider settings.
 - App-authored comments do not appear: verify the live command used App

--- a/docs/security/github-app-broker.md
+++ b/docs/security/github-app-broker.md
@@ -81,6 +81,21 @@ the license store's strict schema verification is unaffected.
    authorization) — is acknowledged with the neutral return page and binds nothing,
    so legitimate updates are never locked out; any *other* code-less callback fails
    closed with `installation_authorization_unverified`.
+   **Already-installed App path.** GitHub does not rerun OAuth-during-install when
+   the user selects an installation that already exists. If the first completion
+   poll remains pending, the native app therefore uses the official App's Device
+   Flow to obtain a transient user access token, enumerates the App installations
+   that identity can access, and requires an explicit installation choice when
+   more than one is available. It then calls device-authenticated
+   `POST /github/connect/authorize-existing` with the original one-shot state, the
+   chosen installation id, and that transient proof. The broker verifies the
+   token against `GET /user/installations/{id}/repositories` **before** resolving
+   the App installation, consumes the same state exactly once, and records the
+   same repository-scoped binding as the callback path. The user token exists only
+   in process memory for this authorization window: it is never persisted,
+   logged, reflected, minted from, or used to post a review. A second completion
+   readback wins if the browser callback lands concurrently, avoiding a false
+   replay failure.
 5. **Return (native to broker).** The app confirms the binding at
    `POST /github/connect/complete` with its device credential and the original
    `state`. See "Return path" for why this is a device poll rather than a
@@ -130,12 +145,13 @@ signature against the stored public key and rejects expired or wrong-subject
 tokens.
 
 The GitHub installation flow is the proof of repository authority, but the
-one-shot state nonce alone is NOT sufficient: it binds the returning browser
-session to the initiating device, yet it does not prove the returning identity
-actually owns the installation id in the callback. So the callback additionally
-requires an **install-time OAuth authorization code** and verifies, via the
-exchanged user identity, that the user can access the requested installation
-before recording any binding (#614, P1). Membership alone
+one-shot state nonce alone is NOT sufficient: it binds the authorization to the
+initiating device, yet it does not prove the returning identity actually owns the
+installation id. A new installation therefore requires an **install-time OAuth
+authorization code**. An existing installation uses a transient Device Flow user
+token plus the device credential and the same one-shot state. Both paths verify,
+via the user identity, that the user can access the requested installation before
+recording any binding (#614, P1). Membership alone
 (`GET /user/installations`) does **not** prove access to every repository in an
 installation — an org install can list for a user who can reach only some of its
 repos. The broker therefore uses `GET /user/installations/{id}/repositories` to
@@ -144,10 +160,10 @@ binding to it; a later `POST /github/token` for any repo outside that set fails
 closed with `repo_outside_authorization`, so an entitled but GitHub-unauthorized
 user can never mint a token for a private repo they cannot access on GitHub. A
 device therefore obtains tokens only for installations — and repositories — whose
-access it proved at callback time — a valid state plus an arbitrary victim installation id binds
-nothing. Enabling OAuth-during-install and provisioning the OAuth client
-credentials is OWNER-GATED (see the staging-registration spec); until then the
-callback fails closed with `installation_authorization_unverified`.
+access it proved at bind time — a valid state plus an arbitrary victim installation
+id binds nothing. Enabling OAuth-during-install and provisioning the OAuth client
+credentials is OWNER-GATED (see the staging-registration spec); until then the new
+installation callback fails closed with `installation_authorization_unverified`.
 
 The authorized repository set is a **bind-time snapshot** — the short-lived user
 OAuth token is deliberately not persisted, so the set is not re-verified on every
@@ -170,8 +186,10 @@ code therefore has nothing to redirect into.
 **v1 decision:** the return is a **device poll**. After the browser callback
 records the binding, the app calls `POST /github/connect/complete` with its device
 credential and the original `state`; the broker returns `pending` until the
-callback lands and `bound` (with the installation id) afterward. No completion
-secret crosses the browser-to-app boundary, so there is no code to intercept.
+callback lands and `bound` (with the installation id) afterward. A pending result
+also activates the documented Device Flow path for an already-installed App. The
+client rechecks completion before submitting that proof so a concurrently landed
+callback wins. No completion secret crosses the browser-to-app boundary.
 
 If #612 adds a registered URL scheme, an optional completion-code redirect can be
 layered on top of the same one-shot state without changing this contract. This is
@@ -179,8 +197,10 @@ a design decision surfaced for #612, not an assumption.
 
 ## Failure and abuse states (typed, all fail closed)
 
-Every failure is a typed reason code; none falls back to a user OAuth token or an
-embedded key (see Rollback in issue #613).
+Every failure is a typed reason code; none uses a user OAuth token as a review
+credential or falls back to an embedded key (see Rollback in issue #613). The
+existing-install route accepts a user token only as transient installation-access
+proof and never persists or returns it.
 
 - `device_not_registered`, `invalid_device_credential` — device auth failures.
 - `state_not_found`, `state_expired`, `state_replayed` — one-shot connect-state
@@ -191,10 +211,9 @@ embedded key (see Rollback in issue #613).
   (discovered at issuance time; there are no webhooks in v1, so uninstall surfaces
   at the next token request or poll failure).
 - `installation_suspended` — the installation is suspended.
-- `installation_authorization_unverified` — the callback did not prove the
-  returning identity owns the installation (missing/invalid install-time OAuth
-  code, or OAuth-during-install not yet provisioned); fail closed, no binding
-  (HTTP 403, #614 P1).
+- `installation_authorization_unverified` — neither the callback nor the
+  existing-install Device Flow proof established that the returning identity can
+  access the exact installation; fail closed, no binding (HTTP 403, #614 P1).
 - `repo_outside_installation` — a requested repo is not in the installation's
   current selection (AC4).
 - `repo_outside_authorization` — a requested repo is in the installation but

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -71,6 +71,16 @@ export interface GitHubInstallationClient {
     installationId: number,
     authorizationCode: string
   ): Promise<string[] | null>;
+  /**
+   * Verify an already-installed App from a transient GitHub App user access
+   * token obtained through Device Flow. The token proves only that the user can
+   * access this exact installation and yields the exact authorized repository
+   * set. It is never persisted, logged, returned, or used to post a review.
+   */
+  verifyInstallationForUserToken(
+    installationId: number,
+    userAccessToken: string
+  ): Promise<string[] | null>;
   /** The installation's current repository selection, with each repo's visibility. */
   listInstallationRepositories(installationId: number): Promise<InstallationRepository[]>;
   /**
@@ -182,6 +192,28 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
     return { token: result.json.token, expires_at: result.json.expires_at };
   }
 
+  async function authorizedRepositoriesForUserToken(
+    installationId: number,
+    userToken: string
+  ): Promise<string[] | null> {
+    const authorized: string[] = [];
+    for (let page = 1; ; page += 1) {
+      let result;
+      try {
+        result = await request<{ repositories?: Array<{ full_name: string }> }>(
+          `/user/installations/${installationId}/repositories?per_page=100&page=${page}`,
+          { token: userToken }
+        );
+      } catch (error) {
+        if (error instanceof GitHubApiStatusError && (error.status === 404 || error.status === 403)) return null;
+        throw error;
+      }
+      const chunk = result.json?.repositories ?? [];
+      for (const repository of chunk) authorized.push(repository.full_name);
+      if (chunk.length < 100) return authorized;
+    }
+  }
+
   return {
     async getInstallation(installationId: number): Promise<InstallationSummary | null> {
       const jwt = createAppJwt(config.appId, config.privateKey);
@@ -253,27 +285,13 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
       // A bad/expired/forged code yields no user token: deny the binding (not a
       // transient error — the identity was not proven).
       if (!userToken) return null;
-      // Enumerate the repositories the authenticated user can access WITHIN this
-      // installation (not just installation membership). The binding is scoped to
-      // this authorized set, so a later token can never reach a private repo the
-      // connecting user cannot access on GitHub. A 404 means the user cannot access
-      // the installation at all -> identity unverified for it (null, fail closed).
-      const authorized: string[] = [];
-      for (let page = 1; ; page += 1) {
-        let result;
-        try {
-          result = await request<{ repositories?: Array<{ full_name: string }> }>(
-            `/user/installations/${installationId}/repositories?per_page=100&page=${page}`,
-            { token: userToken }
-          );
-        } catch (error) {
-          if (error instanceof GitHubApiStatusError && (error.status === 404 || error.status === 403)) return null;
-          throw error;
-        }
-        const chunk = result.json?.repositories ?? [];
-        for (const repository of chunk) authorized.push(repository.full_name);
-        if (chunk.length < 100) return authorized;
-      }
+      return authorizedRepositoriesForUserToken(installationId, userToken);
+    },
+    async verifyInstallationForUserToken(
+      installationId: number,
+      userAccessToken: string
+    ): Promise<string[] | null> {
+      return authorizedRepositoriesForUserToken(installationId, userAccessToken);
     },
     async listInstallationRepositories(installationId: number): Promise<InstallationRepository[]> {
       // Listing an installation's repositories requires an installation token. It is

--- a/services/license-api/src/github-broker/github-app.ts
+++ b/services/license-api/src/github-broker/github-app.ts
@@ -205,7 +205,12 @@ export function createGitHubInstallationClient(config: GitHubAppConfig): GitHubI
           { token: userToken }
         );
       } catch (error) {
-        if (error instanceof GitHubApiStatusError && (error.status === 404 || error.status === 403)) return null;
+        if (
+          error instanceof GitHubApiStatusError
+          && (error.status === 401 || error.status === 403 || error.status === 404)
+        ) {
+          return null;
+        }
         throw error;
       }
       const chunk = result.json?.repositories ?? [];

--- a/services/license-api/src/github-broker/routes.ts
+++ b/services/license-api/src/github-broker/routes.ts
@@ -10,6 +10,7 @@ const BROKER_PATHS = new Set([
   "/device/register",
   "/github/connect/start",
   "/github/connect/callback",
+  "/github/connect/authorize-existing",
   "/github/connect/complete",
   "/github/repositories",
   "/github/token"
@@ -70,6 +71,13 @@ export async function handleGitHubBrokerRequest(
     if (req.method === "GET" && path === "/github/connect/callback") {
       const { html } = await service.connectCallback(new URLSearchParams(rawQuery ?? ""));
       return writeHtml(res, 200, html);
+    }
+    if (req.method === "POST" && path === "/github/connect/authorize-existing") {
+      return writeJson(
+        res,
+        200,
+        await service.connectAuthorizeExisting(req.headers.authorization, await readBody(req))
+      );
     }
     if (req.method === "POST" && path === "/github/connect/complete") {
       return writeJson(res, 200, await service.connectComplete(req.headers.authorization, await readBody(req)));

--- a/services/license-api/src/github-broker/service.ts
+++ b/services/license-api/src/github-broker/service.ts
@@ -21,6 +21,7 @@ const MAX_REPOSITORIES_PER_REQUEST = 50;
 const REPOSITORY_PAGE_SIZE = 50;
 const MAX_REPOSITORY_PAGE = 200;
 const MAX_DISCOVERABLE_REPOSITORIES = REPOSITORY_PAGE_SIZE * MAX_REPOSITORY_PAGE;
+const MAX_USER_ACCESS_TOKEN_LENGTH = 4_096;
 
 /**
  * The server-defined minimal review permission set (matches
@@ -238,6 +239,67 @@ export class GitHubBrokerService {
       );
     }
     return authorized;
+  }
+
+  /**
+   * POST /github/connect/authorize-existing — device-authenticated fallback for
+   * an App that is already installed, where GitHub will not rerun the
+   * OAuth-during-install callback. A transient Device Flow user token is used
+   * only to prove access to the exact installation and derive its authorized
+   * repository set. The token is never stored, logged, reflected, or reused for
+   * review work; App installation tokens remain the only review credential.
+   */
+  async connectAuthorizeExisting(
+    authorization: string | string[] | undefined,
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    if (!this.connectRateLimiter.allow(hashKey(`connect-existing:${deviceId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many existing-install authorization attempts");
+    }
+    const { state, installationId, userAccessToken } = parseExistingAuthorizationRequest(body);
+    const stored = this.store.getConnectState(state);
+    if (!stored || stored.device_id !== deviceId) {
+      throw new BrokerError("state_not_found", "connect state is not recognized");
+    }
+    if (stored.consumed_at) {
+      throw new BrokerError("state_replayed", "connect state was already used");
+    }
+    if (Date.parse(stored.expires_at) <= at.getTime()) {
+      throw new BrokerError("state_expired", "connect state has expired");
+    }
+
+    let authorizedRepositories: string[] | null;
+    try {
+      // Identity proof deliberately precedes App-JWT installation resolution,
+      // preserving the callback path's anti-probing order.
+      authorizedRepositories = await this.githubClient.verifyInstallationForUserToken(
+        installationId,
+        userAccessToken
+      );
+    } catch (error) {
+      throw mapClientError(error);
+    }
+    if (authorizedRepositories === null) {
+      throw new BrokerError(
+        "installation_authorization_unverified",
+        "installation authorization could not be verified for this identity"
+      );
+    }
+
+    const installation = await this.resolveInstallation(installationId);
+    if (!this.store.consumeConnectState(state, installationId, at.toISOString())) {
+      throw new BrokerError("state_replayed", "connect state was already used");
+    }
+    this.store.upsertBinding(
+      deviceId,
+      installationId,
+      installation.account_login,
+      authorizedRepositories,
+      at.toISOString()
+    );
+    return { status: "bound", installationId };
   }
 
   /** POST /github/connect/complete — device polls to confirm the binding landed. */
@@ -570,6 +632,32 @@ function parseTokenRequest(body: unknown): {
     repositories,
     ...(permissions ? { permissions } : {}),
     ...(activationKey ? { activationKey } : {})
+  };
+}
+
+function parseExistingAuthorizationRequest(body: unknown): {
+  state: string;
+  installationId: number;
+  userAccessToken: string;
+} {
+  const record = asObject(body);
+  const state = record.state;
+  const userAccessToken = record.userAccessToken;
+  if (typeof state !== "string" || state.length === 0 || state.length > 512) {
+    throw new BrokerError("invalid_request", "state is invalid");
+  }
+  if (
+    typeof userAccessToken !== "string"
+    || userAccessToken.length === 0
+    || userAccessToken.length > MAX_USER_ACCESS_TOKEN_LENGTH
+    || /\s/.test(userAccessToken)
+  ) {
+    throw new BrokerError("invalid_request", "userAccessToken is invalid");
+  }
+  return {
+    state,
+    installationId: parseInstallationId(record.installationId),
+    userAccessToken
   };
 }
 

--- a/services/license-api/test/github-broker-binding-identity.test.ts
+++ b/services/license-api/test/github-broker-binding-identity.test.ts
@@ -8,6 +8,7 @@ import {
   post,
   registerDevice,
   startBroker,
+  userAccessTokenFor,
   type FakeInstallation
 } from "./github-broker-support.ts";
 
@@ -218,6 +219,112 @@ describe("github broker callback install-binding identity (#620 P1)", () => {
       );
       assert.equal(allowed.status, 200, allowed.text);
       assert.equal(allowed.json.token, harness.mintedToken);
+    } finally {
+      harness.close();
+    }
+  });
+});
+
+describe("github broker existing-install device authorization (#613)", () => {
+  it("binds an already-installed App only after device and user proofs agree on the installation", async () => {
+    const harness = await startBroker({ installations: [VICTIM] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await device.sign()));
+      const state = start.json.state as string;
+
+      const authorized = await post(
+        harness.url,
+        "/github/connect/authorize-existing",
+        {
+          state,
+          installationId: VICTIM.id,
+          userAccessToken: userAccessTokenFor(VICTIM.id)
+        },
+        bearer(await device.sign())
+      );
+      assert.equal(authorized.status, 200, authorized.text);
+      assert.deepEqual(authorized.json, { status: "bound", installationId: VICTIM.id });
+
+      const token = await post(
+        harness.url,
+        "/github/token",
+        { installationId: VICTIM.id, repositories: ["victim-org/site"] },
+        bearer(await device.sign())
+      );
+      assert.equal(token.status, 200, token.text);
+      assert.equal(token.json.token, harness.mintedToken);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("rejects a proof for another installation before resolving the target and never reflects it", async () => {
+    const harness = await startBroker({ installations: [VICTIM, ATTACKER] });
+    try {
+      const device = await makeDevice();
+      await registerDevice(harness.url, device);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await device.sign()));
+      harness.calls.length = 0;
+      const state = start.json.state as string;
+      const proof = userAccessTokenFor(ATTACKER.id);
+
+      const refused = await post(
+        harness.url,
+        "/github/connect/authorize-existing",
+        { state, installationId: VICTIM.id, userAccessToken: proof },
+        bearer(await device.sign())
+      );
+      assert.equal(refused.status, 403, refused.text);
+      assert.equal(refused.json.reason, "installation_authorization_unverified");
+      assert.equal(refused.text.includes(proof), false);
+      assert.equal(harness.calls.some((call) => call.op === "getInstallation"), false);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("binds state to the registered device and consumes it exactly once", async () => {
+    const harness = await startBroker({ installations: [VICTIM] });
+    try {
+      const owner = await makeDevice();
+      const other = await makeDevice();
+      await registerDevice(harness.url, owner);
+      await registerDevice(harness.url, other);
+      const start = await post(harness.url, "/github/connect/start", {}, bearer(await owner.sign()));
+      const state = start.json.state as string;
+      const body = {
+        state,
+        installationId: VICTIM.id,
+        userAccessToken: userAccessTokenFor(VICTIM.id)
+      };
+
+      const crossed = await post(
+        harness.url,
+        "/github/connect/authorize-existing",
+        body,
+        bearer(await other.sign())
+      );
+      assert.equal(crossed.status, 404, crossed.text);
+      assert.equal(crossed.json.reason, "state_not_found");
+
+      const first = await post(
+        harness.url,
+        "/github/connect/authorize-existing",
+        body,
+        bearer(await owner.sign())
+      );
+      assert.equal(first.status, 200, first.text);
+
+      const replay = await post(
+        harness.url,
+        "/github/connect/authorize-existing",
+        body,
+        bearer(await owner.sign())
+      );
+      assert.equal(replay.status, 409, replay.text);
+      assert.equal(replay.json.reason, "state_replayed");
     } finally {
       harness.close();
     }

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -146,6 +146,25 @@ describe("production github installation client wire contract", () => {
     assert.ok(!exchange?.url.includes("//login/oauth"), exchange?.url);
   });
 
+  it("verifies an existing installation from a transient Device Flow user token without an OAuth exchange", async () => {
+    const captured = stubFetch((request) => {
+      if (request.url.includes("/user/installations/6001/repositories")) {
+        return { json: { repositories: [{ full_name: "octo/site" }] } };
+      }
+      return { json: {} };
+    });
+    const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
+
+    assert.deepEqual(
+      await client.verifyInstallationForUserToken(6001, "transient-device-user-proof"),
+      ["octo/site"]
+    );
+    assert.equal(captured.length, 1);
+    assert.ok(captured[0].url.includes("/user/installations/6001/repositories"));
+    assert.equal(captured.some((request) => request.url.includes("/login/oauth/access_token")), false);
+    assert.equal(JSON.stringify(captured).includes("transient-device-user-proof"), false);
+  });
+
   it("paginates /user/installations/{id}/repositories so the authorized set spans every page", async () => {
     const page1 = Array.from({ length: 100 }, (_, i) => ({ full_name: `octo/repo-${i}` }));
     const captured = stubFetch((request) => {

--- a/services/license-api/test/github-broker-client.test.ts
+++ b/services/license-api/test/github-broker-client.test.ts
@@ -165,6 +165,18 @@ describe("production github installation client wire contract", () => {
     assert.equal(JSON.stringify(captured).includes("transient-device-user-proof"), false);
   });
 
+  it("treats a rejected transient Device Flow user token as unverified authorization", async () => {
+    stubFetch((request) => {
+      if (request.url.includes("/user/installations/6001/repositories")) {
+        return { status: 401, json: { message: "Bad credentials" } };
+      }
+      return { json: {} };
+    });
+    const client = createGitHubInstallationClient({ appId: "123", privateKey: appPrivateKey });
+
+    assert.equal(await client.verifyInstallationForUserToken(6001, "expired-device-user-proof"), null);
+  });
+
   it("paginates /user/installations/{id}/repositories so the authorized set spans every page", async () => {
     const page1 = Array.from({ length: 100 }, (_, i) => ({ full_name: `octo/repo-${i}` }));
     const captured = stubFetch((request) => {

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -32,6 +32,11 @@ export function authorizationCodeFor(installationId: number): string {
   return `oauth-code-${installationId}`;
 }
 
+/** Fixture-only Device Flow proof for one exact installation. */
+export function userAccessTokenFor(installationId: number): string {
+  return `device-user-proof-${installationId}`;
+}
+
 /** A device identity mirroring the client: keypair + RFC 7638 thumbprint id. */
 export interface TestDevice {
   deviceId: string;
@@ -86,7 +91,11 @@ export interface FakeInstallation {
 }
 
 export interface FakeGitHubCall {
-  op: "getInstallation" | "listInstallationRepositories" | "createInstallationAccessToken";
+  op:
+    | "getInstallation"
+    | "verifyInstallationForUserToken"
+    | "listInstallationRepositories"
+    | "createInstallationAccessToken";
   installationId: number;
   params?: unknown;
 }
@@ -164,6 +173,15 @@ export function fakeGitHubClient(
       // yields the repositories the user can access in the installation (the
       // authorized set the binding is scoped to) — all installation repos by default.
       if (code !== authorizationCodeFor(installationId)) return null;
+      const installation = byId.get(installationId);
+      if (!installation || installation.missing) return null;
+      return installation.userRepositories ?? installation.repositories.map((repository) => repository.full_name);
+    },
+    async verifyInstallationForUserToken(installationId: number, userAccessToken: string) {
+      // Record only that the proof seam ran. The transient user credential is
+      // deliberately excluded from test call ledgers, mirroring production.
+      calls.push({ op: "verifyInstallationForUserToken", installationId });
+      if (userAccessToken !== userAccessTokenFor(installationId)) return null;
       const installation = byId.get(installationId);
       if (!installation || installation.missing) return null;
       return installation.userRepositories ?? installation.repositories.map((repository) => repository.full_name);


### PR DESCRIPTION
## What Problem This Solves

Related to #613.

GitHub does not rerun OAuth-during-install for a pre-existing App installation, so the paid-beta managed path could remain pending forever after a customer selected an already-installed App.

## User Impact

A customer can preserve the existing official App installation and authorize it from native NeonDiff. Multiple accessible App installations require an explicit choice. Review authorship remains the NeonDiff GitHub App.

## Implementation Notes

- Adds device-authenticated `POST /github/connect/authorize-existing`.
- Uses a transient GitHub App Device Flow user token only to prove access to the exact installation and derive its authoritative repository set.
- Never persists, logs, reflects, mints, or posts reviews with the transient user token.
- Preserves one-shot state/device binding; cross-install proof fails before App installation resolution.
- Treats GitHub 401/403/404 proof rejection as the same fail-closed unverified-authorization denial.
- Adds native device-code UX and explicit multi-install selection.
- Keeps device-authenticated callback completion polling active while Device Flow is pending, so a fresh installation callback wins without a second authorization.
- Uses the verified production boundary public App client ID for managed first-run; no loaded CLI config is required.
- Converges the callback/device-flow submit race with one authoritative completion readback only after `state_replayed`; there is no retry or resubmission.
- Updates README, setup, GitHub App, security, and threat/data-flow documentation.

## Bounded Acceptance Criteria

- An existing App installation can be authorized without uninstall/reinstall.
- A fresh install callback that lands during Device Flow wins without a second authorization.
- Managed first-run can start with the verified public App client ID and no loaded CLI config.
- The transient user token is proof-only; the App installation token remains the only review credential.
- State, device, installation, and repository scope remain exact and fail closed.
- Multiple installations require explicit native selection.
- Callback races before and during authorization converge on authoritative server state.
- Rejected proof and unknown/failure states remain typed terminal failures.

## Explicit Non-goals

- No GitHub App permission or repository-selection change.
- No uninstall/reinstall requirement.
- No entitlement relaxation, billing, signing, website implementation, or release work.
- Public website onboarding copy remains owned by `electricsheephq/neon-diff-agent-website#52`; this PR makes no public-funnel or public first-run claim.
- No production deployment, broker enablement, live token issuance, or live App-authored review.
- This PR does not close broader #613.

## Validation

Failing-first coverage captured the unknown server route/client API, both callback race windows, rejected Device Flow proof classification, missing production-bound client ID, and loss of callback polling before implementation.

- `services/license-api: npm run build`
- `node --import tsx --test test/github-broker-*.test.ts`: 116/116
- `swift test --filter 'GitHubBrokerClientTests|ManagedGitHubOnboardingTests'`: 31/31
- `npm run check:secrets`
- `npm run check:design-source`
- `npm run check:public-claims`
- `git diff --check`
- Broad validation is delegated to canonical remote CI.

## Review Disposition

One bounded independent specification/security/accessibility/design review found a current callback-during-submit race. The fix added a single device-authenticated completion readback on `state_replayed`; a delta-only review cleared that change.

Repository review then found three reproduced current-scope defects: GitHub 401 proof classification, loss of fresh callback polling during Device Flow, and managed first-run dependence on loaded CLI config. Those are fixed through exact head `0f8009f06ba0b13fb9114e87a10c6660aa8ba19d`. Required in-repo onboarding documentation is updated. Website copy remains the separately tracked #52 publication gate. Test-only and theoretical defense-in-depth requests have terminal thread dispositions; no additional general review pass is requested.

## Proof Boundary

This proves only the source and focused-test contract at exact head `0f8009f06ba0b13fb9114e87a10c6660aa8ba19d`.

It does **not** prove production deployment or wiring, a live binding/repository list/token/App-authored review, private-repository entitlement, website publication, a signed artifact, paid beta, release, or customer readiness.

## Safety

- [x] Keychain-only secret invariants remain intact.
- [x] Authoritative GitHub repository binding remains server-verified.
- [x] Review issuance still uses only an App installation token.
- [x] Fail-closed state/device/installation checks are covered.
- [x] No credentials, tokens, or live configuration are committed.
- [x] No deploy, config/secret change, broker enablement, canary mutation, signing, publishing, or release was performed.
- [x] Agent-authored.