### PR TITLE
feat(desktop): add exact B0 BYO release boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ when a release bundle carries the exact `paid-mac-beta-v1` Info.plist contract,
 fixed production broker origin, and explicit broker-enable marker. Those public
 build values are absent by default, so ordinary/debug bundles stay quarantined;
 the server kill switch and every broker/entitlement decision still fail closed.
+The invite-only B0 technical-beta build uses a separate exact
+`paid-mac-beta-byo-v1` release contract with `NeonDiffBYOGitHubEnabled=true` and
+no managed-broker fields. That contract enables the existing local direct/BYO
+path and API-backed native activation without a hidden defaults mutation. It
+does not prove customer-safe private-key custody, a compatible published CLI,
+signing, billing, canaries, or release readiness.
 This source composition is not proof that the production broker is enabled,
 that billing is live, or that a signed customer artifact exists. Generic CLI
 status/deactivate and daemon-admission validation still need exact-candidate

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -3,36 +3,57 @@ import NeonDiffDesktopCore
 
 package struct DesktopProductionBoundary: Sendable {
     package let nativeActivationBrokerVerified: Bool
+    package let byoGitHubEnabled: Bool
     package let managedGitHubBrokerOrigin: URL?
     package let managedGitHubAppClientID: String?
 
     package static let quarantined = DesktopProductionBoundary(
         nativeActivationBrokerVerified: false,
+        byoGitHubEnabled: false,
         managedGitHubBrokerOrigin: nil,
         managedGitHubAppClientID: nil
     )
     package static let testVerified = DesktopProductionBoundary(
         nativeActivationBrokerVerified: true,
+        byoGitHubEnabled: false,
         managedGitHubBrokerOrigin: nil,
         managedGitHubAppClientID: nil
     )
     package static let testManaged = DesktopProductionBoundary(
         nativeActivationBrokerVerified: true,
+        byoGitHubEnabled: false,
         managedGitHubBrokerOrigin: approvedManagedGitHubBrokerOrigin,
         managedGitHubAppClientID: "fixture-client-id"
     )
 
     package static func resolve(infoDictionary: [String: Any]) -> DesktopProductionBoundary {
-        guard infoDictionary["NeonDiffPaidBetaContract"] as? String == "paid-mac-beta-v1",
+        let contract = infoDictionary["NeonDiffPaidBetaContract"] as? String
+        if contract == "paid-mac-beta-byo-v1" {
+            guard infoDictionary["NeonDiffBYOGitHubEnabled"] as? Bool == true,
+                  infoDictionary["NeonDiffManagedGitHubBrokerEnabled"] == nil,
+                  infoDictionary["NeonDiffGitHubBrokerOrigin"] == nil
+            else {
+                return .quarantined
+            }
+            return DesktopProductionBoundary(
+                nativeActivationBrokerVerified: true,
+                byoGitHubEnabled: true,
+                managedGitHubBrokerOrigin: nil,
+                managedGitHubAppClientID: nil
+            )
+        }
+
+        guard contract == "paid-mac-beta-v1",
+              infoDictionary["NeonDiffBYOGitHubEnabled"] == nil,
               infoDictionary["NeonDiffManagedGitHubBrokerEnabled"] as? Bool == true,
               let originText = infoDictionary["NeonDiffGitHubBrokerOrigin"] as? String,
               let origin = URL(string: originText),
-              origin == approvedManagedGitHubBrokerOrigin
-        else {
+              origin == approvedManagedGitHubBrokerOrigin else {
             return .quarantined
         }
         return DesktopProductionBoundary(
             nativeActivationBrokerVerified: true,
+            byoGitHubEnabled: false,
             managedGitHubBrokerOrigin: origin,
             managedGitHubAppClientID: approvedManagedGitHubAppClientID
         )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1571,8 +1571,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         // and activation canaries pass. When enabled, it uses the CLI's explicit
         // no-local-state mode: the app-owned Keychain item remains the only raw
         // credential copy and the key crosses only over bounded stdin.
+        let bundleEnablesActivation = dependencies.productionBoundary.byoGitHubEnabled
+        let rolloutEnablesActivation = dependencies.preferences.bool(forKey: activationCliBackedEnabledKey)
         guard dependencies.productionBoundary.nativeActivationBrokerVerified,
-              dependencies.preferences.bool(forKey: activationCliBackedEnabledKey)
+              bundleEnablesActivation || rolloutEnablesActivation
         else {
             return nil
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1552,6 +1552,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// preserving the existing rollback control for legacy/local builds.
     package var activationHandoffEnabled: Bool {
         managedGitHubAvailable
+            || dependencies.productionBoundary.byoGitHubEnabled
             || dependencies.preferences.bool(forKey: activationHandoffEnabledKey)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -159,15 +159,25 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
 
 @MainActor
 @Suite(.timeLimit(.minutes(1))) struct ManagedGitHubOnboardingTests {
-    @Test func productionBoundaryRequiresExactSignedBuildContract() {
+    @Test func productionBoundaryRequiresExactManagedOrBYOSignedBuildContract() {
         let valid = DesktopProductionBoundary.resolve(infoDictionary: [
             "NeonDiffPaidBetaContract": "paid-mac-beta-v1",
             "NeonDiffManagedGitHubBrokerEnabled": true,
             "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
         ])
         #expect(valid.nativeActivationBrokerVerified)
+        #expect(!valid.byoGitHubEnabled)
         #expect(valid.managedGitHubBrokerOrigin?.absoluteString == "https://neondiff-license.fly.dev")
         #expect(valid.managedGitHubAppClientID == "Iv23liNr6jOVuCFC7DkN")
+
+        let byo = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ])
+        #expect(byo.nativeActivationBrokerVerified)
+        #expect(byo.byoGitHubEnabled)
+        #expect(byo.managedGitHubBrokerOrigin == nil)
+        #expect(byo.managedGitHubAppClientID == nil)
 
         for invalid in [
             [
@@ -184,10 +194,54 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
                 "NeonDiffPaidBetaContract": "paid-mac-beta-v1",
                 "NeonDiffManagedGitHubBrokerEnabled": false,
                 "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
+            ],
+            [
+                "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+                "NeonDiffBYOGitHubEnabled": false
+            ],
+            [
+                "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+                "NeonDiffBYOGitHubEnabled": true,
+                "NeonDiffManagedGitHubBrokerEnabled": true,
+                "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
             ]
         ] {
             #expect(!DesktopProductionBoundary.resolve(infoDictionary: invalid).nativeActivationBrokerVerified)
         }
+    }
+
+    @Test func exactBYOBoundaryEnablesCLIBackedActivationWithoutPreferenceMutation() async throws {
+        let boundary = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ])
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: """
+                {"command":"license activate","ok":true,"status":"active","source":"api",
+                 "checkedAt":"2026-07-20T00:00:00.000Z",
+                 "entitlement":{"status":"active","repoVisibilityScope":"private",
+                 "privateRepoAllowed":true,"updateEntitlement":true}}
+                """,
+                stderr: ""
+            ))],
+            productionBoundary: boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "electric/private", enabled: true)]
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        await fixture.model.submitActivation()
+
+        let call = try #require(fixture.cli.calls.first)
+        #expect(call.standardInput == Data("NDL-BYO-0123456789".utf8))
+        #expect(call.arguments.allSatisfy { !$0.contains("NDL-BYO") })
+        #expect(call.arguments.contains("--persist-local-state"))
+        #expect(call.arguments.contains("--license-machine-id"))
+        #expect(call.arguments.contains("electric/private"))
+        #expect(fixture.model.activationState == .active)
+        #expect(!fixture.preferences.bool(forKey: "neondiff.activationCliBackedValidation"))
     }
 
     @Test func managedConnectUsesBrokerAndKeychainIdentityWithoutLegacyUserTokenFallback() async throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -228,6 +228,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             ))],
             productionBoundary: boundary
         )
+        #expect(fixture.model.activationHandoffEnabled)
         fixture.model.repos = [RepoMonitor(name: "electric/private", enabled: true)]
         fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
         fixture.model.provideExistingActivationKey()

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -42,6 +42,47 @@ SPARKLE_PUBLIC_KEY="${NEONDIFF_SPARKLE_PUBLIC_ED_KEY:-}"
 PAID_BETA_CONTRACT="${NEONDIFF_DESKTOP_PAID_BETA_CONTRACT:-}"
 MANAGED_GITHUB_BROKER_ENABLED="${NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED:-}"
 GITHUB_BROKER_ORIGIN="${NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN:-}"
+BYO_GITHUB_ENABLED="${NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED:-}"
+
+resolve_production_contract_mode() {
+  if [ -z "$PAID_BETA_CONTRACT" ] \
+    && [ -z "$MANAGED_GITHUB_BROKER_ENABLED" ] \
+    && [ -z "$GITHUB_BROKER_ORIGIN" ] \
+    && [ -z "$BYO_GITHUB_ENABLED" ]; then
+    echo "none"
+    return
+  fi
+
+  if [ "$BUILD_CONFIGURATION" != "release" ]; then
+    echo "production configuration is accepted only for release bundles" >&2
+    return 2
+  fi
+
+  if [ "$PAID_BETA_CONTRACT" = "paid-mac-beta-v1" ] \
+    && [ "$MANAGED_GITHUB_BROKER_ENABLED" = "true" ] \
+    && [ "$GITHUB_BROKER_ORIGIN" = "https://neondiff-license.fly.dev" ] \
+    && [ -z "$BYO_GITHUB_ENABLED" ]; then
+    echo "managed"
+    return
+  fi
+
+  if [ "$PAID_BETA_CONTRACT" = "paid-mac-beta-byo-v1" ] \
+    && [ "$BYO_GITHUB_ENABLED" = "true" ] \
+    && [ -z "$MANAGED_GITHUB_BROKER_ENABLED" ] \
+    && [ -z "$GITHUB_BROKER_ORIGIN" ]; then
+    echo "byo"
+    return
+  fi
+
+  echo "production configuration must match exactly one paid beta contract" >&2
+  return 2
+}
+
+PRODUCTION_CONTRACT_MODE="$(resolve_production_contract_mode)"
+if [ "$MODE" = "production-contract-check" ]; then
+  echo "$PRODUCTION_CONTRACT_MODE"
+  exit 0
+fi
 
 if [ -x "$APP_BINARY" ]; then
   while IFS= read -r pid; do
@@ -119,21 +160,17 @@ cat >"$INFO_PLIST" <<PLIST
 </plist>
 PLIST
 
-if [ -n "$PAID_BETA_CONTRACT" ] || [ -n "$MANAGED_GITHUB_BROKER_ENABLED" ] || [ -n "$GITHUB_BROKER_ORIGIN" ]; then
-  if [ "$BUILD_CONFIGURATION" != "release" ]; then
-    echo "managed GitHub production configuration is accepted only for release bundles" >&2
-    exit 2
-  fi
-  if [ "$PAID_BETA_CONTRACT" != "paid-mac-beta-v1" ] \
-    || [ "$MANAGED_GITHUB_BROKER_ENABLED" != "true" ] \
-    || [ "$GITHUB_BROKER_ORIGIN" != "https://neondiff-license.fly.dev" ]; then
-    echo "managed GitHub production configuration must match the exact paid beta contract" >&2
-    exit 2
-  fi
-  /usr/libexec/PlistBuddy -c "Add :NeonDiffPaidBetaContract string $PAID_BETA_CONTRACT" "$INFO_PLIST"
-  /usr/libexec/PlistBuddy -c "Add :NeonDiffManagedGitHubBrokerEnabled bool true" "$INFO_PLIST"
-  /usr/libexec/PlistBuddy -c "Add :NeonDiffGitHubBrokerOrigin string $GITHUB_BROKER_ORIGIN" "$INFO_PLIST"
-fi
+case "$PRODUCTION_CONTRACT_MODE" in
+  managed)
+    /usr/libexec/PlistBuddy -c "Add :NeonDiffPaidBetaContract string $PAID_BETA_CONTRACT" "$INFO_PLIST"
+    /usr/libexec/PlistBuddy -c "Add :NeonDiffManagedGitHubBrokerEnabled bool true" "$INFO_PLIST"
+    /usr/libexec/PlistBuddy -c "Add :NeonDiffGitHubBrokerOrigin string $GITHUB_BROKER_ORIGIN" "$INFO_PLIST"
+    ;;
+  byo)
+    /usr/libexec/PlistBuddy -c "Add :NeonDiffPaidBetaContract string $PAID_BETA_CONTRACT" "$INFO_PLIST"
+    /usr/libexec/PlistBuddy -c "Add :NeonDiffBYOGitHubEnabled bool true" "$INFO_PLIST"
+    ;;
+esac
 
 if [ -n "$SPARKLE_FEED_URL" ] && [ -n "$SPARKLE_PUBLIC_KEY" ]; then
   /usr/libexec/PlistBuddy -c "Add :SUFeedURL string $SPARKLE_FEED_URL" "$INFO_PLIST"

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -246,6 +246,20 @@ public configuration values, not secrets, and do not override the server-side
 kill switch. Generic CLI status/deactivate and daemon-admission validation still
 require exact-candidate integration proof under #630.
 
+The invite-only B0 technical beta has a separate, mutually exclusive release
+bundle contract:
+
+- `NeonDiffPaidBetaContract = paid-mac-beta-byo-v1`
+- `NeonDiffBYOGitHubEnabled = true`
+- no managed-broker enable marker or broker origin
+
+The build inputs are `NEONDIFF_DESKTOP_PAID_BETA_CONTRACT` and
+`NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED`. That exact release-only contract enables
+the existing direct/BYO GitHub path and API-backed native activation without a
+manual UserDefaults rollout mutation. It does not make the managed App path
+available and is not proof that GitHub private-key custody, the compatible CLI
+package, billing, signing, or customer canaries have passed.
+
 ## 4. Check Readiness
 
 Run the GitHub-only doctor first. It verifies App installation visibility and

--- a/tests/desktop-byo-production-contract.test.ts
+++ b/tests/desktop-byo-production-contract.test.ts
@@ -1,0 +1,72 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const script = "apps/neondiff-desktop/script/build_and_run.sh";
+
+function checkContract(overrides: Record<string, string> = {}) {
+  return spawnSync(script, ["production-contract-check"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      HOME: process.env.HOME ?? "/tmp",
+      ...overrides
+    }
+  });
+}
+
+describe("NeonDiff desktop B0 production bundle contract", () => {
+  it("preserves the empty quarantined build and exact managed B1 contract", () => {
+    const empty = checkContract();
+    expect(empty.status).toBe(0);
+    expect(empty.stdout.trim()).toBe("none");
+
+    const managed = checkContract({
+      NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+      NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-v1",
+      NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED: "true",
+      NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN: "https://neondiff-license.fly.dev"
+    });
+    expect(managed.status).toBe(0);
+    expect(managed.stdout.trim()).toBe("managed");
+  });
+
+  it("accepts the exact release-only BYO contract without managed broker fields", () => {
+    const result = checkContract({
+      NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+      NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1",
+      NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true"
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("byo");
+    expect(result.stderr).toBe("");
+  });
+
+  it("rejects debug, partial, and mixed BYO or managed configuration", () => {
+    const invalid = [
+      {
+        NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "debug",
+        NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1",
+        NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true"
+      },
+      {
+        NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+        NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1"
+      },
+      {
+        NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+        NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1",
+        NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true",
+        NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED: "true",
+        NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN: "https://neondiff-license.fly.dev"
+      }
+    ];
+
+    for (const environment of invalid) {
+      const result = checkContract(environment);
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toBe("");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add an exact release-only `paid-mac-beta-byo-v1` desktop bundle contract;
- keep the B0 BYO contract mutually exclusive with the existing managed B1 broker contract;
- enable the existing CLI-backed, API-authoritative native activation adapter from the exact B0 bundle contract without a hidden UserDefaults mutation;
- keep missing, debug, partial, and mixed configuration fail closed;
- document the proof boundary and remaining B0 gates.

## Bounded acceptance criteria

- [x] Exact release B0 configuration resolves to direct/BYO mode with native activation available and no managed broker/client identity.
- [x] Empty/default bundles remain quarantined.
- [x] The exact managed B1 contract remains accepted unchanged.
- [x] Debug, partial, and mixed B0/B1 configuration fails closed.
- [x] Activation key crosses bounded stdin and does not enter argv.
- [x] The unsigned release-configuration bundle contains only `NeonDiffPaidBetaContract=paid-mac-beta-byo-v1` and `NeonDiffBYOGitHubEnabled=true`; managed broker fields are absent.

## Failing-first and local proof

- RED: Swift compilation failed because the B0 boundary did not exist; the build-contract test rejected the exact B0 configuration.
- GREEN: `ManagedGitHubOnboardingTests` — 21/21.
- GREEN: `ProductionBoundaryContractTests` — 11/11.
- GREEN: focused B0 build-contract Vitest — 3/3.
- GREEN: `bash -n`, `git diff --check`, one unsigned release-configuration build, and `release-bundle-check`.

## Explicit non-goals

- No GitHub private-key custody or onboarding UI change.
- No npm publication, signing, notarization, billing replay, checkout enablement, website publication, customer send, or canary.
- No managed-App/#613 architecture change.
- No claim that B0, beta, distribution, or customer readiness is complete.
- Do not close #646 or broader #517/#613/#630.

## Proof boundary

This PR makes a distinct B0 app build possible and removes one hidden clean-Mac activation prerequisite. The prior signed beta.1 artifact remains a B1 managed build and is not B0 evidence. B0 still requires customer-safe BYO GitHub private-key custody, a compatible real CLI distribution, production billing/activation, a rebuilt signed/notarized candidate, clean installs, live public/private reviews, entitlement recovery, support, update/rollback, and immutable prerelease publication.

Refs #646
