### PR TITLE
fix(desktop): require exact B0 GitHub verification

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -179,6 +179,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard !isConfigPatchInProgress else {
             return false
         }
+        if dependencies.productionBoundary.byoGitHubEnabled {
+            guard byoGitHubCredentialOnboardingAvailable,
+                  byoGitHubCredentialsVerified
+            else { return false }
+        }
         guard dependencies.productionBoundary.managedGitHubBrokerOrigin != nil else {
             return true
         }
@@ -266,7 +271,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             guard hasVerifiedManagedGitHubSelection else { return false }
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
-            guard byoGitHubCredentialsStored else { return false }
+            guard byoGitHubCredentialOnboardingAvailable,
+                  byoGitHubCredentialsStored,
+                  byoGitHubCredentialsVerified
+            else { return false }
         }
         return onboardingFlow.canAdvance
     }
@@ -1538,6 +1546,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard result.exitCode == 0,
               let data = result.stdout.data(using: .utf8),
               let report = try? JSONDecoder().decode(BYOGitHubDoctorReport.self, from: data),
+              let expectedRepositories = normalizedExactRepoNames(expectedContext.repositories),
+              let reportedRepositories = normalizedExactRepoNames(report.github.readChecks.map(\.repo)),
+              !expectedRepositories.isEmpty,
+              reportedRepositories == expectedRepositories,
               report.ok,
               report.command == "doctor github",
               report.appCredentials.source == "stdin",
@@ -1547,7 +1559,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
               report.github.readMode == "app_installation",
               !report.github.readChecks.isEmpty,
               report.github.readChecks.allSatisfy({ check in
-                  check.ok
+                  check.skippedByPolicy == nil
+                      && check.ok
                       && check.installationIdPresent
                       && check.appCanReadMetadata
                       && check.appCanReadPullRequests
@@ -1560,7 +1573,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
-        let repositories = report.github.readChecks.map(\.repo).sorted().joined(separator: ", ")
+        let repositories = report.github.readChecks.map(\.repo).sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }.joined(separator: ", ")
         byoGitHubCredentialsVerified = true
         lastError = nil
         byoGitHubCredentialStatus = "Verified App installation access for \(repositories). Worker dry/live review has not run yet."
@@ -3289,6 +3304,7 @@ private struct BYOGitHubDoctorReport: Decodable {
     struct ReadCheck: Decodable {
         let repo: String
         let ok: Bool
+        let skippedByPolicy: String?
         let installationIdPresent: Bool
         let appCanReadMetadata: Bool
         let appCanReadPullRequests: Bool
@@ -3296,6 +3312,7 @@ private struct BYOGitHubDoctorReport: Decodable {
         enum CodingKeys: String, CodingKey {
             case repo
             case ok
+            case skippedByPolicy
             case installationIdPresent = "installation_id_present"
             case appCanReadMetadata = "app_can_read_metadata"
             case appCanReadPullRequests = "app_can_read_pull_requests"
@@ -3395,6 +3412,18 @@ private func uniqueSortedRepoNames(_ names: [String]) -> [String] {
         .filter(isValidRepoName)
         .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
         .filter { seen.insert($0.lowercased()).inserted }
+}
+
+private func normalizedExactRepoNames(_ names: [String]) -> [String]? {
+    let normalized = names.map {
+        $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+    guard normalized.allSatisfy(isValidRepoName),
+          Set(normalized).count == normalized.count
+    else {
+        return nil
+    }
+    return normalized.sorted()
 }
 
 private extension Collection {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -299,6 +299,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var providerVerificationContextGeneration: UInt64 = 0
     private var activeProviderVerificationRequestGeneration: UInt64?
     private var providerKeyRevision: UInt64 = 0
+    private var byoGitHubCredentialRevision: UInt64 = 0
     private var githubAuthorizationTask: Task<Void, Never>?
     private var githubRepositoryRefreshTask: Task<Void, Never>?
     private var managedGitHubConnectionTask: Task<Void, Never>?
@@ -1393,6 +1394,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func storeBYOGitHubAppCredentials() {
         defer { pendingBYOGitHubAppPrivateKey = "" }
+        byoGitHubCredentialRevision &+= 1
         invalidateBYOGitHubVerificationContext()
         guard byoGitHubCredentialOnboardingAvailable else {
             lastError = "Customer-owned GitHub App onboarding is unavailable in this build."
@@ -1429,6 +1431,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func clearBYOGitHubAppCredentials() {
         pendingBYOGitHubAppPrivateKey = ""
         pendingBYOGitHubAppId = ""
+        byoGitHubCredentialRevision &+= 1
         invalidateBYOGitHubVerificationContext()
         do {
             try dependencies.secretStore.deleteSecret(
@@ -1484,6 +1487,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let safeCommand = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --github-app-id \(shellQuote(appId)) --github-app-private-key-stdin true --json < [secure Keychain input]"
         let verificationContext = BYOGitHubVerificationContext(
             appId: appId,
+            credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
             repositories: repos.filter(\.enabled).map(\.name).sorted()
@@ -1531,6 +1535,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let currentContext = storedBYOGitHubAppId.map { appId in
             BYOGitHubVerificationContext(
                 appId: appId,
+                credentialRevision: byoGitHubCredentialRevision,
                 cliPath: cliPath,
                 configPath: configPath,
                 repositories: repos.filter(\.enabled).map(\.name).sorted()
@@ -3322,6 +3327,7 @@ private struct BYOGitHubDoctorReport: Decodable {
 
 private struct BYOGitHubVerificationContext: Equatable, Sendable {
     let appId: String
+    let credentialRevision: UInt64
     let cliPath: String
     let configPath: String
     let repositories: [String]

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -21,7 +21,10 @@ struct BYOGitHubAppCredentialOnboardingTests {
         )
         #expect(fixture.model.byoGitHubPrivateKeyStored)
         #expect(fixture.model.byoGitHubCredentialsStored)
-        #expect(fixture.model.canAdvanceOnboarding)
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(!fixture.model.canAdvanceOnboarding)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.productionDaemonStopAvailable)
         #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
         #expect(fixture.model.pendingBYOGitHubAppId == "123456")
         #expect(fixture.cli.calls.isEmpty)
@@ -105,6 +108,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
             cliOutcomes: [.success(doctorResult)],
             productionBoundary: exactB0Boundary
         )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
         fixture.model.pendingBYOGitHubAppId = "123456"
         fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
         fixture.model.storeBYOGitHubAppCredentials()
@@ -129,11 +133,180 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.byoGitHubCredentialsVerified)
         #expect(!fixture.model.isBYOGitHubVerificationInProgress)
         #expect(fixture.model.byoGitHubCredentialStatus.contains("acme/demo"))
+        #expect(fixture.model.canAdvanceOnboarding)
+        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.productionDaemonStopAvailable)
 
         fixture.model.configPath = "/tmp/changed-config.json"
         #expect(!fixture.model.byoGitHubCredentialsVerified)
         #expect(fixture.model.byoGitHubCredentialStatus.contains("Verify App access again"))
+        #expect(!fixture.model.canAdvanceOnboarding)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.productionDaemonStopAvailable)
     }
+
+    @Test func verificationFailsClosedUnlessDoctorChecksExactlyMatchEnabledRepositories() async throws {
+        struct Scenario {
+            let name: String
+            let configuredRepositories: [RepoMonitor]
+            let readChecks: String
+            let shouldVerify: Bool
+        }
+
+        let matchingChecks = [
+            doctorReadCheck(repo: "acme/api"),
+            doctorReadCheck(repo: "acme/demo")
+        ].joined(separator: ",")
+        let scenarios = [
+            Scenario(
+                name: "all normalized repositories match",
+                configuredRepositories: [
+                    RepoMonitor(name: "Acme/Demo", enabled: true),
+                    RepoMonitor(name: "acme/api", enabled: true)
+                ],
+                readChecks: matchingChecks,
+                shouldVerify: true
+            ),
+            Scenario(
+                name: "stale on-disk repository set is missing the new repository",
+                configuredRepositories: [
+                    RepoMonitor(name: "acme/demo", enabled: true),
+                    RepoMonitor(name: "acme/api", enabled: true)
+                ],
+                readChecks: doctorReadCheck(repo: "acme/demo"),
+                shouldVerify: false
+            ),
+            Scenario(
+                name: "doctor returns an extra repository",
+                configuredRepositories: [RepoMonitor(name: "acme/demo", enabled: true)],
+                readChecks: matchingChecks,
+                shouldVerify: false
+            ),
+            Scenario(
+                name: "doctor returns a duplicate repository",
+                configuredRepositories: [RepoMonitor(name: "acme/demo", enabled: true)],
+                readChecks: [
+                    doctorReadCheck(repo: "acme/demo"),
+                    doctorReadCheck(repo: "ACME/DEMO")
+                ].joined(separator: ","),
+                shouldVerify: false
+            ),
+            Scenario(
+                name: "configured repository is policy skipped",
+                configuredRepositories: [RepoMonitor(name: "acme/demo", enabled: true)],
+                readChecks: doctorReadCheck(
+                    repo: "acme/demo",
+                    skippedByPolicy: "repo_profile_disabled"
+                ),
+                shouldVerify: false
+            ),
+            Scenario(
+                name: "repository permission check failed",
+                configuredRepositories: [RepoMonitor(name: "acme/demo", enabled: true)],
+                readChecks: doctorReadCheck(repo: "acme/demo", ok: false),
+                shouldVerify: false
+            )
+        ]
+
+        for scenario in scenarios {
+            let fixture = ModelDependencyFixture(
+                cliOutcomes: [.success(doctorResult(readChecks: scenario.readChecks))],
+                productionBoundary: exactB0Boundary
+            )
+            fixture.model.repos = scenario.configuredRepositories
+            fixture.model.pendingBYOGitHubAppId = "123456"
+            fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+            fixture.model.storeBYOGitHubAppCredentials()
+
+            fixture.model.verifyBYOGitHubAppCredentials()
+            await waitForBYOVerification(fixture)
+
+            #expect(
+                fixture.model.byoGitHubCredentialsVerified == scenario.shouldVerify,
+                Comment(rawValue: scenario.name)
+            )
+            #expect(
+                fixture.model.productionUsefulWorkAvailable == scenario.shouldVerify,
+                Comment(rawValue: scenario.name)
+            )
+            #expect(fixture.model.productionDaemonStopAvailable)
+        }
+    }
+
+    @Test func enabledRepositoryMutationRevokesUsefulWorkUntilReverified() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.productionUsefulWorkAvailable)
+
+        fixture.model.repos.append(RepoMonitor(name: "acme/api", enabled: true))
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(!fixture.model.canAdvanceOnboarding)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.productionDaemonStopAvailable)
+    }
+
+    @Test func contextMutationWhileDoctorRunsDiscardsOtherwiseSuccessfulProof() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
+            suspendCLIRuns: true,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await fixture.cli.waitUntilCallCount(1)
+        #expect(fixture.model.isBYOGitHubVerificationInProgress)
+
+        fixture.model.repos.append(RepoMonitor(name: "acme/api", enabled: true))
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.byoGitHubCredentialStatus.contains("Configuration changed"))
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.productionDaemonStopAvailable)
+    }
+}
+
+@MainActor
+private func waitForBYOVerification(_ fixture: ModelDependencyFixture) async {
+    await fixture.cli.waitUntilCallCount(1)
+    for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+        await Task.yield()
+    }
+}
+
+private func doctorResult(readChecks: String) -> CLIRunResult {
+    CLIRunResult(
+        exitCode: 0,
+        stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
+        stderr: ""
+    )
+}
+
+private func doctorReadCheck(
+    repo: String,
+    skippedByPolicy: String? = nil,
+    ok: Bool = true
+) -> String {
+    let skippedField = skippedByPolicy.map { #",\"skippedByPolicy\":\"\#($0)\""# } ?? ""
+    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
 }
 
 private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: [

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -282,6 +282,35 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.productionDaemonStopAvailable)
     }
+
+    @Test func privateKeyRotationWhileDoctorRunsDiscardsOldKeyProof() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
+            suspendCLIRuns: true,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await fixture.cli.waitUntilCallCount(1)
+        #expect(fixture.model.isBYOGitHubVerificationInProgress)
+
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = rotatedFixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.byoGitHubCredentialStatus.contains("Configuration changed"))
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.productionDaemonStopAvailable)
+    }
 }
 
 @MainActor
@@ -318,5 +347,10 @@ private let fixturePrivateKeyLabel = "PRIVATE" + " KEY"
 private let fixturePrivateKey = """
 -----BEGIN \(fixturePrivateKeyLabel)-----
 ZmFrZS1maXh0dXJlLXByaXZhdGUta2V5
+-----END \(fixturePrivateKeyLabel)-----
+"""
+private let rotatedFixturePrivateKey = """
+-----BEGIN \(fixturePrivateKeyLabel)-----
+ZmFrZS1maXh0dXJlLXJvdGF0ZWQta2V5
 -----END \(fixturePrivateKeyLabel)-----
 """

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -32,12 +32,17 @@ final class ScriptedDesktopCLIExecutor: DesktopCLIExecuting, @unchecked Sendable
         var calls: [RecordedCLICall] = []
         var outcomes: [Result<CLIRunResult, Error>]
         var waiters: [Waiter] = []
+        var suspendRuns: Bool
+        var suspendedRunContinuations: [CheckedContinuation<Void, Never>] = []
     }
 
     private let state: ModelFixtureLocked<State>
 
-    init(outcomes: [Result<CLIRunResult, Error>] = []) {
-        state = ModelFixtureLocked(State(outcomes: outcomes))
+    init(
+        outcomes: [Result<CLIRunResult, Error>] = [],
+        suspendRuns: Bool = false
+    ) {
+        state = ModelFixtureLocked(State(outcomes: outcomes, suspendRuns: suspendRuns))
     }
 
     var calls: [RecordedCLICall] { state.read(\.calls) }
@@ -56,6 +61,15 @@ final class ScriptedDesktopCLIExecutor: DesktopCLIExecuting, @unchecked Sendable
             }
             if shouldResume { continuation.resume() }
         }
+    }
+
+    func resumeSuspendedRuns() {
+        let continuations = state.update { state -> [CheckedContinuation<Void, Never>] in
+            state.suspendRuns = false
+            defer { state.suspendedRunContinuations.removeAll() }
+            return state.suspendedRunContinuations
+        }
+        continuations.forEach { $0.resume() }
     }
 
     func run(
@@ -79,6 +93,16 @@ final class ScriptedDesktopCLIExecutor: DesktopCLIExecuting, @unchecked Sendable
             return (outcome, ready.map(\.continuation))
         }
         resumptions.forEach { $0.resume() }
+        if state.read(\.suspendRuns) {
+            await withCheckedContinuation { continuation in
+                let shouldResume = state.update { state -> Bool in
+                    guard state.suspendRuns else { return true }
+                    state.suspendedRunContinuations.append(continuation)
+                    return false
+                }
+                if shouldResume { continuation.resume() }
+            }
+        }
         return try outcome.get()
     }
 }
@@ -183,6 +207,7 @@ struct ModelDependencyFixture {
         root: URL = fixtureURL("/fixture/model-app-support", directory: true),
         now: Date = fixtureDate(secondsSince1970: 1_000_000),
         cliOutcomes: [Result<CLIRunResult, Error>] = [],
+        suspendCLIRuns: Bool = false,
         clipboardResult: Bool = true,
         urlResult: Bool = true,
         githubAuthenticator: ScriptedGitHubAuthenticator = ScriptedGitHubAuthenticator(),
@@ -194,7 +219,10 @@ struct ModelDependencyFixture {
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
         urlOpener = RecordingURLOpener(result: urlResult)
-        cli = ScriptedDesktopCLIExecutor(outcomes: cliOutcomes)
+        cli = ScriptedDesktopCLIExecutor(
+            outcomes: cliOutcomes,
+            suspendRuns: suspendCLIRuns
+        )
         dashboard = RecordingDashboardLauncher()
         preferences = MemoryPreferences()
         for (key, value) in preferenceBools {


### PR DESCRIPTION
## Summary

Require current, exact customer-owned GitHub App verification before the B0 native app enables useful work or onboarding completion.

The result gate now accepts `doctor github` proof only when its active repository checks are an exact case-normalized, duplicate-free match for the current enabled repository set. Missing, extra, duplicate, invalid, or policy-skipped checks fail closed.

Related: #646

## Acceptance criteria

- Stored but unverified BYO credentials do not enable B0 useful work or onboarding completion.
- A current successful `doctor github` result for the exact App ID, CLI path, config path, and enabled repository set enables the B0 gate.
- Missing, extra, duplicate, policy-skipped, permission-failed, stale, or invalid repository proof fails closed.
- Repository/config/private-key context mutation revokes prior proof; an in-flight result for an old context is discarded.
- Daemon stop remains available as a safety remediation when useful-work proof is absent or revoked.
- The managed GitHub path remains unchanged.

## Non-goals

- No CLI package rebuild, upload, npm publication, signing, notarization, release, checkout, deployment, or canary.
- No live GitHub authorization or review posting.
- No B1 managed-App/OAuth change.
- Does not close #646 or claim paid-beta readiness.

## Failing-first proof

- Initial RED commit: `75aa8dd`.
- Command: `swift test --package-path apps/neondiff-desktop --filter BYOGitHubAppCredentialOnboardingTests`
- Before the implementation, the focused suite failed with 13 expectation issues: stored-unverified useful work/onboarding passed, and stale/missing/extra/duplicate/policy-skipped repository evidence could be accepted.
- Independent current-head review then reproduced an in-flight private-key rotation race. Delta RED commit `d4d0de4` failed with 3 expectation issues before the credential-revision fix.

## Local validation

- `swift test --package-path apps/neondiff-desktop --filter BYOGitHubAppCredentialOnboardingTests` — 10 passed, 0 failed.
- `swift test --package-path apps/neondiff-desktop --filter ManagedGitHubOnboardingTests` — 21 passed, 0 failed.
- `swift test --package-path apps/neondiff-desktop --filter ProductionBoundaryContractTests` — 11 passed, 0 failed.
- `git diff --check` — passed.

Broad validation belongs to remote CI. The GitHub App private key path remains fixed-account Keychain custody with bounded CLI stdin; the key is not added to argv, config, logs, or evidence.

Agent-authored change.
