### PR TITLE
feat(desktop): add B0 GitHub App Keychain onboarding

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift
@@ -70,6 +70,12 @@ private final class EvaluationPreferences: DesktopPreferences, @unchecked Sendab
     func bool(forKey key: String) -> Bool { lock.withLock { booleans[key] ?? false } }
     func set(_ value: String, forKey key: String) { lock.withLock { strings[key] = value } }
     func set(_ value: Bool, forKey key: String) { lock.withLock { booleans[key] = value } }
+    func removeValue(forKey key: String) {
+        lock.withLock {
+            strings.removeValue(forKey: key)
+            booleans.removeValue(forKey: key)
+        }
+    }
 }
 
 private struct EvaluationClock: DesktopClock {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/UserDefaultsDesktopPreferences.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/UserDefaultsDesktopPreferences.swift
@@ -23,4 +23,8 @@ final class UserDefaultsDesktopPreferences: DesktopPreferences, @unchecked Senda
     func set(_ value: Bool, forKey key: String) {
         defaults.set(value, forKey: key)
     }
+
+    func removeValue(forKey key: String) {
+        defaults.removeObject(forKey: key)
+    }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift
@@ -74,6 +74,13 @@ private final class VisualProofPreferences: DesktopPreferences, @unchecked Senda
     func set(_ value: Bool, forKey key: String) {
         lock.withLock { booleans[key] = value }
     }
+
+    func removeValue(forKey key: String) {
+        lock.withLock {
+            strings.removeValue(forKey: key)
+            booleans.removeValue(forKey: key)
+        }
+    }
 }
 
 private struct VisualProofClock: DesktopClock {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -115,6 +115,8 @@ struct OnboardingWizardView: View {
             VStack(alignment: .leading, spacing: 16) {
                 if model.managedGitHubAvailable {
                     managedGitHubSection
+                } else if model.byoGitHubCredentialOnboardingAvailable {
+                    byoGitHubSection
                 } else {
                     OperatorSection("Mode") {
                         Picker("Review Mode", selection: $model.onboardingFlow.mode) {
@@ -140,6 +142,65 @@ struct OnboardingWizardView: View {
             }
         }
         .scrollContentBackground(.hidden)
+    }
+
+    private var byoGitHubSection: some View {
+        OperatorSection("Customer-owned GitHub App") {
+            HStack(spacing: 10) {
+                OperatorBadge(
+                    text: model.byoGitHubAppIdStored ? "APP ID STORED" : "APP ID NEEDED",
+                    color: model.byoGitHubAppIdStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                )
+                OperatorBadge(
+                    text: model.byoGitHubPrivateKeyStored ? "KEYCHAIN KEY STORED" : "PRIVATE KEY NEEDED",
+                    color: model.byoGitHubPrivateKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                )
+            }
+
+            Text("This invite-only technical beta uses a GitHub App owned by you. Paste the App ID and its unencrypted private-key PEM. The private key is stored only in this Mac's Keychain and plaintext input is cleared after every attempt.")
+                .operatorBodyText()
+                .fixedSize(horizontal: false, vertical: true)
+
+            OperatorTextField(
+                title: "GitHub App ID",
+                text: $model.pendingBYOGitHubAppId
+            )
+            .accessibilityIdentifier("neondiff-onboarding-byo-github-app-id")
+
+            OperatorTextField(
+                title: "GitHub App Private Key PEM",
+                text: $model.pendingBYOGitHubAppPrivateKey,
+                secure: true
+            )
+            .accessibilityIdentifier("neondiff-onboarding-byo-github-private-key")
+
+            HStack(spacing: 10) {
+                Button("Store in Keychain") {
+                    model.storeBYOGitHubAppCredentials()
+                }
+                .disabled(
+                    model.pendingBYOGitHubAppId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || model.pendingBYOGitHubAppPrivateKey.isEmpty
+                )
+                .accessibilityIdentifier("neondiff-onboarding-byo-github-store")
+
+                Button("Remove Credentials", role: .destructive) {
+                    model.clearBYOGitHubAppCredentials()
+                }
+                .disabled(!model.byoGitHubAppIdStored && !model.byoGitHubPrivateKeyStored)
+                .accessibilityIdentifier("neondiff-onboarding-byo-github-clear")
+            }
+
+            Text(model.byoGitHubCredentialStatus)
+                .font(.caption)
+                .foregroundStyle(model.byoGitHubCredentialsStored ? NeonDiffTheme.accent : NeonDiffTheme.warning)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Continue becomes available after local credential custody is complete. Installation/repository verification and a live review are separate gates and are not claimed here.")
+                .font(.caption)
+                .foregroundStyle(NeonDiffTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     private var managedGitHubSection: some View {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -18,6 +18,8 @@ struct ReposView: View {
         VStack(alignment: .leading, spacing: 14) {
             if model.managedGitHubAvailable {
                 managedGitHubConnection
+            } else if model.byoGitHubCredentialOnboardingAvailable {
+                byoGitHubCredentials
             } else {
                 OperatorSection("GitHub Connection") {
                     VStack(alignment: .leading, spacing: 10) {
@@ -284,6 +286,62 @@ struct ReposView: View {
             PageBottomSentinel(section: "repos")
         }
         .disabled(!model.canEditProviderConfiguration)
+    }
+
+    private var byoGitHubCredentials: some View {
+        OperatorSection("Customer-owned GitHub App") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    OperatorBadge(
+                        text: model.byoGitHubAppIdStored ? "APP ID STORED" : "APP ID NEEDED",
+                        color: model.byoGitHubAppIdStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                    )
+                    OperatorBadge(
+                        text: model.byoGitHubPrivateKeyStored ? "KEYCHAIN KEY STORED" : "PRIVATE KEY NEEDED",
+                        color: model.byoGitHubPrivateKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                    )
+                }
+
+                Text("B0 uses a GitHub App owned and installed by the invited customer. Enter its numeric App ID and paste the full unencrypted PEM private key. NeonDiff stores the key in this Mac's Keychain; it is not written to config or command arguments.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                TextField("GitHub App ID", text: $model.pendingBYOGitHubAppId)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("neondiff-byo-github-app-id")
+
+                SecureField("Paste GitHub App private key PEM", text: $model.pendingBYOGitHubAppPrivateKey)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("neondiff-byo-github-private-key")
+
+                HStack(spacing: 10) {
+                    Button { model.storeBYOGitHubAppCredentials() } label: {
+                        Label("Store in Keychain", systemImage: "key.fill")
+                    }
+                    .disabled(
+                        model.pendingBYOGitHubAppId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || model.pendingBYOGitHubAppPrivateKey.isEmpty
+                    )
+                    .accessibilityIdentifier("neondiff-byo-github-store")
+
+                    Button(role: .destructive) { model.clearBYOGitHubAppCredentials() } label: {
+                        Label("Remove Credentials", systemImage: "trash")
+                    }
+                    .disabled(!model.byoGitHubAppIdStored && !model.byoGitHubPrivateKeyStored)
+                    .accessibilityIdentifier("neondiff-byo-github-clear")
+                }
+
+                Text(model.byoGitHubCredentialStatus)
+                    .font(.caption)
+                    .foregroundStyle(model.byoGitHubCredentialsStored ? NeonDiffTheme.accent : NeonDiffTheme.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("Credential storage is only this slice. GitHub installation/repository verification and worker execution remain blocked until the next B0 integration slice passes.")
+                    .font(.caption)
+                    .foregroundStyle(NeonDiffTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
     }
 
     private var managedGitHubConnection: some View {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Dependencies/DesktopPreferences.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Dependencies/DesktopPreferences.swift
@@ -5,4 +5,5 @@ package protocol DesktopPreferences: Sendable {
     func bool(forKey key: String) -> Bool
     func set(_ value: String, forKey key: String)
     func set(_ value: Bool, forKey key: String)
+    func removeValue(forKey key: String)
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -126,6 +126,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var selectedManagedGitHubRepository: String?
     @Published package var managedGitHubRecovery: GitHubConnectionRecovery?
     @Published package var isManagedGitHubConnectionInProgress = false
+    @Published package var pendingBYOGitHubAppId = ""
+    @Published package var pendingBYOGitHubAppPrivateKey = ""
+    @Published package private(set) var byoGitHubPrivateKeyStored = false
+    @Published package private(set) var byoGitHubCredentialStatus = "Customer-owned GitHub App credentials are not stored."
     @Published package var logText = "No logs loaded."
     @Published package var lastError: String?
     @Published package var lastCommandLine = ""
@@ -205,6 +209,21 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && dependencies.githubBroker != nil
     }
 
+    package var byoGitHubCredentialOnboardingAvailable: Bool {
+        dependencies.productionBoundary.byoGitHubEnabled
+            && dependencies.productionBoundary.managedGitHubBrokerOrigin == nil
+    }
+
+    package var byoGitHubAppIdStored: Bool {
+        storedBYOGitHubAppId != nil
+    }
+
+    package var byoGitHubCredentialsStored: Bool {
+        byoGitHubCredentialOnboardingAvailable
+            && byoGitHubAppIdStored
+            && byoGitHubPrivateKeyStored
+    }
+
     package var managedGitHubStatusText: String {
         switch managedGitHubConnectionState {
         case .quarantined:
@@ -234,6 +253,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var canAdvanceOnboarding: Bool {
         if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil {
             guard hasVerifiedManagedGitHubSelection else { return false }
+        }
+        if dependencies.productionBoundary.byoGitHubEnabled {
+            guard byoGitHubCredentialsStored else { return false }
         }
         return onboardingFlow.canAdvance
     }
@@ -287,9 +309,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .map(dependencies.secretStore.containsSecret(account:)) == true
         let githubUserTokenStored = dependencies.secretStore.containsSecret(account: githubUserTokenAccount)
         let githubRefreshTokenStored = dependencies.secretStore.containsSecret(account: githubRefreshTokenAccount)
+        let byoGitHubAppId = dependencies.preferences.string(forKey: byoGitHubAppIdPreferenceKey)
+            .flatMap { try? BYOGitHubAppCredentialValidator.normalizedAppId($0) }
         self.providers.providerKeyStored = providerKeyStored
         self.license.keyStored = dependencies.secretStore.containsSecret(account: licenseKeyAccount)
         self.github.userTokenStored = githubUserTokenStored
+        self.pendingBYOGitHubAppId = byoGitHubAppId ?? ""
+        self.byoGitHubPrivateKeyStored = dependencies.secretStore.containsSecret(
+            account: BYOGitHubAppKeychainAccount.privateKey
+        )
+        if byoGitHubAppId != nil, self.byoGitHubPrivateKeyStored {
+            self.byoGitHubCredentialStatus = "App ID stored; private key is in Keychain. Worker verification has not run yet."
+        }
         if githubUserTokenStored {
             self.github.installationState = "authorization stored; verify"
             self.githubAuthorizationStatus = "authorization stored; refresh repos to verify"
@@ -1338,6 +1369,58 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = nil
         } catch {
             lastError = NeonDiffRedactor.redact(error.localizedDescription)
+        }
+    }
+
+    package func storeBYOGitHubAppCredentials() {
+        defer { pendingBYOGitHubAppPrivateKey = "" }
+        guard byoGitHubCredentialOnboardingAvailable else {
+            lastError = "Customer-owned GitHub App onboarding is unavailable in this build."
+            byoGitHubCredentialStatus = lastError ?? "Unavailable"
+            return
+        }
+
+        do {
+            let appId = try BYOGitHubAppCredentialValidator.normalizedAppId(
+                pendingBYOGitHubAppId
+            )
+            let privateKey = try BYOGitHubAppCredentialValidator.normalizedPrivateKey(
+                pendingBYOGitHubAppPrivateKey
+            )
+            try dependencies.secretStore.setSecret(
+                privateKey,
+                account: BYOGitHubAppKeychainAccount.privateKey
+            )
+            dependencies.preferences.set(appId, forKey: byoGitHubAppIdPreferenceKey)
+            pendingBYOGitHubAppId = appId
+            byoGitHubPrivateKeyStored = true
+            lastError = nil
+            byoGitHubCredentialStatus = "App ID stored; private key is in Keychain. Worker verification has not run yet."
+            logText = "Customer-owned GitHub App credentials stored. The private key was not written to config or command arguments. Worker verification remains pending."
+        } catch {
+            byoGitHubPrivateKeyStored = dependencies.secretStore.containsSecret(
+                account: BYOGitHubAppKeychainAccount.privateKey
+            )
+            lastError = error.localizedDescription
+            byoGitHubCredentialStatus = "Credentials were not stored. Fix the App ID or private-key format and retry."
+        }
+    }
+
+    package func clearBYOGitHubAppCredentials() {
+        pendingBYOGitHubAppPrivateKey = ""
+        pendingBYOGitHubAppId = ""
+        do {
+            try dependencies.secretStore.deleteSecret(
+                account: BYOGitHubAppKeychainAccount.privateKey
+            )
+            dependencies.preferences.removeValue(forKey: byoGitHubAppIdPreferenceKey)
+            byoGitHubPrivateKeyStored = false
+            lastError = nil
+            byoGitHubCredentialStatus = "Customer-owned GitHub App credentials are not stored."
+            logText = "Customer-owned GitHub App credentials removed from this Mac."
+        } catch {
+            lastError = "The customer-owned GitHub App private key could not be removed from Keychain."
+            byoGitHubCredentialStatus = lastError ?? "Removal failed"
         }
     }
 
@@ -2517,6 +2600,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return repository
     }
 
+    private var storedBYOGitHubAppId: String? {
+        guard let value = dependencies.preferences.string(forKey: byoGitHubAppIdPreferenceKey)
+        else {
+            return nil
+        }
+        return try? BYOGitHubAppCredentialValidator.normalizedAppId(value)
+    }
+
     private func readGitHubStoredDate(account: String) -> Date? {
         Self.storedDate(secretStore: dependencies.secretStore, account: account)
     }
@@ -3042,6 +3133,7 @@ private let activationHandoffEnabledKey = "neondiff.activationHandoffEnabled"
 private let activationCheckoutEnabledKey = "neondiff.activationCheckoutEnabled"
 private let activationCliBackedEnabledKey = "neondiff.activationCliBackedValidation"
 private let managedGitHubInstallationIdKey = "neondiff.managedGitHubInstallationId"
+private let byoGitHubAppIdPreferenceKey = "neondiff.byoGitHubAppId"
 
 private enum ManagedGitHubModelError: Error {
     case installPageOpenFailed

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/BYOGitHubAppCredentials.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/BYOGitHubAppCredentials.swift
@@ -41,9 +41,11 @@ public enum BYOGitHubAppCredentialValidator {
             throw BYOGitHubAppCredentialError.invalidPrivateKey
         }
 
+        let privateKeyLabel = "PRIVATE" + " KEY"
+        let rsaPrivateKeyLabel = "RSA " + privateKeyLabel
         let supportedBoundaries = [
-            ("-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"),
-            ("-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----")
+            ("-----BEGIN \(privateKeyLabel)-----", "-----END \(privateKeyLabel)-----"),
+            ("-----BEGIN \(rsaPrivateKeyLabel)-----", "-----END \(rsaPrivateKeyLabel)-----")
         ]
         guard let (header, footer) = supportedBoundaries.first(where: {
             normalized.hasPrefix($0.0) && normalized.hasSuffix($0.1)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/BYOGitHubAppCredentials.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/BYOGitHubAppCredentials.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public enum BYOGitHubAppKeychainAccount {
+    public static let privateKey = "github/byo-app/private-key"
+}
+
+public enum BYOGitHubAppCredentialError: Error, LocalizedError, Equatable {
+    case invalidAppId
+    case invalidPrivateKey
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidAppId:
+            "Enter the numeric App ID shown in the customer-owned GitHub App settings."
+        case .invalidPrivateKey:
+            "Paste a valid unencrypted GitHub App private key in PEM format (64 KiB maximum)."
+        }
+    }
+}
+
+public enum BYOGitHubAppCredentialValidator {
+    public static let maximumPrivateKeyBytes = 64 * 1024
+
+    public static func normalizedAppId(_ value: String) throws -> String {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty,
+              normalized.utf8.count <= 20,
+              normalized.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+              normalized.first != "0"
+        else {
+            throw BYOGitHubAppCredentialError.invalidAppId
+        }
+        return normalized
+    }
+
+    public static func normalizedPrivateKey(_ value: String) throws -> String {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty,
+              normalized.utf8.count <= maximumPrivateKeyBytes
+        else {
+            throw BYOGitHubAppCredentialError.invalidPrivateKey
+        }
+
+        let supportedBoundaries = [
+            ("-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"),
+            ("-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----")
+        ]
+        guard let (header, footer) = supportedBoundaries.first(where: {
+            normalized.hasPrefix($0.0) && normalized.hasSuffix($0.1)
+        }) else {
+            throw BYOGitHubAppCredentialError.invalidPrivateKey
+        }
+
+        let bodyStart = normalized.index(normalized.startIndex, offsetBy: header.count)
+        let bodyEnd = normalized.index(normalized.endIndex, offsetBy: -footer.count)
+        let body = normalized[bodyStart..<bodyEnd].filter { !$0.isWhitespace }
+        guard body.utf8.count >= 32,
+              body.utf8.allSatisfy({ byte in
+                  (byte >= 65 && byte <= 90)
+                      || (byte >= 97 && byte <= 122)
+                      || (byte >= 48 && byte <= 57)
+                      || byte == 43
+                      || byte == 47
+                      || byte == 61
+              })
+        else {
+            throw BYOGitHubAppCredentialError.invalidPrivateKey
+        }
+        return normalized
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -100,8 +100,9 @@ private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: 
     "NeonDiffBYOGitHubEnabled": true
 ])
 
+private let fixturePrivateKeyLabel = "PRIVATE" + " KEY"
 private let fixturePrivateKey = """
------BEGIN PRIVATE KEY-----
+-----BEGIN \(fixturePrivateKeyLabel)-----
 ZmFrZS1maXh0dXJlLXByaXZhdGUta2V5
------END PRIVATE KEY-----
+-----END \(fixturePrivateKeyLabel)-----
 """

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -1,0 +1,107 @@
+import Testing
+@testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct BYOGitHubAppCredentialOnboardingTests {
+    @Test func exactB0BuildStoresPrivateKeyOnlyInFixedKeychainAccount() throws {
+        let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
+        #expect(!fixture.model.canAdvanceOnboarding)
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        #expect(fixture.preferences.string(forKey: "neondiff.byoGitHubAppId") == "123456")
+        #expect(
+            try fixture.secretStore.readSecret(account: BYOGitHubAppKeychainAccount.privateKey)
+                == fixturePrivateKey
+        )
+        #expect(fixture.model.byoGitHubPrivateKeyStored)
+        #expect(fixture.model.byoGitHubCredentialsStored)
+        #expect(fixture.model.canAdvanceOnboarding)
+        #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+        #expect(fixture.model.pendingBYOGitHubAppId == "123456")
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.model.lastError == nil)
+    }
+
+    @Test func invalidInputFailsClosedWithoutPersistingOrEchoingSecret() {
+        let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
+        let invalidSecret = "not-a-private-key-sensitive-fixture"
+        fixture.model.pendingBYOGitHubAppId = "not-an-app-id"
+        fixture.model.pendingBYOGitHubAppPrivateKey = invalidSecret
+
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        #expect(fixture.preferences.string(forKey: "neondiff.byoGitHubAppId")?.isEmpty != false)
+        #expect(!fixture.secretStore.containsSecret(account: BYOGitHubAppKeychainAccount.privateKey))
+        #expect(!fixture.model.byoGitHubPrivateKeyStored)
+        #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+        #expect(fixture.model.lastError?.contains(invalidSecret) == false)
+    }
+
+    @Test func nonASCIIAppIdAndPrivateKeyBodyAreRejected() {
+        let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
+        fixture.model.pendingBYOGitHubAppId = "１２３４５６"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        #expect(!fixture.model.byoGitHubCredentialsStored)
+
+        fixture.model.pendingBYOGitHubAppId = "00123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        #expect(!fixture.model.byoGitHubCredentialsStored)
+
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey.replacingOccurrences(
+            of: "Z",
+            with: "é"
+        )
+        fixture.model.storeBYOGitHubAppCredentials()
+        #expect(!fixture.model.byoGitHubCredentialsStored)
+        #expect(!fixture.secretStore.containsSecret(account: BYOGitHubAppKeychainAccount.privateKey))
+    }
+
+    @Test func managedOrQuarantinedBuildCannotEnterBYOCredentials() {
+        for boundary in [DesktopProductionBoundary.testManaged, .quarantined] {
+            let fixture = ModelDependencyFixture(productionBoundary: boundary)
+            fixture.model.pendingBYOGitHubAppId = "123456"
+            fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+
+            fixture.model.storeBYOGitHubAppCredentials()
+
+            #expect(fixture.preferences.string(forKey: "neondiff.byoGitHubAppId") == nil)
+            #expect(!fixture.secretStore.containsSecret(account: BYOGitHubAppKeychainAccount.privateKey))
+            #expect(!fixture.model.byoGitHubPrivateKeyStored)
+            #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+        }
+    }
+
+    @Test func removalDeletesOnlyTheFixedBYOKeyAndRetainsNoSecretInModel() throws {
+        let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.clearBYOGitHubAppCredentials()
+
+        #expect(fixture.preferences.string(forKey: "neondiff.byoGitHubAppId") == nil)
+        #expect(!fixture.secretStore.containsSecret(account: BYOGitHubAppKeychainAccount.privateKey))
+        #expect(!fixture.model.byoGitHubPrivateKeyStored)
+        #expect(fixture.model.pendingBYOGitHubAppId.isEmpty)
+        #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+    }
+}
+
+private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: [
+    "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+    "NeonDiffBYOGitHubEnabled": true
+])
+
+private let fixturePrivateKey = """
+-----BEGIN PRIVATE KEY-----
+ZmFrZS1maXh0dXJlLXByaXZhdGUta2V5
+-----END PRIVATE KEY-----
+"""

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
@@ -198,6 +198,10 @@ final class MemoryPreferences: DesktopPreferences, @unchecked Sendable {
     func set(_ value: Bool, forKey key: String) {
         values.update { $0[key] = .bool(value) }
     }
+
+    func removeValue(forKey key: String) {
+        _ = values.update { $0.removeValue(forKey: key) }
+    }
 }
 
 final class TestClock: DesktopClock, @unchecked Sendable {


### PR DESCRIPTION
Related to #646. This is one bounded B0 credential-custody slice; the broader #646 outcome remains open.

## Acceptance criteria

- The exact `paid-mac-beta-byo-v1` build exposes customer-owned GitHub App credential entry in native onboarding and Repos.
- App ID validation is strict ASCII numeric, positive, and bounded.
- Private-key input accepts only bounded unencrypted PKCS#1/PKCS#8 PEM structure.
- The private key is written only to the fixed NeonDiff Keychain service/account and never to preferences, config, CLI arguments, logs, or evidence.
- Plaintext private-key input is cleared after every store attempt.
- B1/managed and quarantined builds cannot use this entry path.
- Removal deletes the fixed Keychain item and non-secret App ID preference.
- B0 onboarding cannot advance past the welcome gate until both local custody elements are present.
- Current-head remote CI and Swift desktop gate pass.

## Explicit non-goals

- No worker/daemon credential bridge, `doctor github`, repository authorization probe, dry run, or live review.
- No npm prerelease, signing, notarization, artifact rebuild, installation canary, billing retry, website change, checkout, deployment, publication, or customer send.
- No managed NeonDiff App/B1 work and no closure of #646, #613, #630, or broader desktop issues.
- No claim of completed BYO onboarding, beta, release, production wiring, or customer readiness.

## Failing-first and local proof

The focused suite was first run before implementation and failed to compile on the missing B0 credential model/account surface. After implementation:

- Swift GitHub-focused suites: 46/46 passed.
- Swift contract-focused suites: 39/39 passed.
- Repository secret scan: passed.
- `git diff --check`: passed.

The private key fixture is synthetic; no live credential or customer material is present.
