### PR TITLE
fix(desktop): make release app bundle signable

### DIFF
--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -73,7 +73,6 @@ fi
 
 RESOURCE_DIR="$(find "$BUILD_DIR" "$ROOT_DIR/.build" \( -name "${APP_NAME}_${APP_NAME}.bundle" -o -name "${APP_NAME}_${APP_NAME}.resources" \) -type d -print -quit 2>/dev/null || true)"
 if [ -n "$RESOURCE_DIR" ]; then
-  ditto "$RESOURCE_DIR" "$APP_BUNDLE/$(basename "$RESOURCE_DIR")"
   ditto "$RESOURCE_DIR" "$APP_RESOURCES/$(basename "$RESOURCE_DIR")"
 fi
 
@@ -169,6 +168,12 @@ case "$MODE" in
     ;;
   --bundle-check|bundle-check|release-bundle-check)
     /usr/bin/plutil -lint "$INFO_PLIST" >/dev/null
+    INVALID_BUNDLE_ROOT_ENTRIES="$(find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents -print)"
+    if [ -n "$INVALID_BUNDLE_ROOT_ENTRIES" ]; then
+      echo "app bundle root may contain only Contents:" >&2
+      echo "$INVALID_BUNDLE_ROOT_ENTRIES" >&2
+      exit 1
+    fi
     otool -L "$APP_BINARY"
     if otool -L "$APP_BINARY" | grep -q "Sparkle.framework"; then
       test -d "$APP_FRAMEWORKS/Sparkle.framework"

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -130,6 +130,18 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(script).not.toMatch(/\b(notarytool|stapler|spctl)\b/);
   });
 
+  it("keeps SwiftPM resources inside Contents so the app bundle can be Developer ID sealed", () => {
+    const bundler = read("apps/neondiff-desktop/script/build_and_run.sh");
+
+    expect(bundler).toContain(
+      'ditto "$RESOURCE_DIR" "$APP_RESOURCES/$(basename "$RESOURCE_DIR")"'
+    );
+    expect(bundler).not.toContain(
+      'ditto "$RESOURCE_DIR" "$APP_BUNDLE/$(basename "$RESOURCE_DIR")"'
+    );
+    expect(bundler).toContain('find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents');
+  });
+
   it("documents the desktop smoke artifact as non-release proof", () => {
     const docPath = "apps/neondiff-desktop/docs/desktop-release-smoke.md";
 


### PR DESCRIPTION
Related to #449.

Acceptance criteria:
- SwiftPM resources are packaged only under Contents/Resources.
- bundle-check rejects any app-root entry other than Contents.
- focused desktop release-pipeline test records the failing-first contract and passes at this head.
- the exact Release bundle passes the repository fixture-boundary scanner and Developer ID sealing before notarization proceeds.

Non-goals:
- no activation, entitlement, broker, billing, provider, UI, Sparkle/appcast, deployment, or publication change;
- no claim that the beta is released, customer-ready, notarized, installed, or update-capable.

Observed RED: exact main 248f645 produced an app-root NeonDiffDesktop_NeonDiffDesktop.bundle and codesign failed with unsealed contents present in the bundle root. The focused test failed before the source fix and now passes 4/4.