### PR TITLE
fix(config): allow installed Mac app CLI from root cwd

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1254,7 +1254,7 @@ function validateLicenseConfig(value: unknown, label: string): void {
   }
   assertPathOutsideProtectedRoot({
     path: value.cachePath,
-    protectedRoot: process.cwd(),
+    protectedRoot: undefined,
     protectedRoots: getProtectedCheckoutRoots(),
     pathLabel: `${label}.cachePath`,
     protectedRootLabel: "protected checkout root"
@@ -1270,7 +1270,7 @@ function validateLicenseConfig(value: unknown, label: string): void {
   if (typeof value.keyPath === "string" && value.keyPath.trim().length > 0) {
     assertPathOutsideProtectedRoot({
       path: value.keyPath,
-      protectedRoot: process.cwd(),
+      protectedRoot: undefined,
       protectedRoots: getProtectedCheckoutRoots(),
       pathLabel: `${label}.keyPath`,
       protectedRootLabel: "protected checkout root"

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -25,6 +25,7 @@ export function getProtectedCheckoutRoots(): string[] {
       legacyName: "EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT",
       valueLabel: "protected checkout root"
     }),
+    findGitCheckoutRoot(process.cwd()),
     findPackageRoot(process.cwd()),
     getInstalledPackageRoot()
   ]);
@@ -38,6 +39,16 @@ export function findPackageRoot(startPath: string): string | undefined {
   let current = resolvePathFollowingExistingSymlinks(startPath);
   while (true) {
     if (existsSync(resolve(current, "package.json"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+export function findGitCheckoutRoot(startPath: string): string | undefined {
+  let current = resolvePathFollowingExistingSymlinks(startPath);
+  while (true) {
+    if (existsSync(resolve(current, ".git"))) return current;
     const parent = dirname(current);
     if (parent === current) return undefined;
     current = parent;

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -169,6 +169,41 @@ describe("public NeonDiff CLI surface", () => {
     });
   });
 
+  it("still rejects license state inside a non-package Git checkout", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-non-package-checkout-"));
+    roots.push(root);
+    const checkoutRoot = join(root, "checkout");
+    const configPath = join(root, "config.json");
+    mkdirSync(join(checkoutRoot, ".git"), { recursive: true });
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/private"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      license: {
+        enabled: true,
+        apiBaseUrl: "https://neondiff-license.fly.dev",
+        cachePath: join(checkoutRoot, "state", "entitlement.json"),
+        storageBackend: "file",
+        keyPath: join(checkoutRoot, "state", "license.key")
+      }
+    }, null, 2)}\n`, "utf8");
+
+    await expect(execFileAsync(process.execPath, [
+      tsxCliPath,
+      join(repoRoot, "src/cli.ts"),
+      "config",
+      "inspect",
+      "--config",
+      configPath
+    ], {
+      cwd: checkoutRoot,
+      env: { ...process.env, NODE_OPTIONS: "--experimental-sqlite" }
+    })).rejects.toMatchObject({
+      stdout: expect.stringContaining("config.license.cachePath must be outside protected checkout root")
+    });
+  });
+
   it("refuses the no-local-state CLI path without the matching native Keychain credential", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-native-activation-cli-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -129,6 +129,46 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
   });
 
+  it("initializes a config that remains valid when a desktop launch gives the CLI root cwd", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-desktop-root-cwd-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const cliSourcePath = join(repoRoot, "src/cli.ts");
+
+    const initialized = await execFileAsync(process.execPath, [
+      tsxCliPath,
+      cliSourcePath,
+      "init",
+      "--config",
+      configPath
+    ], {
+      cwd: "/",
+      env: { ...process.env, NODE_OPTIONS: "--experimental-sqlite" }
+    });
+    expect(JSON.parse(initialized.stdout)).toMatchObject({
+      ok: true,
+      command: "init",
+      created: true,
+      configPath
+    });
+
+    const inspected = await execFileAsync(process.execPath, [
+      tsxCliPath,
+      cliSourcePath,
+      "config",
+      "inspect",
+      "--config",
+      configPath
+    ], {
+      cwd: "/",
+      env: { ...process.env, NODE_OPTIONS: "--experimental-sqlite" }
+    });
+    expect(JSON.parse(inspected.stdout)).toMatchObject({
+      ok: true,
+      command: "config inspect"
+    });
+  });
+
   it("refuses the no-local-state CLI path without the matching native Keychain credential", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-native-activation-cli-"));
     roots.push(root);


### PR DESCRIPTION
## Outcome

Make a config created by the packaged NeonDiff CLI remain loadable when the CLI is launched by the real macOS app with `/` as its current working directory.

Related to #646 and #657. This is a bounded clean-install blocker fix and does not close either broader issue.

## Reproduction

The signed/notarized installed build 11010 launched the exact compatible worker from a normal Finder-style app process whose cwd is `/`. `neondiff init` created a config, but the subsequent repository patch failed because license path validation treated `/` as a protected checkout and therefore rejected `/tmp/neondiff/state/license/entitlement-cache.json`.

## Acceptance criteria

- [x] Failing-first child-process test runs `init` and `config inspect` from cwd `/`.
- [x] License cache and key paths remain forbidden inside actual package/checkouts and explicit protected roots.
- [x] A built CLI initialized and inspected a fresh config successfully from cwd `/`.
- [x] Focused license-path regression test, build, and secret scan pass locally.
- [ ] Current-head remote CI and required review surfaces pass.

## Implementation

License cache/key validation now relies on `getProtectedCheckoutRoots()`, which includes the explicit protected-root environment, the Git checkout root found from cwd, the package root found from cwd, and the installed package root. It no longer adds raw `process.cwd()` as a fourth root. This preserves non-Node checkout isolation while avoiding the pathological `/` boundary of a normal GUI launch.

## Local proof

- RED: the new cwd `/` `init` → `config inspect` test failed before the source change.
- GREEN: the same test passed after the change.
- RED/GREEN delta: a new non-package Git checkout test first proved the review regression, then passed after Git-root discovery was added.
- Existing `derives cache path from statePath and rejects license artifacts inside the checkout` test passed.
- Existing packaged-example init test passed.
- `npm run build` passed.
- `npm run check:secrets` passed.
- Built CLI cwd `/` smoke returned `config inspect` with `ok=true` and a revision.

## Explicit non-goals

- No GitHub App credential creation or storage.
- No provider credential, activation, billing, entitlement, review-posting, daemon, deployment, checkout, publication, npm publish, signing, notarization, or customer-canary change.
- No account/workspace switcher implementation.
- No closure of #646, #657, broader #517, or the paid-beta gate.

## Proof boundary

This proves only that real macOS GUI cwd `/` no longer invalidates otherwise outside-checkout license paths. It does not prove the remaining customer journey, free mode, paid activation, live review, beta, or release.
