### PR TITLE
fix(desktop): parse current daemon status envelope

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -14,14 +14,24 @@ public enum DaemonStatusParser {
         let reportedRuntimeOk = json["runtimeOk"] as? Bool ?? effective["runtimeOk"] as? Bool
         let reportedHealthState = (effective["healthState"] as? String)
             ?? (json["healthState"] as? String)
-        let hasSubstantiveStatusShape = reportedRuntimeOk != nil
-            || reportedHealthState?.isEmpty == false
-        guard hasSubstantiveStatusShape else {
-            return nil
-        }
         let wrapperOk = json["ok"] as? Bool
         let effectiveOk = effective["ok"] as? Bool
         let launchd = effective["launchd"] as? [String: Any]
+        let launchdState = (launchd?["state"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let isCurrentDaemonStatusEnvelope =
+            statusPayload != nil
+            && json["command"] as? String == "daemon status"
+            && json["operation"] as? String == "status"
+            && effectiveOk != nil
+            && launchdState?.isEmpty == false
+            && effective["gates"] is [[String: Any]]
+        let hasSubstantiveStatusShape = reportedRuntimeOk != nil
+            || reportedHealthState?.isEmpty == false
+            || isCurrentDaemonStatusEnvelope
+        guard hasSubstantiveStatusShape else {
+            return nil
+        }
 
         let monitoredRepos = (effective["monitoredRepos"] as? [String])
             ?? (json["pilotRepos"] as? [String])
@@ -29,12 +39,18 @@ public enum DaemonStatusParser {
             ?? []
         let repos = monitoredRepos.map { RepoMonitor(name: $0, enabled: true) }
         let ok = wrapperOk ?? effectiveOk ?? false
+        let runtimeOk = reportedRuntimeOk
+            ?? (isCurrentDaemonStatusEnvelope ? effectiveOk : nil)
+            ?? ok
+        let inferredHealthOk = isCurrentDaemonStatusEnvelope
+            ? (effectiveOk ?? false)
+            : ok
         let healthState = reportedHealthState
-            ?? (ok ? "runtime_ok" : "runtime_blocked")
+            ?? (inferredHealthOk ? "runtime_ok" : "runtime_blocked")
         let launchdLabel = launchdLabel ?? launchd?["label"] as? String
         let status = DaemonStatus(
             ok: ok,
-            runtimeOk: reportedRuntimeOk ?? ok,
+            runtimeOk: runtimeOk,
             healthState: healthState,
             checkedAt: effective["checkedAt"] as? String ?? json["checkedAt"] as? String,
             monitoredRepos: monitoredRepos,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -11,15 +11,16 @@ public enum DaemonStatusParser {
 
         let statusPayload = json["status"] as? [String: Any]
         let effective = statusPayload ?? json
-        let reportedRuntimeOk = json["runtimeOk"] as? Bool ?? effective["runtimeOk"] as? Bool
+        let reportedRuntimeOk = strictJSONBool(json["runtimeOk"])
+            ?? strictJSONBool(effective["runtimeOk"])
         let rawReportedHealthState = (effective["healthState"] as? String)
             ?? (json["healthState"] as? String)
         let reportedHealthState = rawReportedHealthState.flatMap { state in
             let normalized = state.trimmingCharacters(in: .whitespacesAndNewlines)
             return normalized.isEmpty ? nil : normalized
         }
-        let wrapperOk = json["ok"] as? Bool
-        let effectiveOk = effective["ok"] as? Bool
+        let wrapperOk = strictJSONBool(json["ok"])
+        let effectiveOk = strictJSONBool(effective["ok"])
         let launchd = effective["launchd"] as? [String: Any]
         let launchdState = (launchd?["state"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -41,7 +42,7 @@ public enum DaemonStatusParser {
             var gateResults: [String: Bool] = [:]
             for row in gateRows {
                 guard let rawName = row["name"] as? String,
-                      let ok = row["ok"] as? Bool
+                      let ok = strictJSONBool(row["ok"])
                 else {
                     return nil
                 }
@@ -74,12 +75,16 @@ public enum DaemonStatusParser {
             ?? []
         let repos = monitoredRepos.map { RepoMonitor(name: $0, enabled: true) }
         let ok = wrapperOk ?? effectiveOk ?? false
-        let runtimeOk = reportedRuntimeOk
-            ?? currentEnvelopeRuntimeOk
-            ?? ok
-        let inferredHealthOk = currentEnvelopeRuntimeOk ?? ok
-        let healthState = reportedHealthState
-            ?? (inferredHealthOk ? "runtime_ok" : "runtime_blocked")
+        let runtimeOk: Bool
+        let healthState: String
+        if hasCurrentDaemonStatusSignature, let currentEnvelopeRuntimeOk {
+            runtimeOk = currentEnvelopeRuntimeOk
+            healthState = currentEnvelopeRuntimeOk ? "runtime_ok" : "runtime_blocked"
+        } else {
+            runtimeOk = reportedRuntimeOk ?? ok
+            healthState = reportedHealthState
+                ?? (ok ? "runtime_ok" : "runtime_blocked")
+        }
         let launchdLabel = launchdLabel ?? launchd?["label"] as? String
         let status = DaemonStatus(
             ok: ok,
@@ -92,6 +97,15 @@ public enum DaemonStatusParser {
         )
         return (status, repos)
     }
+}
+
+private func strictJSONBool(_ value: Any?) -> Bool? {
+    guard let number = value as? NSNumber,
+          CFGetTypeID(number) == CFBooleanGetTypeID()
+    else {
+        return nil
+    }
+    return number.boolValue
 }
 
 private let currentDaemonLaunchdStates: Set<String> = [

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -23,13 +23,43 @@ public enum DaemonStatusParser {
         let launchd = effective["launchd"] as? [String: Any]
         let launchdState = (launchd?["state"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let isCurrentDaemonStatusEnvelope =
-            statusPayload != nil
-            && json["command"] as? String == "daemon status"
-            && json["operation"] as? String == "status"
-            && effectiveOk != nil
-            && launchdState?.isEmpty == false
-            && effective["gates"] is [[String: Any]]
+        let currentEnvelopeRuntimeOk: Bool? = {
+            guard statusPayload != nil,
+                  json["command"] as? String == "daemon status",
+                  json["operation"] as? String == "status",
+                  effectiveOk != nil,
+                  let launchdState,
+                  currentDaemonLaunchdStates.contains(launchdState),
+                  let gateRows = effective["gates"] as? [[String: Any]],
+                  !gateRows.isEmpty
+            else {
+                return nil
+            }
+
+            var gateResults: [String: Bool] = [:]
+            for row in gateRows {
+                guard let rawName = row["name"] as? String,
+                      let ok = row["ok"] as? Bool
+                else {
+                    return nil
+                }
+                let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !name.isEmpty, gateResults[name] == nil else {
+                    return nil
+                }
+                gateResults[name] = ok
+            }
+            guard currentDaemonWorkerGateNames.allSatisfy({
+                gateResults[$0] != nil
+            }) else {
+                return nil
+            }
+            return launchdState == "running"
+                && currentDaemonWorkerGateNames.allSatisfy({
+                    gateResults[$0] == true
+                })
+        }()
+        let isCurrentDaemonStatusEnvelope = currentEnvelopeRuntimeOk != nil
         let hasSubstantiveStatusShape = reportedRuntimeOk != nil
             || reportedHealthState?.isEmpty == false
             || isCurrentDaemonStatusEnvelope
@@ -44,11 +74,9 @@ public enum DaemonStatusParser {
         let repos = monitoredRepos.map { RepoMonitor(name: $0, enabled: true) }
         let ok = wrapperOk ?? effectiveOk ?? false
         let runtimeOk = reportedRuntimeOk
-            ?? (isCurrentDaemonStatusEnvelope ? effectiveOk : nil)
+            ?? currentEnvelopeRuntimeOk
             ?? ok
-        let inferredHealthOk = isCurrentDaemonStatusEnvelope
-            ? (effectiveOk ?? false)
-            : ok
+        let inferredHealthOk = currentEnvelopeRuntimeOk ?? ok
         let healthState = reportedHealthState
             ?? (inferredHealthOk ? "runtime_ok" : "runtime_blocked")
         let launchdLabel = launchdLabel ?? launchd?["label"] as? String
@@ -64,3 +92,22 @@ public enum DaemonStatusParser {
         return (status, repos)
     }
 }
+
+private let currentDaemonLaunchdStates: Set<String> = [
+    "running",
+    "not_running",
+    "unknown"
+]
+
+private let currentDaemonWorkerGateNames: Set<String> = [
+    "launchd_running",
+    "launchd_config",
+    "launchd_node_system_ca",
+    "live_db_no_errors",
+    "provider_cooldown_backlog",
+    "queue_no_failed_jobs",
+    "queue_no_zcode_timeout_failed_jobs",
+    "queue_no_stale_review_leases",
+    "queue_no_retryable_provider_deferred_jobs",
+    "daemon_heartbeat_recent"
+]

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -12,8 +12,12 @@ public enum DaemonStatusParser {
         let statusPayload = json["status"] as? [String: Any]
         let effective = statusPayload ?? json
         let reportedRuntimeOk = json["runtimeOk"] as? Bool ?? effective["runtimeOk"] as? Bool
-        let reportedHealthState = (effective["healthState"] as? String)
+        let rawReportedHealthState = (effective["healthState"] as? String)
             ?? (json["healthState"] as? String)
+        let reportedHealthState = rawReportedHealthState.flatMap { state in
+            let normalized = state.trimmingCharacters(in: .whitespacesAndNewlines)
+            return normalized.isEmpty ? nil : normalized
+        }
         let wrapperOk = json["ok"] as? Bool
         let effectiveOk = effective["ok"] as? Bool
         let launchd = effective["launchd"] as? [String: Any]

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/DaemonStatusParser.swift
@@ -23,10 +23,12 @@ public enum DaemonStatusParser {
         let launchd = effective["launchd"] as? [String: Any]
         let launchdState = (launchd?["state"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasCurrentDaemonStatusSignature =
+            statusPayload != nil
+            && json["command"] as? String == "daemon status"
+            && json["operation"] as? String == "status"
         let currentEnvelopeRuntimeOk: Bool? = {
-            guard statusPayload != nil,
-                  json["command"] as? String == "daemon status",
-                  json["operation"] as? String == "status",
+            guard hasCurrentDaemonStatusSignature,
                   effectiveOk != nil,
                   let launchdState,
                   currentDaemonLaunchdStates.contains(launchdState),
@@ -59,10 +61,9 @@ public enum DaemonStatusParser {
                     gateResults[$0] == true
                 })
         }()
-        let isCurrentDaemonStatusEnvelope = currentEnvelopeRuntimeOk != nil
-        let hasSubstantiveStatusShape = reportedRuntimeOk != nil
-            || reportedHealthState?.isEmpty == false
-            || isCurrentDaemonStatusEnvelope
+        let hasSubstantiveStatusShape = hasCurrentDaemonStatusSignature
+            ? currentEnvelopeRuntimeOk != nil
+            : reportedRuntimeOk != nil || reportedHealthState?.isEmpty == false
         guard hasSubstantiveStatusShape else {
             return nil
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -47,6 +47,50 @@ import NeonDiffDesktopCore
         )
     }
 
+    @Test func currentDaemonStatusEnvelopeIsActionableNotAParseFailure() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": false,
+          "command": "daemon status",
+          "operation": "status",
+          "status": {
+            "ok": false,
+            "checkedAt": "2026-07-27T02:14:31.507Z",
+            "launchd": {
+              "state": "running"
+            },
+            "gates": [
+              {
+                "name": "queue_no_failed_jobs",
+                "ok": false,
+                "detail": "2 failed durable queue job(s)"
+              }
+            ]
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 1, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status.healthState == "runtime_blocked")
+        #expect(fixture.model.status.runtimeOk == false)
+        #expect(fixture.model.statusRefreshFailureMessage == nil)
+        #expect(fixture.model.customerSurfaceStatus == "WORKER ATTENTION")
+        #expect(
+            fixture.model.customerLocalWorkerStatusDetail
+                == "Review worker needs attention — open Advanced Diagnostics"
+        )
+    }
+
     @Test func structuredStatusErrorRemainsActionableAndFailClosed() {
         let fixture = ModelDependencyFixture(suspendCLIRuns: true)
         fixture.model.isOnboardingPresented = false

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -64,9 +64,45 @@ import NeonDiffDesktopCore
             },
             "gates": [
               {
+                "name": "launchd_running",
+                "ok": true
+              },
+              {
+                "name": "launchd_config",
+                "ok": true
+              },
+              {
+                "name": "launchd_node_system_ca",
+                "ok": true
+              },
+              {
+                "name": "live_db_no_errors",
+                "ok": true
+              },
+              {
+                "name": "provider_cooldown_backlog",
+                "ok": true
+              },
+              {
                 "name": "queue_no_failed_jobs",
                 "ok": false,
                 "detail": "2 failed durable queue job(s)"
+              },
+              {
+                "name": "queue_no_zcode_timeout_failed_jobs",
+                "ok": true
+              },
+              {
+                "name": "queue_no_stale_review_leases",
+                "ok": true
+              },
+              {
+                "name": "queue_no_retryable_provider_deferred_jobs",
+                "ok": true
+              },
+              {
+                "name": "daemon_heartbeat_recent",
+                "ok": true
               }
             ]
           }
@@ -91,6 +127,91 @@ import NeonDiffDesktopCore
             fixture.model.customerLocalWorkerStatusDetail
                 == "Review worker needs attention — open Advanced Diagnostics"
         )
+    }
+
+    @Test func releaseReadinessFailureDoesNotMislabelAHealthyWorker() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": false,
+          "command": "daemon status",
+          "operation": "status",
+          "status": {
+            "ok": false,
+            "checkedAt": "2026-07-27T02:14:31.507Z",
+            "launchd": {
+              "state": "running"
+            },
+            "gates": [
+              {"name": "clean_checkout", "ok": false},
+              {"name": "release_branch", "ok": false},
+              {"name": "launchd_running", "ok": true},
+              {"name": "launchd_config", "ok": true},
+              {"name": "launchd_node_system_ca", "ok": true},
+              {"name": "live_db_no_errors", "ok": true},
+              {"name": "provider_cooldown_backlog", "ok": true},
+              {"name": "queue_no_failed_jobs", "ok": true},
+              {"name": "queue_no_zcode_timeout_failed_jobs", "ok": true},
+              {"name": "queue_no_stale_review_leases", "ok": true},
+              {"name": "queue_no_retryable_provider_deferred_jobs", "ok": true},
+              {"name": "daemon_heartbeat_recent", "ok": true}
+            ]
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 1, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status.healthState == "runtime_ok")
+        #expect(fixture.model.status.runtimeOk == true)
+        #expect(fixture.model.statusRefreshFailureMessage == nil)
+        #expect(fixture.model.customerSurfaceStatus == "WORKER READY")
+        #expect(fixture.model.customerLocalWorkerStatusDetail == "Running and ready")
+    }
+
+    @Test func malformedCurrentStatusEnvelopeFailsClosed() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": true,
+          "command": "daemon status",
+          "operation": "status",
+          "status": {
+            "ok": true,
+            "launchd": {
+              "state": "invalid"
+            },
+            "gates": [
+              {}
+            ]
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status == .unknown)
+        #expect(
+            fixture.model.statusRefreshFailureMessage
+                == "Local worker status check failed. Retry or open Advanced Diagnostics."
+        )
+        #expect(fixture.model.customerSurfaceStatus == "NOT CHECKED")
     }
 
     @Test func structuredStatusErrorRemainsActionableAndFailClosed() {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -185,6 +185,8 @@ import NeonDiffDesktopCore
           "ok": true,
           "command": "daemon status",
           "operation": "status",
+          "runtimeOk": true,
+          "healthState": "runtime_ok",
           "status": {
             "ok": true,
             "launchd": {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -57,6 +57,7 @@ import NeonDiffDesktopCore
           "operation": "status",
           "status": {
             "ok": false,
+            "healthState": "",
             "checkedAt": "2026-07-27T02:14:31.507Z",
             "launchd": {
               "state": "running"
@@ -83,6 +84,7 @@ import NeonDiffDesktopCore
 
         #expect(fixture.model.status.healthState == "runtime_blocked")
         #expect(fixture.model.status.runtimeOk == false)
+        #expect(fixture.model.lastError == nil)
         #expect(fixture.model.statusRefreshFailureMessage == nil)
         #expect(fixture.model.customerSurfaceStatus == "WORKER ATTENTION")
         #expect(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DaemonStatusPresentationTests.swift
@@ -129,6 +129,99 @@ import NeonDiffDesktopCore
         )
     }
 
+    @Test func currentDaemonStatusRejectsNumericGateBooleans() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": true,
+          "command": "daemon status",
+          "operation": "status",
+          "status": {
+            "ok": true,
+            "launchd": {
+              "state": "running"
+            },
+            "gates": [
+              {"name": "launchd_running", "ok": 1},
+              {"name": "launchd_config", "ok": 1},
+              {"name": "launchd_node_system_ca", "ok": 1},
+              {"name": "live_db_no_errors", "ok": 1},
+              {"name": "provider_cooldown_backlog", "ok": 1},
+              {"name": "queue_no_failed_jobs", "ok": 1},
+              {"name": "queue_no_zcode_timeout_failed_jobs", "ok": 1},
+              {"name": "queue_no_stale_review_leases", "ok": 1},
+              {"name": "queue_no_retryable_provider_deferred_jobs", "ok": 1},
+              {"name": "daemon_heartbeat_recent", "ok": 1}
+            ]
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status == .unknown)
+        #expect(
+            fixture.model.statusRefreshFailureMessage
+                == "Local worker status check failed. Retry or open Advanced Diagnostics."
+        )
+        #expect(fixture.model.customerSurfaceStatus == "NOT CHECKED")
+    }
+
+    @Test func currentDaemonStatusIgnoresContradictoryLegacyHealthFields() {
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.isOnboardingPresented = false
+        let response = #"""
+        {
+          "ok": false,
+          "command": "daemon status",
+          "operation": "status",
+          "runtimeOk": true,
+          "healthState": "runtime_ok",
+          "status": {
+            "ok": false,
+            "runtimeOk": true,
+            "healthState": "runtime_ok",
+            "launchd": {
+              "state": "running"
+            },
+            "gates": [
+              {"name": "launchd_running", "ok": true},
+              {"name": "launchd_config", "ok": true},
+              {"name": "launchd_node_system_ca", "ok": true},
+              {"name": "live_db_no_errors", "ok": true},
+              {"name": "provider_cooldown_backlog", "ok": true},
+              {"name": "queue_no_failed_jobs", "ok": false},
+              {"name": "queue_no_zcode_timeout_failed_jobs", "ok": true},
+              {"name": "queue_no_stale_review_leases", "ok": true},
+              {"name": "queue_no_retryable_provider_deferred_jobs", "ok": true},
+              {"name": "daemon_heartbeat_recent", "ok": true}
+            ]
+          }
+        }
+        """#
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 1, stdout: response, stderr: ""),
+            fallbackCommand: "neondiff daemon status",
+            configPath: fixture.model.configPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: false,
+            isDaemonStatusCommand: true
+        )
+
+        #expect(fixture.model.status.runtimeOk == false)
+        #expect(fixture.model.status.healthState == "runtime_blocked")
+        #expect(fixture.model.customerSurfaceStatus == "WORKER ATTENTION")
+    }
+
     @Test func releaseReadinessFailureDoesNotMislabelAHealthyWorker() {
         let fixture = ModelDependencyFixture(suspendCLIRuns: true)
         fixture.model.isOnboardingPresented = false


### PR DESCRIPTION
Related: #657

## Outcome

The installed B0 app recognizes the current CLI `daemon status` envelope (`status.ok` + typed launchd state + gates) as valid runtime evidence. Worker health is derived from the required worker gates, not checkout/release-readiness gates. A blocked worker is shown as `WORKER ATTENTION`, a worker blocked only by release-readiness state remains `WORKER READY`, and the full redacted payload remains only in Advanced Diagnostics.

## Acceptance criteria

- Current emitted daemon-status schema maps blocked worker gates to `runtime_blocked` rather than a generic parse failure.
- Checkout, branch, and publication readiness do not mislabel a healthy worker.
- Current-signature envelopes require an allowed launchd state and the complete typed worker-gate set.
- Current-signature envelopes cannot bypass validation through legacy `runtimeOk` / `healthState` fields.
- Existing legacy typed envelopes retain their behavior.
- Empty, timestamp-only, structured-error, and malformed current envelopes fail closed.
- No raw diagnostic JSON is promoted to Overview or the normal Activity summary.

## Non-goals

- No live daemon, launchd, queue, config, credential, billing, update, or release mutation.
- No schema redesign or generalized compatibility harness.
- No change to activation, entitlement, repository binding, posting, or secret handling.
- Does not close the broader #657 owner-acceptance gate.

## Failing-first proof

- The live-schema test initially failed with `unknown`, a generic refresh failure, and five expectation failures.
- Empty health state reproduced blank customer status.
- Release-only failures reproduced false `WORKER ATTENTION`.
- Invalid current evidence with healthy legacy fields reproduced a false `WORKER READY` result before the final targeted fix.

## Focused validation

- `swift test --package-path apps/neondiff-desktop --filter DaemonStatusPresentationTests` — 7/7 pass
- `swift run --package-path apps/neondiff-desktop NeonDiffDesktopCoreSmoke` — pass
- `git diff --check` — pass

Agent-authored change. Broad validation and hosted XCUITest remain GitHub CI gates.
