### PR TITLE
feat(desktop): verify B0 GitHub App access

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -300,6 +300,10 @@ struct ReposView: View {
                         text: model.byoGitHubPrivateKeyStored ? "KEYCHAIN KEY STORED" : "PRIVATE KEY NEEDED",
                         color: model.byoGitHubPrivateKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
                     )
+                    OperatorBadge(
+                        text: model.byoGitHubCredentialsVerified ? "APP VERIFIED" : "VERIFY NEEDED",
+                        color: model.byoGitHubCredentialsVerified ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                    )
                 }
 
                 Text("B0 uses a GitHub App owned and installed by the invited customer. Enter its numeric App ID and paste the full unencrypted PEM private key. NeonDiff stores the key in this Mac's Keychain; it is not written to config or command arguments.")
@@ -329,14 +333,23 @@ struct ReposView: View {
                     }
                     .disabled(!model.byoGitHubAppIdStored && !model.byoGitHubPrivateKeyStored)
                     .accessibilityIdentifier("neondiff-byo-github-clear")
+
+                    Button { model.verifyBYOGitHubAppCredentials() } label: {
+                        Label(
+                            model.isBYOGitHubVerificationInProgress ? "Verifying…" : "Verify App Access",
+                            systemImage: "checkmark.shield"
+                        )
+                    }
+                    .disabled(!model.byoGitHubCredentialsStored || model.isBYOGitHubVerificationInProgress)
+                    .accessibilityIdentifier("neondiff-byo-github-verify")
                 }
 
                 Text(model.byoGitHubCredentialStatus)
                     .font(.caption)
-                    .foregroundStyle(model.byoGitHubCredentialsStored ? NeonDiffTheme.accent : NeonDiffTheme.warning)
+                    .foregroundStyle(model.byoGitHubCredentialsVerified ? NeonDiffTheme.accent : NeonDiffTheme.warning)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Text("Credential storage is only this slice. GitHub installation/repository verification and worker execution remain blocked until the next B0 integration slice passes.")
+                Text("Apply the repository allowlist, then verify App access. Verification uses the private key only through bounded CLI stdin and checks GitHub installation/repository truth; it does not execute or post a review.")
                     .font(.caption)
                     .foregroundStyle(NeonDiffTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -86,17 +86,26 @@ package final class NeonDiffDesktopModel: ObservableObject {
             invalidateManagedRepoApplicationProof()
             invalidateProviderConfigAuthorization()
             invalidateProviderVerificationContext()
+            invalidateBYOGitHubVerificationContext()
         }
     }
     @Published package var cliPath: String {
         didSet {
             guard cliPath != oldValue else { return }
             invalidateProviderVerificationContext()
+            invalidateBYOGitHubVerificationContext()
         }
     }
     @Published package var launchdLabel: String
     @Published package var status: DaemonStatus = .unknown
-    @Published package var repos: [RepoMonitor] = []
+    @Published package var repos: [RepoMonitor] = [] {
+        didSet {
+            let oldAllowlist = oldValue.filter(\.enabled).map(\.name).sorted()
+            let newAllowlist = repos.filter(\.enabled).map(\.name).sorted()
+            guard oldAllowlist != newAllowlist else { return }
+            invalidateBYOGitHubVerificationContext()
+        }
+    }
     @Published package var providers = ProviderSettings() {
         didSet {
             guard providers != oldValue else { return }
@@ -129,6 +138,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var pendingBYOGitHubAppId = ""
     @Published package var pendingBYOGitHubAppPrivateKey = ""
     @Published package private(set) var byoGitHubPrivateKeyStored = false
+    @Published package private(set) var byoGitHubCredentialsVerified = false
+    @Published package private(set) var isBYOGitHubVerificationInProgress = false
     @Published package private(set) var byoGitHubCredentialStatus = "Customer-owned GitHub App credentials are not stored."
     @Published package var logText = "No logs loaded."
     @Published package var lastError: String?
@@ -1374,6 +1385,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func storeBYOGitHubAppCredentials() {
         defer { pendingBYOGitHubAppPrivateKey = "" }
+        invalidateBYOGitHubVerificationContext()
         guard byoGitHubCredentialOnboardingAvailable else {
             lastError = "Customer-owned GitHub App onboarding is unavailable in this build."
             byoGitHubCredentialStatus = lastError ?? "Unavailable"
@@ -1409,6 +1421,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func clearBYOGitHubAppCredentials() {
         pendingBYOGitHubAppPrivateKey = ""
         pendingBYOGitHubAppId = ""
+        invalidateBYOGitHubVerificationContext()
         do {
             try dependencies.secretStore.deleteSecret(
                 account: BYOGitHubAppKeychainAccount.privateKey
@@ -1421,6 +1434,145 @@ package final class NeonDiffDesktopModel: ObservableObject {
         } catch {
             lastError = "The customer-owned GitHub App private key could not be removed from Keychain."
             byoGitHubCredentialStatus = lastError ?? "Removal failed"
+        }
+    }
+
+    package func verifyBYOGitHubAppCredentials() {
+        guard byoGitHubCredentialOnboardingAvailable else {
+            lastError = "Customer-owned GitHub App verification is unavailable in this build."
+            byoGitHubCredentialStatus = lastError ?? "Unavailable"
+            return
+        }
+        guard !isBYOGitHubVerificationInProgress else { return }
+        guard let appId = storedBYOGitHubAppId else {
+            lastError = "Store a valid customer-owned GitHub App ID before verification."
+            byoGitHubCredentialStatus = lastError ?? "App ID missing"
+            return
+        }
+
+        let privateKey: String
+        do {
+            guard let stored = try dependencies.secretStore.readSecret(
+                account: BYOGitHubAppKeychainAccount.privateKey,
+                allowUserInteraction: true
+            ) else {
+                throw BYOGitHubAppCredentialError.invalidPrivateKey
+            }
+            privateKey = try BYOGitHubAppCredentialValidator.normalizedPrivateKey(stored)
+        } catch {
+            byoGitHubCredentialsVerified = false
+            lastError = "The customer-owned GitHub App private key could not be read safely from Keychain."
+            byoGitHubCredentialStatus = lastError ?? "Keychain read failed"
+            return
+        }
+
+        let arguments = [
+            "doctor", "github",
+            "--config", configPath,
+            "--github-app-id", appId,
+            "--github-app-private-key-stdin", "true",
+            "--json"
+        ]
+        let safeCommand = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --github-app-id \(shellQuote(appId)) --github-app-private-key-stdin true --json < [secure Keychain input]"
+        let verificationContext = BYOGitHubVerificationContext(
+            appId: appId,
+            cliPath: cliPath,
+            configPath: configPath,
+            repositories: repos.filter(\.enabled).map(\.name).sorted()
+        )
+        var standardInput = Data(privateKey.utf8)
+        let executablePath = cliPath
+        let cli = dependencies.cli
+        isBYOGitHubVerificationInProgress = true
+        byoGitHubCredentialsVerified = false
+        lastError = nil
+        lastCommandLine = safeCommand
+        byoGitHubCredentialStatus = "Verifying the configured repositories against the customer-owned GitHub App installation…"
+
+        Task.detached {
+            defer {
+                standardInput.resetBytes(in: 0..<standardInput.count)
+            }
+            do {
+                let result = try await cli.run(
+                    executablePath: executablePath,
+                    arguments: arguments,
+                    standardInput: standardInput,
+                    timeout: 30
+                )
+                await MainActor.run {
+                    self.applyBYOGitHubVerificationResult(result, expectedContext: verificationContext)
+                }
+            } catch {
+                await MainActor.run {
+                    self.isBYOGitHubVerificationInProgress = false
+                    self.byoGitHubCredentialsVerified = false
+                    self.lastError = "Customer-owned GitHub App verification failed safely."
+                    self.byoGitHubCredentialStatus = self.lastError ?? "Verification failed"
+                    self.logText = "GitHub verification did not produce authoritative installation/repository proof."
+                }
+            }
+        }
+    }
+
+    private func applyBYOGitHubVerificationResult(
+        _ result: CLIRunResult,
+        expectedContext: BYOGitHubVerificationContext
+    ) {
+        isBYOGitHubVerificationInProgress = false
+        let currentContext = storedBYOGitHubAppId.map { appId in
+            BYOGitHubVerificationContext(
+                appId: appId,
+                cliPath: cliPath,
+                configPath: configPath,
+                repositories: repos.filter(\.enabled).map(\.name).sorted()
+            )
+        }
+        guard currentContext == expectedContext else {
+            byoGitHubCredentialsVerified = false
+            lastError = "GitHub App verification context changed before the check completed."
+            byoGitHubCredentialStatus = "Configuration changed. Verify App access again."
+            logText = "Stale GitHub App verification evidence was discarded."
+            return
+        }
+        guard result.exitCode == 0,
+              let data = result.stdout.data(using: .utf8),
+              let report = try? JSONDecoder().decode(BYOGitHubDoctorReport.self, from: data),
+              report.ok,
+              report.command == "doctor github",
+              report.appCredentials.source == "stdin",
+              report.appCredentials.appIdConfigured,
+              report.appCredentials.privateKeyConfigured,
+              report.github.canPostAsApp,
+              report.github.readMode == "app_installation",
+              !report.github.readChecks.isEmpty,
+              report.github.readChecks.allSatisfy({ check in
+                  check.ok
+                      && check.installationIdPresent
+                      && check.appCanReadMetadata
+                      && check.appCanReadPullRequests
+              })
+        else {
+            byoGitHubCredentialsVerified = false
+            lastError = "GitHub did not verify every configured repository through this App installation."
+            byoGitHubCredentialStatus = lastError ?? "Verification failed"
+            logText = "GitHub verification failed closed. Confirm the App installation, selected repositories, and required permissions."
+            return
+        }
+
+        let repositories = report.github.readChecks.map(\.repo).sorted().joined(separator: ", ")
+        byoGitHubCredentialsVerified = true
+        lastError = nil
+        byoGitHubCredentialStatus = "Verified App installation access for \(repositories). Worker dry/live review has not run yet."
+        logText = "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
+    }
+
+    private func invalidateBYOGitHubVerificationContext() {
+        guard byoGitHubCredentialOnboardingAvailable else { return }
+        byoGitHubCredentialsVerified = false
+        guard !isBYOGitHubVerificationInProgress else { return }
+        if byoGitHubCredentialsStored {
+            byoGitHubCredentialStatus = "Configuration changed. Verify App access again."
         }
     }
 
@@ -3114,6 +3266,48 @@ private enum GitHubDesktopAuthorizationStateError: LocalizedError {
             message
         }
     }
+}
+
+private struct BYOGitHubDoctorReport: Decodable {
+    let ok: Bool
+    let command: String
+    let appCredentials: Credentials
+    let github: GitHub
+
+    struct Credentials: Decodable {
+        let appIdConfigured: Bool
+        let privateKeyConfigured: Bool
+        let source: String
+    }
+
+    struct GitHub: Decodable {
+        let canPostAsApp: Bool
+        let readMode: String
+        let readChecks: [ReadCheck]
+    }
+
+    struct ReadCheck: Decodable {
+        let repo: String
+        let ok: Bool
+        let installationIdPresent: Bool
+        let appCanReadMetadata: Bool
+        let appCanReadPullRequests: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case repo
+            case ok
+            case installationIdPresent = "installation_id_present"
+            case appCanReadMetadata = "app_can_read_metadata"
+            case appCanReadPullRequests = "app_can_read_pull_requests"
+        }
+    }
+}
+
+private struct BYOGitHubVerificationContext: Equatable, Sendable {
+    let appId: String
+    let cliPath: String
+    let configPath: String
+    let repositories: [String]
 }
 
 private let licenseKeyAccount = "license/default"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import NeonDiffDesktopAppCore
 import NeonDiffDesktopCore
@@ -92,6 +93,46 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.byoGitHubPrivateKeyStored)
         #expect(fixture.model.pendingBYOGitHubAppId.isEmpty)
         #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+    }
+
+    @Test func explicitVerificationReadsKeychainAndUsesOnlyBoundedCLIStdin() async throws {
+        let doctorResult = CLIRunResult(
+            exitCode: 0,
+            stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"acme/demo","ok":true,"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+            stderr: ""
+        )
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult)],
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        let call = try #require(fixture.cli.calls.first)
+        #expect(call.arguments == [
+            "doctor", "github",
+            "--config", fixture.model.configPath,
+            "--github-app-id", "123456",
+            "--github-app-private-key-stdin", "true",
+            "--json"
+        ])
+        #expect(call.standardInput == Data(fixturePrivateKey.utf8))
+        #expect(!call.arguments.joined(separator: " ").contains(fixturePrivateKey))
+        #expect(!fixture.model.lastCommandLine.contains(fixturePrivateKey))
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(!fixture.model.isBYOGitHubVerificationInProgress)
+        #expect(fixture.model.byoGitHubCredentialStatus.contains("acme/demo"))
+
+        fixture.model.configPath = "/tmp/changed-config.json"
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.byoGitHubCredentialStatus.contains("Verify App access again"))
     }
 }
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -270,6 +270,21 @@ printing secrets:
 neondiff doctor github --config config.local.json --json
 ```
 
+The invite-only B0 desktop keeps the customer-owned App private key in the
+macOS Keychain. Its explicit **Verify App Access** action sends that key only to
+the local CLI's bounded stdin for this check; the equivalent CLI contract is:
+
+```bash
+neondiff doctor github --config config.local.json \
+  --github-app-id "<numeric-app-id>" \
+  --github-app-private-key-stdin true --json < "/path/to/app-private-key.pem"
+```
+
+The private key must be one unencrypted RSA PKCS#1 or PKCS#8 PEM no larger than
+64 KiB. Do not put it in arguments, environment variables, config, logs, or
+evidence. A passing doctor proves only current installation/repository read
+access for the configured allowlist; it does not execute or post a review.
+
 Check:
 
 - `ok`

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -189,6 +189,14 @@ A stored license key is not treated as active entitlement. Repo selection still
 writes only the local allowlist; the worker's pre-checkout license and GitHub App
 gates remain authoritative for review execution.
 
+In the invite-only B0 build, the Repos pane also accepts a customer-owned
+numeric App ID and unencrypted RSA private key. The key is stored only in the
+fixed macOS Keychain account. **Verify App Access** reads it on that explicit
+action, supplies it to `doctor github` through bounded stdin, and accepts only
+typed App-installation proof for every configured repository. Changing the App
+credentials, CLI/config path, or allowlist invalidates that proof. This step
+does not run a provider, execute a review, or post to GitHub.
+
 ## Local Dashboard Launcher
 
 The dev app no longer opens a browser tab automatically. It exposes explicit

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { createPrivateKey } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { loadConfig, validateLicenseConfigOverride, type BotConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
@@ -398,7 +399,8 @@ async function main(): Promise<void> {
   if (command === "doctor") {
     const config = loadConfig(args.config);
     if (args._[1] === "github") {
-      const result = await buildDoctorGithubReport(config);
+      const credentials = await resolveDoctorGitHubCredentials(args, process.stdin);
+      const result = await buildDoctorGithubReport(config, credentials);
       console.log(stringifyRedactedJson(result));
       if (!result.ok) process.exitCode = 1;
       return;
@@ -2923,8 +2925,21 @@ function isProviderDeferredQueueJobEligible(job: ReviewQueueJobRecord, now: Date
   return !Number.isFinite(eligibleAtMs) || eligibleAtMs <= now.getTime();
 }
 
-async function buildDoctorGithubReport(config: BotConfig) {
-  const github = new GitHubApi(config.github);
+type DoctorGitHubCredentialOverride = {
+  appId: string;
+  privateKey: string;
+  source: "stdin";
+};
+
+async function buildDoctorGithubReport(config: BotConfig, credentials?: DoctorGitHubCredentialOverride) {
+  const github = new GitHubApi(credentials
+    ? {
+        ...config.github,
+        appId: credentials.appId,
+        privateKey: credentials.privateKey,
+        privateKeyPath: undefined
+      }
+    : config.github);
   const monitoredRepos = listReposToScan(config);
   const readChecks = [];
   let activeRepoChecks = 0;
@@ -3007,9 +3022,10 @@ async function buildDoctorGithubReport(config: BotConfig) {
     monitoredRepos,
     activeRepoChecks,
     appCredentials: {
-      appIdConfigured: Boolean(config.github.appId),
-      privateKeyConfigured: Boolean(config.github.privateKeyPath),
-      fallbackTokenConfigured: Boolean(config.github.token)
+      appIdConfigured: Boolean(credentials?.appId ?? config.github.appId),
+      privateKeyConfigured: Boolean(credentials?.privateKey ?? config.github.privateKeyPath),
+      fallbackTokenConfigured: Boolean(config.github.token),
+      source: credentials?.source ?? "configured"
     },
     github: {
       canPostAsApp: appCredentialsConfigured,
@@ -3047,6 +3063,50 @@ async function buildDoctorGithubReport(config: BotConfig) {
       ...(readChecks.some((check) => !check.ok) ? ["Confirm the GitHub App is installed on selected repositories with the required repository permissions."] : [])
     ]
   };
+}
+
+async function resolveDoctorGitHubCredentials(
+  args: ParsedArgs,
+  stdin: NodeJS.ReadableStream
+): Promise<DoctorGitHubCredentialOverride | undefined> {
+  const appIdArg = args["github-app-id"];
+  const privateKeyStdinArg = args["github-app-private-key-stdin"];
+  if (appIdArg === undefined && privateKeyStdinArg === undefined) return undefined;
+
+  if (privateKeyStdinArg !== "true") {
+    throw new Error("doctor github requires --github-app-private-key-stdin true when --github-app-id is supplied");
+  }
+  if (appIdArg === undefined) {
+    throw new Error("doctor github requires --github-app-id with --github-app-private-key-stdin true");
+  }
+  const appId = parseSingleArg(appIdArg, "--github-app-id").trim();
+  if (!/^[1-9][0-9]{0,19}$/.test(appId)) {
+    throw new Error("--github-app-id must be one positive ASCII numeric App ID of at most 20 digits");
+  }
+
+  let privateKey: string;
+  try {
+    privateKey = await readSecretFromStdin(stdin, 64 * 1024, 5_000);
+  } catch (error) {
+    throw new Error((error instanceof Error ? error.message : "GitHub App private-key stdin could not be read")
+      .replaceAll("provider secret", "GitHub App private-key"));
+  }
+  const privateKeyLabel = "PRIVATE" + " KEY";
+  const rsaPrivateKeyLabel = "RSA " + privateKeyLabel;
+  const supportedBoundaries = [
+    [`-----BEGIN ${privateKeyLabel}-----`, `-----END ${privateKeyLabel}-----`],
+    [`-----BEGIN ${rsaPrivateKeyLabel}-----`, `-----END ${rsaPrivateKeyLabel}-----`]
+  ] as const;
+  if (!supportedBoundaries.some(([header, footer]) => privateKey.startsWith(header) && privateKey.endsWith(footer))) {
+    throw new Error("GitHub App private-key stdin must be one unencrypted PKCS#1 or PKCS#8 PEM");
+  }
+  try {
+    const parsed = createPrivateKey(privateKey);
+    if (parsed.asymmetricKeyType !== "rsa") throw new Error("unsupported key type");
+  } catch {
+    throw new Error("GitHub App private-key stdin must be one valid unencrypted RSA private key");
+  }
+  return { appId, privateKey, source: "stdin" };
 }
 
 function buildDoctorGithubLicenseGatePreview(
@@ -3189,7 +3249,9 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
   doctor: {
     description: "Check repo read access, provider env, and issue-enrichment readiness (add `github` for GitHub-only checks).",
     flags: [
-      { name: "--config", description: "Path to the config file (default config.local.json)." }
+      { name: "--config", description: "Path to the config file (default config.local.json)." },
+      { name: "--github-app-id", description: "Nonsecret customer-owned GitHub App ID used with --github-app-private-key-stdin true." },
+      { name: "--github-app-private-key-stdin", description: "true to read one bounded customer-owned GitHub App private key from stdin." }
     ]
   },
   status: {

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,6 +20,7 @@ const MAX_REVIEW_COMMENT_PAGES = 5;
 
 export interface GitHubApiOptions {
   appId?: string;
+  privateKey?: string;
   privateKeyPath?: string;
   token?: string;
   apiBaseUrl?: string;
@@ -89,8 +90,11 @@ export class GitHubApi {
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
 
   constructor(options: GitHubApiOptions) {
+    if (options.privateKey && options.privateKeyPath) {
+      throw new Error("GitHub App private key must be supplied inline or by path, not both.");
+    }
     this.appId = options.appId;
-    this.privateKey = options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined;
+    this.privateKey = options.privateKey ?? (options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined);
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
     this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -98,6 +98,11 @@ describe("public NeonDiff CLI surface", () => {
       expect.objectContaining({ name: "--expected-config-revision" })
     ]));
     expect(output.examples).toContain("neondiff doctor github --config config.local.json --json");
+    const doctorHelp = JSON.parse((await runCli(["doctor", "--help"])).stdout);
+    expect(doctorHelp.usage.flags).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "--github-app-id" }),
+      expect.objectContaining({ name: "--github-app-private-key-stdin" })
+    ]));
     expect(output.examples).toContain("neondiff license status --config config.local.json --json");
     expect(output.examples.some((example: string) => example.includes("--license-key-stdin true"))).toBe(true);
     expect(output.examples.join("\n")).not.toContain("--license-key-env");
@@ -1369,9 +1374,67 @@ exit 1
       expect(stdout).not.toContain(privateKeyPem);
       expect(stdout).not.toContain(privateKeyPath);
       expect(stdout).not.toContain(installationToken);
+
+      const stdinConfig = JSON.parse(readFileSync(configPath, "utf8"));
+      delete stdinConfig.github.appId;
+      delete stdinConfig.github.privateKeyPath;
+      writeFileSync(configPath, `${JSON.stringify(stdinConfig)}\n`);
+
+      const { stdout: stdinStdout } = await runCliWithStdin([
+        "doctor",
+        "github",
+        "--config",
+        configPath,
+        "--github-app-id",
+        "12345",
+        "--github-app-private-key-stdin",
+        "true"
+      ], privateKeyPem);
+      const stdinOutput = JSON.parse(stdinStdout);
+      expect(stdinOutput).toMatchObject({
+        ok: true,
+        command: "doctor github",
+        appCredentials: {
+          appIdConfigured: true,
+          privateKeyConfigured: true,
+          source: "stdin"
+        },
+        github: {
+          canPostAsApp: true,
+          readMode: "app_installation",
+          readChecks: [
+            {
+              repo: "acme/demo",
+              ok: true,
+              visibility_result: "public",
+              installation_id_present: true,
+              app_can_read_metadata: true,
+              app_can_read_pull_requests: true
+            }
+          ]
+        }
+      });
+      expect(stdinStdout).not.toContain(privateKeyPem);
+      expect(stdinStdout).not.toContain(installationToken);
     } finally {
       await closeServer(server);
     }
+  });
+
+  it("doctor github rejects an invalid App ID before consuming an open secret stdin", async () => {
+    const result = await runCliWithOpenStdin([
+      "doctor",
+      "github",
+      "--github-app-id",
+      "001234",
+      "--github-app-private-key-stdin",
+      "true"
+    ], "private-key-input-must-not-be-consumed");
+
+    expect(result.error).toBeTruthy();
+    expect(result.error?.killed).not.toBe(true);
+    expect(result.stderr).toContain("positive ASCII numeric App ID");
+    expect(result.stderr).not.toContain("private-key-input-must-not-be-consumed");
   });
 
   it("doctor github blocks pre-checkout when public repo PR permission is missing", async () => {


### PR DESCRIPTION
## Outcome

Adds the next bounded B0 slice: the invite-only native app can explicitly verify a customer-owned GitHub App against the configured repository allowlist without moving the private key out of Keychain except through bounded local CLI stdin.

Relates to #646. The broader B0 outcome remains open.

## Acceptance criteria

- `doctor github` accepts one strict numeric App ID plus one unencrypted RSA PKCS#1/PKCS#8 private key through bounded stdin only.
- The CLI validates the key cryptographically, keeps it in memory, rejects simultaneous inline/path custody, and emits only redacted typed proof.
- The B0 Repos pane reads the fixed Keychain item only on **Verify App Access** and never places the private key in argv, config, environment, display commands, logs, or evidence.
- Native verification passes only when every configured repository has App-installation mode, an installation ID, metadata access, and pull-request read access.
- Changing App credentials, the CLI/config path, or the enabled allowlist invalidates the proof; stale async results are rejected.
- Public setup/desktop docs describe the bounded contract and exact proof boundary.

## Explicit non-goals

- No dry run, provider call, live review execution, or GitHub comment posting.
- No daemon/runtime wiring, billing/entitlement change, website change, signing/notarization, package publication, or beta/release claim.
- No managed NeonDiff GitHub App or broker work; B1 remains under #613/#630.
- No closure of #646 or any broader native/GA matrix.

## Failing-first and focused checks

- RED: the new CLI stdin invocation failed before the flags/credential seam existed.
- RED: the Swift onboarding test failed before the explicit verification API/state existed.
- `npx -y node@26 ./node_modules/typescript/bin/tsc -p tsconfig.build.json --noEmit`
- `npx -y node@26 ./node_modules/vitest/vitest.mjs run tests/public-cli.test.ts -t 'doctor github'` (5 passed)
- `npx -y node@26 ./node_modules/vitest/vitest.mjs run tests/github-app-read.test.ts tests/secret-stdin.test.ts` (30 passed)
- `swift test --filter BYOGitHubAppCredentialOnboardingTests` (6 passed)
- `swift test --filter ReposReachabilityLayoutContractTests` (7 passed)
- `npx -y node@26 scripts/check-secret-scan.mjs` (781 tracked files)
- `git diff --check`

Broad validation belongs to current-head remote CI.

## Proof boundary

This source/fixture slice proves the bounded transport, Keychain ownership, typed fail-closed parsing, and local focused checks at this PR head. It does not prove a real customer App installation, public/private live review, signed artifact, production billing, deployment, beta, release, or customer readiness.
