### PR TITLE
fix(desktop): reconcile existing local bot setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ entitlement, and repository setup as configured while still requiring fresh,
 repository-scoped GitHub and activation verification before new review work.
 Local config alone can never invent account membership or unlock a review.
 This source composition is not proof that the production broker is enabled,
-that billing is live, or that a signed customer artifact exists. Generic CLI
-status/deactivate and daemon-admission validation still need exact-candidate
-integration proof under #630 before the paid-beta gate can pass.
+that billing is live, or that a signed customer artifact exists. Update,
+rollback, daemon admission, and live-review behavior still require exact signed
+candidate validation before distribution.
 The native Providers pane reads and edits the saved `providers` registry, not
 the legacy `desktop.openAICompatibleEndpoint` field. Load config, Preview, and
 Apply the exact selected provider before Verify is enabled; verification pins

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ Repository**, and **Verify App Access**, so the invited customer does not need a
 terminal or an operator edit to reach the repository-verification gate. This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.
+When the signed-in account already contains a verified bot and its App identity
+matches a local launchd/config candidate on this Mac, the native app reuses that
+authoritative account/bot intersection instead of asking the user to initialize
+or re-enter the existing worker credentials. It may show GitHub, provider,
+entitlement, and repository setup as configured while still requiring fresh,
+repository-scoped GitHub and activation verification before new review work.
+Local config alone can never invent account membership or unlock a review.
 This source composition is not proof that the production broker is enabled,
 that billing is live, or that a signed customer artifact exists. Generic CLI
 status/deactivate and daemon-admission validation still need exact-candidate
@@ -167,7 +174,10 @@ integration proof under #630 before the paid-beta gate can pass.
 The native Providers pane reads and edits the saved `providers` registry, not
 the legacy `desktop.openAICompatibleEndpoint` field. Load config, Preview, and
 Apply the exact selected provider before Verify is enabled; verification pins
-both the provider ID and inspected config revision.
+both the provider ID and inspected config revision. A provider with
+`authMode: zcode-app-config` or `none` does not use a NeonDiff-stored API key,
+so the native app reports its loaded config without showing a false missing-key
+state. `api-key-env` providers retain the Keychain and verification gate.
 
 Create or install the GitHub App before expecting PR reviews to run. The App
 must be installed on the same selected repositories listed in `pilotRepos`; see

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -15,12 +15,7 @@ struct ActivationStateView: View {
     var body: some View {
         let palette = NDPalette(scheme: colorScheme)
         Group {
-            if model.existingLocalBotIdentityReady,
-               model.licenseSetupReady,
-               (
-                   !model.byoGitHubCredentialOnboardingAvailable
-                       || model.currentRepositoryActivationReady
-               ),
+            if model.existingAccountEntitlementSummaryReady,
                let entitlement = model.selectedAccountEntitlementLabel {
                 existingAccountEntitlement(entitlement, palette: palette)
             } else {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -14,9 +14,20 @@ struct ActivationStateView: View {
 
     var body: some View {
         let palette = NDPalette(scheme: colorScheme)
-        let presentation = model.activationPresentation
+        Group {
+            if model.existingLocalBotIdentityReady,
+               model.licenseSetupReady,
+               let entitlement = model.selectedAccountEntitlementLabel {
+                existingAccountEntitlement(entitlement, palette: palette)
+            } else {
+                activationFlow(palette: palette)
+            }
+        }
+    }
 
-        VStack(alignment: .leading, spacing: 14) {
+    private func activationFlow(palette: NDPalette) -> some View {
+        let presentation = model.activationPresentation
+        return VStack(alignment: .leading, spacing: 14) {
             Text("Activation")
                 .ndSectionLabel(palette)
 
@@ -58,6 +69,35 @@ struct ActivationStateView: View {
         .overlay(Rectangle().stroke(palette.borderPrimary, lineWidth: 1))
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("neondiff.activation.state.\(presentation.state.rawValue)")
+    }
+
+    private func existingAccountEntitlement(
+        _ entitlement: String,
+        palette: NDPalette
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Activation")
+                .ndSectionLabel(palette)
+
+            Text("Active")
+                .font(.system(.headline, design: .monospaced).weight(.bold))
+                .foregroundStyle(palette.accentPrimary)
+
+            LabeledContent("Account entitlement", value: entitlement)
+                .font(NDFont.mono)
+                .foregroundStyle(palette.textPrimary)
+
+            Text("This is the authoritative entitlement for the selected existing account and bot. NeonDiff still reverifies the exact repository and current access before starting new work.")
+                .font(NDFont.mono)
+                .foregroundStyle(palette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Rectangle().fill(palette.surface))
+        .overlay(Rectangle().stroke(palette.borderPrimary, lineWidth: 1))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("neondiff.activation.existing-account")
     }
 
     private func keyField(palette: NDPalette) -> some View {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -17,6 +17,10 @@ struct ActivationStateView: View {
         Group {
             if model.existingLocalBotIdentityReady,
                model.licenseSetupReady,
+               (
+                   !model.byoGitHubCredentialOnboardingAvailable
+                       || model.currentRepositoryActivationReady
+               ),
                let entitlement = model.selectedAccountEntitlementLabel {
                 existingAccountEntitlement(entitlement, palette: palette)
             } else {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -17,36 +17,68 @@ struct LogsView: View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 10) {
                 Button { model.refreshStatus() } label: {
-                    Label("Refresh Status Logs", systemImage: "arrow.clockwise")
-                }
-                Button { model.copyCommand(model.statusCommand) } label: {
-                    Label("Copy Last Command", systemImage: "doc.on.doc")
+                    Label("Refresh Activity", systemImage: "arrow.clockwise")
                 }
             }
 
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Redacted Output")
+            OperatorSection("Current Activity") {
+                activityRow(
+                    title: "Account and bot",
+                    detail: model.existingLocalBotIdentityReady
+                        ? "Existing verified bot selected on this Mac"
+                        : "Setup or account selection required",
+                    ready: model.existingLocalBotIdentityReady
+                )
+                activityRow(
+                    title: "Repository configuration",
+                    detail: model.repositorySetupReady
+                        ? "\(model.repos.filter(\.enabled).count) configured repositories loaded"
+                        : "No applied repository configuration",
+                    ready: model.repositorySetupReady
+                )
+                activityRow(
+                    title: "Local worker",
+                    detail: model.status.healthState,
+                    ready: model.status.runtimeOk == true
+                )
+            }
+
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 10) {
+                    TextEditor(text: $model.logText)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(NeonDiffTheme.textPrimary)
+                        .scrollContentBackground(.hidden)
+                        .textSelection(.enabled)
+                        .frame(height: 300)
+                        .padding(8)
+                        .background(Color.black.opacity(0.42))
+                        .overlay {
+                            AngularRectangle(corner: 10)
+                                .stroke(NeonDiffTheme.stroke.opacity(0.7), lineWidth: 0.8)
+                        }
+                        .clipShape(AngularRectangle(corner: 10))
+
+                    HStack {
+                        Button { model.copyCommand(model.statusCommand) } label: {
+                            Label("Copy Status Command", systemImage: "doc.on.doc")
+                        }
+                        Spacer()
+                        Text("Redacted output only")
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                    }
+                }
+                .padding(.top, 10)
+            } label: {
+                Text("// ADVANCED DIAGNOSTICS")
                     .font(NeonDiffTheme.headlineFont)
                     .foregroundStyle(NeonDiffTheme.accentSoft)
-
-                TextEditor(text: $model.logText)
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(NeonDiffTheme.textPrimary)
-                    .scrollContentBackground(.hidden)
-                    .textSelection(.enabled)
-                    .frame(height: 360)
-                    .padding(8)
-                    .background(Color.black.opacity(0.42))
-                    .overlay {
-                        AngularRectangle(corner: 10)
-                            .stroke(NeonDiffTheme.stroke.opacity(0.7), lineWidth: 0.8)
-                    }
-                    .clipShape(AngularRectangle(corner: 10))
             }
             .operatorPanel()
 
             OperatorSection("Display Safety") {
-                Text("Output is redacted before display. Raw provider keys, license keys, tokens, private keys, and credential URLs must not appear here.")
+                Text("Customer activity is shown separately from raw diagnostics. Diagnostic output is redacted before display; keys, tokens, private keys, and credential URLs must never appear here.")
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -54,6 +86,26 @@ struct LogsView: View {
         .padding(24)
         .overlay(alignment: .bottom) {
             PageBottomSentinel(section: "logs")
+        }
+    }
+
+    private func activityRow(
+        title: String,
+        detail: String,
+        ready: Bool
+    ) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: ready ? "checkmark.circle.fill" : "exclamationmark.circle")
+                .foregroundStyle(ready ? NeonDiffTheme.accent : NeonDiffTheme.warning)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(NeonDiffTheme.textSecondary)
+            }
+            Spacer()
         }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -50,7 +50,7 @@ struct LogsView: View {
                         .foregroundStyle(NeonDiffTheme.textPrimary)
                         .scrollContentBackground(.hidden)
                         .textSelection(.enabled)
-                        .frame(height: 300)
+                        .frame(height: 360)
                         .padding(8)
                         .background(Color.black.opacity(0.42))
                         .overlay {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -24,10 +24,8 @@ struct LogsView: View {
             OperatorSection("Current Activity") {
                 activityRow(
                     title: "Account and bot",
-                    detail: model.existingLocalBotIdentityReady
-                        ? "Existing verified bot selected on this Mac"
-                        : "Setup or account selection required",
-                    ready: model.existingLocalBotIdentityReady
+                    detail: accountAndBotDetail,
+                    ready: model.githubSetupReady
                 )
                 activityRow(
                     title: "Repository configuration",
@@ -87,6 +85,16 @@ struct LogsView: View {
         .overlay(alignment: .bottom) {
             PageBottomSentinel(section: "logs")
         }
+    }
+
+    private var accountAndBotDetail: String {
+        if model.existingLocalBotIdentityReady {
+            return "Existing verified bot selected on this Mac"
+        }
+        if model.githubConnectionReady {
+            return "GitHub connection ready"
+        }
+        return "Setup or account selection required"
     }
 
     private func activityRow(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -135,7 +135,9 @@ struct OnboardingWizardView: View {
     private var welcomeStep: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                if model.managedGitHubAvailable {
+                if model.existingLocalBotReconciliationMode {
+                    existingLocalBotSection
+                } else if model.managedGitHubAvailable {
                     managedGitHubSection
                 } else if model.byoGitHubCredentialOnboardingAvailable {
                     byoGitHubSection
@@ -164,6 +166,41 @@ struct OnboardingWizardView: View {
             }
         }
         .scrollContentBackground(.hidden)
+    }
+
+    private var existingLocalBotSection: some View {
+        OperatorSection("Existing Bot Detected") {
+            OperatorBadge(
+                text: model.existingLocalBotSetupReady ? "SETUP CONFIGURED" : "RECOVERY NEEDED",
+                color: model.existingLocalBotSetupReady ? NeonDiffTheme.accent : NeonDiffTheme.warning
+            )
+
+            Text("NeonDiff matched this Mac’s local config to a server-verified bot in the selected account. Existing credentials remain in their current approved stores; setup will not initialize or overwrite the config.")
+                .operatorBodyText()
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let bot = model.selectedBotInstallation {
+                LabeledContent("Bot", value: bot.appSlug)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent(
+                    "GitHub",
+                    value: model.githubSetupReady ? "connected" : "recovery required"
+                )
+                .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent(
+                    "Repositories",
+                    value: model.repositorySetupReady
+                        ? "\(model.repos.filter(\.enabled).count) applied"
+                        : "recovery required"
+                )
+                .foregroundStyle(NeonDiffTheme.textPrimary)
+            }
+
+            Text(model.customerRuntimeBoundaryMessage)
+                .font(.caption)
+                .foregroundStyle(NeonDiffTheme.warning)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     private var byoGitHubSection: some View {
@@ -486,27 +523,43 @@ struct OnboardingWizardView: View {
                     OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
                     OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
                     OperatorTextField(title: "OpenAI-Compatible Endpoint", text: $model.providers.openAICompatibleEndpoint)
-                    OperatorTextField(title: "Provider API Key", text: $model.pendingProviderKey, secure: true)
-
-                    HStack(spacing: 10) {
-                        Button { model.storeProviderKey() } label: {
-                            Label("Store Key", systemImage: "key.fill")
-                        }
-                        OperatorBadge(
-                            text: model.providers.providerKeyStored ? "Stored in Keychain" : "Key Required",
-                            color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                    if model.selectedProviderRequiresAPIKey {
+                        OperatorTextField(
+                            title: "Provider API Key",
+                            text: $model.pendingProviderKey,
+                            secure: true
                         )
+
+                        HStack(spacing: 10) {
+                            Button { model.storeProviderKey() } label: {
+                                Label("Store Key", systemImage: "key.fill")
+                            }
+                            OperatorBadge(
+                                text: model.providers.providerKeyStored ? "Stored in Keychain" : "Key Required",
+                                color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                            )
+                        }
+                    } else {
+                        OperatorBadge(
+                            text: model.providerSetupReady ? "APP CONFIG LOADED" : "CONFIG REQUIRED",
+                            color: model.providerSetupReady ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                        )
+                        Text("This provider uses its own app/config authentication path. No separate NeonDiff provider key is required.")
+                            .operatorBodyText()
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
 
-                OperatorSection("Config Patch") {
-                    OperatorCommandText(text: model.providerPatchPreviewCommand.commandLine, lineLimit: 4)
-                    HStack(spacing: 10) {
-                        Button { model.previewProviderConfigPatch() } label: {
-                            Label("Preview", systemImage: "eye")
-                        }
-                        Button { model.copyCommand(model.providerPatchPreviewCommand) } label: {
-                            Label("Copy", systemImage: "doc.on.doc")
+                if !model.existingLocalBotReconciliationMode {
+                    OperatorSection("Config Patch") {
+                        OperatorCommandText(text: model.providerPatchPreviewCommand.commandLine, lineLimit: 4)
+                        HStack(spacing: 10) {
+                            Button { model.previewProviderConfigPatch() } label: {
+                                Label("Preview", systemImage: "eye")
+                            }
+                            Button { model.copyCommand(model.providerPatchPreviewCommand) } label: {
+                                Label("Copy", systemImage: "doc.on.doc")
+                            }
                         }
                     }
                 }
@@ -568,7 +621,7 @@ struct OnboardingWizardView: View {
                         text: model.onboardingFlow.daemonBootstrapChecked ? "Checked" : "Check Required",
                         color: model.onboardingFlow.daemonBootstrapChecked ? NeonDiffTheme.accent : NeonDiffTheme.warning
                     )
-                    Text(model.productionActivationBoundaryMessage)
+                    Text(model.customerRuntimeBoundaryMessage)
                         .operatorBodyText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -624,7 +677,10 @@ struct OnboardingWizardView: View {
     private var doneStep: some View {
         VStack(alignment: .leading, spacing: 16) {
             OperatorSection("Ready") {
-                LabeledContent("Provider key", value: model.providers.providerKeyStored ? "stored" : "missing")
+                LabeledContent(
+                    "Provider",
+                    value: model.providerSetupReady ? "configured" : "setup required"
+                )
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                 LabeledContent("Daemon check", value: model.onboardingFlow.daemonBootstrapChecked ? "checked" : "not checked")
                     .foregroundStyle(NeonDiffTheme.textPrimary)
@@ -634,8 +690,16 @@ struct OnboardingWizardView: View {
                     LabeledContent("Repository", value: repository)
                         .foregroundStyle(NeonDiffTheme.textPrimary)
                 }
-                LabeledContent("License", value: model.onboardingFlow.licenseActivation == .activated ? "activated" : "service pending")
+                LabeledContent(
+                    "License",
+                    value: model.licenseSetupReady ? "active" : "activation required"
+                )
                     .foregroundStyle(NeonDiffTheme.textPrimary)
+                if model.existingLocalBotReconciliationMode {
+                    Text("This existing setup remains read-only until current GitHub and repository entitlement checks pass for new work.")
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
     }
@@ -678,13 +742,22 @@ struct OnboardingWizardView: View {
 
                 Button {
                     if model.onboardingFlow.currentStep == .done {
-                        model.completeOnboarding()
+                        if model.existingLocalBotReconciliationMode {
+                            model.dismissOnboardingPanel()
+                        } else {
+                            model.completeOnboarding()
+                        }
                     } else {
                         model.advanceOnboarding()
                     }
                 } label: {
                     HStack(spacing: 8) {
-                        Text(model.onboardingFlow.nextActionTitle.uppercased())
+                        Text(
+                            model.existingLocalBotReconciliationMode
+                                && model.onboardingFlow.currentStep == .done
+                                ? "CLOSE"
+                                : model.onboardingFlow.nextActionTitle.uppercased()
+                        )
                         Image(systemName: model.onboardingFlow.currentStep == .done ? "checkmark" : "arrow.right")
                     }
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -539,11 +539,23 @@ struct OnboardingWizardView: View {
                             Button { model.storeProviderKey() } label: {
                                 Label("Store Key", systemImage: "key.fill")
                             }
+                            Button { model.verifyProviderKey() } label: {
+                                Label(
+                                    model.providerVerificationButtonTitle,
+                                    systemImage: "checkmark.shield"
+                                )
+                            }
+                            .disabled(!model.canVerifyProviderKey || !model.productionUsefulWorkAvailable)
                             OperatorBadge(
                                 text: model.providers.providerKeyStored ? "Stored in Keychain" : "Key Required",
                                 color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
                             )
                         }
+
+                        Text(model.providerVerificationStatus)
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     } else {
                         OperatorBadge(
                             text: model.providerSetupReady ? "APP CONFIG LOADED" : "CONFIG REQUIRED",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -139,6 +139,8 @@ struct OnboardingWizardView: View {
                     existingLocalBotSection
                     if model.managedGitHubAvailable {
                         managedGitHubSection
+                    } else if model.byoGitHubCredentialOnboardingAvailable {
+                        byoGitHubSection
                     }
                 } else if model.managedGitHubAvailable {
                     managedGitHubSection
@@ -744,20 +746,14 @@ struct OnboardingWizardView: View {
                 Spacer()
 
                 Button {
-                    if model.onboardingFlow.currentStep == .done {
-                        if model.existingLocalBotReconciliationMode {
-                            model.dismissOnboardingPanel()
-                        } else {
-                            model.completeOnboarding()
-                        }
-                    } else {
-                        model.advanceOnboarding()
-                    }
+                    model.advanceOnboarding()
                 } label: {
                     HStack(spacing: 8) {
                         Text(
                             model.existingLocalBotReconciliationMode
                                 && model.onboardingFlow.currentStep == .done
+                                && (!model.productionUsefulWorkAvailable
+                                    || !model.providerSetupReady)
                                 ? "CLOSE"
                                 : model.onboardingFlow.nextActionTitle.uppercased()
                         )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -137,6 +137,9 @@ struct OnboardingWizardView: View {
             VStack(alignment: .leading, spacing: 16) {
                 if model.existingLocalBotReconciliationMode {
                     existingLocalBotSection
+                    if model.managedGitHubAvailable {
+                        managedGitHubSection
+                    }
                 } else if model.managedGitHubAvailable {
                     managedGitHubSection
                 } else if model.byoGitHubCredentialOnboardingAvailable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -10,25 +10,27 @@ struct DesktopSetupReadiness {
     let licenseStatus: String
     let repository: Bool
     let repositoryName: String
+    let canRunDryRun: Bool
 
     init(model: NeonDiffDesktopModel) {
-        github = model.githubConnectionReady
-        provider = model.providerVerification?.isVerified == true
+        github = model.githubSetupReady
+        provider = model.providerSetupReady
         let publicRepositoryLicenseNotRequired = model.selectedManagedGitHubRepository
             .flatMap { selectedRepository in
                 model.managedGitHubRepositories.first {
                     $0.fullName == selectedRepository
                 }
             }?.visibility == .public
-        let licenseIsActive = model.currentRepositoryActivationReady
+        let licenseIsActive = model.licenseSetupReady
         license = publicRepositoryLicenseNotRequired || licenseIsActive
         licenseStatus = publicRepositoryLicenseNotRequired
             ? "PUBLIC · FREE"
             : (licenseIsActive ? "ACTIVE" : "ACTIVATION REQUIRED")
-        repository = model.repositoryConfigurationReady
+        repository = model.repositorySetupReady
         repositoryName = model.selectedManagedGitHubRepository
             ?? model.repos.first(where: \.enabled)?.name
             ?? "owner/repository"
+        canRunDryRun = model.productionUsefulWorkAvailable
     }
 
     private var gates: [Bool] { [github, provider, license, repository] }
@@ -146,15 +148,13 @@ struct OverviewView: View {
                 .ndSectionLabel(palette)
                 .foregroundStyle(NeonDiffTheme.cyan)
 
-            Text(readiness.isComplete ? "Ready for your first review" : "Set up your first review")
+            Text(heroTitle(readiness))
                 .font(.system(.largeTitle, design: .rounded).weight(.semibold))
                 .foregroundStyle(palette.accentPrimary)
                 .minimumScaleFactor(0.72)
                 .lineLimit(2)
 
-            Text(readiness.isComplete
-                ? "Your review path is configured. Start with a dry run before any live GitHub post."
-                : "Complete the remaining steps below. You can leave setup at any time and return here.")
+            Text(heroDetail(readiness))
                 .font(.body)
                 .foregroundStyle(palette.textPrimary.opacity(0.78))
 
@@ -183,6 +183,26 @@ struct OverviewView: View {
         .padding(.vertical, 8)
     }
 
+    private func heroTitle(_ readiness: DesktopSetupReadiness) -> String {
+        if readiness.canRunDryRun {
+            return "Ready for a dry run"
+        }
+        if readiness.isComplete {
+            return "Existing bot configured"
+        }
+        return "Set up your first review"
+    }
+
+    private func heroDetail(_ readiness: DesktopSetupReadiness) -> String {
+        if readiness.canRunDryRun {
+            return "Start with a dry run before any live GitHub post."
+        }
+        if readiness.isComplete {
+            return "NeonDiff found this bot’s existing account, GitHub, provider, entitlement, and repository setup. Reverify current access before running new work."
+        }
+        return "Complete the remaining steps below. You can leave setup at any time and return here."
+    }
+
     private func repositoryPanel(
         palette: NDPalette,
         readiness: DesktopSetupReadiness
@@ -196,7 +216,9 @@ struct OverviewView: View {
                 .lineLimit(1)
 
             Text(readiness.repository
-                ? "Applied and ready for a dry-run review."
+                ? (readiness.canRunDryRun
+                    ? "Applied and ready for a dry-run review."
+                    : "Applied in the selected local bot config.")
                 : "Choose and apply one repository to begin.")
                 .font(.callout)
                 .foregroundStyle(palette.textSecondary)
@@ -228,9 +250,11 @@ struct OverviewView: View {
                     Text("Welcome to NeonDiff")
                         .font(.system(.callout, design: .monospaced).weight(.medium))
                         .foregroundStyle(palette.textPrimary)
-                    Text(readiness.isComplete
+                    Text(readiness.canRunDryRun
                         ? "Setup is ready for a dry run."
-                        : "Let’s finish your setup.")
+                        : (readiness.isComplete
+                            ? "Existing bot setup detected on this Mac."
+                            : "Let’s finish your setup."))
                         .font(.callout)
                         .foregroundStyle(palette.textSecondary)
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -31,6 +31,7 @@ struct DesktopSetupReadiness {
             ?? model.repos.first(where: \.enabled)?.name
             ?? "owner/repository"
         canRunDryRun = model.productionUsefulWorkAvailable
+            && model.providerSetupReady
     }
 
     private var gates: [Bool] { [github, provider, license, repository] }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -75,16 +75,19 @@ struct ProviderSettingsView: View {
                             .foregroundStyle(NeonDiffTheme.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
-                    Text(model.providerVerificationStatus)
-                        .font(.caption)
-                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                    if model.selectedProviderRequiresAPIKey {
+                        Text(model.providerVerificationStatus)
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                    }
                     if !model.productionUsefulWorkAvailable {
                         Text(model.customerRuntimeBoundaryMessage)
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.warning)
                     }
 
-                    if let verification = model.providerVerification {
+                    if model.selectedProviderRequiresAPIKey,
+                       let verification = model.providerVerification {
                         ProviderVerificationResultCard(snapshot: verification)
                     }
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -38,33 +38,48 @@ struct ProviderSettingsView: View {
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.textSecondary)
                     }
-                    OperatorTextField(title: "Provider API Key", text: $model.pendingProviderKey, secure: true)
-                    HStack(spacing: 10) {
-                        Button { model.storeProviderKey() } label: {
-                            Label("Store Key", systemImage: "key.fill")
-                        }
-                        .disabled(!model.canEditProviderConfiguration)
-                        Button(role: .destructive) { model.clearProviderKey() } label: {
-                            Label("Clear Key", systemImage: "key.slash")
-                        }
-                        .disabled(!model.canEditProviderConfiguration || !model.providers.providerKeyStored)
-                        Button { model.verifyProviderKey() } label: {
-                            Label(
-                                model.providerVerificationButtonTitle,
-                                systemImage: "checkmark.shield"
+                    if model.selectedProviderRequiresAPIKey {
+                        OperatorTextField(
+                            title: "Provider API Key",
+                            text: $model.pendingProviderKey,
+                            secure: true
+                        )
+                        HStack(spacing: 10) {
+                            Button { model.storeProviderKey() } label: {
+                                Label("Store Key", systemImage: "key.fill")
+                            }
+                            .disabled(!model.canEditProviderConfiguration)
+                            Button(role: .destructive) { model.clearProviderKey() } label: {
+                                Label("Clear Key", systemImage: "key.slash")
+                            }
+                            .disabled(!model.canEditProviderConfiguration || !model.providers.providerKeyStored)
+                            Button { model.verifyProviderKey() } label: {
+                                Label(
+                                    model.providerVerificationButtonTitle,
+                                    systemImage: "checkmark.shield"
+                                )
+                            }
+                            .disabled(!model.canVerifyProviderKey || !model.productionUsefulWorkAvailable)
+                            OperatorBadge(
+                                text: model.providers.providerKeyStored ? "Stored in Keychain" : "Not Stored",
+                                color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
                             )
                         }
-                        .disabled(!model.canVerifyProviderKey || !model.productionUsefulWorkAvailable)
+                    } else {
                         OperatorBadge(
-                            text: model.providers.providerKeyStored ? "Stored in Keychain" : "Not Stored",
-                            color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
+                            text: model.providerSetupReady ? "APP CONFIG LOADED" : "CONFIG REQUIRED",
+                            color: model.providerSetupReady ? NeonDiffTheme.accent : NeonDiffTheme.warning
                         )
+                        Text("This provider uses its own app/config authentication path. NeonDiff does not need or store a separate provider API key.")
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     Text(model.providerVerificationStatus)
                         .font(.caption)
                         .foregroundStyle(NeonDiffTheme.textSecondary)
                     if !model.productionUsefulWorkAvailable {
-                        Text(model.productionActivationBoundaryMessage)
+                        Text(model.customerRuntimeBoundaryMessage)
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.warning)
                     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -20,6 +20,8 @@ struct ReposView: View {
                 existingLocalBotConnection
                 if model.managedGitHubAvailable {
                     managedGitHubConnection
+                } else if model.byoGitHubCredentialOnboardingAvailable {
+                    byoGitHubCredentials
                 }
             } else if model.managedGitHubAvailable {
                 managedGitHubConnection

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -327,6 +327,45 @@ struct ReposView: View {
                     .font(.caption)
                     .foregroundStyle(NeonDiffTheme.warning)
                     .fixedSize(horizontal: false, vertical: true)
+
+                if model.byoGitHubCredentialOnboardingAvailable {
+                    HStack(spacing: 10) {
+                        OperatorBadge(
+                            text: model.byoGitHubCredentialsVerified
+                                ? "CURRENT ACCESS VERIFIED"
+                                : "CURRENT ACCESS REQUIRED",
+                            color: model.byoGitHubCredentialsVerified
+                                ? NeonDiffTheme.accent
+                                : NeonDiffTheme.warning
+                        )
+                        Button { model.verifyBYOGitHubAppCredentials() } label: {
+                            Label(
+                                model.isBYOGitHubVerificationInProgress
+                                    ? "Verifying…"
+                                    : "Verify Existing App Access",
+                                systemImage: "checkmark.shield"
+                            )
+                        }
+                        .disabled(
+                            !model.existingLocalBotBYOGitHubVerificationAvailable
+                                || model.isBYOGitHubVerificationInProgress
+                        )
+                        .accessibilityIdentifier("neondiff-existing-byo-github-verify")
+                    }
+
+                    Text(
+                        model.existingLocalBotBYOGitHubVerificationAvailable
+                            ? model.byoGitHubCredentialStatus
+                            : "The existing App identity is matched, but its app-owned Keychain credential is not available for current-access verification on this Mac."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(
+                        model.byoGitHubCredentialsVerified
+                            ? NeonDiffTheme.accent
+                            : NeonDiffTheme.warning
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -18,6 +18,9 @@ struct ReposView: View {
         VStack(alignment: .leading, spacing: 14) {
             if model.existingLocalBotReconciliationMode {
                 existingLocalBotConnection
+                if model.managedGitHubAvailable {
+                    managedGitHubConnection
+                }
             } else if model.managedGitHubAvailable {
                 managedGitHubConnection
             } else if model.byoGitHubCredentialOnboardingAvailable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -16,7 +16,9 @@ struct ReposView: View {
 
     private var pageContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            if model.managedGitHubAvailable {
+            if model.existingLocalBotReconciliationMode {
+                existingLocalBotConnection
+            } else if model.managedGitHubAvailable {
                 managedGitHubConnection
             } else if model.byoGitHubCredentialOnboardingAvailable {
                 byoGitHubCredentials
@@ -286,6 +288,47 @@ struct ReposView: View {
             PageBottomSentinel(section: "repos")
         }
         .disabled(!model.canEditProviderConfiguration)
+    }
+
+    private var existingLocalBotConnection: some View {
+        OperatorSection("Existing GitHub App Connection") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    OperatorBadge(
+                        text: model.githubSetupReady ? "CONNECTED" : "RECOVERY REQUIRED",
+                        color: model.githubSetupReady ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                    )
+                    OperatorBadge(
+                        text: "\(model.repos.filter(\.enabled).count) CONFIGURED REPOS",
+                        color: model.repositorySetupReady ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                    )
+                }
+
+                if let bot = model.selectedBotInstallation {
+                    LabeledContent("Bot", value: bot.appSlug)
+                        .foregroundStyle(NeonDiffTheme.textPrimary)
+                    LabeledContent(
+                        "GitHub account",
+                        value: bot.githubAccountLogin ?? "not verified"
+                    )
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                    LabeledContent(
+                        "Installation",
+                        value: bot.githubInstallationID.map(String.init) ?? "not verified"
+                    )
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                }
+
+                Text("This connection comes from a server-verified account/bot record matched to the exact local config on this Mac. NeonDiff will not copy, migrate, or ask you to re-enter the existing worker private key.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(model.customerRuntimeBoundaryMessage)
+                    .font(.caption)
+                    .foregroundStyle(NeonDiffTheme.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
     }
 
     private var byoGitHubCredentials: some View {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -353,11 +353,7 @@ struct ReposView: View {
                         .accessibilityIdentifier("neondiff-existing-byo-github-verify")
                     }
 
-                    Text(
-                        model.existingLocalBotBYOGitHubVerificationAvailable
-                            ? model.byoGitHubCredentialStatus
-                            : "The existing App identity is matched, but its app-owned Keychain credential is not available for current-access verification on this Mac."
-                    )
+                    Text(model.existingLocalBotBYOGitHubVerificationStatus)
                     .font(.caption)
                     .foregroundStyle(
                         model.byoGitHubCredentialsVerified

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -46,7 +46,7 @@ struct SettingsPane: View {
                             Text(updateController.statusText)
                                 .operatorBodyText()
                                 .fixedSize(horizontal: false, vertical: true)
-                            Text("Future release lane: #116. This dev build does not include a public feed or signing key.")
+                            Text("Automatic updates are not configured for this candidate. Signed update, rollback, and installed-app proof remain required under #116 before release.")
                                 .font(.caption)
                                 .foregroundStyle(NeonDiffTheme.textSecondary)
                                 .fixedSize(horizontal: false, vertical: true)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
@@ -54,9 +54,11 @@ struct SidebarView: View {
                             .frame(width: 7, height: 7)
                     }
 
-                    Text(readiness.isComplete
+                    Text(readiness.canRunDryRun
                         ? "READY FOR A DRY RUN"
-                        : "\(readiness.completedCount) OF \(readiness.totalCount) SETUP STEPS COMPLETE")
+                        : (readiness.isComplete
+                            ? "SETUP CONFIGURED · REVERIFY TO RUN"
+                            : "\(readiness.completedCount) OF \(readiness.totalCount) SETUP STEPS COMPLETE"))
                         .font(.system(.caption2, design: .monospaced).weight(.medium))
                         .foregroundStyle(palette.textSecondary)
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -318,6 +318,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && byoGitHubPrivateKeyStored
     }
 
+    package var existingLocalBotBYOGitHubVerificationAvailable: Bool {
+        guard existingLocalBotIdentityReady,
+              byoGitHubCredentialOnboardingAvailable,
+              byoGitHubPrivateKeyStored,
+              let bot = selectedBotInstallation,
+              let storedAppID = storedBYOGitHubAppId
+        else {
+            return false
+        }
+        return storedAppID == String(bot.appID)
+    }
+
     package var managedGitHubStatusText: String {
         switch managedGitHubConnectionState {
         case .quarantined:
@@ -522,9 +534,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// providers still require their app-owned Keychain state or a current
     /// verification result.
     package var providerSetupReady: Bool {
-        if providerVerification?.isVerified == true {
-            return true
-        }
         guard providerLoadedSnapshot?.configPath == configPath,
               providerLoadedRevision != nil,
               providerLoadedSnapshot == currentProviderConfigurationSnapshot,
@@ -537,7 +546,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case "zcode-app-config", "none":
             return true
         case "api-key-env":
-            return providers.providerKeyStored
+            guard let verification = providerVerification else {
+                return false
+            }
+            return verification.isVerified
+                && verification.providerId == provider.id
+                && verification.configRevision == providerLoadedRevision
         default:
             return false
         }
@@ -1078,6 +1092,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
         if let localConfigPath = bot.localConfigPath {
             configPath = localConfigPath
+            if bot.mode == .byo,
+               dependencies.productionBoundary.byoGitHubEnabled {
+                let appID = String(bot.appID)
+                dependencies.preferences.set(
+                    appID,
+                    forKey: byoGitHubAppIdPreferenceKey
+                )
+                pendingBYOGitHubAppId = appID
+            }
             accountWorkspaceStatus = "Local bot selected. Verify its config and GitHub binding before use."
             inspectConfig()
         } else {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -211,9 +211,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// Public managed repositories need no paid activation; every other beta
     /// path keeps the repository-scoped current-launch proof visible.
     package var existingAccountEntitlementSummaryReady: Bool {
-        guard existingLocalBotIdentityReady, licenseSetupReady else {
+        guard existingLocalBotIdentityReady,
+              let accountEntitlement = selectedAccountWorkspace?.entitlement
+        else {
             return false
         }
+        if case .none = accountEntitlement { return false }
         if managedGitHubAvailable {
             guard let selectedManagedGitHubRepository,
                   let repository = managedGitHubRepositories.first(where: {
@@ -3046,7 +3049,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
             case .license:
                 onboardingFlow.currentStep = .done
             case .done:
-                dismissOnboardingPanel()
+                if productionUsefulWorkAvailable && providerSetupReady {
+                    completeOnboarding()
+                } else {
+                    dismissOnboardingPanel()
+                }
             }
             return
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -182,8 +182,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var customerRuntimeBoundaryMessage: String {
-        if existingLocalBotIdentityReady {
+        if existingLocalBotSetupReady {
             return "Existing setup is configured. Before new work, reverify the current GitHub App access and repository-scoped entitlement for this launch."
+        }
+        if existingLocalBotIdentityReady {
+            return "Existing bot identity is matched. Finish or recover the missing setup items, then reverify the current GitHub App access and repository-scoped entitlement before new work."
         }
         return productionActivationBoundaryMessage
     }
@@ -554,9 +557,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         switch entitlement {
-        case .paid, .internalAdmin, .trial:
+        case .paid, .internalAdmin, .trial, .publicFree:
             return true
-        case .publicFree, .none:
+        case .none:
             return false
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -181,6 +181,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
     }
 
+    package var customerRuntimeBoundaryMessage: String {
+        if existingLocalBotIdentityReady {
+            return "Existing setup is configured. Before new work, reverify the current GitHub App access and repository-scoped entitlement for this launch."
+        }
+        return productionActivationBoundaryMessage
+    }
+
     package var currentRepositoryActivationReady: Bool {
         guard activationVerifiedThisLaunch,
               activationState == .active,
@@ -345,6 +352,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var canAdvanceOnboarding: Bool {
+        if existingLocalBotReconciliationMode {
+            return true
+        }
         if dependencies.productionBoundary.managedGitHubBrokerOrigin != nil {
             guard hasVerifiedManagedGitHubSelection else { return false }
         }
@@ -473,6 +483,134 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var selectedBotInstallation: DesktopBotInstallation? {
         guard let botID = accountWorkspaceSelection.botID else { return nil }
         return selectedAccountWorkspace?.bots.first { $0.id == botID }
+    }
+
+    /// Setup truth for an existing worker is distinct from current-launch
+    /// authorization to perform useful work. This becomes true only after a
+    /// server-authoritative verified bot intersects the exact local config path
+    /// discovered on this Mac. It never consumes local config as membership or
+    /// installation authority.
+    package var existingLocalBotIdentityReady: Bool {
+        guard let account = selectedAccountWorkspace,
+              account.role != nil,
+              let bot = selectedBotInstallation,
+              bot.status == .verified,
+              bot.appID > 0,
+              bot.githubInstallationID != nil,
+              bot.githubAccountLogin?.trimmingCharacters(
+                  in: .whitespacesAndNewlines
+              ).isEmpty == false,
+              let localConfigPath = bot.localConfigPath
+        else {
+            return false
+        }
+        return normalizedPath(localConfigPath) == normalizedPath(configPath)
+    }
+
+    /// Customer-facing connection status may reuse a verified existing bot
+    /// identity. The stricter `githubConnectionReady` property remains the
+    /// current-launch credential proof used by review authorization.
+    package var githubSetupReady: Bool {
+        githubConnectionReady || existingLocalBotIdentityReady
+    }
+
+    /// A loaded non-key provider such as ZCode's app-config adapter is already
+    /// configured; asking for a NeonDiff Keychain API key is incorrect. API-key
+    /// providers still require their app-owned Keychain state or a current
+    /// verification result.
+    package var providerSetupReady: Bool {
+        if providerVerification?.isVerified == true {
+            return true
+        }
+        guard providerLoadedSnapshot?.configPath == configPath,
+              providerLoadedRevision != nil,
+              providerLoadedSnapshot == currentProviderConfigurationSnapshot,
+              let provider = providers.selectedRegistryTarget,
+              provider.enabled
+        else {
+            return false
+        }
+        switch provider.authMode {
+        case "zcode-app-config", "none":
+            return true
+        case "api-key-env":
+            return providers.providerKeyStored
+        default:
+            return false
+        }
+    }
+
+    /// Account entitlement is server authority for the selected existing bot's
+    /// setup display. It does not replace the exact current-launch activation
+    /// checks in `currentRepositoryActivationReady` or
+    /// `productionUsefulWorkAvailable`.
+    package var licenseSetupReady: Bool {
+        if currentRepositoryActivationReady {
+            return true
+        }
+        guard existingLocalBotIdentityReady,
+              let entitlement = selectedAccountWorkspace?.entitlement
+        else {
+            return false
+        }
+        switch entitlement {
+        case .paid, .internalAdmin, .trial:
+            return true
+        case .publicFree, .none:
+            return false
+        }
+    }
+
+    /// Successful config inspection proves that the selected local config
+    /// already contains and read back its repository allowlist. BYO credential
+    /// verification remains a separate current-launch work gate.
+    package var repositorySetupReady: Bool {
+        if repositoryConfigurationReady {
+            return true
+        }
+        let enabledRepositories = uniqueSortedRepoNames(
+            repos.filter(\.enabled).map(\.name)
+        )
+        guard existingLocalBotIdentityReady,
+              !enabledRepositories.isEmpty
+        else {
+            return false
+        }
+        return appliedRepoSelection == AppliedRepoSelection(
+            repositories: enabledRepositories,
+            configPath: configPath
+        )
+    }
+
+    package var existingLocalBotSetupReady: Bool {
+        existingLocalBotIdentityReady
+            && githubSetupReady
+            && providerSetupReady
+            && licenseSetupReady
+            && repositorySetupReady
+    }
+
+    package var existingLocalBotReconciliationMode: Bool {
+        existingLocalBotIdentityReady
+    }
+
+    package var selectedProviderRequiresAPIKey: Bool {
+        providers.selectedRegistryTarget?.authMode == "api-key-env"
+    }
+
+    package var selectedAccountEntitlementLabel: String? {
+        guard existingLocalBotIdentityReady,
+              let entitlement = selectedAccountWorkspace?.entitlement
+        else {
+            return nil
+        }
+        return switch entitlement {
+        case .paid: "Paid account"
+        case .internalAdmin: "Internal administrator"
+        case .trial: "Active trial"
+        case .publicFree: "Public repositories only"
+        case .none: "No active entitlement"
+        }
     }
 
     package var accountLinkAvailable: Bool {
@@ -1060,6 +1198,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .appendingPathComponent("_unselected", isDirectory: true)
             .appendingPathComponent("config.local.json")
             .standardizedFileURL.path
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        URL(filePath: path).standardizedFileURL.path
     }
 
     private func isolatedBotConfigPath(accountID: String, appSlug: String) -> String {
@@ -2827,6 +2969,21 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func advanceOnboarding() {
+        if existingLocalBotReconciliationMode {
+            switch onboardingFlow.currentStep {
+            case .welcome:
+                onboardingFlow.currentStep = .provider
+            case .provider:
+                onboardingFlow.currentStep = .daemon
+            case .daemon:
+                onboardingFlow.currentStep = .license
+            case .license:
+                onboardingFlow.currentStep = .done
+            case .done:
+                dismissOnboardingPanel()
+            }
+            return
+        }
         onboardingFlow.providerKeyStored = providers.providerKeyStored
         guard canAdvanceOnboarding else { return }
         if onboardingFlow.currentStep == .done {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -330,6 +330,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return storedAppID == String(bot.appID)
     }
 
+    package var existingLocalBotBYOGitHubVerificationStatus: String {
+        guard existingLocalBotIdentityReady,
+              let bot = selectedBotInstallation
+        else {
+            return "The selected existing bot identity is not verified for this local config."
+        }
+        guard let storedAppID = storedBYOGitHubAppId else {
+            return "No app-owned Keychain App ID is stored for current-access verification."
+        }
+        guard storedAppID == String(bot.appID) else {
+            return "The stored App ID does not match the selected existing bot. Select the matching bot or replace that bot's Keychain credential."
+        }
+        guard byoGitHubPrivateKeyStored else {
+            return "The App ID matches, but its app-owned private key is missing from Keychain."
+        }
+        return byoGitHubCredentialStatus
+    }
+
     package var managedGitHubStatusText: String {
         switch managedGitHubConnectionState {
         case .quarantined:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -206,6 +206,37 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 == activationVerifiedRepositoryThisLaunch.lowercased()
     }
 
+    /// Existing-account entitlement is useful setup context, but it must not
+    /// replace the recovery control for a managed private/internal repository.
+    /// Public managed repositories need no paid activation; every other beta
+    /// path keeps the repository-scoped current-launch proof visible.
+    package var existingAccountEntitlementSummaryReady: Bool {
+        guard existingLocalBotIdentityReady, licenseSetupReady else {
+            return false
+        }
+        if managedGitHubAvailable {
+            guard let selectedManagedGitHubRepository,
+                  let repository = managedGitHubRepositories.first(where: {
+                      $0.fullName == selectedManagedGitHubRepository
+                  })
+            else {
+                return false
+            }
+            switch repository.visibility {
+            case .public:
+                return true
+            case .private, .internal:
+                return currentRepositoryActivationReady
+            case .unknown:
+                return false
+            }
+        }
+        if byoGitHubCredentialOnboardingAvailable {
+            return currentRepositoryActivationReady
+        }
+        return true
+    }
+
     package var productionUsefulWorkAvailable: Bool {
         guard dependencies.productionBoundary.nativeActivationBrokerVerified else {
             return false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1092,15 +1092,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
         if let localConfigPath = bot.localConfigPath {
             configPath = localConfigPath
-            if bot.mode == .byo,
-               dependencies.productionBoundary.byoGitHubEnabled {
-                let appID = String(bot.appID)
-                dependencies.preferences.set(
-                    appID,
-                    forKey: byoGitHubAppIdPreferenceKey
-                )
-                pendingBYOGitHubAppId = appID
-            }
             accountWorkspaceStatus = "Local bot selected. Verify its config and GitHub binding before use."
             inspectConfig()
         } else {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -17,7 +17,7 @@ public enum DesktopSection: String, CaseIterable, Codable, Identifiable, Sendabl
         case .repos: "Repos"
         case .providers: "Providers"
         case .license: "License"
-        case .logs: "Logs"
+        case .logs: "Activity"
         case .policy: "Policy"
         case .settings: "Settings"
         }
@@ -29,7 +29,7 @@ public enum DesktopSection: String, CaseIterable, Codable, Identifiable, Sendabl
         case .repos: "folder.badge.gearshape"
         case .providers: "cpu"
         case .license: "key"
-        case .logs: "doc.text.magnifyingglass"
+        case .logs: "clock.arrow.circlepath"
         case .policy: "slider.horizontal.3"
         case .settings: "gearshape"
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -147,6 +147,33 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func existingBYOBotExplainsAppIDMismatchWithoutBlamingAMissingKey() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.pendingBYOGitHubAppId = "999999"
+        fixture.model.pendingBYOGitHubAppPrivateKey = existingBotFixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        #expect(!fixture.model.existingLocalBotBYOGitHubVerificationAvailable)
+        #expect(
+            fixture.model.existingLocalBotBYOGitHubVerificationStatus
+                .contains("does not match")
+        )
+        #expect(
+            !fixture.model.existingLocalBotBYOGitHubVerificationStatus
+                .contains("not available")
+        )
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
     @Test func noKeyProviderDoesNotInventAKeyRequirement() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -123,7 +123,7 @@ import NeonDiffDesktopCore
             suspendCLIRuns: true,
             productionBoundary: .testAccountLink
         )
-        fixture.model.pendingBYOGitHubAppId = "999999"
+        fixture.model.pendingBYOGitHubAppId = "4184532"
         fixture.model.pendingBYOGitHubAppPrivateKey = existingBotFixturePrivateKey
         fixture.model.storeBYOGitHubAppCredentials()
         #expect(fixture.model.byoGitHubPrivateKeyStored)
@@ -133,7 +133,10 @@ import NeonDiffDesktopCore
         fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
         fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
 
-        #expect(fixture.model.pendingBYOGitHubAppId == "4184532")
+        #expect(
+            fixture.preferences.string(forKey: "neondiff.byoGitHubAppId")
+                == "4184532"
+        )
         #expect(fixture.model.existingLocalBotIdentityReady)
         #expect(fixture.model.byoGitHubCredentialOnboardingAvailable)
         #expect(fixture.model.byoGitHubAppIdStored)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+@Suite struct ExistingLocalBotReconciliationTests {
+    private let configPath = "/fixture/evaos-code-review-bot/config.local.json"
+
+    @MainActor
+    @Test func verifiedExistingBotReconcilesSetupWithoutUnlockingUsefulWork() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(fixture.model.githubSetupReady)
+        #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.licenseSetupReady)
+        #expect(fixture.model.repositorySetupReady)
+        #expect(fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func accountWithoutEntitlementDoesNotAppearLicenseReady() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .none)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(fixture.model.githubSetupReady)
+        #expect(fixture.model.providerSetupReady)
+        #expect(!fixture.model.licenseSetupReady)
+        #expect(fixture.model.repositorySetupReady)
+        #expect(!fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func apiKeyProviderStillRequiresItsAppOwnedKeyOrVerification() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "api-key-env"))
+
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(!fixture.model.providerSetupReady)
+        #expect(!fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func localConfigCannotInventOrCrossServerBotAuthority() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        let remoteOnly = DesktopBotInstallation(
+            id: "bot-evaos-code-review-bot",
+            appID: 4_184_532,
+            appSlug: "evaos-code-review-bot",
+            mode: .byo,
+            githubInstallationID: 72_001,
+            githubAccountLogin: "electricsheephq",
+            status: .verified,
+            localConfigPath: nil
+        )
+        let account = DesktopAccountWorkspace(
+            id: "account-electric-sheep",
+            kind: .organization,
+            name: "ElectricSheep",
+            role: .admin,
+            entitlement: .internalAdmin,
+            bots: [remoteOnly]
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        fixture.model.selectBotInstallation(remoteOnly.id)
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        #expect(!fixture.model.existingLocalBotIdentityReady)
+        #expect(!fixture.model.githubSetupReady)
+        #expect(!fixture.model.licenseSetupReady)
+        #expect(!fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    private func workspace(
+        entitlement: DesktopAccountEntitlement
+    ) -> DesktopAccountWorkspace {
+        DesktopAccountWorkspace(
+            id: "account-electric-sheep",
+            kind: .organization,
+            name: "ElectricSheep",
+            role: .admin,
+            entitlement: entitlement,
+            bots: [
+                DesktopBotInstallation(
+                    id: "bot-evaos-code-review-bot",
+                    appID: 4_184_532,
+                    appSlug: "evaos-code-review-bot",
+                    mode: .byo,
+                    githubInstallationID: 72_001,
+                    githubAccountLogin: "electricsheephq",
+                    status: .verified,
+                    localConfigPath: configPath
+                )
+            ]
+        )
+    }
+
+    private func existingBotConfig(authMode: String) -> String {
+        let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
+        return #"""
+        {
+          "ok": true,
+          "command": "config inspect",
+          "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "config": {
+            "pilotRepos": ["electricsheephq/WorldOS"],
+            "providers": {
+              "defaultProviderId": "zcode-glm",
+              "providers": {
+                "zcode-glm": {
+                  "enabled": true,
+                  "adapter": "\#(adapter)",
+                  "displayName": "ZCode GLM",
+                  "baseUrl": "",
+                  "model": "GLM-5.2",
+                  "authMode": "\#(authMode)"
+                }
+              }
+            }
+          }
+        }
+        """#
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -246,6 +246,127 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func reconciledGoldenPathCompletionPersistsInsteadOfReopeningEveryLaunch() async {
+        let repository = "electricsheephq/PublicOS"
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: repository, visibility: .public)
+        ])
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(existingBotConfigResult(authMode: "zcode-app-config")),
+                .success(existingBotRepoPatchJSON(repository: repository)),
+                .success(existingBotConfigResult(
+                    authMode: "zcode-app-config",
+                    repository: repository
+                ))
+            ],
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        let bot = DesktopBotInstallation(
+            id: "bot-neondiff-managed",
+            appID: 4_184_532,
+            appSlug: "neondiff",
+            mode: .managed,
+            githubInstallationID: 42,
+            githubAccountLogin: "electricsheephq",
+            status: .verified,
+            localConfigPath: configPath
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            DesktopAccountWorkspace(
+                id: "account-electric-sheep",
+                kind: .organization,
+                name: "ElectricSheep",
+                role: .admin,
+                entitlement: .internalAdmin,
+                bots: [bot]
+            )
+        ]))
+        fixture.model.selectBotInstallation(bot.id)
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: repository)
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+        fixture.model.inspectConfig()
+        await fixture.cli.waitUntilCallCount(3)
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.providerSetupReady)
+
+        fixture.model.onboardingFlow.currentStep = .done
+        fixture.model.advanceOnboarding()
+
+        #expect(!fixture.model.isOnboardingPresented)
+        #expect(
+            fixture.preferences.bool(
+                forKey: "neondiff.hasCompletedActivationOnboarding.v2"
+            )
+        )
+    }
+
+    @MainActor
+    @Test func currentKeyActivationDoesNotRenderAStaleNoEntitlementSummary() async {
+        let repository = "electricsheephq/WorldOS"
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: repository, visibility: .private)
+        ])
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(existingBotConfigResult(authMode: "zcode-app-config")),
+                .success(existingBotRepoPatchJSON(repository: repository))
+            ],
+            githubBroker: broker,
+            activationLicenseClient: ExistingBotActiveActivationClient(),
+            productionBoundary: .testManaged
+        )
+        let bot = DesktopBotInstallation(
+            id: "bot-neondiff-managed",
+            appID: 4_184_532,
+            appSlug: "neondiff",
+            mode: .managed,
+            githubInstallationID: 42,
+            githubAccountLogin: "electricsheephq",
+            status: .verified,
+            localConfigPath: configPath
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            DesktopAccountWorkspace(
+                id: "account-electric-sheep",
+                kind: .organization,
+                name: "ElectricSheep",
+                role: .admin,
+                entitlement: .none,
+                bots: [bot]
+            )
+        ]))
+        fixture.model.selectBotInstallation(bot.id)
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(fullName: repository)
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.selectedAccountEntitlementLabel == "No active entitlement")
+        #expect(!fixture.model.existingAccountEntitlementSummaryReady)
+    }
+
+    @MainActor
     @Test func localConfigCannotInventOrCrossServerBotAuthority() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -330,6 +451,66 @@ import NeonDiffDesktopCore
         }
         """#
     }
+}
+
+private struct ExistingBotActiveActivationClient: ActivationLicenseClienting {
+    func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        .active(.init(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "beta",
+            seats: 1
+        ))
+    }
+
+    func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        try await activate(key: key)
+    }
+}
+
+private func existingBotRepoPatchJSON(repository: String) -> CLIRunResult {
+    CLIRunResult(
+        exitCode: 0,
+        stdout: #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["\#(repository)"],"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"zcode","displayName":"ZCode GLM","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#,
+        stderr: ""
+    )
+}
+
+private func existingBotConfigResult(
+    authMode: String,
+    repository: String = "electricsheephq/WorldOS"
+) -> CLIRunResult {
+    let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
+    return CLIRunResult(
+        exitCode: 0,
+        stdout: #"""
+        {
+          "ok": true,
+          "command": "config inspect",
+          "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "config": {
+            "pilotRepos": ["\#(repository)"],
+            "providers": {
+              "defaultProviderId": "zcode-glm",
+              "providers": {
+                "zcode-glm": {
+                  "enabled": true,
+                  "adapter": "\#(adapter)",
+                  "displayName": "ZCode GLM",
+                  "baseUrl": "",
+                  "model": "GLM-5.2",
+                  "authMode": "\#(authMode)"
+                }
+              }
+            }
+          }
+        }
+        """#,
+        stderr: ""
+    )
 }
 
 private let existingBotFixturePrivateKeyLabel = "PRIVATE" + " KEY"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -46,6 +46,28 @@ import NeonDiffDesktopCore
         #expect(fixture.model.repositorySetupReady)
         #expect(!fixture.model.existingLocalBotSetupReady)
         #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(!fixture.model.customerRuntimeBoundaryMessage.contains("setup is configured"))
+        #expect(fixture.model.customerRuntimeBoundaryMessage.contains("bot identity"))
+    }
+
+    @MainActor
+    @Test func publicFreeEntitlementIsDisplayedWithoutUnlockingUsefulWork() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .publicFree)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "none"))
+
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.licenseSetupReady)
+        #expect(fixture.model.selectedAccountEntitlementLabel == "Public repositories only")
+        #expect(fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
     @MainActor
@@ -63,6 +85,25 @@ import NeonDiffDesktopCore
         #expect(fixture.model.existingLocalBotIdentityReady)
         #expect(!fixture.model.providerSetupReady)
         #expect(!fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func noKeyProviderDoesNotInventAKeyRequirement() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "none"))
+
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(!fixture.model.selectedProviderRequiresAPIKey)
+        #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.existingLocalBotSetupReady)
         #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -193,6 +193,59 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func managedExistingBotKeepsPrivateActivationRecoveryUntilRepositoryProofPasses() async {
+        let broker = ScriptedGitHubBroker(repositories: [
+            GitHubBrokerRepository(fullName: "electricsheephq/WorldOS", visibility: .private),
+            GitHubBrokerRepository(fullName: "electricsheephq/PublicOS", visibility: .public)
+        ])
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            githubBroker: broker,
+            productionBoundary: .testManaged
+        )
+        let bot = DesktopBotInstallation(
+            id: "bot-neondiff-managed",
+            appID: 4_184_532,
+            appSlug: "neondiff",
+            mode: .managed,
+            githubInstallationID: 42,
+            githubAccountLogin: "electricsheephq",
+            status: .verified,
+            localConfigPath: configPath
+        )
+        fixture.model.applyAccountWorkspaceCatalog(
+            DesktopAccountWorkspaceCatalog.loaded([
+                DesktopAccountWorkspace(
+                    id: "account-electric-sheep",
+                    kind: .organization,
+                    name: "ElectricSheep",
+                    role: .admin,
+                    entitlement: .internalAdmin,
+                    bots: [bot]
+                )
+            ])
+        )
+        fixture.model.selectBotInstallation(bot.id)
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        fixture.model.startManagedGitHubConnection()
+        await fixture.waitForManagedGitHubConnectionToFinish()
+        fixture.model.selectManagedGitHubRepository(
+            fullName: "electricsheephq/WorldOS"
+        )
+
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+        #expect(!fixture.model.existingAccountEntitlementSummaryReady)
+
+        fixture.model.selectManagedGitHubRepository(
+            fullName: "electricsheephq/PublicOS"
+        )
+
+        #expect(fixture.model.existingAccountEntitlementSummaryReady)
+    }
+
+    @MainActor
     @Test func localConfigCannotInventOrCrossServerBotAuthority() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -89,6 +89,61 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func failedAPIKeyVerificationDoesNotAppearSetupReady() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "api-key-env"))
+        fixture.model.providers.providerKeyStored = true
+        fixture.model.providerVerification = ProviderVerificationSnapshot(
+            ok: true,
+            command: "providers verify",
+            providerId: "zcode-glm",
+            checkedAt: "2026-07-26T00:00:00Z",
+            state: .configuredUnverified,
+            mode: "metadata_only",
+            detail: "Provider rejected current verification.",
+            troubleshooting: [],
+            configRevision: String(repeating: "a", count: 64)
+        )
+
+        #expect(!fixture.model.providerSetupReady)
+        #expect(!fixture.model.existingLocalBotSetupReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func selectedExistingBYOBotReusesKeychainCredentialForReverification() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.pendingBYOGitHubAppId = "999999"
+        fixture.model.pendingBYOGitHubAppPrivateKey = existingBotFixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        #expect(fixture.model.byoGitHubPrivateKeyStored)
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        #expect(fixture.model.pendingBYOGitHubAppId == "4184532")
+        #expect(fixture.model.existingLocalBotIdentityReady)
+        #expect(fixture.model.byoGitHubCredentialOnboardingAvailable)
+        #expect(fixture.model.byoGitHubAppIdStored)
+        #expect(fixture.model.byoGitHubPrivateKeyStored)
+        #expect(fixture.model.existingLocalBotBYOGitHubVerificationAvailable)
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
     @Test func noKeyProviderDoesNotInventAKeyRequirement() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -193,3 +248,10 @@ import NeonDiffDesktopCore
         """#
     }
 }
+
+private let existingBotFixturePrivateKeyLabel = "PRIVATE" + " KEY"
+private let existingBotFixturePrivateKey = """
+-----BEGIN \(existingBotFixturePrivateKeyLabel)-----
+ZmFrZS1maXh0dXJlLXByaXZhdGUta2V5
+-----END \(existingBotFixturePrivateKeyLabel)-----
+"""

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -136,6 +136,7 @@ import Testing
         #expect(repos.contains("will not copy, migrate, or ask you to re-enter"))
         #expect(repos.contains("neondiff-existing-byo-github-verify"))
         #expect(repos.contains("model.verifyBYOGitHubAppCredentials()"))
+        #expect(repos.contains("model.existingLocalBotBYOGitHubVerificationStatus"))
         #expect(provider.contains("model.selectedProviderRequiresAPIKey"))
         #expect(provider.contains("APP CONFIG LOADED"))
         #expect(provider.contains(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -132,6 +132,11 @@ import Testing
         #expect(onboarding.contains("model.existingLocalBotReconciliationMode"))
         #expect(onboarding.contains("Existing Bot Detected"))
         #expect(onboarding.contains("setup will not initialize or overwrite the config"))
+        #expect(onboarding.contains("model.verifyProviderKey()"))
+        #expect(onboarding.contains("model.providerVerificationButtonTitle"))
+        #expect(onboarding.contains(
+            ".disabled(!model.canVerifyProviderKey || !model.productionUsefulWorkAvailable)"
+        ))
         #expect(onboarding.contains(
             "if model.managedGitHubAvailable {\n"
                 + "                        managedGitHubSection"
@@ -166,6 +171,8 @@ import Testing
         #expect(activation.contains("neondiff.activation.existing-account"))
         #expect(activation.contains("model.existingAccountEntitlementSummaryReady"))
         #expect(activity.contains("OperatorSection(\"Current Activity\")"))
+        #expect(activity.contains("model.githubSetupReady"))
+        #expect(activity.contains("GitHub connection ready"))
         #expect(activity.contains("DisclosureGroup"))
         #expect(activity.contains("// ADVANCED DIAGNOSTICS"))
         #expect(settings.contains("Signed update, rollback, and installed-app proof"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -136,11 +136,19 @@ import Testing
             "if model.managedGitHubAvailable {\n"
                 + "                        managedGitHubSection"
         ))
+        #expect(onboarding.contains(
+            "} else if model.byoGitHubCredentialOnboardingAvailable {\n"
+                + "                        byoGitHubSection"
+        ))
         #expect(repos.contains("Existing GitHub App Connection"))
         #expect(repos.contains("will not copy, migrate, or ask you to re-enter"))
         #expect(repos.contains(
             "if model.managedGitHubAvailable {\n"
                 + "                    managedGitHubConnection"
+        ))
+        #expect(repos.contains(
+            "} else if model.byoGitHubCredentialOnboardingAvailable {\n"
+                + "                    byoGitHubCredentials"
         ))
         #expect(repos.contains("neondiff-existing-byo-github-verify"))
         #expect(repos.contains("model.verifyBYOGitHubAppCredentials()"))
@@ -216,6 +224,10 @@ import Testing
         #expect(overview.contains(#""PUBLIC · FREE""#))
         #expect(overview.contains("model.licenseSetupReady"))
         #expect(overview.contains("model.productionUsefulWorkAvailable"))
+        #expect(overview.contains(
+            "canRunDryRun = model.productionUsefulWorkAvailable\n"
+                + "            && model.providerSetupReady"
+        ))
         #expect(overview.contains("Config and secrets stay on this Mac"))
         #expect(overview.contains("Model context follows your selected provider"))
         #expect(overview.contains("model.providerSetupReady"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -134,6 +134,8 @@ import Testing
         #expect(onboarding.contains("setup will not initialize or overwrite the config"))
         #expect(repos.contains("Existing GitHub App Connection"))
         #expect(repos.contains("will not copy, migrate, or ask you to re-enter"))
+        #expect(repos.contains("neondiff-existing-byo-github-verify"))
+        #expect(repos.contains("model.verifyBYOGitHubAppCredentials()"))
         #expect(provider.contains("model.selectedProviderRequiresAPIKey"))
         #expect(provider.contains("APP CONFIG LOADED"))
         #expect(provider.contains(
@@ -145,6 +147,8 @@ import Testing
                 + "                       let verification = model.providerVerification"
         ))
         #expect(activation.contains("neondiff.activation.existing-account"))
+        #expect(activation.contains("!model.byoGitHubCredentialOnboardingAvailable"))
+        #expect(activation.contains("model.currentRepositoryActivationReady"))
         #expect(activity.contains("OperatorSection(\"Current Activity\")"))
         #expect(activity.contains("DisclosureGroup"))
         #expect(activity.contains("// ADVANCED DIAGNOSTICS"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -132,8 +132,16 @@ import Testing
         #expect(onboarding.contains("model.existingLocalBotReconciliationMode"))
         #expect(onboarding.contains("Existing Bot Detected"))
         #expect(onboarding.contains("setup will not initialize or overwrite the config"))
+        #expect(onboarding.contains(
+            "if model.managedGitHubAvailable {\n"
+                + "                        managedGitHubSection"
+        ))
         #expect(repos.contains("Existing GitHub App Connection"))
         #expect(repos.contains("will not copy, migrate, or ask you to re-enter"))
+        #expect(repos.contains(
+            "if model.managedGitHubAvailable {\n"
+                + "                    managedGitHubConnection"
+        ))
         #expect(repos.contains("neondiff-existing-byo-github-verify"))
         #expect(repos.contains("model.verifyBYOGitHubAppCredentials()"))
         #expect(repos.contains("model.existingLocalBotBYOGitHubVerificationStatus"))
@@ -148,8 +156,7 @@ import Testing
                 + "                       let verification = model.providerVerification"
         ))
         #expect(activation.contains("neondiff.activation.existing-account"))
-        #expect(activation.contains("!model.byoGitHubCredentialOnboardingAvailable"))
-        #expect(activation.contains("model.currentRepositoryActivationReady"))
+        #expect(activation.contains("model.existingAccountEntitlementSummaryReady"))
         #expect(activity.contains("OperatorSection(\"Current Activity\")"))
         #expect(activity.contains("DisclosureGroup"))
         #expect(activity.contains("// ADVANCED DIAGNOSTICS"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -107,6 +107,43 @@ import Testing
         #expect(fixture.model.onboardingFlow.currentStep == .welcome)
     }
 
+    @Test func existingBotUsesReconciliationInsteadOfCleanSetupOrRawDiagnostics() throws {
+        let views = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)
+        let onboarding = try sourceBoundaryText(
+            at: views.appendingPathComponent("OnboardingWizardView.swift")
+        )
+        let repos = try sourceBoundaryText(
+            at: views.appendingPathComponent("ReposView.swift")
+        )
+        let provider = try sourceBoundaryText(
+            at: views.appendingPathComponent("ProviderSettingsView.swift")
+        )
+        let activation = try sourceBoundaryText(
+            at: views.appendingPathComponent("ActivationStateView.swift")
+        )
+        let activity = try sourceBoundaryText(
+            at: views.appendingPathComponent("LogsView.swift")
+        )
+        let settings = try sourceBoundaryText(
+            at: views.appendingPathComponent("SettingsPane.swift")
+        )
+
+        #expect(onboarding.contains("model.existingLocalBotReconciliationMode"))
+        #expect(onboarding.contains("Existing Bot Detected"))
+        #expect(onboarding.contains("setup will not initialize or overwrite the config"))
+        #expect(repos.contains("Existing GitHub App Connection"))
+        #expect(repos.contains("will not copy, migrate, or ask you to re-enter"))
+        #expect(provider.contains("model.selectedProviderRequiresAPIKey"))
+        #expect(provider.contains("APP CONFIG LOADED"))
+        #expect(activation.contains("neondiff.activation.existing-account"))
+        #expect(activity.contains("OperatorSection(\"Current Activity\")"))
+        #expect(activity.contains("DisclosureGroup"))
+        #expect(activity.contains("// ADVANCED DIAGNOSTICS"))
+        #expect(settings.contains("Signed update, rollback, and installed-app proof"))
+        #expect(!settings.contains("This dev build"))
+    }
+
     @Test func shellAndHomeExposeTheOwnerReferenceHierarchy() throws {
         let views = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)
@@ -147,7 +184,8 @@ import Testing
         #expect(!chrome.contains(".ignoresSafeArea(.container, edges: .top)"))
         #expect(chrome.contains("WindowDragRegion"))
         #expect(!chrome.contains("ChromeCircuitBackdrop"))
-        #expect(overview.contains("Ready for your first review"))
+        #expect(overview.contains("Ready for a dry run"))
+        #expect(overview.contains("Existing bot configured"))
         #expect(overview.contains("design: .rounded"))
         for title in ["GITHUB APP", "PROVIDER", "LICENSE", "REPOSITORY"] {
             #expect(overview.contains(title))
@@ -156,10 +194,11 @@ import Testing
         #expect(overview.contains("model.reopenOnboarding(at: .welcome)"))
         #expect(overview.contains("status: readiness.licenseStatus"))
         #expect(overview.contains(#""PUBLIC · FREE""#))
-        #expect(overview.contains("model.currentRepositoryActivationReady"))
+        #expect(overview.contains("model.licenseSetupReady"))
+        #expect(overview.contains("model.productionUsefulWorkAvailable"))
         #expect(overview.contains("Config and secrets stay on this Mac"))
         #expect(overview.contains("Model context follows your selected provider"))
-        #expect(overview.contains("model.providerVerification?.isVerified == true"))
+        #expect(overview.contains("model.providerSetupReady"))
         #expect(!overview.contains("model.providers.providerKeyStored"))
         #expect(overview.contains(#"systemImage: "link""#))
         #expect(!overview.contains(#"systemImage: "arrow.triangle.branch""#))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -136,6 +136,14 @@ import Testing
         #expect(repos.contains("will not copy, migrate, or ask you to re-enter"))
         #expect(provider.contains("model.selectedProviderRequiresAPIKey"))
         #expect(provider.contains("APP CONFIG LOADED"))
+        #expect(provider.contains(
+            "if model.selectedProviderRequiresAPIKey {\n"
+                + "                        Text(model.providerVerificationStatus)"
+        ))
+        #expect(provider.contains(
+            "if model.selectedProviderRequiresAPIKey,\n"
+                + "                       let verification = model.providerVerification"
+        ))
         #expect(activation.contains("neondiff.activation.existing-account"))
         #expect(activity.contains("OperatorSection(\"Current Activity\")"))
         #expect(activity.contains("DisclosureGroup"))

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -279,6 +279,26 @@ This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate
 gates.
 
+### Existing bot on this Mac
+
+After account linking, the native app may find a server-verified bot whose App
+identity and GitHub account intersect an existing launchd/config candidate on
+the same Mac. In that exact case it opens a reconciliation path:
+
+- it loads the existing config and repository allowlist without overwriting it;
+- it does not ask the user to paste or migrate the worker's existing GitHub App
+  private key;
+- it reports the server-authoritative account entitlement separately from
+  current-launch review authorization;
+- it treats `zcode-app-config` and `none` provider auth modes as config-backed,
+  not as missing NeonDiff Keychain API keys;
+- it keeps new work blocked until the exact current GitHub/repository and
+  entitlement checks required by the release path pass.
+
+A local config path, launchd label, App ID, or repository name by itself is not
+authority. Suspended, revoked, pending, mismatched, or server-unrecognized bots
+remain in setup/recovery and fail closed.
+
 ## 4. Check Readiness
 
 Run the GitHub-only doctor first. It verifies App installation visibility and
@@ -343,7 +363,9 @@ entry is the source of truth. Endpoint/model edits are dirty until a successful
 Preview and confirmed Apply/readback. Verify stays disabled until that saved
 state is current, then invokes the exact provider ID and config revision. The
 Keychain value crosses only bounded stdin; it is never added to the registry
-patch, argv, environment, logs, or evidence.
+patch, argv, environment, logs, or evidence. That Keychain flow applies only to
+`api-key-env` providers. `zcode-app-config` and `none` providers use their
+declared app/config path and must not prompt for an unrelated NeonDiff API key.
 
 The full doctor output is JSON. Check:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -104,6 +104,15 @@ integration proof under #630.
    Initialization never uses `--force`; the app updates `pilotRepos` through
    `config patch`, and no operator edits the customer's config file.
 
+If account linking finds a server-verified bot whose exact App identity and
+GitHub account match a local launchd/config candidate on this Mac, NeonDiff
+shows that existing connection instead of presenting clean-install credential
+entry. It does not copy, rotate, or migrate the worker private key. This
+reconciliation proves account/bot/config setup only: current App access and
+repository-scoped entitlement must still pass before a new dry or live review.
+Local config alone never establishes membership, installation authority, or
+review authorization.
+
 Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash


### PR DESCRIPTION
## What Problem This Solves

Related: #657

The installed Mac app could select a verified local NeonDiff bot and read its
configuration, repositories, and provider mode while still presenting that bot
as a clean install with zero setup steps complete. This bounded slice reconciles
the setup display with server-authoritative account/bot membership and exact
local configuration readback.

## User Impact

- A selected verified existing bot shows its known GitHub App identity,
  repository allowlist, provider mode, and account entitlement.
- `zcode-app-config` and provider modes that do not use a desktop-owned API key
  no longer claim that a Keychain API key is missing.
- Existing-bot onboarding is a reversible reconciliation walkthrough that keeps
  valid credentials in place and exposes bounded recovery if a BYO Keychain key
  is missing.
- Existing BYO bots keep current-launch GitHub verification and
  repository-scoped activation recovery reachable.
- A failed API-key provider verification cannot appear setup-ready.
- Overview cannot advertise dry-run readiness without provider readiness.
- A fully verified reconciliation persists completion instead of reopening on
  every launch.
- A current key activation is not masked by a stale no-entitlement account
  snapshot.
- Activity reports a normal clean-install GitHub connection without requiring
  an existing-bot reconciliation identity.
- Reconciled API-key provider onboarding exposes the same bounded verification
  control and status as the Providers page.
- Customer activity is shown before collapsed advanced diagnostics.
- Setup recognition stays separate from authorization to run useful work.

## Implementation Notes

- Reconciles only when the selected bot is verified by the server-authoritative
  account workspace and its normalized local configuration path intersects the
  exact selected local bot.
- Uses successful config readback for provider and repository setup display.
- Uses the selected account entitlement for license setup display.
- Reuses the selected bot's server-authoritative nonsecret App ID only when an
  exact app-owned Keychain credential is present; verification remains the
  bounded stdin-only doctor path.
- Leaves `productionUsefulWorkAvailable` unchanged.

## Bounded Acceptance Criteria

- [x] A selected verified local bot reconciles setup from server-authoritative
      membership plus the exact local config intersection.
- [x] `zcode-app-config` and `none` do not show a false desktop API-key
      requirement.
- [x] Account entitlement, repository config, and GitHub App identity are shown
      as configured without authorizing work.
- [x] Existing-bot onboarding does not overwrite valid credentials and retains
      explicit recovery controls when a BYO Keychain key is missing.
- [x] Existing BYO bots retain GitHub reverification and activation recovery
      until current repository-scoped proof passes.
- [x] `api-key-env` readiness requires a healthy current verification bound to
      the selected provider and loaded config revision.
- [x] Dry-run readiness requires provider readiness.
- [x] Fully verified reconciliation persists the versioned onboarding proof.
- [x] A stale `.none` account snapshot cannot replace a current active-key
      presentation.
- [x] Activity distinguishes a normal connected bot from an existing reconciled
      bot without showing a false setup-required state.
- [x] Reconciled onboarding keeps API-key verification reachable under its
      existing authorization and Keychain gates.
- [x] Raw redacted diagnostics remain available only under an explicit advanced
      disclosure.
- [x] The current useful-work authorization gate is unchanged.

## Validation

- [x] Failing test was added first. The initial focused run failed because the
      reconciliation properties did not exist.
- [x] Focused validation: 91 tests in 6 suites passed:
      `ExistingLocalBotReconciliationTests`,
      `OwnerReferenceUXContractTests`,
      `AccountWorkspaceSelectionTests`,
      `ManagedGitHubOnboardingTests`,
      `BYOGitHubAppCredentialOnboardingTests`, and
      `ProductionBoundaryContractTests`.
- [x] Hosted desktop source contract: 13/13 tests passed after restoring the
      established 360-point Activity diagnostics geometry.
- [x] `git diff --check`
- [ ] GitHub current-head CI and review follow-up.

## Proof Boundary

This PR proves:

- Source-level and focused-test reconciliation of the selected verified
  existing local bot at exact head
  `22339ee40d86f25d9e5ec912658bd8eed337ecce`.
- Setup display does not unlock dry runs or live reviews.

This PR does not prove:

- A signed/notarized installed-app candidate or owner acceptance.
- Production billing, checkout, activation, broker wiring, or live reviews.
- Customer canaries, publication, release, GA, or customer readiness.
- Sparkle/appcast update behavior tracked by #116.
- The broader #517 matrix or complete closure of #657.

## Safety Boundary

- [x] No GitHub App permission expansion.
- [x] No live worker restart, launchd mutation, or beta promotion.
- [x] No package publish, GitHub Release, or repo visibility change.
- [x] No secrets, tokens, credentials, raw private diffs, or customer data in
      the PR.
- [x] Claims stay within the source-available beta boundary.
- [x] Provider setup display remains distinct from current authorization to
      perform useful work.

## Explicit Non-Goals

- No credential migration, creation, or rotation.
- No launchd or live runtime mutation.
- No billing, checkout, broker, distribution, publication, or canary work.
- No #116 updater implementation.
- No broad #517 accessibility or layout matrix.

## Restricted Actions Not Performed

No merge, tag, publish, release, live-config, launchd, credential, billing,
checkout, signed-candidate, or customer-canary action was performed.

## Evidence

- Exact head:
  `22339ee40d86f25d9e5ec912658bd8eed337ecce`
- Focused result: 91 tests, 6 suites, zero failures.
- Hosted desktop source contract: 13 tests, zero failures.
- Public-safe blocker matrix:
  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/657#issuecomment-5084249149

## Agent-Authored PR

- [x] This PR was authored or materially edited by an AI agent.
- [x] The issue was updated before handoff and restricted actions are listed
      above.
