### PR TITLE
fix(desktop): bind activation to an explicit review target

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ authoritative account/bot intersection instead of asking the user to initialize
 or re-enter the existing worker credentials. It may show GitHub, provider,
 entitlement, and repository setup as configured while still requiring fresh,
 repository-scoped GitHub and activation verification before new review work.
+If that existing worker monitors more than one repository, the native app keeps
+the full allowlist intact and asks the user to choose one **Review Target**.
+Native activation and the next review bind to that exact target; selecting it
+does not remove, disable, or rewrite the worker's other repositories. The
+selection is restored only for the same local config path and fails closed if
+that config or repository is no longer current.
 During launch it shows a bounded restoring state while that authorized
 account/bot/config intersection is checked; it does not flash empty first-run
 setup or claim that the existing configuration is missing.

--- a/README.md
+++ b/README.md
@@ -168,10 +168,11 @@ entitlement, and repository setup as configured while still requiring fresh,
 repository-scoped GitHub and activation verification before new review work.
 If that existing worker monitors more than one repository, the native app keeps
 the full allowlist intact and asks the user to choose one **Review Target**.
-Native activation and the next review bind to that exact target; selecting it
-does not remove, disable, or rewrite the worker's other repositories. The
-selection is restored only for the same local config path and fails closed if
-that config or repository is no longer current.
+Native activation binds to that exact target; selecting it does not remove,
+disable, or rewrite the worker's other repositories. Until a targeted runtime
+handoff is available, native review and daemon controls remain blocked for a
+multi-repository worker. The selection is restored only for the same local
+config path and fails closed if that config or repository is no longer current.
 During launch it shows a bounded restoring state while that authorized
 account/bot/config intersection is checked; it does not flash empty first-run
 setup or claim that the existing configuration is missing.

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -40,7 +40,11 @@ struct ActivationStateView: View {
                 .font(.system(.headline, design: .monospaced).weight(.bold))
                 .foregroundStyle(presentation.isSuccess ? palette.accentPrimary : palette.textPrimary)
 
-            Text(presentation.cause)
+            Text(
+                model.activationTargetSelectionRequired
+                    ? "Choose one Review Target in Repositories before activating. The existing worker allowlist will remain unchanged."
+                    : presentation.cause
+            )
                 .font(NDFont.mono)
                 .foregroundStyle(palette.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -50,7 +54,13 @@ struct ActivationStateView: View {
             }
 
             HStack(spacing: 12) {
-                if let recovery = presentation.recovery {
+                if model.activationTargetSelectionRequired {
+                    Button("Choose review target") {
+                        model.reviewActivationTargetSelection()
+                    }
+                    .buttonStyle(NDBracketButtonStyle())
+                    .accessibilityIdentifier("neondiff.activation.choose-review-target")
+                } else if let recovery = presentation.recovery {
                     Button(recovery.label) {
                         Task { await model.performActivationRecovery() }
                     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -31,8 +31,10 @@ struct DesktopSetupReadiness {
             ? "PUBLIC · FREE"
             : (licenseIsActive ? "ACTIVE" : "ACTIVATION REQUIRED")
         repository = model.repositorySetupReady
-        repositoryName = model.selectedManagedGitHubRepository
-            ?? model.repos.first(where: \.enabled)?.name
+        repositoryName = model.selectedReviewRepository
+            ?? (model.repos.filter(\.enabled).count > 1
+                ? "Choose review target"
+                : model.repos.first(where: \.enabled)?.name)
             ?? "owner/repository"
         canRunDryRun = model.productionUsefulWorkAvailable
             && model.providerSetupReady

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -11,6 +11,7 @@ struct DesktopSetupReadiness {
     let license: Bool
     let licenseStatus: String
     let repository: Bool
+    let targetSelectionRequired: Bool
     let repositoryName: String
     let canRunDryRun: Bool
 
@@ -30,7 +31,8 @@ struct DesktopSetupReadiness {
         licenseStatus = publicRepositoryLicenseNotRequired
             ? "PUBLIC · FREE"
             : (licenseIsActive ? "ACTIVE" : "ACTIVATION REQUIRED")
-        repository = model.repositorySetupReady
+        targetSelectionRequired = model.activationTargetSelectionRequired
+        repository = model.repositorySetupReady && !targetSelectionRequired
         repositoryName = model.selectedReviewRepository
             ?? (model.repos.filter(\.enabled).count > 1
                 ? "Choose review target"
@@ -130,13 +132,17 @@ struct OverviewView: View {
                             ? "CHECKING"
                             : (readiness.isRestoreFailed
                                 ? "WAITING FOR ACCOUNT"
-                            : (readiness.repository ? "APPLIED" : "NOT APPLIED")),
+                            : (readiness.targetSelectionRequired
+                                ? "TARGET REQUIRED"
+                                : (readiness.repository ? "APPLIED" : "NOT APPLIED"))),
                         isReady: readiness.repository,
                         actionTitle: readiness.isRestoring
                             ? "WAIT"
                             : (readiness.isRestoreFailed
                                 ? "WAIT"
-                            : (readiness.repository ? "MANAGE" : "ADD")),
+                            : (readiness.targetSelectionRequired
+                                ? "CHOOSE"
+                                : (readiness.repository ? "MANAGE" : "ADD"))),
                         isDisabled: readiness.isRestoring || readiness.isRestoreFailed
                     ) {
                         model.selectedSection = .repos
@@ -280,11 +286,13 @@ struct OverviewView: View {
                 ? "Reading the selected bot’s applied repository configuration."
                 : (readiness.isRestoreFailed
                     ? "Retry account verification before changing local setup."
+                : (readiness.targetSelectionRequired
+                    ? "Choose one Review Target; the applied worker allowlist remains unchanged."
                 : (readiness.repository
                     ? (readiness.canRunDryRun
                         ? "Applied and ready for a dry-run review."
                         : "Applied in the selected local bot config.")
-                    : "Choose and apply one repository to begin.")))
+                    : "Choose and apply one repository to begin."))))
                 .font(.callout)
                 .foregroundStyle(palette.textSecondary)
 
@@ -296,7 +304,9 @@ struct OverviewView: View {
                         ? "Checking Repository"
                         : (readiness.isRestoreFailed
                             ? "Waiting for Account"
-                        : (readiness.repository ? "Manage Repository" : "Add Repository")),
+                        : (readiness.targetSelectionRequired
+                            ? "Choose Review Target"
+                            : (readiness.repository ? "Manage Repository" : "Add Repository"))),
                     systemImage: "plus.circle"
                 )
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -208,7 +208,13 @@ struct ReposView: View {
                             }
                             .buttonStyle(.plain)
                             .disabled(!model.canSelectBYOReviewRepository(fullName: repo.name))
-                            .accessibilityLabel("Use \(repo.name) as the review target")
+                            .accessibilityLabel(
+                                isSelected
+                                    ? "\(repo.name) is the review target"
+                                    : "Use \(repo.name) as the review target"
+                            )
+                            .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                            .accessibilityAddTraits(isSelected ? .isSelected : [])
                             .accessibilityIdentifier("neondiff-repo-review-target-\(repo.name)")
                         } else {
                             Text("—")
@@ -251,7 +257,7 @@ struct ReposView: View {
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.accent)
                             .fixedSize(horizontal: false, vertical: true)
-                    } else if model.repos.filter(\.enabled).count > 1 {
+                    } else if model.activationTargetSelectionRequired {
                         Text("Choose one Review Target above before activation. This does not remove or disable any repository in the existing worker.")
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.warning)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -192,6 +192,29 @@ struct ReposView: View {
                         .disabled(model.managedGitHubAvailable)
                         .accessibilityIdentifier("neondiff-repo-toggle-\(repo.name)")
                     }
+                    TableColumn("Review Target") { repo in
+                        if model.byoGitHubCredentialOnboardingAvailable {
+                            let isSelected = model.selectedBYOReviewRepository?
+                                .caseInsensitiveCompare(repo.name) == .orderedSame
+                            Button {
+                                model.selectBYOReviewRepository(fullName: repo.name)
+                            } label: {
+                                Image(systemName: isSelected ? "scope" : "circle")
+                                    .foregroundStyle(
+                                        isSelected
+                                            ? NeonDiffTheme.accent
+                                            : NeonDiffTheme.textSecondary
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(!repo.enabled)
+                            .accessibilityLabel("Use \(repo.name) as the review target")
+                            .accessibilityIdentifier("neondiff-repo-review-target-\(repo.name)")
+                        } else {
+                            Text("—")
+                                .foregroundStyle(NeonDiffTheme.textSecondary)
+                        }
+                    }
                     TableColumn("Profile", value: \.profile)
                     TableColumn("Access") { repo in
                         if let cue = model.githubAccessCue(for: repo) {
@@ -221,6 +244,20 @@ struct ReposView: View {
                 }
                 .scrollContentBackground(.hidden)
                 .frame(height: 360)
+
+                if model.byoGitHubCredentialOnboardingAvailable {
+                    if let selectedRepository = model.selectedBYOReviewRepository {
+                        Text("Native activation and the next review are bound to \(selectedRepository). The existing worker allowlist remains unchanged.")
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.accent)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else if model.repos.filter(\.enabled).count > 1 {
+                        Text("Choose one Review Target above before activation. This does not remove or disable any repository in the existing worker.")
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.warning)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
 
                 if !model.managedGitHubAvailable {
                     HStack(spacing: 10) {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -207,7 +207,7 @@ struct ReposView: View {
                                     )
                             }
                             .buttonStyle(.plain)
-                            .disabled(!repo.enabled)
+                            .disabled(!model.canSelectBYOReviewRepository(fullName: repo.name))
                             .accessibilityLabel("Use \(repo.name) as the review target")
                             .accessibilityIdentifier("neondiff-repo-review-target-\(repo.name)")
                         } else {
@@ -247,7 +247,7 @@ struct ReposView: View {
 
                 if model.byoGitHubCredentialOnboardingAvailable {
                     if let selectedRepository = model.selectedBYOReviewRepository {
-                        Text("Native activation and the next review are bound to \(selectedRepository). The existing worker allowlist remains unchanged.")
+                        Text("Native activation is bound to \(selectedRepository). The existing worker allowlist remains unchanged. When that worker monitors multiple repositories, native review controls remain blocked until the runtime can be scoped to this target safely.")
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.accent)
                             .fixedSize(horizontal: false, vertical: true)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4278,6 +4278,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         providerPatchProof: PendingProviderPatchProof? = nil,
         repoPatchProof: PendingRepoPatchProof? = nil
     ) {
+        guard !isConfigInspectCommand || self.configPath == configPath else {
+            return
+        }
         if let providerPatchProof,
            pendingProviderPatchProof?.id != providerPatchProof.id {
             return

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3301,6 +3301,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 lastError = "Apply and read back the selected Review Target before activating."
                 return
             }
+            if let activatedRepository,
+               activatedRepository.caseInsensitiveCompare(activationRepository)
+                   != .orderedSame {
+                applyActivationEvent(.activationServiceError)
+                lastError = "This device may already be bound to \(activatedRepository) from an earlier activation attempt. Retry with that Review Target or complete a verified deactivate/rebind before switching repositories."
+                return
+            }
         }
         guard let client = activationLicenseClient else {
             // No CLI-backed validation available (default): never invoke the

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -83,10 +83,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var configPath: String {
         didSet {
             guard configPath != oldValue else { return }
+            selectedBYOReviewRepository = nil
             invalidateRepoApplicationProof()
             invalidateProviderConfigAuthorization()
             invalidateProviderVerificationContext()
             invalidateBYOGitHubVerificationContext()
+            invalidateActivationForRepositoryChange()
         }
     }
     @Published package var cliPath: String {
@@ -107,6 +109,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             invalidateRepoApplicationProof()
             invalidateBYOGitHubVerificationContext()
             invalidateActivationForRepositoryChange()
+            reconcileBYOReviewRepository(enabledRepositories: newAllowlist)
         }
     }
     @Published package var providers = ProviderSettings() {
@@ -138,6 +141,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var managedGitHubRepositories: [GitHubBrokerRepository] = []
     @Published package var managedGitHubInstallationCandidates: [ManagedGitHubInstallationCandidate] = []
     @Published package var selectedManagedGitHubRepository: String?
+    @Published package private(set) var selectedBYOReviewRepository: String?
     @Published package var managedGitHubRecovery: GitHubConnectionRecovery?
     @Published package var isManagedGitHubConnectionInProgress = false
     @Published package var pendingBYOGitHubAppId = ""
@@ -196,16 +200,34 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var currentRepositoryActivationReady: Bool {
         guard activationVerifiedThisLaunch,
               activationState == .active,
-              let activationVerifiedRepositoryThisLaunch
+              let activationVerifiedRepositoryThisLaunch,
+              let selectedReviewRepository
         else {
             return false
         }
-        let enabledRepositories = uniqueSortedRepoNames(
+        return selectedReviewRepository.lowercased()
+            == activationVerifiedRepositoryThisLaunch.lowercased()
+    }
+
+    /// The one repository the native app will activate and use for the next
+    /// review. Existing BYO workers may monitor many repositories; choosing this
+    /// target must never collapse or rewrite that worker allowlist.
+    package var selectedReviewRepository: String? {
+        if managedGitHubAvailable {
+            return selectedManagedGitHubRepository
+        }
+        if byoGitHubCredentialOnboardingAvailable {
+            return selectedBYOReviewRepository
+        }
+        return uniqueSortedRepoNames(
             repos.filter(\.enabled).map(\.name)
-        )
-        return enabledRepositories.count == 1
-            && enabledRepositories[0].lowercased()
-                == activationVerifiedRepositoryThisLaunch.lowercased()
+        ).onlyElement
+    }
+
+    package var activationTargetSelectionRequired: Bool {
+        byoGitHubCredentialOnboardingAvailable
+            && selectedBYOReviewRepository == nil
+            && repos.filter(\.enabled).count > 1
     }
 
     /// Existing-account entitlement is useful setup context, but it must not
@@ -1407,6 +1429,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubRepositories = []
         managedGitHubInstallationCandidates = []
         selectedManagedGitHubRepository = nil
+        selectedBYOReviewRepository = nil
         managedGitHubRecovery = nil
         managedGitHubConnectionState = managedGitHubAvailable ? .disconnected : .quarantined
         byoGitHubCredentialsVerified = false
@@ -2050,6 +2073,36 @@ package final class NeonDiffDesktopModel: ObservableObject {
         repos[index].enabled.toggle()
         lastError = nil
         logText = "Repo allowlist updated locally. Preview or apply the config patch to persist it."
+    }
+
+    package func selectBYOReviewRepository(fullName: String) {
+        guard byoGitHubCredentialOnboardingAvailable,
+              !managedGitHubAvailable,
+              let repository = repos.first(where: {
+                  $0.enabled
+                      && $0.name.caseInsensitiveCompare(fullName) == .orderedSame
+              })
+        else {
+            lastError = "Choose an enabled repository from the applied worker configuration."
+            return
+        }
+        guard selectedBYOReviewRepository?.caseInsensitiveCompare(repository.name)
+                != .orderedSame
+        else {
+            return
+        }
+        invalidateActivationForRepositoryChange()
+        selectedBYOReviewRepository = repository.name
+        dependencies.preferences.set(
+            repository.name,
+            forKey: byoReviewRepositoryKey
+        )
+        dependencies.preferences.set(
+            configPath,
+            forKey: byoReviewRepositoryConfigPathKey
+        )
+        lastError = nil
+        logText = "\(repository.name) selected as the native review target. The existing worker allowlist was not changed."
     }
 
     package func githubAccessCue(for repo: RepoMonitor) -> GitHubRepositoryAccessCue? {
@@ -3015,11 +3068,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
-        let enabledRepositories = repos
-            .filter(\.enabled)
-            .map(\.name)
-            .filter(isValidRepoName)
-        guard enabledRepositories.count == 1,
+        guard let selectedReviewRepository,
+              repos.contains(where: {
+                  $0.enabled
+                      && $0.name.caseInsensitiveCompare(selectedReviewRepository)
+                          == .orderedSame
+              }),
               let identity = try? GitHubBrokerDeviceIdentityStore(
                 secretStore: dependencies.secretStore
               ).loadOrCreate()
@@ -3031,7 +3085,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             executablePath: cliPath,
             configPath: configPath,
             machineId: identity.deviceId,
-            repository: enabledRepositories[0]
+            repository: selectedReviewRepository
         )
     }
 
@@ -3176,6 +3230,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         activationRequestGeneration &+= 1
         let generation = activationRequestGeneration
 
+        guard !activationTargetSelectionRequired else {
+            applyActivationEvent(.activationServiceError)
+            lastError = "Choose one Review Target in Repositories before activating. The existing worker allowlist will remain unchanged."
+            return
+        }
         guard let client = activationLicenseClient else {
             // No CLI-backed validation available (default): never invoke the
             // file-persisting CLI. Land in a retryable state instead.
@@ -3231,7 +3290,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             let plan = summary.plan.map { " · \($0)" } ?? ""
             license.entitlement = "active (\(scope)\(plan))"
             logText = "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
-            if let repository = repos.filter(\.enabled).map(\.name).onlyElement {
+            if let repository = selectedReviewRepository {
                 activationVerifiedRepositoryThisLaunch = repository
                 dependencies.preferences.set(repository, forKey: activationRepositoryKey)
             } else {
@@ -3366,8 +3425,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard existingAccountEntitlementNeedsCurrentAccessVerification else {
             return
         }
+        reviewActivationTargetSelection()
+    }
+
+    package func reviewActivationTargetSelection() {
         selectedSection = .repos
         isOnboardingPresented = false
+        lastError = nil
     }
 
     package func copyCommand(_ command: DesktopCommand) {
@@ -4101,6 +4165,42 @@ package final class NeonDiffDesktopModel: ObservableObject {
         try dependencies.fileWriter.write(data, to: repoSelectionPatchPath)
     }
 
+    private func reconcileBYOReviewRepository(
+        enabledRepositories: [String]
+    ) {
+        guard byoGitHubCredentialOnboardingAvailable,
+              !managedGitHubAvailable
+        else {
+            selectedBYOReviewRepository = nil
+            return
+        }
+        let repositories = uniqueSortedRepoNames(
+            enabledRepositories.filter(isValidRepoName)
+        )
+        if let selectedBYOReviewRepository,
+           repositories.contains(where: {
+               $0.caseInsensitiveCompare(selectedBYOReviewRepository)
+                   == .orderedSame
+           }) {
+            return
+        }
+        let storedConfigPath = dependencies.preferences.string(
+            forKey: byoReviewRepositoryConfigPathKey
+        )
+        let storedRepository = dependencies.preferences.string(
+            forKey: byoReviewRepositoryKey
+        )
+        if storedConfigPath == configPath,
+           let storedRepository,
+           let matchedRepository = repositories.first(where: {
+               $0.caseInsensitiveCompare(storedRepository) == .orderedSame
+           }) {
+            selectedBYOReviewRepository = matchedRepository
+            return
+        }
+        selectedBYOReviewRepository = repositories.onlyElement
+    }
+
     private func applyCLIResult(
         _ result: CLIRunResult,
         fallbackCommand: String,
@@ -4259,6 +4359,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         snapshot.repos
                             .filter(\.enabled)
                             .map(\.name)
+                    )
+                    reconcileBYOReviewRepository(
+                        enabledRepositories: inspectedRepositories
                     )
                     appliedRepoSelection = self.configPath == configPath
                         && !inspectedRepositories.isEmpty
@@ -4709,6 +4812,8 @@ private let onboardingCompletedKey = "neondiff.hasCompletedActivationOnboarding.
 private let activationKeyAccount = "license/default"
 private let activationStateKey = "neondiff.activationState.v1"
 private let activationRepositoryKey = "neondiff.activationRepository.v1"
+private let byoReviewRepositoryKey = "neondiff.byoReviewRepository.v1"
+private let byoReviewRepositoryConfigPathKey = "neondiff.byoReviewRepositoryConfigPath.v1"
 private let activationHandoffEnabledKey = "neondiff.activationHandoffEnabled"
 private let activationCheckoutEnabledKey = "neondiff.activationCheckoutEnabled"
 private let activationCliBackedEnabledKey = "neondiff.activationCliBackedValidation"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -188,6 +188,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var customerRuntimeBoundaryMessage: String {
+        if byoGitHubCredentialOnboardingAvailable,
+           repos.filter(\.enabled).count > 1 {
+            let target = selectedBYOReviewRepository.map {
+                "Activation can be verified for \($0), but "
+            } ?? "Choose one Review Target for activation. "
+            return "\(target)the existing worker still monitors multiple repositories. Native useful-work controls remain blocked until the runtime can be scoped without rewriting that worker."
+        }
         if existingLocalBotSetupReady {
             return "Existing setup is configured. Before new work, reverify the current GitHub App access and repository-scoped entitlement for this launch."
         }
@@ -209,9 +216,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             == activationVerifiedRepositoryThisLaunch.lowercased()
     }
 
-    /// The one repository the native app will activate and use for the next
-    /// review. Existing BYO workers may monitor many repositories; choosing this
-    /// target must never collapse or rewrite that worker allowlist.
+    /// The repository the native app will activate. Existing BYO workers may
+    /// monitor many repositories; choosing this target must never collapse or
+    /// rewrite that worker allowlist. Runtime review scoping is a separate gate.
     package var selectedReviewRepository: String? {
         if managedGitHubAvailable {
             return selectedManagedGitHubRepository
@@ -228,6 +235,22 @@ package final class NeonDiffDesktopModel: ObservableObject {
         byoGitHubCredentialOnboardingAvailable
             && selectedBYOReviewRepository == nil
             && repos.filter(\.enabled).count > 1
+    }
+
+    package var reviewTargetRuntimeReady: Bool {
+        guard byoGitHubCredentialOnboardingAvailable else {
+            return true
+        }
+        let enabledRepositories = uniqueSortedRepoNames(
+            repos.filter(\.enabled).map(\.name)
+        )
+        guard let selectedBYOReviewRepository else {
+            return false
+        }
+        return enabledRepositories.count == 1
+            && enabledRepositories[0].caseInsensitiveCompare(
+                selectedBYOReviewRepository
+            ) == .orderedSame
     }
 
     /// Existing-account entitlement is useful setup context, but it must not
@@ -313,7 +336,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             guard byoGitHubCredentialOnboardingAvailable,
                   byoGitHubCredentialsVerified,
                   repositoryConfigurationReady,
-                  currentRepositoryActivationReady
+                  currentRepositoryActivationReady,
+                  reviewTargetRuntimeReady
             else { return false }
         }
         guard dependencies.productionBoundary.managedGitHubBrokerOrigin != nil else {
@@ -2086,6 +2110,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = "Choose an enabled repository from the applied worker configuration."
             return
         }
+        if activationState == .activationPending {
+            lastError = "Activation is already in progress for \(selectedBYOReviewRepository ?? repository.name). Wait for it to finish or cancel before changing the target."
+            return
+        }
+        if let activatedRepository,
+           activatedRepository.caseInsensitiveCompare(repository.name)
+               != .orderedSame {
+            lastError = "This device activation is bound to \(activatedRepository). Target rebinding is not supported in this beta; keep that target selected until a verified deactivate/rebind flow is available."
+            return
+        }
         guard selectedBYOReviewRepository?.caseInsensitiveCompare(repository.name)
                 != .orderedSame
         else {
@@ -2103,6 +2137,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         )
         lastError = nil
         logText = "\(repository.name) selected as the native review target. The existing worker allowlist was not changed."
+    }
+
+    package func canSelectBYOReviewRepository(fullName: String) -> Bool {
+        guard byoGitHubCredentialOnboardingAvailable,
+              !managedGitHubAvailable,
+              repos.contains(where: {
+                  $0.enabled
+                      && $0.name.caseInsensitiveCompare(fullName) == .orderedSame
+              }),
+              activationState != .activationPending
+        else {
+            return false
+        }
+        guard let activatedRepository else {
+            return true
+        }
+        return activatedRepository.caseInsensitiveCompare(fullName)
+            == .orderedSame
     }
 
     package func githubAccessCue(for repo: RepoMonitor) -> GitHubRepositoryAccessCue? {
@@ -3235,6 +3287,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = "Choose one Review Target in Repositories before activating. The existing worker allowlist will remain unchanged."
             return
         }
+        let activationRepository = selectedReviewRepository
         guard let client = activationLicenseClient else {
             // No CLI-backed validation available (default): never invoke the
             // file-persisting CLI. Land in a retryable state instead.
@@ -3257,6 +3310,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = "No stored \(ActivationTerminology.activationKey) to activate. Enter it again."
             return
         }
+        // Pin the device to the attempted repository before the network await.
+        // A cancelled or lost response may still have bound the server, so
+        // switching targets remains blocked until a verified rebind exists.
+        if let activationRepository {
+            dependencies.preferences.set(
+                activationRepository,
+                forKey: activationRepositoryKey
+            )
+        }
         let outcome: ActivationClientOutcome
         do {
             outcome = try await client.activate(key: ActivationKeyMaterial(rawKey))
@@ -3267,7 +3329,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard generation == activationRequestGeneration else { return }
         let resolved = resolveActivationOutcome(outcome)
         applyActivationEvent(ActivationLicenseOutcomeMapping.event(for: resolved))
-        applyActivationOutcomeSideEffects(resolved)
+        applyActivationOutcomeSideEffects(
+            resolved,
+            repository: activationRepository
+        )
     }
 
     /// A 200-`active` response can still be public-only or `privateRepoAllowed=false`,
@@ -3281,7 +3346,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return outcome
     }
 
-    private func applyActivationOutcomeSideEffects(_ outcome: ActivationClientOutcome) {
+    private func applyActivationOutcomeSideEffects(
+        _ outcome: ActivationClientOutcome,
+        repository: String?
+    ) {
         switch outcome {
         case .active(let summary):
             activationVerifiedThisLaunch = true
@@ -3290,12 +3358,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             let plan = summary.plan.map { " · \($0)" } ?? ""
             license.entitlement = "active (\(scope)\(plan))"
             logText = "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
-            if let repository = selectedReviewRepository {
-                activationVerifiedRepositoryThisLaunch = repository
+            activationVerifiedRepositoryThisLaunch = repository
+            if let repository {
                 dependencies.preferences.set(repository, forKey: activationRepositoryKey)
-            } else {
-                activationVerifiedRepositoryThisLaunch = nil
-                dependencies.preferences.set("", forKey: activationRepositoryKey)
             }
             // Let onboarding finish through the native handoff (Continue enables).
             onboardingFlow.licenseActivation = .activated
@@ -4623,6 +4688,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     private func invalidateActivationForRepositoryChange() {
+        activationRequestGeneration &+= 1
         guard activationVerifiedThisLaunch
                 || activationVerifiedRepositoryThisLaunch != nil
         else {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2110,6 +2110,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = "Choose an enabled repository from the applied worker configuration."
             return
         }
+        guard isAppliedBYOReviewRepository(repository.name) else {
+            lastError = "Apply and read back this repository in the current worker config before using it as the activation target."
+            return
+        }
         if activationState == .activationPending {
             lastError = "Activation is already in progress for \(selectedBYOReviewRepository ?? repository.name). Wait for it to finish or cancel before changing the target."
             return
@@ -2146,6 +2150,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                   $0.enabled
                       && $0.name.caseInsensitiveCompare(fullName) == .orderedSame
               }),
+              isAppliedBYOReviewRepository(fullName),
               activationState != .activationPending
         else {
             return false
@@ -3288,6 +3293,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         let activationRepository = selectedReviewRepository
+        if byoGitHubCredentialOnboardingAvailable {
+            guard let activationRepository,
+                  isAppliedBYOReviewRepository(activationRepository)
+            else {
+                applyActivationEvent(.activationServiceError)
+                lastError = "Apply and read back the selected Review Target before activating."
+                return
+            }
+        }
         guard let client = activationLicenseClient else {
             // No CLI-backed validation available (default): never invoke the
             // file-persisting CLI. Land in a retryable state instead.
@@ -3368,7 +3382,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
             activationVerifiedThisLaunch = false
             activationVerifiedRepositoryThisLaunch = nil
             lastError = "This \(ActivationTerminology.activationKey) does not cover private repositories. Use a key with a private-repo entitlement."
-        case .expired, .revoked, .invalid, .offline, .serviceError, .malformed:
+        case .expired, .revoked, .invalid:
+            activationVerifiedThisLaunch = false
+            activationVerifiedRepositoryThisLaunch = nil
+            dependencies.preferences.set("", forKey: activationRepositoryKey)
+            lastError = activationPresentation.cause
+        case .offline, .serviceError, .malformed:
             activationVerifiedThisLaunch = false
             activationVerifiedRepositoryThisLaunch = nil
             // Cause copy comes from the typed state presentation — never a raw
@@ -4266,6 +4285,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
         selectedBYOReviewRepository = repositories.onlyElement
     }
 
+    private func isAppliedBYOReviewRepository(_ fullName: String) -> Bool {
+        guard let appliedRepoSelection,
+              appliedRepoSelection.configPath == configPath
+        else {
+            return false
+        }
+        return appliedRepoSelection.repositories.contains {
+            $0.caseInsensitiveCompare(fullName) == .orderedSame
+        }
+    }
+
     private func applyCLIResult(
         _ result: CLIRunResult,
         fallbackCommand: String,
@@ -4692,6 +4722,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func invalidateActivationForRepositoryChange() {
         activationRequestGeneration &+= 1
+        if activationState == .activationPending {
+            applyActivationEvent(.checkoutCancelled)
+            onboardingFlow.licenseActivation = .servicePending
+            lastError = "Repository context changed during activation. Review the current target, then retry safely."
+        }
         guard activationVerifiedThisLaunch
                 || activationVerifiedRepositoryThisLaunch != nil
         else {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -121,6 +121,114 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func persistedReviewTargetActivatesWithoutCollapsingExistingMultiRepoAllowlist() async throws {
+        let targetRepository = "electricsheephq/WorldOS"
+        let otherRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let boundary = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ])
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: """
+                {"command":"license activate","ok":true,"status":"active","source":"api",
+                 "checkedAt":"2026-07-27T00:00:00.000Z",
+                 "entitlement":{"status":"active","repoVisibilityScope":"private",
+                 "privateRepoAllowed":true,"updateEntitlement":true}}
+                """,
+                stderr: ""
+            ))],
+            preferenceStrings: [
+                "neondiff.byoReviewRepository.v1": targetRepository
+            ],
+            productionBoundary: boundary
+        )
+        fixture.preferences.set(
+            fixture.model.configPath,
+            forKey: "neondiff.byoReviewRepositoryConfigPath.v1"
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [targetRepository, otherRepository]
+        ))
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        await fixture.model.submitActivation()
+
+        let call = try #require(fixture.cli.calls.first)
+        #expect(call.arguments.contains("--repo"))
+        #expect(call.arguments.contains(targetRepository))
+        #expect(!call.arguments.contains(otherRepository))
+        #expect(fixture.model.repos.filter(\.enabled).count == 2)
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.activationState == .active)
+    }
+
+    @MainActor
+    @Test func selectingReviewTargetPersistsExactConfigContextWithoutChangingAllowlist() {
+        let firstRepository = "electricsheephq/WorldOS"
+        let targetRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [firstRepository, targetRepository]
+        ))
+        let enabledBefore = fixture.model.repos.filter(\.enabled).map(\.name)
+
+        fixture.model.selectBYOReviewRepository(fullName: targetRepository)
+
+        #expect(fixture.model.selectedBYOReviewRepository == targetRepository)
+        #expect(fixture.model.selectedReviewRepository == targetRepository)
+        #expect(fixture.model.repos.filter(\.enabled).map(\.name) == enabledBefore)
+        #expect(
+            fixture.preferences.string(
+                forKey: "neondiff.byoReviewRepository.v1"
+            ) == targetRepository
+        )
+        #expect(
+            fixture.preferences.string(
+                forKey: "neondiff.byoReviewRepositoryConfigPath.v1"
+            ) == fixture.model.configPath
+        )
+    }
+
+    @MainActor
+    @Test func persistedReviewTargetFromAnotherConfigFailsClosed() async {
+        let targetRepository = "electricsheephq/WorldOS"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            preferenceStrings: [
+                "neondiff.byoReviewRepository.v1": targetRepository,
+                "neondiff.byoReviewRepositoryConfigPath.v1": "/fixture/another-bot.json"
+            ],
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [
+                targetRepository,
+                "electricsheephq/evaos-code-review-bot-neondiff"
+            ]
+        ))
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        await fixture.model.submitActivation()
+
+        #expect(fixture.model.selectedBYOReviewRepository == nil)
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.model.activationState == .serviceError)
+        #expect(fixture.model.activationTargetSelectionRequired)
+        #expect(fixture.model.lastError?.contains("Choose one Review Target") == true)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+    }
+
+    @MainActor
     @Test func apiKeyProviderStillRequiresItsAppOwnedKeyOrVerification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -475,15 +583,21 @@ import NeonDiffDesktopCore
         )
     }
 
-    private func existingBotConfig(authMode: String) -> String {
+    private func existingBotConfig(
+        authMode: String,
+        repositories: [String] = ["electricsheephq/WorldOS"]
+    ) -> String {
         let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
+        let repositoryJSON = repositories
+            .map { "\"\($0)\"" }
+            .joined(separator: ", ")
         return #"""
         {
           "ok": true,
           "command": "config inspect",
           "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "config": {
-            "pilotRepos": ["electricsheephq/WorldOS"],
+            "pilotRepos": [\#(repositoryJSON)],
             "providers": {
               "defaultProviderId": "zcode-glm",
               "providers": {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -229,6 +229,78 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func activationAttemptLocksReviewTargetUntilServerBindingCanBeChangedSafely() async {
+        let firstRepository = "electricsheephq/WorldOS"
+        let secondRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let client = ExistingBotGatedActivationClient()
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            activationLicenseClient: client,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [firstRepository, secondRepository]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: firstRepository)
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        let activation = Task {
+            await fixture.model.submitActivation()
+        }
+        #expect(await client.waitUntilStarted())
+        fixture.model.selectBYOReviewRepository(fullName: secondRepository)
+        #expect(fixture.model.selectedBYOReviewRepository == firstRepository)
+        #expect(fixture.model.lastError?.contains("in progress") == true)
+        client.release(.active(.init(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "beta",
+            seats: 1
+        )))
+        await activation.value
+
+        #expect(fixture.model.selectedBYOReviewRepository == firstRepository)
+        #expect(fixture.model.currentRepositoryActivationReady)
+        fixture.model.selectBYOReviewRepository(fullName: secondRepository)
+        #expect(fixture.model.selectedBYOReviewRepository == firstRepository)
+        #expect(fixture.model.lastError?.contains("bound") == true)
+    }
+
+    @MainActor
+    @Test func multiRepoWorkerExplainsRuntimeScopeBlockAfterTargetSelection() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [
+                "electricsheephq/WorldOS",
+                "electricsheephq/evaos-code-review-bot-neondiff"
+            ]
+        ))
+        fixture.model.selectBYOReviewRepository(
+            fullName: "electricsheephq/WorldOS"
+        )
+
+        #expect(
+            fixture.model.customerRuntimeBoundaryMessage
+                .contains("multiple repositories")
+        )
+        #expect(!fixture.model.reviewTargetRuntimeReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
     @Test func apiKeyProviderStillRequiresItsAppOwnedKeyOrVerification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -632,6 +704,58 @@ private struct ExistingBotActiveActivationClient: ActivationLicenseClienting {
 
     func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
         try await activate(key: key)
+    }
+}
+
+private final class ExistingBotGatedActivationClient:
+    ActivationLicenseClienting,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<ActivationClientOutcome, Never>?
+    private var startedContinuation: CheckedContinuation<Void, Never>?
+    private var started = false
+
+    func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        await withCheckedContinuation { continuation in
+            let startedContinuation = lock.withLock {
+                started = true
+                self.continuation = continuation
+                let startedContinuation = self.startedContinuation
+                self.startedContinuation = nil
+                return startedContinuation
+            }
+            startedContinuation?.resume()
+        }
+    }
+
+    func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        try await activate(key: key)
+    }
+
+    func waitUntilStarted() async -> Bool {
+        await withCheckedContinuation { continuation in
+            let alreadyStarted = lock.withLock {
+                if started {
+                    return true
+                }
+                startedContinuation = continuation
+                return false
+            }
+            if alreadyStarted {
+                continuation.resume()
+            }
+        }
+        return true
+    }
+
+    func release(_ outcome: ActivationClientOutcome) {
+        let pending = lock.withLock {
+            let pending = continuation
+            continuation = nil
+            return pending
+        }
+        pending?.resume(returning: outcome)
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -314,6 +314,46 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func ambiguousActivationPinBlocksReconciledDifferentRepositoryRetry() async {
+        let firstRepository = "electricsheephq/WorldOS"
+        let secondRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let client = ExistingBotGatedActivationClient()
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            activationLicenseClient: client,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [firstRepository, secondRepository]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: firstRepository)
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        let activation = Task {
+            await fixture.model.submitActivation()
+        }
+        #expect(await client.waitUntilStarted())
+        fixture.model.configPath = "/fixture/another-bot.json"
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [secondRepository]
+        ))
+        client.release(.offline)
+        await activation.value
+
+        #expect(fixture.model.activationState == .keyReady)
+        #expect(fixture.model.selectedBYOReviewRepository == secondRepository)
+
+        await fixture.model.submitActivation()
+
+        #expect(client.callCount == 1)
+        #expect(fixture.model.activationState == .serviceError)
+        #expect(fixture.model.lastError?.contains(firstRepository) == true)
+    }
+
+    @MainActor
     @Test func definitiveActivationRejectionDoesNotPinRepositoryTarget() async {
         let firstRepository = "electricsheephq/WorldOS"
         let secondRepository = "electricsheephq/evaos-code-review-bot-neondiff"
@@ -848,9 +888,21 @@ private final class ExistingBotGatedActivationClient:
     private var continuation: CheckedContinuation<ActivationClientOutcome, Never>?
     private var startedContinuation: CheckedContinuation<Void, Never>?
     private var started = false
+    private var activationCount = 0
+
+    var callCount: Int {
+        lock.withLock { activationCount }
+    }
 
     func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
-        await withCheckedContinuation { continuation in
+        let shouldGate = lock.withLock {
+            activationCount += 1
+            return activationCount == 1
+        }
+        guard shouldGate else {
+            return .offline
+        }
+        return await withCheckedContinuation { continuation in
             let startedContinuation = lock.withLock {
                 started = true
                 self.continuation = continuation

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -272,6 +272,98 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func repositoryChangeDuringActivationReturnsToRetryableState() async {
+        let firstRepository = "electricsheephq/WorldOS"
+        let client = ExistingBotGatedActivationClient()
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            activationLicenseClient: client,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [
+                firstRepository,
+                "electricsheephq/evaos-code-review-bot-neondiff"
+            ]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: firstRepository)
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        let activation = Task {
+            await fixture.model.submitActivation()
+        }
+        #expect(await client.waitUntilStarted())
+        fixture.model.configPath = "/fixture/another-bot.json"
+
+        #expect(fixture.model.activationState == .keyReady)
+        client.release(.active(.init(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "beta",
+            seats: 1
+        )))
+        await activation.value
+
+        #expect(fixture.model.activationState == .keyReady)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+    }
+
+    @MainActor
+    @Test func definitiveActivationRejectionDoesNotPinRepositoryTarget() async {
+        let firstRepository = "electricsheephq/WorldOS"
+        let secondRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            activationLicenseClient: ExistingBotRejectedActivationClient(),
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [firstRepository, secondRepository]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: firstRepository)
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+
+        await fixture.model.submitActivation()
+        fixture.model.selectBYOReviewRepository(fullName: secondRepository)
+
+        #expect(fixture.model.activationState == .invalid)
+        #expect(fixture.model.selectedBYOReviewRepository == secondRepository)
+    }
+
+    @MainActor
+    @Test func stagedRepositoryCannotBecomeActivationTargetBeforeApply() {
+        let appliedRepository = "electricsheephq/WorldOS"
+        let stagedRepository = "electricsheephq/unapplied"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [
+                appliedRepository,
+                "electricsheephq/evaos-code-review-bot-neondiff"
+            ]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: appliedRepository)
+        fixture.model.pendingRepoName = stagedRepository
+        fixture.model.addPendingRepoToAllowlist()
+
+        fixture.model.selectBYOReviewRepository(fullName: stagedRepository)
+
+        #expect(fixture.model.selectedBYOReviewRepository == appliedRepository)
+        #expect(fixture.model.lastError?.contains("Apply") == true)
+        #expect(!fixture.model.canSelectBYOReviewRepository(fullName: stagedRepository))
+    }
+
+    @MainActor
     @Test func multiRepoWorkerExplainsRuntimeScopeBlockAfterTargetSelection() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -735,6 +827,16 @@ private struct ExistingBotActiveActivationClient: ActivationLicenseClienting {
 
     func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
         try await activate(key: key)
+    }
+}
+
+private struct ExistingBotRejectedActivationClient: ActivationLicenseClienting {
+    func activate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        .invalid
+    }
+
+    func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        .invalid
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -301,6 +301,37 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func staleConfigInspectCannotReplaceCurrentRepositoryState() {
+        let firstConfigPath = "/fixture/first-bot.json"
+        let currentConfigPath = "/fixture/current-bot.json"
+        let firstRepository = "electricsheephq/WorldOS"
+        let currentRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(suspendCLIRuns: true)
+        fixture.model.configPath = firstConfigPath
+        let staleResult = existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [firstRepository]
+        )
+        fixture.loadConfig(staleResult)
+        fixture.model.configPath = currentConfigPath
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [currentRepository]
+        ))
+
+        fixture.model.applyCLIResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: staleResult, stderr: ""),
+            fallbackCommand: "config inspect",
+            configPath: firstConfigPath,
+            launchdLabel: fixture.model.launchdLabel,
+            isConfigInspectCommand: true
+        )
+
+        #expect(fixture.model.configPath == currentConfigPath)
+        #expect(fixture.model.repos.filter(\.enabled).map(\.name) == [currentRepository])
+    }
+
+    @MainActor
     @Test func apiKeyProviderStillRequiresItsAppOwnedKeyOrVerification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -229,7 +229,9 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             productionBoundary: boundary
         )
         #expect(fixture.model.activationHandoffEnabled)
-        fixture.model.repos = [RepoMonitor(name: "electric/private", enabled: true)]
+        fixture.loadConfig(
+            #"{"ok":true,"command":"config inspect","revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","config":{"pilotRepos":["electric/private"]}}"#
+        )
         fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
         fixture.model.provideExistingActivationKey()
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -173,6 +173,9 @@ import Testing
         let activity = try sourceBoundaryText(
             at: views.appendingPathComponent("LogsView.swift")
         )
+        let overview = try sourceBoundaryText(
+            at: views.appendingPathComponent("OverviewView.swift")
+        )
         let model = try sourceBoundaryText(
             at: sourceBoundaryPackageRoot()
                 .appendingPathComponent(
@@ -212,6 +215,13 @@ import Testing
         #expect(repos.contains("neondiff-existing-byo-github-verify"))
         #expect(repos.contains("model.verifyBYOGitHubAppCredentials()"))
         #expect(repos.contains("model.existingLocalBotBYOGitHubVerificationStatus"))
+        #expect(repos.contains("model.canSelectBYOReviewRepository(fullName: repo.name)"))
+        #expect(repos.contains("native review controls remain blocked"))
+        #expect(overview.contains(
+            "targetSelectionRequired = model.activationTargetSelectionRequired"
+        ))
+        #expect(overview.contains("\"TARGET REQUIRED\""))
+        #expect(overview.contains("\"Choose Review Target\""))
         #expect(provider.contains("model.selectedProviderRequiresAPIKey"))
         #expect(provider.contains("APP CONFIG LOADED"))
         #expect(provider.contains(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -217,6 +217,10 @@ import Testing
         #expect(repos.contains("model.existingLocalBotBYOGitHubVerificationStatus"))
         #expect(repos.contains("model.canSelectBYOReviewRepository(fullName: repo.name)"))
         #expect(repos.contains("native review controls remain blocked"))
+        #expect(repos.contains("\"\\(repo.name) is the review target\""))
+        #expect(repos.contains(".accessibilityValue(isSelected ? \"Selected\" : \"Not selected\")"))
+        #expect(repos.contains(".accessibilityAddTraits(isSelected ? .isSelected : [])"))
+        #expect(repos.contains("else if model.activationTargetSelectionRequired"))
         #expect(overview.contains(
             "targetSelectionRequired = model.activationTargetSelectionRequired"
         ))

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -296,8 +296,9 @@ the same Mac. In that exact case it opens a reconciliation path:
 - it treats `zcode-app-config` and `none` provider auth modes as config-backed,
   not as missing NeonDiff Keychain API keys;
 - if the worker allowlist contains multiple repositories, it keeps every entry
-  unchanged and requires one explicit **Review Target** for native activation
-  and the next review; that target is restored only for the same config path;
+  unchanged and requires one explicit **Review Target** for native activation;
+  that target is restored only for the same config path, while native review
+  and daemon controls remain blocked until runtime scoping is available;
 - it keeps new work blocked until the exact current GitHub/repository and
   entitlement checks required by the release path pass.
 
@@ -360,8 +361,10 @@ The exact B0 bundle lets the customer store the customer-owned App key in
 Keychain, select and apply one repository, and verify that installation without
 an operator editing local files. For a reconciled existing worker with a
 multi-repository allowlist, choose one **Review Target** in the repository
-table; this binds activation and the next review without changing the worker's
-other configured repositories. The managed B1 broker remains a separate path.
+table; this binds activation without changing the worker's other configured
+repositories. Native review and daemon controls remain blocked for that
+multi-repository worker until the runtime can be scoped safely. The managed B1
+broker remains a separate path.
 The dashboard shows license status, GitHub App status, daemon status, and
 provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -295,6 +295,9 @@ the same Mac. In that exact case it opens a reconciliation path:
   current-launch review authorization;
 - it treats `zcode-app-config` and `none` provider auth modes as config-backed,
   not as missing NeonDiff Keychain API keys;
+- if the worker allowlist contains multiple repositories, it keeps every entry
+  unchanged and requires one explicit **Review Target** for native activation
+  and the next review; that target is restored only for the same config path;
 - it keeps new work blocked until the exact current GitHub/repository and
   entitlement checks required by the release path pass.
 
@@ -355,7 +358,10 @@ on non-Mac platforms. The local HTML dashboard is the operator/diagnostic surfac
 it drives. On Mac, the native macOS app is the human first-run product surface.
 The exact B0 bundle lets the customer store the customer-owned App key in
 Keychain, select and apply one repository, and verify that installation without
-an operator editing local files. The managed B1 broker remains a separate path.
+an operator editing local files. For a reconciled existing worker with a
+multi-repository allowlist, choose one **Review Target** in the repository
+table; this binds activation and the next review without changing the worker's
+other configured repositories. The managed B1 broker remains a separate path.
 The dashboard shows license status, GitHub App status, daemon status, and
 provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -117,10 +117,12 @@ review authorization.
 
 An existing worker may already monitor several GitHub App-authorized
 repositories. NeonDiff preserves that allowlist and requires one explicit
-**Review Target** in the native repository table. The Activation Key request and
-the next review bind to that target only. The target selection is scoped to the
-exact local config path and does not edit, remove, or disable the worker's other
-repositories.
+**Review Target** in the native repository table. The Activation Key request
+binds to that target only. The target selection is scoped to the exact local
+config path and does not edit, remove, or disable the worker's other
+repositories. Native review and daemon controls stay blocked for a
+multi-repository worker until the runtime can be scoped to that target without
+rewriting the worker configuration.
 
 Keep the private key and local config out of git. A typical shell setup is:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -115,6 +115,13 @@ repository-scoped entitlement must still pass before a new dry or live review.
 Local config alone never establishes membership, installation authority, or
 review authorization.
 
+An existing worker may already monitor several GitHub App-authorized
+repositories. NeonDiff preserves that allowlist and requires one explicit
+**Review Target** in the native repository table. The Activation Key request and
+the next review bind to that target only. The target selection is scoped to the
+exact local config path and does not edit, remove, or disable the worker's other
+repositories.
+
 Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash


### PR DESCRIPTION
## State

**ACTIVE — current-head gate in progress** at `777b2451ce2c1e493e4288ade4ca947e927ee8d9`.

The prior `e95d83d` park decision was superseded by the owner-approved autonomous release goal. This head changes only the verified cross-repository activation retry invariant.

Related to #657 and #646. This PR does not close either issue.

## Bounded outcome

Preserve the full existing worker allowlist, require one explicit native Review Target, bind activation to that target, and fail closed if a reconciled repository differs from an ambiguous or confirmed device pin. Multi-repository native review/daemon controls remain blocked until targeted runtime handoff exists.

## Acceptance criteria

- [x] Failing-first regression reproduces beta18's zero-client activation with a multi-repository worker.
- [x] Review Target persistence is scoped to the exact local config path.
- [x] Activation sends only the selected applied repository and does not rewrite the worker allowlist.
- [x] Mutable UI state cannot credit an in-flight result to another repository.
- [x] Definitive invalid/expired/revoked outcomes clear the attempted pin.
- [x] Ambiguous outcomes retain the pin because the server may already have committed it.
- [x] Failing-first retry regression proves reconciliation can otherwise submit repository B after an ambiguous attempt for A.
- [x] `performActivation()` enforces the retained A pin before Keychain/network use.
- [x] Stale config-inspect results cannot mutate current repository/target state.
- [x] Multi-repository useful-work controls remain fail closed.
- [x] Customer copy and documentation state the bounded behavior without claiming runtime target scope.

## New-head failing-first and focused proof

Before the `777b245` guard, `ambiguousActivationPinBlocksReconciledDifferentRepositoryRetry` failed exactly at the boundary:

- activation client `callCount` was `2`, not `1`;
- model state became `.offline`, not `.serviceError`;
- no error identified the retained repository A.

After the guard:

- focused retry regression passed;
- `ExistingLocalBotReconciliationTests` passed 24/24;
- `ActivationHandoffModelTests` passed 18/18;
- `git diff --check` passed.

## Current remote gate

- Broad CI run `30246625116` — running.
- Swift Desktop Gate run `30246625085` — running.
- CodeQL path-aware check — skipped because the new delta is Swift-only; Swift/static checks remain in the desktop workflow.
- CodeRabbit — rate limited and does not count as the required delta review.
- One Codex delta-only review was requested for `e95d83d..777b245`; no additional general reviewer will be launched.

## Security and customer-safety invariants

- Raw Activation Keys remain Keychain-only and cross only bounded stdin.
- A target must be enabled and read back from the current inspected config.
- Ambiguous repository binding remains pinned until verified deactivate/rebind exists.
- The local worker allowlist is not collapsed or rewritten.
- API-backed entitlement and useful-work gates remain fail closed.

## Explicit non-goals

- Do not close #657, #646, or broader #517.
- No targeted multi-repository runtime handoff, daemon scoping, dry/live review, billing, checkout, publication, release, or customer-readiness claim.
- No generalized fixture/schema/accessibility expansion or another review campaign.

## Merge boundary

Merge only if this exact head has green required CI/hosted proof, the delta review validates the changed invariant, review threads/top-level feedback/annotations are inspected, and no supported-path blocker remains. A merge is not a release; beta19 requires protected-main proof followed by signed/notarized installed-app evidence.
