### PR TITLE
fix(desktop): stop removable-volume prompts on launch

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -254,11 +254,23 @@ struct NDBrandWordmark: View {
     var size: CGFloat
     @Environment(\.colorScheme) private var colorScheme
     private static let resourceBundle: Bundle = {
-#if SWIFT_PACKAGE
-        Bundle.module
-#else
-        Bundle.main
-#endif
+        let bundleName = "NeonDiffDesktop_NeonDiffDesktop"
+        if let packagedURL = Bundle.main.url(
+            forResource: bundleName,
+            withExtension: "bundle"
+        ), let packagedBundle = Bundle(url: packagedURL) {
+            return packagedBundle
+        }
+
+        let swiftPMURL = Bundle.main.bundleURL.appendingPathComponent(
+            "\(bundleName).bundle",
+            isDirectory: true
+        )
+        if let swiftPMBundle = Bundle(url: swiftPMURL) {
+            return swiftPMBundle
+        }
+
+        return Bundle.main
     }()
     private static let image: NSImage? = {
         guard let url = resourceBundle.url(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -124,6 +124,12 @@ public struct ProviderRegistryTarget: Identifiable, Equatable, Sendable {
 }
 
 public struct ProviderSettings: Equatable {
+    public static var defaultZCodeAppConfigPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/zcode/config.json")
+            .path
+    }
+
     public var zcodeModel: String
     public var zcodeCliPath: String
     public var zcodeAppConfigPath: String
@@ -135,7 +141,7 @@ public struct ProviderSettings: Equatable {
     public init(
         zcodeModel: String = "GLM-5.2",
         zcodeCliPath: String = "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
-        zcodeAppConfigPath: String = "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
+        zcodeAppConfigPath: String = ProviderSettings.defaultZCodeAppConfigPath,
         openAICompatibleEndpoint: String = "http://localhost:8000/v1",
         providerKeyStored: Bool = false,
         selectedProviderId: String = "zcode-glm",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -110,7 +110,8 @@ public enum ConfigInspectParser {
         let providers = ProviderSettings(
             zcodeModel: zcode?["model"] as? String ?? "GLM-5.2",
             zcodeCliPath: zcode?["cliPath"] as? String ?? "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
-            zcodeAppConfigPath: zcode?["appConfigPath"] as? String ?? "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
+            zcodeAppConfigPath: zcode?["appConfigPath"] as? String
+                ?? ProviderSettings.defaultZCodeAppConfigPath,
             openAICompatibleEndpoint: desktop?["openAICompatibleEndpoint"] as? String ?? "http://localhost:8000/v1",
             providerKeyStored: providerKeyStored,
             selectedProviderId: selectedProviderId,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -3,6 +3,24 @@ import Testing
 @testable import NeonDiffDesktopAppCore
 
 @Suite struct OwnerReferenceUXContractTests {
+    @Test func packagedWordmarkNeverUsesACompiledSwiftPMBuildPath() throws {
+        let theme = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot()
+                .appendingPathComponent("Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift")
+        )
+
+        let packagedLookup = try #require(theme.range(of: "Bundle.main.url("))
+        let swiftPMSiblingLookup = try #require(
+            theme.range(of: "Bundle.main.bundleURL.appendingPathComponent(")
+        )
+
+        #expect(packagedLookup.lowerBound < swiftPMSiblingLookup.lowerBound)
+        #expect(theme.contains(#"let bundleName = "NeonDiffDesktop_NeonDiffDesktop""#))
+        #expect(theme.contains(#"withExtension: "bundle""#))
+        #expect(theme.contains("return packagedBundle"))
+        #expect(!theme.contains("Bundle.module"))
+    }
+
     @Test func setupUsesAnEscapableIntegratedPanelInsteadOfAModalSheet() throws {
         let views = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)
@@ -82,7 +100,7 @@ import Testing
         #expect(theme.contains("@Environment(\\.isEnabled) private var isEnabled"))
         #expect(theme.contains(".opacity(isEnabled ? 1 : 0.38)"))
         #expect(theme.contains("NDBrandWordmark"))
-        #expect(theme.contains("#if SWIFT_PACKAGE"))
+        #expect(!theme.contains("Bundle.module"))
         #expect(theme.contains("Bundle.main"))
         #expect(theme.contains("interfaceBorder"))
         #expect(!theme.contains(".fill(Color.black.opacity(0.38))"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/CoreImportTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/CoreImportTests.swift
@@ -17,6 +17,5 @@ import Testing
         let settings = ProviderSettings()
 
         #expect(settings.zcodeAppConfigPath == expected)
-        #expect(!settings.zcodeAppConfigPath.hasPrefix("/Volumes/"))
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/CoreImportTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/CoreImportTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import NeonDiffDesktopCore
 
@@ -7,5 +8,15 @@ import Testing
             cliPath: "neondiff",
             configPath: "fixture.json"
         ).commandLine.contains("config inspect"))
+    }
+
+    @Test func providerDefaultsStayUnderTheLocalUserHome() {
+        let expected = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/zcode/config.json")
+            .path
+        let settings = ProviderSettings()
+
+        #expect(settings.zcodeAppConfigPath == expected)
+        #expect(!settings.zcodeAppConfigPath.hasPrefix("/Volumes/"))
     }
 }


### PR DESCRIPTION
Related to #657. This is a bounded installed-app autonomy slice and does not close the broader usability matrix.

## Acceptance criteria

- Packaged wordmark assets resolve from the app bundle before any SwiftPM development location.
- The shipped executable has no compiled SwiftPM build-path fallback.
- The default ZCode config path resolves under the current user home, never a developer-specific removable volume.
- A release-mode BYO functional-smoke bundle builds with zero `/Volumes/LEXAR` strings in its executable.
- Focused resource, provider-default, and config-parser tests pass.

## Proof

- Failing first: the packaged-resource contract failed on direct `Bundle.module` use; the provider-default test failed on `/Volumes/LEXAR/zcode/.zcode/v2/config.json`.
- Focused final: 8 tests passed across `OwnerReferenceUXContractTests`, `CoreImportTests`, and `ConfigParsingTests`.
- Release-mode functional-smoke build 11007 compiled successfully; executable scan found no external-volume strings.
- Installed ad-hoc build reached the real native window and accessibility root. This is functional-smoke evidence only.

## Non-goals

- No TCC grant or permission bypass.
- No Developer ID signing, notarization, prerelease, checkout, billing, deployment, or customer release claim.
- No broader #657 or #517 closure.
- No production credential, entitlement, repository-binding, or daemon changes.