### PR TITLE
fix(desktop): ship customer artifact as NeonDiff

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: neondiff-desktop-unsigned-app
-          path: apps/neondiff-desktop/dist/release-smoke/NeonDiffDesktop.app.zip
+          path: apps/neondiff-desktop/dist/release-smoke/NeonDiff.app.zip
           if-no-files-found: error
           retention-days: 14
 

--- a/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
+++ b/apps/neondiff-desktop/NeonDiffDesktop.xcodeproj/project.pbxproj
@@ -353,7 +353,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "NeonDiff Desktop";
+				INFOPLIST_KEY_CFBundleDisplayName = NeonDiff;
+				INFOPLIST_KEY_CFBundleName = NeonDiff;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -375,7 +376,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "NeonDiff Desktop";
+				INFOPLIST_KEY_CFBundleDisplayName = NeonDiff;
+				INFOPLIST_KEY_CFBundleName = NeonDiff;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -60,7 +60,7 @@ struct NeonDiffDesktopApp: App {
     }
 
     var body: some Scene {
-        WindowGroup("NeonDiff Desktop") {
+        WindowGroup("NeonDiff") {
             evaluationTextSizedContentView
                 .frame(
                     minWidth: CGFloat(minimumContentSize.width),
@@ -82,7 +82,7 @@ struct NeonDiffDesktopApp: App {
         .windowResizability(.contentMinSize)
         .commands {
             CommandGroup(replacing: .appTermination) {
-                Button("Quit NeonDiff Desktop") {
+                Button("Quit NeonDiff") {
                     model.isOnboardingPresented = false
                     DispatchQueue.main.async {
                         NSApplication.shared.terminate(nil)
@@ -92,7 +92,7 @@ struct NeonDiffDesktopApp: App {
             }
 
             CommandGroup(after: .newItem) {
-                Button("Close NeonDiff Desktop Window") {
+                Button("Close NeonDiff Window") {
                     model.isOnboardingPresented = false
                     DispatchQueue.main.async {
                         NSApplication.shared.keyWindow?.performClose(nil)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift
@@ -54,7 +54,7 @@ struct NeonWindowConfigurator: NSViewRepresentable {
     private func configure(window: NSWindow?, coordinator: Coordinator) {
         guard let window else { return }
 
-        window.title = "NeonDiff Desktop"
+        window.title = "NeonDiff"
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -332,7 +332,7 @@ private struct EvaluationRootAccessibilityMarker: View {
         Color.clear
             .frame(width: 1, height: 1)
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("NeonDiff Desktop root")
+            .accessibilityLabel("NeonDiff root")
             .accessibilityIdentifier(identifier)
             .allowsHitTesting(false)
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -72,6 +72,54 @@ import Testing
         #expect(buildScript.contains("NeonDiff.icns"))
     }
 
+    @Test func customerFacingReleaseNameIsSimplyNeonDiff() throws {
+        let root = sourceBoundaryPackageRoot()
+        let app = try sourceBoundaryText(
+            at: root.appendingPathComponent(
+                "Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift"
+            )
+        )
+        let window = try sourceBoundaryText(
+            at: root.appendingPathComponent(
+                "Sources/NeonDiffDesktop/Support/NeonWindowConfigurator.swift"
+            )
+        )
+        let content = try sourceBoundaryText(
+            at: root.appendingPathComponent(
+                "Sources/NeonDiffDesktop/Views/ContentView.swift"
+            )
+        )
+        let project = try sourceBoundaryText(
+            at: root.appendingPathComponent("NeonDiffDesktop.xcodeproj/project.pbxproj")
+        )
+        let bundler = try sourceBoundaryText(
+            at: root.appendingPathComponent("script/build_and_run.sh")
+        )
+        let releaseProof = try sourceBoundaryText(
+            at: root.appendingPathComponent("script/release-proof.sh")
+        )
+
+        #expect(app.contains(#"WindowGroup("NeonDiff")"#))
+        #expect(app.contains(#"Button("Quit NeonDiff")"#))
+        #expect(app.contains(#"Button("Close NeonDiff Window")"#))
+        #expect(window.contains(#"window.title = "NeonDiff""#))
+        #expect(content.contains(#".accessibilityLabel("NeonDiff root")"#))
+        #expect(project.contains(#"INFOPLIST_KEY_CFBundleDisplayName = NeonDiff;"#))
+        #expect(project.contains(#"INFOPLIST_KEY_CFBundleName = NeonDiff;"#))
+        #expect(project.contains(#"PRODUCT_NAME = NeonDiffDesktop;"#))
+
+        #expect(bundler.contains(#"APP_NAME="NeonDiff""#))
+        #expect(bundler.contains(#"PRODUCT_NAME="NeonDiffDesktop""#))
+        #expect(bundler.contains(#"<string>$PRODUCT_NAME</string>"#))
+        #expect(bundler.contains(#"<string>$APP_NAME</string>"#))
+        #expect(bundler.contains(#"BUNDLE_ID="com.electricsheephq.NeonDiffDesktop""#))
+
+        #expect(releaseProof.contains(#"APP_NAME="NeonDiff""#))
+        #expect(releaseProof.contains(#"EXECUTABLE_NAME="NeonDiffDesktop""#))
+        #expect(releaseProof.contains(#"ARTIFACT_NAME="NeonDiff.app.zip""#))
+        #expect(releaseProof.contains(#"ditto "$SOURCE_APP_BUNDLE" "$APP_BUNDLE""#))
+    }
+
     @Test func setupUsesAnEscapableIntegratedPanelInsteadOfAModalSheet() throws {
         let views = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 MODE="${1:-run}"
-APP_NAME="NeonDiffDesktop"
+APP_NAME="NeonDiff"
+PRODUCT_NAME="NeonDiffDesktop"
+BUNDLE_NAME="NeonDiffDesktop"
 BUNDLE_ID="com.electricsheephq.NeonDiffDesktop"
 MIN_SYSTEM_VERSION="14.0"
 
@@ -27,13 +29,13 @@ if [ "$MODE" = "preflight" ] || [ "$MODE" = "--preflight" ]; then
 fi
 
 DIST_DIR="${NEONDIFF_DESKTOP_DIST_DIR:-$ROOT_DIR/dist}"
-APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
+APP_BUNDLE="$DIST_DIR/$BUNDLE_NAME.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_FRAMEWORKS="$APP_CONTENTS/Frameworks"
 APP_HELPERS="$APP_CONTENTS/Helpers"
-APP_BINARY="$APP_MACOS/$APP_NAME"
+APP_BINARY="$APP_MACOS/$PRODUCT_NAME"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 SHORT_VERSION="${NEONDIFF_DESKTOP_VERSION:-0.1.0}"
 BUILD_VERSION="${NEONDIFF_DESKTOP_BUILD:-1}"
@@ -91,16 +93,16 @@ if [ -x "$APP_BINARY" ]; then
     if [ "$proc_path" = "$APP_BINARY" ]; then
       kill "$pid" >/dev/null 2>&1 || true
     fi
-  done < <(pgrep -x "$APP_NAME" 2>/dev/null || true)
+  done < <(pgrep -x "$PRODUCT_NAME" 2>/dev/null || true)
 fi
 
 cd "$ROOT_DIR"
-swift build -c "$BUILD_CONFIGURATION" --product "$APP_NAME"
+swift build -c "$BUILD_CONFIGURATION" --product "$PRODUCT_NAME"
 if [ "$BUILD_CONFIGURATION" = "debug" ]; then
   swift build -c debug --product NeonDiffDesktopFixtureResolve
 fi
 BUILD_DIR="$(swift build -c "$BUILD_CONFIGURATION" --show-bin-path)"
-BUILD_BINARY="$BUILD_DIR/$APP_NAME"
+BUILD_BINARY="$BUILD_DIR/$PRODUCT_NAME"
 
 rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_MACOS" "$APP_RESOURCES"
@@ -116,7 +118,7 @@ if [ "$BUILD_CONFIGURATION" = "debug" ]; then
   chmod +x "$APP_HELPERS/NeonDiffDesktopFixtureResolve"
 fi
 
-RESOURCE_DIR="$(find "$BUILD_DIR" "$ROOT_DIR/.build" \( -name "${APP_NAME}_${APP_NAME}.bundle" -o -name "${APP_NAME}_${APP_NAME}.resources" \) -type d -print -quit 2>/dev/null || true)"
+RESOURCE_DIR="$(find "$BUILD_DIR" "$ROOT_DIR/.build" \( -name "${PRODUCT_NAME}_${PRODUCT_NAME}.bundle" -o -name "${PRODUCT_NAME}_${PRODUCT_NAME}.resources" \) -type d -print -quit 2>/dev/null || true)"
 if [ -n "$RESOURCE_DIR" ]; then
   ditto "$RESOURCE_DIR" "$APP_RESOURCES/$(basename "$RESOURCE_DIR")"
 fi
@@ -149,11 +151,13 @@ cat >"$INFO_PLIST" <<PLIST
 <plist version="1.0">
 <dict>
   <key>CFBundleExecutable</key>
-  <string>$APP_NAME</string>
+  <string>$PRODUCT_NAME</string>
   <key>CFBundleIdentifier</key>
   <string>$BUNDLE_ID</string>
   <key>CFBundleName</key>
-  <string>NeonDiff Desktop</string>
+  <string>$APP_NAME</string>
+  <key>CFBundleDisplayName</key>
+  <string>$APP_NAME</string>
   <key>CFBundleIconFile</key>
   <string>NeonDiff.icns</string>
   <key>CFBundleShortVersionString</key>
@@ -202,7 +206,7 @@ case "$MODE" in
     ;;
   --logs|logs)
     open_app
-    /usr/bin/log stream --info --style compact --predicate "process == \"$APP_NAME\""
+    /usr/bin/log stream --info --style compact --predicate "process == \"$PRODUCT_NAME\""
     ;;
   --telemetry|telemetry)
     open_app
@@ -211,7 +215,7 @@ case "$MODE" in
   --verify|verify)
     open_app
     sleep 1
-    pgrep -x "$APP_NAME" >/dev/null
+    pgrep -x "$PRODUCT_NAME" >/dev/null
     ;;
   --bundle-check|bundle-check|release-bundle-check)
     /usr/bin/plutil -lint "$INFO_PLIST" >/dev/null
@@ -219,6 +223,9 @@ case "$MODE" in
     test -f "$APP_RESOURCES/NeonDiff-Light.icns"
     test -f "$APP_RESOURCES/NeonDiff-Dark.icns"
     test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "$INFO_PLIST")" = "NeonDiff.icns"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST")" = "$PRODUCT_NAME"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$INFO_PLIST")" = "$APP_NAME"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleDisplayName' "$INFO_PLIST")" = "$APP_NAME"
     if [ "$BUILD_CONFIGURATION" = "release" ]; then
       "$SCRIPT_DIR/release-rpaths.sh" assert "$APP_BINARY"
     fi

--- a/apps/neondiff-desktop/script/preflight-credentials.sh
+++ b/apps/neondiff-desktop/script/preflight-credentials.sh
@@ -228,7 +228,7 @@ if [ "$MODE" = "json" ]; then
   printf ']\n'
   printf '}\n'
 else
-  printf 'NeonDiff Desktop — credential preflight doctor\n'
+  printf 'NeonDiff — credential preflight doctor\n'
   printf '(reports presence only; signs/notarizes nothing; no secret values printed)\n\n'
   printf '%-26s %-9s %-9s %s\n' "CREDENTIAL" "STATUS" "REQUIRED" "DETAIL"
   printf '%-26s %-9s %-9s %s\n' "--------------------------" "-------" "--------" "------"

--- a/apps/neondiff-desktop/script/release-proof.sh
+++ b/apps/neondiff-desktop/script/release-proof.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_NAME="NeonDiffDesktop"
-ARTIFACT_NAME="NeonDiffDesktop.app.zip"
+APP_NAME="NeonDiff"
+EXECUTABLE_NAME="NeonDiffDesktop"
+BUNDLE_NAME="NeonDiffDesktop"
+ARTIFACT_NAME="NeonDiff.app.zip"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$ROOT_DIR/../.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
-APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
-INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
+SOURCE_APP_BUNDLE="$DIST_DIR/$BUNDLE_NAME.app"
 RELEASE_SMOKE_DIR="$DIST_DIR/release-smoke"
+APP_BUNDLE="$RELEASE_SMOKE_DIR/$APP_NAME.app"
+INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
 ARTIFACT_PATH="$RELEASE_SMOKE_DIR/$ARTIFACT_NAME"
 METADATA_PATH="$RELEASE_SMOKE_DIR/desktop-release-smoke-metadata.json"
 
@@ -57,7 +60,7 @@ ensure_clean_source_tree() {
 }
 
 verify_existing_app_launch() {
-  local app_binary="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+  local app_binary="$APP_BUNDLE/Contents/MacOS/$EXECUTABLE_NAME"
   /usr/bin/open -n "$APP_BUNDLE"
   local deadline=$((SECONDS + 10))
   while [ "$SECONDS" -lt "$deadline" ]; do
@@ -67,10 +70,10 @@ verify_existing_app_launch() {
       if [ "$proc_path" = "$app_binary" ]; then
         return 0
       fi
-    done < <(pgrep -x "$APP_NAME" 2>/dev/null || true)
+    done < <(pgrep -x "$EXECUTABLE_NAME" 2>/dev/null || true)
     sleep 0.2
   done
-  echo "app launch proof failed: $APP_NAME did not start from $APP_BUNDLE" >&2
+  echo "app launch proof failed: $EXECUTABLE_NAME did not start from $APP_BUNDLE" >&2
   exit 1
 }
 
@@ -92,15 +95,20 @@ else
   SOURCE_REF="$(git -C "$REPO_ROOT" symbolic-ref -q --short HEAD || git -C "$REPO_ROOT" rev-parse --short HEAD)"
 fi
 
-if [ ! -d "$APP_BUNDLE" ]; then
-  echo "missing app bundle: $APP_BUNDLE" >&2
+if [ ! -d "$SOURCE_APP_BUNDLE" ]; then
+  echo "missing app bundle: $SOURCE_APP_BUNDLE" >&2
   exit 1
 fi
 
-if [ ! -f "$INFO_PLIST" ]; then
-  echo "missing Info.plist: $INFO_PLIST" >&2
+if [ ! -f "$SOURCE_APP_BUNDLE/Contents/Info.plist" ]; then
+  echo "missing Info.plist: $SOURCE_APP_BUNDLE/Contents/Info.plist" >&2
   exit 1
 fi
+
+mkdir -p "$RELEASE_SMOKE_DIR"
+rm -rf "$APP_BUNDLE"
+rm -f "$ARTIFACT_PATH" "$METADATA_PATH"
+ditto "$SOURCE_APP_BUNDLE" "$APP_BUNDLE"
 
 if [ "$UI_LAUNCH" = "true" ]; then
   verify_existing_app_launch
@@ -109,7 +117,6 @@ fi
 UI_LAUNCH_JSON="$(normalize_bool "$UI_LAUNCH" "NEONDIFF_DESKTOP_UI_LAUNCH")"
 VISUAL_SMOKE_REQUIRED_JSON="$(normalize_bool "$VISUAL_SMOKE_REQUIRED" "NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED")"
 
-mkdir -p "$RELEASE_SMOKE_DIR"
 ditto -c -k --keepParent "$APP_BUNDLE" "$ARTIFACT_PATH"
 
 ARTIFACT_SHA256="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{print $1}')"
@@ -132,7 +139,7 @@ jq -n \
   --arg artifact_classification "$ARTIFACT_CLASSIFICATION" \
   --arg source_sha "$SOURCE_SHA" \
   --arg source_ref "$SOURCE_REF" \
-  --arg app_bundle_path "apps/neondiff-desktop/dist/$APP_NAME.app" \
+  --arg app_bundle_path "apps/neondiff-desktop/dist/release-smoke/$APP_NAME.app" \
   --arg bundle_id "$BUNDLE_ID" \
   --arg short_version "$SHORT_VERSION" \
   --arg build_version "$BUILD_VERSION" \

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -90,7 +90,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).toMatch(/actions\/upload-artifact@[0-9a-f]{40}/);
     expect(workflow).not.toMatch(/actions\/checkout@v4/);
     expect(workflow).not.toMatch(/actions\/upload-artifact@v4/);
-    expect(workflow).toMatch(/NeonDiffDesktop\.app\.zip/);
+    expect(workflow).toMatch(/NeonDiff\.app\.zip/);
     expect(workflow).toMatch(/desktop-release-smoke-metadata\.json/);
     expect(workflow).toMatch(/NEONDIFF_DESKTOP_UI_LAUNCH/);
     expect(workflow).toMatch(/NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION/);


### PR DESCRIPTION
Bounded #449 customer-facing naming slice

Acceptance criteria:

- Finder/app metadata, window title, quit/close commands, and root accessibility name are `NeonDiff`.
- The packaged customer artifact contains `NeonDiff.app` and is named `NeonDiff.app.zip`.
- The internal executable remains `NeonDiffDesktop`.
- Bundle ID `com.electricsheephq.NeonDiffDesktop`, Keychain identity, production contracts, and update/security boundaries do not change.
- Focused Swift and release-pipeline contracts pass; broad validation remains remote CI.

Non-goals:

- No signing, notarization, tag, GitHub Release, upload, checkout, billing, production deployment, customer canary, or release claim in this PR.
- No Sparkle/appcast implementation; #116 still owns automatic updates.
- No GitHub, provider, activation, entitlement, repository, or runtime behavior change.

Failing-first proof:

- `OwnerReferenceUXContractTests.customerFacingReleaseNameIsSimplyNeonDiff` failed on the old `NeonDiff Desktop` UI strings, old app metadata, and old `NeonDiffDesktop.app.zip` contract, then passed after the bounded change.

Local development proof:

- `NeonDiffDesktopAppCoreTests`: 184 tests passed.
- Three focused Vitest files: 28 tests passed.
- Release-mode bundle check passed.
- Unsigned development package inspection showed ZIP root `NeonDiff.app`, display/name `NeonDiff`, internal executable `NeonDiffDesktop`, and unchanged bundle ID.

Proof boundary:

This is source and unsigned local packaging proof only. It is not signed/notarized installed-app, update, customer, beta, or release proof.
