### PR TITLE
test(desktop): prove Quit escapes mandatory onboarding

### DIFF
--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -6,8 +6,21 @@ final class NeonDiffDesktopUITests: XCTestCase {
     }
 
     func testQuitFromMandatoryOnboardingTerminatesTheApplication() throws {
+        let fixtureURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: "onboarding-welcome", withExtension: "json")
+        )
         let app = XCUIApplication()
-        app.launchArguments = ["--ui-testing"]
+        defer {
+            if app.state != .notRunning {
+                app.terminate()
+            }
+        }
+        app.launchArguments = [
+            "--ui-testing",
+            "--ui-fixture", fixtureURL.path,
+            "--content-size", "760x560",
+            "--disable-animations"
+        ]
         app.launch()
 
         XCTAssertTrue(

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -5,6 +5,30 @@ final class NeonDiffDesktopUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    func testQuitFromMandatoryOnboardingTerminatesTheApplication() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing"]
+        app.launch()
+
+        XCTAssertTrue(
+            app.buttons["neondiff-onboarding-read-only-exit"]
+                .waitForExistence(timeout: 10)
+        )
+
+        let applicationMenu = app.menuBars.menuBarItems["NeonDiff Desktop"]
+        XCTAssertTrue(applicationMenu.waitForExistence(timeout: 5))
+        applicationMenu.click()
+
+        let quit = app.menuItems["Quit NeonDiff Desktop"]
+        XCTAssertTrue(quit.waitForExistence(timeout: 5))
+        quit.click()
+
+        XCTAssertTrue(
+            app.wait(for: .notRunning, timeout: 5),
+            "Quit must terminate even while mandatory onboarding is presented"
+        )
+    }
+
     func testAccessibility3OverrideScalesVisibleProductionSectionTitle() throws {
         let requestedContentSize = HostedContentSize(width: 1040, height: 680)
         let defaultScenario = try captureRenderedTextScaleScenario(

--- a/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
+++ b/apps/neondiff-desktop/UITests/NeonDiffDesktopUITests.swift
@@ -28,13 +28,7 @@ final class NeonDiffDesktopUITests: XCTestCase {
                 .waitForExistence(timeout: 10)
         )
 
-        let applicationMenu = app.menuBars.menuBarItems["NeonDiff Desktop"]
-        XCTAssertTrue(applicationMenu.waitForExistence(timeout: 5))
-        applicationMenu.click()
-
-        let quit = app.menuItems["Quit NeonDiff Desktop"]
-        XCTAssertTrue(quit.waitForExistence(timeout: 5))
-        quit.click()
+        app.typeKey("q", modifierFlags: .command)
 
         XCTAssertTrue(
             app.wait(for: .notRunning, timeout: 5),


### PR DESCRIPTION
## Summary

Adds one hosted-only XCUITest for the owner-observed #657 quit concern. It launches the real mandatory onboarding fixture, invokes the native Command-Q quit shortcut, and requires the process to reach `.notRunning` within five seconds.

Related: #657
Parent: #610, #646

## Acceptance criteria

- Hosted GitHub macOS XCUITest executes Command-Q while mandatory onboarding is visible.
- The real app reaches `.notRunning` within five seconds.
- Local autonomous checks do not invoke XCUITest or trigger the Developer Tools/UI Automation password dialog.
- Exact-head CI, CodeQL, Swift Desktop Gate, review threads, top-level feedback, and annotations are inspected before merge.

## Non-goals

- No application-source change or generalized harness work.
- No onboarding redesign, billing, activation, GitHub authorization, provider, daemon, dry run, live review, signing, notarization, deployment, checkout, publication, canary, #517 matrix, or GA work.
- No TCC reset, password capture, Developer Tools setting change, or security bypass.
- This PR does not close #657 or claim the full customer golden path is usable.

## Validation

- `git diff --check`
- Local XCUITest intentionally not run because Developer Tools mode is disabled and would trigger an interactive password prompt.
- Exact head: `5d829fad4b4bbfe7153ec70a3392ce8675d346a4`
- GitHub run `30178794244`: Swift Desktop Gate passed, including hosted XCUITest.
- Immutable artifact `neondiff-desktop-xcresult-5d829fad4b4bbfe7153ec70a3392ce8675d346a4`: 11 total, 9 passed, 2 intentional skips, 0 failed.
- `testQuitFromMandatoryOnboardingTerminatesTheApplication()` passed in 3 seconds.
- Downloaded artifact ZIP SHA-256: `e42a99ac6b48eec2c543536dbffe1a8a3a17900c8b059a7500a896914d1f67a3`.

## Proof boundary

This proves only that exact-head hosted macOS execution can quit the mandatory onboarding fixture through Command-Q. It classifies the earlier Computer Use menu-click observation as click-through ambiguity rather than a reproduced product defect. It does not prove menu-pointer selection, close-window behavior, the complete installed-app journey, signing/notarization, or release readiness.
