### PR TITLE
feat(account-link): compose Fly and Lovable account authority

### DIFF
--- a/services/license-api/src/account-link/index.ts
+++ b/services/license-api/src/account-link/index.ts
@@ -12,8 +12,8 @@ export {
   type AccountLinkDeps
 } from "./routes.js";
 export {
-  createSupabaseAccountAuthority,
+  createComposedAccountAuthority,
   loadAccountLinkRuntimeConfig,
   type AccountLinkRuntimeConfig,
-  type SupabaseAccountAuthorityOptions
+  type ComposedAccountAuthorityOptions
 } from "./runtime-config.js";

--- a/services/license-api/src/account-link/routes.ts
+++ b/services/license-api/src/account-link/routes.ts
@@ -10,6 +10,7 @@ import {
 const MAX_BODY_BYTES = 16 * 1024;
 const PATHS = new Set([
   "/account/device/register",
+  "/account/device/introspect",
   "/account/connect/start",
   "/account/connect/complete",
   "/account/workspaces"
@@ -75,6 +76,9 @@ export async function handleAccountLinkRequest(
   try {
     if (req.method === "POST" && path === "/account/device/register") {
       return writeJson(res, 200, await service.registerDevice(await readBody(req), context.sourceAddress), corsHeaders);
+    }
+    if (req.method === "POST" && path === "/account/device/introspect") {
+      return writeJson(res, 200, await service.introspectDevice(req.headers.authorization), corsHeaders);
     }
     if (req.method === "POST" && path === "/account/connect/start") {
       return writeJson(res, 200, await service.connectStart(req.headers.authorization), corsHeaders);

--- a/services/license-api/src/account-link/runtime-config.ts
+++ b/services/license-api/src/account-link/runtime-config.ts
@@ -219,13 +219,17 @@ function parseWorkspaceAccounts(value: unknown[]): AccountWorkspaceSnapshot["acc
     ) {
       throw new Error("invalid workspace account");
     }
+    const bots = row.bots.map(parseWorkspaceBot);
+    if (new Set(bots.map((bot) => bot.id)).size !== bots.length) {
+      throw new Error("duplicate workspace bot");
+    }
     return {
       id: row.id,
       kind: row.kind as "personal" | "organization",
       name: row.name,
       role: row.role as "owner" | "admin" | "member",
       entitlement: row.entitlement,
-      bots: row.bots.map(parseWorkspaceBot)
+      bots
     };
   });
   if (new Set(accounts.map((account) => account.id)).size !== accounts.length) {

--- a/services/license-api/src/account-link/runtime-config.ts
+++ b/services/license-api/src/account-link/runtime-config.ts
@@ -158,8 +158,11 @@ export function createComposedAccountAuthority(
         throw new Error("account authority redirect refused");
       }
       if (!response.ok) throw new Error("account authority request failed");
-      const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-      if (!contentType.includes("application/json")) {
+      const mediaType = response.headers.get("content-type")
+        ?.split(";", 1)[0]
+        ?.trim()
+        .toLowerCase();
+      if (mediaType !== "application/json") {
         throw new Error("account authority response is not JSON");
       }
       const body = await boundedJson(response);

--- a/services/license-api/src/account-link/runtime-config.ts
+++ b/services/license-api/src/account-link/runtime-config.ts
@@ -10,7 +10,7 @@ const SETTINGS = [
   "ACCOUNT_LINK_CONNECT_ORIGIN",
   "ACCOUNT_LINK_SUPABASE_URL",
   "ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY",
-  "ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY"
+  "ACCOUNT_LINK_AUTHORITY_URL"
 ] as const;
 const MAX_RESPONSE_BYTES = 256 * 1024;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -63,12 +63,15 @@ export function loadAccountLinkRuntimeConfig(
   if (!supabaseUrl) return invalid("ACCOUNT_LINK_SUPABASE_URL", "invalid");
 
   const publishableKey = required(values, "ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY");
-  const serviceRoleKey = required(values, "ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY");
   if (publishableKey.length > 4_096) {
     return invalid("ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY", "invalid");
   }
-  if (serviceRoleKey.length > 4_096) {
-    return invalid("ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY", "invalid");
+  const authorityUrl = normalizedHttpsUrl(
+    required(values, "ACCOUNT_LINK_AUTHORITY_URL"),
+    { allowPath: "/api/internal/desktop/workspaces" }
+  );
+  if (!authorityUrl || new URL(authorityUrl).hostname !== "www.neondiff.com") {
+    return invalid("ACCOUNT_LINK_AUTHORITY_URL", "invalid");
   }
 
   let store: GitHubBrokerStore;
@@ -83,34 +86,32 @@ export function loadAccountLinkRuntimeConfig(
     deps: {
       store,
       dbPath,
-      authority: createSupabaseAccountAuthority({
+      authority: createComposedAccountAuthority({
         connectOrigin,
         supabaseUrl,
         publishableKey,
-        serviceRoleKey
+        authorityUrl
       })
     }
   };
 }
 
-export interface SupabaseAccountAuthorityOptions {
+export interface ComposedAccountAuthorityOptions {
   connectOrigin: string;
   supabaseUrl: string;
   publishableKey: string;
-  serviceRoleKey: string;
+  authorityUrl: string;
   fetchImpl?: typeof fetch;
-  now?: () => Date;
   requestTimeoutMs?: number;
 }
 
-export function createSupabaseAccountAuthority(
-  options: SupabaseAccountAuthorityOptions
+export function createComposedAccountAuthority(
+  options: ComposedAccountAuthorityOptions
 ): AccountAuthority {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const now = options.now ?? (() => new Date());
   const timeout = options.requestTimeoutMs ?? 8_000;
   const base = options.supabaseUrl.replace(/\/$/, "");
-  const serviceHeaders = supabaseHeaders(options.serviceRoleKey);
+  const authorityUrl = options.authorityUrl;
 
   return {
     connectOrigin: options.connectOrigin,
@@ -123,8 +124,12 @@ export function createSupabaseAccountAuthority(
           Authorization: `Bearer ${accessToken}`,
           Accept: "application/json"
         },
+        redirect: "manual",
         signal: AbortSignal.timeout(timeout)
       });
+      if (response.status >= 300 && response.status < 400) {
+        throw new Error("account identity redirect refused");
+      }
       if (response.status === 401 || response.status === 403) return null;
       if (!response.ok) throw new Error("account identity request failed");
       const body = await boundedJson(response);
@@ -132,95 +137,43 @@ export function createSupabaseAccountAuthority(
       return body.id;
     },
 
-    async loadWorkspaceSnapshot(userId: string): Promise<AccountWorkspaceSnapshot> {
+    async loadWorkspaceSnapshot(
+      userId: string,
+      deviceAuthorization: string
+    ): Promise<AccountWorkspaceSnapshot> {
       if (!UUID.test(userId)) throw new Error("invalid bound user id");
-      const memberships = parseMemberships(await supabaseGet(
-        "/rest/v1/account_memberships",
-        {
-          select: "account_id,role",
-          user_id: `eq.${userId}`
+      if (!/^Bearer [A-Za-z0-9._~-]+$/.test(deviceAuthorization) || deviceAuthorization.length > 4_096) {
+        throw new Error("invalid device authorization");
+      }
+      const response = await fetchImpl(authorityUrl, {
+        method: "POST",
+        headers: {
+          Authorization: deviceAuthorization,
+          Accept: "application/json"
         },
-        serviceHeaders,
-        fetchImpl,
-        base,
-        timeout
-      ));
-      if (memberships.length === 0) return { accounts: [] };
-
-      const accountIds = memberships.map((membership) => membership.accountId);
-      const inFilter = `in.(${accountIds.join(",")})`;
-      const accounts = parseAccounts(await supabaseGet(
-        "/rest/v1/accounts",
-        { select: "id,kind,name", id: inFilter },
-        serviceHeaders,
-        fetchImpl,
-        base,
-        timeout
-      ));
-      const bots = parseBots(await supabaseGet(
-        "/rest/v1/bot_installations",
-        {
-          select: "id,account_id,app_id,app_slug,mode,github_installation_id,github_account_login,status",
-          account_id: inFilter
-        },
-        serviceHeaders,
-        fetchImpl,
-        base,
-        timeout
-      ));
-      const grants = parseGrants(await supabaseGet(
-        "/rest/v1/account_entitlement_grants",
-        {
-          select: "account_id,grant_kind,status,expires_at",
-          account_id: inFilter,
-          status: "eq.active"
-        },
-        serviceHeaders,
-        fetchImpl,
-        base,
-        timeout
-      ));
-
-      return {
-        accounts: memberships.map((membership) => {
-          const account = accounts.find((candidate) => candidate.id === membership.accountId);
-          if (!account) throw new Error("membership account is missing");
-          return {
-            id: account.id,
-            kind: account.kind,
-            name: account.name,
-            role: membership.role,
-            entitlement: entitlementFor(
-              grants.filter((grant) => grant.accountId === account.id),
-              now()
-            ),
-            bots: bots
-              .filter((bot) => bot.accountId === account.id)
-              .map(({ accountId: _accountId, ...bot }) => bot)
-          };
-        })
-      };
+        redirect: "manual",
+        signal: AbortSignal.timeout(timeout)
+      });
+      if (response.status >= 300 && response.status < 400) {
+        throw new Error("account authority redirect refused");
+      }
+      if (!response.ok) throw new Error("account authority request failed");
+      const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error("account authority response is not JSON");
+      }
+      const body = await boundedJson(response);
+      if (
+        !isRecord(body)
+        || body.status !== "ready"
+        || body.userId !== userId
+        || !Array.isArray(body.accounts)
+      ) {
+        throw new Error("account authority identity mismatch");
+      }
+      return { accounts: parseWorkspaceAccounts(body.accounts) };
     }
   };
-}
-
-async function supabaseGet(
-  path: string,
-  query: Record<string, string>,
-  headers: Record<string, string>,
-  fetchImpl: typeof fetch,
-  base: string,
-  timeout: number
-): Promise<unknown> {
-  const url = new URL(`${base}${path}`);
-  for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value);
-  const response = await fetchImpl(url, {
-    method: "GET",
-    headers: { ...headers, Accept: "application/json" },
-    signal: AbortSignal.timeout(timeout)
-  });
-  if (!response.ok) throw new Error("account authority request failed");
-  return boundedJson(response);
 }
 
 async function boundedJson(response: Response): Promise<unknown> {
@@ -247,138 +200,85 @@ async function boundedJson(response: Response): Promise<unknown> {
   return JSON.parse(Buffer.concat(chunks, size).toString("utf8")) as unknown;
 }
 
-function supabaseHeaders(key: string): Record<string, string> {
-  const headers: Record<string, string> = { apikey: key };
-  if (key.split(".").length === 3) headers.Authorization = `Bearer ${key}`;
-  return headers;
-}
-
-function parseMemberships(value: unknown): Array<{
-  accountId: string;
-  role: "owner" | "admin" | "member";
-}> {
-  if (!Array.isArray(value)) throw new Error("invalid memberships response");
-  return value.map((row) => {
-    if (!isRecord(row) || typeof row.account_id !== "string" || !UUID.test(row.account_id)) {
-      throw new Error("invalid membership account");
-    }
-    if (row.role !== "owner" && row.role !== "admin" && row.role !== "member") {
-      throw new Error("invalid membership role");
-    }
-    return { accountId: row.account_id, role: row.role };
-  });
-}
-
-function parseAccounts(value: unknown): Array<{
-  id: string;
-  kind: "personal" | "organization";
-  name: string;
-}> {
-  if (!Array.isArray(value)) throw new Error("invalid accounts response");
-  return value.map((row) => {
-    if (!isRecord(row) || typeof row.id !== "string" || !UUID.test(row.id)) {
-      throw new Error("invalid account id");
-    }
-    if (row.kind !== "personal" && row.kind !== "organization") {
-      throw new Error("invalid account kind");
-    }
-    if (typeof row.name !== "string" || row.name.length === 0 || row.name.length > 120) {
-      throw new Error("invalid account name");
-    }
-    return { id: row.id, kind: row.kind, name: row.name };
-  });
-}
-
-function parseBots(value: unknown): Array<{
-  accountId: string;
-  id: string;
-  appId: number;
-  appSlug: string;
-  mode: "byo" | "managed";
-  githubInstallationId: number | null;
-  githubAccountLogin: string | null;
-  status: "pending" | "verified" | "suspended" | "revoked";
-}> {
-  if (!Array.isArray(value)) throw new Error("invalid bots response");
-  return value.map((row) => {
-    if (!isRecord(row)) throw new Error("invalid bot row");
-    if (typeof row.id !== "string" || !UUID.test(row.id)) throw new Error("invalid bot id");
-    if (typeof row.account_id !== "string" || !UUID.test(row.account_id)) {
-      throw new Error("invalid bot account");
-    }
-    if (typeof row.app_id !== "number" || !Number.isSafeInteger(row.app_id) || row.app_id <= 0) {
-      throw new Error("invalid bot app id");
-    }
-    if (typeof row.app_slug !== "string" || !/^[a-z0-9][a-z0-9-]{0,99}$/.test(row.app_slug)) {
-      throw new Error("invalid bot slug");
-    }
-    if (row.mode !== "byo" && row.mode !== "managed") throw new Error("invalid bot mode");
-    if (!["pending", "verified", "suspended", "revoked"].includes(String(row.status))) {
-      throw new Error("invalid bot status");
-    }
-    const installationId = row.github_installation_id;
+function parseWorkspaceAccounts(value: unknown[]): AccountWorkspaceSnapshot["accounts"] {
+  if (value.length > 100) throw new Error("too many workspace accounts");
+  const accounts = value.map((row) => {
     if (
-      installationId !== null
-      && (typeof installationId !== "number" || !Number.isSafeInteger(installationId) || installationId <= 0)
+      !isRecord(row)
+      || typeof row.id !== "string"
+      || !UUID.test(row.id)
+      || (row.kind !== "personal" && row.kind !== "organization")
+      || typeof row.name !== "string"
+      || row.name.trim().length === 0
+      || row.name.length > 120
+      || /[\r\n]/.test(row.name)
+      || (row.role !== "owner" && row.role !== "admin" && row.role !== "member")
+      || !isEntitlement(row.entitlement)
+      || !Array.isArray(row.bots)
+      || row.bots.length > 100
     ) {
-      throw new Error("invalid installation id");
-    }
-    if (row.status === "verified" && installationId === null) {
-      throw new Error("verified bot has no installation proof");
-    }
-    if (
-      row.github_account_login !== null
-      && (typeof row.github_account_login !== "string" || row.github_account_login.length > 100)
-    ) {
-      throw new Error("invalid GitHub account login");
+      throw new Error("invalid workspace account");
     }
     return {
-      accountId: row.account_id,
       id: row.id,
-      appId: row.app_id,
-      appSlug: row.app_slug,
-      mode: row.mode,
-      githubInstallationId: installationId,
-      githubAccountLogin: row.github_account_login as string | null,
-      status: row.status as "pending" | "verified" | "suspended" | "revoked"
+      kind: row.kind as "personal" | "organization",
+      name: row.name,
+      role: row.role as "owner" | "admin" | "member",
+      entitlement: row.entitlement,
+      bots: row.bots.map(parseWorkspaceBot)
     };
   });
+  if (new Set(accounts.map((account) => account.id)).size !== accounts.length) {
+    throw new Error("duplicate workspace account");
+  }
+  return accounts;
 }
 
-function parseGrants(value: unknown): Array<{
-  accountId: string;
-  kind: "internal_admin" | "trial" | "legacy";
-  expiresAt: string | null;
-}> {
-  if (!Array.isArray(value)) throw new Error("invalid grants response");
-  return value.map((row) => {
-    if (!isRecord(row) || typeof row.account_id !== "string" || !UUID.test(row.account_id)) {
-      throw new Error("invalid grant account");
-    }
-    if (row.status !== "active") throw new Error("inactive grant in active snapshot");
-    if (row.grant_kind !== "internal_admin" && row.grant_kind !== "trial" && row.grant_kind !== "legacy") {
-      throw new Error("invalid grant kind");
-    }
-    if (row.expires_at !== null && (typeof row.expires_at !== "string" || !Number.isFinite(Date.parse(row.expires_at)))) {
-      throw new Error("invalid grant expiry");
-    }
-    return {
-      accountId: row.account_id,
-      kind: row.grant_kind,
-      expiresAt: row.expires_at as string | null
-    };
-  });
+function parseWorkspaceBot(value: unknown): AccountWorkspaceSnapshot["accounts"][number]["bots"][number] {
+  if (!isRecord(value)) throw new Error("invalid workspace bot");
+  const installationId = value.githubInstallationId;
+  if (
+    typeof value.id !== "string"
+    || !UUID.test(value.id)
+    || typeof value.appId !== "number"
+    || !Number.isSafeInteger(value.appId)
+    || value.appId <= 0
+    || typeof value.appSlug !== "string"
+    || !/^[a-z0-9][a-z0-9-]{0,99}$/.test(value.appSlug)
+    || (value.mode !== "byo" && value.mode !== "managed")
+    || !isBotStatus(value.status)
+    || (installationId !== null
+      && (typeof installationId !== "number"
+        || !Number.isSafeInteger(installationId)
+        || installationId <= 0))
+    || (value.status === "verified" && installationId === null)
+    || (value.githubAccountLogin !== null
+      && (typeof value.githubAccountLogin !== "string"
+        || !/^[A-Za-z0-9][A-Za-z0-9-]{0,99}$/.test(value.githubAccountLogin)))
+  ) {
+    throw new Error("invalid workspace bot");
+  }
+  return {
+    id: value.id,
+    appId: value.appId,
+    appSlug: value.appSlug,
+    mode: value.mode,
+    githubInstallationId: installationId,
+    githubAccountLogin: value.githubAccountLogin as string | null,
+    status: value.status
+  };
 }
 
-function entitlementFor(
-  grants: Array<{ kind: "internal_admin" | "trial" | "legacy"; expiresAt: string | null }>,
-  at: Date
-): "public_free" | "paid" | "internal_admin" | "trial" {
-  const active = grants.filter((grant) => !grant.expiresAt || Date.parse(grant.expiresAt) > at.getTime());
-  if (active.some((grant) => grant.kind === "internal_admin")) return "internal_admin";
-  if (active.some((grant) => grant.kind === "trial")) return "trial";
-  if (active.some((grant) => grant.kind === "legacy")) return "paid";
-  return "public_free";
+function isEntitlement(value: unknown): value is AccountWorkspaceSnapshot["accounts"][number]["entitlement"] {
+  return value === "public_free"
+    || value === "paid"
+    || value === "internal_admin"
+    || value === "trial"
+    || value === "none";
+}
+
+function isBotStatus(value: unknown): value is AccountWorkspaceSnapshot["accounts"][number]["bots"][number]["status"] {
+  return value === "pending" || value === "verified" || value === "suspended" || value === "revoked";
 }
 
 function sameFileIdentity(left: string, right: string): boolean {

--- a/services/license-api/src/account-link/service.ts
+++ b/services/license-api/src/account-link/service.ts
@@ -32,7 +32,10 @@ export interface AccountWorkspaceSnapshot {
 export interface AccountAuthority {
   connectOrigin: string;
   verifyAccessToken(accessToken: string): Promise<string | null>;
-  loadWorkspaceSnapshot(userId: string): Promise<AccountWorkspaceSnapshot>;
+  loadWorkspaceSnapshot(
+    userId: string,
+    deviceAuthorization: string
+  ): Promise<AccountWorkspaceSnapshot>;
 }
 
 export interface AccountLinkServiceOptions {
@@ -196,7 +199,10 @@ export class AccountLinkService {
     try {
       return {
         status: "ready",
-        ...(await this.authority.loadWorkspaceSnapshot(binding.user_id))
+        ...(await this.authority.loadWorkspaceSnapshot(
+          binding.user_id,
+          deviceBearerAuthorization(authorization)
+        ))
       };
     } catch {
       throw new BrokerError(
@@ -204,6 +210,24 @@ export class AccountLinkService {
         "account workspace service is unavailable"
       );
     }
+  }
+
+  async introspectDevice(
+    authorization: string | string[] | undefined
+  ): Promise<Record<string, unknown>> {
+    const at = this.now();
+    const deviceId = await authenticateDevice(this.store, authorization, at);
+    if (!this.workspaceRateLimiter.allow(
+      hash(`account-introspect:${deviceId}`),
+      at.getTime()
+    )) {
+      throw new BrokerError("rate_limited", "too many account device introspections");
+    }
+    const binding = this.store.getAccountBinding(deviceId);
+    if (!binding) {
+      throw new BrokerError("account_link_required", "link a signed-in NeonDiff account first");
+    }
+    return { status: "account_device_bound", userId: binding.user_id };
   }
 }
 
@@ -234,6 +258,16 @@ function accountBearerToken(authorization: string | string[] | undefined): strin
     throw new BrokerError("account_identity_unverified", "signed-in account proof is invalid");
   }
   return token;
+}
+
+function deviceBearerAuthorization(
+  authorization: string | string[] | undefined
+): string {
+  const value = Array.isArray(authorization) ? authorization[0] : authorization;
+  if (!value || value.length > MAX_ACCESS_TOKEN_LENGTH || !/^Bearer [A-Za-z0-9._~-]+$/.test(value)) {
+    throw new BrokerError("invalid_device_credential", "device authentication is invalid");
+  }
+  return value;
 }
 
 function asObject(body: unknown): Record<string, unknown> {

--- a/services/license-api/src/account-link/service.ts
+++ b/services/license-api/src/account-link/service.ts
@@ -197,12 +197,13 @@ export class AccountLinkService {
     )) {
       throw new BrokerError("rate_limited", "too many account workspace refreshes");
     }
+    const deviceAuthorization = deviceBearerAuthorization(authorization);
     try {
       return {
         status: "ready",
         ...(await this.authority.loadWorkspaceSnapshot(
           binding.user_id,
-          deviceBearerAuthorization(authorization)
+          deviceAuthorization
         ))
       };
     } catch {
@@ -264,11 +265,18 @@ function accountBearerToken(authorization: string | string[] | undefined): strin
 function deviceBearerAuthorization(
   authorization: string | string[] | undefined
 ): string {
-  const value = Array.isArray(authorization) ? authorization[0] : authorization;
-  if (!value || value.length > MAX_ACCESS_TOKEN_LENGTH || !/^Bearer [A-Za-z0-9._~-]+$/.test(value)) {
+  if (Array.isArray(authorization)) {
     throw new BrokerError("invalid_device_credential", "device authentication is invalid");
   }
-  return value;
+  const prefix = "Bearer ";
+  if (!authorization?.startsWith(prefix)) {
+    throw new BrokerError("invalid_device_credential", "device authentication is invalid");
+  }
+  const token = authorization.slice(prefix.length);
+  if (!token || token.length > MAX_ACCESS_TOKEN_LENGTH || !/^[A-Za-z0-9._~-]+$/.test(token)) {
+    throw new BrokerError("invalid_device_credential", "device authentication is invalid");
+  }
+  return authorization;
 }
 
 function asObject(body: unknown): Record<string, unknown> {

--- a/services/license-api/test/account-authority-compose.test.ts
+++ b/services/license-api/test/account-authority-compose.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  bearer,
+  makeDevice,
+  post,
+  startBroker,
+  type BrokerHarness
+} from "./github-broker-support.ts";
+import {
+  createComposedAccountAuthority,
+  loadAccountLinkRuntimeConfig
+} from "../src/account-link/runtime-config.ts";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const ACCOUNT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const BOT_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const DEVICE_AUTHORIZATION = "Bearer device-jwt-fixture";
+const CONNECT_ORIGIN = "https://www.neondiff.com/desktop/connect";
+const AUTHORITY_URL = "https://www.neondiff.com/api/internal/desktop/workspaces";
+
+const workspaceSnapshot = {
+  accounts: [{
+    id: ACCOUNT_ID,
+    kind: "organization" as const,
+    name: "ElectricSheep",
+    role: "admin" as const,
+    entitlement: "internal_admin" as const,
+    bots: [{
+      id: BOT_ID,
+      appId: 4_184_532,
+      appSlug: "evaos-code-review-bot",
+      mode: "byo" as const,
+      githubInstallationId: null,
+      githubAccountLogin: "electricsheephq",
+      status: "pending" as const
+    }]
+  }]
+};
+
+describe("composed Lovable account authority", () => {
+  test("runtime configuration requires only public Supabase verification and the pinned Lovable bridge", () => {
+    const directory = mkdtempSync(join(tmpdir(), "account-compose-"));
+    try {
+      const brokerPath = join(directory, "github-broker.sqlite");
+      const result = loadAccountLinkRuntimeConfig({
+        ACCOUNT_LINK_ENABLED: "true",
+        ACCOUNT_LINK_DB_PATH: brokerPath,
+        GITHUB_BROKER_DB_PATH: brokerPath,
+        ACCOUNT_LINK_CONNECT_ORIGIN: CONNECT_ORIGIN,
+        ACCOUNT_LINK_SUPABASE_URL: "https://project.supabase.co",
+        ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_fixture",
+        ACCOUNT_LINK_AUTHORITY_URL: AUTHORITY_URL
+      }, join(directory, "license.sqlite"));
+
+      assert.equal(result.status, "ready");
+      if (result.status === "ready") result.deps.store?.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("transient browser identity and device workspace authority use separate bounded requests", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      contentType: string | null;
+      redirect: RequestRedirect | undefined;
+    }> = [];
+    const authority = createComposedAccountAuthority({
+      connectOrigin: CONNECT_ORIGIN,
+      supabaseUrl: "https://project.supabase.co",
+      publishableKey: "sb_publishable_fixture",
+      authorityUrl: AUTHORITY_URL,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({
+          url,
+          authorization: new Headers(init?.headers).get("authorization"),
+          contentType: new Headers(init?.headers).get("content-type"),
+          redirect: init?.redirect
+        });
+        if (url.endsWith("/auth/v1/user")) {
+          return Response.json({ id: USER_ID, email: "never-return@example.com" });
+        }
+        return Response.json({ status: "ready", userId: USER_ID, ...workspaceSnapshot });
+      }
+    });
+
+    assert.equal(await authority.verifyAccessToken("transient-browser-token"), USER_ID);
+    assert.deepEqual(
+      await authority.loadWorkspaceSnapshot(USER_ID, DEVICE_AUTHORIZATION),
+      workspaceSnapshot
+    );
+    assert.deepEqual(requests, [
+      {
+        url: "https://project.supabase.co/auth/v1/user",
+        authorization: "Bearer transient-browser-token",
+        contentType: null,
+        redirect: "manual"
+      },
+      {
+        url: AUTHORITY_URL,
+        authorization: DEVICE_AUTHORIZATION,
+        contentType: null,
+        redirect: "manual"
+      }
+    ]);
+  });
+
+  test("workspace authority rejects a user mismatch, redirects, and oversized responses", async () => {
+    for (const response of [
+      Response.json({ status: "ready", userId: "22222222-2222-4222-8222-222222222222", ...workspaceSnapshot }),
+      new Response(null, { status: 302, headers: { location: "https://evil.example" } }),
+      new Response(JSON.stringify({ status: "ready", userId: USER_ID, ...workspaceSnapshot }), {
+        headers: { "content-length": String(300 * 1024), "content-type": "application/json" }
+      })
+    ]) {
+      const authority = createComposedAccountAuthority({
+        connectOrigin: CONNECT_ORIGIN,
+        supabaseUrl: "https://project.supabase.co",
+        publishableKey: "sb_publishable_fixture",
+        authorityUrl: AUTHORITY_URL,
+        fetchImpl: async () => response
+      });
+      await assert.rejects(
+        authority.loadWorkspaceSnapshot(USER_ID, DEVICE_AUTHORIZATION)
+      );
+    }
+  });
+});
+
+describe("device introspection", () => {
+  const harnesses: BrokerHarness[] = [];
+
+  afterEach(() => {
+    while (harnesses.length > 0) harnesses.pop()?.close();
+  });
+
+  test("returns only the bound user UUID after device authentication", async () => {
+    const harness = await startBroker({
+      accountAuthority: {
+        connectOrigin: CONNECT_ORIGIN,
+        async verifyAccessToken() {
+          return USER_ID;
+        },
+        async loadWorkspaceSnapshot() {
+          return workspaceSnapshot;
+        }
+      }
+    });
+    harnesses.push(harness);
+    const device = await makeDevice();
+    await post(harness.url, "/account/device/register", { publicKeyJwk: device.publicJwk });
+
+    const before = await post(
+      harness.url,
+      "/account/device/introspect",
+      {},
+      bearer(await device.sign())
+    );
+    assert.equal(before.status, 403);
+    assert.equal(before.json.reason, "account_link_required");
+
+    const start = await post(
+      harness.url,
+      "/account/connect/start",
+      {},
+      bearer(await device.sign())
+    );
+    await post(
+      harness.url,
+      "/account/connect/complete",
+      { state: start.json.state },
+      bearer("lovable-user-token")
+    );
+    const bound = await post(
+      harness.url,
+      "/account/device/introspect",
+      {},
+      bearer(await device.sign())
+    );
+
+    assert.equal(bound.status, 200);
+    assert.deepEqual(bound.json, { status: "account_device_bound", userId: USER_ID });
+  });
+});

--- a/services/license-api/test/account-authority-compose.test.ts
+++ b/services/license-api/test/account-authority-compose.test.ts
@@ -124,6 +124,9 @@ describe("composed Lovable account authority", () => {
     for (const response of [
       Response.json({ status: "ready", userId: "22222222-2222-4222-8222-222222222222", ...workspaceSnapshot }),
       new Response(null, { status: 302, headers: { location: "https://evil.example" } }),
+      new Response(JSON.stringify({ status: "ready", userId: USER_ID, ...workspaceSnapshot }), {
+        headers: { "content-type": "application/jsonp" }
+      }),
       Response.json({ status: "ready", userId: USER_ID, ...duplicateBotSnapshot }),
       Response.json({
         status: "ready",

--- a/services/license-api/test/account-authority-compose.test.ts
+++ b/services/license-api/test/account-authority-compose.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, test } from "node:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { SignJWT } from "jose";
 import {
   bearer,
+  FIXED_NOW,
   makeDevice,
   post,
   startBroker,
@@ -111,12 +113,23 @@ describe("composed Lovable account authority", () => {
     ]);
   });
 
-  test("workspace authority rejects a user mismatch, redirects, and oversized responses", async () => {
+  test("workspace authority rejects identity, redirect, duplicate-bot, and response-size failures", async () => {
+    const duplicateBotSnapshot = {
+      ...workspaceSnapshot,
+      accounts: workspaceSnapshot.accounts.map((account) => ({
+        ...account,
+        bots: [account.bots[0], account.bots[0]]
+      }))
+    };
     for (const response of [
       Response.json({ status: "ready", userId: "22222222-2222-4222-8222-222222222222", ...workspaceSnapshot }),
       new Response(null, { status: 302, headers: { location: "https://evil.example" } }),
-      new Response(JSON.stringify({ status: "ready", userId: USER_ID, ...workspaceSnapshot }), {
-        headers: { "content-length": String(300 * 1024), "content-type": "application/json" }
+      Response.json({ status: "ready", userId: USER_ID, ...duplicateBotSnapshot }),
+      Response.json({
+        status: "ready",
+        userId: USER_ID,
+        ...workspaceSnapshot,
+        padding: "x".repeat(300 * 1024)
       })
     ]) {
       const authority = createComposedAccountAuthority({
@@ -140,7 +153,7 @@ describe("device introspection", () => {
     while (harnesses.length > 0) harnesses.pop()?.close();
   });
 
-  test("returns only the bound user UUID after device authentication", async () => {
+  test("returns only the bound user UUID for the exact linked device", async () => {
     const harness = await startBroker({
       accountAuthority: {
         connectOrigin: CONNECT_ORIGIN,
@@ -154,7 +167,9 @@ describe("device introspection", () => {
     });
     harnesses.push(harness);
     const device = await makeDevice();
+    const otherDevice = await makeDevice();
     await post(harness.url, "/account/device/register", { publicKeyJwk: device.publicJwk });
+    await post(harness.url, "/account/device/register", { publicKeyJwk: otherDevice.publicJwk });
 
     const before = await post(
       harness.url,
@@ -186,5 +201,30 @@ describe("device introspection", () => {
 
     assert.equal(bound.status, 200);
     assert.deepEqual(bound.json, { status: "account_device_bound", userId: USER_ID });
+
+    const unbound = await post(
+      harness.url,
+      "/account/device/introspect",
+      {},
+      bearer(await otherDevice.sign())
+    );
+    assert.equal(unbound.status, 403);
+    assert.equal(unbound.json.reason, "account_link_required");
+
+    const nowSeconds = Math.floor(FIXED_NOW.getTime() / 1_000);
+    const oversizedAssertion = await new SignJWT({ padding: "x".repeat(5_000) })
+      .setProtectedHeader({ alg: "ES256" })
+      .setSubject(device.deviceId)
+      .setIssuedAt(nowSeconds)
+      .setExpirationTime(nowSeconds + 120)
+      .sign(device.privateKey);
+    const malformedWorkspaceCredential = await post(
+      harness.url,
+      "/account/workspaces",
+      {},
+      bearer(oversizedAssertion)
+    );
+    assert.equal(malformedWorkspaceCredential.status, 401);
+    assert.equal(malformedWorkspaceCredential.json.reason, "invalid_device_credential");
   });
 });

--- a/services/license-api/test/account-link-runtime.test.ts
+++ b/services/license-api/test/account-link-runtime.test.ts
@@ -3,10 +3,7 @@ import { describe, test } from "node:test";
 import { linkSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  createSupabaseAccountAuthority,
-  loadAccountLinkRuntimeConfig
-} from "../src/account-link/runtime-config.ts";
+import { loadAccountLinkRuntimeConfig } from "../src/account-link/runtime-config.ts";
 
 const BASE_ENV = {
   ACCOUNT_LINK_ENABLED: "true",
@@ -15,7 +12,7 @@ const BASE_ENV = {
   ACCOUNT_LINK_CONNECT_ORIGIN: "https://www.neondiff.com/desktop/connect",
   ACCOUNT_LINK_SUPABASE_URL: "https://project.supabase.co",
   ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_fixture",
-  ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY: "sb_secret_fixture"
+  ACCOUNT_LINK_AUTHORITY_URL: "https://www.neondiff.com/api/internal/desktop/workspaces"
 } as const;
 
 describe("account-link runtime configuration", () => {
@@ -27,12 +24,12 @@ describe("account-link runtime configuration", () => {
 
   test("an enabled missing setting fails closed without returning submitted values", () => {
     const result = loadAccountLinkRuntimeConfig(
-      { ...BASE_ENV, ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY: undefined },
+      { ...BASE_ENV, ACCOUNT_LINK_AUTHORITY_URL: undefined },
       "/data/license.sqlite"
     );
     assert.deepEqual(result, {
       status: "invalid",
-      setting: "ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY",
+      setting: "ACCOUNT_LINK_AUTHORITY_URL",
       reason: "missing"
     });
     assert.doesNotMatch(JSON.stringify(result), /sb_publishable_fixture/);
@@ -59,21 +56,39 @@ describe("account-link runtime configuration", () => {
       reason: "must_match_github_broker_db"
     });
 
-    const dir = mkdtempSync(join(tmpdir(), "account-link-config-"));
+    const directory = mkdtempSync(join(tmpdir(), "account-link-config-"));
     try {
-      const brokerPath = join(dir, "github-broker.sqlite");
+      const brokerPath = join(directory, "github-broker.sqlite");
       const ready = loadAccountLinkRuntimeConfig(
         {
           ...BASE_ENV,
           ACCOUNT_LINK_DB_PATH: brokerPath,
           GITHUB_BROKER_DB_PATH: brokerPath
         },
-        join(dir, "license.sqlite")
+        join(directory, "license.sqlite")
       );
       assert.equal(ready.status, "ready");
       if (ready.status === "ready") ready.deps.store?.close();
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("pins the Lovable authority route and refuses any foreign or broader endpoint", () => {
+    for (const authorityUrl of [
+      "https://evil.example/api/internal/desktop/workspaces",
+      "https://www.neondiff.com/api/internal/desktop",
+      "https://www.neondiff.com/api/internal/desktop/workspaces?debug=true"
+    ]) {
+      const result = loadAccountLinkRuntimeConfig(
+        { ...BASE_ENV, ACCOUNT_LINK_AUTHORITY_URL: authorityUrl },
+        "/data/license.sqlite"
+      );
+      assert.deepEqual(result, {
+        status: "invalid",
+        setting: "ACCOUNT_LINK_AUTHORITY_URL",
+        reason: "invalid"
+      });
     }
   });
 
@@ -90,15 +105,15 @@ describe("account-link runtime configuration", () => {
   });
 
   test("rejects symlink and hard-link aliases of the license database", () => {
-    const dir = mkdtempSync(join(tmpdir(), "account-link-identity-"));
+    const directory = mkdtempSync(join(tmpdir(), "account-link-identity-"));
     try {
-      const licensePath = join(dir, "license.sqlite");
+      const licensePath = join(directory, "license.sqlite");
       writeFileSync(licensePath, "");
       for (const [label, createAlias] of [
         ["symlink", (path: string) => symlinkSync(licensePath, path)],
         ["hard-link", (path: string) => linkSync(licensePath, path)]
       ] as const) {
-        const aliasPath = join(dir, `${label}.sqlite`);
+        const aliasPath = join(directory, `${label}.sqlite`);
         createAlias(aliasPath);
         const result = loadAccountLinkRuntimeConfig(
           { ...BASE_ENV, ACCOUNT_LINK_DB_PATH: aliasPath },
@@ -112,187 +127,7 @@ describe("account-link runtime configuration", () => {
         });
       }
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmSync(directory, { recursive: true, force: true });
     }
-  });
-});
-
-describe("Supabase account authority", () => {
-  test("verifies the transient user token, then returns only allowed snapshot fields", async () => {
-    const requests: Array<{ url: string; headers: Headers }> = [];
-    const authority = createSupabaseAccountAuthority({
-      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
-      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
-      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
-      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
-      now: () => new Date("2026-07-26T06:00:00.000Z"),
-      fetchImpl: async (input, init) => {
-        const url = String(input);
-        const headers = new Headers(init?.headers);
-        requests.push({ url, headers });
-        if (url.endsWith("/auth/v1/user")) {
-          return Response.json({ id: "11111111-1111-4111-8111-111111111111", email: "never-return@example.com" });
-        }
-        if (url.includes("/account_memberships")) {
-          return Response.json([
-            { account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", role: "admin" }
-          ]);
-        }
-        if (url.includes("/accounts")) {
-          return Response.json([
-            {
-              id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-              kind: "organization",
-              name: "ElectricSheep"
-            }
-          ]);
-        }
-        if (url.includes("/bot_installations")) {
-          return Response.json([
-            {
-              id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-              account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-              app_id: 4_184_532,
-              app_slug: "evaos-code-review-bot",
-              mode: "byo",
-              github_installation_id: null,
-              github_account_login: "electricsheephq",
-              status: "pending"
-            }
-          ]);
-        }
-        if (url.includes("/account_entitlement_grants")) {
-          return Response.json([
-            {
-              account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-              grant_kind: "internal_admin",
-              status: "active",
-              expires_at: null
-            }
-          ]);
-        }
-        return new Response("not found", { status: 404 });
-      }
-    });
-
-    assert.equal(
-      await authority.verifyAccessToken("transient-user-token"),
-      "11111111-1111-4111-8111-111111111111"
-    );
-    const snapshot = await authority.loadWorkspaceSnapshot(
-      "11111111-1111-4111-8111-111111111111"
-    );
-    assert.deepEqual(snapshot, {
-      accounts: [
-        {
-          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-          kind: "organization",
-          name: "ElectricSheep",
-          role: "admin",
-          entitlement: "internal_admin",
-          bots: [
-            {
-              id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-              appId: 4_184_532,
-              appSlug: "evaos-code-review-bot",
-              mode: "byo",
-              githubInstallationId: null,
-              githubAccountLogin: "electricsheephq",
-              status: "pending"
-            }
-          ]
-        }
-      ]
-    });
-    assert.doesNotMatch(JSON.stringify(snapshot), /email|transient-user-token/);
-    assert.equal(requests[0]?.headers.get("Authorization"), "Bearer transient-user-token");
-    assert.equal(requests[1]?.headers.get("Authorization"), null);
-    assert.equal(requests[1]?.headers.get("apikey"), "sb_secret_fixture");
-  });
-
-  test("malformed verified bot state fails closed", async () => {
-    const authority = createSupabaseAccountAuthority({
-      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
-      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
-      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
-      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
-      fetchImpl: async (input) => {
-        const url = String(input);
-        if (url.includes("/account_memberships")) {
-          return Response.json([{ account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", role: "admin" }]);
-        }
-        if (url.includes("/accounts")) {
-          return Response.json([{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", kind: "organization", name: "ElectricSheep" }]);
-        }
-        if (url.includes("/bot_installations")) {
-          return Response.json([{
-            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-            account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-            app_id: 4_184_532,
-            app_slug: "evaos-code-review-bot",
-            mode: "byo",
-            github_installation_id: null,
-            github_account_login: "electricsheephq",
-            status: "verified"
-          }]);
-        }
-        if (url.includes("/account_entitlement_grants")) return Response.json([]);
-        return Response.json({ id: "11111111-1111-4111-8111-111111111111" });
-      }
-    });
-    await assert.rejects(
-      authority.loadWorkspaceSnapshot("11111111-1111-4111-8111-111111111111")
-    );
-  });
-
-  test("maps an active legacy customer grant to paid entitlement", async () => {
-    const authority = createSupabaseAccountAuthority({
-      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
-      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
-      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
-      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
-      fetchImpl: async (input) => {
-        const url = String(input);
-        if (url.includes("/account_memberships")) {
-          return Response.json([{ account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", role: "owner" }]);
-        }
-        if (url.includes("/accounts")) {
-          return Response.json([{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", kind: "personal", name: "Legacy customer" }]);
-        }
-        if (url.includes("/bot_installations")) return Response.json([]);
-        if (url.includes("/account_entitlement_grants")) {
-          return Response.json([{
-            account_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-            grant_kind: "legacy",
-            status: "active",
-            expires_at: null
-          }]);
-        }
-        return Response.json({ id: "11111111-1111-4111-8111-111111111111" });
-      }
-    });
-
-    const snapshot = await authority.loadWorkspaceSnapshot("11111111-1111-4111-8111-111111111111");
-    assert.equal(snapshot.accounts[0]?.entitlement, "paid");
-  });
-
-  test("stops reading an undeclared oversized Supabase response at the byte cap", async () => {
-    let pulls = 0;
-    const authority = createSupabaseAccountAuthority({
-      connectOrigin: BASE_ENV.ACCOUNT_LINK_CONNECT_ORIGIN,
-      supabaseUrl: BASE_ENV.ACCOUNT_LINK_SUPABASE_URL,
-      publishableKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_PUBLISHABLE_KEY,
-      serviceRoleKey: BASE_ENV.ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY,
-      fetchImpl: async () => new Response(new ReadableStream({
-        pull(controller) {
-          pulls += 1;
-          if (pulls === 1) controller.enqueue(new Uint8Array(300 * 1024));
-          else throw new Error("response was read beyond the configured cap");
-        }
-      }))
-    });
-
-    await assert.rejects(authority.verifyAccessToken("transient-user-token"), /too large/);
-    assert.ok(pulls <= 2, `stream pulled ${pulls} chunks after crossing the cap`);
   });
 });


### PR DESCRIPTION
## Outcome

Complete the server half of #668’s owner-approved Lovable Cloud authority architecture without placing a Supabase service-role credential in Fly or the native app.

## Acceptance criteria

- Fly verifies transient browser identity only through Supabase’s public user endpoint.
- Fly exposes a device-authenticated introspection route returning only the bound user UUID.
- The pinned `https://www.neondiff.com/api/internal/desktop/workspaces` route receives the device bearer credential and returns the Lovable-authoritative account/workspace/bot/entitlement snapshot.
- Fly rejects redirects, foreign/broader authority URLs, oversized or non-JSON responses, malformed identifiers, and user-ID mismatches.
- Workspace loading remains bound to the exact consumed state and current device binding from #672.
- `ACCOUNT_LINK_SUPABASE_SERVICE_ROLE_KEY` is removed from the Fly runtime contract.
- Account linking remains feature-flagged off until protected configuration and end-to-end canary proof exist.

## Focused proof

- license-api TypeScript build: passed
- composed authority + account-link + migration suites: 26/26 passed
- diff check: passed
- no Fly service-role-key references remain in `services/license-api`

## Non-goals

- No Lovable or Fly deployment, protected-environment change, checkout, billing mutation, signing, publication, or customer canary.
- No native Supabase credential or direct database access.
- No broader #517, #646, #630, or GA closure.
- Does not close #668; live configuration, account/workspace/bot validation, installed-app proof, and kill-switch/rollback proof remain open.

Relates to #668 and #610. Website counterpart: electricsheephq/neon-diff-agent-website#73 (merged, not deployed).
