### PR TITLE
Fix installed local worker runtime directory

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -3,15 +3,31 @@ import NeonDiffDesktopAppCore
 import NeonDiffDesktopCore
 
 struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
+    private let localBotConfigurations: [DesktopLocalBotConfiguration]
+    private let defaultWorkingDirectory: URL?
+
+    init(
+        localBotConfigurations: [DesktopLocalBotConfiguration] = [],
+        defaultWorkingDirectory: URL? = NeonDiffCLIResolver.defaultWorkingDirectory()
+    ) {
+        self.localBotConfigurations = localBotConfigurations
+        self.defaultWorkingDirectory = defaultWorkingDirectory
+    }
+
     func run(
         executablePath: String,
         arguments: [String],
         standardInput: Data?,
         timeout: TimeInterval
     ) async throws -> CLIRunResult {
+        let workingDirectory = DesktopLocalBotWorkingDirectoryResolver.resolve(
+            arguments: arguments,
+            localBotConfigurations: localBotConfigurations,
+            fallback: defaultWorkingDirectory
+        )
         let client = NeonDiffCLIClient(
             executablePath: executablePath,
-            workingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory()
+            workingDirectory: workingDirectory
         )
         return try await client.runCancellable(
             arguments: arguments,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -16,7 +16,14 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
               let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
                   data: data,
                   expectedLabel: label,
-                  configExists: { fileManager.fileExists(atPath: $0.path) }
+                  configExists: { fileManager.fileExists(atPath: $0.path) },
+                  workingDirectoryExists: {
+                      var isDirectory: ObjCBool = false
+                      return fileManager.fileExists(
+                          atPath: $0.path,
+                          isDirectory: &isDirectory
+                      ) && isDirectory.boolValue
+                  }
               )
         else {
             return []

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -35,10 +35,15 @@ enum NeonDiffDesktopCompositionRoot {
         if productionBoundary.managedGitHubBrokerOrigin != nil, githubBroker == nil {
             productionBoundary = .quarantined
         }
+        let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
+        let localBotConfigurations = LaunchAgentLocalBotConfigurationDiscovery.discover()
         return NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: AppKitClipboard(),
             urlOpener: AppKitURLOpener(),
-            cli: FoundationDesktopCLIExecutor(),
+            cli: FoundationDesktopCLIExecutor(
+                localBotConfigurations: localBotConfigurations,
+                defaultWorkingDirectory: cliWorkingDirectory
+            ),
             dashboard: FoundationDesktopDashboardLauncher(),
             preferences: UserDefaultsDesktopPreferences(.standard),
             clock: ContinuousDesktopClock(),
@@ -49,8 +54,8 @@ enum NeonDiffDesktopCompositionRoot {
             githubBroker: githubBroker,
             accountLink: accountLink,
             productionBoundary: productionBoundary,
-            cliWorkingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory(),
-            localBotConfigurations: LaunchAgentLocalBotConfigurationDiscovery.discover()
+            cliWorkingDirectory: cliWorkingDirectory,
+            localBotConfigurations: localBotConfigurations
         ))
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -8,10 +8,16 @@ import Foundation
 package struct DesktopLocalBotConfiguration: Equatable, Sendable {
     package let appID: Int64
     package let configPath: String
+    package let workingDirectory: String?
 
-    package init(appID: Int64, configPath: String) {
+    package init(
+        appID: Int64,
+        configPath: String,
+        workingDirectory: String? = nil
+    ) {
         self.appID = appID
         self.configPath = configPath
+        self.workingDirectory = workingDirectory
     }
 }
 
@@ -24,7 +30,8 @@ package enum DesktopLaunchAgentBotConfigurationParser {
     package static func parse(
         data: Data,
         expectedLabel: String,
-        configExists: (URL) -> Bool
+        configExists: (URL) -> Bool,
+        workingDirectoryExists: (URL) -> Bool
     ) -> DesktopLocalBotConfiguration? {
         guard let propertyList = try? PropertyListSerialization.propertyList(
             from: data,
@@ -82,9 +89,51 @@ package enum DesktopLaunchAgentBotConfigurationParser {
         let configURL = URL(filePath: rawConfigPath).standardizedFileURL
         guard configExists(configURL) else { return nil }
 
+        guard let rawWorkingDirectory = root["WorkingDirectory"] as? String,
+              rawWorkingDirectory.hasPrefix("/")
+        else {
+            return nil
+        }
+        let workingDirectoryURL = URL(filePath: rawWorkingDirectory)
+            .standardizedFileURL
+        guard workingDirectoryExists(workingDirectoryURL) else { return nil }
+
         return DesktopLocalBotConfiguration(
             appID: appID,
-            configPath: configURL.path
+            configPath: configURL.path,
+            workingDirectory: workingDirectoryURL.path
         )
+    }
+}
+
+package enum DesktopLocalBotWorkingDirectoryResolver {
+    package static func resolve(
+        arguments: [String],
+        localBotConfigurations: [DesktopLocalBotConfiguration],
+        fallback: URL?
+    ) -> URL? {
+        let configIndexes = arguments.indices.filter {
+            arguments[$0] == "--config"
+        }
+        guard configIndexes.count == 1,
+              let configIndex = configIndexes.first,
+              arguments.index(after: configIndex) < arguments.endIndex
+        else {
+            return fallback
+        }
+
+        let rawConfigPath = arguments[arguments.index(after: configIndex)]
+        guard rawConfigPath.hasPrefix("/") else { return fallback }
+        let configPath = URL(filePath: rawConfigPath).standardizedFileURL.path
+        let matches = localBotConfigurations.filter {
+            URL(filePath: $0.configPath).standardizedFileURL.path == configPath
+                && $0.workingDirectory != nil
+        }
+        guard matches.count == 1,
+              let workingDirectory = matches[0].workingDirectory
+        else {
+            return fallback
+        }
+        return URL(filePath: workingDirectory).standardizedFileURL
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -24,12 +24,17 @@ import Testing
         let parsed = DesktopLaunchAgentBotConfigurationParser.parse(
             data: data,
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
-            configExists: { $0 == configURL }
+            configExists: { $0 == configURL },
+            workingDirectoryExists: {
+                $0 == URL(filePath: "/Volumes/LEXAR/repos/evaos-code-review-bot")
+                    .standardizedFileURL
+            }
         )
 
         #expect(parsed == DesktopLocalBotConfiguration(
             appID: 4_184_532,
-            configPath: configURL.path
+            configPath: configURL.path,
+            workingDirectory: "/Volumes/LEXAR/repos/evaos-code-review-bot"
         ))
     }
 
@@ -52,12 +57,14 @@ import Testing
         #expect(DesktopLaunchAgentBotConfigurationParser.parse(
             data: wrongLabel,
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
-            configExists: { _ in true }
+            configExists: { _ in true },
+            workingDirectoryExists: { _ in true }
         ) == nil)
         #expect(DesktopLaunchAgentBotConfigurationParser.parse(
             data: conflictingIDs,
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
-            configExists: { _ in true }
+            configExists: { _ in true },
+            workingDirectoryExists: { _ in true }
         ) == nil)
         #expect(DesktopLaunchAgentBotConfigurationParser.parse(
             data: try propertyList(
@@ -66,7 +73,29 @@ import Testing
                 arguments: ["neondiff", "--config", configURL.path]
             ),
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
-            configExists: { _ in false }
+            configExists: { _ in false },
+            workingDirectoryExists: { _ in true }
+        ) == nil)
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
+                arguments: ["neondiff", "--config", configURL.path],
+                workingDirectory: "relative/path"
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { _ in true },
+            workingDirectoryExists: { _ in true }
+        ) == nil)
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
+                arguments: ["neondiff", "--config", configURL.path]
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            configExists: { _ in true },
+            workingDirectoryExists: { _ in false }
         ) == nil)
     }
 
@@ -86,20 +115,64 @@ import Testing
         #expect(DesktopLaunchAgentBotConfigurationParser.parse(
             data: duplicateConfig,
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
-            configExists: { _ in true }
+            configExists: { _ in true },
+            workingDirectoryExists: { _ in true }
         ) == nil)
+    }
+
+    @Test func resolvesOnlyOneExactLocalConfigToItsVerifiedWorkingDirectory() {
+        let configuration = DesktopLocalBotConfiguration(
+            appID: 4_184_532,
+            configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+            workingDirectory: "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        )
+        let fallback = URL(filePath: "/fallback")
+
+        #expect(DesktopLocalBotWorkingDirectoryResolver.resolve(
+            arguments: [
+                "daemon",
+                "status",
+                "--config",
+                configuration.configPath,
+                "--launchd-label",
+                "com.electricsheephq.evaos-code-review-bot"
+            ],
+            localBotConfigurations: [configuration],
+            fallback: fallback
+        ) == URL(filePath: configuration.workingDirectory!).standardizedFileURL)
+
+        #expect(DesktopLocalBotWorkingDirectoryResolver.resolve(
+            arguments: [
+                "daemon",
+                "status",
+                "--config",
+                configuration.configPath,
+                "--config",
+                configuration.configPath
+            ],
+            localBotConfigurations: [configuration],
+            fallback: fallback
+        ) == fallback)
+
+        #expect(DesktopLocalBotWorkingDirectoryResolver.resolve(
+            arguments: ["daemon", "status", "--config", "/other/config.json"],
+            localBotConfigurations: [configuration],
+            fallback: fallback
+        ) == fallback)
     }
 
     private func propertyList(
         label: String,
         environment: [String: String],
-        arguments: [String]
+        arguments: [String],
+        workingDirectory: String = "/Volumes/LEXAR/repos/evaos-code-review-bot"
     ) throws -> Data {
         try PropertyListSerialization.data(
             fromPropertyList: [
                 "Label": label,
                 "EnvironmentVariables": environment,
-                "ProgramArguments": arguments
+                "ProgramArguments": arguments,
+                "WorkingDirectory": workingDirectory
             ],
             format: .xml,
             options: 0


### PR DESCRIPTION
## Scope

Bounded installed-app follow-up for #666. The signed private beta.9 candidate discovered the existing local worker correctly, but `daemon status` ran without that launch agent's working directory and failed before reaching the worker:

`fatal: not a git repository (or any of the parent directories): .git`

This change carries the launch agent's verified public `WorkingDirectory` alongside its exact App ID/config coordinate and uses it only when a CLI command contains exactly one absolute `--config` that matches exactly one discovered local worker.

## Acceptance criteria

- require the exact known launch-agent label, a valid public App ID, one absolute existing config, and one absolute existing working directory
- use the matched working directory only for commands whose single `--config` exactly matches that discovered local configuration
- fall back for missing, relative, duplicate, ambiguous, or unrelated config coordinates
- preserve server-authoritative account/App intersection and never read or carry private-key material
- real read-only desktop refresh reaches structured worker status instead of the Git working-directory failure
- live config content and the running launch agent remain unchanged

## Non-goals

- no daemon start/stop or runtime mutation
- no queue retry or live review
- no new local identity or authority
- no billing, entitlement, checkout, signing, publication, or release change
- no claim that beta.9 is owner-accepted or customer-ready
- no closure of the broader #666 installed usability gate

## Proof

- failing-first parser/resolver contract was added before the implementation
- focused Swift tests: 41 passed across account link, workspace selection, local launch-agent discovery/resolution, and owner-reference UX
- `swift build`: passed
- desktop bundle check: passed
- `git diff --check`: passed
- local unsigned desktop smoke: `daemon status` returned structured worker health; the previous Git working-directory error was absent
- post-action safety: live config SHA-256/mode/mtime/size unchanged; launch agent remained loaded and running

Related to #666.
