### PR TITLE
feat(account): add device-linked Lovable authority service

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -66,7 +66,9 @@ package struct DesktopBotInstallation: Identifiable, Codable, Equatable, Sendabl
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, appID, appSlug, mode, githubInstallationID, githubAccountLogin, status
+        case id, appSlug, mode, githubAccountLogin, status
+        case appID = "appId"
+        case githubInstallationID = "githubInstallationId"
     }
 
     /// `localConfigPath` is local-only evidence discovered on this Mac. It is

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -71,11 +71,13 @@ import NeonDiffDesktopCore
     }
 
     @Test func serverCatalogCannotInjectALocalConfigPath() throws {
-        let data = Data(#"{"id":"bot-remote","appID":4184532,"appSlug":"evaos-code-review-bot","mode":"byo","githubInstallationID":72001,"githubAccountLogin":"electricsheephq","status":"verified","localConfigPath":"/tmp/server-controlled.json"}"#.utf8)
+        let data = Data(#"{"id":"bot-remote","appId":4184532,"appSlug":"evaos-code-review-bot","mode":"byo","githubInstallationId":72001,"githubAccountLogin":"electricsheephq","status":"verified","localConfigPath":"/tmp/server-controlled.json"}"#.utf8)
 
         let decoded = try JSONDecoder().decode(DesktopBotInstallation.self, from: data)
 
         #expect(decoded.localConfigPath == nil)
+        #expect(decoded.appID == 4_184_532)
+        #expect(decoded.githubInstallationID == 72_001)
     }
 
     @Test func newBotUsesADistinctPendingIdentityAndNeverReusesExistingConfig() throws {

--- a/services/license-api/docker-entrypoint.sh
+++ b/services/license-api/docker-entrypoint.sh
@@ -8,12 +8,19 @@ set -eu
 : "${GITHUB_BROKER_ENABLED:=false}"
 : "${GITHUB_BROKER_DB_PATH:=/data/github-broker.sqlite}"
 : "${GITHUB_BROKER_LITESTREAM_CONFIG:=/etc/litestream-broker.yml}"
+: "${ACCOUNT_LINK_ENABLED:=false}"
+: "${ACCOUNT_LINK_DB_PATH:=/data/github-broker.sqlite}"
 export LICENSE_DB_PATH LITESTREAM_CONFIG LITESTREAM_SYNC_INTERVAL LICENSE_LITESTREAM_REQUIRED
 export GITHUB_BROKER_ENABLED GITHUB_BROKER_DB_PATH GITHUB_BROKER_LITESTREAM_CONFIG
+export ACCOUNT_LINK_ENABLED ACCOUNT_LINK_DB_PATH
 
 mkdir -p "$(dirname "$LICENSE_DB_PATH")"
 
 broker_replication_configured=false
+if [ "$ACCOUNT_LINK_ENABLED" = "true" ] && [ "$ACCOUNT_LINK_DB_PATH" != "$GITHUB_BROKER_DB_PATH" ]; then
+  echo "ACCOUNT_LINK_DB_PATH must match GITHUB_BROKER_DB_PATH; refusing to start account linking outside the replicated broker database." >&2
+  exit 1
+fi
 if [ -n "${GITHUB_BROKER_REPLICA_URL:-}" ]; then
   if [ "$GITHUB_BROKER_DB_PATH" = "$LICENSE_DB_PATH" ]; then
     echo "GITHUB_BROKER_DB_PATH must differ from LICENSE_DB_PATH; refusing to start." >&2
@@ -30,11 +37,15 @@ if [ -n "${GITHUB_BROKER_REPLICA_URL:-}" ]; then
 elif [ "$GITHUB_BROKER_ENABLED" = "true" ]; then
   echo "GITHUB_BROKER_REPLICA_URL is unset; refusing to enable the managed GitHub broker without independent Litestream DR replication." >&2
   exit 1
+elif [ "$ACCOUNT_LINK_ENABLED" = "true" ]; then
+  echo "GITHUB_BROKER_REPLICA_URL is unset; refusing to enable account linking without independent Litestream DR replication." >&2
+  exit 1
 fi
 
 if [ -z "${LICENSE_REPLICA_URL:-}" ]; then
   if [ "$LICENSE_LITESTREAM_REQUIRED" = "true" ] ||
     [ "$GITHUB_BROKER_ENABLED" = "true" ] ||
+    [ "$ACCOUNT_LINK_ENABLED" = "true" ] ||
     [ "$broker_replication_configured" = "true" ]; then
     echo "LICENSE_REPLICA_URL is unset; refusing to start production license-api without Litestream DR replication. Set LICENSE_REPLICA_URL via Fly secrets, or set LICENSE_LITESTREAM_REQUIRED=false for local/dev only." >&2
     exit 1

--- a/services/license-api/fly.toml
+++ b/services/license-api/fly.toml
@@ -21,6 +21,7 @@ primary_region = "iad"  # placeholder — set to wherever the fleet/owner is clo
   LITESTREAM_SYNC_INTERVAL = "1s"
   LICENSE_LITESTREAM_REQUIRED = "true"
   GITHUB_BROKER_DB_PATH = "/data/github-broker.sqlite"
+  ACCOUNT_LINK_DB_PATH = "/data/github-broker.sqlite"
   GITHUB_BROKER_LITESTREAM_CONFIG = "/etc/litestream-broker.yml"
   # LICENSE_REPLICA_URL is intentionally not committed here. The owner sets
   # the object-store replica URL and provider credentials via `flyctl secrets`

--- a/services/license-api/src/account-link/index.ts
+++ b/services/license-api/src/account-link/index.ts
@@ -1,0 +1,19 @@
+export {
+  AccountLinkService,
+  type AccountAuthority,
+  type AccountBotSnapshot,
+  type AccountLinkServiceOptions,
+  type AccountWorkspaceSnapshot
+} from "./service.js";
+export {
+  createAccountLinkService,
+  handleAccountLinkRequest,
+  isAccountLinkPath,
+  type AccountLinkDeps
+} from "./routes.js";
+export {
+  createSupabaseAccountAuthority,
+  loadAccountLinkRuntimeConfig,
+  type AccountLinkRuntimeConfig,
+  type SupabaseAccountAuthorityOptions
+} from "./runtime-config.js";

--- a/services/license-api/src/account-link/routes.ts
+++ b/services/license-api/src/account-link/routes.ts
@@ -1,0 +1,120 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RateLimiter } from "../service.js";
+import { BrokerError } from "../github-broker/errors.js";
+import { GitHubBrokerStore } from "../github-broker/store.js";
+import {
+  AccountLinkService,
+  type AccountAuthority
+} from "./service.js";
+
+const MAX_BODY_BYTES = 16 * 1024;
+const PATHS = new Set([
+  "/account/device/register",
+  "/account/connect/start",
+  "/account/connect/complete",
+  "/account/workspaces"
+]);
+
+class BodyTooLargeError extends Error {}
+
+export interface AccountLinkDeps {
+  store?: GitHubBrokerStore;
+  dbPath?: string;
+  authority: AccountAuthority;
+  now?: () => Date;
+  registerRateLimiter?: RateLimiter;
+  connectRateLimiter?: RateLimiter;
+}
+
+export function isAccountLinkPath(path: string | undefined): boolean {
+  return path !== undefined && PATHS.has(path);
+}
+
+export function createAccountLinkService(deps: AccountLinkDeps): AccountLinkService {
+  const store = deps.store ?? new GitHubBrokerStore(deps.dbPath ?? ":memory:");
+  return new AccountLinkService({
+    store,
+    authority: deps.authority,
+    now: deps.now,
+    registerRateLimiter: deps.registerRateLimiter,
+    connectRateLimiter: deps.connectRateLimiter
+  });
+}
+
+export async function handleAccountLinkRequest(
+  service: AccountLinkService,
+  req: IncomingMessage,
+  res: ServerResponse,
+  context: { sourceAddress: string }
+): Promise<void> {
+  const path = req.url?.split("?")[0];
+  try {
+    if (req.method === "POST" && path === "/account/device/register") {
+      return writeJson(res, 200, await service.registerDevice(await readBody(req), context.sourceAddress));
+    }
+    if (req.method === "POST" && path === "/account/connect/start") {
+      return writeJson(res, 200, await service.connectStart(req.headers.authorization));
+    }
+    if (req.method === "POST" && path === "/account/connect/complete") {
+      return writeJson(
+        res,
+        200,
+        await service.connectComplete(req.headers.authorization, await readBody(req))
+      );
+    }
+    if (req.method === "POST" && path === "/account/workspaces") {
+      return writeJson(res, 200, await service.workspaces(req.headers.authorization));
+    }
+    return writeJson(res, 404, { status: "error", reason: "invalid_request", detail: "unknown account route" });
+  } catch (error) {
+    if (error instanceof BrokerError) return writeJson(res, error.httpStatus, error.body());
+    if (error instanceof BodyTooLargeError) {
+      return writeJson(res, 413, { status: "error", reason: "invalid_request", detail: "request body too large" });
+    }
+    return writeJson(res, 500, {
+      status: "error",
+      reason: "account_authority_unavailable",
+      detail: "internal error"
+    });
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let tooLarge = false;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      if (tooLarge) return;
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        tooLarge = true;
+        chunks.length = 0;
+        reject(new BodyTooLargeError("request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (tooLarge) return;
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new BrokerError("invalid_request", "request body must be valid JSON"));
+      }
+    });
+    req.on("error", (error) => {
+      if (!tooLarge) reject(error);
+    });
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store"
+  });
+  res.end(JSON.stringify(body));
+}

--- a/services/license-api/src/account-link/routes.ts
+++ b/services/license-api/src/account-link/routes.ts
@@ -24,6 +24,7 @@ export interface AccountLinkDeps {
   now?: () => Date;
   registerRateLimiter?: RateLimiter;
   connectRateLimiter?: RateLimiter;
+  completeRateLimiter?: RateLimiter;
 }
 
 export function isAccountLinkPath(path: string | undefined): boolean {
@@ -37,7 +38,8 @@ export function createAccountLinkService(deps: AccountLinkDeps): AccountLinkServ
     authority: deps.authority,
     now: deps.now,
     registerRateLimiter: deps.registerRateLimiter,
-    connectRateLimiter: deps.connectRateLimiter
+    connectRateLimiter: deps.connectRateLimiter,
+    completeRateLimiter: deps.completeRateLimiter
   });
 }
 
@@ -48,35 +50,81 @@ export async function handleAccountLinkRequest(
   context: { sourceAddress: string }
 ): Promise<void> {
   const path = req.url?.split("?")[0];
+  const corsHeaders = accountCorsHeaders(req, service.connectOrigin);
+  if (req.headers.origin && !corsHeaders) {
+    return writeJson(res, 403, {
+      status: "error",
+      reason: "invalid_request",
+      detail: "origin is not allowed"
+    });
+  }
+  if (req.method === "OPTIONS") {
+    if (!corsHeaders || !validPreflight(req)) {
+      return writeJson(res, 403, {
+        status: "error",
+        reason: "invalid_request",
+        detail: "preflight is not allowed"
+      });
+    }
+    res.writeHead(204, corsHeaders);
+    res.end();
+    return;
+  }
   try {
     if (req.method === "POST" && path === "/account/device/register") {
-      return writeJson(res, 200, await service.registerDevice(await readBody(req), context.sourceAddress));
+      return writeJson(res, 200, await service.registerDevice(await readBody(req), context.sourceAddress), corsHeaders);
     }
     if (req.method === "POST" && path === "/account/connect/start") {
-      return writeJson(res, 200, await service.connectStart(req.headers.authorization));
+      return writeJson(res, 200, await service.connectStart(req.headers.authorization), corsHeaders);
     }
     if (req.method === "POST" && path === "/account/connect/complete") {
       return writeJson(
         res,
         200,
-        await service.connectComplete(req.headers.authorization, await readBody(req))
+        await service.connectComplete(req.headers.authorization, await readBody(req)),
+        corsHeaders
       );
     }
     if (req.method === "POST" && path === "/account/workspaces") {
-      return writeJson(res, 200, await service.workspaces(req.headers.authorization));
+      return writeJson(res, 200, await service.workspaces(req.headers.authorization), corsHeaders);
     }
-    return writeJson(res, 404, { status: "error", reason: "invalid_request", detail: "unknown account route" });
+    return writeJson(res, 404, { status: "error", reason: "invalid_request", detail: "unknown account route" }, corsHeaders);
   } catch (error) {
-    if (error instanceof BrokerError) return writeJson(res, error.httpStatus, error.body());
+    if (error instanceof BrokerError) return writeJson(res, error.httpStatus, error.body(), corsHeaders);
     if (error instanceof BodyTooLargeError) {
-      return writeJson(res, 413, { status: "error", reason: "invalid_request", detail: "request body too large" });
+      return writeJson(res, 413, { status: "error", reason: "invalid_request", detail: "request body too large" }, corsHeaders);
     }
     return writeJson(res, 500, {
       status: "error",
       reason: "account_authority_unavailable",
       detail: "internal error"
-    });
+    }, corsHeaders);
   }
+}
+
+function accountCorsHeaders(
+  req: IncomingMessage,
+  connectOrigin: string
+): Record<string, string> | undefined {
+  const requestOrigin = req.headers.origin;
+  if (!requestOrigin) return {};
+  if (requestOrigin !== new URL(connectOrigin).origin) return undefined;
+  return {
+    "Access-Control-Allow-Origin": requestOrigin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    "Access-Control-Max-Age": "600",
+    Vary: "Origin"
+  };
+}
+
+function validPreflight(req: IncomingMessage): boolean {
+  if (req.headers["access-control-request-method"] !== "POST") return false;
+  const requested = String(req.headers["access-control-request-headers"] ?? "")
+    .split(",")
+    .map((header) => header.trim().toLowerCase())
+    .filter(Boolean);
+  return requested.every((header) => header === "authorization" || header === "content-type");
 }
 
 function readBody(req: IncomingMessage): Promise<unknown> {
@@ -111,10 +159,16 @@ function readBody(req: IncomingMessage): Promise<unknown> {
   });
 }
 
-function writeJson(res: ServerResponse, status: number, body: unknown): void {
+function writeJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+): void {
   res.writeHead(status, {
     "Content-Type": "application/json",
-    "Cache-Control": "no-store"
+    "Cache-Control": "no-store",
+    ...headers
   });
   res.end(JSON.stringify(body));
 }

--- a/services/license-api/src/account-link/routes.ts
+++ b/services/license-api/src/account-link/routes.ts
@@ -25,6 +25,7 @@ export interface AccountLinkDeps {
   registerRateLimiter?: RateLimiter;
   connectRateLimiter?: RateLimiter;
   completeRateLimiter?: RateLimiter;
+  workspaceRateLimiter?: RateLimiter;
 }
 
 export function isAccountLinkPath(path: string | undefined): boolean {
@@ -39,7 +40,8 @@ export function createAccountLinkService(deps: AccountLinkDeps): AccountLinkServ
     now: deps.now,
     registerRateLimiter: deps.registerRateLimiter,
     connectRateLimiter: deps.connectRateLimiter,
-    completeRateLimiter: deps.completeRateLimiter
+    completeRateLimiter: deps.completeRateLimiter,
+    workspaceRateLimiter: deps.workspaceRateLimiter
   });
 }
 

--- a/services/license-api/src/account-link/runtime-config.ts
+++ b/services/license-api/src/account-link/runtime-config.ts
@@ -1,0 +1,399 @@
+import { isAbsolute, resolve } from "node:path";
+import { GitHubBrokerStore } from "../github-broker/store.js";
+import type { AccountLinkDeps } from "./routes.js";
+import type { AccountAuthority, AccountWorkspaceSnapshot } from "./service.js";
+
+const SETTINGS = [
+  "ACCOUNT_LINK_DB_PATH",
+  "ACCOUNT_LINK_CONNECT_ORIGIN",
+  "ACCOUNT_LINK_SUPABASE_URL",
+  "ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY",
+  "ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY"
+] as const;
+const MAX_RESPONSE_BYTES = 256 * 1024;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type Setting = (typeof SETTINGS)[number];
+type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type AccountLinkRuntimeConfig =
+  | { status: "disabled" }
+  | { status: "invalid"; setting: string; reason: string }
+  | { status: "ready"; deps: AccountLinkDeps };
+
+export function loadAccountLinkRuntimeConfig(
+  environment: RuntimeEnvironment,
+  licenseDbPath: string
+): AccountLinkRuntimeConfig {
+  const enabled = normalized(environment.ACCOUNT_LINK_ENABLED);
+  if (enabled === undefined || enabled === "false") return { status: "disabled" };
+  if (enabled !== "true") return invalid("ACCOUNT_LINK_ENABLED", "must_be_true_or_false");
+
+  const values = new Map<Setting, string>();
+  for (const setting of SETTINGS) {
+    const value = normalized(environment[setting]);
+    if (!value) return invalid(setting, "missing");
+    values.set(setting, value);
+  }
+
+  const dbPath = required(values, "ACCOUNT_LINK_DB_PATH");
+  if (!isAbsolute(dbPath)) return invalid("ACCOUNT_LINK_DB_PATH", "must_be_absolute");
+  if (resolve(dbPath) === resolve(licenseDbPath)) {
+    return invalid("ACCOUNT_LINK_DB_PATH", "must_differ_from_license_db");
+  }
+
+  const connectOrigin = normalizedHttpsUrl(
+    required(values, "ACCOUNT_LINK_CONNECT_ORIGIN"),
+    { allowPath: "/desktop/connect" }
+  );
+  if (!connectOrigin) return invalid("ACCOUNT_LINK_CONNECT_ORIGIN", "invalid");
+  const supabaseUrl = normalizedHttpsUrl(
+    required(values, "ACCOUNT_LINK_SUPABASE_URL"),
+    { allowPath: "" }
+  );
+  if (!supabaseUrl) return invalid("ACCOUNT_LINK_SUPABASE_URL", "invalid");
+
+  const publishableKey = required(values, "ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY");
+  const serviceRoleKey = required(values, "ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY");
+  if (publishableKey.length > 4_096) {
+    return invalid("ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY", "invalid");
+  }
+  if (serviceRoleKey.length > 4_096) {
+    return invalid("ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY", "invalid");
+  }
+
+  let store: GitHubBrokerStore;
+  try {
+    store = new GitHubBrokerStore(dbPath);
+  } catch {
+    return invalid("ACCOUNT_LINK_DB_PATH", "open_failed");
+  }
+
+  return {
+    status: "ready",
+    deps: {
+      store,
+      dbPath,
+      authority: createSupabaseAccountAuthority({
+        connectOrigin,
+        supabaseUrl,
+        publishableKey,
+        serviceRoleKey
+      })
+    }
+  };
+}
+
+export interface SupabaseAccountAuthorityOptions {
+  connectOrigin: string;
+  supabaseUrl: string;
+  publishableKey: string;
+  serviceRoleKey: string;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  requestTimeoutMs?: number;
+}
+
+export function createSupabaseAccountAuthority(
+  options: SupabaseAccountAuthorityOptions
+): AccountAuthority {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const timeout = options.requestTimeoutMs ?? 8_000;
+  const base = options.supabaseUrl.replace(/\/$/, "");
+  const serviceHeaders = supabaseHeaders(options.serviceRoleKey);
+
+  return {
+    connectOrigin: options.connectOrigin,
+
+    async verifyAccessToken(accessToken: string): Promise<string | null> {
+      const response = await fetchImpl(`${base}/auth/v1/user`, {
+        method: "GET",
+        headers: {
+          apikey: options.publishableKey,
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/json"
+        },
+        signal: AbortSignal.timeout(timeout)
+      });
+      if (response.status === 401 || response.status === 403) return null;
+      if (!response.ok) throw new Error("account identity request failed");
+      const body = await boundedJson(response);
+      if (!isRecord(body) || typeof body.id !== "string" || !UUID.test(body.id)) return null;
+      return body.id;
+    },
+
+    async loadWorkspaceSnapshot(userId: string): Promise<AccountWorkspaceSnapshot> {
+      if (!UUID.test(userId)) throw new Error("invalid bound user id");
+      const memberships = parseMemberships(await supabaseGet(
+        "/rest/v1/account_memberships",
+        {
+          select: "account_id,role",
+          user_id: `eq.${userId}`
+        },
+        serviceHeaders,
+        fetchImpl,
+        base,
+        timeout
+      ));
+      if (memberships.length === 0) return { accounts: [] };
+
+      const accountIds = memberships.map((membership) => membership.accountId);
+      const inFilter = `in.(${accountIds.join(",")})`;
+      const accounts = parseAccounts(await supabaseGet(
+        "/rest/v1/accounts",
+        { select: "id,kind,name", id: inFilter },
+        serviceHeaders,
+        fetchImpl,
+        base,
+        timeout
+      ));
+      const bots = parseBots(await supabaseGet(
+        "/rest/v1/bot_installations",
+        {
+          select: "id,account_id,app_id,app_slug,mode,github_installation_id,github_account_login,status",
+          account_id: inFilter
+        },
+        serviceHeaders,
+        fetchImpl,
+        base,
+        timeout
+      ));
+      const grants = parseGrants(await supabaseGet(
+        "/rest/v1/account_entitlement_grants",
+        {
+          select: "account_id,grant_kind,status,expires_at",
+          account_id: inFilter,
+          status: "eq.active"
+        },
+        serviceHeaders,
+        fetchImpl,
+        base,
+        timeout
+      ));
+
+      return {
+        accounts: memberships.map((membership) => {
+          const account = accounts.find((candidate) => candidate.id === membership.accountId);
+          if (!account) throw new Error("membership account is missing");
+          return {
+            id: account.id,
+            kind: account.kind,
+            name: account.name,
+            role: membership.role,
+            entitlement: entitlementFor(
+              grants.filter((grant) => grant.accountId === account.id),
+              now()
+            ),
+            bots: bots
+              .filter((bot) => bot.accountId === account.id)
+              .map(({ accountId: _accountId, ...bot }) => bot)
+          };
+        })
+      };
+    }
+  };
+}
+
+async function supabaseGet(
+  path: string,
+  query: Record<string, string>,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  base: string,
+  timeout: number
+): Promise<unknown> {
+  const url = new URL(`${base}${path}`);
+  for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: { ...headers, Accept: "application/json" },
+    signal: AbortSignal.timeout(timeout)
+  });
+  if (!response.ok) throw new Error("account authority request failed");
+  return boundedJson(response);
+}
+
+async function boundedJson(response: Response): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (declared > MAX_RESPONSE_BYTES) throw new Error("account authority response too large");
+  const text = await response.text();
+  if (Buffer.byteLength(text) > MAX_RESPONSE_BYTES) {
+    throw new Error("account authority response too large");
+  }
+  return JSON.parse(text) as unknown;
+}
+
+function supabaseHeaders(key: string): Record<string, string> {
+  const headers: Record<string, string> = { apikey: key };
+  if (key.split(".").length === 3) headers.Authorization = `Bearer ${key}`;
+  return headers;
+}
+
+function parseMemberships(value: unknown): Array<{
+  accountId: string;
+  role: "owner" | "admin" | "member";
+}> {
+  if (!Array.isArray(value)) throw new Error("invalid memberships response");
+  return value.map((row) => {
+    if (!isRecord(row) || typeof row.account_id !== "string" || !UUID.test(row.account_id)) {
+      throw new Error("invalid membership account");
+    }
+    if (row.role !== "owner" && row.role !== "admin" && row.role !== "member") {
+      throw new Error("invalid membership role");
+    }
+    return { accountId: row.account_id, role: row.role };
+  });
+}
+
+function parseAccounts(value: unknown): Array<{
+  id: string;
+  kind: "personal" | "organization";
+  name: string;
+}> {
+  if (!Array.isArray(value)) throw new Error("invalid accounts response");
+  return value.map((row) => {
+    if (!isRecord(row) || typeof row.id !== "string" || !UUID.test(row.id)) {
+      throw new Error("invalid account id");
+    }
+    if (row.kind !== "personal" && row.kind !== "organization") {
+      throw new Error("invalid account kind");
+    }
+    if (typeof row.name !== "string" || row.name.length === 0 || row.name.length > 120) {
+      throw new Error("invalid account name");
+    }
+    return { id: row.id, kind: row.kind, name: row.name };
+  });
+}
+
+function parseBots(value: unknown): Array<{
+  accountId: string;
+  id: string;
+  appId: number;
+  appSlug: string;
+  mode: "byo" | "managed";
+  githubInstallationId: number | null;
+  githubAccountLogin: string | null;
+  status: "pending" | "verified" | "suspended" | "revoked";
+}> {
+  if (!Array.isArray(value)) throw new Error("invalid bots response");
+  return value.map((row) => {
+    if (!isRecord(row)) throw new Error("invalid bot row");
+    if (typeof row.id !== "string" || !UUID.test(row.id)) throw new Error("invalid bot id");
+    if (typeof row.account_id !== "string" || !UUID.test(row.account_id)) {
+      throw new Error("invalid bot account");
+    }
+    if (typeof row.app_id !== "number" || !Number.isSafeInteger(row.app_id) || row.app_id <= 0) {
+      throw new Error("invalid bot app id");
+    }
+    if (typeof row.app_slug !== "string" || !/^[a-z0-9][a-z0-9-]{0,99}$/.test(row.app_slug)) {
+      throw new Error("invalid bot slug");
+    }
+    if (row.mode !== "byo" && row.mode !== "managed") throw new Error("invalid bot mode");
+    if (!["pending", "verified", "suspended", "revoked"].includes(String(row.status))) {
+      throw new Error("invalid bot status");
+    }
+    const installationId = row.github_installation_id;
+    if (
+      installationId !== null
+      && (typeof installationId !== "number" || !Number.isSafeInteger(installationId) || installationId <= 0)
+    ) {
+      throw new Error("invalid installation id");
+    }
+    if (row.status === "verified" && installationId === null) {
+      throw new Error("verified bot has no installation proof");
+    }
+    if (
+      row.github_account_login !== null
+      && (typeof row.github_account_login !== "string" || row.github_account_login.length > 100)
+    ) {
+      throw new Error("invalid GitHub account login");
+    }
+    return {
+      accountId: row.account_id,
+      id: row.id,
+      appId: row.app_id,
+      appSlug: row.app_slug,
+      mode: row.mode,
+      githubInstallationId: installationId,
+      githubAccountLogin: row.github_account_login as string | null,
+      status: row.status as "pending" | "verified" | "suspended" | "revoked"
+    };
+  });
+}
+
+function parseGrants(value: unknown): Array<{
+  accountId: string;
+  kind: "internal_admin" | "trial" | "legacy";
+  expiresAt: string | null;
+}> {
+  if (!Array.isArray(value)) throw new Error("invalid grants response");
+  return value.map((row) => {
+    if (!isRecord(row) || typeof row.account_id !== "string" || !UUID.test(row.account_id)) {
+      throw new Error("invalid grant account");
+    }
+    if (row.status !== "active") throw new Error("inactive grant in active snapshot");
+    if (row.grant_kind !== "internal_admin" && row.grant_kind !== "trial" && row.grant_kind !== "legacy") {
+      throw new Error("invalid grant kind");
+    }
+    if (row.expires_at !== null && (typeof row.expires_at !== "string" || !Number.isFinite(Date.parse(row.expires_at)))) {
+      throw new Error("invalid grant expiry");
+    }
+    return {
+      accountId: row.account_id,
+      kind: row.grant_kind,
+      expiresAt: row.expires_at as string | null
+    };
+  });
+}
+
+function entitlementFor(
+  grants: Array<{ kind: "internal_admin" | "trial" | "legacy"; expiresAt: string | null }>,
+  at: Date
+): "public_free" | "internal_admin" | "trial" {
+  const active = grants.filter((grant) => !grant.expiresAt || Date.parse(grant.expiresAt) > at.getTime());
+  if (active.some((grant) => grant.kind === "internal_admin")) return "internal_admin";
+  if (active.some((grant) => grant.kind === "trial")) return "trial";
+  return "public_free";
+}
+
+function normalized(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function required(values: ReadonlyMap<Setting, string>, setting: Setting): string {
+  const value = values.get(setting);
+  if (!value) throw new Error(`missing validated setting: ${setting}`);
+  return value;
+}
+
+function normalizedHttpsUrl(value: string, options: { allowPath: string }): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (
+    url.protocol !== "https:"
+    || url.username
+    || url.password
+    || url.port
+    || url.search
+    || url.hash
+    || url.pathname.replace(/\/$/, "") !== options.allowPath
+  ) {
+    return undefined;
+  }
+  url.pathname = options.allowPath || "/";
+  return url.toString().replace(/\/$/, "");
+}
+
+function invalid(setting: string, reason: string): AccountLinkRuntimeConfig {
+  return { status: "invalid", setting, reason };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/services/license-api/src/account-link/runtime-config.ts
+++ b/services/license-api/src/account-link/runtime-config.ts
@@ -6,6 +6,7 @@ import type { AccountAuthority, AccountWorkspaceSnapshot } from "./service.js";
 
 const SETTINGS = [
   "ACCOUNT_LINK_DB_PATH",
+  "GITHUB_BROKER_DB_PATH",
   "ACCOUNT_LINK_CONNECT_ORIGIN",
   "ACCOUNT_LINK_SUPABASE_URL",
   "ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY",
@@ -41,6 +42,13 @@ export function loadAccountLinkRuntimeConfig(
   if (!isAbsolute(dbPath)) return invalid("ACCOUNT_LINK_DB_PATH", "must_be_absolute");
   if (sameFileIdentity(dbPath, licenseDbPath)) {
     return invalid("ACCOUNT_LINK_DB_PATH", "must_differ_from_license_db");
+  }
+  const brokerDbPath = required(values, "GITHUB_BROKER_DB_PATH");
+  if (!isAbsolute(brokerDbPath)) {
+    return invalid("GITHUB_BROKER_DB_PATH", "must_be_absolute");
+  }
+  if (!sameFileIdentity(dbPath, brokerDbPath)) {
+    return invalid("ACCOUNT_LINK_DB_PATH", "must_match_github_broker_db");
   }
 
   const connectOrigin = normalizedHttpsUrl(

--- a/services/license-api/src/account-link/runtime-config.ts
+++ b/services/license-api/src/account-link/runtime-config.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, resolve } from "node:path";
+import { statSync } from "node:fs";
 import { GitHubBrokerStore } from "../github-broker/store.js";
 import type { AccountLinkDeps } from "./routes.js";
 import type { AccountAuthority, AccountWorkspaceSnapshot } from "./service.js";
@@ -38,7 +39,7 @@ export function loadAccountLinkRuntimeConfig(
 
   const dbPath = required(values, "ACCOUNT_LINK_DB_PATH");
   if (!isAbsolute(dbPath)) return invalid("ACCOUNT_LINK_DB_PATH", "must_be_absolute");
-  if (resolve(dbPath) === resolve(licenseDbPath)) {
+  if (sameFileIdentity(dbPath, licenseDbPath)) {
     return invalid("ACCOUNT_LINK_DB_PATH", "must_differ_from_license_db");
   }
 
@@ -217,11 +218,25 @@ async function supabaseGet(
 async function boundedJson(response: Response): Promise<unknown> {
   const declared = Number(response.headers.get("content-length") ?? 0);
   if (declared > MAX_RESPONSE_BYTES) throw new Error("account authority response too large");
-  const text = await response.text();
-  if (Buffer.byteLength(text) > MAX_RESPONSE_BYTES) {
-    throw new Error("account authority response too large");
+  if (!response.body) return JSON.parse("") as unknown;
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error("account authority response too large");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
   }
-  return JSON.parse(text) as unknown;
+  return JSON.parse(Buffer.concat(chunks, size).toString("utf8")) as unknown;
 }
 
 function supabaseHeaders(key: string): Record<string, string> {
@@ -350,11 +365,23 @@ function parseGrants(value: unknown): Array<{
 function entitlementFor(
   grants: Array<{ kind: "internal_admin" | "trial" | "legacy"; expiresAt: string | null }>,
   at: Date
-): "public_free" | "internal_admin" | "trial" {
+): "public_free" | "paid" | "internal_admin" | "trial" {
   const active = grants.filter((grant) => !grant.expiresAt || Date.parse(grant.expiresAt) > at.getTime());
   if (active.some((grant) => grant.kind === "internal_admin")) return "internal_admin";
   if (active.some((grant) => grant.kind === "trial")) return "trial";
+  if (active.some((grant) => grant.kind === "legacy")) return "paid";
   return "public_free";
+}
+
+function sameFileIdentity(left: string, right: string): boolean {
+  if (resolve(left) === resolve(right)) return true;
+  try {
+    const leftStat = statSync(left);
+    const rightStat = statSync(right);
+    return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino;
+  } catch {
+    return false;
+  }
 }
 
 function normalized(value: string | undefined): string | undefined {

--- a/services/license-api/src/account-link/service.ts
+++ b/services/license-api/src/account-link/service.ts
@@ -1,0 +1,189 @@
+import { createHash, randomBytes } from "node:crypto";
+import { RateLimiter } from "../service.js";
+import { authenticateDevice, deviceIdFromPublicJwk } from "../github-broker/device-auth.js";
+import { BrokerError } from "../github-broker/errors.js";
+import { GitHubBrokerStore } from "../github-broker/store.js";
+
+const STATE_TTL_MS = 10 * 60 * 1_000;
+const MAX_ACCESS_TOKEN_LENGTH = 4_096;
+
+export interface AccountBotSnapshot {
+  id: string;
+  appId: number;
+  appSlug: string;
+  mode: "byo" | "managed";
+  githubInstallationId: number | null;
+  githubAccountLogin: string | null;
+  status: "pending" | "verified" | "suspended" | "revoked";
+}
+
+export interface AccountWorkspaceSnapshot {
+  accounts: Array<{
+    id: string;
+    kind: "personal" | "organization";
+    name: string;
+    role: "owner" | "admin" | "member";
+    entitlement: "public_free" | "paid" | "internal_admin" | "trial" | "none";
+    bots: AccountBotSnapshot[];
+  }>;
+}
+
+/** Trusted server seam for Lovable/Supabase identity verification and snapshots. */
+export interface AccountAuthority {
+  connectOrigin: string;
+  verifyAccessToken(accessToken: string): Promise<string | null>;
+  loadWorkspaceSnapshot(userId: string): Promise<AccountWorkspaceSnapshot>;
+}
+
+export interface AccountLinkServiceOptions {
+  store: GitHubBrokerStore;
+  authority: AccountAuthority;
+  now?: () => Date;
+  registerRateLimiter?: RateLimiter;
+  connectRateLimiter?: RateLimiter;
+}
+
+/** B0-safe account linking; independent from the managed GitHub App runtime. */
+export class AccountLinkService {
+  private readonly store: GitHubBrokerStore;
+  private readonly authority: AccountAuthority;
+  private readonly now: () => Date;
+  private readonly registerRateLimiter: RateLimiter;
+  private readonly connectRateLimiter: RateLimiter;
+
+  constructor(options: AccountLinkServiceOptions) {
+    this.store = options.store;
+    this.authority = options.authority;
+    this.now = options.now ?? (() => new Date());
+    this.registerRateLimiter =
+      options.registerRateLimiter ?? new RateLimiter({ maxPerWindow: 20, windowMs: 60_000 });
+    this.connectRateLimiter =
+      options.connectRateLimiter ?? new RateLimiter({ maxPerWindow: 30, windowMs: 60_000 });
+  }
+
+  async registerDevice(body: unknown, sourceAddress: string): Promise<Record<string, unknown>> {
+    const at = this.now();
+    if (!this.registerRateLimiter.allow(hash(`account-register:${sourceAddress}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many account device registrations");
+    }
+    const record = asObject(body);
+    const { deviceId, publicJwk } = await deviceIdFromPublicJwk(record.publicKeyJwk);
+    this.store.upsertDevice(deviceId, JSON.stringify(publicJwk), at.toISOString());
+    return { status: "registered", deviceId };
+  }
+
+  async connectStart(
+    authorization: string | string[] | undefined
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    if (!this.connectRateLimiter.allow(hash(`account-connect:${deviceId}`), at.getTime())) {
+      throw new BrokerError("rate_limited", "too many account link attempts");
+    }
+    const state = randomBytes(32).toString("base64url");
+    const expiresAt = new Date(at.getTime() + STATE_TTL_MS);
+    this.store.createAccountConnectState(
+      hash(state),
+      deviceId,
+      at.toISOString(),
+      expiresAt.toISOString()
+    );
+    const connectUrl = new URL(this.authority.connectOrigin);
+    connectUrl.searchParams.set("state", state);
+    return {
+      status: "account_connect_started",
+      connectUrl: connectUrl.toString(),
+      state,
+      expiresAt: expiresAt.toISOString()
+    };
+  }
+
+  async connectComplete(
+    authorization: string | string[] | undefined,
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const state = requiredState(body);
+    const stateHash = hash(state);
+    const stored = this.store.getAccountConnectState(stateHash);
+    if (!stored) throw new BrokerError("state_not_found", "account link state is not recognized");
+    if (stored.consumed_at) throw new BrokerError("state_replayed", "account link state was already used");
+    if (Date.parse(stored.expires_at) <= at.getTime()) {
+      throw new BrokerError("state_expired", "account link state has expired");
+    }
+
+    let userId: string | null;
+    try {
+      userId = await this.authority.verifyAccessToken(accountBearerToken(authorization));
+    } catch (error) {
+      if (error instanceof BrokerError) throw error;
+      throw new BrokerError(
+        "account_authority_unavailable",
+        "account identity service is unavailable"
+      );
+    }
+    if (!userId) {
+      throw new BrokerError(
+        "account_identity_unverified",
+        "the signed-in account identity could not be verified"
+      );
+    }
+    if (!this.store.consumeAccountConnectStateAndBind(stateHash, userId, at.toISOString())) {
+      throw new BrokerError("state_replayed", "account link state was already used");
+    }
+    return { status: "account_linked" };
+  }
+
+  async workspaces(
+    authorization: string | string[] | undefined
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    const binding = this.store.getAccountBinding(deviceId);
+    if (!binding) {
+      throw new BrokerError("account_link_required", "link a signed-in NeonDiff account first");
+    }
+    try {
+      return {
+        status: "ready",
+        ...(await this.authority.loadWorkspaceSnapshot(binding.user_id))
+      };
+    } catch {
+      throw new BrokerError(
+        "account_authority_unavailable",
+        "account workspace service is unavailable"
+      );
+    }
+  }
+}
+
+function requiredState(body: unknown): string {
+  const state = asObject(body).state;
+  if (typeof state !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(state)) {
+    throw new BrokerError("invalid_request", "state is invalid");
+  }
+  return state;
+}
+
+function accountBearerToken(authorization: string | string[] | undefined): string {
+  const value = Array.isArray(authorization) ? authorization[0] : authorization;
+  if (!value?.startsWith("Bearer ")) {
+    throw new BrokerError("account_identity_unverified", "signed-in account proof is required");
+  }
+  const token = value.slice("Bearer ".length);
+  if (!token || token.length > MAX_ACCESS_TOKEN_LENGTH || /\s/.test(token)) {
+    throw new BrokerError("account_identity_unverified", "signed-in account proof is invalid");
+  }
+  return token;
+}
+
+function asObject(body: unknown): Record<string, unknown> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new BrokerError("invalid_request", "request body must be a JSON object");
+  }
+  return body as Record<string, unknown>;
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/services/license-api/src/account-link/service.ts
+++ b/services/license-api/src/account-link/service.ts
@@ -41,6 +41,7 @@ export interface AccountLinkServiceOptions {
   now?: () => Date;
   registerRateLimiter?: RateLimiter;
   connectRateLimiter?: RateLimiter;
+  completeRateLimiter?: RateLimiter;
 }
 
 /** B0-safe account linking; independent from the managed GitHub App runtime. */
@@ -50,6 +51,7 @@ export class AccountLinkService {
   private readonly now: () => Date;
   private readonly registerRateLimiter: RateLimiter;
   private readonly connectRateLimiter: RateLimiter;
+  private readonly completeRateLimiter: RateLimiter;
 
   constructor(options: AccountLinkServiceOptions) {
     this.store = options.store;
@@ -59,6 +61,12 @@ export class AccountLinkService {
       options.registerRateLimiter ?? new RateLimiter({ maxPerWindow: 20, windowMs: 60_000 });
     this.connectRateLimiter =
       options.connectRateLimiter ?? new RateLimiter({ maxPerWindow: 30, windowMs: 60_000 });
+    this.completeRateLimiter =
+      options.completeRateLimiter ?? new RateLimiter({ maxPerWindow: 10, windowMs: 60_000 });
+  }
+
+  get connectOrigin(): string {
+    return this.authority.connectOrigin;
   }
 
   async registerDevice(body: unknown, sourceAddress: string): Promise<Record<string, unknown>> {
@@ -110,6 +118,14 @@ export class AccountLinkService {
     if (stored.consumed_at) throw new BrokerError("state_replayed", "account link state was already used");
     if (Date.parse(stored.expires_at) <= at.getTime()) {
       throw new BrokerError("state_expired", "account link state has expired");
+    }
+    if (
+      !this.completeRateLimiter.allow(
+        hash(`account-complete:${stored.device_id}`),
+        at.getTime()
+      )
+    ) {
+      throw new BrokerError("rate_limited", "too many account completion attempts");
     }
 
     let userId: string | null;

--- a/services/license-api/src/account-link/service.ts
+++ b/services/license-api/src/account-link/service.ts
@@ -42,6 +42,7 @@ export interface AccountLinkServiceOptions {
   registerRateLimiter?: RateLimiter;
   connectRateLimiter?: RateLimiter;
   completeRateLimiter?: RateLimiter;
+  workspaceRateLimiter?: RateLimiter;
 }
 
 /** B0-safe account linking; independent from the managed GitHub App runtime. */
@@ -52,6 +53,7 @@ export class AccountLinkService {
   private readonly registerRateLimiter: RateLimiter;
   private readonly connectRateLimiter: RateLimiter;
   private readonly completeRateLimiter: RateLimiter;
+  private readonly workspaceRateLimiter: RateLimiter;
 
   constructor(options: AccountLinkServiceOptions) {
     this.store = options.store;
@@ -63,6 +65,8 @@ export class AccountLinkService {
       options.connectRateLimiter ?? new RateLimiter({ maxPerWindow: 30, windowMs: 60_000 });
     this.completeRateLimiter =
       options.completeRateLimiter ?? new RateLimiter({ maxPerWindow: 10, windowMs: 60_000 });
+    this.workspaceRateLimiter =
+      options.workspaceRateLimiter ?? new RateLimiter({ maxPerWindow: 30, windowMs: 60_000 });
   }
 
   get connectOrigin(): string {
@@ -144,7 +148,15 @@ export class AccountLinkService {
         "the signed-in account identity could not be verified"
       );
     }
-    if (!this.store.consumeAccountConnectStateAndBind(stateHash, userId, at.toISOString())) {
+    const completedAt = this.now();
+    if (Date.parse(stored.expires_at) <= completedAt.getTime()) {
+      throw new BrokerError("state_expired", "account link state has expired");
+    }
+    if (!this.store.consumeAccountConnectStateAndBind(
+      stateHash,
+      userId,
+      completedAt.toISOString()
+    )) {
       throw new BrokerError("state_replayed", "account link state was already used");
     }
     return { status: "account_linked" };
@@ -158,6 +170,12 @@ export class AccountLinkService {
     const binding = this.store.getAccountBinding(deviceId);
     if (!binding) {
       throw new BrokerError("account_link_required", "link a signed-in NeonDiff account first");
+    }
+    if (!this.workspaceRateLimiter.allow(
+      hash(`account-workspaces:${deviceId}`),
+      at.getTime()
+    )) {
+      throw new BrokerError("rate_limited", "too many account workspace refreshes");
     }
     try {
       return {

--- a/services/license-api/src/github-broker/errors.ts
+++ b/services/license-api/src/github-broker/errors.ts
@@ -16,6 +16,9 @@ export type BrokerReason =
   | "installation_uninstalled"
   | "installation_suspended"
   | "installation_authorization_unverified"
+  | "account_link_required"
+  | "account_identity_unverified"
+  | "account_authority_unavailable"
   | "repo_outside_installation"
   | "repo_outside_authorization"
   | "repo_renamed_or_transferred"
@@ -43,6 +46,9 @@ const REASON_STATUS: Record<BrokerReason, number> = {
   installation_uninstalled: 409,
   installation_suspended: 409,
   installation_authorization_unverified: 403,
+  account_link_required: 403,
+  account_identity_unverified: 403,
+  account_authority_unavailable: 503,
   repo_outside_installation: 403,
   repo_outside_authorization: 403,
   repo_renamed_or_transferred: 409,

--- a/services/license-api/src/github-broker/routes.ts
+++ b/services/license-api/src/github-broker/routes.ts
@@ -135,7 +135,10 @@ function readBody(req: IncomingMessage): Promise<unknown> {
 
 function writeJson(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body);
-  res.writeHead(status, { "Content-Type": "application/json" });
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store"
+  });
   res.end(payload);
 }
 

--- a/services/license-api/src/github-broker/store.ts
+++ b/services/license-api/src/github-broker/store.ts
@@ -342,16 +342,20 @@ export class GitHubBrokerStore {
     this.db.exec("begin immediate");
     try {
       const state = this.getAccountConnectState(stateHash);
-      if (!state || state.consumed_at) {
+      if (
+        !state
+        || state.consumed_at
+        || Date.parse(state.expires_at) <= Date.parse(consumedAt)
+      ) {
         this.db.exec("rollback");
         return false;
       }
       const info = this.db
         .prepare(
           `update account_connect_states set consumed_at = ?
-           where state_hash = ? and consumed_at is null`
+           where state_hash = ? and consumed_at is null and expires_at > ?`
         )
-        .run(consumedAt, stateHash);
+        .run(consumedAt, stateHash, consumedAt);
       if (Number(info.changes) === 0) {
         this.db.exec("rollback");
         return false;

--- a/services/license-api/src/github-broker/store.ts
+++ b/services/license-api/src/github-broker/store.ts
@@ -13,7 +13,7 @@ import { DatabaseSync } from "node:sqlite";
  * states, installation bindings, and an append-only decision ledger. No tokens,
  * private keys, source, or diffs are ever stored.
  */
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const DEFAULT_BUSY_TIMEOUT_MS = 250;
 
 /**
@@ -29,6 +29,24 @@ const BINDING_REPOSITORIES_TABLE = `
     primary key (device_id, installation_id, full_name),
     foreign key (device_id, installation_id)
       references installation_bindings(device_id, installation_id) on delete cascade
+  );
+`;
+
+const ACCOUNT_LINK_TABLES = `
+  create table account_connect_states (
+    state_hash text primary key,
+    device_id text not null,
+    created_at text not null,
+    expires_at text not null,
+    consumed_at text,
+    foreign key (device_id) references devices(device_id)
+  );
+
+  create table account_bindings (
+    device_id text primary key,
+    user_id text not null,
+    linked_at text not null,
+    foreign key (device_id) references devices(device_id)
   );
 `;
 
@@ -60,6 +78,8 @@ const SCHEMA = `
   );
 
   ${BINDING_REPOSITORIES_TABLE.trim()}
+
+  ${ACCOUNT_LINK_TABLES.trim()}
 
   create table decision_ledger (
     id integer primary key autoincrement,
@@ -94,6 +114,20 @@ export interface InstallationBindingRow {
   created_at: string;
 }
 
+export interface AccountConnectStateRow {
+  state_hash: string;
+  device_id: string;
+  created_at: string;
+  expires_at: string;
+  consumed_at: string | null;
+}
+
+export interface AccountBindingRow {
+  device_id: string;
+  user_id: string;
+  linked_at: string;
+}
+
 export interface DecisionLedgerRow {
   id: number;
   device_id: string;
@@ -121,7 +155,7 @@ export class GitHubBrokerStore {
   private ensureSchema(): void {
     const version = this.readUserVersion();
     if (version === SCHEMA_VERSION) return;
-    if (version !== 0 && version !== 1) {
+    if (version !== 0 && version !== 1 && version !== 2) {
       throw new Error(`unsupported github broker schema version ${version}`);
     }
     this.db.exec("begin immediate");
@@ -135,12 +169,16 @@ export class GitHubBrokerStore {
       if (current === 0) {
         // Fresh bootstrap: the full schema (already includes binding_repositories).
         this.db.exec(SCHEMA);
-      } else {
+      } else if (current === 1) {
         // v1 -> v2 upgrade: base v1 shipped installation_bindings WITHOUT the
         // per-repo authorized-set table, so an existing broker DB must gain it in
         // place — otherwise upsertBinding/listBindingRepositories hit "no such
         // table". Idempotent and crash-safe under the same writer transaction.
         this.db.exec(BINDING_REPOSITORIES_TABLE);
+        this.db.exec(ACCOUNT_LINK_TABLES);
+      } else {
+        // v2 -> v3 adds the account-link state and device/user binding tables.
+        this.db.exec(ACCOUNT_LINK_TABLES);
       }
       this.db.exec(`pragma user_version = ${SCHEMA_VERSION}`);
       this.db.exec("commit");
@@ -258,6 +296,72 @@ export class GitHubBrokerStore {
       .prepare("select full_name from binding_repositories where device_id = ? and installation_id = ?")
       .all(deviceId, installationId) as Array<{ full_name: string }>;
     return rows.map((row) => row.full_name);
+  }
+
+  createAccountConnectState(
+    stateHash: string,
+    deviceId: string,
+    createdAt: string,
+    expiresAt: string
+  ): void {
+    this.db
+      .prepare(
+        `insert into account_connect_states
+         (state_hash, device_id, created_at, expires_at)
+         values (?, ?, ?, ?)`
+      )
+      .run(stateHash, deviceId, createdAt, expiresAt);
+  }
+
+  getAccountConnectState(stateHash: string): AccountConnectStateRow | undefined {
+    return this.db
+      .prepare("select * from account_connect_states where state_hash = ?")
+      .get(stateHash) as AccountConnectStateRow | undefined;
+  }
+
+  /** Atomically consume a one-shot account state and bind its device to one user. */
+  consumeAccountConnectStateAndBind(
+    stateHash: string,
+    userId: string,
+    consumedAt: string
+  ): boolean {
+    this.db.exec("begin immediate");
+    try {
+      const state = this.getAccountConnectState(stateHash);
+      if (!state || state.consumed_at) {
+        this.db.exec("rollback");
+        return false;
+      }
+      const info = this.db
+        .prepare(
+          `update account_connect_states set consumed_at = ?
+           where state_hash = ? and consumed_at is null`
+        )
+        .run(consumedAt, stateHash);
+      if (Number(info.changes) === 0) {
+        this.db.exec("rollback");
+        return false;
+      }
+      this.db
+        .prepare(
+          `insert into account_bindings (device_id, user_id, linked_at)
+           values (?, ?, ?)
+           on conflict (device_id)
+           do update set user_id = excluded.user_id, linked_at = excluded.linked_at`
+        )
+        .run(state.device_id, userId, consumedAt);
+      this.db.exec("commit");
+      return true;
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  getAccountBinding(deviceId: string): AccountBindingRow | undefined {
+    return this.db
+      .prepare("select * from account_bindings where device_id = ?")
+      .get(deviceId) as AccountBindingRow | undefined;
   }
 
   /** Append a public-safe decision row. Never carries repo content or key material. */

--- a/services/license-api/src/github-broker/store.ts
+++ b/services/license-api/src/github-broker/store.ts
@@ -15,6 +15,7 @@ import { DatabaseSync } from "node:sqlite";
  */
 const SCHEMA_VERSION = 3;
 const DEFAULT_BUSY_TIMEOUT_MS = 250;
+const ACCOUNT_CONNECT_CONSUMED_RETENTION_MS = 24 * 60 * 60 * 1_000;
 
 /**
  * The per-repo authorized-set table. Extracted so a fresh bootstrap and the
@@ -304,6 +305,19 @@ export class GitHubBrokerStore {
     createdAt: string,
     expiresAt: string
   ): void {
+    const createdAtMs = Date.parse(createdAt);
+    if (Number.isFinite(createdAtMs)) {
+      const consumedCutoff = new Date(
+        createdAtMs - ACCOUNT_CONNECT_CONSUMED_RETENTION_MS
+      ).toISOString();
+      this.db
+        .prepare(
+          `delete from account_connect_states
+           where expires_at <= ?
+              or (consumed_at is not null and consumed_at <= ?)`
+        )
+        .run(createdAt, consumedCutoff);
+    }
     this.db
       .prepare(
         `insert into account_connect_states

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -43,6 +43,12 @@ import {
   isGitHubBrokerPath,
   type GitHubBrokerDeps
 } from "./github-broker/index.js";
+import {
+  createAccountLinkService,
+  handleAccountLinkRequest,
+  isAccountLinkPath,
+  type AccountLinkDeps
+} from "./account-link/index.js";
 
 const MAX_BODY_BYTES = 16 * 1024;
 const CANONICAL_GITHUB_REPOSITORY_PATTERN =
@@ -63,6 +69,8 @@ export interface LicenseHttpOptions {
   now?: () => Date;
   /** Managed GitHub App authorization broker (#613). Omitted → broker routes 503. */
   githubBroker?: GitHubBrokerDeps;
+  /** Lovable account linking is independent from the managed GitHub App lane. */
+  accountLink?: AccountLinkDeps;
 }
 
 type Handler = (store: LicenseStore, req: LicenseRequest, now: Date) => ServiceResult;
@@ -92,12 +100,26 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
   const githubBrokerService = options.githubBroker
     ? createGitHubBrokerService(options.githubBroker)
     : undefined;
+  const accountLinkService = options.accountLink
+    ? createAccountLinkService(options.accountLink)
+    : undefined;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (req.method === "GET" && req.url === "/healthz") {
       return writeJson(res, 200, { status: "ok" });
     }
     const path = req.url?.split("?")[0];
+    if (isAccountLinkPath(path)) {
+      if (!accountLinkService) {
+        const unavailable = new BrokerError(
+          "account_authority_unavailable",
+          "account linking is not configured"
+        );
+        return writeJson(res, unavailable.httpStatus, unavailable.body());
+      }
+      const sourceAddress = resolveClientAddress(req, options.trustFlyProxyHeaders === true);
+      return handleAccountLinkRequest(accountLinkService, req, res, { sourceAddress });
+    }
     if (isGitHubBrokerPath(path)) {
       if (!githubBrokerService) {
         // Fail closed with the broker's typed contract so clients (and tests) can

--- a/services/license-api/src/server.ts
+++ b/services/license-api/src/server.ts
@@ -4,6 +4,7 @@ import { createGitHubActionsOidcVerifier } from "./oidc-lifecycle.js";
 import { RateLimiter } from "./service.js";
 import { loadGitHubBrokerRuntimeConfig } from "./github-broker/runtime-config.js";
 import { createLicenseStoreEntitlementResolver } from "./github-broker/license-entitlement.js";
+import { loadAccountLinkRuntimeConfig } from "./account-link/runtime-config.js";
 
 /**
  * Production entrypoint. SQLite lives on a mounted volume in deploy
@@ -19,6 +20,7 @@ async function main(): Promise<void> {
   const trustFlyProxyHeaders = Boolean(process.env.FLY_APP_NAME?.trim());
   const store = new LicenseStore(dbPath);
   const githubBrokerRuntime = loadGitHubBrokerRuntimeConfig(process.env, dbPath);
+  const accountLinkRuntime = loadAccountLinkRuntimeConfig(process.env, dbPath);
   if (githubBrokerRuntime.status === "invalid") {
     // Setting name + fixed reason are public-safe. Never log the submitted value.
     // The license API remains available while every broker route fails closed
@@ -26,6 +28,13 @@ async function main(): Promise<void> {
     // eslint-disable-next-line no-console
     console.error(
       `github broker unavailable: ${githubBrokerRuntime.setting} ${githubBrokerRuntime.reason}`
+    );
+  }
+  if (accountLinkRuntime.status === "invalid") {
+    // Setting name + fixed reason only; never log Supabase keys or submitted values.
+    // eslint-disable-next-line no-console
+    console.error(
+      `account link unavailable: ${accountLinkRuntime.setting} ${accountLinkRuntime.reason}`
     );
   }
   const { url } = await startLicenseServer({
@@ -39,6 +48,9 @@ async function main(): Promise<void> {
       windowMs: 60_000
     }),
     lifecycleOidcVerifier: createGitHubActionsOidcVerifier(),
+    ...(accountLinkRuntime.status === "ready"
+      ? { accountLink: accountLinkRuntime.deps }
+      : {}),
     ...(githubBrokerRuntime.status === "ready"
       ? {
           githubBroker: {

--- a/services/license-api/test/account-link-contract.test.ts
+++ b/services/license-api/test/account-link-contract.test.ts
@@ -7,6 +7,7 @@ import {
   startBroker,
   type BrokerHarness
 } from "./github-broker-support.ts";
+import { RateLimiter } from "../src/service.ts";
 
 const CONNECT_ORIGIN = "https://www.neondiff.com/desktop/connect";
 
@@ -220,6 +221,89 @@ describe("Lovable account link contract", () => {
     assert.equal(outage.status, 503);
     assert.equal(outage.json.reason, "account_authority_unavailable");
     assert.doesNotMatch(outage.text, /sensitive upstream detail/);
+  });
+
+  test("rate-limits browser completion before calling the Supabase identity seam", async () => {
+    let identityCalls = 0;
+    const harness = await startBroker({
+      accountCompleteRateLimiter: new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 }),
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          identityCalls += 1;
+          return null;
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    await registerAccountDevice(harness.url, device);
+    const start = await post(
+      harness.url,
+      "/account/connect/start",
+      {},
+      bearer(await device.sign())
+    );
+
+    const first = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("first-invalid-token")
+    );
+    const throttled = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("second-invalid-token")
+    );
+
+    assert.equal(first.status, 403);
+    assert.equal(throttled.status, 429);
+    assert.equal(throttled.json.reason, "rate_limited");
+    assert.equal(identityCalls, 1);
+  });
+
+  test("permits CORS only for the configured NeonDiff connect origin", async () => {
+    const harness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return "user-owner";
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+
+    const allowed = await fetch(`${harness.url}/account/connect/complete`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://www.neondiff.com",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "authorization,content-type"
+      }
+    });
+    assert.equal(allowed.status, 204);
+    assert.equal(allowed.headers.get("access-control-allow-origin"), "https://www.neondiff.com");
+    assert.equal(allowed.headers.get("vary"), "Origin");
+
+    const denied = await fetch(`${harness.url}/account/connect/complete`, {
+      method: "POST",
+      headers: {
+        Origin: "https://attacker.example",
+        Authorization: "Bearer never-forwarded",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ state: "a".repeat(43) })
+    });
+    assert.equal(denied.status, 403);
+    assert.equal(denied.headers.get("access-control-allow-origin"), null);
   });
 
   test("expired state and disabled account runtime return typed safe failures", async () => {

--- a/services/license-api/test/account-link-contract.test.ts
+++ b/services/license-api/test/account-link-contract.test.ts
@@ -267,6 +267,51 @@ describe("Lovable account link contract", () => {
     assert.equal(identityCalls, 1);
   });
 
+  test("rate-limits workspace refreshes before calling the Supabase authority", async () => {
+    let workspaceCalls = 0;
+    const harness = await startBroker({
+      accountWorkspaceRateLimiter: new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 }),
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return "user-owner";
+        },
+        async loadWorkspaceSnapshot() {
+          workspaceCalls += 1;
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    await registerAccountDevice(harness.url, device);
+    const start = await post(harness.url, "/account/connect/start", {}, bearer(await device.sign()));
+    await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+
+    const first = await post(
+      harness.url,
+      "/account/workspaces",
+      {},
+      bearer(await device.sign())
+    );
+    const throttled = await post(
+      harness.url,
+      "/account/workspaces",
+      {},
+      bearer(await device.sign())
+    );
+
+    assert.equal(first.status, 200);
+    assert.equal(throttled.status, 429);
+    assert.equal(throttled.json.reason, "rate_limited");
+    assert.equal(workspaceCalls, 1);
+  });
+
   test("permits CORS only for the configured NeonDiff connect origin", async () => {
     const harness = await startBroker({
       accountAuthority: {
@@ -344,6 +389,50 @@ describe("Lovable account link contract", () => {
     const unavailable = await post(disabled.url, "/account/connect/start", {});
     assert.equal(unavailable.status, 503);
     assert.equal(unavailable.json.reason, "account_authority_unavailable");
+  });
+
+  test("state that expires during identity verification is not consumed or bound", async () => {
+    let clock = new Date("2026-07-26T06:00:00.000Z");
+    const harness = await startBroker({
+      clock: () => clock,
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          clock = new Date("2026-07-26T06:10:00.001Z");
+          return "user-owner";
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    await registerAccountDevice(harness.url, device);
+    const start = await post(
+      harness.url,
+      "/account/connect/start",
+      {},
+      bearer(await device.sign({ now: clock }))
+    );
+
+    const expired = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+    const workspace = await post(
+      harness.url,
+      "/account/workspaces",
+      {},
+      bearer(await device.sign({ now: clock }))
+    );
+
+    assert.equal(expired.status, 409);
+    assert.equal(expired.json.reason, "state_expired");
+    assert.equal(workspace.status, 403);
+    assert.equal(workspace.json.reason, "account_link_required");
   });
 });
 

--- a/services/license-api/test/account-link-contract.test.ts
+++ b/services/license-api/test/account-link-contract.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+import {
+  bearer,
+  makeDevice,
+  post,
+  startBroker,
+  type BrokerHarness
+} from "./github-broker-support.ts";
+
+const CONNECT_ORIGIN = "https://www.neondiff.com/desktop/connect";
+
+const workspaceSnapshot = {
+  accounts: [
+    {
+      id: "account-electric-sheep",
+      kind: "organization",
+      name: "ElectricSheep",
+      role: "admin",
+      entitlement: "internal_admin",
+      bots: [
+        {
+          id: "bot-evaos-code-review-bot",
+          appId: 4_184_532,
+          appSlug: "evaos-code-review-bot",
+          mode: "byo",
+          githubInstallationId: null,
+          githubAccountLogin: "electricsheephq",
+          status: "pending"
+        }
+      ]
+    }
+  ]
+} as const;
+
+describe("Lovable account link contract", () => {
+  const harnesses: BrokerHarness[] = [];
+
+  afterEach(() => {
+    while (harnesses.length > 0) harnesses.pop()?.close();
+  });
+
+  test("signed device starts, authenticated browser completes, and that device loads the snapshot", async () => {
+    const seenTokens: string[] = [];
+    const harness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken(token: string) {
+          seenTokens.push(token);
+          return token === "lovable-user-token" ? "user-owner" : null;
+        },
+        async loadWorkspaceSnapshot(userId: string) {
+          assert.equal(userId, "user-owner");
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    assert.equal((await registerAccountDevice(harness.url, device)).status, 200);
+
+    const start = await post(
+      harness.url,
+      "/account/connect/start",
+      {},
+      bearer(await device.sign())
+    );
+    assert.equal(start.status, 200);
+    assert.equal(start.json.status, "account_connect_started");
+    assert.match(start.json.connectUrl, /^https:\/\/www\.neondiff\.com\/desktop\/connect\?state=/);
+    assert.equal(typeof start.json.state, "string");
+
+    const complete = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+    assert.equal(complete.status, 200);
+    assert.deepEqual(complete.json, { status: "account_linked" });
+
+    const snapshot = await post(
+      harness.url,
+      "/account/workspaces",
+      {},
+      bearer(await device.sign())
+    );
+    assert.equal(snapshot.status, 200);
+    assert.deepEqual(snapshot.json, { status: "ready", ...workspaceSnapshot });
+    assert.deepEqual(seenTokens, ["lovable-user-token"]);
+    assert.doesNotMatch(JSON.stringify(snapshot.json), /lovable-user-token/);
+  });
+
+  test("link state is single-use", async () => {
+    const harness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return "user-owner";
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    await registerAccountDevice(harness.url, device);
+    const start = await post(harness.url, "/account/connect/start", {}, bearer(await device.sign()));
+
+    const first = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+    const replay = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+
+    assert.equal(first.status, 200);
+    assert.equal(replay.status, 409);
+    assert.equal(replay.json.reason, "state_replayed");
+  });
+
+  test("a different device cannot read the linked account", async () => {
+    const harness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return "user-owner";
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const ownerDevice = await makeDevice();
+    const otherDevice = await makeDevice();
+    await registerAccountDevice(harness.url, ownerDevice);
+    await registerAccountDevice(harness.url, otherDevice);
+    const start = await post(harness.url, "/account/connect/start", {}, bearer(await ownerDevice.sign()));
+    await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+
+    const denied = await post(
+      harness.url,
+      "/account/workspaces",
+      {},
+      bearer(await otherDevice.sign())
+    );
+    assert.equal(denied.status, 403);
+    assert.equal(denied.json.reason, "account_link_required");
+  });
+
+  test("invalid browser identity and authority outage both fail closed", async () => {
+    const invalidHarness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return null;
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(invalidHarness);
+    const invalidDevice = await makeDevice();
+    await registerAccountDevice(invalidHarness.url, invalidDevice);
+    const invalidStart = await post(
+      invalidHarness.url,
+      "/account/connect/start",
+      {},
+      bearer(await invalidDevice.sign())
+    );
+    const invalid = await post(
+      invalidHarness.url,
+      "/account/connect/complete",
+      { state: invalidStart.json.state },
+      bearer("bad-token")
+    );
+    assert.equal(invalid.status, 403);
+    assert.equal(invalid.json.reason, "account_identity_unverified");
+
+    const outageHarness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          throw new Error("sensitive upstream detail");
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(outageHarness);
+    const outageDevice = await makeDevice();
+    await registerAccountDevice(outageHarness.url, outageDevice);
+    const outageStart = await post(
+      outageHarness.url,
+      "/account/connect/start",
+      {},
+      bearer(await outageDevice.sign())
+    );
+    const outage = await post(
+      outageHarness.url,
+      "/account/connect/complete",
+      { state: outageStart.json.state },
+      bearer("lovable-user-token")
+    );
+    assert.equal(outage.status, 503);
+    assert.equal(outage.json.reason, "account_authority_unavailable");
+    assert.doesNotMatch(outage.text, /sensitive upstream detail/);
+  });
+
+  test("expired state and disabled account runtime return typed safe failures", async () => {
+    let clock = new Date("2026-07-26T06:00:00.000Z");
+    const harness = await startBroker({
+      clock: () => clock,
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return "user-owner";
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    await registerAccountDevice(harness.url, device);
+    const start = await post(
+      harness.url,
+      "/account/connect/start",
+      {},
+      bearer(await device.sign({ now: clock }))
+    );
+    clock = new Date(clock.getTime() + 10 * 60 * 1_000 + 1);
+    const expired = await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+    assert.equal(expired.status, 409);
+    assert.equal(expired.json.reason, "state_expired");
+
+    const disabled = await startBroker();
+    harnesses.push(disabled);
+    const unavailable = await post(disabled.url, "/account/connect/start", {});
+    assert.equal(unavailable.status, 503);
+    assert.equal(unavailable.json.reason, "account_authority_unavailable");
+  });
+});
+
+async function registerAccountDevice(url: string, device: Awaited<ReturnType<typeof makeDevice>>) {
+  return post(url, "/account/device/register", { publicKeyJwk: device.publicJwk });
+}

--- a/services/license-api/test/account-link-runtime.test.ts
+++ b/services/license-api/test/account-link-runtime.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createSupabaseAccountAuthority,
+  loadAccountLinkRuntimeConfig
+} from "../src/account-link/runtime-config.ts";
+
+const BASE_ENV = {
+  ACCOUNT_LINK_ENABLED: "true",
+  ACCOUNT_LINK_DB_PATH: "/data/account-link.sqlite",
+  ACCOUNT_LINK_CONNECT_ORIGIN: "https://www.neondiff.com/desktop/connect",
+  ACCOUNT_LINK_SUPABASE_URL: "https://project.supabase.co",
+  ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_fixture",
+  ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY: "sb_secret_fixture"
+} as const;
+
+describe("account-link runtime configuration", () => {
+  test("is independently disabled without affecting the managed GitHub broker", () => {
+    assert.deepEqual(loadAccountLinkRuntimeConfig({}, "/data/license.sqlite"), {
+      status: "disabled"
+    });
+  });
+
+  test("an enabled missing setting fails closed without returning submitted values", () => {
+    const result = loadAccountLinkRuntimeConfig(
+      { ...BASE_ENV, ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY: undefined },
+      "/data/license.sqlite"
+    );
+    assert.deepEqual(result, {
+      status: "invalid",
+      setting: "ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY",
+      reason: "missing"
+    });
+    assert.doesNotMatch(JSON.stringify(result), /sb_publishable_fixture/);
+  });
+
+  test("ready configuration is separate from the license database", () => {
+    const same = loadAccountLinkRuntimeConfig(
+      { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: "/data/license.sqlite" },
+      "/data/license.sqlite"
+    );
+    assert.deepEqual(same, {
+      status: "invalid",
+      setting: "ACCOUNT_LINK_DB_PATH",
+      reason: "must_differ_from_license_db"
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), "account-link-config-"));
+    try {
+      const ready = loadAccountLinkRuntimeConfig(
+        { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: join(dir, "account-link.sqlite") },
+        join(dir, "license.sqlite")
+      );
+      assert.equal(ready.status, "ready");
+      if (ready.status === "ready") ready.deps.store?.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Supabase account authority", () => {
+  test("verifies the transient user token, then returns only allowed snapshot fields", async () => {
+    const requests: Array<{ url: string; headers: Headers }> = [];
+    const authority = createSupabaseAccountAuthority({
+      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
+      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
+      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
+      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
+      now: () => new Date("2026-07-26T06:00:00.000Z"),
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        const headers = new Headers(init?.headers);
+        requests.push({ url, headers });
+        if (url.endsWith("/auth/v1/user")) {
+          return Response.json({ id: "11111111-1111-4111-8111-111111111111", email: "never-return@example.com" });
+        }
+        if (url.includes("/account_memberships")) {
+          return Response.json([
+            { account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", role: "admin" }
+          ]);
+        }
+        if (url.includes("/accounts")) {
+          return Response.json([
+            {
+              id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              kind: "organization",
+              name: "ElectricSheep"
+            }
+          ]);
+        }
+        if (url.includes("/bot_installations")) {
+          return Response.json([
+            {
+              id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+              account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              app_id: 4_184_532,
+              app_slug: "evaos-code-review-bot",
+              mode: "byo",
+              github_installation_id: null,
+              github_account_login: "electricsheephq",
+              status: "pending"
+            }
+          ]);
+        }
+        if (url.includes("/account_entitlement_grants")) {
+          return Response.json([
+            {
+              account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              grant_kind: "internal_admin",
+              status: "active",
+              expires_at: null
+            }
+          ]);
+        }
+        return new Response("not found", { status: 404 });
+      }
+    });
+
+    assert.equal(
+      await authority.verifyAccessToken("transient-user-token"),
+      "11111111-1111-4111-8111-111111111111"
+    );
+    const snapshot = await authority.loadWorkspaceSnapshot(
+      "11111111-1111-4111-8111-111111111111"
+    );
+    assert.deepEqual(snapshot, {
+      accounts: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          kind: "organization",
+          name: "ElectricSheep",
+          role: "admin",
+          entitlement: "internal_admin",
+          bots: [
+            {
+              id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+              appId: 4_184_532,
+              appSlug: "evaos-code-review-bot",
+              mode: "byo",
+              githubInstallationId: null,
+              githubAccountLogin: "electricsheephq",
+              status: "pending"
+            }
+          ]
+        }
+      ]
+    });
+    assert.doesNotMatch(JSON.stringify(snapshot), /email|transient-user-token/);
+    assert.equal(requests[0]?.headers.get("Authorization"), "Bearer transient-user-token");
+    assert.equal(requests[1]?.headers.get("Authorization"), null);
+    assert.equal(requests[1]?.headers.get("apikey"), "sb_secret_fixture");
+  });
+
+  test("malformed verified bot state fails closed", async () => {
+    const authority = createSupabaseAccountAuthority({
+      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
+      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
+      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
+      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/account_memberships")) {
+          return Response.json([{ account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", role: "admin" }]);
+        }
+        if (url.includes("/accounts")) {
+          return Response.json([{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", kind: "organization", name: "ElectricSheep" }]);
+        }
+        if (url.includes("/bot_installations")) {
+          return Response.json([{
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            app_id: 4_184_532,
+            app_slug: "evaos-code-review-bot",
+            mode: "byo",
+            github_installation_id: null,
+            github_account_login: "electricsheephq",
+            status: "verified"
+          }]);
+        }
+        if (url.includes("/account_entitlement_grants")) return Response.json([]);
+        return Response.json({ id: "11111111-1111-4111-8111-111111111111" });
+      }
+    });
+    await assert.rejects(
+      authority.loadWorkspaceSnapshot("11111111-1111-4111-8111-111111111111")
+    );
+  });
+});

--- a/services/license-api/test/account-link-runtime.test.ts
+++ b/services/license-api/test/account-link-runtime.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { linkSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { linkSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -10,7 +10,8 @@ import {
 
 const BASE_ENV = {
   ACCOUNT_LINK_ENABLED: "true",
-  ACCOUNT_LINK_DB_PATH: "/data/account-link.sqlite",
+  ACCOUNT_LINK_DB_PATH: "/data/github-broker.sqlite",
+  GITHUB_BROKER_DB_PATH: "/data/github-broker.sqlite",
   ACCOUNT_LINK_CONNECT_ORIGIN: "https://www.neondiff.com/desktop/connect",
   ACCOUNT_LINK_SUPABASE_URL: "https://project.supabase.co",
   ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_fixture",
@@ -37,7 +38,7 @@ describe("account-link runtime configuration", () => {
     assert.doesNotMatch(JSON.stringify(result), /sb_publishable_fixture/);
   });
 
-  test("ready configuration is separate from the license database", () => {
+  test("ready configuration uses the independently replicated GitHub broker database", () => {
     const same = loadAccountLinkRuntimeConfig(
       { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: "/data/license.sqlite" },
       "/data/license.sqlite"
@@ -48,10 +49,25 @@ describe("account-link runtime configuration", () => {
       reason: "must_differ_from_license_db"
     });
 
+    const unreplicated = loadAccountLinkRuntimeConfig(
+      { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: "/data/account-link.sqlite" },
+      "/data/license.sqlite"
+    );
+    assert.deepEqual(unreplicated, {
+      status: "invalid",
+      setting: "ACCOUNT_LINK_DB_PATH",
+      reason: "must_match_github_broker_db"
+    });
+
     const dir = mkdtempSync(join(tmpdir(), "account-link-config-"));
     try {
+      const brokerPath = join(dir, "github-broker.sqlite");
       const ready = loadAccountLinkRuntimeConfig(
-        { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: join(dir, "account-link.sqlite") },
+        {
+          ...BASE_ENV,
+          ACCOUNT_LINK_DB_PATH: brokerPath,
+          GITHUB_BROKER_DB_PATH: brokerPath
+        },
         join(dir, "license.sqlite")
       );
       assert.equal(ready.status, "ready");
@@ -59,6 +75,18 @@ describe("account-link runtime configuration", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  test("production entrypoint keeps enabled account-link state on the broker replica", () => {
+    const entrypoint = readFileSync(new URL("../docker-entrypoint.sh", import.meta.url), "utf8");
+    const litestream = readFileSync(new URL("../litestream-broker.yml", import.meta.url), "utf8");
+    const fly = readFileSync(new URL("../fly.toml", import.meta.url), "utf8");
+
+    assert.match(entrypoint, /ACCOUNT_LINK_ENABLED/);
+    assert.match(entrypoint, /ACCOUNT_LINK_DB_PATH/);
+    assert.match(entrypoint, /GITHUB_BROKER_REPLICA_URL is unset; refusing to enable account linking/);
+    assert.match(litestream, /path: \$\{GITHUB_BROKER_DB_PATH\}/);
+    assert.match(fly, /ACCOUNT_LINK_DB_PATH = "\/data\/github-broker\.sqlite"/);
   });
 
   test("rejects symlink and hard-link aliases of the license database", () => {

--- a/services/license-api/test/account-link-runtime.test.ts
+++ b/services/license-api/test/account-link-runtime.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { linkSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -56,6 +56,33 @@ describe("account-link runtime configuration", () => {
       );
       assert.equal(ready.status, "ready");
       if (ready.status === "ready") ready.deps.store?.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects symlink and hard-link aliases of the license database", () => {
+    const dir = mkdtempSync(join(tmpdir(), "account-link-identity-"));
+    try {
+      const licensePath = join(dir, "license.sqlite");
+      writeFileSync(licensePath, "");
+      for (const [label, createAlias] of [
+        ["symlink", (path: string) => symlinkSync(licensePath, path)],
+        ["hard-link", (path: string) => linkSync(licensePath, path)]
+      ] as const) {
+        const aliasPath = join(dir, `${label}.sqlite`);
+        createAlias(aliasPath);
+        const result = loadAccountLinkRuntimeConfig(
+          { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: aliasPath },
+          licensePath
+        );
+        if (result.status === "ready") result.deps.store?.close();
+        assert.deepEqual(result, {
+          status: "invalid",
+          setting: "ACCOUNT_LINK_DB_PATH",
+          reason: "must_differ_from_license_db"
+        });
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -188,5 +215,56 @@ describe("Supabase account authority", () => {
     await assert.rejects(
       authority.loadWorkspaceSnapshot("11111111-1111-4111-8111-111111111111")
     );
+  });
+
+  test("maps an active legacy customer grant to paid entitlement", async () => {
+    const authority = createSupabaseAccountAuthority({
+      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
+      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
+      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
+      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/account_memberships")) {
+          return Response.json([{ account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", role: "owner" }]);
+        }
+        if (url.includes("/accounts")) {
+          return Response.json([{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", kind: "personal", name: "Legacy customer" }]);
+        }
+        if (url.includes("/bot_installations")) return Response.json([]);
+        if (url.includes("/account_entitlement_grants")) {
+          return Response.json([{
+            account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            grant_kind: "legacy",
+            status: "active",
+            expires_at: null
+          }]);
+        }
+        return Response.json({ id: "11111111-1111-4111-8111-111111111111" });
+      }
+    });
+
+    const snapshot = await authority.loadWorkspaceSnapshot("11111111-1111-4111-8111-111111111111");
+    assert.equal(snapshot.accounts[0]?.entitlement, "paid");
+  });
+
+  test("stops reading an undeclared oversized Supabase response at the byte cap", async () => {
+    let pulls = 0;
+    const authority = createSupabaseAccountAuthority({
+      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
+      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
+      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
+      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
+      fetchImpl: async () => new Response(new ReadableStream({
+        pull(controller) {
+          pulls += 1;
+          if (pulls === 1) controller.enqueue(new Uint8Array(300 * 1024));
+          else throw new Error("response was read beyond the configured cap");
+        }
+      }))
+    });
+
+    await assert.rejects(authority.verifyAccessToken("transient-user-token"), /too large/);
+    assert.ok(pulls <= 2, `stream pulled ${pulls} chunks after crossing the cap`);
   });
 });

--- a/services/license-api/test/github-broker-reason-contract.test.ts
+++ b/services/license-api/test/github-broker-reason-contract.test.ts
@@ -19,7 +19,10 @@ const ENTITLEMENT_REASON_STATUS: Array<[BrokerReason, number]> = [
   ["entitlement_seat_exhausted", 409],
   ["entitlement_replay_conflict", 409],
   ["entitlement_service_unavailable", 503],
-  ["visibility_unknown", 403]
+  ["visibility_unknown", 403],
+  ["account_link_required", 403],
+  ["account_identity_unverified", 403],
+  ["account_authority_unavailable", 503]
 ];
 
 describe("github broker #614 typed reason-code contract", () => {

--- a/services/license-api/test/github-broker-store-migration.test.ts
+++ b/services/license-api/test/github-broker-store-migration.test.ts
@@ -132,4 +132,44 @@ describe("github broker store v1/v2 -> v3 migration", () => {
       store.close();
     }
   });
+
+  it("prunes expired and old consumed account-link states during state creation", () => {
+    const path = seedV2Database();
+    const store = new GitHubBrokerStore(path);
+    try {
+      store.createAccountConnectState(
+        "expired-state",
+        "dev-1",
+        "2026-07-24T00:00:00.000Z",
+        "2026-07-24T00:10:00.000Z"
+      );
+      store.createAccountConnectState(
+        "consumed-state",
+        "dev-1",
+        "2026-07-24T00:00:00.000Z",
+        "2026-07-30T00:00:00.000Z"
+      );
+      assert.equal(
+        store.consumeAccountConnectStateAndBind(
+          "consumed-state",
+          "user-owner",
+          "2026-07-24T00:05:00.000Z"
+        ),
+        true
+      );
+
+      store.createAccountConnectState(
+        "current-state",
+        "dev-1",
+        "2026-07-26T00:00:00.000Z",
+        "2026-07-26T00:10:00.000Z"
+      );
+
+      assert.equal(store.getAccountConnectState("expired-state"), undefined);
+      assert.equal(store.getAccountConnectState("consumed-state"), undefined);
+      assert.equal(store.getAccountConnectState("current-state")?.device_id, "dev-1");
+    } finally {
+      store.close();
+    }
+  });
 });

--- a/services/license-api/test/github-broker-store-migration.test.ts
+++ b/services/license-api/test/github-broker-store-migration.test.ts
@@ -14,7 +14,7 @@ import { GitHubBrokerStore } from "../src/github-broker/index.ts";
  * `upsertBinding` / `listBindingRepositories` threw "no such table" — bricking
  * every existing deployment on upgrade (it fails closed, but the broker 500s on
  * every connect/token). These tests pin the v1 -> v2 migration: the table is
- * created in place, a bind/list round-trips, and re-opening is idempotent.
+ * created in place, then v3 adds account-link tables without losing bindings.
  */
 
 const V1_SCHEMA = `
@@ -72,10 +72,28 @@ function seedV1Database(): string {
   return path;
 }
 
-describe("github broker store v1 -> v2 migration", () => {
+function seedV2Database(): string {
+  const path = seedV1Database();
+  const db = new DatabaseSync(path);
+  db.exec(`
+    create table binding_repositories (
+      device_id text not null,
+      installation_id integer not null,
+      full_name text not null,
+      primary key (device_id, installation_id, full_name),
+      foreign key (device_id, installation_id)
+        references installation_bindings(device_id, installation_id) on delete cascade
+    );
+    pragma user_version = 2;
+  `);
+  db.close();
+  return path;
+}
+
+describe("github broker store v1/v2 -> v3 migration", () => {
   it("adds binding_repositories on an existing v1 DB and a bind/list round-trips", () => {
     const path = seedV1Database();
-    // Opening the store runs ensureSchema, which must migrate v1 -> v2 in place.
+    // Opening the store runs both required upgrades in place.
     const store = new GitHubBrokerStore(path);
     try {
       // The migrated table now exists (this threw "no such table" before the fix),
@@ -89,7 +107,7 @@ describe("github broker store v1 -> v2 migration", () => {
     }
   });
 
-  it("re-opening the migrated DB is idempotent (stays at v2, data intact)", () => {
+  it("re-opening the migrated DB is idempotent at v3 with data intact", () => {
     const path = seedV1Database();
     const first = new GitHubBrokerStore(path);
     first.upsertBinding("dev-1", 4242, "octo", ["octo/a"], new Date().toISOString());
@@ -100,6 +118,18 @@ describe("github broker store v1 -> v2 migration", () => {
       assert.deepEqual(second.listBindingRepositories("dev-1", 4242), ["octo/a"]);
     } finally {
       second.close();
+    }
+  });
+
+  it("adds account-link tables to an existing v2 DB", () => {
+    const path = seedV2Database();
+    const store = new GitHubBrokerStore(path);
+    try {
+      const now = new Date().toISOString();
+      store.createAccountConnectState("state-hash", "dev-1", now, now);
+      assert.equal(store.getAccountConnectState("state-hash")?.device_id, "dev-1");
+    } finally {
+      store.close();
     }
   });
 });

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -216,6 +216,7 @@ export async function startBroker(
     tokenRateLimiter?: RateLimiter;
     connectRateLimiter?: RateLimiter;
     accountAuthority?: unknown;
+    accountCompleteRateLimiter?: RateLimiter;
   } = {}
 ): Promise<BrokerHarness> {
   const licenseStore = options.licenseStore ?? new LicenseStore(":memory:");
@@ -241,7 +242,8 @@ export async function startBroker(
           accountLink: {
             dbPath: ":memory:",
             authority: options.accountAuthority,
-            now: nowFn
+            now: nowFn,
+            completeRateLimiter: options.accountCompleteRateLimiter
           }
         }
       : {})

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -215,6 +215,7 @@ export async function startBroker(
     deviceRegisterRateLimiter?: RateLimiter;
     tokenRateLimiter?: RateLimiter;
     connectRateLimiter?: RateLimiter;
+    accountAuthority?: unknown;
   } = {}
 ): Promise<BrokerHarness> {
   const licenseStore = options.licenseStore ?? new LicenseStore(":memory:");
@@ -234,7 +235,16 @@ export async function startBroker(
       deviceRegisterRateLimiter: options.deviceRegisterRateLimiter,
       tokenRateLimiter: options.tokenRateLimiter,
       connectRateLimiter: options.connectRateLimiter
-    }
+    },
+    ...(options.accountAuthority
+      ? {
+          accountLink: {
+            dbPath: ":memory:",
+            authority: options.accountAuthority,
+            now: nowFn
+          }
+        }
+      : {})
   } as never);
   return {
     url: started.url,

--- a/services/license-api/test/github-broker-support.ts
+++ b/services/license-api/test/github-broker-support.ts
@@ -217,6 +217,7 @@ export async function startBroker(
     connectRateLimiter?: RateLimiter;
     accountAuthority?: unknown;
     accountCompleteRateLimiter?: RateLimiter;
+    accountWorkspaceRateLimiter?: RateLimiter;
   } = {}
 ): Promise<BrokerHarness> {
   const licenseStore = options.licenseStore ?? new LicenseStore(":memory:");
@@ -243,7 +244,8 @@ export async function startBroker(
             dbPath: ":memory:",
             authority: options.accountAuthority,
             now: nowFn,
-            completeRateLimiter: options.accountCompleteRateLimiter
+            completeRateLimiter: options.accountCompleteRateLimiter,
+            workspaceRateLimiter: options.accountWorkspaceRateLimiter
           }
         }
       : {})


### PR DESCRIPTION
## Outcome

Implements the first bounded server half of #668: a B0-safe account-link service that is independent from the managed GitHub App runtime. It verifies a transient Lovable/Supabase user session in the browser, binds only the existing device public-key identity, and returns a minimal server-authoritative workspace snapshot.

## Acceptance criteria for this PR

- Separate `/account/*` runtime and database path; B0 does not depend on `GITHUB_BROKER_ENABLED`.
- Device registration and polling require ES256 device identity.
- Browser state is random, hashed at rest, single-use, and ten-minute expiring.
- Supabase user access token is verified transiently and never persisted or returned.
- Workspace reads use service-owned Supabase access with an explicit bound-user membership filter and return only allowed fields.
- Verified bot rows without an installation id fail closed.
- Runtime misconfiguration exposes setting name and fixed reason only.
- Existing GitHub broker and license routes remain unchanged in behavior.

## Explicit non-goals

- No website completion route or native client/UI wiring in this PR.
- No paid subscription-to-account mapping, GitHub installation verification, bot creation, credential rotation, Fly deploy, checkout, signed artifact, or release claim.
- The seeded `evaos-code-review-bot` remains pending and unverified.
- Does not close #668, #666, #646, #630, or #517.

## Proof

- RED: five focused contract cases initially returned 404 for all account routes.
- GREEN: 32 focused service, runtime, migration, reason-contract, and unchanged GitHub wire tests pass; TypeScript build passes.
- `git diff --check` is clean.

Stacked on #667 only for the native account model types; retarget to main after #667 merges. Relates to #668 and #610.