### PR TITLE
fix(desktop): remove machine-local release rpaths

### DIFF
--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -160,8 +160,8 @@ export NEONDIFF_DESKTOP_BUILD="<build>"
 export NEONDIFF_SPARKLE_PUBLIC_ED_KEY="<owner-provided-public-key>"
 export NEONDIFF_SPARKLE_FEED_URL="<owner-approved-feed-url>"
 
-script/build_and_run.sh build
-script/build_and_run.sh bundle-check
+script/build_and_run.sh release-build
+script/build_and_run.sh release-bundle-check
 ```
 
 Expected output artifact:

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -44,6 +44,48 @@ MANAGED_GITHUB_BROKER_ENABLED="${NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED:
 GITHUB_BROKER_ORIGIN="${NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN:-}"
 BYO_GITHUB_ENABLED="${NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED:-}"
 
+list_binary_rpaths() {
+  otool -l "$APP_BINARY" | awk '
+    /^[[:space:]]*cmd LC_RPATH$/ { waiting_for_path = 1; next }
+    waiting_for_path && /^[[:space:]]*path / {
+      print $2
+      waiting_for_path = 0
+    }
+  '
+}
+
+is_portable_release_rpath() {
+  case "$1" in
+    @*|/usr/lib/swift|/System/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+sanitize_release_rpaths() {
+  local rpath
+  while IFS= read -r rpath; do
+    [ -n "$rpath" ] || continue
+    if ! is_portable_release_rpath "$rpath"; then
+      install_name_tool -delete_rpath "$rpath" "$APP_BINARY"
+    fi
+  done < <(list_binary_rpaths)
+}
+
+assert_portable_release_rpaths() {
+  local rpath
+  while IFS= read -r rpath; do
+    [ -n "$rpath" ] || continue
+    if ! is_portable_release_rpath "$rpath"; then
+      echo "release bundle contains a non-portable absolute LC_RPATH: $rpath" >&2
+      return 1
+    fi
+  done < <(list_binary_rpaths)
+}
+
 resolve_production_contract_mode() {
   if [ -z "$PAID_BETA_CONTRACT" ] \
     && [ -z "$MANAGED_GITHUB_BROKER_ENABLED" ] \
@@ -106,6 +148,10 @@ rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_MACOS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
 chmod +x "$APP_BINARY"
+if [ "$BUILD_CONFIGURATION" = "release" ]; then
+  sanitize_release_rpaths
+  assert_portable_release_rpaths
+fi
 if [ "$BUILD_CONFIGURATION" = "debug" ]; then
   mkdir -p "$APP_HELPERS"
   cp "$BUILD_DIR/NeonDiffDesktopFixtureResolve" "$APP_HELPERS/NeonDiffDesktopFixtureResolve"
@@ -205,6 +251,9 @@ case "$MODE" in
     ;;
   --bundle-check|bundle-check|release-bundle-check)
     /usr/bin/plutil -lint "$INFO_PLIST" >/dev/null
+    if [ "$BUILD_CONFIGURATION" = "release" ]; then
+      assert_portable_release_rpaths
+    fi
     INVALID_BUNDLE_ROOT_ENTRIES="$(find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents -print)"
     if [ -n "$INVALID_BUNDLE_ROOT_ENTRIES" ]; then
       echo "app bundle root may contain only Contents:" >&2

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -44,48 +44,6 @@ MANAGED_GITHUB_BROKER_ENABLED="${NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED:
 GITHUB_BROKER_ORIGIN="${NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN:-}"
 BYO_GITHUB_ENABLED="${NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED:-}"
 
-list_binary_rpaths() {
-  otool -l "$APP_BINARY" | awk '
-    /^[[:space:]]*cmd LC_RPATH$/ { waiting_for_path = 1; next }
-    waiting_for_path && /^[[:space:]]*path / {
-      print $2
-      waiting_for_path = 0
-    }
-  '
-}
-
-is_portable_release_rpath() {
-  case "$1" in
-    @*|/usr/lib/swift|/System/*)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
-sanitize_release_rpaths() {
-  local rpath
-  while IFS= read -r rpath; do
-    [ -n "$rpath" ] || continue
-    if ! is_portable_release_rpath "$rpath"; then
-      install_name_tool -delete_rpath "$rpath" "$APP_BINARY"
-    fi
-  done < <(list_binary_rpaths)
-}
-
-assert_portable_release_rpaths() {
-  local rpath
-  while IFS= read -r rpath; do
-    [ -n "$rpath" ] || continue
-    if ! is_portable_release_rpath "$rpath"; then
-      echo "release bundle contains a non-portable absolute LC_RPATH: $rpath" >&2
-      return 1
-    fi
-  done < <(list_binary_rpaths)
-}
-
 resolve_production_contract_mode() {
   if [ -z "$PAID_BETA_CONTRACT" ] \
     && [ -z "$MANAGED_GITHUB_BROKER_ENABLED" ] \
@@ -149,8 +107,8 @@ mkdir -p "$APP_MACOS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
 chmod +x "$APP_BINARY"
 if [ "$BUILD_CONFIGURATION" = "release" ]; then
-  sanitize_release_rpaths
-  assert_portable_release_rpaths
+  "$SCRIPT_DIR/release-rpaths.sh" sanitize "$APP_BINARY"
+  "$SCRIPT_DIR/release-rpaths.sh" assert "$APP_BINARY"
 fi
 if [ "$BUILD_CONFIGURATION" = "debug" ]; then
   mkdir -p "$APP_HELPERS"
@@ -252,7 +210,7 @@ case "$MODE" in
   --bundle-check|bundle-check|release-bundle-check)
     /usr/bin/plutil -lint "$INFO_PLIST" >/dev/null
     if [ "$BUILD_CONFIGURATION" = "release" ]; then
-      assert_portable_release_rpaths
+      "$SCRIPT_DIR/release-rpaths.sh" assert "$APP_BINARY"
     fi
     INVALID_BUNDLE_ROOT_ENTRIES="$(find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents -print)"
     if [ -n "$INVALID_BUNDLE_ROOT_ENTRIES" ]; then

--- a/apps/neondiff-desktop/script/release-rpaths.sh
+++ b/apps/neondiff-desktop/script/release-rpaths.sh
@@ -21,7 +21,10 @@ list_binary_rpaths() {
   printf '%s\n' "$otool_output" | awk '
     /^[[:space:]]*cmd LC_RPATH$/ { waiting_for_path = 1; next }
     waiting_for_path && /^[[:space:]]*path / {
-      print $2
+      path = $0
+      sub(/^[[:space:]]*path[[:space:]]+/, "", path)
+      sub(/[[:space:]]+\(offset[[:space:]]+[0-9]+\)$/, "", path)
+      print path
       waiting_for_path = 0
     }
   '

--- a/apps/neondiff-desktop/script/release-rpaths.sh
+++ b/apps/neondiff-desktop/script/release-rpaths.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+APP_BINARY="${2:-}"
+OTOOL_BIN="${NEONDIFF_OTOOL_BIN:-otool}"
+INSTALL_NAME_TOOL_BIN="${NEONDIFF_INSTALL_NAME_TOOL_BIN:-install_name_tool}"
+
+if [ -z "$APP_BINARY" ] || [ ! -f "$APP_BINARY" ]; then
+  echo "usage: $0 [sanitize|assert] <app-binary>" >&2
+  exit 2
+fi
+
+list_binary_rpaths() {
+  local otool_output
+  if ! otool_output="$($OTOOL_BIN -l "$APP_BINARY")"; then
+    echo "unable to inspect release bundle LC_RPATH entries" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$otool_output" | awk '
+    /^[[:space:]]*cmd LC_RPATH$/ { waiting_for_path = 1; next }
+    waiting_for_path && /^[[:space:]]*path / {
+      print $2
+      waiting_for_path = 0
+    }
+  '
+}
+
+is_portable_release_rpath() {
+  case "$1" in
+    /usr/lib/swift|@loader_path|@executable_path/../Frameworks)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+capture_rpaths() {
+  local captured
+  if ! captured="$(list_binary_rpaths)"; then
+    return 1
+  fi
+  printf '%s' "$captured"
+}
+
+sanitize_release_rpaths() {
+  local rpaths rpath
+  rpaths="$(capture_rpaths)"
+  while IFS= read -r rpath; do
+    [ -n "$rpath" ] || continue
+    if ! is_portable_release_rpath "$rpath"; then
+      "$INSTALL_NAME_TOOL_BIN" -delete_rpath "$rpath" "$APP_BINARY"
+    fi
+  done <<< "$rpaths"
+}
+
+assert_portable_release_rpaths() {
+  local rpaths rpath
+  rpaths="$(capture_rpaths)"
+  while IFS= read -r rpath; do
+    [ -n "$rpath" ] || continue
+    if ! is_portable_release_rpath "$rpath"; then
+      echo "release bundle contains a non-portable LC_RPATH: $rpath" >&2
+      return 1
+    fi
+  done <<< "$rpaths"
+}
+
+case "$MODE" in
+  sanitize)
+    sanitize_release_rpaths
+    ;;
+  assert)
+    assert_portable_release_rpaths
+    ;;
+  *)
+    echo "usage: $0 [sanitize|assert] <app-binary>" >&2
+    exit 2
+    ;;
+esac

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -169,7 +169,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
         [
           "/usr/lib/swift",
           "@loader_path",
-          "/Volumes/BuildDisk/Xcode.app/Contents/Developer/usr/lib/swift",
+          "/Volumes/Build Disk/Xcode.app/Contents/Developer/usr/lib/swift",
           "@executable_path/../Frameworks"
         ].join("\n") + "\n"
       );

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -244,4 +244,11 @@ mv "$NEONDIFF_RPATH_STATE.next" "$NEONDIFF_RPATH_STATE"
     expect(docs).toMatch(/visible smoke/i);
     expect(docs).not.toMatch(/\b(codesign|notarytool|stapler|spctl)\b/);
   });
+
+  it("documents release-mode bundle commands for the Developer ID flow", () => {
+    const runbook = read("apps/neondiff-desktop/docs/mac-release-runbook.md");
+
+    expect(runbook).toContain("script/build_and_run.sh release-build");
+    expect(runbook).toContain("script/build_and_run.sh release-bundle-check");
+  });
 });

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -142,6 +142,15 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(bundler).toContain('find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents');
   });
 
+  it("removes machine-local absolute runtime search paths from release bundles", () => {
+    const bundler = read("apps/neondiff-desktop/script/build_and_run.sh");
+
+    expect(bundler).toContain("sanitize_release_rpaths");
+    expect(bundler).toContain('install_name_tool -delete_rpath "$rpath" "$APP_BINARY"');
+    expect(bundler).toContain("assert_portable_release_rpaths");
+    expect(bundler).toContain("release bundle contains a non-portable absolute LC_RPATH");
+  });
+
   it("documents the desktop smoke artifact as non-release proof", () => {
     const docPath = "apps/neondiff-desktop/docs/desktop-release-smoke.md";
 

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -1,4 +1,14 @@
-import { existsSync, readFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
 
@@ -140,15 +150,79 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
       'ditto "$RESOURCE_DIR" "$APP_BUNDLE/$(basename "$RESOURCE_DIR")"'
     );
     expect(bundler).toContain('find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents');
+    expect(bundler).toContain('"$SCRIPT_DIR/release-rpaths.sh" sanitize "$APP_BINARY"');
+    expect(bundler).toContain('"$SCRIPT_DIR/release-rpaths.sh" assert "$APP_BINARY"');
   });
 
-  it("removes machine-local absolute runtime search paths from release bundles", () => {
-    const bundler = read("apps/neondiff-desktop/script/build_and_run.sh");
+  it("removes machine-local release rpaths and fails closed on inspection errors", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-release-rpaths-"));
+    const binary = join(root, "NeonDiffDesktop");
+    const state = join(root, "rpaths.txt");
+    const otool = join(root, "otool");
+    const installNameTool = join(root, "install_name_tool");
+    const helper = "apps/neondiff-desktop/script/release-rpaths.sh";
 
-    expect(bundler).toContain("sanitize_release_rpaths");
-    expect(bundler).toContain('install_name_tool -delete_rpath "$rpath" "$APP_BINARY"');
-    expect(bundler).toContain("assert_portable_release_rpaths");
-    expect(bundler).toContain("release bundle contains a non-portable absolute LC_RPATH");
+    try {
+      writeFileSync(binary, "fixture");
+      writeFileSync(
+        state,
+        [
+          "/usr/lib/swift",
+          "@loader_path",
+          "/Volumes/BuildDisk/Xcode.app/Contents/Developer/usr/lib/swift",
+          "@executable_path/../Frameworks"
+        ].join("\n") + "\n"
+      );
+      writeFileSync(
+        otool,
+        `#!/bin/sh
+set -eu
+while IFS= read -r rpath; do
+  printf '          cmd LC_RPATH\\n      cmdsize 64\\n         path %s (offset 12)\\n' "$rpath"
+done < "$NEONDIFF_RPATH_STATE"
+`
+      );
+      writeFileSync(
+        installNameTool,
+        `#!/bin/sh
+set -eu
+test "$1" = "-delete_rpath"
+grep -Fvx "$2" "$NEONDIFF_RPATH_STATE" > "$NEONDIFF_RPATH_STATE.next"
+mv "$NEONDIFF_RPATH_STATE.next" "$NEONDIFF_RPATH_STATE"
+`
+      );
+      chmodSync(otool, 0o755);
+      chmodSync(installNameTool, 0o755);
+
+      const env = {
+        ...process.env,
+        NEONDIFF_RPATH_STATE: state,
+        NEONDIFF_OTOOL_BIN: otool,
+        NEONDIFF_INSTALL_NAME_TOOL_BIN: installNameTool
+      };
+      const sanitize = spawnSync(helper, ["sanitize", binary], { encoding: "utf8", env });
+      expect(sanitize.status).toBe(0);
+      expect(readFileSync(state, "utf8").trim().split("\n")).toEqual([
+        "/usr/lib/swift",
+        "@loader_path",
+        "@executable_path/../Frameworks"
+      ]);
+
+      const assertion = spawnSync(helper, ["assert", binary], { encoding: "utf8", env });
+      expect(assertion.status).toBe(0);
+
+      writeFileSync(state, "@loader_path/../../escape\n");
+      const rejected = spawnSync(helper, ["assert", binary], { encoding: "utf8", env });
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stderr).toContain("non-portable LC_RPATH");
+
+      writeFileSync(otool, "#!/bin/sh\nexit 7\n");
+      const unreadable = spawnSync(helper, ["assert", binary], { encoding: "utf8", env });
+      expect(unreadable.status).not.toBe(0);
+      expect(unreadable.stderr).toContain("unable to inspect release bundle LC_RPATH entries");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   it("documents the desktop smoke artifact as non-release proof", () => {


### PR DESCRIPTION
## Outcome

Release bundles no longer retain absolute runtime search paths to the build machine's Xcode/toolchain volume. The release bundler removes non-portable `LC_RPATH` entries before signing and the release bundle check rejects any that remain.

Related to #449 and #657. This does not close either issue.

## Acceptance criteria

- failing-first test captures the portable release-rpath contract
- release bundling deletes machine-local/non-portable search paths while preserving system and bundle-relative paths
- release bundle check fails closed if a non-portable path remains
- a real release bundle from this head contains only `/usr/lib/swift`, `@loader_path`, and `@executable_path/../Frameworks`
- current-head CI and one independent release/security review pass before merge

## Evidence

- RED: focused Vitest failed because the sanitizer/assertion contract was absent
- GREEN: `tests/desktop-release-pipeline.test.ts` — 5/5
- shell syntax: `bash -n apps/neondiff-desktop/script/build_and_run.sh`
- real release-bundle check passed; resulting `LC_RPATH` values:
  - `/usr/lib/swift`
  - `@loader_path`
  - `@executable_path/../Frameworks`

## Non-goals

- no signing or notarization in this PR
- no public/private artifact upload
- no checkout, billing, GitHub App, Sparkle/appcast, or runtime behavior change
- no beta/release/customer-readiness claim
- no broader #517 or #657 closure
