### PR TITLE
fix(desktop): keep worker diagnostics out of customer overview

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -36,7 +36,7 @@ struct LogsView: View {
                 )
                 activityRow(
                     title: "Local worker",
-                    detail: localWorkerDetail,
+                    detail: model.customerLocalWorkerStatusDetail,
                     ready: model.status.runtimeOk == true
                 )
             }
@@ -95,19 +95,6 @@ struct LogsView: View {
             return "GitHub connection ready"
         }
         return "Setup or account selection required"
-    }
-
-    private var localWorkerDetail: String {
-        if model.isExistingLocalBotRestoreInProgress {
-            return "Checking the selected bot’s local worker"
-        }
-        if let failure = model.statusRefreshFailureMessage {
-            return "Check failed — \(failure)"
-        }
-        if model.status == .unknown {
-            return "Not checked yet — choose Refresh Activity"
-        }
-        return model.status.healthState
     }
 
     private func activityRow(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4403,6 +4403,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             }
         } else if isDaemonStatusCommand {
             let message = "Local worker status check failed. Retry or open Advanced Diagnostics."
+            status = .unknown
+            onboardingFlow.daemonBootstrapChecked = false
             lastError = message
             statusRefreshFailureMessage = message
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -751,7 +751,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return "ACCOUNT CHECK FAILED"
         }
         if status.healthState != DaemonStatus.unknown.healthState {
-            return status.healthState
+            return switch status.healthState {
+            case "runtime_ok": "WORKER READY"
+            case "runtime_blocked": "WORKER ATTENTION"
+            case "coverage_blocked": "COVERAGE ATTENTION"
+            default:
+                status.healthState
+                    .replacingOccurrences(of: "_", with: " ")
+                    .uppercased()
+            }
         }
         if existingLocalBotSetupReady {
             return "SETUP CONFIGURED"
@@ -760,6 +768,27 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return "SETUP INCOMPLETE"
         }
         return "NOT CHECKED"
+    }
+
+    package var customerLocalWorkerStatusDetail: String {
+        if isExistingLocalBotRestoreInProgress {
+            return "Checking the selected bot’s local worker"
+        }
+        if statusRefreshFailureMessage != nil {
+            return "Status check failed — retry"
+        }
+        if status == .unknown {
+            return "Not checked yet — choose Refresh Activity"
+        }
+        return switch status.healthState {
+        case "runtime_ok": "Running and ready"
+        case "runtime_blocked": "Running, but review gates need attention"
+        case "coverage_blocked": "Review coverage needs attention"
+        default:
+            status.healthState
+                .replacingOccurrences(of: "_", with: " ")
+                .capitalized
+        }
     }
 
     package var selectedProviderRequiresAPIKey: Bool {
@@ -4360,6 +4389,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         if let parsed = DaemonStatusParser.parse(result.stdout, launchdLabel: launchdLabel, fallbackCommand: fallbackCommand) {
             status = parsed.0
             statusRefreshFailureMessage = nil
+            if isDaemonStatusCommand {
+                // A valid status envelope may intentionally use a nonzero exit
+                // when one or more runtime gates need attention. Keep the full
+                // redacted envelope in `logText` for Advanced Diagnostics, but
+                // do not surface that JSON as a generic customer error.
+                lastError = nil
+            }
             onboardingFlow.daemonBootstrapChecked = true
             if !parsed.1.isEmpty {
                 repos = parsed.1
@@ -4375,14 +4411,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         fallbackCommand: String,
         configPath: String,
         launchdLabel: String,
-        isConfigInspectCommand: Bool
+        isConfigInspectCommand: Bool,
+        isDaemonStatusCommand: Bool = false
     ) {
         applyCLIResult(
             result,
             fallbackCommand: fallbackCommand,
             configPath: configPath,
             launchdLabel: launchdLabel,
-            isConfigInspectCommand: isConfigInspectCommand
+            isConfigInspectCommand: isConfigInspectCommand,
+            isDaemonStatusCommand: isDaemonStatusCommand
         )
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -782,7 +782,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         return switch status.healthState {
         case "runtime_ok": "Running and ready"
-        case "runtime_blocked": "Running, but review gates need attention"
+        case "runtime_blocked":
+            "Review worker needs attention — open Advanced Diagnostics"
         case "coverage_blocked": "Review coverage needs attention"
         default:
             status.healthState
@@ -4401,8 +4402,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 repos = parsed.1
             }
         } else if isDaemonStatusCommand {
-            statusRefreshFailureMessage = lastError
-                ?? "Local worker returned an invalid status response."
+            let message = "Local worker status check failed. Retry or open Advanced Diagnostics."
+            lastError = message
+            statusRefreshFailureMessage = message
         }
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -11,6 +11,14 @@ public enum DaemonStatusParser {
 
         let statusPayload = json["status"] as? [String: Any]
         let effective = statusPayload ?? json
+        let hasDirectStatusShape = effective["runtimeOk"] != nil
+            || effective["healthState"] != nil
+            || effective["checkedAt"] != nil
+            || effective["launchd"] != nil
+            || effective["monitoredRepos"] != nil
+        guard statusPayload != nil || hasDirectStatusShape else {
+            return nil
+        }
         let wrapperOk = json["ok"] as? Bool
         let effectiveOk = effective["ok"] as? Bool
         let launchd = effective["launchd"] as? [String: Any]

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -16,7 +16,7 @@ public enum DaemonStatusParser {
             || effective["checkedAt"] != nil
             || effective["launchd"] != nil
             || effective["monitoredRepos"] != nil
-        guard statusPayload != nil || hasDirectStatusShape else {
+        guard hasDirectStatusShape else {
             return nil
         }
         let wrapperOk = json["ok"] as? Bool

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -11,12 +11,12 @@ public enum DaemonStatusParser {
 
         let statusPayload = json["status"] as? [String: Any]
         let effective = statusPayload ?? json
-        let hasDirectStatusShape = effective["runtimeOk"] != nil
-            || effective["healthState"] != nil
-            || effective["checkedAt"] != nil
-            || effective["launchd"] != nil
-            || effective["monitoredRepos"] != nil
-        guard hasDirectStatusShape else {
+        let reportedRuntimeOk = json["runtimeOk"] as? Bool ?? effective["runtimeOk"] as? Bool
+        let reportedHealthState = (effective["healthState"] as? String)
+            ?? (json["healthState"] as? String)
+        let hasSubstantiveStatusShape = reportedRuntimeOk != nil
+            || reportedHealthState?.isEmpty == false
+        guard hasSubstantiveStatusShape else {
             return nil
         }
         let wrapperOk = json["ok"] as? Bool
@@ -29,13 +29,12 @@ public enum DaemonStatusParser {
             ?? []
         let repos = monitoredRepos.map { RepoMonitor(name: $0, enabled: true) }
         let ok = wrapperOk ?? effectiveOk ?? false
-        let healthState = (effective["healthState"] as? String)
-            ?? (json["healthState"] as? String)
+        let healthState = reportedHealthState
             ?? (ok ? "runtime_ok" : "runtime_blocked")
         let launchdLabel = launchdLabel ?? launchd?["label"] as? String
         let status = DaemonStatus(
             ok: ok,
-            runtimeOk: json["runtimeOk"] as? Bool ?? effective["runtimeOk"] as? Bool ?? ok,
+            runtimeOk: reportedRuntimeOk ?? ok,
             healthState: healthState,
             checkedAt: effective["checkedAt"] as? String ?? json["checkedAt"] as? String,
             monitoredRepos: monitoredRepos,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+@MainActor
+@Suite struct DaemonStatusPresentationTests {
+    @Test func parsedBlockedStatusStaysBehindDiagnostics() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": false,
+          "command": "daemon status",
+          "status": {
+            "ok": false,
+            "runtimeOk": false,
+            "healthState": "runtime_blocked",
+            "checkedAt": "2026-07-27T00:36:22.385Z",
+            "summary": {
+              "failedQueueJobs": 2
+            }
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 1, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status.healthState == "runtime_blocked")
+        #expect(fixture.model.status.runtimeOk == false)
+        #expect(fixture.model.lastError == nil)
+        #expect(fixture.model.statusRefreshFailureMessage == nil)
+        #expect(fixture.model.logText.contains(#""failedQueueJobs": 2"#))
+        #expect(fixture.model.customerSurfaceStatus == "WORKER ATTENTION")
+        #expect(
+            fixture.model.customerLocalWorkerStatusDetail
+                == "Running, but review gates need attention"
+        )
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -16,6 +16,9 @@ import NeonDiffDesktopCore
             "runtimeOk": false,
             "healthState": "runtime_blocked",
             "checkedAt": "2026-07-27T00:36:22.385Z",
+            "launchd": {
+              "state": "not_running"
+            },
             "summary": {
               "failedQueueJobs": 2
             }
@@ -40,7 +43,47 @@ import NeonDiffDesktopCore
         #expect(fixture.model.customerSurfaceStatus == "WORKER ATTENTION")
         #expect(
             fixture.model.customerLocalWorkerStatusDetail
-                == "Running, but review gates need attention"
+                == "Review worker needs attention — open Advanced Diagnostics"
+        )
+    }
+
+    @Test func structuredStatusErrorRemainsActionableAndFailClosed() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": false,
+          "command": "daemon status",
+          "error": {
+            "code": "config_invalid",
+            "message": "The selected config could not be loaded."
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 1, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status == .unknown)
+        #expect(
+            fixture.model.lastError
+                == "Local worker status check failed. Retry or open Advanced Diagnostics."
+        )
+        #expect(
+            fixture.model.statusRefreshFailureMessage
+                == "Local worker status check failed. Retry or open Advanced Diagnostics."
+        )
+        #expect(fixture.model.logText.contains("config_invalid"))
+        #expect(fixture.model.customerSurfaceStatus == "NOT CHECKED")
+        #expect(
+            fixture.model.customerLocalWorkerStatusDetail
+                == "Status check failed — retry"
         )
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -136,4 +136,34 @@ import NeonDiffDesktopCore
         )
         #expect(fixture.model.customerSurfaceStatus == "NOT CHECKED")
     }
+
+    @Test func timestampOnlyNestedStatusEnvelopeFailsClosed() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": true,
+          "command": "daemon status",
+          "status": {
+            "checkedAt": "2026-07-27T00:35:00.000Z"
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status == .unknown)
+        #expect(
+            fixture.model.statusRefreshFailureMessage
+                == "Local worker status check failed. Retry or open Advanced Diagnostics."
+        )
+        #expect(fixture.model.customerSurfaceStatus == "NOT CHECKED")
+    }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -50,6 +50,18 @@ import NeonDiffDesktopCore
     @Test func structuredStatusErrorRemainsActionableAndFailClosed() {
         let fixture = ModelDependencyFixture(suspendCLIRuns: true)
         fixture.model.isOnboardingPresented = false
+        let healthyResponse = #"""
+        {
+          "ok": true,
+          "command": "daemon status",
+          "status": {
+            "ok": true,
+            "runtimeOk": true,
+            "healthState": "runtime_ok",
+            "checkedAt": "2026-07-27T00:35:00.000Z"
+          }
+        }
+        """#
         let response = #"""
         {
           "ok": false,
@@ -60,6 +72,16 @@ import NeonDiffDesktopCore
           }
         }
         """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: healthyResponse, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+        #expect(fixture.model.status.runtimeOk == true)
 
         fixture.model.applyCLIResultForTesting(
             CLIRunResult(exitCode: 1, stdout: response, stderr: ""),
@@ -85,5 +107,33 @@ import NeonDiffDesktopCore
             fixture.model.customerLocalWorkerStatusDetail
                 == "Status check failed — retry"
         )
+    }
+
+    @Test func emptyNestedStatusEnvelopeFailsClosed() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": true,
+          "command": "daemon status",
+          "status": {}
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status == .unknown)
+        #expect(
+            fixture.model.statusRefreshFailureMessage
+                == "Local worker status check failed. Retry or open Advanced Diagnostics."
+        )
+        #expect(fixture.model.customerSurfaceStatus == "NOT CHECKED")
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -173,6 +173,12 @@ import Testing
         let activity = try sourceBoundaryText(
             at: views.appendingPathComponent("LogsView.swift")
         )
+        let model = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot()
+                .appendingPathComponent(
+                    "Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift"
+                )
+        )
         let settings = try sourceBoundaryText(
             at: views.appendingPathComponent("SettingsPane.swift")
         )
@@ -230,8 +236,10 @@ import Testing
         #expect(activity.contains("OperatorSection(\"Current Activity\")"))
         #expect(activity.contains("model.githubSetupReady"))
         #expect(activity.contains("GitHub connection ready"))
-        #expect(activity.contains("Not checked yet — choose Refresh Activity"))
-        #expect(activity.contains("Check failed —"))
+        #expect(activity.contains("model.customerLocalWorkerStatusDetail"))
+        #expect(model.contains("Not checked yet — choose Refresh Activity"))
+        #expect(model.contains("Status check failed — retry"))
+        #expect(model.contains("Running, but review gates need attention"))
         #expect(activity.contains("DisclosureGroup"))
         #expect(activity.contains("// ADVANCED DIAGNOSTICS"))
         #expect(settings.contains("Signed update, rollback, and installed-app proof"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -239,7 +239,7 @@ import Testing
         #expect(activity.contains("model.customerLocalWorkerStatusDetail"))
         #expect(model.contains("Not checked yet — choose Refresh Activity"))
         #expect(model.contains("Status check failed — retry"))
-        #expect(model.contains("Running, but review gates need attention"))
+        #expect(model.contains("Review worker needs attention — open Advanced Diagnostics"))
         #expect(activity.contains("DisclosureGroup"))
         #expect(activity.contains("// ADVANCED DIAGNOSTICS"))
         #expect(settings.contains("Signed update, rollback, and installed-app proof"))


### PR DESCRIPTION
Related: #657

## Outcome

Keep a valid nonzero `daemon status` envelope truthful and fail-closed without rendering its full redacted JSON as a large customer-facing Overview error. Translate internal worker health codes into customer language while retaining the exact payload behind Advanced Diagnostics.

## Bounded acceptance criteria

- A parsed `runtime_blocked` status still sets `status.runtimeOk = false` and does not unlock work.
- The parsed status no longer populates shared `lastError`, so Overview does not render the raw JSON payload.
- `logText` retains the full redacted status for Advanced Diagnostics.
- The status chip says `WORKER ATTENTION`, and Activity says `Running, but review gates need attention`.
- Invalid/unparseable transport failures keep their existing fail-closed error path.

## Explicit non-goals

- No daemon, queue, launchd, checkout, or live-runtime mutation.
- No reinterpretation or weakening of CLI runtime gates.
- No GitHub App credential migration, activation bypass, billing, checkout, updater, signing, publication, or canary work.
- Does not close #657, broader #517, #610, or #646.

## Failing-first and focused proof

RED before implementation:
- `DaemonStatusPresentationTests.parsedBlockedStatusStaysBehindDiagnostics` failed because `lastError` held the full JSON and `customerSurfaceStatus` exposed `runtime_blocked`.

GREEN after implementation:
- `swift test --package-path apps/neondiff-desktop --filter DaemonStatusPresentationTests`
- `swift test --package-path apps/neondiff-desktop --filter "DaemonStatusPresentationTests|ConfigurationControlCenterTests|ExistingLocalBotReconciliationTests|OwnerReferenceUXContractTests"` — 27 passed
- `git diff --check`

Agent-authored. No secrets, live config, raw customer logs, runtime mutations, or release claims are included.