### PR TITLE
feat(desktop): add account and bot switcher state

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/ApplicationSupportFileWriter.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/ApplicationSupportFileWriter.swift
@@ -16,6 +16,10 @@ final class ApplicationSupportFileWriter: DesktopFileWriting, @unchecked Sendabl
             .standardizedFileURL
     }
 
+    func fileExists(at url: URL) -> Bool {
+        fileManager.fileExists(atPath: url.standardizedFileURL.path)
+    }
+
     func write(_ data: Data, to url: URL) throws {
         let destination = url.standardizedFileURL
         let rootPath = applicationSupportDirectory.path

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/DesktopEvaluationDependencies.swift
@@ -90,6 +90,7 @@ private struct EvaluationClock: DesktopClock {
 
 private struct EvaluationFileWriter: DesktopFileWriting {
     let applicationSupportDirectory = URL(filePath: "/fixture/NeonDiffDesktop", directoryHint: .isDirectory)
+    func fileExists(at url: URL) -> Bool { false }
     func write(_ data: Data, to url: URL) throws {}
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift
@@ -94,6 +94,7 @@ private struct VisualProofClock: DesktopClock {
 private struct VisualProofFileWriter: DesktopFileWriting {
     let applicationSupportDirectory = URL(filePath: "/visual-proof/NeonDiffDesktop", directoryHint: .isDirectory)
 
+    func fileExists(at url: URL) -> Bool { false }
     func write(_ data: Data, to url: URL) throws {}
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -170,7 +170,12 @@ private struct ReferenceShellLayout: View {
                     HStack(spacing: 0) {
                         SidebarView(
                             selection: $model.selectedSection,
-                            readiness: DesktopSetupReadiness(model: model)
+                            readiness: DesktopSetupReadiness(model: model),
+                            accountCatalog: model.accountWorkspaceCatalog,
+                            accountSelection: model.accountWorkspaceSelection,
+                            selectAccount: model.selectAccountWorkspace,
+                            selectBot: model.selectBotInstallation,
+                            beginNewBot: { model.beginNewBot() }
                         )
                             .frame(width: proxy.size.width < 980 ? 204 : 242)
                         .evaluationAccessibilityRegion(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
@@ -90,80 +90,90 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func accountMenu(palette: NDPalette) -> some View {
-        Menu {
-            switch accountCatalog {
-            case .idle:
-                Text("SIGN IN REQUIRED")
-            case .loading:
-                Text("LOADING ACCOUNTS…")
-            case .failed:
-                Text("ACCOUNT SERVICE UNAVAILABLE")
-            case .loaded:
-                if accountCatalog.accounts.isEmpty {
-                    Text("NO AUTHORIZED ACCOUNTS")
-                } else {
-                    ForEach(accountCatalog.accounts) { account in
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                NDBrandWordmark(size: 22)
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(palette.textSecondary)
+            }
+            Text(selectedAccountName ?? "AI CODE REVIEW SYSTEM")
+                .font(.system(.caption2, design: .monospaced).weight(.medium))
+                .tracking(0.9)
+                .foregroundStyle(palette.textSecondary)
+                .lineLimit(1)
+        }
+        .contentShape(Rectangle())
+        .overlay {
+            Menu {
+                accountMenuEntries
+            } label: {
+                Color.clear
+                    .contentShape(Rectangle())
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .accessibilityLabel("NeonDiff account and bot menu")
+            .accessibilityIdentifier("neondiff-account-menu")
+        }
+    }
+
+    @ViewBuilder
+    private var accountMenuEntries: some View {
+        switch accountCatalog {
+        case .idle:
+            Text("SIGN IN REQUIRED")
+        case .loading:
+            Text("LOADING ACCOUNTS…")
+        case .failed:
+            Text("ACCOUNT SERVICE UNAVAILABLE")
+        case .loaded:
+            if accountCatalog.accounts.isEmpty {
+                Text("NO AUTHORIZED ACCOUNTS")
+            } else {
+                ForEach(accountCatalog.accounts) { account in
+                    Button {
+                        selectAccount(account.id)
+                    } label: {
+                        Label(
+                            account.name,
+                            systemImage: accountSelection.accountID == account.id
+                                ? "checkmark.circle.fill"
+                                : account.kind == .organization ? "building.2" : "person"
+                        )
+                    }
+                    .accessibilityIdentifier("neondiff-account-option-\(account.id)")
+                }
+
+                if let selected = accountCatalog.accounts.first(where: {
+                    $0.id == accountSelection.accountID
+                }) {
+                    Divider()
+                    ForEach(selected.bots) { bot in
                         Button {
-                            selectAccount(account.id)
+                            selectBot(bot.id)
                         } label: {
                             Label(
-                                account.name,
-                                systemImage: accountSelection.accountID == account.id
-                                    ? "checkmark.circle.fill"
-                                    : account.kind == .organization ? "building.2" : "person"
+                                bot.appSlug,
+                                systemImage: accountSelection.botID == bot.id
+                                    ? "checkmark.square.fill"
+                                    : bot.isAvailableOnThisMac ? "laptopcomputer" : "app.badge"
                             )
                         }
-                        .accessibilityIdentifier("neondiff-account-option-\(account.id)")
+                        .disabled(bot.status == .revoked || bot.status == .suspended)
+                        .accessibilityIdentifier("neondiff-bot-option-\(bot.id)")
                     }
-
-                    if let selected = accountCatalog.accounts.first(where: {
-                        $0.id == accountSelection.accountID
-                    }) {
-                        Divider()
-                        ForEach(selected.bots) { bot in
-                            Button {
-                                selectBot(bot.id)
-                            } label: {
-                                Label(
-                                    bot.appSlug,
-                                    systemImage: accountSelection.botID == bot.id
-                                        ? "checkmark.square.fill"
-                                        : bot.isAvailableOnThisMac ? "laptopcomputer" : "app.badge"
-                                )
-                            }
-                            .disabled(bot.status == .revoked || bot.status == .suspended)
-                            .accessibilityIdentifier("neondiff-bot-option-\(bot.id)")
-                        }
-                        Button {
-                            beginNewBot()
-                        } label: {
-                            Label("NEW BOT", systemImage: "plus.circle")
-                        }
-                        .accessibilityIdentifier("neondiff-new-bot")
+                    Button {
+                        beginNewBot()
+                    } label: {
+                        Label("NEW BOT", systemImage: "plus.circle")
                     }
+                    .accessibilityIdentifier("neondiff-new-bot")
                 }
             }
-        } label: {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 8) {
-                    NDBrandWordmark(size: 22)
-                    Spacer(minLength: 4)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(palette.textSecondary)
-                }
-                Text(selectedAccountName ?? "AI CODE REVIEW SYSTEM")
-                    .font(.system(.caption2, design: .monospaced).weight(.medium))
-                    .tracking(0.9)
-                    .foregroundStyle(palette.textSecondary)
-                    .lineLimit(1)
-            }
-            .contentShape(Rectangle())
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .accessibilityLabel("NeonDiff account and bot menu")
-        .accessibilityIdentifier("neondiff-account-menu")
     }
 
     private var selectedAccountName: String? {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
@@ -105,11 +105,13 @@ struct SidebarView: View {
                 .lineLimit(1)
         }
         .contentShape(Rectangle())
+        .accessibilityHidden(true)
         .overlay {
             Menu {
                 accountMenuEntries
             } label: {
                 Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .contentShape(Rectangle())
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
@@ -1,9 +1,15 @@
 import SwiftUI
+import NeonDiffDesktopAppCore
 import NeonDiffDesktopCore
 
 struct SidebarView: View {
     @Binding var selection: DesktopSection
     let readiness: DesktopSetupReadiness
+    let accountCatalog: DesktopAccountWorkspaceCatalog
+    let accountSelection: DesktopAccountWorkspaceSelection
+    let selectAccount: (String) -> Void
+    let selectBot: (String) -> Void
+    let beginNewBot: () -> Void
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -13,13 +19,7 @@ struct SidebarView: View {
             palette.surface
 
             VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 6) {
-                    NDBrandWordmark(size: 22)
-                    Text("AI CODE REVIEW SYSTEM")
-                        .font(.system(.caption2, design: .monospaced).weight(.medium))
-                        .tracking(0.9)
-                        .foregroundStyle(palette.textSecondary)
-                }
+                accountMenu(palette: palette)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
 
@@ -86,6 +86,88 @@ struct SidebarView: View {
             .padding(.top, 18)
             .padding(.bottom, 16)
         }
+    }
+
+    @ViewBuilder
+    private func accountMenu(palette: NDPalette) -> some View {
+        Menu {
+            switch accountCatalog {
+            case .idle:
+                Text("SIGN IN REQUIRED")
+            case .loading:
+                Text("LOADING ACCOUNTS…")
+            case .failed:
+                Text("ACCOUNT SERVICE UNAVAILABLE")
+            case .loaded:
+                if accountCatalog.accounts.isEmpty {
+                    Text("NO AUTHORIZED ACCOUNTS")
+                } else {
+                    ForEach(accountCatalog.accounts) { account in
+                        Button {
+                            selectAccount(account.id)
+                        } label: {
+                            Label(
+                                account.name,
+                                systemImage: accountSelection.accountID == account.id
+                                    ? "checkmark.circle.fill"
+                                    : account.kind == .organization ? "building.2" : "person"
+                            )
+                        }
+                        .accessibilityIdentifier("neondiff-account-option-\(account.id)")
+                    }
+
+                    if let selected = accountCatalog.accounts.first(where: {
+                        $0.id == accountSelection.accountID
+                    }) {
+                        Divider()
+                        ForEach(selected.bots) { bot in
+                            Button {
+                                selectBot(bot.id)
+                            } label: {
+                                Label(
+                                    bot.appSlug,
+                                    systemImage: accountSelection.botID == bot.id
+                                        ? "checkmark.square.fill"
+                                        : bot.isAvailableOnThisMac ? "laptopcomputer" : "app.badge"
+                                )
+                            }
+                            .disabled(bot.status == .revoked || bot.status == .suspended)
+                            .accessibilityIdentifier("neondiff-bot-option-\(bot.id)")
+                        }
+                        Button {
+                            beginNewBot()
+                        } label: {
+                            Label("NEW BOT", systemImage: "plus.circle")
+                        }
+                        .accessibilityIdentifier("neondiff-new-bot")
+                    }
+                }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    NDBrandWordmark(size: 22)
+                    Spacer(minLength: 4)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(palette.textSecondary)
+                }
+                Text(selectedAccountName ?? "AI CODE REVIEW SYSTEM")
+                    .font(.system(.caption2, design: .monospaced).weight(.medium))
+                    .tracking(0.9)
+                    .foregroundStyle(palette.textSecondary)
+                    .lineLimit(1)
+            }
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .accessibilityLabel("NeonDiff account and bot menu")
+        .accessibilityIdentifier("neondiff-account-menu")
+    }
+
+    private var selectedAccountName: String? {
+        accountCatalog.accounts.first { $0.id == accountSelection.accountID }?.name.uppercased()
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Dependencies/DesktopFileWriting.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Dependencies/DesktopFileWriting.swift
@@ -2,5 +2,6 @@ import Foundation
 
 package protocol DesktopFileWriting: Sendable {
     var applicationSupportDirectory: URL { get }
+    func fileExists(at url: URL) -> Bool
     func write(_ data: Data, to url: URL) throws
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -162,6 +162,22 @@ package struct DesktopAccountWorkspace: Identifiable, Codable, Equatable, Sendab
         }
         return result
     }
+
+    /// Compares only the server-authoritative account and installation fields.
+    /// Local config discovery may enrich a catalog without changing authority.
+    package func hasSameAuthority(as other: DesktopAccountWorkspace) -> Bool {
+        func authorityOnly(_ workspace: DesktopAccountWorkspace) -> DesktopAccountWorkspace {
+            var result = workspace
+            result.bots = workspace.bots.map { bot in
+                var authoritativeBot = bot
+                authoritativeBot.localConfigPath = nil
+                return authoritativeBot
+            }.sorted { $0.id < $1.id }
+            return result
+        }
+
+        return authorityOnly(self) == authorityOnly(other)
+    }
 }
 
 package enum DesktopAccountWorkspaceCatalog: Equatable, Sendable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -64,6 +64,35 @@ package struct DesktopBotInstallation: Identifiable, Codable, Equatable, Sendabl
     package var isAvailableOnThisMac: Bool {
         localConfigPath != nil
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, appID, appSlug, mode, githubInstallationID, githubAccountLogin, status
+    }
+
+    /// `localConfigPath` is local-only evidence discovered on this Mac. It is
+    /// absent from the wire representation so a service cannot select a path.
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        appID = try container.decode(Int64.self, forKey: .appID)
+        appSlug = try container.decode(String.self, forKey: .appSlug)
+        mode = try container.decode(DesktopBotMode.self, forKey: .mode)
+        githubInstallationID = try container.decodeIfPresent(Int64.self, forKey: .githubInstallationID)
+        githubAccountLogin = try container.decodeIfPresent(String.self, forKey: .githubAccountLogin)
+        status = try container.decode(DesktopBotStatus.self, forKey: .status)
+        localConfigPath = nil
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(appID, forKey: .appID)
+        try container.encode(appSlug, forKey: .appSlug)
+        try container.encode(mode, forKey: .mode)
+        try container.encodeIfPresent(githubInstallationID, forKey: .githubInstallationID)
+        try container.encodeIfPresent(githubAccountLogin, forKey: .githubAccountLogin)
+        try container.encode(status, forKey: .status)
+    }
 }
 
 package struct DesktopLocalBotCandidate: Equatable, Sendable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -194,7 +194,8 @@ package struct DesktopNewBotPlan: Equatable, Sendable {
         account: DesktopAccountWorkspace,
         appSlug: String,
         applicationSupportDirectory: URL,
-        occupiedConfigPaths: Set<String>
+        occupiedConfigPaths: Set<String>,
+        fileExists: (URL) -> Bool = { _ in false }
     ) throws -> DesktopNewBotPlan {
         guard account.role != nil else {
             throw DesktopNewBotPlanError.accountMembershipRequired
@@ -216,7 +217,7 @@ package struct DesktopNewBotPlan: Equatable, Sendable {
             .standardizedFileURL.path
         var suffix = 2
         while occupiedConfigPaths.contains(candidate)
-            || FileManager.default.fileExists(atPath: candidate) {
+            || fileExists(URL(filePath: candidate)) {
             candidate = baseDirectory
                 .appendingPathComponent("\(appSlug)-\(suffix)", isDirectory: true)
                 .appendingPathComponent("config.local.json")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+package enum DesktopAccountKind: String, Codable, Equatable, Sendable {
+    case personal
+    case organization
+}
+
+package enum DesktopAccountRole: String, Codable, Equatable, Sendable {
+    case owner
+    case admin
+    case member
+}
+
+package enum DesktopAccountEntitlement: String, Codable, Equatable, Sendable {
+    case publicFree = "public_free"
+    case paid
+    case internalAdmin = "internal_admin"
+    case trial
+    case none
+}
+
+package enum DesktopBotMode: String, Codable, Equatable, Sendable {
+    case byo
+    case managed
+}
+
+package enum DesktopBotStatus: String, Codable, Equatable, Sendable {
+    case pending
+    case verified
+    case suspended
+    case revoked
+}
+
+package struct DesktopBotInstallation: Identifiable, Codable, Equatable, Sendable {
+    package let id: String
+    package let appID: Int64
+    package let appSlug: String
+    package let mode: DesktopBotMode
+    package let githubInstallationID: Int64?
+    package let githubAccountLogin: String?
+    package let status: DesktopBotStatus
+    package var localConfigPath: String?
+
+    package init(
+        id: String,
+        appID: Int64,
+        appSlug: String,
+        mode: DesktopBotMode,
+        githubInstallationID: Int64?,
+        githubAccountLogin: String?,
+        status: DesktopBotStatus,
+        localConfigPath: String?
+    ) {
+        self.id = id
+        self.appID = appID
+        self.appSlug = appSlug
+        self.mode = mode
+        self.githubInstallationID = githubInstallationID
+        self.githubAccountLogin = githubAccountLogin
+        self.status = status
+        self.localConfigPath = localConfigPath
+    }
+
+    package var isAvailableOnThisMac: Bool {
+        localConfigPath != nil
+    }
+}
+
+package struct DesktopLocalBotCandidate: Equatable, Sendable {
+    package let appID: Int64
+    package let appSlug: String
+    package let githubAccountLogin: String
+    package let configPath: String
+
+    package init(
+        appID: Int64,
+        appSlug: String,
+        githubAccountLogin: String,
+        configPath: String
+    ) {
+        self.appID = appID
+        self.appSlug = appSlug
+        self.githubAccountLogin = githubAccountLogin
+        self.configPath = configPath
+    }
+}
+
+package struct DesktopAccountWorkspace: Identifiable, Codable, Equatable, Sendable {
+    package let id: String
+    package let kind: DesktopAccountKind
+    package let name: String
+    package let role: DesktopAccountRole?
+    package let entitlement: DesktopAccountEntitlement
+    package var bots: [DesktopBotInstallation]
+
+    package init(
+        id: String,
+        kind: DesktopAccountKind,
+        name: String,
+        role: DesktopAccountRole?,
+        entitlement: DesktopAccountEntitlement,
+        bots: [DesktopBotInstallation]
+    ) {
+        self.id = id
+        self.kind = kind
+        self.name = name
+        self.role = role
+        self.entitlement = entitlement
+        self.bots = bots
+    }
+
+    /// A local candidate is displayable only when it intersects an already
+    /// verified server installation by App identity and GitHub account. Local
+    /// config is a convenience cache; it can never create membership or proof.
+    package func merging(
+        localCandidates: [DesktopLocalBotCandidate]
+    ) -> DesktopAccountWorkspace {
+        var result = self
+        result.bots = bots.map { bot in
+            guard bot.status == .verified,
+                  let account = bot.githubAccountLogin,
+                  let local = localCandidates.first(where: {
+                      $0.appID == bot.appID
+                          && $0.appSlug.caseInsensitiveCompare(bot.appSlug) == .orderedSame
+                          && $0.githubAccountLogin.caseInsensitiveCompare(account) == .orderedSame
+                  })
+            else {
+                return bot
+            }
+            var merged = bot
+            merged.localConfigPath = local.configPath
+            return merged
+        }
+        return result
+    }
+}
+
+package enum DesktopAccountWorkspaceCatalog: Equatable, Sendable {
+    case idle
+    case loading
+    case loaded([DesktopAccountWorkspace])
+    case failed(String)
+
+    package var accounts: [DesktopAccountWorkspace] {
+        guard case .loaded(let accounts) = self else { return [] }
+        return accounts.filter { $0.role != nil }
+    }
+}
+
+package struct DesktopAccountWorkspaceSelection: Equatable, Sendable {
+    package private(set) var accountID: String?
+    package private(set) var botID: String?
+    package private(set) var repository: String?
+    package private(set) var providerID: String?
+
+    package init(
+        accountID: String? = nil,
+        botID: String? = nil,
+        repository: String? = nil,
+        providerID: String? = nil
+    ) {
+        self.accountID = accountID
+        self.botID = botID
+        self.repository = repository
+        self.providerID = providerID
+    }
+
+    package mutating func selectAccount(_ id: String) {
+        guard id != accountID else { return }
+        accountID = id
+        botID = nil
+        repository = nil
+        providerID = nil
+    }
+
+    package mutating func selectBot(_ id: String?) {
+        guard id != botID else { return }
+        botID = id
+        repository = nil
+        providerID = nil
+    }
+}
+
+package enum DesktopNewBotPlanError: Error, Equatable {
+    case invalidSlug
+    case accountMembershipRequired
+}
+
+package struct DesktopNewBotPlan: Equatable, Sendable {
+    package let accountID: String
+    package let bot: DesktopBotInstallation
+
+    package static func make(
+        account: DesktopAccountWorkspace,
+        appSlug: String,
+        applicationSupportDirectory: URL,
+        occupiedConfigPaths: Set<String>
+    ) throws -> DesktopNewBotPlan {
+        guard account.role != nil else {
+            throw DesktopNewBotPlanError.accountMembershipRequired
+        }
+        guard appSlug.range(
+            of: "^[a-z0-9][a-z0-9-]{0,99}$",
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopNewBotPlanError.invalidSlug
+        }
+
+        let baseDirectory = applicationSupportDirectory
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(account.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+        var candidate = baseDirectory
+            .appendingPathComponent(appSlug, isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
+        var suffix = 2
+        while occupiedConfigPaths.contains(candidate) {
+            candidate = baseDirectory
+                .appendingPathComponent("\(appSlug)-\(suffix)", isDirectory: true)
+                .appendingPathComponent("config.local.json")
+                .standardizedFileURL.path
+            suffix += 1
+        }
+
+        return DesktopNewBotPlan(
+            accountID: account.id,
+            bot: DesktopBotInstallation(
+                id: "pending-\(UUID().uuidString.lowercased())",
+                appID: 0,
+                appSlug: appSlug,
+                mode: .byo,
+                githubInstallationID: nil,
+                githubAccountLogin: nil,
+                status: .pending,
+                localConfigPath: candidate
+            )
+        )
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -215,7 +215,8 @@ package struct DesktopNewBotPlan: Equatable, Sendable {
             .appendingPathComponent("config.local.json")
             .standardizedFileURL.path
         var suffix = 2
-        while occupiedConfigPaths.contains(candidate) {
+        while occupiedConfigPaths.contains(candidate)
+            || FileManager.default.fileExists(atPath: candidate) {
             candidate = baseDirectory
                 .appendingPathComponent("\(appSlug)-\(suffix)", isDirectory: true)
                 .appendingPathComponent("config.local.json")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -560,6 +560,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             accountWorkspaceStatus = "Local bot selected. Verify its config and GitHub binding before use."
             inspectConfig()
         } else {
+            configPath = isolatedBotConfigPath(
+                accountID: account.id,
+                appSlug: bot.appSlug
+            )
             accountWorkspaceStatus = "Bot selected. Complete setup on this Mac before use."
             reopenOnboarding(at: .welcome)
         }
@@ -634,6 +638,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         isConfigPatchInProgress = false
         isConfigInspectInProgress = false
         isControlCenterOperationInProgress = false
+        configPath = unselectedWorkspaceConfigPath
         invalidateProviderConfigAuthorization()
         invalidateControlCenterAuthorization("Workspace changed. Load the selected bot config before editing.")
         invalidateProviderVerificationContext(
@@ -659,6 +664,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         pendingLicenseKey = ""
         onboardingFlow = OnboardingFlow(providerKeyStored: false)
         lastError = nil
+    }
+
+    private var unselectedWorkspaceConfigPath: String {
+        dependencies.fileWriter.applicationSupportDirectory
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent("_unselected", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
+    }
+
+    private func isolatedBotConfigPath(accountID: String, appSlug: String) -> String {
+        dependencies.fileWriter.applicationSupportDirectory
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(accountID, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent(appSlug, isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
     }
 
     #if DEBUG

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -473,6 +473,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// Installs a server-authoritative snapshot. Accounts without a membership
     /// are filtered by the catalog and can never become selectable client-side.
     package func applyAccountWorkspaceCatalog(_ catalog: DesktopAccountWorkspaceCatalog) {
+        let previousSelectedBot = selectedBotInstallation
         accountWorkspaceCatalog = catalog
         guard !catalog.accounts.isEmpty else {
             accountWorkspaceSelection = DesktopAccountWorkspaceSelection()
@@ -484,6 +485,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         if let selectedAccountID = accountWorkspaceSelection.accountID,
            let selectedAccount = catalog.accounts.first(where: { $0.id == selectedAccountID }) {
             if let selectedBotID = accountWorkspaceSelection.botID {
+                if let pendingNewBotPlan,
+                   pendingNewBotPlan.accountID == selectedAccountID,
+                   pendingNewBotPlan.bot.id == selectedBotID {
+                    accountWorkspaceStatus = "New bot setup remains local until its server registration is verified."
+                    return
+                }
                 guard let selectedBot = selectedAccount.bots.first(where: {
                     $0.id == selectedBotID
                         && ($0.status == .verified || $0.status == .pending)
@@ -495,11 +502,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     accountWorkspaceStatus = "The selected bot is no longer authorized. Choose another bot or create a new one."
                     return
                 }
-                if let localConfigPath = selectedBot.localConfigPath,
-                   localConfigPath != configPath {
+                if previousSelectedBot?.localConfigPath != selectedBot.localConfigPath {
                     resetWorkspaceBoundRuntimeState()
-                    configPath = localConfigPath
-                    inspectConfig()
+                    if let localConfigPath = selectedBot.localConfigPath {
+                        configPath = localConfigPath
+                        inspectConfig()
+                    } else {
+                        configPath = isolatedBotConfigPath(
+                            accountID: selectedAccount.id,
+                            appSlug: selectedBot.appSlug
+                        )
+                        accountWorkspaceStatus = "This bot is not configured on this Mac. Complete setup before use."
+                        reopenOnboarding(at: .welcome)
+                        return
+                    }
                 }
             }
             accountWorkspaceStatus = "Account authority verified."
@@ -550,6 +566,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             accountWorkspaceStatus = "That bot is not authorized for the selected account."
             return
         }
+        guard accountWorkspaceSelection.botID != botID else { return }
 
         resetWorkspaceBoundRuntimeState()
         accountWorkspaceSelection.selectBot(botID)
@@ -618,6 +635,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// and reverified for the new context before useful work is available.
     private func resetWorkspaceBoundRuntimeState() {
         workspaceContextGeneration &+= 1
+        activationRequestGeneration &+= 1
         githubAuthorizationTask?.cancel()
         githubAuthorizationTask = nil
         githubRepositoryRefreshTask?.cancel()
@@ -640,6 +658,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         isConfigInspectInProgress = false
         isControlCenterOperationInProgress = false
         configPath = unselectedWorkspaceConfigPath
+        controlCenter = DesktopControlCenterSettings()
+        pendingIssueRepoName = ""
         invalidateProviderConfigAuthorization()
         invalidateControlCenterAuthorization("Workspace changed. Load the selected bot config before editing.")
         invalidateProviderVerificationContext(
@@ -659,6 +679,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
+        activationState = ActivationStateMachine.initialState
+        dependencies.preferences.set(activationState.rawValue, forKey: activationStateKey)
+        activationKeyRedactedPrefix = nil
+        pendingActivationKey = ""
         appliedRepoSelection = nil
         pendingRepoName = ""
         pendingProviderKey = ""
@@ -1394,6 +1418,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard !isGitHubRepositoryRefreshInProgress, !isGitHubAuthorizationInProgress else { return }
         githubRepositoryRefreshTask?.cancel()
         let requestGeneration = githubRepositoryRefreshGate.begin()
+        let requestWorkspaceGeneration = workspaceContextGeneration
         isGitHubRepositoryRefreshInProgress = true
         githubRepositoryRefreshTask = Task { [weak self] in
             guard let self else { return }
@@ -1406,8 +1431,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
             do {
                 githubAuthorizationStatus = "refreshing repositories"
                 githubRecovery = nil
-                let accessToken = try await gitHubAccessTokenForAPI()
+                let accessToken = try await gitHubAccessTokenForAPI(
+                    workspaceGeneration: requestWorkspaceGeneration
+                )
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 let user = try await dependencies.githubAuthenticator.fetchCurrentUser(accessToken: accessToken)
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 let discovered = try await dependencies.githubAuthenticator.listAccessibleRepositories(accessToken: accessToken)
                 guard !Task.isCancelled, githubRepositoryRefreshGate.isCurrent(requestGeneration) else { return }
                 applyGitHubDiscovery(user: user, discovered: discovered)
@@ -1848,7 +1877,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
-            repositories: repos.filter(\.enabled).map(\.name).sorted()
+            repositories: repos.filter(\.enabled).map(\.name).sorted(),
+            workspaceGeneration: workspaceContextGeneration
         )
         var standardInput = Data(privateKey.utf8)
         let executablePath = cliPath
@@ -1875,6 +1905,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 }
             } catch {
                 await MainActor.run {
+                    guard self.isCurrentWorkspace(verificationContext.workspaceGeneration) else { return }
                     self.isBYOGitHubVerificationInProgress = false
                     self.byoGitHubCredentialsVerified = false
                     self.lastError = "Customer-owned GitHub App verification failed safely."
@@ -1889,6 +1920,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         _ result: CLIRunResult,
         expectedContext: BYOGitHubVerificationContext
     ) {
+        guard isCurrentWorkspace(expectedContext.workspaceGeneration) else { return }
         isBYOGitHubVerificationInProgress = false
         let currentContext = storedBYOGitHubAppId.map { appId in
             BYOGitHubVerificationContext(
@@ -1896,7 +1928,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 credentialRevision: byoGitHubCredentialRevision,
                 cliPath: cliPath,
                 configPath: configPath,
-                repositories: repos.filter(\.enabled).map(\.name).sorted()
+                repositories: repos.filter(\.enabled).map(\.name).sorted(),
+                workspaceGeneration: workspaceContextGeneration
             )
         }
         guard currentContext == expectedContext else {
@@ -2774,26 +2807,33 @@ package final class NeonDiffDesktopModel: ObservableObject {
         )
     }
 
-    private func gitHubAccessTokenForAPI() async throws -> String {
+    private func gitHubAccessTokenForAPI(workspaceGeneration: UInt64) async throws -> String {
+        guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
         guard let accessToken = try dependencies.secretStore.readSecret(account: githubUserTokenAccount), !accessToken.isEmpty else {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             clearStoredGitHubAuthorization(status: "connect GitHub first")
             throw GitHubDesktopAuthorizationStateError.reconnectRequired("Connect GitHub before refreshing accessible repositories.")
         }
         guard let expiresAt = readGitHubStoredDate(account: githubTokenExpiresAtAccount) else {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             return accessToken
         }
         if expiresAt > dependencies.clock.now.addingTimeInterval(60) {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             return accessToken
         }
         guard let clientId = github.clientId?.trimmingCharacters(in: .whitespacesAndNewlines), !clientId.isEmpty else {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             clearStoredGitHubAuthorization(status: "authorization expired; reconnect GitHub")
             throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub authorization expired and the public client ID is missing. Reconnect GitHub after loading config.")
         }
         guard let refreshToken = try dependencies.secretStore.readSecret(account: githubRefreshTokenAccount), !refreshToken.isEmpty else {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             clearStoredGitHubAuthorization(status: "authorization expired; reconnect GitHub")
             throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub authorization expired. Reconnect GitHub.")
         }
         if let refreshExpiresAt = readGitHubStoredDate(account: githubRefreshTokenExpiresAtAccount), refreshExpiresAt <= dependencies.clock.now {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             clearStoredGitHubAuthorization(status: "refresh expired; reconnect GitHub")
             throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub refresh token expired. Reconnect GitHub.")
         }
@@ -2802,10 +2842,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         do {
             refreshedToken = try await dependencies.githubAuthenticator.refreshUserToken(clientId: clientId, refreshToken: refreshToken)
         } catch {
+            guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
             clearStoredGitHubAuthorization(status: "refresh failed; reconnect GitHub")
             throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub authorization refresh failed. Reconnect GitHub.")
         }
+        guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
         try storeGitHubToken(refreshedToken)
+        guard isCurrentWorkspace(workspaceGeneration) else { throw CancellationError() }
         githubAuthorizationStatus = "GitHub authorization refreshed"
         return refreshedToken.accessToken
     }
@@ -3798,6 +3841,7 @@ private struct BYOGitHubVerificationContext: Equatable, Sendable {
     let cliPath: String
     let configPath: String
     let repositories: [String]
+    let workspaceGeneration: UInt64
 }
 
 private let licenseKeyAccount = "license/default"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -583,7 +583,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 account: account,
                 appSlug: appSlug,
                 applicationSupportDirectory: dependencies.fileWriter.applicationSupportDirectory,
-                occupiedConfigPaths: occupiedPaths
+                occupiedConfigPaths: occupiedPaths,
+                fileExists: dependencies.fileWriter.fileExists(at:)
             )
             resetWorkspaceBoundRuntimeState()
             pendingNewBotPlan = plan

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -160,6 +160,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var pendingLicenseKey = ""
     @Published package var onboardingFlow = OnboardingFlow()
     @Published package var isOnboardingPresented = false
+    @Published package var accountWorkspaceCatalog: DesktopAccountWorkspaceCatalog = .idle
+    @Published package private(set) var accountWorkspaceSelection = DesktopAccountWorkspaceSelection()
+    @Published package private(set) var accountWorkspaceStatus = "Sign in to load your personal and organization accounts."
+    @Published package private(set) var pendingNewBotPlan: DesktopNewBotPlan?
 
     // Issue #612 — native purchase-to-activation state. Restored from preferences
     // (its raw value) so onboarding resumes exactly across relaunch / cancel /
@@ -391,6 +395,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var previewedProviderExpectedRevision: String?
     private var pendingProviderPatchProof: PendingProviderPatchProof?
     private var pendingRepoPatchProof: PendingRepoPatchProof?
+    private let accountWorkspacePreferenceKey = "neondiff.accountWorkspaceID"
+    private let accountBotPreferenceKey = "neondiff.accountBotID"
 
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
@@ -451,6 +457,142 @@ package final class NeonDiffDesktopModel: ObservableObject {
             self.activationState = ActivationStateMachine.initialState
         }
         self.lastCommandLine = statusCommand.commandLine
+    }
+
+    package var selectedAccountWorkspace: DesktopAccountWorkspace? {
+        guard let accountID = accountWorkspaceSelection.accountID else { return nil }
+        return accountWorkspaceCatalog.accounts.first { $0.id == accountID }
+    }
+
+    package var selectedBotInstallation: DesktopBotInstallation? {
+        guard let botID = accountWorkspaceSelection.botID else { return nil }
+        return selectedAccountWorkspace?.bots.first { $0.id == botID }
+    }
+
+    /// Installs a server-authoritative snapshot. Accounts without a membership
+    /// are filtered by the catalog and can never become selectable client-side.
+    package func applyAccountWorkspaceCatalog(_ catalog: DesktopAccountWorkspaceCatalog) {
+        accountWorkspaceCatalog = catalog
+        guard !catalog.accounts.isEmpty else {
+            accountWorkspaceSelection = DesktopAccountWorkspaceSelection()
+            accountWorkspaceStatus = catalogFailureOrEmptyMessage(catalog)
+            resetWorkspaceBoundRuntimeState()
+            return
+        }
+
+        if let selected = accountWorkspaceSelection.accountID,
+           catalog.accounts.contains(where: { $0.id == selected }) {
+            accountWorkspaceStatus = "Account authority verified."
+            return
+        }
+
+        let saved = dependencies.preferences.string(forKey: accountWorkspacePreferenceKey)
+        let initial = catalog.accounts.first(where: { $0.id == saved }) ?? catalog.accounts[0]
+        selectAccountWorkspace(initial.id)
+    }
+
+    package func selectAccountWorkspace(_ accountID: String) {
+        guard accountWorkspaceCatalog.accounts.contains(where: { $0.id == accountID }) else {
+            accountWorkspaceStatus = "That account is not available to this signed-in user."
+            return
+        }
+        guard accountWorkspaceSelection.accountID != accountID else { return }
+
+        resetWorkspaceBoundRuntimeState()
+        accountWorkspaceSelection.selectAccount(accountID)
+        pendingNewBotPlan = nil
+        dependencies.preferences.set(accountID, forKey: accountWorkspacePreferenceKey)
+        dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+        accountWorkspaceStatus = "Account selected. Choose an existing bot or create a new one."
+    }
+
+    package func selectBotInstallation(_ botID: String) {
+        guard let account = selectedAccountWorkspace,
+              let bot = account.bots.first(where: { $0.id == botID }),
+              bot.status == .verified || bot.status == .pending
+        else {
+            accountWorkspaceStatus = "That bot is not authorized for the selected account."
+            return
+        }
+
+        resetWorkspaceBoundRuntimeState()
+        accountWorkspaceSelection.selectBot(botID)
+        pendingNewBotPlan = nil
+        dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
+        if let localConfigPath = bot.localConfigPath {
+            configPath = localConfigPath
+            accountWorkspaceStatus = "Local bot selected. Verify its config and GitHub binding before use."
+            inspectConfig()
+        } else {
+            accountWorkspaceStatus = "Bot selected. Complete setup on this Mac before use."
+            reopenOnboarding(at: .welcome)
+        }
+    }
+
+    package func beginNewBot(appSlug: String = "new-neondiff-bot") {
+        guard let account = selectedAccountWorkspace else {
+            accountWorkspaceStatus = "Choose an account before creating a bot."
+            return
+        }
+        do {
+            let occupiedPaths = Set(account.bots.compactMap(\.localConfigPath))
+            let plan = try DesktopNewBotPlan.make(
+                account: account,
+                appSlug: appSlug,
+                applicationSupportDirectory: dependencies.fileWriter.applicationSupportDirectory,
+                occupiedConfigPaths: occupiedPaths
+            )
+            resetWorkspaceBoundRuntimeState()
+            pendingNewBotPlan = plan
+            accountWorkspaceSelection.selectBot(plan.bot.id)
+            configPath = plan.bot.localConfigPath ?? configPath
+            dependencies.preferences.set(plan.bot.id, forKey: accountBotPreferenceKey)
+            accountWorkspaceStatus = "New bot setup is isolated from existing bot configs."
+            reopenOnboarding(at: .welcome)
+        } catch {
+            accountWorkspaceStatus = "A new bot setup could not be created safely."
+        }
+    }
+
+    private func catalogFailureOrEmptyMessage(
+        _ catalog: DesktopAccountWorkspaceCatalog
+    ) -> String {
+        switch catalog {
+        case .idle:
+            "Sign in to load your personal and organization accounts."
+        case .loading:
+            "Loading account authority…"
+        case .loaded:
+            "No authorized accounts were returned."
+        case .failed(let message):
+            message
+        }
+    }
+
+    /// Runtime proof is account-bound. Switching accounts or bots invalidates
+    /// it without deleting Keychain material; credentials must be reselected
+    /// and reverified for the new context before useful work is available.
+    private func resetWorkspaceBoundRuntimeState() {
+        repos = []
+        providers = ProviderSettings()
+        license = LicenseStatus()
+        github = GitHubConnectionStatus()
+        discoveredGitHubRepos = []
+        managedGitHubRepositories = []
+        managedGitHubInstallationCandidates = []
+        selectedManagedGitHubRepository = nil
+        managedGitHubRecovery = nil
+        managedGitHubConnectionState = managedGitHubAvailable ? .disconnected : .quarantined
+        byoGitHubCredentialsVerified = false
+        providerVerification = nil
+        providerVerificationStatus = "Verify the selected account's provider credential when ready."
+        activationVerifiedThisLaunch = false
+        activationVerifiedRepositoryThisLaunch = nil
+        appliedRepoSelection = nil
+        pendingRepoName = ""
+        pendingProviderKey = ""
+        pendingLicenseKey = ""
+        lastError = nil
     }
 
     #if DEBUG

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -473,6 +473,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// Installs a server-authoritative snapshot. Accounts without a membership
     /// are filtered by the catalog and can never become selectable client-side.
     package func applyAccountWorkspaceCatalog(_ catalog: DesktopAccountWorkspaceCatalog) {
+        let previousSelectedAccount = selectedAccountWorkspace
         let previousSelectedBot = selectedBotInstallation
         accountWorkspaceCatalog = catalog
         guard !catalog.accounts.isEmpty else {
@@ -487,7 +488,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             if let selectedBotID = accountWorkspaceSelection.botID {
                 if let pendingNewBotPlan,
                    pendingNewBotPlan.accountID == selectedAccountID,
-                   pendingNewBotPlan.bot.id == selectedBotID {
+                   pendingNewBotPlan.bot.id == selectedBotID,
+                   previousSelectedAccount == selectedAccount {
                     accountWorkspaceStatus = "New bot setup remains local until its server registration is verified."
                     return
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -489,7 +489,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 if let pendingNewBotPlan,
                    pendingNewBotPlan.accountID == selectedAccountID,
                    pendingNewBotPlan.bot.id == selectedBotID,
-                   previousSelectedAccount == selectedAccount {
+                   previousSelectedAccount?.hasSameAuthority(as: selectedAccount) == true {
                     accountWorkspaceStatus = "New bot setup remains local until its server registration is verified."
                     return
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -395,6 +395,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var previewedProviderExpectedRevision: String?
     private var pendingProviderPatchProof: PendingProviderPatchProof?
     private var pendingRepoPatchProof: PendingRepoPatchProof?
+    private var workspaceContextGeneration: UInt64 = 0
     private let accountWorkspacePreferenceKey = "neondiff.accountWorkspaceID"
     private let accountBotPreferenceKey = "neondiff.accountBotID"
 
@@ -480,18 +481,51 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
-        if let selected = accountWorkspaceSelection.accountID,
-           catalog.accounts.contains(where: { $0.id == selected }) {
+        if let selectedAccountID = accountWorkspaceSelection.accountID,
+           let selectedAccount = catalog.accounts.first(where: { $0.id == selectedAccountID }) {
+            if let selectedBotID = accountWorkspaceSelection.botID {
+                guard let selectedBot = selectedAccount.bots.first(where: {
+                    $0.id == selectedBotID
+                        && ($0.status == .verified || $0.status == .pending)
+                }) else {
+                    resetWorkspaceBoundRuntimeState()
+                    accountWorkspaceSelection.selectBot(nil)
+                    pendingNewBotPlan = nil
+                    dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+                    accountWorkspaceStatus = "The selected bot is no longer authorized. Choose another bot or create a new one."
+                    return
+                }
+                if let localConfigPath = selectedBot.localConfigPath,
+                   localConfigPath != configPath {
+                    resetWorkspaceBoundRuntimeState()
+                    configPath = localConfigPath
+                    inspectConfig()
+                }
+            }
             accountWorkspaceStatus = "Account authority verified."
             return
         }
 
         let saved = dependencies.preferences.string(forKey: accountWorkspacePreferenceKey)
         let initial = catalog.accounts.first(where: { $0.id == saved }) ?? catalog.accounts[0]
-        selectAccountWorkspace(initial.id)
+        let savedBotID = dependencies.preferences.string(forKey: accountBotPreferenceKey)
+        selectAccountWorkspace(initial.id, clearSavedBot: false)
+        if let savedBotID,
+           initial.bots.contains(where: {
+               $0.id == savedBotID
+                   && ($0.status == .verified || $0.status == .pending)
+           }) {
+            selectBotInstallation(savedBotID)
+        } else {
+            dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+        }
     }
 
     package func selectAccountWorkspace(_ accountID: String) {
+        selectAccountWorkspace(accountID, clearSavedBot: true)
+    }
+
+    private func selectAccountWorkspace(_ accountID: String, clearSavedBot: Bool) {
         guard accountWorkspaceCatalog.accounts.contains(where: { $0.id == accountID }) else {
             accountWorkspaceStatus = "That account is not available to this signed-in user."
             return
@@ -502,7 +536,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         accountWorkspaceSelection.selectAccount(accountID)
         pendingNewBotPlan = nil
         dependencies.preferences.set(accountID, forKey: accountWorkspacePreferenceKey)
-        dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+        if clearSavedBot {
+            dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+        }
         accountWorkspaceStatus = "Account selected. Choose an existing bot or create a new one."
     }
 
@@ -535,7 +571,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         do {
-            let occupiedPaths = Set(account.bots.compactMap(\.localConfigPath))
+            var occupiedPaths = Set(account.bots.compactMap(\.localConfigPath))
+            if let pendingPath = pendingNewBotPlan?.bot.localConfigPath {
+                occupiedPaths.insert(pendingPath)
+            }
             let plan = try DesktopNewBotPlan.make(
                 account: account,
                 appSlug: appSlug,
@@ -573,6 +612,33 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// it without deleting Keychain material; credentials must be reselected
     /// and reverified for the new context before useful work is available.
     private func resetWorkspaceBoundRuntimeState() {
+        workspaceContextGeneration &+= 1
+        githubAuthorizationTask?.cancel()
+        githubAuthorizationTask = nil
+        githubRepositoryRefreshTask?.cancel()
+        githubRepositoryRefreshTask = nil
+        _ = githubRepositoryRefreshGate.begin()
+        managedGitHubConnectionTask?.cancel()
+        managedGitHubConnectionTask = nil
+        pendingManagedGitHubAuthorization = nil
+        isGitHubAuthorizationInProgress = false
+        isGitHubRepositoryRefreshInProgress = false
+        isManagedGitHubConnectionInProgress = false
+        githubAuthorizationCode = nil
+        githubRecovery = nil
+        pendingBYOGitHubAppId = ""
+        pendingBYOGitHubAppPrivateKey = ""
+        byoGitHubCredentialRevision &+= 1
+        isBYOGitHubVerificationInProgress = false
+        isConfigInitializationInProgress = false
+        isConfigPatchInProgress = false
+        isConfigInspectInProgress = false
+        isControlCenterOperationInProgress = false
+        invalidateProviderConfigAuthorization()
+        invalidateControlCenterAuthorization("Workspace changed. Load the selected bot config before editing.")
+        invalidateProviderVerificationContext(
+            status: "Verify the selected account's provider credential when ready."
+        )
         repos = []
         providers = ProviderSettings()
         license = LicenseStatus()
@@ -584,7 +650,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubRecovery = nil
         managedGitHubConnectionState = managedGitHubAvailable ? .disconnected : .quarantined
         byoGitHubCredentialsVerified = false
-        providerVerification = nil
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
@@ -592,6 +657,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         pendingRepoName = ""
         pendingProviderKey = ""
         pendingLicenseKey = ""
+        onboardingFlow = OnboardingFlow(providerKeyStored: false)
         lastError = nil
     }
 
@@ -1221,18 +1287,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
         githubAuthorizationStatus = "requesting device code"
         githubRecovery = nil
         lastError = nil
+        let requestWorkspaceGeneration = workspaceContextGeneration
         githubAuthorizationTask = Task { [weak self] in
             guard let self else { return }
             do {
                 let code = try await dependencies.githubAuthenticator.requestDeviceCode(clientId: clientId)
-                if Task.isCancelled { return }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 githubAuthorizationCode = code
                 githubAuthorizationStatus = "enter code \(code.userCode)"
                 github.installationState = "waiting for GitHub authorization"
                 logText = "Open \(code.verificationURI.absoluteString) and enter code \(code.userCode)."
-                await pollGitHubAuthorization(clientId: clientId, code: code)
+                await pollGitHubAuthorization(
+                    clientId: clientId,
+                    code: code,
+                    workspaceGeneration: requestWorkspaceGeneration
+                )
             } catch {
-                if Task.isCancelled { return }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 isGitHubAuthorizationInProgress = false
                 applyGitHubFailure(error, fallbackStatus: "authorization failed")
             }
@@ -1359,18 +1430,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
         selectedManagedGitHubRepository = nil
         lastError = nil
 
+        let requestWorkspaceGeneration = workspaceContextGeneration
         managedGitHubConnectionTask = Task { [weak self] in
             guard let self else { return }
             defer {
-                isManagedGitHubConnectionInProgress = false
-                managedGitHubConnectionTask = nil
+                if workspaceContextGeneration == requestWorkspaceGeneration {
+                    isManagedGitHubConnectionInProgress = false
+                    managedGitHubConnectionTask = nil
+                }
             }
             do {
                 let identity = try GitHubBrokerDeviceIdentityStore(
                     secretStore: dependencies.secretStore
                 ).loadOrCreate()
                 try await broker.register(identity: identity)
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 let connection = try await broker.startConnection(identity: identity)
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 guard dependencies.urlOpener.open(connection.installURL) else {
                     throw ManagedGitHubModelError.installPageOpenFailed
                 }
@@ -1387,12 +1463,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     guard let existingInstallationId = try await authorizeExistingManagedGitHubInstallation(
                         broker: broker,
                         identity: identity,
-                        connection: connection
+                        connection: connection,
+                        workspaceGeneration: requestWorkspaceGeneration
                     ) else {
                         return
                     }
                     installationId = existingInstallationId
                 }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 dependencies.preferences.set(
                     String(installationId),
                     forKey: managedGitHubInstallationIdKey
@@ -1400,10 +1478,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 try await loadManagedGitHubRepositories(
                     broker: broker,
                     identity: identity,
-                    installationId: installationId
+                    installationId: installationId,
+                    workspaceGeneration: requestWorkspaceGeneration
                 )
             } catch {
-                guard !Task.isCancelled else { return }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 applyManagedGitHubFailure(error)
             }
         }
@@ -1424,13 +1503,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubConnectionState = .connecting
         managedGitHubRecovery = nil
         lastError = nil
+        let requestWorkspaceGeneration = workspaceContextGeneration
         managedGitHubConnectionTask = Task { [weak self] in
             guard let self else { return }
             defer {
-                pendingManagedGitHubAuthorization = nil
-                githubAuthorizationCode = nil
-                isManagedGitHubConnectionInProgress = false
-                managedGitHubConnectionTask = nil
+                if workspaceContextGeneration == requestWorkspaceGeneration {
+                    pendingManagedGitHubAuthorization = nil
+                    githubAuthorizationCode = nil
+                    isManagedGitHubConnectionInProgress = false
+                    managedGitHubConnectionTask = nil
+                }
             }
             do {
                 let boundInstallationId: Int
@@ -1449,6 +1531,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         userAccessToken: pending.userAccessToken
                     )
                 }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 managedGitHubInstallationCandidates = []
                 dependencies.preferences.set(
                     String(boundInstallationId),
@@ -1457,10 +1540,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 try await loadManagedGitHubRepositories(
                     broker: broker,
                     identity: pending.identity,
-                    installationId: boundInstallationId
+                    installationId: boundInstallationId,
+                    workspaceGeneration: requestWorkspaceGeneration
                 )
             } catch {
-                guard !Task.isCancelled else { return }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 managedGitHubInstallationCandidates = []
                 applyManagedGitHubFailure(error)
             }
@@ -1494,11 +1578,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         selectedManagedGitHubRepository = nil
         lastError = nil
 
+        let requestWorkspaceGeneration = workspaceContextGeneration
         managedGitHubConnectionTask = Task { [weak self] in
             guard let self else { return }
             defer {
-                isManagedGitHubConnectionInProgress = false
-                managedGitHubConnectionTask = nil
+                if workspaceContextGeneration == requestWorkspaceGeneration {
+                    isManagedGitHubConnectionInProgress = false
+                    managedGitHubConnectionTask = nil
+                }
             }
             do {
                 let identity = try GitHubBrokerDeviceIdentityStore(
@@ -1507,10 +1594,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 try await loadManagedGitHubRepositories(
                     broker: broker,
                     identity: identity,
-                    installationId: installationId
+                    installationId: installationId,
+                    workspaceGeneration: requestWorkspaceGeneration
                 )
             } catch {
-                guard !Task.isCancelled else { return }
+                guard isCurrentWorkspace(requestWorkspaceGeneration) else { return }
                 applyManagedGitHubFailure(error)
             }
         }
@@ -2455,6 +2543,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         lastCommandLine = displayCommand.commandLine
         let executablePath = cliPath
         let cli = dependencies.cli
+        let operationWorkspaceGeneration = workspaceContextGeneration
         Task.detached { [configPath, launchdLabel] in
             do {
                 let result = try await cli.run(
@@ -2464,6 +2553,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     timeout: 15
                 )
                 await MainActor.run {
+                    guard self.workspaceContextGeneration == operationWorkspaceGeneration else {
+                        return
+                    }
                     self.applyCLIResult(
                         result,
                         fallbackCommand: displayCommand.commandLine,
@@ -2484,6 +2576,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 }
             } catch {
                 await MainActor.run {
+                    guard self.workspaceContextGeneration == operationWorkspaceGeneration else {
+                        return
+                    }
                     self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
                     self.logText = self.lastError ?? "Unknown CLI error"
                     if isConfigInitializeCommand {
@@ -2691,20 +2786,29 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return refreshedToken.accessToken
     }
 
-    private func pollGitHubAuthorization(clientId: String, code: GitHubDeviceAuthorizationCode) async {
+    private func pollGitHubAuthorization(
+        clientId: String,
+        code: GitHubDeviceAuthorizationCode,
+        workspaceGeneration: UInt64
+    ) async {
         var intervalSeconds = code.intervalSeconds
-        while !Task.isCancelled && dependencies.clock.now < code.expiresAt {
+        while isCurrentWorkspace(workspaceGeneration)
+            && dependencies.clock.now < code.expiresAt {
             do {
                 try await dependencies.clock.sleep(for: .seconds(max(1, intervalSeconds)))
+                guard isCurrentWorkspace(workspaceGeneration) else { return }
                 let result = try await dependencies.githubAuthenticator.pollDeviceAuthorization(clientId: clientId, deviceCode: code.deviceCode)
+                guard isCurrentWorkspace(workspaceGeneration) else { return }
                 switch result {
                 case .pending(let nextInterval):
                     intervalSeconds = max(1, nextInterval)
                     githubAuthorizationStatus = "waiting for authorization"
                 case .authorized(let token):
-                    try storeGitHubToken(token)
                     let user = try await dependencies.githubAuthenticator.fetchCurrentUser(accessToken: token.accessToken)
+                    guard isCurrentWorkspace(workspaceGeneration) else { return }
                     let discovered = try await dependencies.githubAuthenticator.listAccessibleRepositories(accessToken: token.accessToken)
+                    guard isCurrentWorkspace(workspaceGeneration) else { return }
+                    try storeGitHubToken(token)
                     applyGitHubDiscovery(user: user, discovered: discovered)
                     isGitHubAuthorizationInProgress = false
                     githubAuthorizationCode = nil
@@ -2720,13 +2824,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     return
                 }
             } catch {
-                if Task.isCancelled { return }
+                guard isCurrentWorkspace(workspaceGeneration) else { return }
                 isGitHubAuthorizationInProgress = false
                 applyGitHubFailure(error, fallbackStatus: "authorization failed")
                 return
             }
         }
-        if !Task.isCancelled {
+        if isCurrentWorkspace(workspaceGeneration) {
             isGitHubAuthorizationInProgress = false
             let recovery = GitHubConnectionRecoveryClassifier.deviceCodeExpired
             githubAuthorizationStatus = recovery.status
@@ -2807,7 +2911,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func authorizeExistingManagedGitHubInstallation(
         broker: any GitHubBrokerConnecting,
         identity: GitHubBrokerDeviceIdentity,
-        connection: GitHubBrokerConnection
+        connection: GitHubBrokerConnection,
+        workspaceGeneration: UInt64
     ) async throws -> Int? {
         guard let clientId = dependencies.productionBoundary.managedGitHubAppClientID?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -2816,16 +2921,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
             throw ManagedGitHubModelError.clientIdMissing
         }
         let code = try await dependencies.githubAuthenticator.requestDeviceCode(clientId: clientId)
-        guard !Task.isCancelled else { return nil }
+        guard isCurrentWorkspace(workspaceGeneration) else { return nil }
         githubAuthorizationCode = code
         managedGitHubConnectionState = .awaitingAuthorization
         logText = "Authorize NeonDiff at \(code.verificationURI.absoluteString) with code \(code.userCode). The user token is transient proof only; reviews use the GitHub App."
 
         var intervalSeconds = code.intervalSeconds
-        while !Task.isCancelled,
+        while isCurrentWorkspace(workspaceGeneration),
               dependencies.clock.now < code.expiresAt,
               dependencies.clock.now < connection.expiresAt {
             try await dependencies.clock.sleep(for: .seconds(max(1, intervalSeconds)))
+            guard isCurrentWorkspace(workspaceGeneration) else { return nil }
             switch try await broker.completeConnection(
                 identity: identity,
                 state: connection.state
@@ -2835,6 +2941,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             case .pending:
                 break
             }
+            guard isCurrentWorkspace(workspaceGeneration) else { return nil }
             switch try await dependencies.githubAuthenticator.pollDeviceAuthorization(
                 clientId: clientId,
                 deviceCode: code.deviceCode
@@ -2853,6 +2960,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 let discovered = try await dependencies.githubAuthenticator.listAccessibleRepositories(
                     accessToken: token.accessToken
                 )
+                guard isCurrentWorkspace(workspaceGeneration) else { return nil }
                 let grouped = Dictionary(grouping: discovered, by: \.installationId)
                 let candidates: [ManagedGitHubInstallationCandidate] = grouped.compactMap { element -> ManagedGitHubInstallationCandidate? in
                     let installationId = element.key
@@ -2885,6 +2993,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         )
                     }
                 }
+                guard isCurrentWorkspace(workspaceGeneration) else { return nil }
                 pendingManagedGitHubAuthorization = PendingManagedGitHubAuthorization(
                     identity: identity,
                     connection: connection,
@@ -2935,16 +3044,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func loadManagedGitHubRepositories(
         broker: any GitHubBrokerConnecting,
         identity: GitHubBrokerDeviceIdentity,
-        installationId: Int
+        installationId: Int,
+        workspaceGeneration: UInt64
     ) async throws {
         var pageNumber = 1
         var repositories: [GitHubBrokerRepository] = []
-        while !Task.isCancelled {
+        while isCurrentWorkspace(workspaceGeneration) {
             let page = try await broker.listRepositories(
                 identity: identity,
                 installationId: installationId,
                 page: pageNumber
             )
+            guard isCurrentWorkspace(workspaceGeneration) else { return }
             guard page.installationId == installationId,
                   page.page == pageNumber
             else {
@@ -2957,7 +3068,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             }
             pageNumber = nextPage
         }
-        guard !Task.isCancelled else { return }
+        guard isCurrentWorkspace(workspaceGeneration) else { return }
         let names = repositories.map(\.fullName)
         guard !repositories.isEmpty,
               Set(names).count == names.count
@@ -2971,6 +3082,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubRecovery = nil
         lastError = nil
         logText = "\(repositories.count) server-bound GitHub repositories verified. Select one to continue."
+    }
+
+    private func isCurrentWorkspace(_ generation: UInt64) -> Bool {
+        !Task.isCancelled && workspaceContextGeneration == generation
     }
 
     private func applyManagedGitHubFailure(_ error: Error) {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -86,6 +86,33 @@ import NeonDiffDesktopCore
         #expect(plan.bot.localConfigPath?.contains("electric-sheep-secondary") == true)
     }
 
+    @Test func newBotSkipsAnOrphanedConfigAlreadyPresentOnDisk() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let occupied = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(electricSheep.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("electric-sheep-secondary", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+        try FileManager.default.createDirectory(
+            at: occupied.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("orphaned".utf8).write(to: occupied)
+
+        let plan = try DesktopNewBotPlan.make(
+            account: electricSheep,
+            appSlug: "electric-sheep-secondary",
+            applicationSupportDirectory: root,
+            occupiedConfigPaths: []
+        )
+
+        #expect(plan.bot.localConfigPath != occupied.standardizedFileURL.path)
+        #expect(plan.bot.localConfigPath?.contains("electric-sheep-secondary-2") == true)
+    }
+
     @Test func switchingAccountClearsEveryWorkspaceBoundRuntimeSelection() {
         var selection = DesktopAccountWorkspaceSelection(
             accountID: personal.id,
@@ -121,6 +148,122 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func catalogRefreshRevokesASelectedBotAndItsWorkspaceProof() {
+        let localBot = bot(
+            id: "bot-local",
+            slug: "local-bot",
+            configPath: "/fixture/local-bot/config.local.json"
+        )
+        let account = workspace(id: "account-a", name: "Account A", bots: [localBot])
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        fixture.model.selectBotInstallation(localBot.id)
+        fixture.model.repos = [RepoMonitor(name: "account-a/private", enabled: true)]
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(id: account.id, name: account.name, bots: [])
+        ]))
+
+        #expect(fixture.model.accountWorkspaceSelection.botID == nil)
+        #expect(fixture.model.selectedBotInstallation == nil)
+        #expect(fixture.model.repos.isEmpty)
+        #expect(fixture.preferences.string(forKey: "neondiff.accountBotID") == nil)
+    }
+
+    @MainActor
+    @Test func switchingWorkspaceClearsConfigAuthorizationOnboardingProofAndTransientGitHubInput() {
+        let localBot = bot(
+            id: "bot-local",
+            slug: "local-bot",
+            configPath: "/fixture/local-bot/config.local.json"
+        )
+        let accountA = workspace(id: "account-a", name: "Account A", bots: [localBot])
+        let accountB = workspace(id: "account-b", name: "Account B", bots: [])
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
+        fixture.model.configPath = localBot.localConfigPath!
+        fixture.loadConfig()
+        fixture.model.controlCenter.pollIntervalMs += 1
+        #expect(fixture.model.canPreviewControlCenter)
+        fixture.model.onboardingFlow.daemonBootstrapChecked = true
+        fixture.model.onboardingFlow.licenseActivation = .activated
+        fixture.model.pendingBYOGitHubAppId = "4184532"
+        fixture.model.pendingBYOGitHubAppPrivateKey = "fixture-private-key"
+        fixture.model.githubAuthorizationCode = GitHubDeviceAuthorizationCode(
+            deviceCode: "fixture-device-code",
+            userCode: "ABCD-EFGH",
+            verificationURI: URL(string: "https://github.com/login/device")!,
+            expiresAt: Date(timeIntervalSince1970: 2_000_000_000),
+            intervalSeconds: 2
+        )
+        fixture.model.isGitHubAuthorizationInProgress = true
+        fixture.model.isGitHubRepositoryRefreshInProgress = true
+
+        fixture.model.selectAccountWorkspace(accountB.id)
+
+        #expect(!fixture.model.canPreviewControlCenter)
+        #expect(!fixture.model.onboardingFlow.daemonBootstrapChecked)
+        #expect(fixture.model.onboardingFlow.licenseActivation == .servicePending)
+        #expect(fixture.model.pendingBYOGitHubAppId.isEmpty)
+        #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+        #expect(fixture.model.githubAuthorizationCode == nil)
+        #expect(!fixture.model.isGitHubAuthorizationInProgress)
+        #expect(!fixture.model.isGitHubRepositoryRefreshInProgress)
+    }
+
+    @MainActor
+    @Test func firstCatalogRestoresTheSavedAuthorizedBot() {
+        let savedBot = bot(
+            id: "bot-saved",
+            slug: "saved-bot",
+            configPath: nil
+        )
+        let account = workspace(id: "account-saved", name: "Saved Account", bots: [savedBot])
+        let fixture = ModelDependencyFixture(preferenceStrings: [
+            "neondiff.accountWorkspaceID": account.id,
+            "neondiff.accountBotID": savedBot.id
+        ])
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+
+        #expect(fixture.model.accountWorkspaceSelection.accountID == account.id)
+        #expect(fixture.model.accountWorkspaceSelection.botID == savedBot.id)
+        #expect(fixture.preferences.string(forKey: "neondiff.accountBotID") == savedBot.id)
+    }
+
+    @MainActor
+    @Test func staleConfigInspectCannotPopulateTheNewWorkspace() async throws {
+        let botA = bot(id: "bot-a", slug: "bot-a", configPath: "/fixture/a/config.local.json")
+        let botB = bot(id: "bot-b", slug: "bot-b", configPath: "/fixture/b/config.local.json")
+        let accountA = workspace(id: "account-a", name: "Account A", bots: [botA])
+        let accountB = workspace(id: "account-b", name: "Account B", bots: [botB])
+        let resultA = ModelDependencyFixture.configInspectJSON
+            .replacingOccurrences(of: "neondiff-bot", with: "bot-a")
+        let resultB = ModelDependencyFixture.configInspectJSON
+            .replacingOccurrences(of: "neondiff-bot", with: "bot-b")
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(exitCode: 0, stdout: resultA, stderr: "")),
+                .success(CLIRunResult(exitCode: 0, stdout: resultB, stderr: ""))
+            ],
+            suspendCLIRuns: true
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
+        fixture.model.selectBotInstallation(botA.id)
+        await fixture.cli.waitUntilCallCount(1)
+
+        fixture.model.selectAccountWorkspace(accountB.id)
+        fixture.model.selectBotInstallation(botB.id)
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(fixture.cli.calls.count == 2)
+
+        fixture.cli.resumeSuspendedRuns()
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(fixture.model.configPath == botB.localConfigPath)
+        #expect(fixture.model.github.botLogin == "bot-b")
+    }
+
+    @MainActor
     @Test func modelNewBotStartsAnIsolatedLocalPlanWithoutInventingAServerBot() throws {
         let fixture = ModelDependencyFixture()
         fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
@@ -132,5 +275,52 @@ import NeonDiffDesktopCore
         #expect(fixture.model.selectedBotInstallation == nil)
         #expect(fixture.model.configPath == plan.bot.localConfigPath)
         #expect(fixture.model.isOnboardingPresented)
+    }
+
+    @MainActor
+    @Test func repeatedNewBotPlanDoesNotReuseThePendingConfigPath() throws {
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
+        let firstPath = try #require(fixture.model.pendingNewBotPlan?.bot.localConfigPath)
+
+        fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
+        let secondPath = try #require(fixture.model.pendingNewBotPlan?.bot.localConfigPath)
+
+        #expect(secondPath != firstPath)
+        #expect(secondPath.contains("electric-sheep-secondary-2"))
+    }
+
+    private func bot(
+        id: String,
+        slug: String,
+        configPath: String?,
+        status: DesktopBotStatus = .verified
+    ) -> DesktopBotInstallation {
+        DesktopBotInstallation(
+            id: id,
+            appID: 4_184_532,
+            appSlug: slug,
+            mode: .byo,
+            githubInstallationID: 72_001,
+            githubAccountLogin: "electricsheephq",
+            status: status,
+            localConfigPath: configPath
+        )
+    }
+
+    private func workspace(
+        id: String,
+        name: String,
+        bots: [DesktopBotInstallation]
+    ) -> DesktopAccountWorkspace {
+        DesktopAccountWorkspace(
+            id: id,
+            kind: .organization,
+            name: name,
+            role: .admin,
+            entitlement: .internalAdmin,
+            bots: bots
+        )
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -106,7 +106,8 @@ import NeonDiffDesktopCore
             account: electricSheep,
             appSlug: "electric-sheep-secondary",
             applicationSupportDirectory: root,
-            occupiedConfigPaths: []
+            occupiedConfigPaths: [],
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) }
         )
 
         #expect(plan.bot.localConfigPath != occupied.standardizedFileURL.path)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -259,6 +259,28 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func localBotDiscoveryDoesNotInvalidateAPendingNewBotPlan() throws {
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
+        let original = try #require(fixture.model.pendingNewBotPlan)
+        let local = DesktopLocalBotCandidate(
+            appID: 4_184_532,
+            appSlug: "evaos-code-review-bot",
+            githubAccountLogin: "electricsheephq",
+            configPath: "/fixture/evaos-code-review-bot/config.local.json"
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            electricSheep.merging(localCandidates: [local])
+        ]))
+
+        #expect(fixture.model.pendingNewBotPlan == original)
+        #expect(fixture.model.accountWorkspaceSelection.botID == original.bot.id)
+        #expect(fixture.model.configPath == original.bot.localConfigPath)
+    }
+
+    @MainActor
     @Test func authorityChangeInvalidatesAPendingNewBotPlanAndRuntimeState() {
         let fixture = ModelDependencyFixture()
         fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -259,6 +259,30 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func authorityChangeInvalidatesAPendingNewBotPlanAndRuntimeState() {
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
+        fixture.model.repos = [RepoMonitor(name: "electric/private", enabled: true)]
+        fixture.model.providers.providerKeyStored = true
+        let withdrawn = DesktopAccountWorkspace(
+            id: electricSheep.id,
+            kind: electricSheep.kind,
+            name: electricSheep.name,
+            role: electricSheep.role,
+            entitlement: .none,
+            bots: electricSheep.bots
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([withdrawn]))
+
+        #expect(fixture.model.pendingNewBotPlan == nil)
+        #expect(fixture.model.accountWorkspaceSelection.botID == nil)
+        #expect(fixture.model.repos.isEmpty)
+        #expect(!fixture.model.providers.providerKeyStored)
+    }
+
+    @MainActor
     @Test func switchingWorkspaceClearsConfigAuthorizationOnboardingProofAndTransientGitHubInput() {
         let localBot = bot(
             id: "bot-local",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -113,6 +113,20 @@ import NeonDiffDesktopCore
         #expect(plan.bot.localConfigPath?.contains("electric-sheep-secondary-2") == true)
     }
 
+    @Test func newBotRejectsASlugWithATrailingLineTerminator() {
+        #expect(throws: DesktopNewBotPlanError.invalidSlug) {
+            try DesktopNewBotPlan.make(
+                account: electricSheep,
+                appSlug: "electric-sheep-secondary\n",
+                applicationSupportDirectory: URL(
+                    filePath: "/Users/test/Library/Application Support/NeonDiff",
+                    directoryHint: .isDirectory
+                ),
+                occupiedConfigPaths: []
+            )
+        }
+    }
+
     @Test func switchingAccountClearsEveryWorkspaceBoundRuntimeSelection() {
         var selection = DesktopAccountWorkspaceSelection(
             accountID: personal.id,
@@ -132,11 +146,11 @@ import NeonDiffDesktopCore
     @MainActor
     @Test func modelAccountSwitchInvalidatesPriorWorkspaceProofWithoutDeletingAuthority() {
         let fixture = ModelDependencyFixture()
+        fixture.secretStore.values = ["provider/anthropic": "fixture-secret"]
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([personal, electricSheep]))
         fixture.model.repos = [RepoMonitor(name: "personal/private-repo", enabled: true)]
         fixture.model.providers.providerKeyStored = true
         fixture.model.github.installationCount = 1
-        fixture.secretStore.values = ["provider/anthropic": "fixture-secret"]
-        fixture.model.applyAccountWorkspaceCatalog(.loaded([personal, electricSheep]))
 
         fixture.model.selectAccountWorkspace(electricSheep.id)
 
@@ -145,6 +159,11 @@ import NeonDiffDesktopCore
         #expect(!fixture.model.providers.providerKeyStored)
         #expect(fixture.model.github.installationCount == 0)
         #expect(fixture.secretStore.values == ["provider/anthropic": "fixture-secret"])
+        #expect(fixture.model.configPath == fixture.fileWriter.applicationSupportDirectory
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent("_unselected", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path)
     }
 
     @MainActor
@@ -267,6 +286,7 @@ import NeonDiffDesktopCore
     @Test func modelNewBotStartsAnIsolatedLocalPlanWithoutInventingAServerBot() throws {
         let fixture = ModelDependencyFixture()
         fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        let authoritativeBotIDs = fixture.model.selectedAccountWorkspace?.bots.map(\.id)
 
         fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
 
@@ -274,6 +294,27 @@ import NeonDiffDesktopCore
         #expect(plan.accountID == electricSheep.id)
         #expect(fixture.model.selectedBotInstallation == nil)
         #expect(fixture.model.configPath == plan.bot.localConfigPath)
+        #expect(fixture.model.isOnboardingPresented)
+        #expect(fixture.model.selectedAccountWorkspace?.bots.map(\.id) == authoritativeBotIDs)
+        #expect(fixture.model.selectedAccountWorkspace?.bots.contains(where: {
+            $0.id == plan.bot.id
+        }) == false)
+    }
+
+    @MainActor
+    @Test func serverBotWithoutALocalMatchGetsItsOwnIsolatedSetupPath() {
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+
+        #expect(fixture.model.configPath == fixture.fileWriter.applicationSupportDirectory
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(electricSheep.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("evaos-code-review-bot", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path)
         #expect(fixture.model.isOnboardingPresented)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -70,6 +70,14 @@ import NeonDiffDesktopCore
         #expect(merged.bots[0].localConfigPath == nil)
     }
 
+    @Test func serverCatalogCannotInjectALocalConfigPath() throws {
+        let data = Data(#"{"id":"bot-remote","appID":4184532,"appSlug":"evaos-code-review-bot","mode":"byo","githubInstallationID":72001,"githubAccountLogin":"electricsheephq","status":"verified","localConfigPath":"/tmp/server-controlled.json"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(DesktopBotInstallation.self, from: data)
+
+        #expect(decoded.localConfigPath == nil)
+    }
+
     @Test func newBotUsesADistinctPendingIdentityAndNeverReusesExistingConfig() throws {
         let existingPath = "/Users/test/Library/Application Support/NeonDiff/config.local.json"
         let plan = try DesktopNewBotPlan.make(
@@ -191,6 +199,66 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func reselectingTheCurrentBotPreservesVerifiedRuntimeState() {
+        let localBot = bot(
+            id: "bot-local",
+            slug: "local-bot",
+            configPath: "/fixture/local-bot/config.local.json"
+        )
+        let account = workspace(id: "account-a", name: "Account A", bots: [localBot])
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        fixture.model.selectBotInstallation(localBot.id)
+        fixture.model.repos = [RepoMonitor(name: "account-a/private", enabled: true)]
+        fixture.model.providers.providerKeyStored = true
+
+        fixture.model.selectBotInstallation(localBot.id)
+
+        #expect(fixture.model.repos == [RepoMonitor(name: "account-a/private", enabled: true)])
+        #expect(fixture.model.providers.providerKeyStored)
+    }
+
+    @MainActor
+    @Test func catalogLocalPathLossInvalidatesSelectedBotRuntimeState() {
+        let localBot = bot(
+            id: "bot-local",
+            slug: "local-bot",
+            configPath: "/fixture/local-bot/config.local.json"
+        )
+        let account = workspace(id: "account-a", name: "Account A", bots: [localBot])
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        fixture.model.selectBotInstallation(localBot.id)
+        fixture.model.repos = [RepoMonitor(name: "account-a/private", enabled: true)]
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(
+                id: account.id,
+                name: account.name,
+                bots: [bot(id: localBot.id, slug: localBot.appSlug, configPath: nil)]
+            )
+        ]))
+
+        #expect(fixture.model.repos.isEmpty)
+        #expect(fixture.model.configPath.contains("Accounts/account-a/Bots/local-bot/config.local.json"))
+        #expect(fixture.model.isOnboardingPresented)
+    }
+
+    @MainActor
+    @Test func unchangedCatalogRefreshPreservesAPendingNewBotPlan() throws {
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
+        let original = try #require(fixture.model.pendingNewBotPlan)
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+
+        #expect(fixture.model.pendingNewBotPlan == original)
+        #expect(fixture.model.accountWorkspaceSelection.botID == original.bot.id)
+        #expect(fixture.model.configPath == original.bot.localConfigPath)
+    }
+
+    @MainActor
     @Test func switchingWorkspaceClearsConfigAuthorizationOnboardingProofAndTransientGitHubInput() {
         let localBot = bot(
             id: "bot-local",
@@ -209,6 +277,9 @@ import NeonDiffDesktopCore
         fixture.model.onboardingFlow.licenseActivation = .activated
         fixture.model.pendingBYOGitHubAppId = "4184532"
         fixture.model.pendingBYOGitHubAppPrivateKey = "fixture-private-key"
+        fixture.model.pendingActivationKey = "NDL-OLD-WORKSPACE-123456"
+        fixture.model.pendingIssueRepoName = "account-a/old"
+        fixture.model.controlCenter.pollIntervalMs += 1
         fixture.model.githubAuthorizationCode = GitHubDeviceAuthorizationCode(
             deviceCode: "fixture-device-code",
             userCode: "ABCD-EFGH",
@@ -226,6 +297,9 @@ import NeonDiffDesktopCore
         #expect(fixture.model.onboardingFlow.licenseActivation == .servicePending)
         #expect(fixture.model.pendingBYOGitHubAppId.isEmpty)
         #expect(fixture.model.pendingBYOGitHubAppPrivateKey.isEmpty)
+        #expect(fixture.model.pendingActivationKey.isEmpty)
+        #expect(fixture.model.pendingIssueRepoName.isEmpty)
+        #expect(fixture.model.controlCenter == DesktopControlCenterSettings())
         #expect(fixture.model.githubAuthorizationCode == nil)
         #expect(!fixture.model.isGitHubAuthorizationInProgress)
         #expect(!fixture.model.isGitHubRepositoryRefreshInProgress)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+@Suite struct AccountWorkspaceSelectionTests {
+    private let personal = DesktopAccountWorkspace(
+        id: "account-personal",
+        kind: .personal,
+        name: "Benjamin",
+        role: .owner,
+        entitlement: .publicFree,
+        bots: []
+    )
+
+    private let electricSheep = DesktopAccountWorkspace(
+        id: "account-electric-sheep",
+        kind: .organization,
+        name: "ElectricSheep",
+        role: .admin,
+        entitlement: .internalAdmin,
+        bots: [
+            DesktopBotInstallation(
+                id: "bot-evaos-code-review-bot",
+                appID: 4_184_532,
+                appSlug: "evaos-code-review-bot",
+                mode: .byo,
+                githubInstallationID: 72_001,
+                githubAccountLogin: "electricsheephq",
+                status: .verified,
+                localConfigPath: nil
+            )
+        ]
+    )
+
+    @Test func authoritativeMembershipControlsVisibleAccounts() {
+        let catalog = DesktopAccountWorkspaceCatalog.loaded([personal, electricSheep])
+
+        #expect(catalog.accounts.map(\.name) == ["Benjamin", "ElectricSheep"])
+        #expect(catalog.accounts.allSatisfy { $0.role != nil })
+    }
+
+    @Test func matchingLocalBotIsMergedWithoutDuplicatingTheServerInstallation() throws {
+        let local = DesktopLocalBotCandidate(
+            appID: 4_184_532,
+            appSlug: "evaos-code-review-bot",
+            githubAccountLogin: "electricsheephq",
+            configPath: "/Users/test/Library/Application Support/NeonDiff/config.local.json"
+        )
+
+        let merged = electricSheep.merging(localCandidates: [local])
+        let bot = try #require(merged.bots.first)
+
+        #expect(merged.bots.count == 1)
+        #expect(bot.localConfigPath == local.configPath)
+        #expect(bot.isAvailableOnThisMac)
+    }
+
+    @Test func localBotCannotCrossAnAuthoritativeGitHubAccountBoundary() {
+        let local = DesktopLocalBotCandidate(
+            appID: 4_184_532,
+            appSlug: "evaos-code-review-bot",
+            githubAccountLogin: "someone-else",
+            configPath: "/tmp/other/config.local.json"
+        )
+
+        let merged = electricSheep.merging(localCandidates: [local])
+
+        #expect(merged.bots.count == 1)
+        #expect(merged.bots[0].localConfigPath == nil)
+    }
+
+    @Test func newBotUsesADistinctPendingIdentityAndNeverReusesExistingConfig() throws {
+        let existingPath = "/Users/test/Library/Application Support/NeonDiff/config.local.json"
+        let plan = try DesktopNewBotPlan.make(
+            account: electricSheep,
+            appSlug: "electric-sheep-secondary",
+            applicationSupportDirectory: URL(filePath: "/Users/test/Library/Application Support/NeonDiff", directoryHint: .isDirectory),
+            occupiedConfigPaths: [existingPath]
+        )
+
+        #expect(plan.accountID == electricSheep.id)
+        #expect(plan.bot.status == .pending)
+        #expect(plan.bot.localConfigPath != existingPath)
+        #expect(plan.bot.localConfigPath?.contains("account-electric-sheep") == true)
+        #expect(plan.bot.localConfigPath?.contains("electric-sheep-secondary") == true)
+    }
+
+    @Test func switchingAccountClearsEveryWorkspaceBoundRuntimeSelection() {
+        var selection = DesktopAccountWorkspaceSelection(
+            accountID: personal.id,
+            botID: "personal-bot",
+            repository: "personal/private-repo",
+            providerID: "anthropic"
+        )
+
+        selection.selectAccount(electricSheep.id)
+
+        #expect(selection.accountID == electricSheep.id)
+        #expect(selection.botID == nil)
+        #expect(selection.repository == nil)
+        #expect(selection.providerID == nil)
+    }
+
+    @MainActor
+    @Test func modelAccountSwitchInvalidatesPriorWorkspaceProofWithoutDeletingAuthority() {
+        let fixture = ModelDependencyFixture()
+        fixture.model.repos = [RepoMonitor(name: "personal/private-repo", enabled: true)]
+        fixture.model.providers.providerKeyStored = true
+        fixture.model.github.installationCount = 1
+        fixture.secretStore.values = ["provider/anthropic": "fixture-secret"]
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([personal, electricSheep]))
+
+        fixture.model.selectAccountWorkspace(electricSheep.id)
+
+        #expect(fixture.model.selectedAccountWorkspace?.id == electricSheep.id)
+        #expect(fixture.model.repos.isEmpty)
+        #expect(!fixture.model.providers.providerKeyStored)
+        #expect(fixture.model.github.installationCount == 0)
+        #expect(fixture.secretStore.values == ["provider/anthropic": "fixture-secret"])
+    }
+
+    @MainActor
+    @Test func modelNewBotStartsAnIsolatedLocalPlanWithoutInventingAServerBot() throws {
+        let fixture = ModelDependencyFixture()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+
+        fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
+
+        let plan = try #require(fixture.model.pendingNewBotPlan)
+        #expect(plan.accountID == electricSheep.id)
+        #expect(fixture.model.selectedBotInstallation == nil)
+        #expect(fixture.model.configPath == plan.bot.localConfigPath)
+        #expect(fixture.model.isOnboardingPresented)
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -307,6 +307,37 @@ import NeonDiffDesktopCore
         #expect(model.onboardingFlow.licenseActivation != .activated)
     }
 
+    @Test func staleResultAfterWorkspaceSwitchIsDropped() async {
+        let keychain = RecordingKeychain()
+        let gate = GatedActivationClient()
+        let model = makeModel(secretStore: keychain, client: gate)
+        let accountA = DesktopAccountWorkspace(
+            id: "account-a", kind: .organization, name: "Account A", role: .admin,
+            entitlement: .paid, bots: []
+        )
+        let accountB = DesktopAccountWorkspace(
+            id: "account-b", kind: .organization, name: "Account B", role: .admin,
+            entitlement: .paid, bots: []
+        )
+        model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
+        model.activationState = .checkoutPaused
+        model.pendingActivationKey = "NDL-GOOD-0123456789"
+        model.provideExistingActivationKey()
+
+        let task = Task { await model.submitActivation() }
+        var spins = 0
+        while model.activationState != .activationPending && spins < 10_000 {
+            await Task.yield(); spins += 1
+        }
+        model.selectAccountWorkspace(accountB.id)
+        gate.release(activeSummary())
+        await task.value
+
+        #expect(model.selectedAccountWorkspace?.id == accountB.id)
+        #expect(model.activationState != .active)
+        #expect(model.onboardingFlow.licenseActivation != .activated)
+    }
+
     /// Thread 7: a keyReady state restored without a Keychain item must return to
     /// key entry, not get stuck on Activating.
     @Test func missingKeyDuringActivationReturnsToKeyEntry() async {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -357,6 +357,31 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.productionDaemonStopAvailable)
     }
 
+    @Test func workspaceSwitchDiscardsAStaleDoctorFailureWithoutMutatingNewWorkspace() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.failure(NSError(domain: "fixture-old-workspace", code: 1))],
+            suspendCLIRuns: true,
+            productionBoundary: exactB0Boundary
+        )
+        let accountA = fixtureWorkspace(id: "account-a")
+        let accountB = fixtureWorkspace(id: "account-b")
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await fixture.cli.waitUntilCallCount(1)
+
+        fixture.model.selectAccountWorkspace(accountB.id)
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 { await Task.yield() }
+
+        #expect(fixture.model.selectedAccountWorkspace?.id == accountB.id)
+        #expect(fixture.model.lastError == nil)
+        #expect(!fixture.model.isBYOGitHubVerificationInProgress)
+    }
+
     @Test func privateKeyRotationWhileDoctorRunsDiscardsOldKeyProof() async throws {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
@@ -385,6 +410,17 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.productionDaemonStopAvailable)
     }
+}
+
+private func fixtureWorkspace(id: String) -> DesktopAccountWorkspace {
+    DesktopAccountWorkspace(
+        id: id,
+        kind: .organization,
+        name: id,
+        role: .admin,
+        entitlement: .internalAdmin,
+        bots: []
+    )
 }
 
 @MainActor

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/GitHubAuthorizationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/GitHubAuthorizationTests.swift
@@ -78,6 +78,44 @@ import NeonDiffDesktopCore
         #expect(fixture.secretStore.values["github/user-refresh-token"] == nil)
     }
 
+    @Test func staleTokenRefreshCannotOverwriteCredentialsAfterWorkspaceSwitch() async throws {
+        let now = fixtureDate(secondsSince1970: 1_000_000)
+        let authenticator = ScriptedGitHubAuthenticator(
+            refreshedToken: GitHubUserToken(
+                accessToken: "old-workspace-refreshed-access",
+                refreshToken: "old-workspace-refreshed-refresh",
+                expiresAt: now.addingTimeInterval(3_600),
+                refreshTokenExpiresAt: now.addingTimeInterval(7_200)
+            ),
+            suspendRefresh: true
+        )
+        let fixture = ModelDependencyFixture(now: now, githubAuthenticator: authenticator)
+        let accountA = DesktopAccountWorkspace(
+            id: "account-a", kind: .organization, name: "Account A", role: .admin,
+            entitlement: .paid, bots: []
+        )
+        let accountB = DesktopAccountWorkspace(
+            id: "account-b", kind: .organization, name: "Account B", role: .admin,
+            entitlement: .paid, bots: []
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
+        fixture.model.github.clientId = "fixture-client-id"
+        try fixture.secretStore.setSecret("old-access", account: "github/user-access-token")
+        try fixture.secretStore.setSecret("old-refresh", account: "github/user-refresh-token")
+        try fixture.secretStore.setSecret(fixtureISO8601String(now), account: "github/user-token-expires-at")
+
+        fixture.model.refreshGitHubRepositories()
+        while authenticator.refreshTokens.isEmpty { await Task.yield() }
+        fixture.model.selectAccountWorkspace(accountB.id)
+        try fixture.secretStore.setSecret("new-access", account: "github/user-access-token")
+        try fixture.secretStore.setSecret("new-refresh", account: "github/user-refresh-token")
+        authenticator.resumeSuspendedRefreshes()
+        for _ in 0..<20 { await Task.yield() }
+
+        #expect(fixture.secretStore.values["github/user-access-token"] == "new-access")
+        #expect(fixture.secretStore.values["github/user-refresh-token"] == "new-refresh")
+    }
+
     @Test func devicePollingAdoptsServerIntervalWithoutWallClockSleep() async throws {
         let now = fixtureDate(secondsSince1970: 1_000_000)
         let deviceCode = GitHubDeviceAuthorizationCode(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -76,6 +76,7 @@ import Testing
         #expect(sidebar.contains("Menu"))
         #expect(sidebar.contains("neondiff-account-menu"))
         #expect(sidebar.contains("neondiff-account-option-"))
+        #expect(sidebar.contains("neondiff-bot-option-"))
         #expect(sidebar.contains("NEW BOT"))
         #expect(sidebar.contains("neondiff-new-bot"))
         #expect(sidebar.contains("SYSTEM READINESS"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -73,6 +73,11 @@ import Testing
         )
 
         #expect(sidebar.contains("AI CODE REVIEW SYSTEM"))
+        #expect(sidebar.contains("Menu"))
+        #expect(sidebar.contains("neondiff-account-menu"))
+        #expect(sidebar.contains("neondiff-account-option-"))
+        #expect(sidebar.contains("NEW BOT"))
+        #expect(sidebar.contains("neondiff-new-bot"))
         #expect(sidebar.contains("SYSTEM READINESS"))
         #expect(sidebar.contains("CONFIG + SECRETS STAY LOCAL"))
         #expect(sidebar.contains("neondiff-sidebar-readiness"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -119,6 +119,8 @@ final class ScriptedGitHubAuthenticator: GitHubDesktopAuthenticating, @unchecked
         var refreshTokens: [String] = []
         var fetchedAccessTokens: [String] = []
         var listedAccessTokens: [String] = []
+        var suspendRefresh: Bool
+        var suspendedRefreshContinuations: [CheckedContinuation<Void, Never>] = []
     }
 
     private let state: ModelFixtureLocked<State>
@@ -134,14 +136,16 @@ final class ScriptedGitHubAuthenticator: GitHubDesktopAuthenticating, @unchecked
         pollResults: [GitHubDeviceAuthorizationPollResult] = [],
         refreshedToken: GitHubUserToken = GitHubUserToken(accessToken: "fixture-refreshed-token"),
         user: GitHubAuthenticatedUser = GitHubAuthenticatedUser(login: "fixture-user"),
-        repositories: [GitHubDiscoveredRepository] = []
+        repositories: [GitHubDiscoveredRepository] = [],
+        suspendRefresh: Bool = false
     ) {
         state = ModelFixtureLocked(State(
             deviceCode: deviceCode,
             pollResults: pollResults,
             refreshedToken: refreshedToken,
             user: user,
-            repositories: repositories
+            repositories: repositories,
+            suspendRefresh: suspendRefresh
         ))
     }
 
@@ -170,7 +174,26 @@ final class ScriptedGitHubAuthenticator: GitHubDesktopAuthenticating, @unchecked
 
     func refreshUserToken(clientId: String, refreshToken: String) async throws -> GitHubUserToken {
         state.update { $0.refreshTokens.append(refreshToken) }
+        if state.read(\.suspendRefresh) {
+            await withCheckedContinuation { continuation in
+                let shouldResume = state.update { state -> Bool in
+                    guard state.suspendRefresh else { return true }
+                    state.suspendedRefreshContinuations.append(continuation)
+                    return false
+                }
+                if shouldResume { continuation.resume() }
+            }
+        }
         return state.read(\.refreshedToken)
+    }
+
+    func resumeSuspendedRefreshes() {
+        let continuations = state.update { state -> [CheckedContinuation<Void, Never>] in
+            state.suspendRefresh = false
+            defer { state.suspendedRefreshContinuations.removeAll() }
+            return state.suspendedRefreshContinuations
+        }
+        continuations.forEach { $0.resume() }
     }
 
     func fetchCurrentUser(accessToken: String) async throws -> GitHubAuthenticatedUser {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
@@ -243,6 +243,13 @@ final class TemporaryFileWriter: DesktopFileWriting, @unchecked Sendable {
 
     var writes: [RecordedFileWrite] { recordedWrites.read { $0 } }
 
+    func fileExists(at url: URL) -> Bool {
+        let destination = url.standardizedFileURL
+        return recordedWrites.read { writes in
+            writes.contains { $0.url.standardizedFileURL == destination }
+        } || FileManager.default.fileExists(atPath: destination.path)
+    }
+
     func write(_ data: Data, to url: URL) throws {
         let destination = url.standardizedFileURL
         let rootPath = applicationSupportDirectory.path


### PR DESCRIPTION
## Outcome

Adds the first bounded native slice of #666: authoritative account/workspace models, a clickable NeonDiff logo menu, account and bot selection, local-config intersection rules, and an isolated New bot plan.

## Acceptance criteria for this PR

- Account options are sourced only from a server-authoritative catalog with membership.
- Switching account or bot clears workspace-bound repository, provider, GitHub, license, and proof state without deleting Keychain material.
- A local config attaches only to a verified server bot matching App ID, slug, and GitHub account.
- New bot creates a distinct pending identity and config path; it does not invent a server installation.
- Logo menu exposes loading, error, empty, account, bot, and New bot states with accessibility identifiers.
- Focused failing-first native tests and source-contract tests pass.

## Explicit non-goals

- No direct Lovable/Supabase admin credential in the native app.
- No live account snapshot transport, browser sign-in, GitHub installation verification, or server-side bot creation in this PR.
- No credential rotation, checkout, publication, signed artifact, customer canary, or release claim.
- Does not close broader #666, #646, #630, or #517.

## Proof

- RED: focused native target failed to compile with 52 missing-type errors before implementation.
- GREEN: AccountWorkspaceSelectionTests 7/7 and OwnerReferenceUXContractTests 4/4.
- git diff --check is clean.

Relates to #666 and #610.