### PR TITLE
test(license): pin lifecycle contract clock

### DIFF
--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -342,6 +342,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
       config,
       licenseKey: key,
       repo: "owner/private",
+      now: LIFECYCLE_START,
       fetchImpl: service.fetchFor("machine-a")
     });
     expect(activated.status).toBe("active");
@@ -358,6 +359,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
       config,
       repo: "owner/private",
       refresh: true,
+      now: LIFECYCLE_START,
       fetchImpl: service.fetchFor("machine-a")
     });
     expect(activeAfterRenewal.status).toBe("active");
@@ -379,24 +381,29 @@ describe("client ↔ service contract (real src/license.ts against real service)
       config,
       repo: "owner/private",
       refresh: true,
+      now: cancellationTime,
       fetchImpl: service.fetchFor("machine-a")
     });
     expect(activeAfterCancellation.status).toBe("active");
 
-    service.setNow(new Date("2026-07-21T00:00:00.000Z"));
+    const afterOriginalTrialTime = new Date("2026-07-21T00:00:00.000Z");
+    service.setNow(afterOriginalTrialTime);
     const activeAfterOriginalTrial = await getLicenseStatus({
       config,
       repo: "owner/private",
       refresh: true,
+      now: afterOriginalTrialTime,
       fetchImpl: service.fetchFor("machine-a")
     });
     expect(activeAfterOriginalTrial.status).toBe("active");
 
-    service.setNow(new Date("2026-08-13T00:00:01.000Z"));
+    const paidEndTime = new Date("2026-08-13T00:00:01.000Z");
+    service.setNow(paidEndTime);
     const expired = await getLicenseStatus({
       config,
       repo: "owner/private",
       refresh: true,
+      now: paidEndTime,
       fetchImpl: service.fetchFor("machine-a")
     });
     expect(expired.status).toBe("expired");
@@ -415,6 +422,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     const activated = await activateLicense({
       config,
       licenseKey: key,
+      now: LIFECYCLE_START,
       fetchImpl: service.fetchFor("machine-r")
     });
     expect(activated.status).toBe("active");
@@ -428,6 +436,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     const revoked = await getLicenseStatus({
       config,
       refresh: true,
+      now: LIFECYCLE_START,
       fetchImpl: service.fetchFor("machine-r")
     });
     expect(revoked.status).toBe("revoked");
@@ -449,6 +458,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     const stillRevoked = await getLicenseStatus({
       config,
       refresh: true,
+      now: LIFECYCLE_START,
       fetchImpl: service.fetchFor("machine-r")
     });
     expect(stillRevoked.status).toBe("revoked");


### PR DESCRIPTION
## Summary

Pin the lifecycle contract client clock to the same explicit fixture clock already used by the in-process license service.

## Reproduced failure

On 2026-07-20, two otherwise unchanged contract tests began returning `invalid` instead of `active`: the fixture service issued a seven-day checkout trial from fixed `2026-07-13`, while the real client parser used the advancing wall clock. The fixed fixture crossed its own expiry date.

## Acceptance criteria

- [x] Initial activation, renewal, cancellation, paid-end, revoke, and post-revoke checks pass the matching explicit fixture time to the real client.
- [x] Product/service behavior is unchanged.
- [x] Focused `license-service-contract.test.ts` proof passes 4/4.
- [x] `git diff --check` passes.

## Non-goals

- No lifecycle policy, entitlement, billing, production configuration, B0/B1 product behavior, release, or customer state change.

## Proof boundary

This repairs a deterministic CI fixture. It is not production billing or activation proof and does not advance a beta/release claim.

Refs #562
