### PR TITLE
fix(desktop): restore escapable native window behavior

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -77,7 +77,29 @@ struct NeonDiffDesktopApp: App {
                     windowConfigurator.allowsHitTesting(false)
                 )
         }
+        .defaultSize(width: 1200, height: 760)
+        .windowResizability(.contentMinSize)
         .commands {
+            CommandGroup(replacing: .appTermination) {
+                Button("Quit NeonDiff Desktop") {
+                    model.isOnboardingPresented = false
+                    DispatchQueue.main.async {
+                        NSApplication.shared.terminate(nil)
+                    }
+                }
+                .keyboardShortcut("q", modifiers: [.command])
+            }
+
+            CommandGroup(after: .newItem) {
+                Button("Close NeonDiff Desktop Window") {
+                    model.isOnboardingPresented = false
+                    DispatchQueue.main.async {
+                        NSApplication.shared.keyWindow?.performClose(nil)
+                    }
+                }
+                .keyboardShortcut("w", modifiers: [.command])
+            }
+
             CommandMenu("NeonDiff") {
                 Button("Open Local Dashboard") {
                     model.openDashboard()
@@ -526,17 +548,15 @@ private extension View {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldRestoreSecureApplicationState(_ app: NSApplication) -> Bool {
-#if DEBUG
-        if CommandLine.arguments.contains("--ui-testing") { return false }
-#endif
-        return true
+        false
     }
 
     func applicationShouldSaveSecureApplicationState(_ app: NSApplication) -> Bool {
-#if DEBUG
-        if CommandLine.arguments.contains("--ui-testing") { return false }
-#endif
-        return true
+        false
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        .terminateNow
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift
@@ -99,6 +99,45 @@ struct NeonWindowConfigurator: NSViewRepresentable {
             }
         } else {
             window.minSize = NSSize(width: 1040, height: 680)
+            if coordinator.configuredProductionWindowNumber != window.windowNumber,
+               let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame {
+                let targetFrameSize = DesktopWindowGeometryPolicy.productionLaunchFrameSize(
+                    currentFrame: DesktopWindowContentSize(
+                        width: window.frame.width,
+                        height: window.frame.height
+                    ),
+                    currentContent: DesktopWindowContentSize(
+                        width: window.contentLayoutRect.width,
+                        height: window.contentLayoutRect.height
+                    ),
+                    visibleFrame: DesktopWindowContentSize(
+                        width: visibleFrame.width,
+                        height: visibleFrame.height
+                    )
+                )
+                let targetOrigin = DesktopWindowGeometryPolicy.centeredOrigin(
+                    frameSize: targetFrameSize,
+                    visibleOrigin: DesktopWindowOrigin(
+                        x: visibleFrame.minX,
+                        y: visibleFrame.minY
+                    ),
+                    visibleFrame: DesktopWindowContentSize(
+                        width: visibleFrame.width,
+                        height: visibleFrame.height
+                    )
+                )
+                window.setFrame(
+                    NSRect(
+                        origin: NSPoint(x: targetOrigin.x, y: targetOrigin.y),
+                        size: NSSize(
+                            width: targetFrameSize.width,
+                            height: targetFrameSize.height
+                        )
+                    ),
+                    display: true
+                )
+                coordinator.configuredProductionWindowNumber = window.windowNumber
+            }
         }
         if requestedContentSize != nil,
            coordinator.positionedWindowNumber != window.windowNumber {
@@ -143,6 +182,7 @@ struct NeonWindowConfigurator: NSViewRepresentable {
 
     final class Coordinator {
         var positionedWindowNumber: Int?
+        var configuredProductionWindowNumber: Int?
 #if DEBUG
         var readinessSampling = false
         var readinessEmitted = false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift
@@ -98,7 +98,23 @@ struct NeonWindowConfigurator: NSViewRepresentable {
                 )
             }
         } else {
-            window.minSize = NSSize(width: 1040, height: 680)
+            let productionMinimumContentSize =
+                DesktopWindowGeometryPolicy.minimumContentSize(requested: nil)
+            let productionMinimumFrameSize = DesktopWindowGeometryPolicy.targetFrameSize(
+                requestedContent: productionMinimumContentSize,
+                currentFrame: DesktopWindowContentSize(
+                    width: window.frame.width,
+                    height: window.frame.height
+                ),
+                currentContent: DesktopWindowContentSize(
+                    width: window.contentLayoutRect.width,
+                    height: window.contentLayoutRect.height
+                )
+            )
+            window.minSize = NSSize(
+                width: productionMinimumFrameSize.width,
+                height: productionMinimumFrameSize.height
+            )
             if coordinator.configuredProductionWindowNumber != window.windowNumber,
                let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame {
                 let targetFrameSize = DesktopWindowGeometryPolicy.productionLaunchFrameSize(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import NeonDiffDesktopAppCore
 import NeonDiffDesktopCore
@@ -77,6 +78,7 @@ struct ContentView: View {
                 .frame(height: 34)
                 .shadow(color: NeonDiffTheme.accent.opacity(0.80), radius: 8, y: 1)
                 .ignoresSafeArea(.container, edges: .top)
+                .allowsHitTesting(false)
 
             VStack(spacing: 0) {
                 NeonChromeStrip(model: model, updateController: updateController)
@@ -123,7 +125,6 @@ struct ContentView: View {
                 .buttonStyle(OperatorButtonStyle())
                 .tint(NeonDiffTheme.accent)
                 .preferredColorScheme(preferredColorScheme)
-                .interactiveDismissDisabled(model.onboardingFlow.currentStep != .done)
                 .onAppear { onSurfaceReady?(model.selectedSection) }
         }
     }
@@ -322,10 +323,15 @@ private struct NeonChromeStrip: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Rectangle()
-                .fill(NeonDiffTheme.accent)
-                .frame(height: 28)
-                .shadow(color: NeonDiffTheme.accent.opacity(0.54), radius: 8, y: 1)
+            ZStack {
+                Rectangle()
+                    .fill(NeonDiffTheme.accent)
+                    .shadow(color: NeonDiffTheme.accent.opacity(0.54), radius: 8, y: 1)
+                    .allowsHitTesting(false)
+                WindowDragRegion()
+                    .accessibilityHidden(true)
+            }
+            .frame(height: 28)
 
             HStack(spacing: 14) {
                 Color.clear
@@ -388,7 +394,22 @@ private struct NeonChromeStrip: View {
                     .frame(height: 2)
             }
         }
-        .contentShape(Rectangle())
+    }
+}
+
+private struct WindowDragRegion: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        WindowDragNSView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private final class WindowDragNSView: NSView {
+    override var mouseDownCanMoveWindow: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -609,7 +609,7 @@ struct OnboardingWizardView: View {
 
             Spacer()
 
-            if !model.productionUsefulWorkAvailable {
+            if model.incompleteOnboardingEscapeAvailable {
                 Button("Open Read-Only App") {
                     model.openReadOnlyAppFromQuarantinedOnboarding()
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -614,6 +614,8 @@ struct OnboardingWizardView: View {
                     model.openReadOnlyAppFromQuarantinedOnboarding()
                 }
                 .help("Inspect setup and settings without completing activation onboarding. Useful work remains blocked.")
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("neondiff-onboarding-read-only-exit")
             }
 
             if let lastError = model.lastError, !lastError.isEmpty {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopWindowGeometryPolicy.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopWindowGeometryPolicy.swift
@@ -25,7 +25,7 @@ public enum DesktopWindowGeometryPolicy {
     public static func minimumContentSize(
         requested: DesktopWindowContentSize?
     ) -> DesktopWindowContentSize {
-        requested ?? DesktopWindowContentSize(width: 1040, height: 680)
+        requested ?? DesktopWindowContentSize(width: 760, height: 560)
     }
 
     public static func targetFrameSize(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopWindowGeometryPolicy.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopWindowGeometryPolicy.swift
@@ -8,7 +8,20 @@ public struct DesktopWindowContentSize: Equatable, Sendable {
     }
 }
 
+public struct DesktopWindowOrigin: Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
 public enum DesktopWindowGeometryPolicy {
+    public static let productionDefaultContentSize =
+        DesktopWindowContentSize(width: 1200, height: 760)
+
     public static func minimumContentSize(
         requested: DesktopWindowContentSize?
     ) -> DesktopWindowContentSize {
@@ -23,6 +36,33 @@ public enum DesktopWindowGeometryPolicy {
         DesktopWindowContentSize(
             width: requestedContent.width + Swift.max(0, currentFrame.width - currentContent.width),
             height: requestedContent.height + Swift.max(0, currentFrame.height - currentContent.height)
+        )
+    }
+
+    public static func productionLaunchFrameSize(
+        currentFrame: DesktopWindowContentSize,
+        currentContent: DesktopWindowContentSize,
+        visibleFrame: DesktopWindowContentSize
+    ) -> DesktopWindowContentSize {
+        let target = targetFrameSize(
+            requestedContent: productionDefaultContentSize,
+            currentFrame: currentFrame,
+            currentContent: currentContent
+        )
+        return DesktopWindowContentSize(
+            width: Swift.min(target.width, visibleFrame.width),
+            height: Swift.min(target.height, visibleFrame.height)
+        )
+    }
+
+    public static func centeredOrigin(
+        frameSize: DesktopWindowContentSize,
+        visibleOrigin: DesktopWindowOrigin,
+        visibleFrame: DesktopWindowContentSize
+    ) -> DesktopWindowOrigin {
+        DesktopWindowOrigin(
+            x: visibleOrigin.x + Swift.max(0, (visibleFrame.width - frameSize.width) / 2),
+            y: visibleOrigin.y + Swift.max(0, (visibleFrame.height - frameSize.height) / 2)
         )
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2131,10 +2131,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func openReadOnlyAppFromQuarantinedOnboarding() {
-        guard !dependencies.productionBoundary.nativeActivationBrokerVerified else { return }
+        guard !productionUsefulWorkAvailable else { return }
         isOnboardingPresented = false
         lastError = nil
-        logText = "Opened the read-only setup surface. \(productionActivationBoundaryMessage)"
+        logText = dependencies.productionBoundary.nativeActivationBrokerVerified
+            ? "Opened the read-only setup surface. Finish GitHub, repository, provider, and activation setup before starting a review."
+            : "Opened the read-only setup surface. \(productionActivationBoundaryMessage)"
     }
 
     @discardableResult

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -222,6 +222,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.productionBoundary.nativeActivationBrokerVerified
     }
 
+    package var incompleteOnboardingEscapeAvailable: Bool {
+        isOnboardingPresented
+            && !dependencies.preferences.bool(forKey: onboardingCompletedKey)
+    }
+
     package var managedGitHubAvailable: Bool {
         dependencies.productionBoundary.managedGitHubBrokerOrigin != nil
             && dependencies.githubBroker != nil
@@ -2131,7 +2136,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func openReadOnlyAppFromQuarantinedOnboarding() {
-        guard !productionUsefulWorkAvailable else { return }
+        guard incompleteOnboardingEscapeAvailable else { return }
         isOnboardingPresented = false
         lastError = nil
         logText = dependencies.productionBoundary.nativeActivationBrokerVerified

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -167,6 +167,12 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.canAdvanceOnboarding)
         #expect(fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.productionDaemonStopAvailable)
+        #expect(fixture.model.isOnboardingPresented)
+
+        fixture.model.openReadOnlyAppFromQuarantinedOnboarding()
+
+        #expect(!fixture.model.isOnboardingPresented)
+        #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
 
         fixture.model.configPath = "/tmp/changed-config.json"
         #expect(!fixture.model.byoGitHubCredentialsVerified)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopEvaluationStateTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopEvaluationStateTests.swift
@@ -23,7 +23,7 @@ struct DesktopEvaluationStateTests {
             currentContent: DesktopWindowContentSize(width: 1040, height: 648)
         ) == DesktopWindowContentSize(width: 760, height: 592))
         #expect(DesktopWindowGeometryPolicy.minimumContentSize(requested: nil)
-            == DesktopWindowContentSize(width: 1040, height: 680))
+            == DesktopWindowContentSize(width: 760, height: 560))
         #expect(DesktopWindowGeometryPolicy.minimumContentSize(
             requested: DesktopWindowContentSize(width: 760, height: 560)
         ) == DesktopWindowContentSize(width: 760, height: 560))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopEvaluationStateTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopEvaluationStateTests.swift
@@ -29,6 +29,40 @@ struct DesktopEvaluationStateTests {
         ) == DesktopWindowContentSize(width: 760, height: 560))
     }
 
+    @Test func productionLaunchUsesCenteredBoundedWindowInsteadOfScreenFillingFrame() {
+        let frameSize = DesktopWindowGeometryPolicy.productionLaunchFrameSize(
+            currentFrame: DesktopWindowContentSize(width: 1920, height: 983),
+            currentContent: DesktopWindowContentSize(width: 1920, height: 951),
+            visibleFrame: DesktopWindowContentSize(width: 1920, height: 983)
+        )
+
+        #expect(frameSize == DesktopWindowContentSize(width: 1200, height: 792))
+        #expect(
+            DesktopWindowGeometryPolicy.centeredOrigin(
+                frameSize: frameSize,
+                visibleOrigin: DesktopWindowOrigin(x: 0, y: 31),
+                visibleFrame: DesktopWindowContentSize(width: 1920, height: 983)
+            ) == DesktopWindowOrigin(x: 360, y: 126.5)
+        )
+    }
+
+    @Test func productionLaunchFrameStaysInsideSmallerVisibleScreen() {
+        let frameSize = DesktopWindowGeometryPolicy.productionLaunchFrameSize(
+            currentFrame: DesktopWindowContentSize(width: 1100, height: 700),
+            currentContent: DesktopWindowContentSize(width: 1100, height: 668),
+            visibleFrame: DesktopWindowContentSize(width: 1100, height: 700)
+        )
+
+        #expect(frameSize == DesktopWindowContentSize(width: 1100, height: 700))
+        #expect(
+            DesktopWindowGeometryPolicy.centeredOrigin(
+                frameSize: frameSize,
+                visibleOrigin: DesktopWindowOrigin(x: -1100, y: 0),
+                visibleFrame: DesktopWindowContentSize(width: 1100, height: 700)
+            ) == DesktopWindowOrigin(x: -1100, y: 0)
+        )
+    }
+
     @Test func appliesASettledProviderFixtureWithoutLiveDependencies() {
         let dependencies = RecordingDesktopDependencies(
             root: fixtureURL("/fixture/evaluation", directory: true)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -56,7 +56,9 @@ import Testing
 
         #expect(!fixture.model.isOnboardingPresented)
         #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
-        #expect(fixture.model.logText.contains("read-only setup surface"))
+        #expect(fixture.model.logText.contains(
+            "Finish GitHub, repository, provider, and activation setup"
+        ))
     }
 
     @Test func installedWindowPreservesNativeEscapeMovementAndBoundedLaunchSize() throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -41,6 +41,61 @@ import Testing
     }
 
     @MainActor
+    @Test func verifiedButIncompleteBetaOffersNonPersistentReadOnlyEscape() throws {
+        let boundary = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ])
+        let fixture = ModelDependencyFixture(productionBoundary: boundary)
+
+        #expect(boundary.nativeActivationBrokerVerified)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.isOnboardingPresented)
+
+        fixture.model.openReadOnlyAppFromQuarantinedOnboarding()
+
+        #expect(!fixture.model.isOnboardingPresented)
+        #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
+        #expect(fixture.model.logText.contains("read-only setup surface"))
+    }
+
+    @Test func installedWindowPreservesNativeEscapeMovementAndBoundedLaunchSize() throws {
+        let packageRoot = sourceBoundaryPackageRoot()
+        let contentView = try sourceBoundaryText(
+            at: packageRoot.appendingPathComponent(
+                "Sources/NeonDiffDesktop/Views/ContentView.swift"
+            )
+        )
+        let app = try sourceBoundaryText(
+            at: packageRoot.appendingPathComponent(
+                "Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift"
+            )
+        )
+
+        #expect(!contentView.contains(".interactiveDismissDisabled("))
+        #expect(contentView.contains(".allowsHitTesting(false)"))
+        #expect(contentView.contains("WindowDragRegion()"))
+        #expect(contentView.contains("override var mouseDownCanMoveWindow: Bool { true }"))
+        #expect(contentView.contains("window?.performDrag(with: event)"))
+        #expect(!contentView.contains(".contentShape(Rectangle())"))
+        #expect(app.contains(".defaultSize(width: 1200, height: 760)"))
+        #expect(app.contains(".windowResizability(.contentMinSize)"))
+        #expect(app.contains("CommandGroup(replacing: .appTermination)"))
+        #expect(app.contains("CommandGroup(after: .newItem)"))
+        #expect(app.contains("model.isOnboardingPresented = false"))
+        #expect(app.contains("NSApplication.shared.keyWindow?.performClose(nil)"))
+        #expect(app.contains(
+            "func applicationShouldRestoreSecureApplicationState(_ app: NSApplication) -> Bool {\n        false"
+        ))
+        #expect(app.contains(
+            "func applicationShouldSaveSecureApplicationState(_ app: NSApplication) -> Bool {\n        false"
+        ))
+        #expect(app.contains(
+            "func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {\n        .terminateNow"
+        ))
+    }
+
+    @MainActor
     @Test func verifiedActivationCompletionWritesOnlyTheVersionedProofStamp() throws {
         let fixture = ModelDependencyFixture(productionBoundary: .testVerified)
         fixture.model.onboardingFlow.licenseActivation = .activated

--- a/tests/worktree-cleanup.test.ts
+++ b/tests/worktree-cleanup.test.ts
@@ -50,6 +50,7 @@ describe("stale review worktree cleanup", () => {
     const fixture = createFixture(roots, 2);
     makeStale(fixture.paths[1]);
     writeFileSync(join(fixture.paths[1], "untracked.txt"), "keep\n");
+    makeStale(fixture.paths[1]);
 
     const result = cleanupStaleReviewWorktrees(baseInput(fixture));
 
@@ -64,6 +65,7 @@ describe("stale review worktree cleanup", () => {
     const fixture = createFixture(roots, 1);
     makeStale(fixture.paths[0]);
     writeFileSync(join(fixture.paths[0], "review-cache.log"), "keep\n");
+    makeStale(fixture.paths[0]);
 
     const result = cleanupStaleReviewWorktrees(baseInput(fixture));
 


### PR DESCRIPTION
## Outcome

Fix the owner-reproduced installed-app trap as a bounded slice of #657. The paid-beta release train remains paused.

Affected installed builds:
- owner-tested `1.1.0 (11001)` from `50677cc4358505b53e99ba37ec6b1cd095a57711`
- private candidate `1.1.0 (11003)` from `5c8d11e86da8ed8b223b210becb375270c1be282`

Both showed a mandatory onboarding sheet whose visible read-only exit, Escape, Command-W, and Command-Q did not provide a reliable way out; the main window also opened screen-filling.

## Bounded acceptance criteria

- **Open Read-Only App** and Escape dismiss incomplete onboarding without persisting false completion.
- Command-W dismisses onboarding and closes the current window.
- Command-Q dismisses onboarding and terminates the app.
- Production launch uses a centered `1200x760` content target bounded by the visible screen instead of restoring a screen-filling frame.
- The main window remains resizable and exposes an explicit native AppKit drag region.
- Keychain, activation, repository authorization, entitlement, update, and review-posting gates are unchanged and remain fail closed.

## Exact local proof at head `a97c27f3603d51a72b437fb8deec0ba0627336df`

- failing-first model and source-contract tests captured the read-only no-op, missing native close/quit overrides, and absent bounded production geometry
- `swift test --filter 'ProductionBoundaryContractTests|DesktopEvaluationStateTests'`: 18 passed
- release-config B0 bundle check passed for version `1.1.0`, build `11004`
- real Launch Services run (not a fixture): onboarding sheet rendered; visible read-only exit and Escape revealed normal tab navigation
- exact AppKit main-window geometry: centered `1200x792` frame at `(360,127)` on a `1920x983` visible screen
- native zoom/unzoom changed the frame to `1920x983` and back to `1200x792`
- Command-W from active onboarding left zero on-screen windows; reopening restored a coherent main window
- Command-Q from active onboarding exited the process
- local unsigned executable SHA-256: `53188bc1ffe91c7f9e896a695136ed8793b3f5394001f8e394e62372dfd0d072`

## Explicit non-goals

- No billing canary, checkout, website publish, service promotion, signing, notarization, prerelease, GitHub Release, or public distribution.
- No claim that activation, provider/repository setup, dry run, live review, entitlement recovery, update, rollback, or the full B0 golden path has passed.
- No generalized fixture/schema expansion or broader #517 closure.
- #657 remains open until the exact signed candidate is installed and personally accepted by the owner.

Related to #657, #646, and #610.
