### PR TITLE
fix(desktop): detect the verified local bot setup

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -1,0 +1,26 @@
+import Foundation
+import NeonDiffDesktopAppCore
+
+enum LaunchAgentLocalBotConfigurationDiscovery {
+    static let defaultLabel = "com.electricsheephq.evaos-code-review-bot"
+
+    static func discover(
+        label: String = defaultLabel,
+        fileManager: FileManager = .default
+    ) -> [DesktopLocalBotConfiguration] {
+        let launchAgentURL = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+            .appendingPathComponent("\(label).plist")
+            .standardizedFileURL
+        guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe),
+              let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
+                  data: data,
+                  expectedLabel: label,
+                  configExists: { fileManager.fileExists(atPath: $0.path) }
+              )
+        else {
+            return []
+        }
+        return [configuration]
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -49,7 +49,8 @@ enum NeonDiffDesktopCompositionRoot {
             githubBroker: githubBroker,
             accountLink: accountLink,
             productionBoundary: productionBoundary,
-            cliWorkingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory()
+            cliWorkingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory(),
+            localBotConfigurations: LaunchAgentLocalBotConfigurationDiscovery.discover()
         ))
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -179,6 +179,7 @@ private struct ReferenceShellLayout: View {
                             accountLinkAvailable: model.accountLinkAvailable,
                             accountCatalog: model.accountWorkspaceCatalog,
                             accountSelection: model.accountWorkspaceSelection,
+                            accountStatus: model.accountWorkspaceStatus,
                             selectAccount: model.selectAccountWorkspace,
                             selectBot: model.selectBotInstallation,
                             beginNewBot: { model.beginNewBot() },

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
@@ -8,6 +8,7 @@ struct SidebarView: View {
     let accountLinkAvailable: Bool
     let accountCatalog: DesktopAccountWorkspaceCatalog
     let accountSelection: DesktopAccountWorkspaceSelection
+    let accountStatus: String
     let selectAccount: (String) -> Void
     let selectBot: (String) -> Void
     let beginNewBot: () -> Void
@@ -141,7 +142,7 @@ struct SidebarView: View {
                 Text("ACCOUNT LINK UNAVAILABLE")
             }
         case .loading:
-            Text("LOADING ACCOUNTS…")
+            Text(accountStatus.uppercased())
             Button {
                 cancelAccountLink()
             } label: {
@@ -193,7 +194,9 @@ struct SidebarView: View {
                             selectBot(bot.id)
                         } label: {
                             Label(
-                                bot.appSlug,
+                                bot.isAvailableOnThisMac
+                                    ? "\(bot.appSlug) · THIS MAC"
+                                    : bot.appSlug,
                                 systemImage: accountSelection.botID == bot.id
                                     ? "checkmark.square.fill"
                                     : bot.isAvailableOnThisMac ? "laptopcomputer" : "app.badge"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -114,6 +114,7 @@ package struct DesktopAppDependencies {
     package let accountLink: (any NeonDiffAccountLinkConnecting)?
     package let productionBoundary: DesktopProductionBoundary
     package let cliWorkingDirectory: URL?
+    package let localBotConfigurations: [DesktopLocalBotConfiguration]
 
     package init(
         clipboard: any DesktopClipboard,
@@ -129,7 +130,8 @@ package struct DesktopAppDependencies {
         githubBroker: (any GitHubBrokerConnecting)? = nil,
         accountLink: (any NeonDiffAccountLinkConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
-        cliWorkingDirectory: URL? = nil
+        cliWorkingDirectory: URL? = nil,
+        localBotConfigurations: [DesktopLocalBotConfiguration] = []
     ) {
         self.clipboard = clipboard
         self.urlOpener = urlOpener
@@ -145,5 +147,6 @@ package struct DesktopAppDependencies {
         self.accountLink = accountLink
         self.productionBoundary = productionBoundary
         self.cliWorkingDirectory = cliWorkingDirectory
+        self.localBotConfigurations = localBotConfigurations
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopAccountWorkspace.swift
@@ -98,17 +98,20 @@ package struct DesktopBotInstallation: Identifiable, Codable, Equatable, Sendabl
 }
 
 package struct DesktopLocalBotCandidate: Equatable, Sendable {
+    package let botID: String
     package let appID: Int64
     package let appSlug: String?
     package let githubAccountLogin: String
     package let configPath: String
 
     package init(
+        botID: String,
         appID: Int64,
         appSlug: String?,
         githubAccountLogin: String,
         configPath: String
     ) {
+        self.botID = botID
         self.appID = appID
         self.appSlug = appSlug
         self.githubAccountLogin = githubAccountLogin
@@ -151,7 +154,8 @@ package struct DesktopAccountWorkspace: Identifiable, Codable, Equatable, Sendab
             guard bot.status == .verified,
                   let account = bot.githubAccountLogin,
                   let local = localCandidates.first(where: {
-                      $0.appID == bot.appID
+                      $0.botID == bot.id
+                          && $0.appID == bot.appID
                           && ($0.appSlug == nil
                               || $0.appSlug?.caseInsensitiveCompare(bot.appSlug) == .orderedSame)
                           && $0.githubAccountLogin.caseInsensitiveCompare(account) == .orderedSame

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Public, non-secret coordinates for an existing local NeonDiff worker.
+///
+/// This never contains a private-key path or value. Server-authoritative
+/// account and installation data must still intersect the App ID before the
+/// config can be attached to a selectable bot.
+package struct DesktopLocalBotConfiguration: Equatable, Sendable {
+    package let appID: Int64
+    package let configPath: String
+
+    package init(appID: Int64, configPath: String) {
+        self.appID = appID
+        self.configPath = configPath
+    }
+}
+
+package enum DesktopLaunchAgentBotConfigurationParser {
+    private static let supportedAppIDKeys = [
+        "NEONDIFF_GITHUB_APP_ID",
+        "EVAOS_REVIEW_BOT_APP_ID"
+    ]
+
+    package static func parse(
+        data: Data,
+        expectedLabel: String,
+        configExists: (URL) -> Bool
+    ) -> DesktopLocalBotConfiguration? {
+        guard let propertyList = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ),
+        let root = propertyList as? [String: Any],
+        root["Label"] as? String == expectedLabel,
+        let environment = root["EnvironmentVariables"] as? [String: Any],
+        let arguments = root["ProgramArguments"] as? [String]
+        else {
+            return nil
+        }
+
+        let presentAppIDs = supportedAppIDKeys.compactMap { key -> String? in
+            guard let value = environment[key] else { return nil }
+            return value as? String
+        }
+        let presentAppIDKeyCount = supportedAppIDKeys.filter {
+            environment[$0] != nil
+        }.count
+        guard !presentAppIDs.isEmpty,
+              presentAppIDs.count == presentAppIDKeyCount
+        else {
+            return nil
+        }
+        let normalizedAppIDs = presentAppIDs.compactMap { raw -> Int64? in
+            guard !raw.isEmpty,
+                  raw.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+                  let value = Int64(raw),
+                  value > 0
+            else {
+                return nil
+            }
+            return value
+        }
+        guard normalizedAppIDs.count == presentAppIDs.count,
+              Set(normalizedAppIDs).count == 1,
+              let appID = normalizedAppIDs.first
+        else {
+            return nil
+        }
+
+        let configIndexes = arguments.indices.filter { index in
+            arguments[index] == "--config"
+                && arguments.index(after: index) < arguments.endIndex
+        }
+        guard configIndexes.count == 1,
+              let configIndex = configIndexes.first
+        else {
+            return nil
+        }
+        let rawConfigPath = arguments[arguments.index(after: configIndex)]
+        guard rawConfigPath.hasPrefix("/") else { return nil }
+        let configURL = URL(filePath: rawConfigPath).standardizedFileURL
+        guard configExists(configURL) else { return nil }
+
+        return DesktopLocalBotConfiguration(
+            appID: appID,
+            configPath: configURL.path
+        )
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -68,12 +68,12 @@ package enum DesktopLaunchAgentBotConfigurationParser {
             return nil
         }
 
-        let configIndexes = arguments.indices.filter { index in
-            arguments[index] == "--config"
-                && arguments.index(after: index) < arguments.endIndex
+        let configIndexes = arguments.indices.filter {
+            arguments[$0] == "--config"
         }
         guard configIndexes.count == 1,
-              let configIndex = configIndexes.first
+              let configIndex = configIndexes.first,
+              arguments.index(after: configIndex) < arguments.endIndex
         else {
             return nil
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -690,10 +690,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func currentLocalBotCandidates(
         snapshot: NeonDiffAccountWorkspaceSnapshot
     ) -> [DesktopLocalBotCandidate] {
-        if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil,
-           let installationID = Self.savedManagedGitHubInstallationId(
-               preferences: dependencies.preferences
-           ) {
+        if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil {
+            guard let installationID = Self.savedManagedGitHubInstallationId(
+                preferences: dependencies.preferences
+            ) else {
+                return []
+            }
             guard dependencies.fileWriter.fileExists(at: URL(filePath: configPath)) else {
                 return []
             }
@@ -717,6 +719,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             )]
         }
 
+        guard dependencies.productionBoundary.byoGitHubEnabled else {
+            return []
+        }
+
         var candidates: [DesktopLocalBotCandidate] = []
         for configuration in dependencies.localBotConfigurations {
             let configurationURL = URL(filePath: configuration.configPath)
@@ -724,45 +730,25 @@ package final class NeonDiffDesktopModel: ObservableObject {
             guard dependencies.fileWriter.fileExists(at: configurationURL) else {
                 continue
             }
-            let matches = snapshot.accounts.flatMap(\.bots).filter {
-                $0.mode == .byo
-                    && $0.appID == configuration.appID
-                    && $0.status == .verified
-                    && $0.githubAccountLogin?.isEmpty == false
-            }
-            guard matches.count == 1,
-                  let matchedBot = matches.first,
-                  let githubAccountLogin = matchedBot.githubAccountLogin
-            else {
-                continue
-            }
-            candidates.append(DesktopLocalBotCandidate(
+            if let candidate = verifiedBYOLocalBotCandidate(
                 appID: configuration.appID,
-                appSlug: matchedBot.appSlug,
-                githubAccountLogin: githubAccountLogin,
-                configPath: configurationURL.path
-            ))
+                configPath: configurationURL.path,
+                snapshot: snapshot
+            ) {
+                candidates.append(candidate)
+            }
         }
 
         if dependencies.fileWriter.fileExists(at: URL(filePath: configPath)),
            let rawAppID = dependencies.preferences.string(forKey: byoGitHubAppIdPreferenceKey),
            let appID = Int64(rawAppID),
            appID > 0 {
-            let matches = snapshot.accounts.flatMap(\.bots).filter {
-                $0.mode == .byo
-                    && $0.appID == appID
-                    && $0.status == .verified
-                    && $0.githubAccountLogin?.isEmpty == false
-            }
-            if matches.count == 1,
-               let matchedBot = matches.first,
-               let githubAccountLogin = matchedBot.githubAccountLogin {
-                candidates.append(DesktopLocalBotCandidate(
-                    appID: appID,
-                    appSlug: matchedBot.appSlug,
-                    githubAccountLogin: githubAccountLogin,
-                    configPath: URL(filePath: configPath).standardizedFileURL.path
-                ))
+            if let candidate = verifiedBYOLocalBotCandidate(
+                appID: appID,
+                configPath: URL(filePath: configPath).standardizedFileURL.path,
+                snapshot: snapshot
+            ) {
+                candidates.append(candidate)
             }
         }
 
@@ -770,6 +756,31 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return candidates.filter {
             seen.insert("\($0.appID):\($0.configPath)").inserted
         }
+    }
+
+    private func verifiedBYOLocalBotCandidate(
+        appID: Int64,
+        configPath: String,
+        snapshot: NeonDiffAccountWorkspaceSnapshot
+    ) -> DesktopLocalBotCandidate? {
+        let matches = snapshot.accounts.flatMap(\.bots).filter {
+            $0.mode == .byo
+                && $0.appID == appID
+                && $0.status == .verified
+                && $0.githubAccountLogin?.isEmpty == false
+        }
+        guard matches.count == 1,
+              let matchedBot = matches.first,
+              let githubAccountLogin = matchedBot.githubAccountLogin
+        else {
+            return nil
+        }
+        return DesktopLocalBotCandidate(
+            appID: appID,
+            appSlug: matchedBot.appSlug,
+            githubAccountLogin: githubAccountLogin,
+            configPath: configPath
+        )
     }
 
     private func applyAccountLinkFailure(_ error: Error, generation: UInt64) {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -712,6 +712,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 return []
             }
             return [DesktopLocalBotCandidate(
+                botID: managed.id,
                 appID: managed.appID,
                 appSlug: managed.appSlug,
                 githubAccountLogin: githubAccountLogin,
@@ -776,6 +777,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return nil
         }
         return DesktopLocalBotCandidate(
+            botID: matchedBot.id,
             appID: appID,
             appSlug: matchedBot.appSlug,
             githubAccountLogin: githubAccountLogin,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -690,14 +690,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func currentLocalBotCandidates(
         snapshot: NeonDiffAccountWorkspaceSnapshot
     ) -> [DesktopLocalBotCandidate] {
-        guard dependencies.fileWriter.fileExists(at: URL(filePath: configPath)) else {
-            return []
-        }
-
         if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil,
            let installationID = Self.savedManagedGitHubInstallationId(
                preferences: dependencies.preferences
            ) {
+            guard dependencies.fileWriter.fileExists(at: URL(filePath: configPath)) else {
+                return []
+            }
             let managedMatches = snapshot.accounts.flatMap(\.bots).filter {
                 $0.mode == .managed
                     && $0.githubInstallationID == Int64(installationID)
@@ -718,30 +717,59 @@ package final class NeonDiffDesktopModel: ObservableObject {
             )]
         }
 
-        guard let rawAppID = dependencies.preferences.string(forKey: byoGitHubAppIdPreferenceKey),
-              let appID = Int64(rawAppID),
-              appID > 0
-        else {
-            return []
+        var candidates: [DesktopLocalBotCandidate] = []
+        for configuration in dependencies.localBotConfigurations {
+            let configurationURL = URL(filePath: configuration.configPath)
+                .standardizedFileURL
+            guard dependencies.fileWriter.fileExists(at: configurationURL) else {
+                continue
+            }
+            let matches = snapshot.accounts.flatMap(\.bots).filter {
+                $0.mode == .byo
+                    && $0.appID == configuration.appID
+                    && $0.status == .verified
+                    && $0.githubAccountLogin?.isEmpty == false
+            }
+            guard matches.count == 1,
+                  let matchedBot = matches.first,
+                  let githubAccountLogin = matchedBot.githubAccountLogin
+            else {
+                continue
+            }
+            candidates.append(DesktopLocalBotCandidate(
+                appID: configuration.appID,
+                appSlug: matchedBot.appSlug,
+                githubAccountLogin: githubAccountLogin,
+                configPath: configurationURL.path
+            ))
         }
 
-        let matches = snapshot.accounts.flatMap(\.bots).filter {
-            $0.appID == appID
-                && $0.status == .verified
-                && $0.githubAccountLogin?.isEmpty == false
+        if dependencies.fileWriter.fileExists(at: URL(filePath: configPath)),
+           let rawAppID = dependencies.preferences.string(forKey: byoGitHubAppIdPreferenceKey),
+           let appID = Int64(rawAppID),
+           appID > 0 {
+            let matches = snapshot.accounts.flatMap(\.bots).filter {
+                $0.mode == .byo
+                    && $0.appID == appID
+                    && $0.status == .verified
+                    && $0.githubAccountLogin?.isEmpty == false
+            }
+            if matches.count == 1,
+               let matchedBot = matches.first,
+               let githubAccountLogin = matchedBot.githubAccountLogin {
+                candidates.append(DesktopLocalBotCandidate(
+                    appID: appID,
+                    appSlug: matchedBot.appSlug,
+                    githubAccountLogin: githubAccountLogin,
+                    configPath: URL(filePath: configPath).standardizedFileURL.path
+                ))
+            }
         }
-        guard matches.count == 1, let matchedBot = matches.first else {
-            return []
+
+        var seen = Set<String>()
+        return candidates.filter {
+            seen.insert("\($0.appID):\($0.configPath)").inserted
         }
-        guard let githubAccountLogin = matchedBot.githubAccountLogin else {
-            return []
-        }
-        return [DesktopLocalBotCandidate(
-            appID: appID,
-            appSlug: matchedBot.appSlug,
-            githubAccountLogin: githubAccountLogin,
-            configPath: URL(filePath: configPath).standardizedFileURL.path
-        )]
     }
 
     private func applyAccountLinkFailure(_ error: Error, generation: UInt64) {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountLinkModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountLinkModelTests.swift
@@ -216,6 +216,45 @@ import NeonDiffDesktopCore
         #expect(model.selectedBotInstallation?.localConfigPath == configURL.path)
     }
 
+    @Test func verifiedBYOBotDiscoversTheKnownLocalLaunchAgentConfigWithoutClientAuthority() async throws {
+        let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
+            .appendingPathComponent("neondiff-account-local-discovery-\(UUID().uuidString)", isDirectory: true)
+        let fileWriter = TemporaryFileWriter(root: root)
+        let configURL = root.appendingPathComponent("existing-worker.json")
+        try fileWriter.write(Data("{}".utf8), to: configURL)
+        let preferences = MemoryPreferences()
+        let model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
+            clipboard: RecordingClipboard(),
+            urlOpener: RecordingURLOpener(),
+            cli: RecordingCLIExecutor(),
+            dashboard: RecordingDashboardLauncher(),
+            preferences: preferences,
+            clock: TestClock(),
+            fileWriter: fileWriter,
+            providerVerifier: RecordingProviderVerifier(),
+            secretStore: AccountLinkMemorySecretStore(),
+            githubAuthenticator: StubGitHubAuthenticator(),
+            accountLink: ScriptedAccountLink(workspaceResults: [
+                .success(AccountLinkFixtures.electricSheep)
+            ]),
+            productionBoundary: .testAccountLink,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4242,
+                    configPath: configURL.path
+                )
+            ]
+        ))
+
+        model.connectNeonDiffAccount()
+        await model.waitForAccountLinkOperation()
+
+        #expect(model.selectedBotInstallation?.appSlug == "evaos-code-review-bot")
+        #expect(model.selectedBotInstallation?.localConfigPath == configURL.path)
+        #expect(model.configPath == configURL.path)
+        #expect(preferences.string(forKey: "neondiff.byoGitHubAppId") == nil)
+    }
+
     @Test func cancelledAccountLinkCannotInstallALateWorkspaceResult() async {
         let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
             .appendingPathComponent("neondiff-account-late-\(UUID().uuidString)", isDirectory: true)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountLinkModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountLinkModelTests.swift
@@ -165,6 +165,100 @@ import NeonDiffDesktopCore
         })
     }
 
+    @Test func ambiguousDiscoveredBYOAppAcrossAccountsNeverAttachesTheLocalConfig() async throws {
+        let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
+            .appendingPathComponent(
+                "neondiff-account-discovered-ambiguous-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        let fileWriter = TemporaryFileWriter(root: root)
+        let configURL = root.appendingPathComponent("existing-worker.json")
+        try fileWriter.write(Data("{}".utf8), to: configURL)
+        let snapshot = NeonDiffAccountWorkspaceSnapshot(accounts: [
+            AccountLinkFixtures.workspace(
+                id: "11111111-1111-4111-8111-111111111111",
+                name: "Personal",
+                login: "100yenadmin",
+                botID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+            ),
+            AccountLinkFixtures.workspace(
+                id: "22222222-2222-4222-8222-222222222222",
+                name: "Electric Sheep",
+                login: "electricsheephq",
+                botID: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+            )
+        ])
+        let model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
+            clipboard: RecordingClipboard(),
+            urlOpener: RecordingURLOpener(),
+            cli: RecordingCLIExecutor(),
+            dashboard: RecordingDashboardLauncher(),
+            preferences: MemoryPreferences(),
+            clock: TestClock(),
+            fileWriter: fileWriter,
+            providerVerifier: RecordingProviderVerifier(),
+            secretStore: AccountLinkMemorySecretStore(),
+            githubAuthenticator: StubGitHubAuthenticator(),
+            accountLink: ScriptedAccountLink(workspaceResults: [.success(snapshot)]),
+            productionBoundary: .testAccountLink,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4242,
+                    configPath: configURL.path
+                )
+            ]
+        ))
+
+        model.connectNeonDiffAccount()
+        await model.waitForAccountLinkOperation()
+
+        #expect(model.accountWorkspaceCatalog.accounts.flatMap(\.bots).allSatisfy {
+            $0.localConfigPath == nil
+        })
+        #expect(model.configPath != configURL.path)
+    }
+
+    @Test func managedOnlyBuildNeverAttachesDiscoveredBYOConfiguration() async throws {
+        let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
+            .appendingPathComponent(
+                "neondiff-account-managed-no-byo-fallback-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        let fileWriter = TemporaryFileWriter(root: root)
+        let configURL = root.appendingPathComponent("legacy-byo-worker.json")
+        try fileWriter.write(Data("{}".utf8), to: configURL)
+        let model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
+            clipboard: RecordingClipboard(),
+            urlOpener: RecordingURLOpener(),
+            cli: RecordingCLIExecutor(),
+            dashboard: RecordingDashboardLauncher(),
+            preferences: MemoryPreferences(),
+            clock: TestClock(),
+            fileWriter: fileWriter,
+            providerVerifier: RecordingProviderVerifier(),
+            secretStore: AccountLinkMemorySecretStore(),
+            githubAuthenticator: StubGitHubAuthenticator(),
+            accountLink: ScriptedAccountLink(workspaceResults: [
+                .success(AccountLinkFixtures.electricSheep)
+            ]),
+            productionBoundary: .testManagedAccountLink,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4242,
+                    configPath: configURL.path
+                )
+            ]
+        ))
+
+        model.connectNeonDiffAccount()
+        await model.waitForAccountLinkOperation()
+
+        #expect(model.accountWorkspaceCatalog.accounts.flatMap(\.bots).allSatisfy {
+            $0.localConfigPath == nil
+        })
+        #expect(model.configPath != configURL.path)
+    }
+
     @Test func managedInstallationReconcilesOnlyByItsSavedInstallationID() async throws {
         let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
             .appendingPathComponent("neondiff-account-managed-\(UUID().uuidString)", isDirectory: true)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -42,6 +42,7 @@ import NeonDiffDesktopCore
 
     @Test func matchingLocalBotIsMergedWithoutDuplicatingTheServerInstallation() throws {
         let local = DesktopLocalBotCandidate(
+            botID: "bot-evaos-code-review-bot",
             appID: 4_184_532,
             appSlug: "evaos-code-review-bot",
             githubAccountLogin: "electricsheephq",
@@ -56,8 +57,42 @@ import NeonDiffDesktopCore
         #expect(bot.isAvailableOnThisMac)
     }
 
+    @Test func localCandidateAttachesOnlyToItsExactAuthoritativeBot() {
+        let managedTwin = DesktopBotInstallation(
+            id: "bot-managed-twin",
+            appID: 4_184_532,
+            appSlug: "evaos-code-review-bot",
+            mode: .managed,
+            githubInstallationID: 72_002,
+            githubAccountLogin: "electricsheephq",
+            status: .verified,
+            localConfigPath: nil
+        )
+        let workspace = DesktopAccountWorkspace(
+            id: electricSheep.id,
+            kind: electricSheep.kind,
+            name: electricSheep.name,
+            role: electricSheep.role,
+            entitlement: electricSheep.entitlement,
+            bots: electricSheep.bots + [managedTwin]
+        )
+        let local = DesktopLocalBotCandidate(
+            botID: "bot-evaos-code-review-bot",
+            appID: 4_184_532,
+            appSlug: "evaos-code-review-bot",
+            githubAccountLogin: "electricsheephq",
+            configPath: "/Users/test/Library/Application Support/NeonDiff/config.local.json"
+        )
+
+        let merged = workspace.merging(localCandidates: [local])
+
+        #expect(merged.bots[0].localConfigPath == local.configPath)
+        #expect(merged.bots[1].localConfigPath == nil)
+    }
+
     @Test func localBotCannotCrossAnAuthoritativeGitHubAccountBoundary() {
         let local = DesktopLocalBotCandidate(
+            botID: "bot-evaos-code-review-bot",
             appID: 4_184_532,
             appSlug: "evaos-code-review-bot",
             githubAccountLogin: "someone-else",
@@ -267,6 +302,7 @@ import NeonDiffDesktopCore
         fixture.model.beginNewBot(appSlug: "electric-sheep-secondary")
         let original = try #require(fixture.model.pendingNewBotPlan)
         let local = DesktopLocalBotCandidate(
+            botID: "bot-evaos-code-review-bot",
             appID: 4_184_532,
             appSlug: "evaos-code-review-bot",
             githubAccountLogin: "electricsheephq",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopAppCore
+
+@Suite struct LaunchAgentLocalBotConfigurationTests {
+    @Test func parsesOnlyTheKnownLabelPublicAppIDAndAbsoluteConfigPath() throws {
+        let configURL = URL(filePath: NSTemporaryDirectory())
+            .appendingPathComponent("existing-neondiff-worker.json")
+            .standardizedFileURL
+        let data = try propertyList(
+            label: "com.electricsheephq.evaos-code-review-bot",
+            environment: [
+                "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": "/never/read/this.pem"
+            ],
+            arguments: [
+                "/opt/homebrew/bin/neondiff",
+                "daemon",
+                "--config",
+                configURL.path
+            ]
+        )
+
+        let parsed = DesktopLaunchAgentBotConfigurationParser.parse(
+            data: data,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { $0 == configURL }
+        )
+
+        #expect(parsed == DesktopLocalBotConfiguration(
+            appID: 4_184_532,
+            configPath: configURL.path
+        ))
+    }
+
+    @Test func rejectsWrongLabelMissingConfigAndConflictingAppIDs() throws {
+        let configURL = URL(filePath: "/tmp/existing-neondiff-worker.json")
+        let wrongLabel = try propertyList(
+            label: "com.example.other",
+            environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
+            arguments: ["neondiff", "--config", configURL.path]
+        )
+        let conflictingIDs = try propertyList(
+            label: "com.electricsheephq.evaos-code-review-bot",
+            environment: [
+                "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                "NEONDIFF_GITHUB_APP_ID": "4332113"
+            ],
+            arguments: ["neondiff", "--config", configURL.path]
+        )
+
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: wrongLabel,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { _ in true }
+        ) == nil)
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: conflictingIDs,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { _ in true }
+        ) == nil)
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
+                arguments: ["neondiff", "--config", configURL.path]
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { _ in false }
+        ) == nil)
+    }
+
+    private func propertyList(
+        label: String,
+        environment: [String: String],
+        arguments: [String]
+    ) throws -> Data {
+        try PropertyListSerialization.data(
+            fromPropertyList: [
+                "Label": label,
+                "EnvironmentVariables": environment,
+                "ProgramArguments": arguments
+            ],
+            format: .xml,
+            options: 0
+        )
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -70,6 +70,26 @@ import Testing
         ) == nil)
     }
 
+    @Test func rejectsDuplicateConfigFlagsIncludingATrailingBareFlag() throws {
+        let configURL = URL(filePath: "/tmp/existing-neondiff-worker.json")
+        let duplicateConfig = try propertyList(
+            label: "com.electricsheephq.evaos-code-review-bot",
+            environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
+            arguments: [
+                "neondiff",
+                "--config",
+                configURL.path,
+                "--config"
+            ]
+        )
+
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: duplicateConfig,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { _ in true }
+        ) == nil)
+    }
+
     private func propertyList(
         label: String,
         environment: [String: String],

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -128,6 +128,8 @@ import Testing
         #expect(sidebar.contains("neondiff-account-menu"))
         #expect(sidebar.contains("neondiff-account-option-"))
         #expect(sidebar.contains("neondiff-bot-option-"))
+        #expect(sidebar.contains("THIS MAC"))
+        #expect(sidebar.contains("accountStatus.uppercased()"))
         #expect(sidebar.contains("NEW BOT"))
         #expect(sidebar.contains("neondiff-new-bot"))
         #expect(sidebar.contains("SYSTEM READINESS"))


### PR DESCRIPTION
## Outcome

Make the installed NeonDiff app recognize the existing local `evaos-code-review-bot` configuration only after the server workspace snapshot marks that exact App installation verified. The account menu then labels it `THIS MAC` and shows the live browser-link status while account linking is in progress.

Relates to #666, #646, and #610. This is a bounded beta-usability slice and does not close #666.

## Acceptance criteria

- Extract only the known local launch agent's public App ID and absolute config path for model use.
- Require one exact intersection with a server-authoritative, verified BYO bot installation before attaching a local config.
- Reject wrong launch-agent labels, conflicting/invalid App IDs, duplicate or malformed config flags, relative or missing config paths, pending/revoked bots, and ambiguous server matches.
- Do not dereference the launch agent's private-key path or read, copy, store, log, or display private-key material.
- Keep managed-only builds out of legacy BYO discovery and bind local config to the exact authoritative bot ID.
- Label the matched bot `THIS MAC`; keep credential verification and repository/entitlement gates unchanged.
- Surface the current account-link progress text in the logo menu and preserve Cancel/retry recovery.

## Failing-first and focused proof

RED:

- The initial focused Swift command failed because the local configuration/parser contract and dependency seam did not exist.
- The managed-only regression failed before the boundary guard.
- The duplicate trailing `--config` regression failed before the parser correction.
- The same-App BYO/managed regression failed before exact bot-ID binding.

GREEN:

```text
swift test --filter 'AccountLinkModelTests|AccountWorkspaceSelectionTests|LaunchAgentLocalBotConfigurationTests|OwnerReferenceUXContractTests'
40 tests passed

git diff --check
passed
```

Exact head: `17b35ec07a7a35d5b43016116dee3d4a1ed17192`

## Runtime precondition proved separately

GitHub's organization-admin API reports App ID `4184532` / slug `evaos-code-review-bot` installed and unsuspended on `electricsheephq`. The Lovable authority row was conditionally reconciled from pending/no installation to that exact verified installation; no credentials or repository access were changed.

`THIS MAC` means a compatible local config is present on this Mac. It is not a claim that launchd is currently loaded or healthy; runtime status and recovery remain separate.

## Non-goals

- No private-key import, Keychain mutation, credential rotation, or live worker/config mutation.
- No activation or entitlement bypass; no change to B0's paid-all-repositories contract.
- No custom launch-agent label discovery in this bounded exact-default-worker slice.
- No claim that broader first-run docs/onboarding are complete.
- No checkout, billing, download, publication, canary, signed-artifact, beta, GA, or customer-readiness claim.
- No closure of broader #666, #646, #517, #612, #613, or #630.
