### PR TITLE
build: add private B0 CLI candidate packager

### DIFF
--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -136,6 +136,18 @@ function main() {
     fail(`candidate head is not the fetched protected-main head ${protectedMainHead}`);
   }
   ensureClean(repoRoot, "preflight");
+  execFileSync("npm", [
+    "run",
+    "build"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (!existsSync(join(repoRoot, "dist", "src", "cli.js"))) {
+    fail("exact candidate build did not emit dist/src/cli.js");
+  }
+  ensureClean(repoRoot, "post-build");
 
   const outputDirectory = assertOutputDirectory(repoRoot, requestedOutputDirectory);
   const packagePath = join(repoRoot, "package.json");
@@ -147,10 +159,6 @@ function main() {
   if (packageMetadata.name !== "neondiff" || basePackageVersion !== "1.0.4") {
     fail("B0 candidate packaging requires the reviewed neondiff@1.0.4 source baseline");
   }
-  if (!existsSync(join(repoRoot, "dist", "src", "cli.js"))) {
-    fail("built dist/src/cli.js is required; run npm run build first");
-  }
-
   const installRoot = mkdtempSync(join(tmpdir(), "neondiff-b0-cli-install-"));
   let manifest;
   let tarballPath;
@@ -205,6 +213,7 @@ function main() {
       installRoot,
       tarballPath
     ], {
+      cwd: installRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
     });

--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLEAN_STATUS_COMMAND = "git status --porcelain";
+const CANDIDATE_VERSION_PATTERN = /^1\.1\.0-beta\.[1-9][0-9]{0,3}$/;
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const PRIVATE_BUCKET_TARGET = "neondiff-beta-canary";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(values) {
+  const args = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index];
+    const value = values[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      fail(`invalid argument list near ${key ?? "(missing)"}`);
+    }
+    args.set(key.slice(2), value);
+  }
+  return args;
+}
+
+function required(args, name) {
+  const value = args.get(name);
+  if (!value) fail(`--${name} is required`);
+  return value;
+}
+
+function git(repoRoot, args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function sha256(path) {
+  const hash = createHash("sha256");
+  hash.update(readFileSync(path));
+  return hash.digest("hex");
+}
+
+function parseHelp(binaryPath, command) {
+  const output = execFileSync(binaryPath, [command, "--help"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  const parsed = JSON.parse(output);
+  if (parsed?.ok !== true || parsed?.command !== command || !Array.isArray(parsed?.usage?.flags)) {
+    fail(`installed ${command} help is not the expected structured contract`);
+  }
+  return parsed;
+}
+
+function requireFlags(help, expected, label) {
+  const flags = new Set(help.usage.flags.map((entry) => entry?.name).filter(Boolean));
+  for (const flag of expected) {
+    if (!flags.has(flag)) fail(`installed candidate is missing ${label} flag ${flag}`);
+  }
+  return expected;
+}
+
+function assertOutputDirectory(repoRoot, requestedOutputDirectory) {
+  if (!isAbsolute(requestedOutputDirectory)) {
+    fail("output directory must be absolute");
+  }
+  const outputDirectory = resolve(requestedOutputDirectory);
+  const relativeToRepo = relative(repoRoot, outputDirectory);
+  if (relativeToRepo === "" || (!relativeToRepo.startsWith(`..${sep}`) && relativeToRepo !== "..")) {
+    fail("output directory must be outside the repository");
+  }
+  if (existsSync(outputDirectory)) {
+    if (!statSync(outputDirectory).isDirectory()) fail("output path must be a directory");
+    if (readdirSync(outputDirectory).length > 0) fail("output directory must be empty");
+  } else {
+    mkdirSync(outputDirectory, { recursive: true, mode: 0o700 });
+  }
+  return outputDirectory;
+}
+
+function ensureClean(repoRoot, stage) {
+  const status = git(repoRoot, ["status", "--porcelain", "--untracked-files=all"]);
+  if (status) fail(`${stage}: source tree must be clean (${CLEAN_STATUS_COMMAND})`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const candidateHead = required(args, "candidate-head");
+  const packageVersion = required(args, "package-version");
+  const requestedOutputDirectory = required(args, "output-dir");
+
+  if (!FULL_SHA_PATTERN.test(candidateHead)) {
+    fail("candidate head must be one lowercase full Git SHA");
+  }
+  if (!CANDIDATE_VERSION_PATTERN.test(packageVersion)) {
+    fail("package version must match 1.1.0-beta.N");
+  }
+
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const nodeMajorVersion = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+  if (!Number.isInteger(nodeMajorVersion) || nodeMajorVersion < 26) {
+    fail("B0 candidate packaging requires Node.js 26 or newer");
+  }
+  const exactHead = git(repoRoot, ["rev-parse", "HEAD"]);
+  if (exactHead !== candidateHead) {
+    fail(`candidate head mismatch: checkout is ${exactHead}`);
+  }
+  const protectedMainHead = git(repoRoot, ["rev-parse", "refs/remotes/origin/main"]);
+  if (protectedMainHead !== candidateHead) {
+    fail(`candidate head is not the fetched protected-main head ${protectedMainHead}`);
+  }
+  ensureClean(repoRoot, "preflight");
+
+  const outputDirectory = assertOutputDirectory(repoRoot, requestedOutputDirectory);
+  const packagePath = join(repoRoot, "package.json");
+  const packageLockPath = join(repoRoot, "package-lock.json");
+  const originalPackage = readFileSync(packagePath);
+  const originalPackageLock = readFileSync(packageLockPath);
+  const packageMetadata = JSON.parse(originalPackage.toString("utf8"));
+  const basePackageVersion = packageMetadata.version;
+  if (packageMetadata.name !== "neondiff" || basePackageVersion !== "1.0.4") {
+    fail("B0 candidate packaging requires the reviewed neondiff@1.0.4 source baseline");
+  }
+  if (!existsSync(join(repoRoot, "dist", "src", "cli.js"))) {
+    fail("built dist/src/cli.js is required; run npm run build first");
+  }
+
+  const installRoot = mkdtempSync(join(tmpdir(), "neondiff-b0-cli-install-"));
+  let manifest;
+  let tarballPath;
+  let packJsonPath;
+  try {
+    execFileSync("npm", [
+      "version",
+      packageVersion,
+      "--no-git-tag-version",
+      "--allow-same-version"
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    const packOutput = execFileSync("npm", [
+      "pack",
+      "--json",
+      "--pack-destination",
+      outputDirectory
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    const parsedPack = JSON.parse(packOutput);
+    const pack = parsedPack[0];
+    if (!pack || parsedPack.length !== 1 || pack.name !== "neondiff" || pack.version !== packageVersion) {
+      fail("npm pack did not emit the exact requested neondiff candidate");
+    }
+
+    packJsonPath = join(outputDirectory, "pack.json");
+    writeFileSync(packJsonPath, `${JSON.stringify(parsedPack, null, 2)}\n`, { mode: 0o600 });
+    execFileSync(process.execPath, [join(repoRoot, "scripts", "check-packlist.mjs"), packJsonPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    tarballPath = join(outputDirectory, pack.filename);
+    if (!existsSync(tarballPath) || !statSync(tarballPath).isFile()) {
+      fail("npm pack tarball is missing");
+    }
+
+    execFileSync("npm", [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--prefix",
+      installRoot,
+      tarballPath
+    ], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    const installedBinary = join(installRoot, "node_modules", ".bin", "neondiff");
+    const reportedVersion = execFileSync(installedBinary, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    }).trim();
+    if (reportedVersion !== packageVersion) {
+      fail(`installed candidate reports unexpected version ${reportedVersion}`);
+    }
+
+    const activationFlags = requireFlags(
+      parseHelp(installedBinary, "license"),
+      ["--license-key-stdin", "--persist-local-state", "--license-machine-id"],
+      "native activation"
+    );
+    const githubDoctorFlags = requireFlags(
+      parseHelp(installedBinary, "doctor"),
+      ["--github-app-id", "--github-app-private-key-stdin"],
+      "BYO GitHub verification"
+    );
+
+    manifest = {
+      schemaVersion: 1,
+      candidateClass: "b0-access-controlled-cli",
+      source: {
+        repository: "electricsheephq/evaos-code-review-bot-neondiff",
+        candidateHead,
+        protectedMainVerified: true,
+        sourceTreeCleanBeforePackaging: true,
+        packageMetadataMutation: "version-only-ephemeral-restored"
+      },
+      package: {
+        name: "neondiff",
+        basePackageVersion,
+        packageVersion,
+        filename: pack.filename,
+        sha256: sha256(tarballPath),
+        shasum: pack.shasum,
+        integrity: pack.integrity,
+        fileCount: Array.isArray(pack.files) ? pack.files.length : null,
+        unpackedSize: pack.unpackedSize ?? null
+      },
+      installedCompatibility: {
+        nodeVersion: process.versions.node,
+        nodeEngine: packageMetadata.engines?.node ?? null,
+        reportedVersion,
+        activationFlags,
+        githubDoctorFlags,
+        isolatedInstallPassed: true
+      },
+      distribution: {
+        privateBucketTarget: PRIVATE_BUCKET_TARGET,
+        objectPrefix: `b0/${packageVersion}/${candidateHead}`,
+        uploaded: false,
+        authenticatedReadbackPassed: false,
+        publicNpmPublished: false,
+        tagCreated: false,
+        githubReleaseCreated: false,
+        publicDownloadEnabled: false
+      },
+      proofBoundary: {
+        allows: [
+          "exact clean protected-main source was packed with version-only ephemeral metadata",
+          "isolated installed CLI exposes the B0 native activation and BYO GitHub verification flags"
+        ],
+        excludes: [
+          "private bucket upload or authenticated readback",
+          "public npm publication or dist-tag mutation",
+          "Git tag or GitHub Release",
+          "signed or notarized Mac artifact",
+          "billing, activation, dry-run, live review, canary, beta, release, or customer readiness"
+        ]
+      }
+    };
+  } finally {
+    writeFileSync(packagePath, originalPackage);
+    writeFileSync(packageLockPath, originalPackageLock);
+    rmSync(installRoot, { recursive: true, force: true });
+  }
+
+  ensureClean(repoRoot, "post-package restoration");
+  if (!manifest || !tarballPath || !packJsonPath) fail("candidate packaging did not complete");
+
+  const manifestPath = join(
+    outputDirectory,
+    `neondiff-${packageVersion}-b0-candidate-manifest.json`
+  );
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  console.log(JSON.stringify({
+    ok: true,
+    candidateHead,
+    packageVersion,
+    tarballPath,
+    packJsonPath,
+    manifestPath,
+    sha256: manifest.package.sha256,
+    privateBucketTarget: PRIVATE_BUCKET_TARGET,
+    uploaded: false
+  }));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -4,8 +4,10 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
+  realpathSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -83,17 +85,23 @@ function assertOutputDirectory(repoRoot, requestedOutputDirectory) {
     fail("output directory must be absolute");
   }
   const outputDirectory = resolve(requestedOutputDirectory);
-  const relativeToRepo = relative(repoRoot, outputDirectory);
-  if (relativeToRepo === "" || (!relativeToRepo.startsWith(`..${sep}`) && relativeToRepo !== "..")) {
-    fail("output directory must be outside the repository");
-  }
   if (existsSync(outputDirectory)) {
+    if (lstatSync(outputDirectory).isSymbolicLink()) fail("output directory must not be a symbolic link");
     if (!statSync(outputDirectory).isDirectory()) fail("output path must be a directory");
     if (readdirSync(outputDirectory).length > 0) fail("output directory must be empty");
   } else {
     mkdirSync(outputDirectory, { recursive: true, mode: 0o700 });
   }
-  return outputDirectory;
+  const realRepoRoot = realpathSync(repoRoot);
+  const realOutputDirectory = realpathSync(outputDirectory);
+  const relativeToRepo = relative(realRepoRoot, realOutputDirectory);
+  if (relativeToRepo === "" || (!relativeToRepo.startsWith(`..${sep}`) && relativeToRepo !== "..")) {
+    fail("output directory must resolve outside the repository");
+  }
+  if ((statSync(realOutputDirectory).mode & 0o077) !== 0) {
+    fail("output directory must be private to the current user (0700)");
+  }
+  return realOutputDirectory;
 }
 
 function ensureClean(repoRoot, stage) {

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -66,6 +66,9 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).toContain("npm");
     expect(script).toContain("pack");
     expect(script).toContain("check-packlist.mjs");
+    expect(script).toMatch(/execFileSync\("npm", \[\s*"run",\s*"build"/);
+    expect(script.search(/"run",\s*"build"/)).toBeLessThan(script.indexOf('"pack"'));
+    expect(script).toContain('ensureClean(repoRoot, "post-build")');
     expect(script).toContain("--persist-local-state");
     expect(script).toContain("--license-machine-id");
     expect(script).toContain("--github-app-id");

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -71,6 +71,8 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).toContain("--github-app-id");
     expect(script).toContain("--github-app-private-key-stdin");
     expect(script).toContain("git status --porcelain");
+    expect(script).toContain("must not be a symbolic link");
+    expect(script).toContain("must be private to the current user (0700)");
     expect(script).toContain("neondiff-beta-canary");
     expect(script).not.toMatch(/\bnpm publish\b/);
     expect(script).not.toMatch(/\bnpm dist-tag\b/);

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+const workflowPath = ".github/workflows/b0-cli-candidate.yml";
+const scriptPath = "scripts/build-b0-cli-candidate.mjs";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("B0 access-controlled CLI candidate", () => {
+  it("does not expose the private candidate as a public-repository Actions artifact", () => {
+    expect(existsSync(workflowPath)).toBe(false);
+  });
+
+  it("validates candidate identity before touching package metadata", () => {
+    expect(existsSync(scriptPath)).toBe(true);
+
+    const invalidHead = spawnSync(process.execPath, [
+      scriptPath,
+      "--candidate-head", "HEAD",
+      "--package-version", "1.1.0-beta.2",
+      "--output-dir", "/tmp/neondiff-b0-invalid-head"
+    ], { encoding: "utf8" });
+    expect(invalidHead.status).not.toBe(0);
+    expect(invalidHead.stderr).toContain("candidate head must be one lowercase full Git SHA");
+
+    const invalidVersion = spawnSync(process.execPath, [
+      scriptPath,
+      "--candidate-head", "0".repeat(40),
+      "--package-version", "latest",
+      "--output-dir", "/tmp/neondiff-b0-invalid-version"
+    ], { encoding: "utf8" });
+    expect(invalidVersion.status).not.toBe(0);
+    expect(invalidVersion.stderr).toContain("package version must match 1.1.0-beta.N");
+  });
+
+  it("records exact package identity, installed capabilities, and the proof boundary", () => {
+    expect(existsSync(scriptPath)).toBe(true);
+
+    const script = read(scriptPath);
+    for (const field of [
+      "schemaVersion",
+      "candidateClass",
+      "candidateHead",
+      "protectedMainVerified",
+      "basePackageVersion",
+      "packageVersion",
+      "filename",
+      "sha256",
+      "shasum",
+      "integrity",
+      "reportedVersion",
+      "nodeVersion",
+      "activationFlags",
+      "githubDoctorFlags",
+      "publicNpmPublished",
+      "tagCreated",
+      "githubReleaseCreated",
+      "privateBucketTarget",
+      "uploaded",
+      "proofBoundary"
+    ]) {
+      expect(script).toContain(field);
+    }
+    expect(script).toContain("npm");
+    expect(script).toContain("pack");
+    expect(script).toContain("check-packlist.mjs");
+    expect(script).toContain("--persist-local-state");
+    expect(script).toContain("--license-machine-id");
+    expect(script).toContain("--github-app-id");
+    expect(script).toContain("--github-app-private-key-stdin");
+    expect(script).toContain("git status --porcelain");
+    expect(script).toContain("neondiff-beta-canary");
+    expect(script).not.toMatch(/\bnpm publish\b/);
+    expect(script).not.toMatch(/\bnpm dist-tag\b/);
+    expect(script).not.toMatch(/\bgh release\b/);
+    expect(script).not.toMatch(/\bgit tag\b/);
+  });
+});


### PR DESCRIPTION
Related: #646

## Outcome

Add one bounded packager for a B0-compatible `neondiff` CLI tarball from an exact clean fetched protected-main head. It applies only an ephemeral `1.1.0-beta.N` package-version mutation, restores the source tree, checks the existing packlist, installs the tarball in isolation, proves the native activation and BYO GitHub secure-stdin flags, and emits a redacted manifest for the existing private `neondiff-beta-canary` bucket.

The repository is public, so this PR intentionally creates no GitHub Actions artifact workflow. Remote CI validates the source; after merge, the exact clean main tarball is built locally and uploaded only to the existing private bucket with authenticated checksum readback.

## Acceptance criteria

- Require one lowercase full candidate SHA equal to both checkout HEAD and fetched `origin/main`.
- Require Node 26+, clean source before packaging, output outside the repo, and an empty destination.
- Restrict candidate identity to `1.1.0-beta.N` on the reviewed `neondiff@1.0.4` source baseline.
- Restore `package.json` and `package-lock.json`, then require a clean source tree before success.
- Verify packlist, isolated installed version, native activation flags, and BYO GitHub doctor flags.
- Emit SHA-256, npm shasum/integrity, source/version identity, private-target state, and explicit proof boundaries.
- Preserve public download, npm publication, tag, and GitHub Release as false.

## Failing-first evidence

`tests/b0-cli-candidate.test.ts` initially failed 3/3 because the packager and prohibited public-repo workflow contract did not exist. After implementation it passes 3/3.

## Focused validation

- Node 26 `npm run build` — passed.
- Candidate contract, public CLI, GitHub App read, secret stdin, and license suites — passed; public CLI 95/95 and license 60/60.
- Tracked-file secret scan — 783 files, passed.
- Clean-clone functional pack and isolated install at development-only version `1.1.0-beta.9999` — passed.
- Repeated clean-clone pack SHA-256 matched exactly: `b94ff89f9b07d2a963ed542a5a5097ae18657f70718244aced92429a80a43bfb`.
- `git diff --check` and post-pack clean-tree check — passed.

## Explicit non-goals

- No public npm publication or dist-tag mutation.
- No GitHub Actions candidate artifact, Git tag, GitHub Release, website download, or customer send.
- No signed/notarized Mac rebuild.
- No Supabase upload in this source PR.
- No billing replay, lifecycle enablement, activation canary, daemon mutation, dry/live review, B1 managed-App work, beta, release, or customer-readiness claim.

## Proof boundary

This PR can prove a deterministic private-candidate packaging mechanism and installed CLI capability contract only. Merge/CI are not private bucket upload/readback, signed distribution, production billing, customer canary, beta, or release proof.