### PR TITLE
fix(desktop): complete B0 repository onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,13 @@ The invite-only B0 technical-beta build uses a separate exact
 `paid-mac-beta-byo-v1` release contract with `NeonDiffBYOGitHubEnabled=true` and
 no managed-broker fields. That contract enables the existing local direct/BYO
 path and API-backed native activation without a hidden defaults mutation. It
-does not prove customer-safe private-key custody, a compatible published CLI,
-signing, billing, canaries, or release readiness.
+is a paid path for every repository and does not claim the managed public-free
+model. On a clean Mac, native first run exposes **Initialize Local Config**
+(non-destructive; never force-overwrites), **Add Repository**, **Apply
+Repository**, and **Verify App Access**, so the invited customer does not need a
+terminal or an operator edit to reach the repository-verification gate. This
+source path does not prove customer-safe private-key custody, a compatible
+published CLI, signing, billing, canaries, or release readiness.
 This source composition is not proof that the production broker is enabled,
 that billing is live, or that a signed customer artifact exists. Generic CLI
 status/deactivate and daemon-admission validation still need exact-candidate
@@ -167,15 +172,16 @@ both the provider ID and inspected config revision.
 Create or install the GitHub App before expecting PR reviews to run. The App
 must be installed on the same selected repositories listed in `pilotRepos`; see
 [docs/github-app-setup.md](docs/github-app-setup.md) for the permission set and
-selected-repo install path. The rollout-disabled managed desktop path uses the
+selected-repo install path. The rollout-disabled managed desktop source uses the
 broker-issued GitHub App install/OAuth URL and keeps polling its device-bound
 completion state while authorization is pending. A fresh installation callback
-wins without asking the customer to authorize twice. If the official App was
-already installed and GitHub therefore sends no install callback, the verified
-managed build uses its compiled public App client ID to show Device Flow as a
-transient installation-access proof. That user token stays in process memory
-only for the authorization window and is never a review credential. Legacy
-direct-install builds still read their public client ID from local config.
+wins without asking the customer to authorize twice. The unshipped source still
+contains Device Flow as an existing-install fallback. Before B1 release, #613
+must move that managed customer path to broker-hosted web OAuth with state and
+PKCE; Device Flow remains only an optional CLI/headless fallback. Both paths
+must verify the exact user-authorized installation/repository intersection, and
+installation tokens remain the only review credential. Legacy direct-install
+builds still read their public client ID from local config.
 
 Do not store the GitHub App private key, provider API key, license key, tokens,
 or customer data in this repository. Keep local config, secrets, state DBs, and

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -193,10 +193,85 @@ struct OnboardingWizardView: View {
 
             Text(model.byoGitHubCredentialStatus)
                 .font(.caption)
-                .foregroundStyle(model.byoGitHubCredentialsStored ? NeonDiffTheme.accent : NeonDiffTheme.warning)
+                .foregroundStyle(model.byoGitHubCredentialsVerified ? NeonDiffTheme.accent : NeonDiffTheme.warning)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text("Continue becomes available after local credential custody is complete. Installation/repository verification and a live review are separate gates and are not claimed here.")
+            Divider()
+                .overlay(NeonDiffTheme.stroke.opacity(0.54))
+
+            Text("Repository to review")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(NeonDiffTheme.textPrimary)
+
+            Text("B0 onboarding supports one repository at a time. Add its owner/repo name, apply that allowlist to the local worker config, then verify the customer-owned App installation before continuing.")
+                .operatorBodyText()
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 10) {
+                OperatorTextField(
+                    title: "owner/repo",
+                    text: $model.pendingRepoName
+                )
+                .accessibilityIdentifier("neondiff-onboarding-byo-repository")
+
+                Button { model.addPendingRepoToAllowlist() } label: {
+                    Label("Add Repository", systemImage: "plus.circle")
+                }
+                .disabled(
+                    model.pendingRepoName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || model.isConfigPatchInProgress
+                        || model.isConfigInspectInProgress
+                )
+                .accessibilityIdentifier("neondiff-onboarding-byo-repository-add")
+            }
+
+            ForEach(model.repos.filter(\.enabled)) { repository in
+                HStack(spacing: 10) {
+                    Text(repository.name)
+                        .font(NeonDiffTheme.commandFont)
+                        .foregroundStyle(NeonDiffTheme.textPrimary)
+                        .textSelection(.enabled)
+
+                    Spacer()
+
+                    Button(role: .destructive) {
+                        model.removeRepoFromAllowlist(repository)
+                    } label: {
+                        Label("Remove", systemImage: "minus.circle")
+                    }
+                    .disabled(model.isConfigPatchInProgress || model.isConfigInspectInProgress)
+                    .accessibilityIdentifier("neondiff-onboarding-byo-repository-remove-\(repository.name)")
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button { model.applyRepoAllowlistPatch() } label: {
+                    Label("Apply Repository", systemImage: "checkmark.seal")
+                }
+                .disabled(
+                    model.repos.filter(\.enabled).count != 1
+                        || model.isConfigPatchInProgress
+                        || model.isConfigInspectInProgress
+                )
+                .accessibilityIdentifier("neondiff-onboarding-byo-repository-apply")
+
+                Button { model.verifyBYOGitHubAppCredentials() } label: {
+                    Label(
+                        model.isBYOGitHubVerificationInProgress ? "Verifying…" : "Verify App Access",
+                        systemImage: "checkmark.shield"
+                    )
+                }
+                .disabled(
+                    !model.byoGitHubCredentialsStored
+                        || model.repos.filter(\.enabled).count != 1
+                        || model.isConfigPatchInProgress
+                        || model.isConfigInspectInProgress
+                        || model.isBYOGitHubVerificationInProgress
+                )
+                .accessibilityIdentifier("neondiff-onboarding-byo-github-verify")
+            }
+
+            Text("Continue becomes available only after GitHub verifies the exact configured repository through this App installation. A dry run and live review remain separate gates and are not claimed here.")
                 .font(.caption)
                 .foregroundStyle(NeonDiffTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -203,8 +203,27 @@ struct OnboardingWizardView: View {
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(NeonDiffTheme.textPrimary)
 
-            Text("B0 onboarding supports one repository at a time. Add its owner/repo name, apply that allowlist to the local worker config, then verify the customer-owned App installation before continuing.")
+            Text("B0 onboarding supports one repository at a time. On a clean install, initialize the local config first. This never overwrites an existing config. Then add owner/repo, apply that allowlist, and verify the customer-owned App installation.")
                 .operatorBodyText()
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button { model.initializeConfigForOnboarding() } label: {
+                Label(
+                    model.isConfigInitializationInProgress ? "Initializing…" : "Initialize Local Config",
+                    systemImage: "doc.badge.plus"
+                )
+            }
+            .disabled(
+                !model.canEditProviderConfiguration
+                    || model.isConfigInitializationInProgress
+                    || model.isConfigPatchInProgress
+                    || model.isConfigInspectInProgress
+            )
+            .accessibilityIdentifier("neondiff-onboarding-byo-config-initialize")
+
+            Text(model.configInitializationStatus)
+                .font(.caption)
+                .foregroundStyle(NeonDiffTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             HStack(spacing: 10) {
@@ -219,6 +238,8 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     model.pendingRepoName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || !model.canEditProviderConfiguration
+                        || model.isConfigInitializationInProgress
                         || model.isConfigPatchInProgress
                         || model.isConfigInspectInProgress
                 )
@@ -239,7 +260,12 @@ struct OnboardingWizardView: View {
                     } label: {
                         Label("Remove", systemImage: "minus.circle")
                     }
-                    .disabled(model.isConfigPatchInProgress || model.isConfigInspectInProgress)
+                    .disabled(
+                        !model.canEditProviderConfiguration
+                            || model.isConfigInitializationInProgress
+                            || model.isConfigPatchInProgress
+                            || model.isConfigInspectInProgress
+                    )
                     .accessibilityIdentifier("neondiff-onboarding-byo-repository-remove-\(repository.name)")
                 }
             }
@@ -250,6 +276,8 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     model.repos.filter(\.enabled).count != 1
+                        || !model.canEditProviderConfiguration
+                        || model.isConfigInitializationInProgress
                         || model.isConfigPatchInProgress
                         || model.isConfigInspectInProgress
                 )
@@ -264,6 +292,8 @@ struct OnboardingWizardView: View {
                 .disabled(
                     !model.byoGitHubCredentialsStored
                         || model.repos.filter(\.enabled).count != 1
+                        || !model.canEditProviderConfiguration
+                        || model.isConfigInitializationInProgress
                         || model.isConfigPatchInProgress
                         || model.isConfigInspectInProgress
                         || model.isBYOGitHubVerificationInProgress

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -119,6 +119,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var controlCenter = DesktopControlCenterSettings()
     @Published package var controlCenterStatus = "Load current config before editing."
     @Published package var isControlCenterOperationInProgress = false
+    @Published package private(set) var isConfigInitializationInProgress = false
+    @Published package private(set) var configInitializationStatus = "Initialize a local config once on a clean install. Existing configs are never overwritten."
     @Published package var isConfigPatchInProgress = false
     @Published package var isConfigInspectInProgress = false
     @Published package var pendingIssueRepoName = ""
@@ -491,6 +493,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         NeonDiffCommandBuilder.configInspect(cliPath: cliPath, configPath: configPath)
     }
 
+    package var configInitializeCommand: DesktopCommand {
+        NeonDiffCommandBuilder.configInitialize(cliPath: cliPath, configPath: configPath)
+    }
+
     package var providerPatchPreviewCommand: DesktopCommand {
         NeonDiffCommandBuilder.configPatch(
             cliPath: cliPath,
@@ -749,6 +755,26 @@ package final class NeonDiffDesktopModel: ObservableObject {
         runCLI(arguments: ["config", "inspect", "--config", configPath], displayCommand: configInspectCommand)
     }
 
+    package func initializeConfigForOnboarding() {
+        guard byoGitHubCredentialOnboardingAvailable else {
+            lastError = "Local config initialization is available only in the customer-owned GitHub App beta path."
+            return
+        }
+        guard canEditProviderConfiguration else {
+            lastError = providerVerificationSafetyLatchMessage ?? "Wait for provider verification cleanup before changing config."
+            return
+        }
+        guard !isConfigInitializationInProgress, !isConfigPatchInProgress, !isConfigInspectInProgress else {
+            lastError = "Another config operation is still running."
+            return
+        }
+        configInitializationStatus = "Creating a new local config without overwriting existing data…"
+        runCLI(
+            arguments: ["init", "--config", configPath],
+            displayCommand: configInitializeCommand
+        )
+    }
+
     package func addPendingIssueRepo() {
         guard canEditProviderConfiguration else {
             lastError = providerVerificationSafetyLatchMessage ?? "Wait for provider verification cleanup before changing config."
@@ -955,6 +981,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func removeRepoFromAllowlist(_ repo: RepoMonitor) {
         guard !managedGitHubAvailable else {
             lastError = "Managed mode repository scope comes from the verified GitHub App binding."
+            return
+        }
+        guard canEditProviderConfiguration else {
+            lastError = providerVerificationSafetyLatchMessage ?? "Wait for provider verification cleanup before changing config."
             return
         }
         repos.removeAll { $0.id == repo.id }
@@ -2166,7 +2196,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         let isConfigPatchCommand = arguments.count >= 2 && arguments[0] == "config" && arguments[1] == "patch"
         let isConfigInspectCommand = arguments.count >= 2 && arguments[0] == "config" && arguments[1] == "inspect"
-        if (isConfigPatchCommand || isConfigInspectCommand)
+        let isConfigInitializeCommand = arguments.first == "init"
+        let isConfigOperation = isConfigInitializeCommand || isConfigPatchCommand || isConfigInspectCommand
+        if isConfigOperation
             && (isProviderVerificationInProgress || isProviderVerificationCancelling) {
             lastError = "Wait for provider verification cleanup before changing config."
             clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
@@ -2174,7 +2206,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             if controlCenterOperation != nil { isControlCenterOperationInProgress = false }
             return
         }
-        if isConfigPatchCommand && (isConfigPatchInProgress || isConfigInspectInProgress) {
+        if isConfigOperation
+            && (isConfigInitializationInProgress || isConfigPatchInProgress || isConfigInspectInProgress) {
             lastError = "Another config operation is still running."
             clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
             if controlCenterOperation != nil {
@@ -2183,10 +2216,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             }
             return
         }
-        if isConfigInspectCommand && (isConfigPatchInProgress || isConfigInspectInProgress) {
-            lastError = "Another config operation is still running."
-            return
-        }
+        if isConfigInitializeCommand { isConfigInitializationInProgress = true }
         if isConfigPatchCommand { isConfigPatchInProgress = true }
         if isConfigInspectCommand { isConfigInspectInProgress = true }
         lastCommandLine = displayCommand.commandLine
@@ -2207,10 +2237,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         configPath: configPath,
                         launchdLabel: launchdLabel,
                         isConfigInspectCommand: isConfigInspectCommand,
+                        isConfigInitializeCommand: isConfigInitializeCommand,
                         controlCenterOperation: controlCenterOperation,
                         providerPatchProof: providerPatchProof,
                         managedRepoPatchProof: managedRepoPatchProof
                     )
+                    if isConfigInitializeCommand { self.isConfigInitializationInProgress = false }
                     if isConfigPatchCommand { self.isConfigPatchInProgress = false }
                     if isConfigInspectCommand { self.isConfigInspectInProgress = false }
                     if controlCenterOperation != nil { self.isControlCenterOperationInProgress = false }
@@ -2221,6 +2253,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 await MainActor.run {
                     self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
                     self.logText = self.lastError ?? "Unknown CLI error"
+                    if isConfigInitializeCommand {
+                        self.isConfigInitializationInProgress = false
+                        self.configInitializationStatus = self.lastError ?? "Local config initialization failed."
+                    }
                     if isConfigPatchCommand { self.isConfigPatchInProgress = false }
                     self.clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
                     self.clearPendingManagedRepoPatchProof(ifOwnedBy: managedRepoPatchProof)
@@ -2809,6 +2845,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         configPath: String,
         launchdLabel: String,
         isConfigInspectCommand: Bool,
+        isConfigInitializeCommand: Bool = false,
         controlCenterOperation: ControlCenterOperation? = nil,
         providerPatchProof: PendingProviderPatchProof? = nil,
         managedRepoPatchProof: PendingManagedRepoPatchProof? = nil
@@ -2827,6 +2864,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         logText = [result.redactedStdout, result.redactedStderr].filter { !$0.isEmpty }.joined(separator: "\n")
 
         let commandName = parseCommandName(result.stdout)
+        if isConfigInitializeCommand {
+            guard result.exitCode == 0, commandName == "init" else {
+                lastError = lastError ?? "Local config initialization returned an invalid response."
+                configInitializationStatus = lastError ?? "Local config initialization failed."
+                return
+            }
+            configInitializationStatus = "Local config created. Add one repository, apply it, then verify App access."
+        }
         var parsedSnapshot = (commandName == "config inspect" || commandName == "config patch")
             ? ConfigInspectParser.parse(
                 result.stdout,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 public enum NeonDiffCommandBuilder {
+    public static func configInitialize(cliPath: String, configPath: String) -> DesktopCommand {
+        DesktopCommand(
+            title: "Initialize config",
+            commandLine: "\(shellQuote(cliPath)) init --config \(shellQuote(configPath))"
+        )
+    }
+
     public static func configInspect(cliPath: String, configPath: String) -> DesktopCommand {
         DesktopCommand(
             title: "Inspect config",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -6,6 +6,37 @@ import NeonDiffDesktopCore
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
 struct BYOGitHubAppCredentialOnboardingTests {
+    @Test func cleanInstallInitializationUsesNonDestructiveCLIInit() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: #"{"ok":true,"command":"init","created":true}"#,
+                stderr: ""
+            ))],
+            productionBoundary: exactB0Boundary
+        )
+
+        fixture.model.initializeConfigForOnboarding()
+        await fixture.cli.waitUntilCallCount(1)
+
+        #expect(fixture.cli.calls[0].arguments == ["init", "--config", fixture.model.configPath])
+        #expect(!fixture.cli.calls[0].arguments.contains("--force"))
+        #expect(fixture.model.configInitializeCommand.commandLine.contains(" init --config "))
+        #expect(!fixture.model.configInitializeCommand.commandLine.contains("--force"))
+    }
+
+    @Test func repositoryRemovalIsBlockedDuringProviderVerificationCleanup() {
+        let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
+        let repository = RepoMonitor(name: "acme/demo", enabled: true)
+        fixture.model.repos = [repository]
+        fixture.model.isProviderVerificationInProgress = true
+
+        fixture.model.removeRepoFromAllowlist(repository)
+
+        #expect(fixture.model.repos == [repository])
+        #expect(fixture.model.lastError?.contains("provider verification cleanup") == true)
+    }
+
     @Test func exactB0BuildStoresPrivateKeyOnlyInFixedKeychainAccount() throws {
         let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
         #expect(!fixture.model.canAdvanceOnboarding)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -165,6 +165,8 @@ import Testing
             .appendingPathComponent("Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift")
         let source = try sourceBoundaryText(at: onboardingView)
 
+        #expect(source.contains("model.initializeConfigForOnboarding()"))
+        #expect(source.contains("neondiff-onboarding-byo-config-initialize"))
         #expect(source.contains("model.addPendingRepoToAllowlist()"))
         #expect(source.contains("neondiff-onboarding-byo-repository-add"))
         #expect(source.contains("neondiff-onboarding-byo-repository-apply"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -160,6 +160,18 @@ import Testing
         #expect(source.contains("neondiff-onboarding-repository-apply"))
     }
 
+    @Test func b0OnboardingExposesRepositorySetupAndAppVerificationActions() throws {
+        let onboardingView = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift")
+        let source = try sourceBoundaryText(at: onboardingView)
+
+        #expect(source.contains("model.addPendingRepoToAllowlist()"))
+        #expect(source.contains("neondiff-onboarding-byo-repository-add"))
+        #expect(source.contains("neondiff-onboarding-byo-repository-apply"))
+        #expect(source.contains("model.verifyBYOGitHubAppCredentials()"))
+        #expect(source.contains("neondiff-onboarding-byo-github-verify"))
+    }
+
     @Test func managedSafetyStopIsNotDisabledByUsefulWorkProofLoss() throws {
         let viewsDirectory = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -260,6 +260,22 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
+For an invited B0 customer, the native first-run path is:
+
+1. Create and install a customer-owned GitHub App with the permissions in
+   [`github-app-setup.md`](github-app-setup.md), selecting one repository.
+2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
+   PEM, then choose **Store in Keychain**.
+3. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
+   Repository**. The app writes the allowlist through the typed local `config
+   patch` command; the customer does not edit a config file.
+4. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
+   the exact configured repository through that App installation.
+
+This first-run step proves only current App installation and repository access.
+Provider verification, activation, dry run, and live review remain separate
+gates.
+
 ## 4. Check Readiness
 
 Run the GitHub-only doctor first. It verifies App installation visibility and
@@ -304,11 +320,12 @@ neondiff doctor --config config.local.json --json
 
 This SETUP guide is the operator/advanced CLI-first path, and the first-run path
 on non-Mac platforms. The local HTML dashboard is the operator/diagnostic surface
-it drives. On Mac, the native macOS app is the human first-run product surface —
-the customer starts there; until the native broker/launchd proof lands (see the
-native-broker note above) the app hands off to this operator path for the setup
-actions it cannot yet complete natively. The dashboard shows license status,
-GitHub App status, daemon status, and provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
+it drives. On Mac, the native macOS app is the human first-run product surface.
+The exact B0 bundle lets the customer store the customer-owned App key in
+Keychain, select and apply one repository, and verify that installation without
+an operator editing local files. The managed B1 broker remains a separate path.
+The dashboard shows license status, GitHub App status, daemon status, and
+provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing
 the submitted key.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -266,10 +266,13 @@ For an invited B0 customer, the native first-run path is:
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
 2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
    PEM, then choose **Store in Keychain**.
-3. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
+3. On a clean install, choose **Initialize Local Config**. This invokes the
+   non-destructive `neondiff init` path and never supplies `--force`; an existing
+   config is not overwritten.
+4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command; the customer does not edit a config file.
-4. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
+5. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
    the exact configured repository through that App installation.
 
 This first-run step proves only current App installation and repository access.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -98,10 +98,11 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In native NeonDiff first run, store the App ID and private key, enter the same
-   `owner/repo`, choose **Add Repository**, **Apply Repository**, and then
-   **Verify App Access**. The app updates `pilotRepos` through `config patch`; no
-   operator edits the customer's config file.
+7. In native NeonDiff first run, store the App ID and private key, and on a clean
+   install choose **Initialize Local Config**. Enter the same `owner/repo`, then
+   choose **Add Repository**, **Apply Repository**, and **Verify App Access**.
+   Initialization never uses `--force`; the app updates `pilotRepos` through
+   `config patch`, and no operator edits the customer's config file.
 
 Keep the private key and local config out of git. A typical shell setup is:
 
@@ -116,9 +117,11 @@ authorization flow. Do not put user access tokens or refresh tokens in config;
 desktop user tokens belong in Keychain.
 
 Device Flow is not part of the B0 customer-owned App path. The managed B1 path
-tracks browser OAuth for existing installations under #613; Device Flow remains
-only an optional CLI/headless fallback and is not GitHub approval of the public
-App.
+tracks broker-hosted browser OAuth with state/PKCE for existing installations
+under #613; fresh installs retain install-time OAuth. The unshipped managed
+source still contains a Device Flow fallback, but it is not the B1 release
+architecture. Device Flow remains only an optional CLI/headless fallback and is
+not GitHub approval of the public App.
 
 ## Verify Installation
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,20 +5,22 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface:
-it drives the device-flow "Connect GitHub" authorization described below, while
-this document remains the operator/CLI reference for the App identity, permission
-set, and install path. The matching public website onboarding copy for this
-Mac-first journey lives in the website repo and is tracked in
-neon-diff-agent-website#52; it is intentionally not edited here (cross-repo
-change).
+On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
+The invite-only B0 build accepts the invited customer's own App ID and private
+key, one selected repository, and runs the explicit installation check from the
+wizard. The managed B1 path uses the official NeonDiff App and broker under
+#613; it is separate from B0. This document remains the operator/CLI reference
+for both paths' App identity, permission set, and install boundary. Matching
+public website onboarding copy lives in the website repo under
+neon-diff-agent-website#52.
 
 ## Install URL
 
-Use the public NeonDiff GitHub App install URL from the release notes or website
-for the beta you are testing. Until the public App registration is finalized,
-operators can create an equivalent App with the permission set below and record
-the generated install URL in the issue or release evidence packet.
+For B0, create a customer-owned GitHub App in the invited customer's GitHub
+account or organization, then use that App's install link. Record its numeric
+App ID, generate one private key, and keep the downloaded PEM outside git. The
+public, organization-owned NeonDiff App is the separate managed B1 path; do not
+use it to describe or prove B0.
 
 Install only on selected repositories. NeonDiff does not need organization-wide
 discovery for the v1.0 MVP, and the worker only reviews repos present in your
@@ -90,13 +92,16 @@ user-token discovery path are disabled in managed mode. Generic CLI
 status/deactivate and daemon-admission validation still require exact-candidate
 integration proof under #630.
 
-1. Open the NeonDiff GitHub App install URL.
+1. Open the customer-owned GitHub App's install URL.
 2. Choose the user or organization that owns the repositories.
 3. Select `Only select repositories`.
-4. Pick the repos you want NeonDiff to review.
+4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. Add the same repos to `pilotRepos` in your local `config.local.json`.
+7. In native NeonDiff first run, store the App ID and private key, enter the same
+   `owner/repo`, choose **Add Repository**, **Apply Repository**, and then
+   **Verify App Access**. The app updates `pilotRepos` through `config patch`; no
+   operator edits the customer's config file.
 
 Keep the private key and local config out of git. A typical shell setup is:
 
@@ -110,9 +115,10 @@ export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-
 authorization flow. Do not put user access tokens or refresh tokens in config;
 desktop user tokens belong in Keychain.
 
-For the desktop Repos pane, enable device flow in the GitHub App settings before
-testing "Connect GitHub". If device flow is disabled, GitHub returns
-`device_flow_disabled` and the desktop cannot issue a user code.
+Device Flow is not part of the B0 customer-owned App path. The managed B1 path
+tracks browser OAuth for existing installations under #613; Device Flow remains
+only an optional CLI/headless fallback and is not GitHub approval of the public
+App.
 
 ## Verify Installation
 

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -189,13 +189,16 @@ A stored license key is not treated as active entitlement. Repo selection still
 writes only the local allowlist; the worker's pre-checkout license and GitHub App
 gates remain authoritative for review execution.
 
-In the invite-only B0 build, the Repos pane also accepts a customer-owned
-numeric App ID and unencrypted RSA private key. The key is stored only in the
-fixed macOS Keychain account. **Verify App Access** reads it on that explicit
-action, supplies it to `doctor github` through bounded stdin, and accepts only
-typed App-installation proof for every configured repository. Changing the App
-credentials, CLI/config path, or allowlist invalidates that proof. This step
-does not run a provider, execute a review, or post to GitHub.
+In the invite-only B0 build, first-run onboarding and the Repos pane accept a
+customer-owned numeric App ID and unencrypted RSA private key. The key is stored
+only in the fixed macOS Keychain account. First run also lets the customer add
+one `owner/repo`, apply it through the typed local config patch, and choose
+**Verify App Access** without leaving onboarding or asking an operator to edit a
+file. Verification reads the key only on that explicit action, supplies it to
+`doctor github` through bounded stdin, and accepts only typed App-installation
+proof for the exact configured repository. Changing the App credentials,
+CLI/config path, or allowlist invalidates that proof. This step does not run a
+provider, execute a review, or post to GitHub.
 
 ## Local Dashboard Launcher
 

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -191,10 +191,12 @@ gates remain authoritative for review execution.
 
 In the invite-only B0 build, first-run onboarding and the Repos pane accept a
 customer-owned numeric App ID and unencrypted RSA private key. The key is stored
-only in the fixed macOS Keychain account. First run also lets the customer add
-one `owner/repo`, apply it through the typed local config patch, and choose
-**Verify App Access** without leaving onboarding or asking an operator to edit a
-file. Verification reads the key only on that explicit action, supplies it to
+only in the fixed macOS Keychain account. On a clean install, first run exposes
+the non-destructive **Initialize Local Config** action before the customer adds
+one `owner/repo`, applies it through the typed local config patch, and chooses
+**Verify App Access**. Initialization never force-overwrites an existing config,
+and the customer does not need an operator edit. Verification reads the key only
+on that explicit action, supplies it to
 `doctor github` through bounded stdin, and accepts only typed App-installation
 proof for the exact configured repository. Changing the App credentials,
 CLI/config path, or allowlist invalidates that proof. This step does not run a


### PR DESCRIPTION
## Outcome

Completes the bounded invite-only B0 repository-onboarding slice without claiming the broader customer journey. A clean install can create its local config through the existing non-destructive CLI init path, store customer-owned GitHub App credentials through the existing Keychain-only path, add and apply exactly one repository, and run the existing fail-closed App-access check from native first run.

Related to #646. This bounded slice does not close #646.

Coordinated website copy: electricsheephq/neon-diff-agent-website#67.

## Acceptance criteria

- Clean-install native first run exposes `Initialize Local Config`, invoking only `init --config <path>` and never `--force`.
- The customer can store the App ID/private key using the existing Keychain-only custody path.
- The customer can add one `owner/repo`, apply it through the existing typed config patch, and run `Verify App Access` without editing a file.
- Continue remains gated by exact GitHub installation/repository verification.
- Repository mutation is disabled and model-guarded during provider verification cleanup or its restart-required latch.
- README, setup docs, desktop docs, GitHub App docs, and the coordinated unpublished website candidate distinguish paid customer-owned B0 from managed public-free/private-paid B1.

## Non-goals

- No change to credential validation, Keychain storage, CLI stdin handling, GitHub doctor semantics, or review posting.
- No provider, activation, entitlement, daemon, billing, broker/OAuth, signing, publication, or live-review implementation.
- No B1 managed App implementation; #613 retains broker-hosted web OAuth and authoritative installation/repository binding.
- No website publication, checkout enablement, beta, release, or customer-readiness claim.

## Failing-first proof

- Parent `40aaf8f`: the initial B0 source-contract test failed all required action/identifier expectations.
- Review delta on `78b762e`: clean-install test failed to compile because no native config-initialization action existed; source inspection confirmed `config patch` rejects a missing config.
- Current local head `a0fdba1`: B0 onboarding 12/12, provider-verification state machine 8/8, production-boundary contracts 12/12, docs/public contracts 29/29, forbidden-claims scan, and `git diff --check` pass.

## Proof boundary

This proves focused source and local automated contracts only until current-head remote CI and hosted desktop evidence pass. It does not prove a signed artifact, clean-Mac customer canary, production billing/activation, dry/live review, beta, or release.
