### PR TITLE
fix: isolate repository scan failures from queue draining

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2603,6 +2603,7 @@ function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): 
       result.queue.providerDeferred += 1;
       break;
     case "closed_retired":
+      result.skippedStaleHead += 1;
       result.queue.closedRetired += 1;
       break;
     case "skipped_draft":

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2687,6 +2687,7 @@ function applyReviewStatus(result: ScheduledRunResult, status: ReviewPullResult 
       break;
     case "skipped_closed":
     case "closed_retired":
+      result.skippedStaleHead += 1;
       result.queue.closedRetired += 1;
       break;
     case "failed":

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -82,6 +82,7 @@ import {
 export interface ScheduledRunResult extends RunOnceResult {
   commandFetchErrors: number;
   statusCommentFailures: number;
+  repositoryScanErrors: Array<{ repo: string; error: string }>;
   queue: {
     enqueued: number;
     alreadyQueued: number;
@@ -186,9 +187,22 @@ export async function runScheduledCycleWithDeps(input: {
       continue;
     }
 
-    const pulls = input.options.pullNumber
-      ? [await input.github.getPull(repo, input.options.pullNumber)]
-      : await input.github.listOpenPulls(repo);
+    let pulls: PullRequestSummary[];
+    try {
+      pulls = input.options.pullNumber
+        ? [await input.github.getPull(repo, input.options.pullNumber)]
+        : await input.github.listOpenPulls(repo);
+    } catch (error) {
+      // A daemon-wide discovery cycle must keep draining already-durable queue
+      // work when one unrelated installation lookup fails. Explicit operator
+      // scopes stay fail-fast so a targeted command never reports partial work.
+      if (input.options.repo || input.options.pullNumber !== undefined) throw error;
+      result.repositoryScanErrors.push({
+        repo,
+        error: redactSecrets(error instanceof Error ? error.message : String(error))
+      });
+      continue;
+    }
     result.pullsSeen += pulls.length;
     const admittedPulls = pulls.filter((pull) => {
       const decision = authorizeAdmissionForVisibility(
@@ -1749,6 +1763,8 @@ function reviewResultStatusCommentState(
       return "provider_deferred";
     case "skipped_stale_head":
       return "stale_head";
+    case "skipped_closed":
+      return "closed_or_merged_before_review";
     case "skipped_capacity":
       return "provider_deferred";
     case "skipped_context_budget":
@@ -1947,6 +1963,8 @@ function readinessStateForReviewResult(
       return "skipped";
     case "skipped_stale_head":
       return "stale";
+    case "skipped_closed":
+      return "closed";
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_command_stop":
@@ -1987,6 +2005,8 @@ function readinessReasonForReviewResult(
       return processed?.error ?? "context_budget_overflow";
     case "skipped_stale_head":
       return "stale_head";
+    case "skipped_closed":
+      return processed?.error ?? "closed_or_merged_before_review";
     case "skipped_draft":
       return "draft_pr";
     case "skipped_canary":
@@ -2208,6 +2228,7 @@ function updateReviewerSessionJobAfterReviewStatus(input: {
     case "skipped_command_explain":
     case "skipped_finishing_touch_draft":
     case "skipped_stale_head":
+    case "skipped_closed":
     case "skipped_context_budget":
       updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
       return;
@@ -2294,6 +2315,16 @@ function updateQueueJobAfterReviewStatus(input: {
         now: input.now
       });
       return;
+    case "skipped_closed": {
+      const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "closed_retired",
+        lastError: processed?.error ?? "closed_or_merged_before_review",
+        now: input.now
+      });
+      return;
+    }
     case "skipped_processed":
       const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
       if (parseProviderCooldownError(processed?.error)) {
@@ -2654,6 +2685,7 @@ function applyReviewStatus(result: ScheduledRunResult, status: ReviewPullResult 
       result.skippedStaleHead += 1;
       result.queue.staleRetired += 1;
       break;
+    case "skipped_closed":
     case "closed_retired":
       result.queue.closedRetired += 1;
       break;
@@ -2688,6 +2720,7 @@ function emptyScheduledRunResult(): ScheduledRunResult {
     baselinedExisting: 0,
     commandFetchErrors: 0,
     statusCommentFailures: 0,
+    repositoryScanErrors: [],
     policySkips: [],
     queue: {
       enqueued: 0,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -231,7 +231,7 @@ export interface RetryFailedHeadResult {
   repo: string;
   pullNumber: number;
   headSha: string;
-  status: ReviewPullResult | "failed" | "dry_run" | "skipped_closed";
+  status: ReviewPullResult | "failed" | "dry_run";
 }
 
 export interface FailedHeadRetryTarget {
@@ -294,7 +294,8 @@ export type ReviewPullResult =
   | "skipped_capacity"
   | "skipped_context_budget"
   | "skipped_provider_cooldown"
-  | "skipped_stale_head";
+  | "skipped_stale_head"
+  | "skipped_closed";
 
 export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"]): boolean {
   switch (status) {
@@ -455,6 +456,7 @@ export function applyReviewPullResultToRunOnceResult(result: RunOnceResult, stat
       return;
     case "posted_stale_head":
     case "skipped_stale_head":
+    case "skipped_closed":
       result.skippedStaleHead += 1;
       return;
     case "skipped_draft":
@@ -2008,12 +2010,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     exactOwnerReviewRequested = exactOwnerReviewRequested || authorization.status === "eligible";
     manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     if (reviewEventPolicyMode === "trusted_command_only") {
-      const liveBeforeConsume = await github.getPull(repo, pull.number);
-      const staleBeforeConsume = detectStalePullHead({ expected: pull, live: liveBeforeConsume, phase: "before_post" });
-      if (staleBeforeConsume) {
-        recordStaleHeadSkip({ state, repo, pull, stale: staleBeforeConsume, evidenceDir });
-        return "skipped_stale_head";
-      }
+      const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
+      if (lifecycleResult) return lifecycleResult;
     }
     const reviewEventResolution = decideAndConsumeReviewEvent({
       mode: reviewEventPolicyMode,
@@ -2025,12 +2023,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       dryRun: false
     });
     const reviewEventDecisionEvidence = buildReviewEventDecisionEvidence(reviewEventResolution, false);
-    if (
-      reviewEventResolution.consumed &&
-      await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })
-    ) {
-      writeRedactedJson(join(evidenceDir, "review-event-decision.json"), reviewEventDecisionEvidence);
-      return "skipped_stale_head";
+    if (reviewEventResolution.consumed) {
+      const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
+      if (lifecycleResult) {
+        writeRedactedJson(join(evidenceDir, "review-event-decision.json"), reviewEventDecisionEvidence);
+        return lifecycleResult;
+      }
     }
     writeRedactedJson(
       join(evidenceDir, "review-event-decision.json"),
@@ -2102,11 +2100,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       evidenceDir,
       walkthrough: plan.walkthrough
     });
-    if (
-      walkthroughPostAttempted &&
-      await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })
-    ) {
-      return "skipped_stale_head";
+    if (walkthroughPostAttempted) {
+      const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
+      if (lifecycleResult) return lifecycleResult;
     }
     const enrichmentPostAttempted = Boolean(
       config.enrichment?.enabled === true && plan.enrichment?.postIssueComment && reviewGithub.canPostAsApp()
@@ -2120,16 +2116,13 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       enrichment: plan.enrichment,
       evidenceDir
     });
-    if (
-      enrichmentPostAttempted &&
-      await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })
-    ) {
-      return "skipped_stale_head";
+    if (enrichmentPostAttempted) {
+      const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
+      if (lifecycleResult) return lifecycleResult;
     }
     writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
-    if (await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })) {
-      return "skipped_stale_head";
-    }
+    const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
+    if (lifecycleResult) return lifecycleResult;
     const priorPosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
     const preservedPriorBlockingRow = Boolean(
       priorPosted?.status === "posted" && priorPosted.event === "REQUEST_CHANGES" && plan.event === "COMMENT"
@@ -3065,18 +3058,52 @@ function recordStaleHeadSkip(input: {
   });
 }
 
-async function recordStaleHeadBeforePostIfMoved(input: {
+async function recordPullLifecycleBeforePost(input: {
   state: ReviewStateStore;
   github: GitHubApi;
   repo: string;
   pull: PullRequestSummary;
   evidenceDir: string;
-}): Promise<boolean> {
+}): Promise<"skipped_stale_head" | "skipped_closed" | undefined> {
   const live = await input.github.getPull(input.repo, input.pull.number);
+  if (isClosedPull(live)) {
+    recordClosedPullBeforeReviewPost({ ...input, live });
+    return "skipped_closed";
+  }
   const stale = detectStalePullHead({ expected: input.pull, live, phase: "before_post" });
-  if (!stale) return false;
+  if (!stale) return undefined;
   recordStaleHeadSkip({ ...input, stale });
-  return true;
+  return "skipped_stale_head";
+}
+
+function recordClosedPullBeforeReviewPost(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  live: PullRequestSummary;
+  evidenceDir: string;
+}): void {
+  const state = input.live.state ?? "unknown";
+  const mergedAt = input.live.merged_at ? `; merged_at=${input.live.merged_at}` : "";
+  const error = `closed_or_merged_before_review state=${state}${mergedAt}`;
+  mkdirSync(input.evidenceDir, { recursive: true });
+  writeRedactedJson(join(input.evidenceDir, "closed-before-review-post.json"), {
+    reason: "closed_or_merged_before_review",
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    state,
+    ...(input.live.merged_at ? { mergedAt: input.live.merged_at } : {}),
+    expectedHeadSha: input.pull.head.sha,
+    liveHeadSha: input.live.head.sha
+  });
+  if (input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha)?.status === "posted") return;
+  input.state.recordProcessed({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    status: "skipped",
+    error
+  });
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1948,12 +1948,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     }
     headClaim = headClaimAttempt.claim;
 
-    const liveBeforePost = await github.getPull(repo, pull.number);
-    const staleBeforePost = detectStalePullHead({ expected: pull, live: liveBeforePost, phase: "before_post" });
-    if (staleBeforePost) {
-      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforePost, evidenceDir });
-      return "skipped_stale_head";
-    }
+    const initialLifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
+    if (initialLifecycleResult) return initialLifecycleResult;
 
     const authorization = await lookupQueuedReviewEventAuthorization({
       mode: reviewEventPolicyMode,
@@ -2010,6 +2006,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     exactOwnerReviewRequested = exactOwnerReviewRequested || authorization.status === "eligible";
     manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     if (reviewEventPolicyMode === "trusted_command_only") {
+      // Check before the irreversible authorization-consumption boundary.
       const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
       if (lifecycleResult) return lifecycleResult;
     }
@@ -2024,6 +2021,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     });
     const reviewEventDecisionEvidence = buildReviewEventDecisionEvidence(reviewEventResolution, false);
     if (reviewEventResolution.consumed) {
+      // Re-read after consumption so an external close wins before any public POST.
       const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
       if (lifecycleResult) {
         writeRedactedJson(join(evidenceDir, "review-event-decision.json"), reviewEventDecisionEvidence);
@@ -2121,6 +2119,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       if (lifecycleResult) return lifecycleResult;
     }
     writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
+    // This deliberately stays the final server read before createReview: PR state
+    // can change independently even when the preceding local work is synchronous.
     const lifecycleResult = await recordPullLifecycleBeforePost({ state, github, repo, pull, evidenceDir });
     if (lifecycleResult) return lifecycleResult;
     const priorPosted = state.getProcessedReview(repo, pull.number, pull.head.sha);

--- a/tests/run-once-result.test.ts
+++ b/tests/run-once-result.test.ts
@@ -29,7 +29,8 @@ describe("runOnce review result aggregation", () => {
   it.each([
     ["posted_stale_head", { skippedStaleHead: 1, failed: 0 }],
     ["posted_head_unverified", { skippedStaleHead: 0, failed: 1 }],
-    ["skipped_consumed_authorization", { skippedStaleHead: 0, failed: 1 }]
+    ["skipped_consumed_authorization", { skippedStaleHead: 0, failed: 1 }],
+    ["skipped_closed", { skippedStaleHead: 1, failed: 0 }]
   ] as const)("maps %s without counting a completed review", (status, expected) => {
     const result = emptyResult();
     applyReviewPullResultToRunOnceResult(result, status);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -99,6 +99,119 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("isolates an unscoped repository scan failure and retires unrelated merged queue work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-scan-isolation-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/unavailable", "org/queued"]);
+    config.reviewConcurrency.maxActiveRuns = 1;
+    config.reviewScheduler!.maxProviderActive = 1;
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const queued = state.enqueueReviewQueueJob({
+      repo: "org/queued",
+      pullNumber: 2,
+      headSha: HEAD_B,
+      baseSha: "base"
+    }).job;
+    const mergedPull = pull("org/queued", 2, HEAD_B, "base", {
+      state: "closed",
+      mergedAt: "2026-07-20T10:01:55.000Z"
+    });
+    const statusCalls: StatusCommentCall[] = [];
+    const baseGithub = githubFromMap(new Map([["org/queued", [mergedPull]]]), new Map(), statusCalls);
+    const github: SchedulerGitHubApi = {
+      ...baseGithub,
+      listOpenPulls: async (repo) => {
+        if (repo === "org/unavailable") {
+          throw new Error("GitHub API 404 for /repos/org/unavailable/installation: ghp_scan_secret");
+        }
+        return baseGithub.listOpenPulls(repo);
+      }
+    };
+    let reviewCalls = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        reviewCalls += 1;
+        return "reviewed";
+      },
+      now: new Date("2026-07-20T15:31:35.111Z")
+    });
+
+    expect(result.repositoryScanErrors).toEqual([{
+      repo: "org/unavailable",
+      error: "GitHub API 404 for /repos/org/unavailable/installation: [redacted-secret]"
+    }]);
+    expect(result.queue).toMatchObject({ leased: 1, closedRetired: 1, failedQueueJobs: 0 });
+    expect(reviewCalls).toBe(0);
+    expect(state.getReviewQueueJob(queued.jobId)).toMatchObject({
+      state: "closed_retired",
+      lastError: "closed_or_merged_before_review state=closed"
+    });
+    expect(statusCalls.map(statusFromBody)).toEqual(["closed_or_merged_before_review"]);
+    expect(JSON.stringify(result)).not.toContain("ghp_scan_secret");
+    state.close();
+  });
+
+  it("keeps explicitly scoped repository discovery fail-fast", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-scoped-fail-fast-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/unavailable"]);
+    const state = new ReviewStateStore(config.statePath);
+    const failure = new Error("GitHub API 404 for /repos/org/unavailable/installation");
+
+    await expect(runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map()),
+        listOpenPulls: async () => { throw failure; }
+      },
+      state,
+      options: { dryRun: false, repo: "org/unavailable" },
+      reviewPullImpl: async () => "reviewed"
+    })).rejects.toThrow(failure.message);
+
+    expect(state.listReviewQueueJobs()).toEqual([]);
+    state.close();
+  });
+
+  it("settles a worker skipped_closed result as a terminal closed queue status", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-active-close-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => "skipped_closed"
+    });
+
+    expect(result.queue).toMatchObject({ leased: 1, closedRetired: 1, failedQueueJobs: 0 });
+    expect(state.listReviewQueueJobs()).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        state: "closed_retired",
+        lastError: "closed_or_merged_before_review"
+      })
+    ]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "closed",
+      reason: "closed_or_merged_before_review"
+    });
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "closed_or_merged_before_review"]);
+    state.close();
+  });
+
   it("queues a multi-repo burst and leases up to provider capacity with per-repo caps", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-burst-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -196,6 +196,7 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.queue).toMatchObject({ leased: 1, closedRetired: 1, failedQueueJobs: 0 });
+    expect(result.skippedStaleHead).toBe(1);
     expect(state.listReviewQueueJobs()).toEqual([
       expect.objectContaining({
         repo: "org/repo-a",

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -2199,6 +2199,7 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.queue.closedRetired).toBe(1);
+    expect(result.skippedStaleHead).toBe(1);
     expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "closed_retired" });
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
       state: "closed",

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -1399,6 +1399,34 @@ describe("worker context budget preflight", () => {
     scenario.state.close();
   });
 
+  it("returns skipped_closed without posting when the pull merges during an active review", async () => {
+    const headSha = "d".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 518,
+      headSha,
+      commandComment: requestChangesComment(58, 518, headSha),
+      commandCommentId: 58,
+      closeAfterConsume: true
+    });
+
+    expect(scenario.error).toBeUndefined();
+    expect(scenario.result).toBe("skipped_closed");
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 518, headSha)).toMatchObject({
+      status: "skipped",
+      error: "closed_or_merged_before_review state=closed; merged_at=2026-07-20T10:01:55.000Z"
+    });
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "closed-before-review-post.json"), "utf8"))).toMatchObject({
+      reason: "closed_or_merged_before_review",
+      state: "closed",
+      mergedAt: "2026-07-20T10:01:55.000Z",
+      expectedHeadSha: headSha,
+      liveHeadSha: headSha
+    });
+    scenario.state.close();
+  });
+
   it("keeps a successful review posted when the immediate post-review head lookup fails", async () => {
     const headSha = "c".repeat(40);
     const lookupSecret = "ghp_post_lookup_secret";
@@ -1562,6 +1590,7 @@ async function runOwnerPolicyReview(input: {
   moveHeadDuringPost?: string;
   moveHeadAfterConsume?: string;
   moveHeadAfterAuxiliaryPost?: string;
+  closeAfterConsume?: boolean;
   postReviewHeadLookupError?: Error;
   enableWalkthrough?: boolean;
   enableWalkthroughPost?: boolean;
@@ -1588,11 +1617,19 @@ async function runOwnerPolicyReview(input: {
   const pull = pullSummary(input.pullNumber, headSha);
   let livePull = pull;
   input.configureState?.(state);
-  if (input.moveHeadAfterConsume) {
+  if (input.moveHeadAfterConsume || input.closeAfterConsume) {
     const consume = state.tryConsumeReviewEventAuthorization.bind(state);
     vi.spyOn(state, "tryConsumeReviewEventAuthorization").mockImplementation((authorization) => {
       const consumed = consume(authorization);
-      livePull = pullSummary(input.pullNumber, input.moveHeadAfterConsume!);
+      if (input.closeAfterConsume) {
+        livePull = {
+          ...pull,
+          state: "closed",
+          merged_at: "2026-07-20T10:01:55.000Z"
+        };
+      } else {
+        livePull = pullSummary(input.pullNumber, input.moveHeadAfterConsume!);
+      }
       return consumed;
     });
   }

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -1427,6 +1427,34 @@ describe("worker context budget preflight", () => {
     scenario.state.close();
   });
 
+  it("prefers skipped_closed when a changed pull head closes before final posting", async () => {
+    const headSha = "e".repeat(40);
+    const liveHeadSha = "f".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 526,
+      headSha,
+      commandComment: requestChangesComment(85, 526, headSha),
+      commandCommentId: 85,
+      closeAfterHeadClaimWithSha: liveHeadSha
+    });
+
+    expect(scenario.error).toBeUndefined();
+    expect(scenario.result).toBe("skipped_closed");
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 526, headSha)).toMatchObject({
+      status: "skipped",
+      error: "closed_or_merged_before_review state=closed; merged_at=2026-07-20T10:01:55.000Z"
+    });
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "closed-before-review-post.json"), "utf8"))).toMatchObject({
+      reason: "closed_or_merged_before_review",
+      state: "closed",
+      expectedHeadSha: headSha,
+      liveHeadSha
+    });
+    scenario.state.close();
+  });
+
   it("keeps a successful review posted when the immediate post-review head lookup fails", async () => {
     const headSha = "c".repeat(40);
     const lookupSecret = "ghp_post_lookup_secret";
@@ -1591,6 +1619,7 @@ async function runOwnerPolicyReview(input: {
   moveHeadAfterConsume?: string;
   moveHeadAfterAuxiliaryPost?: string;
   closeAfterConsume?: boolean;
+  closeAfterHeadClaimWithSha?: string;
   postReviewHeadLookupError?: Error;
   enableWalkthrough?: boolean;
   enableWalkthroughPost?: boolean;
@@ -1617,6 +1646,18 @@ async function runOwnerPolicyReview(input: {
   const pull = pullSummary(input.pullNumber, headSha);
   let livePull = pull;
   input.configureState?.(state);
+  if (input.closeAfterHeadClaimWithSha) {
+    const tryClaim = state.tryClaimReviewHeadWithOutcome.bind(state);
+    vi.spyOn(state, "tryClaimReviewHeadWithOutcome").mockImplementation((claim) => {
+      const outcome = tryClaim(claim);
+      livePull = {
+        ...pullSummary(input.pullNumber, input.closeAfterHeadClaimWithSha!),
+        state: "closed",
+        merged_at: "2026-07-20T10:01:55.000Z"
+      };
+      return outcome;
+    });
+  }
   if (input.moveHeadAfterConsume || input.closeAfterConsume) {
     const consume = state.tryConsumeReviewEventAuthorization.bind(state);
     vi.spyOn(state, "tryConsumeReviewEventAuthorization").mockImplementation((authorization) => {


### PR DESCRIPTION
## What Problem This Solves

Tracks #561. Keep #561 open after source merge until a separately authorized live canary proves the installed daemon.

One configured repository's installation lookup failure currently aborts the whole scheduler cycle before unrelated durable queue work can be leased. Merged PRs can therefore remain visibly queued. A second race allows a formal review POST when a PR closes during active analysis.

## User Impact

An unrelated repository discovery failure no longer blocks already-queued reviews from reaching terminal state. If a queued or actively reviewed PR closes, NeonDiff retires it as `closed_or_merged_before_review` and does not post a formal review.

## Implementation Notes

- Add redacted `repositoryScanErrors` to `ScheduledRunResult`.
- Isolate initial repository discovery failures only for unscoped daemon-wide cycles; explicit repo/PR operator scopes remain fail-fast.
- Continue leasing durable queue work after an isolated scan failure.
- Export `skipped_closed` from `ReviewPullResult` and settle it as `closed_retired`, closed readiness, terminal sticky status, and a skipped reviewer-session job.
- Extend every pre-post lifecycle read to distinguish closed PRs from stale heads; record redacted evidence and return before `createReview`.
- Reuse the narrow isolation approach from preserved commit `c2ecc5f` without importing #599 transport telemetry/retry work.

## Validation

- [x] Failing test, smoke, or eval was added/updated first: three focused regressions failed before source changes (unscoped scan isolation, terminal `skipped_closed` queue settlement, active-review close race).
- [x] Focused validation: Node 26.4.0, 143/143 tests across `scheduler`, `worker-context-budget`, and `run-once-result`.
- [ ] `npm test`: canonical full suite is delegated to exact-head GitHub Actions.
- [x] `npm run build`: equivalent Node 26 build and postbuild commands passed locally.
- [ ] GitHub CI/review-bot follow-up: pending on the exact PR head.

## Proof Boundary

This PR proves:

- Source-level unscoped repository-scan failure containment.
- Same-cycle terminal retirement of unrelated already-queued merged work.
- Final pre-post protection when a PR closes during active review.
- Redacted diagnostics, explicit scoped fail-fast behavior, and no formal review invocation for the closed cases under test.

This PR does not prove:

- Installed-daemon behavior, queue repair for existing live rows, deployment, restart, canary, package publication, release, or customer readiness.
- The broader #599 transport retry/broker work or #572 queue-position/ETA work.

## Safety Boundary

- [x] No GitHub App permission expansion.
- [x] No live worker restart, launchd mutation, or beta promotion.
- [x] No package publish, GitHub Release, or repo visibility change.
- [x] No secrets, tokens, credentials, raw private diffs, or customer data in the PR.
- [x] Claims stay within the source-available beta boundary.
- [x] Provider status claims distinguish tested, compatible-by-interface, planned, and untested/resource-only states.

## Restricted Actions Not Performed

No live config or installation-scope change, daemon restart/deploy, existing queue-row mutation, sticky-comment repair, tag, package publish, release, branch-protection change, or beta promotion was performed.

## Evidence

- Fresh runtime recurrence and proof boundary: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/561#issuecomment-5024053077
- Local evidence root: `/Volumes/LEXAR/Codex/review-governance/evidence/2026-07-20/`
- Gate status: `GATE INCOMPLETE` pending exact-head CI and one independent semantic review covering queue isolation, cross-repository failure containment, terminal status, and duplicate/stale review prevention.

## Agent-Authored PR

- [x] This PR was authored or materially edited by an AI agent.
- [x] The agent updated #561 before publication and listed restricted actions not performed.
