### PR TITLE
fix(desktop): show one activation credential surface

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
@@ -9,30 +9,8 @@ struct LicenseView: View {
             VStack(alignment: .leading, spacing: 18) {
                 if model.activationHandoffEnabled {
                     ActivationStateView(model: model)
-                }
-                OperatorSection("License") {
-                    OperatorTextField(title: "License Key", text: $model.pendingLicenseKey, secure: true)
-                    HStack(spacing: 10) {
-                        Button { model.storeLicenseKey() } label: {
-                            Label("Activation Unavailable", systemImage: "lock.shield")
-                        }
-                        .disabled(!model.productionUsefulWorkAvailable)
-                        OperatorBadge(
-                            text: model.license.keyStored ? "Stored Locally" : "No Key Stored",
-                            color: model.license.keyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
-                        )
-                    }
-                    Divider()
-                        .overlay(NeonDiffTheme.stroke.opacity(0.6))
-                    LabeledContent("Entitlement", value: model.license.entitlement)
-                        .foregroundStyle(NeonDiffTheme.textPrimary)
-                    LabeledContent("Update Channel", value: model.license.updateChannel)
-                        .foregroundStyle(NeonDiffTheme.textPrimary)
-                }
-
-                OperatorSection("Boundary") {
-                    Text(model.productionActivationBoundaryMessage)
-                        .operatorBodyText()
+                } else {
+                    legacyLicenseContent
                 }
             }
             .padding(24)
@@ -42,5 +20,33 @@ struct LicenseView: View {
         }
         .accessibilityIdentifier("neondiff-license-outer-scroll")
         .scrollContentBackground(.hidden)
+    }
+
+    @ViewBuilder
+    private var legacyLicenseContent: some View {
+        OperatorSection("License") {
+            OperatorTextField(title: "License Key", text: $model.pendingLicenseKey, secure: true)
+            HStack(spacing: 10) {
+                Button { model.storeLicenseKey() } label: {
+                    Label("Activation Unavailable", systemImage: "lock.shield")
+                }
+                .disabled(!model.productionUsefulWorkAvailable)
+                OperatorBadge(
+                    text: model.license.keyStored ? "Stored Locally" : "No Key Stored",
+                    color: model.license.keyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
+                )
+            }
+            Divider()
+                .overlay(NeonDiffTheme.stroke.opacity(0.6))
+            LabeledContent("Entitlement", value: model.license.entitlement)
+                .foregroundStyle(NeonDiffTheme.textPrimary)
+            LabeledContent("Update Channel", value: model.license.updateChannel)
+                .foregroundStyle(NeonDiffTheme.textPrimary)
+        }
+
+        OperatorSection("Boundary") {
+            Text(model.productionActivationBoundaryMessage)
+                .operatorBodyText()
+        }
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -249,6 +249,19 @@ import Testing
         #expect(source.contains("neondiff-onboarding-byo-github-verify"))
     }
 
+    @Test func activationEnabledLicenseViewHidesLegacyCredentialAndFalseBoundary() throws {
+        let licenseView = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views/LicenseView.swift")
+        let source = try sourceBoundaryText(at: licenseView)
+
+        #expect(source.contains(
+            "if model.activationHandoffEnabled {\n                    ActivationStateView(model: model)\n                } else {\n                    legacyLicenseContent"
+        ))
+        #expect(source.contains("private var legacyLicenseContent: some View"))
+        #expect(source.contains("OperatorSection(\"License\")"))
+        #expect(source.contains("OperatorSection(\"Boundary\")"))
+    }
+
     @Test func managedSafetyStopIsNotDisabledByUsefulWorkProofLoss() throws {
         let viewsDirectory = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)


### PR DESCRIPTION
## Outcome

Activation-enabled B0 and managed beta builds show one canonical NeonDiff Activation Key surface. They no longer render the obsolete local License Key form and the false “activation unavailable” boundary under the working activation state machine.

Related: #612
Related: #657
Tracker: #610

## Bounded acceptance criteria

- B0/managed builds with `activationHandoffEnabled` render `ActivationStateView` only.
- Quarantined/legacy builds retain the existing diagnostic License form and production-boundary message.
- No activation, entitlement, Keychain, repository-binding, billing, or daemon behavior changes.
- The exact current head passes focused Swift proof and the repository’s broad remote gates.
- One independent semantic review covers the credential/activation presentation boundary before merge.

## Failing-first proof

Before the source change:

```text
swift test --filter ProductionBoundaryContractTests.activationEnabledLicenseViewHidesLegacyCredentialAndFalseBoundary
```

failed with two expectations because `LicenseView` rendered the legacy content unconditionally and had no gated legacy content block.

After the change:

```text
swift test --filter ProductionBoundaryContractTests
```

passes 16/16. The executable target recompiles, and `git diff --check` passes.

## Explicit non-goals

- No checkout enablement, billing lifecycle mutation, production activation canary, or entitlement change.
- No GitHub App/broker change, BYO credential storage change, provider/daemon/review behavior, or broader onboarding redesign.
- No local XCUITest, signing, notarization, artifact replacement, deployment, publication, or customer canary.
- Does not close #612, #657, #646, #610, or broader #517.

## Proof boundary

This PR proves only the bounded activation-screen correction in source and hosted validation. It does not prove purchase, live activation, GitHub/provider setup, dry run, live review, installed customer behavior, beta, release, or customer readiness.
