### PR TITLE
ci(neondiff): smoke Release-configuration desktop bundle

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -48,7 +48,8 @@ jobs:
         run: script/build_and_run.sh release-bundle-check
 
       - name: Enforce release-only fixture boundary
-        run: test ! -e dist/NeonDiffDesktop.app/Contents/Helpers/NeonDiffDesktopFixtureResolve
+        working-directory: .
+        run: npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiffDesktop.app
 
       - name: Package unsigned app bundle and metadata
         env:

--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -41,11 +41,14 @@ jobs:
       - name: Run desktop appcast checks
         run: swift run NeonDiffDesktopAppcastChecks
 
-      - name: Build unsigned app bundle
-        run: script/build_and_run.sh build
+      - name: Build unsigned Release app bundle
+        run: script/build_and_run.sh release-build
 
-      - name: Check unsigned app bundle
-        run: script/build_and_run.sh bundle-check
+      - name: Check unsigned Release app bundle
+        run: script/build_and_run.sh release-bundle-check
+
+      - name: Enforce release-only fixture boundary
+        run: test ! -e dist/NeonDiffDesktop.app/Contents/Helpers/NeonDiffDesktopFixtureResolve
 
       - name: Package unsigned app bundle and metadata
         env:
@@ -54,7 +57,7 @@ jobs:
           NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION: unsigned-desktop-release-smoke
           NEONDIFF_DESKTOP_UI_LAUNCH: "false"
           NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED: "true"
-          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, macOS 15 Keychain contract compilation, appcast checks, bundle structure check, artifact checksum, and metadata only
+          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release Release-configuration app bundle build, macOS 15 Keychain contract compilation, appcast checks, bundle structure and fixture-exclusion checks, artifact checksum, and metadata only
         run: script/release-proof.sh
 
       - name: Upload unsigned app bundle

--- a/apps/neondiff-desktop/docs/desktop-release-smoke.md
+++ b/apps/neondiff-desktop/docs/desktop-release-smoke.md
@@ -1,6 +1,6 @@
 # Desktop Release Smoke
 
-`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, runs `NeonDiffDesktopCoreTests` with explicit nonzero discovery, compiles `NeonDiffDesktopKeychainChecks`, runs the hosted-safe appcast checks, builds the `.app`, validates bundle structure, and uploads the zipped bundle with metadata.
+`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, runs `NeonDiffDesktopCoreTests` with explicit nonzero discovery, compiles `NeonDiffDesktopKeychainChecks`, runs the hosted-safe appcast checks, builds the `.app` in Release configuration, validates bundle structure, verifies that the Debug-only fixture resolver is absent, and uploads the zipped bundle with metadata.
 
 The uploaded bundle is non-release proof. Its metadata marks `release_ready: false`, `customer_ready: false`, and `artifact_classification: unsigned-desktop-release-smoke`, so it is customer-not-ready by design.
 

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -27,7 +27,13 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
         {
           "runs-on"?: string;
           defaults?: { run?: { "working-directory"?: string } };
-          steps?: Array<{ name?: string; uses?: string; run?: string; with?: Record<string, string> }>;
+          steps?: Array<{
+            name?: string;
+            uses?: string;
+            run?: string;
+            with?: Record<string, string>;
+            "working-directory"?: string;
+          }>;
         }
       >;
     };
@@ -48,8 +54,8 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
       "scripts/run-required-swift-test-suite.sh NeonDiffDesktopEvaluationSupportTests",
       "swift build --target NeonDiffDesktopKeychainChecks",
       "swift run NeonDiffDesktopAppcastChecks",
-      "script/build_and_run.sh build",
-      "script/build_and_run.sh bundle-check",
+      "script/build_and_run.sh release-build",
+      "script/build_and_run.sh release-bundle-check",
       "script/release-proof.sh"
     ]) {
       expect(workflow).toContain(command);
@@ -59,6 +65,13 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).not.toContain(retiredCoreChecksTarget);
     expect(workflow).not.toContain("swift run NeonDiffDesktopKeychainChecks");
     expect(workflow).not.toMatch(/Test run with \[1-9\]/);
+    const fixtureBoundaryStep = job?.steps?.find(
+      (step) => step.name === "Enforce release-only fixture boundary"
+    );
+    expect(fixtureBoundaryStep?.["working-directory"]).toBe(".");
+    expect(fixtureBoundaryStep?.run).toBe(
+      "npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiffDesktop.app"
+    );
     expect(workflow).toContain("unsigned");
     expect(workflow).toMatch(/macOS 15 Keychain contract compilation/);
     expect(workflow).toMatch(/persist-credentials:\s*false/);


### PR DESCRIPTION
Related to #449.

## Bounded acceptance criteria

- The unsigned desktop release-smoke lane builds the app in Swift Release configuration.
- The lane validates that Release bundle and fails if the Debug-only `NeonDiffDesktopFixtureResolve` helper is packaged.
- Uploaded metadata continues to classify the artifact as unsigned, not release-ready, not customer-ready, and requiring visual smoke.
- Remote CI produces an immutable artifact whose app binary/configuration and fixture-exclusion boundary can be inspected.

## Failing-first proof

The source contract failed on the base head because the workflow invoked `build`/`bundle-check` and had no fixture-exclusion assertion. The same focused contract now passes with `release-build`, `release-bundle-check`, and the explicit helper absence gate. Workflow YAML parses and `git diff --check` passes.

## Explicit non-goals

- No Developer ID signing, notarization, stapling, installation, launcher, update, rollback, publication, prerelease, beta, or customer-readiness claim.
- No version/build/tag/channel choice.
- No architecture expansion; the hosted macOS runner remains the artifact architecture authority for this smoke.
- No Sparkle/appcast production claim.
- No GitHub App, billing, entitlement, checkout, website, or production-service change.
