### PR TITLE
fix(desktop): initialize clean-install config in Application Support

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -395,7 +395,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
         self.activationLicenseClientOverride = activationLicenseClient
-        self.configPath = dependencies.preferences.string(forKey: "neondiff.configPath") ?? "config.local.json"
+        self.configPath = dependencies.preferences.string(forKey: "neondiff.configPath")
+            ?? dependencies.fileWriter.applicationSupportDirectory
+                .appendingPathComponent("config.local.json")
+                .standardizedFileURL.path
         self.cliPath = dependencies.preferences.string(forKey: "neondiff.cliPath") ?? "neondiff"
         self.launchdLabel = dependencies.preferences.string(forKey: "neondiff.launchdLabel") ?? "com.electricsheephq.evaos-code-review-bot"
         let providerKeyStored = ProviderKeychainAccount.account(providerId: providers.selectedProviderId)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -19,7 +19,11 @@ struct BYOGitHubAppCredentialOnboardingTests {
         fixture.model.initializeConfigForOnboarding()
         await fixture.cli.waitUntilCallCount(1)
 
-        #expect(fixture.cli.calls[0].arguments == ["init", "--config", fixture.model.configPath])
+        let expectedConfigPath = fixture.fileWriter.applicationSupportDirectory
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
+        #expect(fixture.model.configPath == expectedConfigPath)
+        #expect(fixture.cli.calls[0].arguments == ["init", "--config", expectedConfigPath])
         #expect(!fixture.cli.calls[0].arguments.contains("--force"))
         #expect(fixture.model.configInitializeCommand.commandLine.contains(" init --config "))
         #expect(!fixture.model.configInitializeCommand.commandLine.contains("--force"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ConfigurationControlCenterTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ConfigurationControlCenterTests.swift
@@ -42,7 +42,7 @@ import NeonDiffDesktopCore
         #expect(write.url == root.appending(path: "control-center-patch.json").standardizedFileURL)
         #expect(write.data == expectedBytes)
         #expect(fixture.cli.calls[0].arguments == [
-            "config", "patch", "--config", "config.local.json",
+            "config", "patch", "--config", root.appending(path: "config.local.json").path,
             "--input", root.appending(path: "control-center-patch.json").path,
             "--dry-run", "true", "--expected-revision", revision
         ])

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NeonDiffDesktopModelConstructionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/NeonDiffDesktopModelConstructionTests.swift
@@ -3,6 +3,18 @@ import Testing
 
 @MainActor
 @Suite struct NeonDiffDesktopModelConstructionTests {
+    @Test func constructingModelDefaultsConfigInsideApplicationSupport() {
+        let root = fixtureURL("/fixture/application-support", directory: true)
+        let fixture = RecordingDesktopDependencies(root: root)
+
+        let model = NeonDiffDesktopModel(dependencies: fixture.dependencies)
+
+        #expect(
+            model.configPath
+                == root.appendingPathComponent("config.local.json").standardizedFileURL.path
+        )
+    }
+
     @Test func constructingModelReadsOnlyInjectedState() {
         let fixture = RecordingDesktopDependencies(
             root: fixtureURL("/fixture/application-support", directory: true)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderVerificationStateMachineTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderVerificationStateMachineTests.swift
@@ -26,7 +26,7 @@ import NeonDiffDesktopCore
         legacy.expect(fixture.cli.calls.count == 1, "concurrent Verify clicks launch one operation")
         legacy.expect(
             fixture.cli.calls[0].arguments == [
-                "providers", "verify", "--config", "config.local.json", "--provider", "zcode-glm",
+                "providers", "verify", "--config", fixture.model.configPath, "--provider", "zcode-glm",
                 "--expected-config-revision", ProviderModelFixture.loadedRevision, "--api-key-stdin", "true",
                 "--allow-remote-smoke", "true", "--json"
             ],

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -291,13 +291,19 @@ neondiff doctor github --config config.local.json --json
 
 The invite-only B0 desktop keeps the customer-owned App private key in the
 macOS Keychain. Its explicit **Verify App Access** action sends that key only to
-the local CLI's bounded stdin for this check; the equivalent CLI contract is:
+the local CLI's bounded stdin for this check. The native app's clean-install
+config lives in its user-writable Application Support directory; the equivalent
+CLI contract is:
 
 ```bash
-neondiff doctor github --config config.local.json \
+NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
+neondiff doctor github --config "$NATIVE_CONFIG" \
   --github-app-id "<numeric-app-id>" \
   --github-app-private-key-stdin true --json < "/path/to/app-private-key.pem"
 ```
+
+The relative `config.local.json` examples elsewhere in this guide remain the
+separate CLI-first/operator path; they do not inspect the native app's config.
 
 The private key must be one unencrypted RSA PKCS#1 or PKCS#8 PEM no larger than
 64 KiB. Do not put it in arguments, environment variables, config, logs, or

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -134,8 +134,12 @@ NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.js
 neondiff doctor github --config "$NATIVE_CONFIG" --json
 ```
 
-CLI-first and non-Mac setups may instead use the checkout-local
-`--config config.local.json` path documented in [SETUP.md](SETUP.md).
+CLI-first and non-Mac setups may instead use the checkout-local path documented
+in [SETUP.md](SETUP.md):
+
+```bash
+neondiff doctor github --config config.local.json --json
+```
 
 The command verifies App credential presence, App installation visibility, and
 repo read access for the enabled repos in your local config. It does not run

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -125,11 +125,17 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-Run the GitHub-only doctor before provider or daemon checks:
+Run the GitHub-only doctor before provider or daemon checks. For the native B0
+app, use the config created in the app's user-writable Application Support
+directory:
 
 ```bash
-neondiff doctor github --config config.local.json --json
+NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
+neondiff doctor github --config "$NATIVE_CONFIG" --json
 ```
+
+CLI-first and non-Mac setups may instead use the checkout-local
+`--config config.local.json` path documented in [SETUP.md](SETUP.md).
 
 The command verifies App credential presence, App installation visibility, and
 repo read access for the enabled repos in your local config. It does not run


### PR DESCRIPTION
## Outcome

Fixes the reproduced clean-installed-app P0 where **Initialize Local Config** attempted to write `/config.local.json` and failed with `EROFS`.

Related to #657 and #449. This does not close either broader issue.

## Bounded acceptance criteria

- With no saved `neondiff.configPath`, the desktop model defaults to the injected Application Support root plus `config.local.json`.
- A saved explicit config path still wins.
- Clean-install onboarding invokes non-destructive `neondiff init --config <absolute Application Support path>`.
- The initialization command does not add `--force`.
- Native B0 setup documentation uses the same quoted Application Support path; CLI-first examples remain a separate path.

## Failing-first proof

Before the implementation change, `constructingModelDefaultsConfigInsideApplicationSupport` failed because the model returned the relative path `config.local.json` instead of the injected Application Support path.

Focused checks at current head:

- `NeonDiffDesktopModelConstructionTests` — 2 passed
- `cleanInstallInitializationUsesNonDestructiveCLIInit` — 1 passed
- `ConfigurationControlCenterTests` — 5 passed
- `concurrentVerifyClicksLaunchOneStdinOnlyOperation` — 1 passed
- `git diff --check` — passed

The first hosted Swift run correctly exposed two stale absolute-path expectations. Both were updated and reproduced green locally; current-head remote CI is canonical.

## Non-goals

- No stale saved-path migration.
- No CLI bundling or global npm installation changes.
- No activation, GitHub App, provider, dry-run, or live-review behavior changes.
- No broader #517 accessibility/layout matrix work.
- No website rewrite.
- No signing, notarization, release, checkout, deployment, or customer-readiness claim.
