### PR TITLE
fix(review): bind provider status to the verified config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,13 @@ disable, or rewrite the worker's other repositories. The app may reuse the
 exact matched LaunchAgent's App ID and private-key file coordinate only inside
 the child process for that config; it never copies the key into the app,
 Keychain, arguments, logs, or UI. Overview can then run `review-pr` for one
-selected repository and pull request. Live posting remains disabled until that
-exact target returns a successful dry-run head and the user confirms the pinned
-head. For that multi-repository worker, daemon-wide start remains blocked. The
-selection and dry-run approval fail closed if the config, target, pull request,
-workspace, or head changes.
+selected repository and pull request through the configured provider. Live
+posting remains disabled until that exact target and config revision return a
+successful dry-run head and the user confirms the pinned head. A transport
+failure revokes that approval instead of permitting a blind retry. For that
+multi-repository worker, daemon-wide start remains blocked. The selection and
+dry-run approval fail closed if the config, target, pull request, workspace, or
+head changes.
 During launch it shows a bounded restoring state while that authorized
 account/bot/config intersection is checked; it does not flash empty first-run
 setup or claim that the existing configuration is missing.

--- a/README.md
+++ b/README.md
@@ -169,10 +169,15 @@ repository-scoped GitHub and activation verification before new review work.
 If that existing worker monitors more than one repository, the native app keeps
 the full allowlist intact and asks the user to choose one **Review Target**.
 Native activation binds to that exact target; selecting it does not remove,
-disable, or rewrite the worker's other repositories. Until a targeted runtime
-handoff is available, native review and daemon controls remain blocked for a
-multi-repository worker. The selection is restored only for the same local
-config path and fails closed if that config or repository is no longer current.
+disable, or rewrite the worker's other repositories. The app may reuse the
+exact matched LaunchAgent's App ID and private-key file coordinate only inside
+the child process for that config; it never copies the key into the app,
+Keychain, arguments, logs, or UI. Overview can then run `review-pr` for one
+selected repository and pull request. Live posting remains disabled until that
+exact target returns a successful dry-run head and the user confirms the pinned
+head. Daemon-wide start remains blocked for a multi-repository worker. The
+selection and dry-run approval fail closed if the config, target, pull request,
+workspace, or head changes.
 During launch it shows a bounded restoring state while that authorized
 account/bot/config intersection is checked; it does not flash empty first-run
 setup or claim that the existing configuration is missing.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ the child process for that config; it never copies the key into the app,
 Keychain, arguments, logs, or UI. Overview can then run `review-pr` for one
 selected repository and pull request. Live posting remains disabled until that
 exact target returns a successful dry-run head and the user confirms the pinned
-head. Daemon-wide start remains blocked for a multi-repository worker. The
+head. For that multi-repository worker, daemon-wide start remains blocked. The
 selection and dry-run approval fail closed if the config, target, pull request,
 workspace, or head changes.
 During launch it shows a bounded restoring state while that authorized

--- a/README.md
+++ b/README.md
@@ -269,10 +269,12 @@ neondiff review-pr \
   --config config.local.json \
   --repo owner/name \
   --pr 123 \
+  --expected-config-revision <verified-config-revision> \
   --dry-run true \
-  --zcode false
+  --zcode true
 ```
 
+Use the exact `configRevision` returned by the successful provider verification.
 Inspect the JSON result and evidence path. Only switch to `--dry-run false`
 after setup checks, focused tests, and the relevant GitHub issue record the
 exact repo, PR, head SHA, config path, and public-safe evidence.

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -39,13 +39,18 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
                 arguments: arguments,
                 executionContexts: localBotExecutionContexts
             ) ?? executablePath
+        let resolvedArguments = DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: executablePath,
+            arguments: arguments,
+            executionContexts: localBotExecutionContexts
+        )
         let client = NeonDiffCLIClient(
             executablePath: resolvedExecutablePath,
             workingDirectory: workingDirectory,
             environmentOverrides: environmentOverrides
         )
         return try await client.runCancellable(
-            arguments: arguments,
+            arguments: resolvedArguments,
             standardInput: standardInput,
             timeout: timeout
         )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -33,8 +33,14 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
             arguments: arguments,
             executionContexts: localBotExecutionContexts
         )
+        let resolvedExecutablePath =
+            DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                executablePath: executablePath,
+                arguments: arguments,
+                executionContexts: localBotExecutionContexts
+            ) ?? executablePath
         let client = NeonDiffCLIClient(
-            executablePath: executablePath,
+            executablePath: resolvedExecutablePath,
             workingDirectory: workingDirectory,
             environmentOverrides: environmentOverrides
         )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -4,13 +4,16 @@ import NeonDiffDesktopCore
 
 struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
     private let localBotConfigurations: [DesktopLocalBotConfiguration]
+    private let localBotExecutionContexts: [DesktopLocalBotExecutionContext]
     private let defaultWorkingDirectory: URL?
 
     init(
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
+        localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         defaultWorkingDirectory: URL? = NeonDiffCLIResolver.defaultWorkingDirectory()
     ) {
         self.localBotConfigurations = localBotConfigurations
+        self.localBotExecutionContexts = localBotExecutionContexts
         self.defaultWorkingDirectory = defaultWorkingDirectory
     }
 
@@ -25,9 +28,15 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
             localBotConfigurations: localBotConfigurations,
             fallback: defaultWorkingDirectory
         )
+        let environmentOverrides = DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: executablePath,
+            arguments: arguments,
+            executionContexts: localBotExecutionContexts
+        )
         let client = NeonDiffCLIClient(
             executablePath: executablePath,
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            environmentOverrides: environmentOverrides
         )
         return try await client.runCancellable(
             arguments: arguments,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -5,53 +5,59 @@ import Darwin
 enum LaunchAgentLocalBotConfigurationDiscovery {
     static let defaultLabel = "com.electricsheephq.evaos-code-review-bot"
 
-    static func discover(
+    struct Snapshot {
+        let configurations: [DesktopLocalBotConfiguration]
+        let executionContexts: [DesktopLocalBotExecutionContext]
+    }
+
+    static func discoverSnapshot(
         label: String = defaultLabel,
         fileManager: FileManager = .default
-    ) -> [DesktopLocalBotConfiguration] {
+    ) -> Snapshot {
         let launchAgentURL = fileManager.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
             .appendingPathComponent("\(label).plist")
             .standardizedFileURL
-        guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe),
-              let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
-                  data: data,
-                  expectedLabel: label,
-                  configExists: { fileManager.fileExists(atPath: $0.path) },
-                  workingDirectoryExists: {
-                      var isDirectory: ObjCBool = false
-                      return fileManager.fileExists(
-                          atPath: $0.path,
-                          isDirectory: &isDirectory
-                      ) && isDirectory.boolValue
-                  }
-              )
-        else {
-            return []
+        guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe) else {
+            return Snapshot(configurations: [], executionContexts: [])
         }
-        return [configuration]
+        let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
+            data: data,
+            expectedLabel: label,
+            configExists: { fileManager.fileExists(atPath: $0.path) },
+            workingDirectoryExists: {
+                var isDirectory: ObjCBool = false
+                return fileManager.fileExists(
+                    atPath: $0.path,
+                    isDirectory: &isDirectory
+                ) && isDirectory.boolValue
+            }
+        )
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: data,
+            expectedLabel: label,
+            privateKeyPathIsSafe: { url in
+                isSafePrivateKeyFile(url, fileManager: fileManager)
+            }
+        )
+        return Snapshot(
+            configurations: configuration.map { [$0] } ?? [],
+            executionContexts: context.map { [$0] } ?? []
+        )
+    }
+
+    static func discover(
+        label: String = defaultLabel,
+        fileManager: FileManager = .default
+    ) -> [DesktopLocalBotConfiguration] {
+        discoverSnapshot(label: label, fileManager: fileManager).configurations
     }
 
     static func discoverExecutionContexts(
         label: String = defaultLabel,
         fileManager: FileManager = .default
     ) -> [DesktopLocalBotExecutionContext] {
-        let launchAgentURL = fileManager.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-            .appendingPathComponent("\(label).plist")
-            .standardizedFileURL
-        guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe),
-              let context = DesktopLaunchAgentExecutionContextParser.parse(
-                  data: data,
-                  expectedLabel: label,
-                  privateKeyPathIsSafe: { url in
-                      isSafePrivateKeyFile(url, fileManager: fileManager)
-                  }
-              )
-        else {
-            return []
-        }
-        return [context]
+        discoverSnapshot(label: label, fileManager: fileManager).executionContexts
     }
 
     private static func isSafePrivateKeyFile(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NeonDiffDesktopAppCore
+import Darwin
 
 enum LaunchAgentLocalBotConfigurationDiscovery {
     static let defaultLabel = "com.electricsheephq.evaos-code-review-bot"
@@ -29,5 +30,45 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             return []
         }
         return [configuration]
+    }
+
+    static func discoverExecutionContexts(
+        label: String = defaultLabel,
+        fileManager: FileManager = .default
+    ) -> [DesktopLocalBotExecutionContext] {
+        let launchAgentURL = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+            .appendingPathComponent("\(label).plist")
+            .standardizedFileURL
+        guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe),
+              let context = DesktopLaunchAgentExecutionContextParser.parse(
+                  data: data,
+                  expectedLabel: label,
+                  privateKeyPathIsSafe: { url in
+                      isSafePrivateKeyFile(url, fileManager: fileManager)
+                  }
+              )
+        else {
+            return []
+        }
+        return [context]
+    }
+
+    private static func isSafePrivateKeyFile(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        var statBuffer = stat()
+        guard lstat(url.path, &statBuffer) == 0,
+              (statBuffer.st_mode & S_IFMT) == S_IFREG,
+              statBuffer.st_uid == getuid(),
+              (statBuffer.st_mode & 0o077) == 0,
+              statBuffer.st_size > 0,
+              statBuffer.st_size <= 64 * 1024,
+              fileManager.isReadableFile(atPath: url.path)
+        else {
+            return false
+        }
+        return true
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -36,9 +36,10 @@ enum NeonDiffDesktopCompositionRoot {
             productionBoundary = .quarantined
         }
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
-        let localBotConfigurations = LaunchAgentLocalBotConfigurationDiscovery.discover()
-        let localBotExecutionContexts =
-            LaunchAgentLocalBotConfigurationDiscovery.discoverExecutionContexts()
+        let localBotSnapshot =
+            LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
+        let localBotConfigurations = localBotSnapshot.configurations
+        let localBotExecutionContexts = localBotSnapshot.executionContexts
         return NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: AppKitClipboard(),
             urlOpener: AppKitURLOpener(),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -58,7 +58,10 @@ enum NeonDiffDesktopCompositionRoot {
             accountLink: accountLink,
             productionBoundary: productionBoundary,
             cliWorkingDirectory: cliWorkingDirectory,
-            localBotConfigurations: localBotConfigurations
+            localBotConfigurations: localBotConfigurations,
+            localBotExecutionConfigPaths: localBotExecutionContexts.map(
+                \.configPath
+            )
         ))
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -37,11 +37,14 @@ enum NeonDiffDesktopCompositionRoot {
         }
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
         let localBotConfigurations = LaunchAgentLocalBotConfigurationDiscovery.discover()
+        let localBotExecutionContexts =
+            LaunchAgentLocalBotConfigurationDiscovery.discoverExecutionContexts()
         return NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: AppKitClipboard(),
             urlOpener: AppKitURLOpener(),
             cli: FoundationDesktopCLIExecutor(
                 localBotConfigurations: localBotConfigurations,
+                localBotExecutionContexts: localBotExecutionContexts,
                 defaultWorkingDirectory: cliWorkingDirectory
             ),
             dashboard: FoundationDesktopDashboardLauncher(),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -616,7 +616,7 @@ struct OnboardingWizardView: View {
                             Button { model.startDaemon() } label: {
                                 Label("Start/Restart", systemImage: "play.circle")
                             }
-                            .disabled(!model.productionUsefulWorkAvailable)
+                            .disabled(!model.productionDaemonStartAvailable)
                             Button { model.stopDaemon() } label: {
                                 Label("Stop", systemImage: "stop.circle")
                             }
@@ -627,7 +627,7 @@ struct OnboardingWizardView: View {
                             Button { model.previewStartDaemon() } label: {
                                 Label("Preview Start", systemImage: "eye")
                             }
-                            .disabled(!model.productionUsefulWorkAvailable)
+                            .disabled(!model.productionDaemonStartAvailable)
                             Button { model.copyCommand(model.statusCommand) } label: {
                                 Label("Copy Status", systemImage: "doc.on.doc")
                             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -58,6 +58,7 @@ struct DesktopSetupReadiness {
 struct OverviewView: View {
     @ObservedObject var model: NeonDiffDesktopModel
     @Environment(\.colorScheme) private var colorScheme
+    @State private var isLiveReviewConfirmationPresented = false
 
     var body: some View {
         let nd = NDPalette(scheme: colorScheme)
@@ -149,6 +150,11 @@ struct OverviewView: View {
                     }
                 }
 
+                if model.byoGitHubCredentialOnboardingAvailable,
+                   model.selectedReviewRepository != nil {
+                    scopedReviewPanel(palette: nd)
+                }
+
                 ViewThatFits(in: .horizontal) {
                     HStack(alignment: .top, spacing: 14) {
                         repositoryPanel(palette: nd, readiness: readiness)
@@ -189,6 +195,24 @@ struct OverviewView: View {
         .background(nd.background)
         .accessibilityIdentifier("neondiff-overview-outer-scroll")
         .scrollContentBackground(.hidden)
+        .confirmationDialog(
+            "Post this live GitHub review?",
+            isPresented: $isLiveReviewConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            if let repository = model.selectedReviewRepository,
+               let headSHA = model.scopedDryRunHeadSHA {
+                Button(
+                    "Post \(repository)#\(model.pendingReviewPullNumber) at \(headSHA.prefix(12))",
+                    role: .destructive
+                ) {
+                    model.runScopedLiveReview()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Only the exact repository, pull request, and commit proven by the latest dry run will be posted.")
+        }
     }
 
     private func hero(palette: NDPalette, readiness: DesktopSetupReadiness) -> some View {
@@ -352,6 +376,69 @@ struct OverviewView: View {
         .frame(maxWidth: .infinity, minHeight: 174, alignment: .topLeading)
     }
 
+    private func scopedReviewPanel(palette: NDPalette) -> some View {
+        ReferenceHomePanel(title: "// RUN A REVIEW", palette: palette) {
+            if let repository = model.selectedReviewRepository {
+                Text(repository)
+                    .font(.system(.callout, design: .monospaced).weight(.semibold))
+                    .foregroundStyle(palette.textPrimary)
+                    .lineLimit(1)
+            }
+
+            Text("Start with a dry run. NeonDiff will enable live posting only for the exact pull request head returned by that run.")
+                .font(.callout)
+                .foregroundStyle(palette.textSecondary)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 10) { scopedReviewControls }
+                VStack(alignment: .leading, spacing: 10) { scopedReviewControls }
+            }
+
+            Text(model.scopedReviewStatus)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(
+                    model.lastError == nil ? palette.textSecondary : palette.danger
+                )
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("neondiff-scoped-review-status")
+        }
+    }
+
+    @ViewBuilder
+    private var scopedReviewControls: some View {
+        TextField("PR number", text: $model.pendingReviewPullNumber)
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 130)
+            .accessibilityLabel("Pull request number")
+            .accessibilityIdentifier("neondiff-scoped-review-pr")
+
+        Button {
+            model.runScopedDryReview()
+        } label: {
+            Label(
+                model.isScopedReviewInProgress ? "Running…" : "Run Dry Review",
+                systemImage: "checkmark.shield"
+            )
+        }
+        .buttonStyle(ReferenceOutlineButtonStyle())
+        .disabled(
+            !model.productionUsefulWorkAvailable
+                || !model.providerSetupReady
+                || model.isScopedReviewInProgress
+                || Int(model.pendingReviewPullNumber) == nil
+        )
+        .accessibilityIdentifier("neondiff-scoped-review-dry")
+
+        Button {
+            isLiveReviewConfirmationPresented = true
+        } label: {
+            Label("Post Live Review", systemImage: "paperplane")
+        }
+        .buttonStyle(ReferenceOutlineButtonStyle())
+        .disabled(!model.scopedLiveReviewConfirmationAvailable)
+        .accessibilityIdentifier("neondiff-scoped-review-live")
+    }
+
     private func advancedDiagnostics(palette: NDPalette) -> some View {
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 14) {
@@ -408,7 +495,7 @@ struct OverviewView: View {
         Button { model.previewStartDaemon() } label: {
             Label("Preview Start", systemImage: "play.circle")
         }
-        .disabled(!model.productionUsefulWorkAvailable)
+        .disabled(!model.productionDaemonStartAvailable)
         .accessibilityIdentifier("neondiff-preview-start-daemon")
 
         Button { model.previewStopDaemon() } label: {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -422,10 +422,10 @@ struct OverviewView: View {
         }
         .buttonStyle(ReferenceOutlineButtonStyle())
         .disabled(
-            !model.productionUsefulWorkAvailable
+            !model.scopedReviewExecutionAvailable
                 || !model.providerSetupReady
                 || model.isScopedReviewInProgress
-                || Int(model.pendingReviewPullNumber) == nil
+                || model.positivePendingReviewPullNumber == nil
         )
         .accessibilityIdentifier("neondiff-scoped-review-dry")
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -367,7 +367,7 @@ struct ReposView: View {
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                 }
 
-                Text("This connection comes from a server-verified account/bot record matched to the exact local config on this Mac. NeonDiff reuses that worker only for an exact scoped command; it will not copy, migrate, print, or ask you to re-enter the private key.")
+                Text("This connection comes from a server-verified account/bot record matched to the exact local config on this Mac. NeonDiff reuses that worker only for an exact scoped command; it will not copy, migrate, or ask you to re-enter the private key, and it will never print it.")
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -326,7 +326,7 @@ struct ReposView: View {
             .operatorPanel()
 
             OperatorSection("Boundary") {
-                Text("Repo changes are written through `config patch` only; the desktop does not post reviews or bypass daemon gates.")
+                Text("Repo changes are written through `config patch` only. A review runs only from Overview after an exact repository and pull request are selected; live posting requires a successful dry run and explicit confirmation.")
                     .operatorBodyText()
                     .accessibilityIdentifier("neondiff-repos-boundary")
             }
@@ -367,7 +367,7 @@ struct ReposView: View {
                     .foregroundStyle(NeonDiffTheme.textPrimary)
                 }
 
-                Text("This connection comes from a server-verified account/bot record matched to the exact local config on this Mac. NeonDiff will not copy, migrate, or ask you to re-enter the existing worker private key.")
+                Text("This connection comes from a server-verified account/bot record matched to the exact local config on this Mac. NeonDiff reuses that worker only for an exact scoped command; it will not copy, migrate, print, or ask you to re-enter the private key.")
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -386,7 +386,7 @@ struct ReposView: View {
                                 ? NeonDiffTheme.accent
                                 : NeonDiffTheme.warning
                         )
-                        Button { model.verifyBYOGitHubAppCredentials() } label: {
+                        Button { model.verifyExistingLocalBotGitHubAccess() } label: {
                             Label(
                                 model.isBYOGitHubVerificationInProgress
                                     ? "Verifying…"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -115,6 +115,7 @@ package struct DesktopAppDependencies {
     package let productionBoundary: DesktopProductionBoundary
     package let cliWorkingDirectory: URL?
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
+    package let localBotExecutionConfigPaths: [String]
 
     package init(
         clipboard: any DesktopClipboard,
@@ -131,7 +132,8 @@ package struct DesktopAppDependencies {
         accountLink: (any NeonDiffAccountLinkConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
         cliWorkingDirectory: URL? = nil,
-        localBotConfigurations: [DesktopLocalBotConfiguration] = []
+        localBotConfigurations: [DesktopLocalBotConfiguration] = [],
+        localBotExecutionConfigPaths: [String] = []
     ) {
         self.clipboard = clipboard
         self.urlOpener = urlOpener
@@ -148,5 +150,6 @@ package struct DesktopAppDependencies {
         self.productionBoundary = productionBoundary
         self.cliWorkingDirectory = cliWorkingDirectory
         self.localBotConfigurations = localBotConfigurations
+        self.localBotExecutionConfigPaths = localBotExecutionConfigPaths
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -21,6 +21,24 @@ package struct DesktopLocalBotConfiguration: Equatable, Sendable {
     }
 }
 
+/// Process-only coordinates for invoking an already-configured local worker.
+///
+/// The private-key path is never exposed to the model or UI. The desktop
+/// composition root may pass these normalized environment overrides only to
+/// an exact `--config` invocation that matches this context.
+package struct DesktopLocalBotExecutionContext: Equatable, Sendable {
+    package let configPath: String
+    package let environmentOverrides: [String: String]
+
+    package init(
+        configPath: String,
+        environmentOverrides: [String: String]
+    ) {
+        self.configPath = configPath
+        self.environmentOverrides = environmentOverrides
+    }
+}
+
 package enum DesktopLaunchAgentBotConfigurationParser {
     private static let supportedAppIDKeys = [
         "NEONDIFF_GITHUB_APP_ID",
@@ -106,6 +124,101 @@ package enum DesktopLaunchAgentBotConfigurationParser {
     }
 }
 
+package enum DesktopLaunchAgentExecutionContextParser {
+    private static let appIDKeys = [
+        "NEONDIFF_GITHUB_APP_ID",
+        "EVAOS_REVIEW_BOT_APP_ID"
+    ]
+    private static let privateKeyPathKeys = [
+        "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
+        "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH"
+    ]
+
+    package static func parse(
+        data: Data,
+        expectedLabel: String,
+        privateKeyPathIsSafe: (URL) -> Bool
+    ) -> DesktopLocalBotExecutionContext? {
+        guard let propertyList = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ),
+        let root = propertyList as? [String: Any],
+        root["Label"] as? String == expectedLabel,
+        let environment = root["EnvironmentVariables"] as? [String: Any],
+        let arguments = root["ProgramArguments"] as? [String]
+        else {
+            return nil
+        }
+
+        let appIDs = values(
+            for: appIDKeys,
+            in: environment
+        )
+        guard let appID = oneConsistentValue(appIDs),
+              !appID.isEmpty,
+              appID.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+              Int64(appID).map({ $0 > 0 }) == true
+        else {
+            return nil
+        }
+
+        let privateKeyPaths = values(
+            for: privateKeyPathKeys,
+            in: environment
+        )
+        guard let rawPrivateKeyPath = oneConsistentValue(privateKeyPaths),
+              rawPrivateKeyPath.hasPrefix("/")
+        else {
+            return nil
+        }
+        let privateKeyURL = URL(filePath: rawPrivateKeyPath).standardizedFileURL
+        guard privateKeyPathIsSafe(privateKeyURL) else { return nil }
+
+        let configIndexes = arguments.indices.filter {
+            arguments[$0] == "--config"
+        }
+        guard configIndexes.count == 1,
+              let configIndex = configIndexes.first,
+              arguments.index(after: configIndex) < arguments.endIndex
+        else {
+            return nil
+        }
+        let rawConfigPath = arguments[arguments.index(after: configIndex)]
+        guard rawConfigPath.hasPrefix("/") else { return nil }
+        let configPath = URL(filePath: rawConfigPath).standardizedFileURL.path
+
+        return DesktopLocalBotExecutionContext(
+            configPath: configPath,
+            environmentOverrides: [
+                "NEONDIFF_GITHUB_APP_ID": appID,
+                "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyURL.path
+            ]
+        )
+    }
+
+    private static func values(
+        for keys: [String],
+        in environment: [String: Any]
+    ) -> [String]? {
+        let presentKeys = keys.filter { environment[$0] != nil }
+        guard !presentKeys.isEmpty else { return nil }
+        let values = presentKeys.compactMap { environment[$0] as? String }
+        guard values.count == presentKeys.count else { return nil }
+        return values
+    }
+
+    private static func oneConsistentValue(_ values: [String]?) -> String? {
+        guard let values,
+              Set(values).count == 1
+        else {
+            return nil
+        }
+        return values.first
+    }
+}
+
 package enum DesktopLocalBotWorkingDirectoryResolver {
     package static func resolve(
         arguments: [String],
@@ -135,5 +248,36 @@ package enum DesktopLocalBotWorkingDirectoryResolver {
             return fallback
         }
         return URL(filePath: workingDirectory).standardizedFileURL
+    }
+}
+
+package enum DesktopLocalBotExecutionContextResolver {
+    package static func resolve(
+        executablePath: String,
+        arguments: [String],
+        executionContexts: [DesktopLocalBotExecutionContext]
+    ) -> [String: String] {
+        guard executablePath == "neondiff" else { return [:] }
+        let commandIsAllowed = arguments.first == "review-pr"
+            || Array(arguments.prefix(2)) == ["doctor", "github"]
+        guard commandIsAllowed else { return [:] }
+        let configIndexes = arguments.indices.filter {
+            arguments[$0] == "--config"
+        }
+        guard configIndexes.count == 1,
+              let configIndex = configIndexes.first,
+              arguments.index(after: configIndex) < arguments.endIndex
+        else {
+            return [:]
+        }
+
+        let rawConfigPath = arguments[arguments.index(after: configIndex)]
+        guard rawConfigPath.hasPrefix("/") else { return [:] }
+        let configPath = URL(filePath: rawConfigPath).standardizedFileURL.path
+        let matches = executionContexts.filter {
+            URL(filePath: $0.configPath).standardizedFileURL.path == configPath
+        }
+        guard matches.count == 1 else { return [:] }
+        return matches[0].environmentOverrides
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -59,8 +59,18 @@ package enum DesktopLaunchAgentBotConfigurationParser {
         let root = propertyList as? [String: Any],
         root["Label"] as? String == expectedLabel,
         let environment = root["EnvironmentVariables"] as? [String: Any],
-        let arguments = root["ProgramArguments"] as? [String]
+        let arguments = root["ProgramArguments"] as? [String],
+        let rawWorkingDirectory = root["WorkingDirectory"] as? String,
+        rawWorkingDirectory.hasPrefix("/")
         else {
+            return nil
+        }
+        let workingDirectoryURL = URL(filePath: rawWorkingDirectory)
+            .standardizedFileURL
+        guard approvedNeonDiffDaemonInvocation(
+            arguments,
+            workingDirectory: workingDirectoryURL
+        ) else {
             return nil
         }
 
@@ -107,13 +117,6 @@ package enum DesktopLaunchAgentBotConfigurationParser {
         let configURL = URL(filePath: rawConfigPath).standardizedFileURL
         guard configExists(configURL) else { return nil }
 
-        guard let rawWorkingDirectory = root["WorkingDirectory"] as? String,
-              rawWorkingDirectory.hasPrefix("/")
-        else {
-            return nil
-        }
-        let workingDirectoryURL = URL(filePath: rawWorkingDirectory)
-            .standardizedFileURL
         guard workingDirectoryExists(workingDirectoryURL) else { return nil }
 
         return DesktopLocalBotConfiguration(
@@ -147,8 +150,18 @@ package enum DesktopLaunchAgentExecutionContextParser {
         let root = propertyList as? [String: Any],
         root["Label"] as? String == expectedLabel,
         let environment = root["EnvironmentVariables"] as? [String: Any],
-        let arguments = root["ProgramArguments"] as? [String]
+        let arguments = root["ProgramArguments"] as? [String],
+        let rawWorkingDirectory = root["WorkingDirectory"] as? String,
+        rawWorkingDirectory.hasPrefix("/")
         else {
+            return nil
+        }
+        let workingDirectoryURL = URL(filePath: rawWorkingDirectory)
+            .standardizedFileURL
+        guard approvedNeonDiffDaemonInvocation(
+            arguments,
+            workingDirectory: workingDirectoryURL
+        ) else {
             return nil
         }
 
@@ -217,6 +230,37 @@ package enum DesktopLaunchAgentExecutionContextParser {
         }
         return values.first
     }
+}
+
+private func approvedNeonDiffDaemonInvocation(
+    _ arguments: [String],
+    workingDirectory: URL
+) -> Bool {
+    guard !arguments.isEmpty else { return false }
+    let executableName = URL(filePath: arguments[0]).lastPathComponent
+    if executableName == "neondiff" {
+        return arguments.count >= 2 && arguments[1] == "daemon"
+    }
+    guard executableName == "node", arguments.count >= 3 else {
+        return false
+    }
+
+    let sourceRunner = workingDirectory
+        .appendingPathComponent("node_modules/tsx/dist/cli.mjs")
+        .standardizedFileURL.path
+    if arguments.count >= 4,
+       URL(filePath: arguments[1]).standardizedFileURL.path == sourceRunner,
+       arguments[2] == "src/cli.ts",
+       arguments[3] == "daemon"
+    {
+        return true
+    }
+
+    let bundledCLI = workingDirectory
+        .appendingPathComponent("dist/cli.js")
+        .standardizedFileURL.path
+    return URL(filePath: arguments[1]).standardizedFileURL.path == bundledCLI
+        && arguments[2] == "daemon"
 }
 
 package enum DesktopLocalBotWorkingDirectoryResolver {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -202,12 +202,22 @@ package enum DesktopLaunchAgentExecutionContextParser {
         guard rawConfigPath.hasPrefix("/") else { return nil }
         let configPath = URL(filePath: rawConfigPath).standardizedFileURL.path
 
+        var environmentOverrides = [
+            "NEONDIFF_GITHUB_APP_ID": appID,
+            "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyURL.path
+        ]
+        if let rawNodeOptions = environment["NODE_OPTIONS"] {
+            guard let nodeOptions = rawNodeOptions as? String,
+                  nodeOptions == "--use-system-ca"
+            else {
+                return nil
+            }
+            environmentOverrides["NODE_OPTIONS"] = nodeOptions
+        }
+
         return DesktopLocalBotExecutionContext(
             configPath: configPath,
-            environmentOverrides: [
-                "NEONDIFF_GITHUB_APP_ID": appID,
-                "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyURL.path
-            ]
+            environmentOverrides: environmentOverrides
         )
     }
 
@@ -257,7 +267,7 @@ private func approvedNeonDiffDaemonInvocation(
     }
 
     let bundledCLI = workingDirectory
-        .appendingPathComponent("dist/cli.js")
+        .appendingPathComponent("dist/src/cli.js")
         .standardizedFileURL.path
     return URL(filePath: arguments[1]).standardizedFileURL.path == bundledCLI
         && arguments[2] == "daemon"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -29,15 +29,18 @@ package struct DesktopLocalBotConfiguration: Equatable, Sendable {
 package struct DesktopLocalBotExecutionContext: Equatable, Sendable {
     package let configPath: String
     package let executablePath: String?
+    package let argumentPrefix: [String]
     package let environmentOverrides: [String: String]
 
     package init(
         configPath: String,
         executablePath: String? = nil,
+        argumentPrefix: [String] = [],
         environmentOverrides: [String: String]
     ) {
         self.configPath = configPath
         self.executablePath = executablePath
+        self.argumentPrefix = argumentPrefix
         self.environmentOverrides = environmentOverrides
     }
 }
@@ -218,14 +221,36 @@ package enum DesktopLaunchAgentExecutionContextParser {
             environmentOverrides["NODE_OPTIONS"] = nodeOptions
         }
 
-        let directExecutablePath =
-            URL(filePath: arguments[0]).lastPathComponent == "neondiff"
-                && arguments[0] != "neondiff"
-            ? URL(filePath: arguments[0]).standardizedFileURL.path
-            : nil
+        let executableName = URL(filePath: arguments[0]).lastPathComponent
+        let directExecutablePath: String?
+        let argumentPrefix: [String]
+        if executableName == "neondiff" {
+            directExecutablePath = arguments[0] == "neondiff"
+                ? nil
+                : URL(filePath: arguments[0]).standardizedFileURL.path
+            argumentPrefix = []
+        } else {
+            directExecutablePath = arguments[0].hasPrefix("/")
+                ? URL(filePath: arguments[0]).standardizedFileURL.path
+                : arguments[0]
+            let sourceRunner = workingDirectoryURL
+                .appendingPathComponent("node_modules/tsx/dist/cli.mjs")
+                .standardizedFileURL.path
+            if arguments.count >= 4,
+               URL(filePath: arguments[1]).standardizedFileURL.path == sourceRunner,
+               arguments[2] == "src/cli.ts"
+            {
+                argumentPrefix = [sourceRunner, "src/cli.ts"]
+            } else {
+                argumentPrefix = [
+                    URL(filePath: arguments[1]).standardizedFileURL.path
+                ]
+            }
+        }
         return DesktopLocalBotExecutionContext(
             configPath: configPath,
             executablePath: directExecutablePath,
+            argumentPrefix: argumentPrefix,
             environmentOverrides: environmentOverrides
         )
     }
@@ -340,6 +365,21 @@ package enum DesktopLocalBotExecutionContextResolver {
             arguments: arguments,
             executionContexts: executionContexts
         )?.executablePath
+    }
+
+    package static func resolveArguments(
+        executablePath: String,
+        arguments: [String],
+        executionContexts: [DesktopLocalBotExecutionContext]
+    ) -> [String] {
+        guard let context = matchingContext(
+            executablePath: executablePath,
+            arguments: arguments,
+            executionContexts: executionContexts
+        ) else {
+            return arguments
+        }
+        return context.argumentPrefix + arguments
     }
 
     private static func matchingContext(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -28,13 +28,16 @@ package struct DesktopLocalBotConfiguration: Equatable, Sendable {
 /// an exact `--config` invocation that matches this context.
 package struct DesktopLocalBotExecutionContext: Equatable, Sendable {
     package let configPath: String
+    package let executablePath: String?
     package let environmentOverrides: [String: String]
 
     package init(
         configPath: String,
+        executablePath: String? = nil,
         environmentOverrides: [String: String]
     ) {
         self.configPath = configPath
+        self.executablePath = executablePath
         self.environmentOverrides = environmentOverrides
     }
 }
@@ -215,8 +218,14 @@ package enum DesktopLaunchAgentExecutionContextParser {
             environmentOverrides["NODE_OPTIONS"] = nodeOptions
         }
 
+        let directExecutablePath =
+            URL(filePath: arguments[0]).lastPathComponent == "neondiff"
+                && arguments[0] != "neondiff"
+            ? URL(filePath: arguments[0]).standardizedFileURL.path
+            : nil
         return DesktopLocalBotExecutionContext(
             configPath: configPath,
+            executablePath: directExecutablePath,
             environmentOverrides: environmentOverrides
         )
     }
@@ -249,6 +258,9 @@ private func approvedNeonDiffDaemonInvocation(
     guard !arguments.isEmpty else { return false }
     let executableName = URL(filePath: arguments[0]).lastPathComponent
     if executableName == "neondiff" {
+        guard arguments[0] == "neondiff" || arguments[0].hasPrefix("/") else {
+            return false
+        }
         return arguments.count >= 2 && arguments[1] == "daemon"
     }
     guard executableName == "node", arguments.count >= 3 else {
@@ -311,10 +323,34 @@ package enum DesktopLocalBotExecutionContextResolver {
         arguments: [String],
         executionContexts: [DesktopLocalBotExecutionContext]
     ) -> [String: String] {
-        guard executablePath == "neondiff" else { return [:] }
+        matchingContext(
+            executablePath: executablePath,
+            arguments: arguments,
+            executionContexts: executionContexts
+        )?.environmentOverrides ?? [:]
+    }
+
+    package static func resolveExecutablePath(
+        executablePath: String,
+        arguments: [String],
+        executionContexts: [DesktopLocalBotExecutionContext]
+    ) -> String? {
+        matchingContext(
+            executablePath: executablePath,
+            arguments: arguments,
+            executionContexts: executionContexts
+        )?.executablePath
+    }
+
+    private static func matchingContext(
+        executablePath: String,
+        arguments: [String],
+        executionContexts: [DesktopLocalBotExecutionContext]
+    ) -> DesktopLocalBotExecutionContext? {
+        guard executablePath == "neondiff" else { return nil }
         let commandIsAllowed = arguments.first == "review-pr"
             || Array(arguments.prefix(2)) == ["doctor", "github"]
-        guard commandIsAllowed else { return [:] }
+        guard commandIsAllowed else { return nil }
         let configIndexes = arguments.indices.filter {
             arguments[$0] == "--config"
         }
@@ -322,16 +358,16 @@ package enum DesktopLocalBotExecutionContextResolver {
               let configIndex = configIndexes.first,
               arguments.index(after: configIndex) < arguments.endIndex
         else {
-            return [:]
+            return nil
         }
 
         let rawConfigPath = arguments[arguments.index(after: configIndex)]
-        guard rawConfigPath.hasPrefix("/") else { return [:] }
+        guard rawConfigPath.hasPrefix("/") else { return nil }
         let configPath = URL(filePath: rawConfigPath).standardizedFileURL.path
         let matches = executionContexts.filter {
             URL(filePath: $0.configPath).standardizedFileURL.path == configPath
         }
-        guard matches.count == 1 else { return [:] }
-        return matches[0].environmentOverrides
+        guard matches.count == 1 else { return nil }
+        return matches[0]
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -191,6 +191,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var activationVerifiedThisLaunch = false
     private var activationVerifiedRepositoryThisLaunch: String?
     private var appliedRepoSelection: AppliedRepoSelection?
+    private var scopedReviewTask: Task<Void, Never>?
     private var scopedDryRunApproval: ScopedReviewApproval?
 
     package var productionActivationBoundaryMessage: String {
@@ -399,10 +400,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var scopedLiveReviewConfirmationAvailable: Bool {
-        guard productionUsefulWorkAvailable,
+        guard scopedReviewExecutionAvailable,
               !isScopedReviewInProgress,
               let approval = scopedDryRunApproval,
-              let pullNumber = Int(pendingReviewPullNumber),
+              let pullNumber = positivePendingReviewPullNumber,
               let selectedReviewRepository
         else {
             return false
@@ -411,8 +412,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 == .orderedSame
             && approval.pullNumber == pullNumber
             && approval.configPath == configPath
+            && approval.configRevision == providerLoadedRevision
             && approval.workspaceGeneration == workspaceContextGeneration
             && isValidGitHubCommitSHA(approval.headSHA)
+    }
+
+    package var scopedReviewExecutionAvailable: Bool {
+        productionUsefulWorkAvailable && existingLocalAgentAccessAvailable
     }
 
     /// Stopping an already-running daemon is a safety remediation, not useful
@@ -503,10 +509,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard existingLocalBotIdentityReady,
               byoGitHubCredentialOnboardingAvailable,
               cliPath == "neondiff",
-              let bot = selectedBotInstallation
+              matchingLocalBotConfigurationAvailable
         else {
             return false
         }
+        return dependencies.localBotExecutionConfigPaths.contains { path in
+            normalizedPath(path) == normalizedPath(configPath)
+        }
+    }
+
+    private var matchingLocalBotConfigurationAvailable: Bool {
+        guard let bot = selectedBotInstallation else { return false }
         return dependencies.localBotConfigurations.contains { configuration in
             configuration.appID == bot.appID
                 && normalizedPath(configuration.configPath)
@@ -527,6 +540,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         if cliPath != "neondiff" {
             return "Reset the CLI setting to neondiff before reusing an existing local agent. Custom executables never receive its credential environment."
+        }
+        if matchingLocalBotConfigurationAvailable {
+            return "The local agent needs recovery before reuse because its credential-safe execution context is unavailable."
         }
         guard let storedAppID = storedBYOGitHubAppId else {
             return "No app-owned Keychain App ID is stored for current-access verification."
@@ -1495,6 +1511,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         _ = githubRepositoryRefreshGate.begin()
         managedGitHubConnectionTask?.cancel()
         managedGitHubConnectionTask = nil
+        scopedReviewTask?.cancel()
+        scopedReviewTask = nil
         pendingManagedGitHubAuthorization = nil
         isGitHubAuthorizationInProgress = false
         isGitHubRepositoryRefreshInProgress = false
@@ -1937,10 +1955,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard requireScopedReviewAuthorization() else { return }
         guard !isScopedReviewInProgress else { return }
         guard let repository = selectedReviewRepository,
-              let pullNumber = positivePendingReviewPullNumber
+              let pullNumber = positivePendingReviewPullNumber,
+              let configRevision = providerLoadedRevision
         else {
-            lastError = "Enter a positive pull request number."
-            scopedReviewStatus = lastError ?? "Pull request required"
+            lastError = positivePendingReviewPullNumber == nil
+                ? "Enter a positive pull request number."
+                : "Reload the selected configuration before running a review."
+            scopedReviewStatus = lastError ?? "Review setup required"
             return
         }
 
@@ -1949,6 +1970,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             pullNumber: pullNumber,
             headSHA: "",
             configPath: configPath,
+            configRevision: configRevision,
             workspaceGeneration: workspaceContextGeneration
         )
         let arguments = [
@@ -1956,8 +1978,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "--config", configPath,
             "--repo", repository,
             "--pr", String(pullNumber),
+            "--expected-config-revision", configRevision,
             "--dry-run", "true",
-            "--zcode", "false"
+            "--zcode", "true"
         ]
         let executablePath = cliPath
         let cli = dependencies.cli
@@ -1971,10 +1994,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "--config", shellQuote(configPath),
             "--repo", shellQuote(repository),
             "--pr", String(pullNumber),
-            "--dry-run true --zcode false"
+            "--expected-config-revision", shellQuote(configRevision),
+            "--dry-run true --zcode true"
         ].joined(separator: " ")
 
-        Task.detached {
+        scopedReviewTask = Task.detached {
             do {
                 let result = try await cli.run(
                     executablePath: executablePath,
@@ -1994,6 +2018,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         context.workspaceGeneration
                     ) else { return }
                     self.isScopedReviewInProgress = false
+                    self.scopedReviewTask = nil
                     self.invalidateScopedReviewApproval()
                     self.lastError = "The scoped dry review failed safely."
                     self.scopedReviewStatus =
@@ -2020,9 +2045,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "--repo", approval.repo,
             "--pr", String(approval.pullNumber),
             "--head-sha", approval.headSHA,
+            "--expected-config-revision", approval.configRevision,
             "--dry-run", "false",
             "--confirm", "true",
-            "--zcode", "false"
+            "--zcode", "true"
         ]
         let executablePath = cliPath
         let cli = dependencies.cli
@@ -2036,10 +2062,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "--repo", shellQuote(approval.repo),
             "--pr", String(approval.pullNumber),
             "--head-sha", shellQuote(approval.headSHA),
-            "--dry-run false --confirm true --zcode false"
+            "--expected-config-revision", shellQuote(approval.configRevision),
+            "--dry-run false --confirm true --zcode true"
         ].joined(separator: " ")
 
-        Task.detached {
+        scopedReviewTask = Task.detached {
             do {
                 let result = try await cli.run(
                     executablePath: executablePath,
@@ -2059,9 +2086,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         approval.workspaceGeneration
                     ) else { return }
                     self.isScopedReviewInProgress = false
+                    self.scopedReviewTask = nil
+                    self.invalidateScopedReviewApproval()
                     self.lastError = "The scoped live review failed safely."
                     self.scopedReviewStatus =
-                        "Live review failed. Verify GitHub before retrying."
+                        "Live review failed. Check GitHub, then run a new dry review before retrying."
                 }
             }
         }
@@ -3143,6 +3172,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
             logText = "Stale GitHub App verification evidence was discarded."
             return
         }
+        let expectedCredentialSource: String
+        switch expectedContext.source {
+        case .keychainStdin:
+            expectedCredentialSource = "stdin"
+        case .existingLocalAgent:
+            expectedCredentialSource = "configured"
+        }
         guard result.exitCode == 0,
               let data = result.stdout.data(using: .utf8),
               let report = try? JSONDecoder().decode(BYOGitHubDoctorReport.self, from: data),
@@ -3152,11 +3188,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
               reportedRepositories == expectedRepositories,
               report.ok,
               report.command == "doctor github",
-              report.appCredentials.source == (
-                  expectedContext.source == .keychainStdin
-                      ? "stdin"
-                      : "configured"
-              ),
+              report.appCredentials.source == expectedCredentialSource,
               report.appCredentials.appIdConfigured,
               report.appCredentials.privateKeyConfigured,
               report.github.canPostAsApp,
@@ -3836,10 +3868,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
             }
             return false
         }
+        guard existingLocalAgentAccessAvailable else {
+            lastError =
+                "Connect a verified local NeonDiff agent before running a scoped review."
+            scopedReviewStatus = lastError ?? "Local agent required"
+            return false
+        }
         return true
     }
 
-    private var positivePendingReviewPullNumber: Int? {
+    package var positivePendingReviewPullNumber: Int? {
         let trimmed = pendingReviewPullNumber
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard let value = Int(trimmed), value > 0 else { return nil }
@@ -3854,6 +3892,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         isScopedReviewInProgress = false
+        scopedReviewTask = nil
         guard currentScopedReviewCoordinatesMatch(expectedContext),
               result.exitCode == 0,
               let data = result.stdout.data(using: .utf8),
@@ -3882,6 +3921,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             pullNumber: report.scope.pullNumber,
             headSHA: report.scope.headSha.lowercased(),
             configPath: expectedContext.configPath,
+            configRevision: expectedContext.configRevision,
             workspaceGeneration: expectedContext.workspaceGeneration
         )
         scopedDryRunApproval = approval
@@ -3899,6 +3939,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         isScopedReviewInProgress = false
+        scopedReviewTask = nil
         guard currentScopedReviewCoordinatesMatch(expectedApproval),
               scopedDryRunApproval == expectedApproval,
               result.exitCode == 0,
@@ -3910,6 +3951,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
               report.ok,
               report.command == "review-pr",
               !report.dryRun,
+              report.result.reviewed == 1,
+              report.result.skippedProcessed == 0,
               report.scope.repo.caseInsensitiveCompare(expectedApproval.repo)
                   == .orderedSame,
               report.scope.pullNumber == expectedApproval.pullNumber,
@@ -3921,7 +3964,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 "GitHub did not confirm a live review for the exact approved head."
             scopedReviewStatus =
                 "Live review failed closed. Re-run the dry review before retrying."
-            invalidateScopedReviewApproval()
+            invalidateScopedReviewApproval(preserveStatus: true)
             return
         }
 
@@ -3939,7 +3982,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
               let selectedReviewRepository,
               selectedReviewRepository.caseInsensitiveCompare(approval.repo)
                   == .orderedSame,
-              positivePendingReviewPullNumber == approval.pullNumber
+              positivePendingReviewPullNumber == approval.pullNumber,
+              providerLoadedRevision == approval.configRevision
         else {
             return false
         }
@@ -5393,6 +5437,7 @@ private struct ScopedReviewApproval: Equatable, Sendable {
     let pullNumber: Int
     let headSHA: String
     let configPath: String
+    let configRevision: String
     let workspaceGeneration: UInt64
 }
 
@@ -5403,10 +5448,30 @@ private struct ScopedReviewCommandReport: Decodable {
         let headSha: String
     }
 
+    struct Result: Decodable {
+        let reviewed: Int
+        let skippedProcessed: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case reviewed
+            case skippedProcessed
+        }
+
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            reviewed = try values.decode(Int.self, forKey: .reviewed)
+            skippedProcessed = try values.decodeIfPresent(
+                Int.self,
+                forKey: .skippedProcessed
+            ) ?? 0
+        }
+    }
+
     let ok: Bool
     let command: String
     let dryRun: Bool
     let scope: Scope
+    let result: Result
 }
 
 private let licenseKeyAccount = "license/default"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3080,7 +3080,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             verifyBYOGitHubAppCredentials()
             return
         }
-        verifyGitHubAccessThroughExistingLocalAgent()
+        let diagnosis = existingLocalBotBYOGitHubVerificationStatus
+        lastError = diagnosis
+        byoGitHubCredentialStatus = diagnosis
     }
 
     private func verifyGitHubAccessThroughExistingLocalAgent() {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -396,7 +396,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// review. A multi-repository worker cannot be started from the native app
     /// until its runtime scope can be narrowed without rewriting the allowlist.
     package var productionDaemonStartAvailable: Bool {
-        productionUsefulWorkAvailable && reviewTargetRuntimeReady
+        productionUsefulWorkAvailable
+            && reviewTargetRuntimeReady
+            && scopedReviewProviderReady
     }
 
     package var scopedLiveReviewConfirmationAvailable: Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3053,6 +3053,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func verifyExistingLocalBotGitHubAccess() {
+        if existingLocalAgentAccessAvailable,
+           selectedBotInstallation != nil
+        {
+            verifyGitHubAccessThroughExistingLocalAgent()
+            return
+        }
         if let bot = selectedBotInstallation,
            let storedAppID = storedBYOGitHubAppId,
            storedAppID == String(bot.appID),
@@ -3061,6 +3067,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             verifyBYOGitHubAppCredentials()
             return
         }
+        verifyGitHubAccessThroughExistingLocalAgent()
+    }
+
+    private func verifyGitHubAccessThroughExistingLocalAgent() {
         guard !isSetupMutationBlocked else {
             lastError = "Retry account verification before verifying GitHub App setup."
             byoGitHubCredentialStatus = lastError ?? "Account check required"
@@ -3074,7 +3084,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
             byoGitHubCredentialStatus = lastError ?? "Local agent unavailable"
             return
         }
-
         let arguments = [
             "doctor", "github",
             "--config", configPath,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -793,6 +793,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var scopedReviewProviderReady: Bool {
         providerSetupReady
             && providers.selectedRegistryTarget?.authMode == "zcode-app-config"
+            && providers.zcodeProviderId == providers.selectedProviderId
     }
 
     /// Account entitlement is server authority for the selected existing bot's

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -150,6 +150,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var byoGitHubCredentialsVerified = false
     @Published package private(set) var isBYOGitHubVerificationInProgress = false
     @Published package private(set) var byoGitHubCredentialStatus = "Customer-owned GitHub App credentials are not stored."
+    @Published package var pendingReviewPullNumber = "" {
+        didSet {
+            guard pendingReviewPullNumber != oldValue else { return }
+            invalidateScopedReviewApproval()
+        }
+    }
+    @Published package private(set) var isScopedReviewInProgress = false
+    @Published package private(set) var scopedDryRunHeadSHA: String?
+    @Published package private(set) var scopedReviewStatus = "Verify current access before running a dry review."
     @Published package var logText = "No logs loaded."
     @Published package var lastError: String?
     @Published package var lastCommandLine = ""
@@ -182,6 +191,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var activationVerifiedThisLaunch = false
     private var activationVerifiedRepositoryThisLaunch: String?
     private var appliedRepoSelection: AppliedRepoSelection?
+    private var scopedDryRunApproval: ScopedReviewApproval?
 
     package var productionActivationBoundaryMessage: String {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
@@ -337,7 +347,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                   byoGitHubCredentialsVerified,
                   repositoryConfigurationReady,
                   currentRepositoryActivationReady,
-                  reviewTargetRuntimeReady
+                  scopedReviewTargetReady
             else { return false }
         }
         guard dependencies.productionBoundary.managedGitHubBrokerOrigin != nil else {
@@ -367,6 +377,42 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case .unknown:
             return false
         }
+    }
+
+    /// A scoped `review-pr` command always carries one exact repository and PR.
+    /// It can therefore use an explicitly selected repository from an existing
+    /// multi-repository worker without widening or rewriting that worker.
+    package var scopedReviewTargetReady: Bool {
+        guard let selectedReviewRepository else { return false }
+        return repos.contains {
+            $0.enabled
+                && $0.name.caseInsensitiveCompare(selectedReviewRepository)
+                    == .orderedSame
+        }
+    }
+
+    /// Starting the long-running daemon remains stricter than one scoped
+    /// review. A multi-repository worker cannot be started from the native app
+    /// until its runtime scope can be narrowed without rewriting the allowlist.
+    package var productionDaemonStartAvailable: Bool {
+        productionUsefulWorkAvailable && reviewTargetRuntimeReady
+    }
+
+    package var scopedLiveReviewConfirmationAvailable: Bool {
+        guard productionUsefulWorkAvailable,
+              !isScopedReviewInProgress,
+              let approval = scopedDryRunApproval,
+              let pullNumber = Int(pendingReviewPullNumber),
+              let selectedReviewRepository
+        else {
+            return false
+        }
+        return approval.repo.caseInsensitiveCompare(selectedReviewRepository)
+                == .orderedSame
+            && approval.pullNumber == pullNumber
+            && approval.configPath == configPath
+            && approval.workspaceGeneration == workspaceContextGeneration
+            && isValidGitHubCommitSHA(approval.headSHA)
     }
 
     /// Stopping an already-running daemon is a safety remediation, not useful
@@ -439,6 +485,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var existingLocalBotBYOGitHubVerificationAvailable: Bool {
+        if existingLocalAgentAccessAvailable {
+            return true
+        }
         guard existingLocalBotIdentityReady,
               byoGitHubCredentialOnboardingAvailable,
               byoGitHubPrivateKeyStored,
@@ -450,11 +499,34 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return storedAppID == String(bot.appID)
     }
 
+    package var existingLocalAgentAccessAvailable: Bool {
+        guard existingLocalBotIdentityReady,
+              byoGitHubCredentialOnboardingAvailable,
+              cliPath == "neondiff",
+              let bot = selectedBotInstallation
+        else {
+            return false
+        }
+        return dependencies.localBotConfigurations.contains { configuration in
+            configuration.appID == bot.appID
+                && normalizedPath(configuration.configPath)
+                    == normalizedPath(configPath)
+        }
+    }
+
     package var existingLocalBotBYOGitHubVerificationStatus: String {
         guard existingLocalBotIdentityReady,
               let bot = selectedBotInstallation
         else {
             return "The selected existing bot identity is not verified for this local config."
+        }
+        if existingLocalAgentAccessAvailable {
+            return byoGitHubCredentialsVerified
+                ? "Verified through the existing local agent for this launch."
+                : "The exact existing local agent is ready for current-access verification. Its private key will not be copied or printed."
+        }
+        if cliPath != "neondiff" {
+            return "Reset the CLI setting to neondiff before reusing an existing local agent. Custom executables never receive its credential environment."
         }
         guard let storedAppID = storedBYOGitHubAppId else {
             return "No app-owned Keychain App ID is stored for current-access verification."
@@ -1433,6 +1505,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         pendingBYOGitHubAppPrivateKey = ""
         byoGitHubCredentialRevision &+= 1
         isBYOGitHubVerificationInProgress = false
+        isScopedReviewInProgress = false
+        pendingReviewPullNumber = ""
+        invalidateScopedReviewApproval()
         isConfigInitializationInProgress = false
         isConfigPatchInProgress = false
         isConfigInspectInProgress = false
@@ -1840,7 +1915,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func previewStartDaemon() {
-        guard requireProductionUsefulWorkAuthorization() else { return }
+        guard requireProductionDaemonStartAuthorization() else { return }
         runCLI(arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: startDaemonDryRunCommand)
     }
 
@@ -1850,12 +1925,146 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func startDaemon() {
-        guard requireProductionUsefulWorkAuthorization() else { return }
+        guard requireProductionDaemonStartAuthorization() else { return }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
             displayCommand: startDaemonCommand
         )
+    }
+
+    package func runScopedDryReview() {
+        guard requireScopedReviewAuthorization() else { return }
+        guard !isScopedReviewInProgress else { return }
+        guard let repository = selectedReviewRepository,
+              let pullNumber = positivePendingReviewPullNumber
+        else {
+            lastError = "Enter a positive pull request number."
+            scopedReviewStatus = lastError ?? "Pull request required"
+            return
+        }
+
+        let context = ScopedReviewApproval(
+            repo: repository,
+            pullNumber: pullNumber,
+            headSHA: "",
+            configPath: configPath,
+            workspaceGeneration: workspaceContextGeneration
+        )
+        let arguments = [
+            "review-pr",
+            "--config", configPath,
+            "--repo", repository,
+            "--pr", String(pullNumber),
+            "--dry-run", "true",
+            "--zcode", "false"
+        ]
+        let executablePath = cliPath
+        let cli = dependencies.cli
+        invalidateScopedReviewApproval()
+        isScopedReviewInProgress = true
+        lastError = nil
+        scopedReviewStatus =
+            "Running a dry review for \(repository)#\(pullNumber)…"
+        lastCommandLine = [
+            shellQuote(cliPath), "review-pr",
+            "--config", shellQuote(configPath),
+            "--repo", shellQuote(repository),
+            "--pr", String(pullNumber),
+            "--dry-run true --zcode false"
+        ].joined(separator: " ")
+
+        Task.detached {
+            do {
+                let result = try await cli.run(
+                    executablePath: executablePath,
+                    arguments: arguments,
+                    standardInput: nil,
+                    timeout: 600
+                )
+                await MainActor.run {
+                    self.applyScopedDryReviewResult(
+                        result,
+                        expectedContext: context
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    guard self.isCurrentWorkspace(
+                        context.workspaceGeneration
+                    ) else { return }
+                    self.isScopedReviewInProgress = false
+                    self.invalidateScopedReviewApproval()
+                    self.lastError = "The scoped dry review failed safely."
+                    self.scopedReviewStatus =
+                        "Dry review failed. No GitHub review was posted."
+                }
+            }
+        }
+    }
+
+    package func runScopedLiveReview() {
+        guard requireScopedReviewAuthorization() else { return }
+        guard scopedLiveReviewConfirmationAvailable,
+              let approval = scopedDryRunApproval
+        else {
+            lastError =
+                "Run a successful dry review for this exact repository and pull request before posting."
+            scopedReviewStatus = lastError ?? "Dry review required"
+            return
+        }
+
+        let arguments = [
+            "review-pr",
+            "--config", approval.configPath,
+            "--repo", approval.repo,
+            "--pr", String(approval.pullNumber),
+            "--head-sha", approval.headSHA,
+            "--dry-run", "false",
+            "--confirm", "true",
+            "--zcode", "false"
+        ]
+        let executablePath = cliPath
+        let cli = dependencies.cli
+        isScopedReviewInProgress = true
+        lastError = nil
+        scopedReviewStatus =
+            "Posting the approved review for \(approval.repo)#\(approval.pullNumber) at \(approval.headSHA.prefix(12))…"
+        lastCommandLine = [
+            shellQuote(cliPath), "review-pr",
+            "--config", shellQuote(approval.configPath),
+            "--repo", shellQuote(approval.repo),
+            "--pr", String(approval.pullNumber),
+            "--head-sha", shellQuote(approval.headSHA),
+            "--dry-run false --confirm true --zcode false"
+        ].joined(separator: " ")
+
+        Task.detached {
+            do {
+                let result = try await cli.run(
+                    executablePath: executablePath,
+                    arguments: arguments,
+                    standardInput: nil,
+                    timeout: 600
+                )
+                await MainActor.run {
+                    self.applyScopedLiveReviewResult(
+                        result,
+                        expectedApproval: approval
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    guard self.isCurrentWorkspace(
+                        approval.workspaceGeneration
+                    ) else { return }
+                    self.isScopedReviewInProgress = false
+                    self.lastError = "The scoped live review failed safely."
+                    self.scopedReviewStatus =
+                        "Live review failed. Verify GitHub before retrying."
+                }
+            }
+        }
     }
 
     package func stopDaemon() {
@@ -2129,6 +2338,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return
         }
+        invalidateScopedReviewApproval()
         invalidateActivationForRepositoryChange()
         selectedBYOReviewRepository = repository.name
         dependencies.preferences.set(
@@ -2770,6 +2980,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let safeCommand = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --github-app-id \(shellQuote(appId)) --github-app-private-key-stdin true --json < [secure Keychain input]"
         let verificationContext = BYOGitHubVerificationContext(
             appId: appId,
+            source: .keychainStdin,
             credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
@@ -2812,21 +3023,118 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
+    package func verifyExistingLocalBotGitHubAccess() {
+        if let bot = selectedBotInstallation,
+           let storedAppID = storedBYOGitHubAppId,
+           storedAppID == String(bot.appID),
+           byoGitHubPrivateKeyStored
+        {
+            verifyBYOGitHubAppCredentials()
+            return
+        }
+        guard !isSetupMutationBlocked else {
+            lastError = "Retry account verification before verifying GitHub App setup."
+            byoGitHubCredentialStatus = lastError ?? "Account check required"
+            return
+        }
+        guard !isBYOGitHubVerificationInProgress else { return }
+        guard existingLocalAgentAccessAvailable,
+              let bot = selectedBotInstallation
+        else {
+            lastError = "The selected bot does not match one exact configured local agent."
+            byoGitHubCredentialStatus = lastError ?? "Local agent unavailable"
+            return
+        }
+
+        let arguments = [
+            "doctor", "github",
+            "--config", configPath,
+            "--json"
+        ]
+        let verificationContext = BYOGitHubVerificationContext(
+            appId: String(bot.appID),
+            source: .existingLocalAgent,
+            credentialRevision: byoGitHubCredentialRevision,
+            cliPath: cliPath,
+            configPath: configPath,
+            repositories: repos.filter(\.enabled).map(\.name).sorted(),
+            workspaceGeneration: workspaceContextGeneration
+        )
+        let executablePath = cliPath
+        let cli = dependencies.cli
+        isBYOGitHubVerificationInProgress = true
+        byoGitHubCredentialsVerified = false
+        lastError = nil
+        lastCommandLine = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --json"
+        byoGitHubCredentialStatus =
+            "Verifying current App installation access through the exact existing local agent…"
+
+        Task.detached {
+            do {
+                let result = try await cli.run(
+                    executablePath: executablePath,
+                    arguments: arguments,
+                    standardInput: nil,
+                    timeout: 30
+                )
+                await MainActor.run {
+                    self.applyBYOGitHubVerificationResult(
+                        result,
+                        expectedContext: verificationContext
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    guard self.isCurrentWorkspace(
+                        verificationContext.workspaceGeneration
+                    ) else { return }
+                    self.isBYOGitHubVerificationInProgress = false
+                    self.byoGitHubCredentialsVerified = false
+                    self.lastError =
+                        "Existing local agent GitHub verification failed safely."
+                    self.byoGitHubCredentialStatus =
+                        self.lastError ?? "Verification failed"
+                    self.logText =
+                        "The existing local agent did not produce authoritative installation/repository proof. No credential was copied."
+                }
+            }
+        }
+    }
+
     private func applyBYOGitHubVerificationResult(
         _ result: CLIRunResult,
         expectedContext: BYOGitHubVerificationContext
     ) {
         guard isCurrentWorkspace(expectedContext.workspaceGeneration) else { return }
         isBYOGitHubVerificationInProgress = false
-        let currentContext = storedBYOGitHubAppId.map { appId in
-            BYOGitHubVerificationContext(
-                appId: appId,
-                credentialRevision: byoGitHubCredentialRevision,
-                cliPath: cliPath,
-                configPath: configPath,
-                repositories: repos.filter(\.enabled).map(\.name).sorted(),
-                workspaceGeneration: workspaceContextGeneration
-            )
+        let currentContext: BYOGitHubVerificationContext?
+        switch expectedContext.source {
+        case .keychainStdin:
+            currentContext = storedBYOGitHubAppId.map { appId in
+                BYOGitHubVerificationContext(
+                    appId: appId,
+                    source: .keychainStdin,
+                    credentialRevision: byoGitHubCredentialRevision,
+                    cliPath: cliPath,
+                    configPath: configPath,
+                    repositories: repos.filter(\.enabled).map(\.name).sorted(),
+                    workspaceGeneration: workspaceContextGeneration
+                )
+            }
+        case .existingLocalAgent:
+            currentContext = existingLocalAgentAccessAvailable
+                ? selectedBotInstallation.map { bot in
+                    BYOGitHubVerificationContext(
+                        appId: String(bot.appID),
+                        source: .existingLocalAgent,
+                        credentialRevision: byoGitHubCredentialRevision,
+                        cliPath: cliPath,
+                        configPath: configPath,
+                        repositories: repos.filter(\.enabled).map(\.name).sorted(),
+                        workspaceGeneration: workspaceContextGeneration
+                    )
+                }
+                : nil
         }
         guard currentContext == expectedContext else {
             byoGitHubCredentialsVerified = false
@@ -2844,7 +3152,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
               reportedRepositories == expectedRepositories,
               report.ok,
               report.command == "doctor github",
-              report.appCredentials.source == "stdin",
+              report.appCredentials.source == (
+                  expectedContext.source == .keychainStdin
+                      ? "stdin"
+                      : "configured"
+              ),
               report.appCredentials.appIdConfigured,
               report.appCredentials.privateKeyConfigured,
               report.github.canPostAsApp,
@@ -2870,11 +3182,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }.joined(separator: ", ")
         byoGitHubCredentialsVerified = true
         lastError = nil
-        byoGitHubCredentialStatus = "Verified App installation access for \(repositories). Worker dry/live review has not run yet."
-        logText = "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
+        byoGitHubCredentialStatus = expectedContext.source == .existingLocalAgent
+            ? "Verified existing local agent App installation access for \(repositories). Worker dry/live review has not run yet."
+            : "Verified App installation access for \(repositories). Worker dry/live review has not run yet."
+        logText = expectedContext.source == .existingLocalAgent
+            ? "Existing local agent GitHub App installation and repository access verified. No credential was copied and no review was executed or posted."
+            : "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
     }
 
     private func invalidateBYOGitHubVerificationContext() {
+        invalidateScopedReviewApproval()
         guard byoGitHubCredentialOnboardingAvailable else { return }
         byoGitHubCredentialsVerified = false
         guard !isBYOGitHubVerificationInProgress else { return }
@@ -3492,6 +3809,161 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         return true
+    }
+
+    @discardableResult
+    private func requireProductionDaemonStartAuthorization() -> Bool {
+        guard productionDaemonStartAvailable else {
+            lastError = reviewTargetRuntimeReady
+                ? "Verify the selected repository, provider, and entitlement before starting the worker."
+                : "This existing worker monitors multiple repositories. Run a scoped review from NeonDiff; daemon-wide start remains blocked."
+            logText = lastError ?? "Daemon start is unavailable."
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    private func requireScopedReviewAuthorization() -> Bool {
+        guard requireProductionUsefulWorkAuthorization(),
+              providerSetupReady
+        else {
+            if providerSetupReady == false {
+                lastError =
+                    "Verify the selected provider before running a review."
+                scopedReviewStatus =
+                    lastError ?? "Provider verification required"
+            }
+            return false
+        }
+        return true
+    }
+
+    private var positivePendingReviewPullNumber: Int? {
+        let trimmed = pendingReviewPullNumber
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let value = Int(trimmed), value > 0 else { return nil }
+        return value
+    }
+
+    private func applyScopedDryReviewResult(
+        _ result: CLIRunResult,
+        expectedContext: ScopedReviewApproval
+    ) {
+        guard isCurrentWorkspace(expectedContext.workspaceGeneration) else {
+            return
+        }
+        isScopedReviewInProgress = false
+        guard currentScopedReviewCoordinatesMatch(expectedContext),
+              result.exitCode == 0,
+              let data = result.stdout.data(using: .utf8),
+              let report = try? JSONDecoder().decode(
+                  ScopedReviewCommandReport.self,
+                  from: data
+              ),
+              report.ok,
+              report.command == "review-pr",
+              report.dryRun,
+              report.scope.repo.caseInsensitiveCompare(expectedContext.repo)
+                  == .orderedSame,
+              report.scope.pullNumber == expectedContext.pullNumber,
+              isValidGitHubCommitSHA(report.scope.headSha)
+        else {
+            invalidateScopedReviewApproval()
+            lastError =
+                "The dry review did not produce exact repository, pull request, and head proof."
+            scopedReviewStatus =
+                "Dry review failed closed. No live review is authorized."
+            return
+        }
+
+        let approval = ScopedReviewApproval(
+            repo: report.scope.repo,
+            pullNumber: report.scope.pullNumber,
+            headSHA: report.scope.headSha.lowercased(),
+            configPath: expectedContext.configPath,
+            workspaceGeneration: expectedContext.workspaceGeneration
+        )
+        scopedDryRunApproval = approval
+        scopedDryRunHeadSHA = approval.headSHA
+        lastError = nil
+        scopedReviewStatus =
+            "Dry review complete for \(approval.repo)#\(approval.pullNumber) at \(approval.headSHA.prefix(12)). Confirm to post this exact head."
+    }
+
+    private func applyScopedLiveReviewResult(
+        _ result: CLIRunResult,
+        expectedApproval: ScopedReviewApproval
+    ) {
+        guard isCurrentWorkspace(expectedApproval.workspaceGeneration) else {
+            return
+        }
+        isScopedReviewInProgress = false
+        guard currentScopedReviewCoordinatesMatch(expectedApproval),
+              scopedDryRunApproval == expectedApproval,
+              result.exitCode == 0,
+              let data = result.stdout.data(using: .utf8),
+              let report = try? JSONDecoder().decode(
+                  ScopedReviewCommandReport.self,
+                  from: data
+              ),
+              report.ok,
+              report.command == "review-pr",
+              !report.dryRun,
+              report.scope.repo.caseInsensitiveCompare(expectedApproval.repo)
+                  == .orderedSame,
+              report.scope.pullNumber == expectedApproval.pullNumber,
+              report.scope.headSha.caseInsensitiveCompare(
+                  expectedApproval.headSHA
+              ) == .orderedSame
+        else {
+            lastError =
+                "GitHub did not confirm a live review for the exact approved head."
+            scopedReviewStatus =
+                "Live review failed closed. Re-run the dry review before retrying."
+            invalidateScopedReviewApproval()
+            return
+        }
+
+        lastError = nil
+        scopedReviewStatus =
+            "Review posted for \(expectedApproval.repo)#\(expectedApproval.pullNumber) at \(expectedApproval.headSHA.prefix(12))."
+        invalidateScopedReviewApproval(preserveStatus: true)
+    }
+
+    private func currentScopedReviewCoordinatesMatch(
+        _ approval: ScopedReviewApproval
+    ) -> Bool {
+        guard approval.workspaceGeneration == workspaceContextGeneration,
+              approval.configPath == configPath,
+              let selectedReviewRepository,
+              selectedReviewRepository.caseInsensitiveCompare(approval.repo)
+                  == .orderedSame,
+              positivePendingReviewPullNumber == approval.pullNumber
+        else {
+            return false
+        }
+        return true
+    }
+
+    private func isValidGitHubCommitSHA(_ value: String) -> Bool {
+        value.utf8.count == 40
+            && value.utf8.allSatisfy {
+                ($0 >= 48 && $0 <= 57)
+                    || ($0 >= 65 && $0 <= 70)
+                    || ($0 >= 97 && $0 <= 102)
+            }
+    }
+
+    private func invalidateScopedReviewApproval(
+        preserveStatus: Bool = false
+    ) {
+        scopedDryRunApproval = nil
+        scopedDryRunHeadSHA = nil
+        if !preserveStatus && !isScopedReviewInProgress {
+            scopedReviewStatus =
+                "Run a dry review before posting an exact pull request head."
+        }
     }
 
     @discardableResult
@@ -4902,12 +5374,39 @@ private struct BYOGitHubDoctorReport: Decodable {
 }
 
 private struct BYOGitHubVerificationContext: Equatable, Sendable {
+    enum CredentialSource: Equatable, Sendable {
+        case keychainStdin
+        case existingLocalAgent
+    }
+
     let appId: String
+    let source: CredentialSource
     let credentialRevision: UInt64
     let cliPath: String
     let configPath: String
     let repositories: [String]
     let workspaceGeneration: UInt64
+}
+
+private struct ScopedReviewApproval: Equatable, Sendable {
+    let repo: String
+    let pullNumber: Int
+    let headSHA: String
+    let configPath: String
+    let workspaceGeneration: UInt64
+}
+
+private struct ScopedReviewCommandReport: Decodable {
+    struct Scope: Decodable {
+        let repo: String
+        let pullNumber: Int
+        let headSha: String
+    }
+
+    let ok: Bool
+    let command: String
+    let dryRun: Bool
+    let scope: Scope
 }
 
 private let licenseKeyAccount = "license/default"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3903,6 +3903,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
               report.ok,
               report.command == "review-pr",
               report.dryRun,
+              report.result.reviewed == 1,
+              report.result.skippedProcessed == 0,
               report.scope.repo.caseInsensitiveCompare(expectedContext.repo)
                   == .orderedSame,
               report.scope.pullNumber == expectedContext.pullNumber,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -418,7 +418,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var scopedReviewExecutionAvailable: Bool {
-        productionUsefulWorkAvailable && existingLocalAgentAccessAvailable
+        productionUsefulWorkAvailable
+            && existingLocalAgentAccessAvailable
+            && scopedReviewProviderReady
     }
 
     /// Stopping an already-running daemon is a safety remediation, not useful
@@ -781,6 +783,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         default:
             return false
         }
+    }
+
+    /// The current scoped-review bridge executes ZCode, so its authorization
+    /// must be bound to the same app configuration ZCode will read. A provider
+    /// verified through NeonDiff's separate API-key adapter remains valid for
+    /// provider setup, but cannot authorize this bridge until direct adapter
+    /// execution is supported.
+    package var scopedReviewProviderReady: Bool {
+        providerSetupReady
+            && providers.selectedRegistryTarget?.authMode == "zcode-app-config"
     }
 
     /// Account entitlement is server authority for the selected existing bot's
@@ -3866,15 +3878,21 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     @discardableResult
     private func requireScopedReviewAuthorization() -> Bool {
-        guard requireProductionUsefulWorkAuthorization(),
-              providerSetupReady
-        else {
-            if providerSetupReady == false {
-                lastError =
-                    "Verify the selected provider before running a review."
-                scopedReviewStatus =
-                    lastError ?? "Provider verification required"
-            }
+        guard requireProductionUsefulWorkAuthorization() else {
+            return false
+        }
+        guard providerSetupReady else {
+            lastError =
+                "Verify the selected provider before running a review."
+            scopedReviewStatus =
+                lastError ?? "Provider verification required"
+            return false
+        }
+        guard scopedReviewProviderReady else {
+            lastError =
+                "Scoped reviews currently require a provider backed by the verified ZCode app configuration."
+            scopedReviewStatus =
+                lastError ?? "ZCode provider configuration required"
             return false
         }
         guard existingLocalAgentAccessAvailable else {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -133,6 +133,7 @@ public struct ProviderSettings: Equatable {
     public var zcodeModel: String
     public var zcodeCliPath: String
     public var zcodeAppConfigPath: String
+    public var zcodeProviderId: String
     public var openAICompatibleEndpoint: String
     public var providerKeyStored: Bool
     public var selectedProviderId: String
@@ -142,6 +143,7 @@ public struct ProviderSettings: Equatable {
         zcodeModel: String = "GLM-5.2",
         zcodeCliPath: String = "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
         zcodeAppConfigPath: String = ProviderSettings.defaultZCodeAppConfigPath,
+        zcodeProviderId: String = "zcode-glm",
         openAICompatibleEndpoint: String = "http://localhost:8000/v1",
         providerKeyStored: Bool = false,
         selectedProviderId: String = "zcode-glm",
@@ -150,6 +152,7 @@ public struct ProviderSettings: Equatable {
         self.zcodeModel = zcodeModel
         self.zcodeCliPath = zcodeCliPath
         self.zcodeAppConfigPath = zcodeAppConfigPath
+        self.zcodeProviderId = zcodeProviderId
         self.openAICompatibleEndpoint = openAICompatibleEndpoint
         self.providerKeyStored = providerKeyStored
         self.selectedProviderId = selectedProviderId

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -112,6 +112,7 @@ public enum ConfigInspectParser {
             zcodeCliPath: zcode?["cliPath"] as? String ?? "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
             zcodeAppConfigPath: zcode?["appConfigPath"] as? String
                 ?? ProviderSettings.defaultZCodeAppConfigPath,
+            zcodeProviderId: zcode?["providerId"] as? String ?? selectedProviderId,
             openAICompatibleEndpoint: desktop?["openAICompatibleEndpoint"] as? String ?? "http://localhost:8000/v1",
             providerKeyStored: providerKeyStored,
             selectedProviderId: selectedProviderId,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -112,7 +112,11 @@ public enum ConfigInspectParser {
             zcodeCliPath: zcode?["cliPath"] as? String ?? "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
             zcodeAppConfigPath: zcode?["appConfigPath"] as? String
                 ?? ProviderSettings.defaultZCodeAppConfigPath,
-            zcodeProviderId: zcode?["providerId"] as? String ?? selectedProviderId,
+            // A legacy config without an explicit execution provider is not
+            // bound. Do not invent equality with the selected registry entry:
+            // the ZCode runtime may otherwise choose a different enabled
+            // provider for a private diff.
+            zcodeProviderId: zcode?["providerId"] as? String ?? "",
             openAICompatibleEndpoint: desktop?["openAICompatibleEndpoint"] as? String ?? "http://localhost:8000/v1",
             providerKeyStored: providerKeyStored,
             selectedProviderId: selectedProviderId,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -77,15 +77,21 @@ public final class NeonDiffCLICancellation: @unchecked Sendable {
 public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable {
     private let executablePath: String
     private let workingDirectory: URL?
+    private let environmentOverrides: [String: String]
     private let standardInputPipeFactory: () -> Pipe
     private let monotonicNow: () -> DispatchTime
     private let standardInputWriter: (Int32, UnsafeRawPointer?, Int) -> Int
     private let beforeProcessLaunch: () -> Void
     private let afterProcessLaunch: () -> Void
 
-    public init(executablePath: String, workingDirectory: URL? = nil) {
+    public init(
+        executablePath: String,
+        workingDirectory: URL? = nil,
+        environmentOverrides: [String: String] = [:]
+    ) {
         self.executablePath = executablePath
         self.workingDirectory = workingDirectory
+        self.environmentOverrides = environmentOverrides
         self.standardInputPipeFactory = { Pipe() }
         self.monotonicNow = { DispatchTime.now() }
         self.standardInputWriter = { descriptor, buffer, count in
@@ -98,6 +104,7 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
     @_spi(Testing) public init(
         executablePath: String,
         workingDirectory: URL? = nil,
+        environmentOverrides: [String: String] = [:],
         standardInputPipeFactory: @escaping () -> Pipe = { Pipe() },
         monotonicNow: @escaping () -> DispatchTime = { DispatchTime.now() },
         standardInputWriter: @escaping (Int32, UnsafeRawPointer?, Int) -> Int = { descriptor, buffer, count in
@@ -108,6 +115,7 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
     ) {
         self.executablePath = executablePath
         self.workingDirectory = workingDirectory
+        self.environmentOverrides = environmentOverrides
         self.standardInputPipeFactory = standardInputPipeFactory
         self.monotonicNow = monotonicNow
         self.standardInputWriter = standardInputWriter
@@ -170,7 +178,9 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
             process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
             process.arguments = [executablePath] + arguments
         }
-        process.environment = guiSafeEnvironment()
+        process.environment = guiSafeEnvironment().merging(environmentOverrides) {
+            _, override in override
+        }
         if let workingDirectory {
             process.currentDirectoryURL = workingDirectory
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -17,7 +17,8 @@ public enum ProviderRegistryPatchBuilder {
             "zcode": [
                 "cliPath": providers.zcodeCliPath,
                 "appConfigPath": providers.zcodeAppConfigPath,
-                "model": providers.zcodeModel
+                "model": target.model,
+                "providerId": target.id
             ],
             "providers": [
                 "defaultProviderId": target.id,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -18,13 +18,17 @@ public enum ProviderRegistryPatchBuilder {
             .isEmpty
             ? providers.zcodeModel
             : target.model
+        var zcodePatch: [String: Any] = [
+            "cliPath": providers.zcodeCliPath,
+            "appConfigPath": providers.zcodeAppConfigPath,
+            "model": providers.zcodeModel
+        ]
+        if target.authMode == "zcode-app-config" {
+            zcodePatch["model"] = selectedModel
+            zcodePatch["providerId"] = target.id
+        }
         let patch: [String: Any] = [
-            "zcode": [
-                "cliPath": providers.zcodeCliPath,
-                "appConfigPath": providers.zcodeAppConfigPath,
-                "model": selectedModel,
-                "providerId": target.id
-            ],
+            "zcode": zcodePatch,
             "providers": [
                 "defaultProviderId": target.id,
                 "providers": [

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -13,11 +13,16 @@ public enum ProviderRegistryPatchBuilder {
         guard let target = providers.selectedRegistryTarget else {
             throw ProviderRegistryPatchBuilderError.missingSelectedProvider
         }
+        let selectedModel = target.model
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+            ? providers.zcodeModel
+            : target.model
         let patch: [String: Any] = [
             "zcode": [
                 "cliPath": providers.zcodeCliPath,
                 "appConfigPath": providers.zcodeAppConfigPath,
-                "model": target.model,
+                "model": selectedModel,
                 "providerId": target.id
             ],
             "providers": [
@@ -25,7 +30,7 @@ public enum ProviderRegistryPatchBuilder {
                 "providers": [
                     target.id: [
                         "baseUrl": target.baseUrl,
-                        "model": target.model
+                        "model": selectedModel
                     ]
                 ]
             ]

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -540,6 +540,185 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func selectedExistingBYOBotReverifiesThroughItsExactLocalAgentWithoutCredentialRepaste() async throws {
+        let repositories = [
+            "electricsheephq/WorldOS",
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        ]
+        let readChecks = repositories.map { repository in
+            #"{"repo":"\#(repository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+        }.joined(separator: ",")
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: repositories
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
+                    stderr: ""
+                ))
+            ],
+            suspendCLIRuns: true,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(1)
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: repositories
+        ))
+
+        #expect(fixture.model.existingLocalAgentAccessAvailable)
+        #expect(fixture.model.existingLocalBotBYOGitHubVerificationAvailable)
+        #expect(!fixture.model.byoGitHubAppIdStored)
+        #expect(!fixture.model.byoGitHubPrivateKeyStored)
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        let call = try #require(fixture.cli.calls.last)
+        #expect(call.arguments == [
+            "doctor", "github",
+            "--config", configPath,
+            "--json"
+        ])
+        #expect(call.standardInput == nil)
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(
+            fixture.model.existingLocalBotBYOGitHubVerificationStatus
+                .contains("existing local agent")
+        )
+
+        fixture.model.cliPath = "/tmp/untrusted-neondiff"
+        #expect(!fixture.model.existingLocalAgentAccessAvailable)
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(
+            fixture.model.existingLocalBotBYOGitHubVerificationStatus
+                .contains("Custom executables never receive")
+        )
+    }
+
+    @MainActor
+    @Test func selectedTargetUnlocksScopedReviewButNotMultiRepoDaemonStart() async throws {
+        let targetRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let otherRepository = "electricsheephq/WorldOS"
+        let headSHA = String(repeating: "a", count: 40)
+        let boundary = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ])
+        let activation = ExistingBotActiveActivationClient()
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [otherRepository, targetRepository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"electricsheephq/WorldOS","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true},{"repo":"electricsheephq/evaos-code-review-bot-neondiff","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":false,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":false,"useZCode":false,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0}}"#,
+                    stderr: ""
+                ))
+            ],
+            suspendCLIRuns: true,
+            activationLicenseClient: activation,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            productionBoundary: boundary
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(1)
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [otherRepository, targetRepository]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: targetRepository)
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(!fixture.model.productionDaemonStartAvailable)
+
+        fixture.model.pendingReviewPullNumber = "685"
+        fixture.model.runScopedDryReview()
+        await fixture.cli.waitUntilCallCount(3)
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.scopedDryRunHeadSHA == headSHA)
+        #expect(fixture.model.scopedLiveReviewConfirmationAvailable)
+
+        fixture.model.runScopedLiveReview()
+        await fixture.cli.waitUntilCallCount(4)
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        let liveCall = try #require(fixture.cli.calls.last)
+        #expect(liveCall.arguments.contains("--head-sha"))
+        #expect(liveCall.arguments.contains(headSHA))
+        #expect(liveCall.arguments.contains("--confirm"))
+        #expect(liveCall.arguments.contains("false"))
+        #expect(fixture.model.scopedReviewStatus.contains("posted"))
+    }
+
+    @MainActor
     @Test func existingBYOBotExplainsAppIDMismatchWithoutBlamingAMissingKey() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -691,6 +691,11 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":0,"failed":0,"skippedProcessed":1}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
                     stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
                     stderr: ""
                 )),
@@ -755,11 +760,20 @@ import NeonDiffDesktopCore
             await Task.yield()
         }
 
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+        #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
+
+        fixture.model.runScopedDryReview()
+        await fixture.cli.waitUntilCallCount(4)
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
         #expect(fixture.model.scopedDryRunHeadSHA == headSHA)
         #expect(fixture.model.scopedLiveReviewConfirmationAvailable)
 
         fixture.model.runScopedLiveReview()
-        await fixture.cli.waitUntilCallCount(4)
+        await fixture.cli.waitUntilCallCount(5)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -768,12 +782,12 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
 
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(5)
+        await fixture.cli.waitUntilCallCount(6)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
         fixture.model.runScopedLiveReview()
-        await fixture.cli.waitUntilCallCount(6)
+        await fixture.cli.waitUntilCallCount(7)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -557,6 +557,23 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedReviewRejectsAMissingExplicitZCodeProviderBinding() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(
+            existingBotConfig(
+                authMode: "zcode-app-config",
+                zcodeProviderId: nil
+            )
+        )
+
+        #expect(fixture.model.providerSetupReady)
+        #expect(!fixture.model.scopedReviewProviderReady)
+    }
+
+    @MainActor
     @Test func selectedExistingBYOBotReusesKeychainCredentialForReverification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -1041,6 +1058,34 @@ import NeonDiffDesktopCore
         }
         #expect(fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.productionDaemonStartAvailable)
+
+        fixture.loadConfig(existingBotConfig(
+            authMode: "api-key-env",
+            repositories: [repository]
+        ))
+        fixture.model.providers.providerKeyStored = true
+        fixture.model.providerVerification = ProviderVerificationSnapshot(
+            ok: true,
+            command: "providers verify",
+            providerId: "zcode-glm",
+            checkedAt: "2026-07-27T00:00:00Z",
+            state: .healthy,
+            mode: "live",
+            detail: "Provider accepted current verification.",
+            troubleshooting: [],
+            configRevision: String(repeating: "a", count: 64)
+        )
+
+        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.providerSetupReady)
+        #expect(!fixture.model.scopedReviewProviderReady)
+        #expect(!fixture.model.productionDaemonStartAvailable)
+
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [repository]
+        ))
 
         fixture.model.onboardingFlow.currentStep = .done
         fixture.model.advanceOnboarding()
@@ -1169,10 +1214,13 @@ import NeonDiffDesktopCore
     private func existingBotConfig(
         authMode: String,
         repositories: [String] = ["electricsheephq/WorldOS"],
-        zcodeProviderId: String = "zcode-glm",
+        zcodeProviderId: String? = "zcode-glm",
         revision: String = String(repeating: "a", count: 64)
     ) -> String {
         let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
+        let zcodeProviderEntry = zcodeProviderId.map {
+            #""providerId": "\#($0)","#
+        } ?? ""
         let repositoryJSON = repositories
             .map { "\"\($0)\"" }
             .joined(separator: ", ")
@@ -1184,7 +1232,7 @@ import NeonDiffDesktopCore
           "config": {
             "pilotRepos": [\#(repositoryJSON)],
             "zcode": {
-              "providerId": "\#(zcodeProviderId)",
+              \#(zcodeProviderEntry)
               "model": "GLM-5.2",
               "cliPath": "zcode",
               "appConfigPath": "zcode.json"
@@ -1322,6 +1370,12 @@ private func existingBotConfigResult(
           "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "config": {
             "pilotRepos": ["\#(repository)"],
+            "zcode": {
+              "providerId": "zcode-glm",
+              "model": "GLM-5.2",
+              "cliPath": "zcode",
+              "appConfigPath": "zcode.json"
+            },
             "providers": {
               "defaultProviderId": "zcode-glm",
               "providers": {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -711,6 +711,11 @@ import NeonDiffDesktopCore
             fixture.model.existingLocalBotBYOGitHubVerificationStatus
                 .contains("recovery")
         )
+        let diagnosis =
+            fixture.model.existingLocalBotBYOGitHubVerificationStatus
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(fixture.model.lastError == diagnosis)
+        #expect(fixture.model.byoGitHubCredentialStatus == diagnosis)
     }
 
     @MainActor

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -540,6 +540,23 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedReviewRejectsAProviderDifferentFromTheOneZCodeWillExecute() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(
+            existingBotConfig(
+                authMode: "zcode-app-config",
+                zcodeProviderId: "different-provider"
+            )
+        )
+
+        #expect(fixture.model.providerSetupReady)
+        #expect(!fixture.model.scopedReviewProviderReady)
+    }
+
+    @MainActor
     @Test func selectedExistingBYOBotReusesKeychainCredentialForReverification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -1147,6 +1164,7 @@ import NeonDiffDesktopCore
     private func existingBotConfig(
         authMode: String,
         repositories: [String] = ["electricsheephq/WorldOS"],
+        zcodeProviderId: String = "zcode-glm",
         revision: String = String(repeating: "a", count: 64)
     ) -> String {
         let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
@@ -1160,6 +1178,12 @@ import NeonDiffDesktopCore
           "revision": "\#(revision)",
           "config": {
             "pilotRepos": [\#(repositoryJSON)],
+            "zcode": {
+              "providerId": "\#(zcodeProviderId)",
+              "model": "GLM-5.2",
+              "cliPath": "zcode",
+              "appConfigPath": "zcode.json"
+            },
             "providers": {
               "defaultProviderId": "zcode-glm",
               "providers": {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -511,6 +511,35 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedReviewRequiresTheProviderConfigurationUsedByZCode() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(authMode: "api-key-env"))
+        fixture.model.providers.providerKeyStored = true
+        fixture.model.providerVerification = ProviderVerificationSnapshot(
+            ok: true,
+            command: "providers verify",
+            providerId: "zcode-glm",
+            checkedAt: "2026-07-27T00:00:00Z",
+            state: .healthy,
+            mode: "live",
+            detail: "Provider accepted current verification.",
+            troubleshooting: [],
+            configRevision: String(repeating: "a", count: 64)
+        )
+
+        #expect(fixture.model.providerSetupReady)
+        #expect(!fixture.model.scopedReviewProviderReady)
+
+        fixture.loadConfig(existingBotConfig(authMode: "zcode-app-config"))
+
+        #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.scopedReviewProviderReady)
+    }
+
+    @MainActor
     @Test func selectedExistingBYOBotReusesKeychainCredentialForReverification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -572,6 +572,7 @@ import NeonDiffDesktopCore
                     workingDirectory: "/fixture/evaos-code-review-bot"
                 )
             ],
+            localBotExecutionConfigPaths: [configPath],
             productionBoundary: .testAccountLink
         )
         fixture.model.applyAccountWorkspaceCatalog(.loaded([
@@ -622,6 +623,48 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func publicBotDiscoveryWithoutAnExecutionContextStaysInRecovery() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: ["electricsheephq/WorldOS"]
+                    ),
+                    stderr: ""
+                ))
+            ],
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: ["electricsheephq/WorldOS"]
+        ))
+
+        #expect(!fixture.model.existingLocalAgentAccessAvailable)
+        #expect(
+            fixture.model.existingLocalBotBYOGitHubVerificationStatus
+                .contains("recovery")
+        )
+    }
+
+    @MainActor
     @Test func selectedTargetUnlocksScopedReviewButNotMultiRepoDaemonStart() async throws {
         let targetRepository = "electricsheephq/evaos-code-review-bot-neondiff"
         let otherRepository = "electricsheephq/WorldOS"
@@ -648,12 +691,22 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":false,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0}}"#,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 1,
+                    stdout: #"{"ok":false,"command":"review-pr","dryRun":false,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":0,"failed":0,"skippedProcessed":1}}"#,
                     stderr: ""
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"review-pr","dryRun":false,"useZCode":false,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0}}"#,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":false,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
                     stderr: ""
                 ))
             ],
@@ -666,6 +719,7 @@ import NeonDiffDesktopCore
                     workingDirectory: "/fixture/evaos-code-review-bot"
                 )
             ],
+            localBotExecutionConfigPaths: [configPath],
             productionBoundary: boundary
         )
         fixture.model.applyAccountWorkspaceCatalog(.loaded([
@@ -710,11 +764,33 @@ import NeonDiffDesktopCore
             await Task.yield()
         }
 
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+        #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
+
+        fixture.model.runScopedDryReview()
+        await fixture.cli.waitUntilCallCount(5)
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+        fixture.model.runScopedLiveReview()
+        await fixture.cli.waitUntilCallCount(6)
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
         let liveCall = try #require(fixture.cli.calls.last)
-        #expect(liveCall.arguments.contains("--head-sha"))
-        #expect(liveCall.arguments.contains(headSHA))
-        #expect(liveCall.arguments.contains("--confirm"))
-        #expect(liveCall.arguments.contains("false"))
+        #expect(liveCall.arguments == [
+            "review-pr",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--pr", "685",
+            "--head-sha", headSHA,
+            "--expected-config-revision",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--dry-run", "false",
+            "--confirm", "true",
+            "--zcode", "true"
+        ])
         #expect(fixture.model.scopedReviewStatus.contains("posted"))
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -540,7 +540,7 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
-    @Test func selectedExistingBYOBotReverifiesThroughItsExactLocalAgentWithoutCredentialRepaste() async throws {
+    @Test func selectedExistingBYOBotPrefersItsExactLocalAgentOverStoredKeychainMaterial() async throws {
         let repositories = [
             "electricsheephq/WorldOS",
             "electricsheephq/evaos-code-review-bot-neondiff"
@@ -588,11 +588,14 @@ import NeonDiffDesktopCore
             authMode: "zcode-app-config",
             repositories: repositories
         ))
+        fixture.model.pendingBYOGitHubAppId = "4184532"
+        fixture.model.pendingBYOGitHubAppPrivateKey = existingBotFixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
 
         #expect(fixture.model.existingLocalAgentAccessAvailable)
         #expect(fixture.model.existingLocalBotBYOGitHubVerificationAvailable)
-        #expect(!fixture.model.byoGitHubAppIdStored)
-        #expect(!fixture.model.byoGitHubPrivateKeyStored)
+        #expect(fixture.model.byoGitHubAppIdStored)
+        #expect(fixture.model.byoGitHubPrivateKeyStored)
 
         fixture.model.verifyExistingLocalBotGitHubAccess()
         await fixture.cli.waitUntilCallCount(2)
@@ -711,6 +714,11 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
                     stdout: #"{"ok":true,"command":"review-pr","dryRun":false,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
                     stderr: ""
                 ))
@@ -786,8 +794,28 @@ import NeonDiffDesktopCore
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
+        #expect(fixture.model.scopedLiveReviewConfirmationAvailable)
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [otherRepository, targetRepository],
+            revision: String(repeating: "b", count: 64)
+        ))
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
         fixture.model.runScopedLiveReview()
+        await Task.yield()
+        #expect(fixture.cli.calls.count == 6)
+
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [otherRepository, targetRepository]
+        ))
+        fixture.model.runScopedDryReview()
         await fixture.cli.waitUntilCallCount(7)
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+        fixture.model.runScopedLiveReview()
+        await fixture.cli.waitUntilCallCount(8)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -1089,7 +1117,8 @@ import NeonDiffDesktopCore
 
     private func existingBotConfig(
         authMode: String,
-        repositories: [String] = ["electricsheephq/WorldOS"]
+        repositories: [String] = ["electricsheephq/WorldOS"],
+        revision: String = String(repeating: "a", count: 64)
     ) -> String {
         let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
         let repositoryJSON = repositories
@@ -1099,7 +1128,7 @@ import NeonDiffDesktopCore
         {
           "ok": true,
           "command": "config inspect",
-          "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "revision": "\#(revision)",
           "config": {
             "pilotRepos": [\#(repositoryJSON)],
             "providers": {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -276,7 +276,8 @@ import Testing
             "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyPath,
             "NODE_OPTIONS": "--use-system-ca"
         ])
-        #expect(context?.executablePath == nil)
+        #expect(context?.executablePath == "/opt/homebrew/bin/node")
+        #expect(context?.argumentPrefix == ["\(workingDirectory)/dist/src/cli.js"])
 
         var unsafeEnvironment = baseEnvironment
         unsafeEnvironment["NODE_OPTIONS"] = "--require /tmp/injected.js"
@@ -290,6 +291,42 @@ import Testing
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
             privateKeyPathIsSafe: { _ in true }
         ) == nil)
+    }
+
+    @Test func preservesTheAcceptedSourceRunnerInvocationForDesktopCommands() throws {
+        let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let nodePath = "/opt/homebrew/bin/node"
+        let sourceRunner = "\(workingDirectory)/node_modules/tsx/dist/cli.mjs"
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: [
+                    "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                    "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                ],
+                arguments: [
+                    nodePath,
+                    sourceRunner,
+                    "src/cli.ts",
+                    "daemon",
+                    "--config",
+                    configPath
+                ],
+                workingDirectory: workingDirectory
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        )
+
+        #expect(context?.executablePath == nodePath)
+        #expect(context?.argumentPrefix == [sourceRunner, "src/cli.ts"])
+        #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: "neondiff",
+            arguments: ["review-pr", "--config", configPath],
+            executionContexts: [context!]
+        ) == [sourceRunner, "src/cli.ts", "review-pr", "--config", configPath])
     }
 
     @Test func rejectsUnsafeOrConflictingExistingWorkerCredentialCoordinates() throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -43,7 +43,7 @@ import Testing
         let wrongLabel = try propertyList(
             label: "com.example.other",
             environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
-            arguments: ["neondiff", "--config", configURL.path]
+            arguments: ["neondiff", "daemon", "--config", configURL.path]
         )
         let conflictingIDs = try propertyList(
             label: "com.electricsheephq.evaos-code-review-bot",
@@ -51,7 +51,7 @@ import Testing
                 "EVAOS_REVIEW_BOT_APP_ID": "4184532",
                 "NEONDIFF_GITHUB_APP_ID": "4332113"
             ],
-            arguments: ["neondiff", "--config", configURL.path]
+            arguments: ["neondiff", "daemon", "--config", configURL.path]
         )
 
         #expect(DesktopLaunchAgentBotConfigurationParser.parse(
@@ -70,7 +70,7 @@ import Testing
             data: try propertyList(
                 label: "com.electricsheephq.evaos-code-review-bot",
                 environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
-                arguments: ["neondiff", "--config", configURL.path]
+                arguments: ["neondiff", "daemon", "--config", configURL.path]
             ),
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
             configExists: { _ in false },
@@ -80,7 +80,7 @@ import Testing
             data: try propertyList(
                 label: "com.electricsheephq.evaos-code-review-bot",
                 environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
-                arguments: ["neondiff", "--config", configURL.path],
+                arguments: ["neondiff", "daemon", "--config", configURL.path],
                 workingDirectory: "relative/path"
             ),
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
@@ -91,7 +91,7 @@ import Testing
             data: try propertyList(
                 label: "com.electricsheephq.evaos-code-review-bot",
                 environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
-                arguments: ["neondiff", "--config", configURL.path]
+                arguments: ["neondiff", "daemon", "--config", configURL.path]
             ),
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
             configExists: { _ in true },
@@ -106,6 +106,7 @@ import Testing
             environment: ["EVAOS_REVIEW_BOT_APP_ID": "4184532"],
             arguments: [
                 "neondiff",
+                "daemon",
                 "--config",
                 configURL.path,
                 "--config"
@@ -300,7 +301,7 @@ import Testing
         let data = try propertyList(
             label: "com.electricsheephq.evaos-code-review-bot",
             environment: baseEnvironment,
-            arguments: ["neondiff", "--config", configPath]
+            arguments: ["neondiff", "daemon", "--config", configPath]
         )
         #expect(DesktopLaunchAgentExecutionContextParser.parse(
             data: data,
@@ -314,7 +315,7 @@ import Testing
             data: try propertyList(
                 label: "com.electricsheephq.evaos-code-review-bot",
                 environment: conflicting,
-                arguments: ["neondiff", "--config", configPath]
+                arguments: ["neondiff", "daemon", "--config", configPath]
             ),
             expectedLabel: "com.electricsheephq.evaos-code-review-bot",
             privateKeyPathIsSafe: { _ in true }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -161,6 +161,88 @@ import Testing
         ) == fallback)
     }
 
+    @Test func normalizesExistingWorkerCredentialCoordinatesForOneExactConfig() throws {
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyURL = URL(filePath: "/Users/test/.config/neondiff/app.pem")
+            .standardizedFileURL
+        let data = try propertyList(
+            label: "com.electricsheephq.evaos-code-review-bot",
+            environment: [
+                "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyURL.path
+            ],
+            arguments: ["neondiff", "daemon", "--config", configPath]
+        )
+
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: data,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0 == privateKeyURL }
+        )
+
+        #expect(context == DesktopLocalBotExecutionContext(
+            configPath: configPath,
+            environmentOverrides: [
+                "NEONDIFF_GITHUB_APP_ID": "4184532",
+                "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyURL.path
+            ]
+        ))
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: ["review-pr", "--config", configPath, "--repo", "owner/repo"],
+            executionContexts: [context!]
+        ) == context?.environmentOverrides)
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: [
+                "review-pr",
+                "--config", configPath,
+                "--config", configPath
+            ],
+            executionContexts: [context!]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "/tmp/untrusted-neondiff",
+            arguments: ["review-pr", "--config", configPath],
+            executionContexts: [context!]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: ["config", "inspect", "--config", configPath],
+            executionContexts: [context!]
+        ).isEmpty)
+    }
+
+    @Test func rejectsUnsafeOrConflictingExistingWorkerCredentialCoordinates() throws {
+        let configPath = "/tmp/neondiff.json"
+        let baseEnvironment = [
+            "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+            "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": "/Users/test/app.pem"
+        ]
+        let data = try propertyList(
+            label: "com.electricsheephq.evaos-code-review-bot",
+            environment: baseEnvironment,
+            arguments: ["neondiff", "--config", configPath]
+        )
+        #expect(DesktopLaunchAgentExecutionContextParser.parse(
+            data: data,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { _ in false }
+        ) == nil)
+
+        var conflicting = baseEnvironment
+        conflicting["NEONDIFF_GITHUB_APP_ID"] = "4332113"
+        #expect(DesktopLaunchAgentExecutionContextParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: conflicting,
+                arguments: ["neondiff", "--config", configPath]
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { _ in true }
+        ) == nil)
+    }
+
     private func propertyList(
         label: String,
         environment: [String: String],

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -213,6 +213,53 @@ import Testing
         ).isEmpty)
     }
 
+    @Test func acceptsPackagedCLIAndPreservesOnlyTheExactSystemCAOption() throws {
+        let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let baseEnvironment = [
+            "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+            "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath,
+            "NODE_OPTIONS": "--use-system-ca"
+        ]
+        let arguments = [
+            "/opt/homebrew/bin/node",
+            "\(workingDirectory)/dist/src/cli.js",
+            "daemon",
+            "--config",
+            configPath
+        ]
+
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: baseEnvironment,
+                arguments: arguments,
+                workingDirectory: workingDirectory
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        )
+        #expect(context?.environmentOverrides == [
+            "NEONDIFF_GITHUB_APP_ID": "4184532",
+            "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyPath,
+            "NODE_OPTIONS": "--use-system-ca"
+        ])
+
+        var unsafeEnvironment = baseEnvironment
+        unsafeEnvironment["NODE_OPTIONS"] = "--require /tmp/injected.js"
+        #expect(DesktopLaunchAgentExecutionContextParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: unsafeEnvironment,
+                arguments: arguments,
+                workingDirectory: workingDirectory
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { _ in true }
+        ) == nil)
+    }
+
     @Test func rejectsUnsafeOrConflictingExistingWorkerCredentialCoordinates() throws {
         let configPath = "/tmp/neondiff.json"
         let baseEnvironment = [

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -243,6 +243,29 @@ import Testing
         ) == nil)
     }
 
+    @Test func rejectsSameLabelCredentialPlistForAnUnrelatedCommand() throws {
+        let configPath = "/tmp/neondiff.json"
+        let data = try propertyList(
+            label: "com.electricsheephq.evaos-code-review-bot",
+            environment: [
+                "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": "/Users/test/app.pem"
+            ],
+            arguments: [
+                "/usr/bin/python3",
+                "/tmp/unrelated.py",
+                "--config",
+                configPath
+            ]
+        )
+
+        #expect(DesktopLaunchAgentExecutionContextParser.parse(
+            data: data,
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { _ in true }
+        ) == nil)
+    }
+
     private func propertyList(
         label: String,
         environment: [String: String],

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -213,6 +213,36 @@ import Testing
         ).isEmpty)
     }
 
+    @Test func preservesTheExactDirectCLIExecutableFromTheExistingLaunchAgent() throws {
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let executablePath = "/Users/test/.nvm/versions/node/v24.0.0/bin/neondiff"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: [
+                    "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                    "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                ],
+                arguments: [
+                    executablePath,
+                    "daemon",
+                    "--config",
+                    configPath
+                ]
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        )
+
+        #expect(context?.executablePath == executablePath)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: ["review-pr", "--config", configPath],
+            executionContexts: [context!]
+        ) == executablePath)
+    }
+
     @Test func acceptsPackagedCLIAndPreservesOnlyTheExactSystemCAOption() throws {
         let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
         let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
@@ -245,6 +275,7 @@ import Testing
             "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": privateKeyPath,
             "NODE_OPTIONS": "--use-system-ca"
         ])
+        #expect(context?.executablePath == nil)
 
         var unsafeEnvironment = baseEnvironment
         unsafeEnvironment["NODE_OPTIONS"] = "--require /tmp/injected.js"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -724,7 +724,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.cli.calls.isEmpty)
     }
 
-    @Test func daemonRequiresExactManagedSelectionToBeAppliedAndReadBack() async {
+    @Test func daemonRequiresExactManagedSelectionToBeAppliedAndReadBack() async throws {
         let broker = ScriptedGitHubBroker()
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
@@ -745,6 +745,9 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         fixture.model.applyRepoAllowlistPatch()
         await fixture.waitForConfigPatchToFinish()
         #expect(fixture.model.productionUsefulWorkAvailable)
+        fixture.loadConfig(managedConfigInspectJSON(repository: "electric/public"))
+        try #require(fixture.model.scopedReviewProviderReady)
+        try #require(fixture.model.productionDaemonStartAvailable)
 
         fixture.model.startDaemon()
         await fixture.cli.waitUntilCallCount(2)
@@ -816,5 +819,9 @@ private func managedRepoPatchJSON(repository: String, wrote: Bool = true) -> Str
     let revisionAfter = wrote
         ? "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    return #"{"ok":true,"command":"config patch","dryRun":false,"wrote":\#(wrote),"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"\#(revisionAfter)","config":{"pilotRepos":["\#(repository)"]}}"#
+    return #"{"ok":true,"command":"config patch","dryRun":false,"wrote":\#(wrote),"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"\#(revisionAfter)","config":{"pilotRepos":["\#(repository)"],"zcode":{"providerId":"zcode-glm","model":"GLM-5.2","cliPath":"zcode","appConfigPath":"zcode.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"zcode","displayName":"ZCode GLM","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
+}
+
+private func managedConfigInspectJSON(repository: String) -> String {
+    #"{"ok":true,"command":"config inspect","revision":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["\#(repository)"],"zcode":{"providerId":"zcode-glm","model":"GLM-5.2","cliPath":"zcode","appConfigPath":"zcode.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"zcode","displayName":"ZCode GLM","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -249,6 +249,25 @@ import Testing
         #expect(source.contains("neondiff-onboarding-byo-github-verify"))
     }
 
+    @Test func b0OverviewExposesDryFirstPinnedLiveReviewActions() throws {
+        let viewsDirectory = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)
+        let overview = try sourceBoundaryText(
+            at: viewsDirectory.appendingPathComponent("OverviewView.swift")
+        )
+        let repos = try sourceBoundaryText(
+            at: viewsDirectory.appendingPathComponent("ReposView.swift")
+        )
+
+        #expect(overview.contains("model.runScopedDryReview()"))
+        #expect(overview.contains("neondiff-scoped-review-dry"))
+        #expect(overview.contains("model.scopedLiveReviewConfirmationAvailable"))
+        #expect(overview.contains("model.runScopedLiveReview()"))
+        #expect(overview.contains("confirmationDialog("))
+        #expect(overview.contains("neondiff-scoped-review-live"))
+        #expect(repos.contains("model.verifyExistingLocalBotGitHubAccess()"))
+    }
+
     @Test func activationEnabledLicenseViewHidesLegacyCredentialAndFalseBoundary() throws {
         let licenseView = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views/LicenseView.swift")

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -259,6 +259,11 @@ import Testing
                 separatedBy: ".disabled(!model.productionDaemonStartAvailable)"
             ).count - 1 == 2
         )
+        #expect(
+            source.components(
+                separatedBy: ".disabled(!model.productionUsefulWorkAvailable)"
+            ).count - 1 == 1
+        )
     }
 
     @Test func b0OverviewExposesDryFirstPinnedLiveReviewActions() throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -249,6 +249,18 @@ import Testing
         #expect(source.contains("neondiff-onboarding-byo-github-verify"))
     }
 
+    @Test func onboardingDaemonActionsUseTheDaemonSpecificReadinessGate() throws {
+        let onboardingView = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift")
+        let source = try sourceBoundaryText(at: onboardingView)
+
+        #expect(
+            source.components(
+                separatedBy: ".disabled(!model.productionDaemonStartAvailable)"
+            ).count - 1 == 2
+        )
+    }
+
     @Test func b0OverviewExposesDryFirstPinnedLiveReviewActions() throws {
         let viewsDirectory = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Views", isDirectory: true)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -239,6 +239,7 @@ struct ModelDependencyFixture {
         preferenceBools: [String: Bool] = [:],
         preferenceStrings: [String: String] = [:],
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
+        localBotExecutionConfigPaths: [String] = [],
         productionBoundary: DesktopProductionBoundary = .testVerified
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
@@ -274,7 +275,8 @@ struct ModelDependencyFixture {
             githubAuthenticator: githubAuthenticator,
             githubBroker: githubBroker,
             productionBoundary: productionBoundary,
-            localBotConfigurations: localBotConfigurations
+            localBotConfigurations: localBotConfigurations,
+            localBotExecutionConfigPaths: localBotExecutionConfigPaths
         ), activationLicenseClient: activationLicenseClient)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -238,6 +238,7 @@ struct ModelDependencyFixture {
         activationLicenseClient: (any ActivationLicenseClienting)? = nil,
         preferenceBools: [String: Bool] = [:],
         preferenceStrings: [String: String] = [:],
+        localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         productionBoundary: DesktopProductionBoundary = .testVerified
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
@@ -272,7 +273,8 @@ struct ModelDependencyFixture {
             secretStore: secretStore,
             githubAuthenticator: githubAuthenticator,
             githubBroker: githubBroker,
-            productionBoundary: productionBoundary
+            productionBoundary: productionBoundary,
+            localBotConfigurations: localBotConfigurations
         ), activationLicenseClient: activationLicenseClient)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CommandBuilderScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CommandBuilderScenarios.swift
@@ -67,6 +67,24 @@ import Darwin
     context.expect(standardInputResult.stdout.contains("\"receivedBytes\":22"), "CLI standard-input transport returns only redacted metadata")
     context.expect(!standardInputResult.stdout.contains("fixture-provider-value"), "CLI output never echoes standard input")
 
+    let environmentClient = NeonDiffCLIClient(
+        executablePath: localCLI.path,
+        workingDirectory: tempRoot,
+        environmentOverrides: [
+            "NEONDIFF_GITHUB_APP_ID": "4184532",
+            "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH": "/fixture/app.pem"
+        ]
+    )
+    let environmentResult = try environmentClient.run(
+        arguments: ["environment-check"],
+        standardInput: nil,
+        timeout: 5
+    )
+    context.expect(
+        environmentResult.exitCode == 0
+            && environmentResult.stdout.contains("\"environment\":\"present\""),
+        "CLI process receives only the explicit normalized environment overrides"
+    )
 
       return context.assertions
   }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 9, sortedMessageSHA256: "706ee5a8c88d44eab64f6210f3eb7f5d131c6a7ceb57a56c4e264edb32948b90"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 11, sortedMessageSHA256: "411c12dddad04616c56edb9e176052e208d1c82cf28f2190b4f3fadf4e1857a1"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 390)
-        #expect(Set(messages).count == 296)
-        #expect(coreChecksSHA256(messages.sorted()) == "128abf7e165503cbc4638509141efde6ac605190136f87d493facbcd02a4e083")
+        #expect(messages.count == 392)
+        #expect(Set(messages).count == 298)
+        #expect(coreChecksSHA256(messages.sorted()) == "88f583466611bd5121e4062caac06d5bb1d62f3d5cb5bbb5c1f347d92622d575")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 11, sortedMessageSHA256: "411c12dddad04616c56edb9e176052e208d1c82cf28f2190b4f3fadf4e1857a1"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 12, sortedMessageSHA256: "6e1aedf761fbafb911a260182d8e81110ab90f26ad1f26d26dfd8faf190529ef"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 392)
-        #expect(Set(messages).count == 298)
-        #expect(coreChecksSHA256(messages.sorted()) == "88f583466611bd5121e4062caac06d5bb1d62f3d5cb5bbb5c1f347d92622d575")
+        #expect(messages.count == 393)
+        #expect(Set(messages).count == 299)
+        #expect(coreChecksSHA256(messages.sorted()) == "3b058009d4feec1492e1f9d55e1f1de2bf44461c45046936f8171a9fcec168ce")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 12, sortedMessageSHA256: "6e1aedf761fbafb911a260182d8e81110ab90f26ad1f26d26dfd8faf190529ef"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 13, sortedMessageSHA256: "6bb85adae3951f123b8f4754bd23e0c0c7fffc33ea55cc8cdff83b71964f6713"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 393)
-        #expect(Set(messages).count == 299)
-        #expect(coreChecksSHA256(messages.sorted()) == "3b058009d4feec1492e1f9d55e1f1de2bf44461c45046936f8171a9fcec168ce")
+        #expect(messages.count == 394)
+        #expect(Set(messages).count == 300)
+        #expect(coreChecksSHA256(messages.sorted()) == "9ae56c81aaf49619e16d11a7f94ce462005cdf2a27907713fbc0b60ec077dfbc")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -23,7 +23,7 @@ struct LegacyCoreChecksScenarioInventory: Sendable {
 
 let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChecksScenarioInventory] = [
     .onboardingFlowContracts: .init(assertionCount: 10, sortedMessageSHA256: "fa52ef66cfc15da0fc622891de083cb4f8c6989b75cda294aa0dce7965ffed11"),
-    .cliResolutionAndStandardInputContracts: .init(assertionCount: 5, sortedMessageSHA256: "3d313d66cf17ecdf294b1235dc1f34401b74f52d33ad7d78ed4fb3d783ce1a86"),
+    .cliResolutionAndStandardInputContracts: .init(assertionCount: 6, sortedMessageSHA256: "562eaee1dd13c170588d3482b5a822bf6e1fe6d363d2221c908f47e857cf8889"),
     .cliCancellationContracts: .init(assertionCount: 10, sortedMessageSHA256: "4d93d68b30b32e326aad8d2f93dacf515d346cc3fb373a1a9061f829f3c0c0ad"),
     .cliStandardInputTimeoutContracts: .init(assertionCount: 14, sortedMessageSHA256: "a979b18020324519db8eb863c445a7bd2ca9d3a61f7f8e6a447a3742527864d4"),
     .cliCleanupDeadlineAndOutputContracts: .init(assertionCount: 15, sortedMessageSHA256: "8c562230f44b6c485ddbb0a3f414bb193a05f53a22207445c9da3590b39b2989"),
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 389)
-        #expect(Set(messages).count == 295)
-        #expect(coreChecksSHA256(messages.sorted()) == "72e1d514eeaca9cc913d0f9318274572466e599e88acec0af35db6cc9ccb3a85")
+        #expect(messages.count == 390)
+        #expect(Set(messages).count == 296)
+        #expect(coreChecksSHA256(messages.sorted()) == "128abf7e165503cbc4638509141efde6ac605190136f87d493facbcd02a4e083")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksTestSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksTestSupport.swift
@@ -111,6 +111,15 @@ final class CoreCLIFixture {
           printf '{"ok":false}\n'
           exit 2
         fi
+        if [[ "$1" == "environment-check" ]]; then
+          if [[ "$NEONDIFF_GITHUB_APP_ID" == "4184532" ]] && \
+             [[ "$NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH" == "/fixture/app.pem" ]]; then
+            printf '{"ok":true,"environment":"present"}\n'
+            exit 0
+          fi
+          printf '{"ok":false,"environment":"missing"}\n'
+          exit 3
+        fi
         printf '{"command":"%s","args":%d}\n' "$1" "$#"
         """.write(to: cliURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -25,17 +25,35 @@ import Darwin
         let providerPatchEntries = providerPatchRegistry?["providers"] as? [String: Any]
         let selectedProviderPatch = providerPatchEntries?["gateway"] as? [String: Any]
         context.expect(selectedProviderPatch?["baseUrl"] as? String == "https://saved.example/v1", "provider patch uses the selected saved registry target")
-        context.expect(providerPatchZCode?["providerId"] as? String == "gateway", "provider patch binds ZCode execution to the selected verified provider")
-        context.expect(providerPatchZCode?["model"] as? String == "saved-model", "provider patch binds ZCode execution to the selected verified model")
+        context.expect(providerPatchZCode?["providerId"] == nil, "direct provider patch preserves the existing ZCode execution provider")
+        context.expect(providerPatchZCode?["model"] as? String == "zcode-model", "direct provider patch preserves the existing ZCode execution model")
         context.expect(!providerPatchText.contains("https://legacy.example/v1"), "legacy desktop endpoint cannot enter the provider registry patch")
         context.expect(
             Set(providerPatchObject?.keys.map { $0 } ?? []) == Set(["zcode", "providers"])
-                && Set(providerPatchZCode?.keys.map { $0 } ?? []) == Set(["cliPath", "appConfigPath", "model", "providerId"])
+                && Set(providerPatchZCode?.keys.map { $0 } ?? []) == Set(["cliPath", "appConfigPath", "model"])
                 && Set(providerPatchRegistry?.keys.map { $0 } ?? []) == Set(["defaultProviderId", "providers"])
                 && Set(providerPatchEntries?.keys.map { $0 } ?? []) == Set(["gateway"])
                 && Set(selectedProviderPatch?.keys.map { $0 } ?? []) == Set(["baseUrl", "model"]),
             "provider registry patch contains only the explicit non-secret schema"
         )
+    }
+
+    let zcodeManagedSnapshot = ConfigInspectParser.parse(
+        #"{"ok":true,"command":"config inspect","revision":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","config":{"zcode":{"model":"zcode-model","cliPath":"zcode","appConfigPath":"zcode.json","providerId":"prior-zcode"},"providers":{"defaultProviderId":"zcode","providers":{"zcode":{"enabled":true,"adapter":"zcode","displayName":"ZCode","model":"zcode-model","authMode":"zcode-app-config"}}}}}"#,
+        providerKeyStored: false,
+        licenseKeyStored: false
+    )
+    if let providerSettings = zcodeManagedSnapshot?.providers {
+        let providerPatchData = try ProviderRegistryPatchBuilder.data(for: providerSettings)
+        let providerPatchObject = try JSONSerialization.jsonObject(with: providerPatchData) as? [String: Any]
+        let providerPatchZCode = providerPatchObject?["zcode"] as? [String: Any]
+        context.expect(
+            providerPatchZCode?["providerId"] as? String == "zcode"
+                && providerPatchZCode?["model"] as? String == "zcode-model",
+            "ZCode-managed provider patch binds the exact selected execution provider and model"
+        )
+    } else {
+        context.expect(false, "ZCode-managed registry snapshot remains parseable")
     }
 
     let emptyModelSnapshot = ConfigInspectParser.parse(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -25,10 +25,12 @@ import Darwin
         let providerPatchEntries = providerPatchRegistry?["providers"] as? [String: Any]
         let selectedProviderPatch = providerPatchEntries?["gateway"] as? [String: Any]
         context.expect(selectedProviderPatch?["baseUrl"] as? String == "https://saved.example/v1", "provider patch uses the selected saved registry target")
+        context.expect(providerPatchZCode?["providerId"] as? String == "gateway", "provider patch binds ZCode execution to the selected verified provider")
+        context.expect(providerPatchZCode?["model"] as? String == "saved-model", "provider patch binds ZCode execution to the selected verified model")
         context.expect(!providerPatchText.contains("https://legacy.example/v1"), "legacy desktop endpoint cannot enter the provider registry patch")
         context.expect(
             Set(providerPatchObject?.keys.map { $0 } ?? []) == Set(["zcode", "providers"])
-                && Set(providerPatchZCode?.keys.map { $0 } ?? []) == Set(["cliPath", "appConfigPath", "model"])
+                && Set(providerPatchZCode?.keys.map { $0 } ?? []) == Set(["cliPath", "appConfigPath", "model", "providerId"])
                 && Set(providerPatchRegistry?.keys.map { $0 } ?? []) == Set(["defaultProviderId", "providers"])
                 && Set(providerPatchEntries?.keys.map { $0 } ?? []) == Set(["gateway"])
                 && Set(selectedProviderPatch?.keys.map { $0 } ?? []) == Set(["baseUrl", "model"]),

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -38,5 +38,30 @@ import Darwin
         )
     }
 
+    let emptyModelSnapshot = ConfigInspectParser.parse(
+        #"{"ok":true,"command":"config inspect","revision":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"zcode":{"model":"fallback-model","cliPath":"zcode","appConfigPath":"zcode.json"},"providers":{"defaultProviderId":"gateway","providers":{"gateway":{"enabled":true,"adapter":"openai-compatible","displayName":"Gateway","baseUrl":"https://saved.example/v1","model":"","authMode":"api-key-env"}}}}}"#,
+        providerKeyStored: true,
+        licenseKeyStored: false
+    )
+    if let providerSettings = emptyModelSnapshot?.providers {
+        let providerPatchData = try ProviderRegistryPatchBuilder.data(
+            for: providerSettings
+        )
+        let providerPatchObject = try JSONSerialization.jsonObject(
+            with: providerPatchData
+        ) as? [String: Any]
+        let providerPatchZCode = providerPatchObject?["zcode"]
+            as? [String: Any]
+        context.expect(
+            providerPatchZCode?["model"] as? String == "fallback-model",
+            "empty registry models fall back to the current ZCode model"
+        )
+    } else {
+        context.expect(
+            false,
+            "empty-model registry snapshot remains parseable for safe fallback"
+        )
+    }
+
       return context.assertions
   }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -413,10 +413,12 @@ neondiff review-pr \
   --config config.local.json \
   --repo owner/name \
   --pr 123 \
+  --expected-config-revision <verified-config-revision> \
   --dry-run true \
-  --zcode false
+  --zcode true
 ```
 
+Use the exact `configRevision` returned by the successful provider verification.
 Do not run with `--dry-run false` until dry-run evidence, focused tests, and
 the relevant issue explicitly approve the exact repo, PR, head SHA, and config
 path.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -297,8 +297,14 @@ the same Mac. In that exact case it opens a reconciliation path:
   not as missing NeonDiff Keychain API keys;
 - if the worker allowlist contains multiple repositories, it keeps every entry
   unchanged and requires one explicit **Review Target** for native activation;
-  that target is restored only for the same config path, while native review
-  and daemon controls remain blocked until runtime scoping is available;
+  that target is restored only for the same config path;
+- it can reverify and invoke the exact matched LaunchAgent configuration without
+  copying its private key. The key file must be a current-user-owned regular
+  file with no group/other permissions and is passed to the CLI only as a
+  child-process environment coordinate for the exact config;
+- Overview runs one repository/PR-scoped dry review first. A live review is
+  enabled only for the returned 40-character head SHA and requires explicit
+  confirmation; daemon-wide start stays blocked for multi-repository workers;
 - it keeps new work blocked until the exact current GitHub/repository and
   entitlement checks required by the release path pass.
 
@@ -362,9 +368,10 @@ Keychain, select and apply one repository, and verify that installation without
 an operator editing local files. For a reconciled existing worker with a
 multi-repository allowlist, choose one **Review Target** in the repository
 table; this binds activation without changing the worker's other configured
-repositories. Native review and daemon controls remain blocked for that
-multi-repository worker until the runtime can be scoped safely. The managed B1
-broker remains a separate path.
+repositories. The native app can run one scoped dry review through the exact
+matched local agent, then offer a confirmed live post pinned to that dry-run
+head. It still does not start the multi-repository daemon or rewrite its
+allowlist. The managed B1 broker remains a separate path.
 The dashboard shows license status, GitHub App status, daemon status, and
 provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -300,11 +300,12 @@ the same Mac. In that exact case it opens a reconciliation path:
   that target is restored only for the same config path;
 - it can reverify and invoke the exact matched LaunchAgent configuration without
   copying its private key. The key file must be a current-user-owned regular
-  file with no group/other permissions and is passed to the CLI only as a
-  child-process environment coordinate for the exact config;
+  file with no group/other permissions. Only its file path—not its key bytes—is
+  supplied as a child-process environment coordinate for the exact config;
 - Overview runs one repository/PR-scoped dry review first. A live review is
   enabled only for the returned 40-character head SHA and requires explicit
-  confirmation; daemon-wide start stays blocked for multi-repository workers;
+  confirmation (see [Run A Dry-Run Review](#5-run-a-dry-run-review));
+  daemon-wide start stays blocked for multi-repository workers;
 - it keeps new work blocked until the exact current GitHub/repository and
   entitlement checks required by the release path pass.
 
@@ -339,9 +340,11 @@ The relative `config.local.json` examples elsewhere in this guide remain the
 separate CLI-first/operator path; they do not inspect the native app's config.
 
 The private key must be one unencrypted RSA PKCS#1 or PKCS#8 PEM no larger than
-64 KiB. Do not put it in arguments, environment variables, config, logs, or
-evidence. A passing doctor proves only current installation/repository read
-access for the configured allowlist; it does not execute or post a review.
+64 KiB. Do not put the private-key bytes in arguments, environment variables,
+config, logs, or evidence. The reconciled-existing-worker path may supply only
+the already-configured private-key file path to the exact child process. A
+passing doctor proves only current installation/repository read access for the
+configured allowlist; it does not execute or post a review.
 
 Check:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -302,9 +302,11 @@ the same Mac. In that exact case it opens a reconciliation path:
   copying its private key. The key file must be a current-user-owned regular
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
-- Overview runs one repository/PR-scoped dry review first. A live review is
-  enabled only for the returned 40-character head SHA and requires explicit
-  confirmation (see [Run A Dry-Run Review](#5-run-a-dry-run-review));
+- Overview runs one provider-backed repository/PR-scoped dry review first. A
+  live review is enabled only for that config revision and the returned
+  40-character head SHA, and requires explicit confirmation (see
+  [Run A Dry-Run Review](#5-run-a-dry-run-review)); a transport failure revokes
+  the approval and requires a new dry review;
   daemon-wide start stays blocked for multi-repository workers;
 - it keeps new work blocked until the exact current GitHub/repository and
   entitlement checks required by the release path pass.

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -65,7 +65,13 @@ npm install -g neondiff
 cp config.example.json "$RUNNER_TEMP/config.local.json"
 neondiff doctor github --config "$RUNNER_TEMP/config.local.json" --json
 neondiff providers list --config "$RUNNER_TEMP/config.local.json" --json
-neondiff review-pr --config "$RUNNER_TEMP/config.local.json" --repo owner/name --pr "$PR_NUMBER" --dry-run true
+neondiff review-pr \
+  --config "$RUNNER_TEMP/config.local.json" \
+  --repo owner/name \
+  --pr "$PR_NUMBER" \
+  --expected-config-revision "<verified-config-revision>" \
+  --zcode true \
+  --dry-run true
 ```
 
 Use CI for one-shot checks. Use [docs/systemd.md](systemd.md) or

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -123,9 +123,10 @@ config path and does not edit, remove, or disable the worker's other
 repositories. For an exact matched LaunchAgent, the app may pass the existing
 App ID and private-key file coordinate only to the child CLI process for that
 config; it does not read, copy, print, or store the key. Overview runs one
-repository/PR-scoped dry review, records the returned head SHA, and requires
-explicit confirmation before a live post pinned to that head. Daemon-wide start
-stays blocked for a multi-repository worker.
+provider-backed repository/PR-scoped dry review, records the config revision and
+returned head SHA, and requires explicit confirmation before a live post pinned
+to both. Any transport failure revokes approval and requires a new dry review.
+Daemon-wide start stays blocked for a multi-repository worker.
 
 Keep the private key and local config out of git. A typical shell setup is:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -120,9 +120,12 @@ repositories. NeonDiff preserves that allowlist and requires one explicit
 **Review Target** in the native repository table. The Activation Key request
 binds to that target only. The target selection is scoped to the exact local
 config path and does not edit, remove, or disable the worker's other
-repositories. Native review and daemon controls stay blocked for a
-multi-repository worker until the runtime can be scoped to that target without
-rewriting the worker configuration.
+repositories. For an exact matched LaunchAgent, the app may pass the existing
+App ID and private-key file coordinate only to the child CLI process for that
+config; it does not read, copy, print, or store the key. Overview runs one
+repository/PR-scoped dry review, records the returned head SHA, and requires
+explicit confirmation before a live post pinned to that head. Daemon-wide start
+stays blocked for a multi-repository worker.
 
 Keep the private key and local config out of git. A typical shell setup is:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -223,10 +223,12 @@ neondiff review-pr \
   --config config.local.json \
   --repo owner/name \
   --pr 123 \
+  --expected-config-revision <verified-config-revision> \
   --dry-run true \
-  --zcode false
+  --zcode true
 ```
 
+Use the exact `configRevision` returned by the successful provider verification.
 Only move to live review after the dry-run output and evidence are inspected and
 the exact repo, PR, head SHA, config path, and posting intent are recorded in
 the relevant issue.

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -240,10 +240,13 @@ evaos-review-bot status --config config.local.json
 - `init --config <path>`: copy `config.example.json` to a local config path
   without embedding credentials. Refuses to overwrite unless `--force true` is
   supplied.
-- `review-pr --repo <owner/name> --pr <number> --dry-run true`: public alias for
-  the existing scoped `run-once` review command. Live posting through this
-  public alias requires `--dry-run false --confirm true` after the exact repo,
-  PR, head SHA, and config path are approved.
+- `review-pr --config <path> --repo <owner/name> --pr <number>
+  --expected-config-revision <verified-revision> --zcode true --dry-run true`:
+  public alias for the existing scoped `run-once` review command. Use the exact
+  `configRevision` returned by successful provider verification; the command
+  fails closed if the config or ZCode provider binding changes. Live posting
+  through this public alias requires `--dry-run false --confirm true` after the
+  exact repo, PR, head SHA, config path, and revision are approved.
 - `daemon start|stop|status`: JSON-first macOS launchd controls. On Linux and
   other non-Darwin platforms these subcommands fail closed with
   `serviceManager: "systemd"` and a pointer to [docs/systemd.md](systemd.md)

--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -269,8 +269,9 @@ neondiff review-pr \
   --config "$work_dir/config.local.json" \
   --repo owner/name \
   --pr 123 \
+  --expected-config-revision "<verified-config-revision>" \
   --dry-run true \
-  --zcode false
+  --zcode true
 ```
 
 Evidence to capture:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2053,6 +2053,9 @@ async function main(): Promise<void> {
       }
     }
     const useZCode = args.zcode !== "false";
+    const expectedConfigRevision = args["expected-config-revision"]
+      ? parseSingleArg(args["expected-config-revision"], "--expected-config-revision")
+      : undefined;
     let pullNumber: number | undefined;
     try {
       pullNumber = args.pr ? parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr") : undefined;
@@ -2076,7 +2079,12 @@ async function main(): Promise<void> {
         repo,
         pullNumber,
         useZCode,
-        expectedHeadSha: reviewPrExpectedHeadSha
+        expectedHeadSha: reviewPrExpectedHeadSha,
+        expectedConfigRevision,
+        processedHeadPolicy:
+          command === "review-pr" && !dryRun && reviewPrExpectedHeadSha
+            ? "approved_dry_run"
+            : "normal"
       },
       commandName: command,
       admitImpl: async () => {
@@ -3304,7 +3312,8 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--repo", description: "Repo to review, owner/name (required)." },
       { name: "--pr", description: "Pull request number to review (required)." },
       { name: "--dry-run", description: "true (default) or false; false requires --confirm true." },
-      { name: "--confirm", description: "Must be true to allow --dry-run false." }
+      { name: "--confirm", description: "Must be true to allow --dry-run false." },
+      { name: "--expected-config-revision", description: "Optional lowercase SHA-256 config revision pin for dry and live execution." }
     ]
   },
   "run-once": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2104,7 +2104,9 @@ async function main(): Promise<void> {
         processedHeadPolicy:
           command === "review-pr" && !dryRun && reviewPrExpectedHeadSha
             ? "approved_dry_run"
-            : "normal"
+            : command === "review-pr" && dryRun
+              ? "refresh_dry_run"
+              : "normal"
       },
       commandName: command,
       admitImpl: async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2072,6 +2072,26 @@ async function main(): Promise<void> {
       }
       throw error;
     }
+    if (command === "review-pr" && !expectedConfigRevision) {
+      console.log(JSON.stringify({
+        ok: false,
+        command: "review-pr",
+        ...(repo ? { repo } : {}),
+        error: "review-pr requires --expected-config-revision for dry and live review approval"
+      }, null, 2));
+      process.exitCode = 1;
+      return;
+    }
+    if (command === "review-pr" && !useZCode) {
+      console.log(JSON.stringify({
+        ok: false,
+        command: "review-pr",
+        ...(repo ? { repo } : {}),
+        error: "review-pr requires --zcode true so the approved dry run and live review execute the same provider path"
+      }, null, 2));
+      process.exitCode = 1;
+      return;
+    }
     const result = await runOnceCliCommand({
       options: {
         configPath: args.config,
@@ -2422,7 +2442,7 @@ function runInitCommand(args: ParsedArgs): {
     ...(backupPath ? { backupPath } : {}),
     recommendedCommands: [
       `neondiff doctor --config ${configPath} --json`,
-      `neondiff review-pr --config ${configPath} --repo owner/name --pr 123 --dry-run true --zcode false`,
+      `neondiff review-pr --config ${configPath} --repo owner/name --pr 123 --expected-config-revision <verified-config-revision> --dry-run true --zcode true`,
       `neondiff status --config ${configPath} --json`
     ],
   };
@@ -3064,7 +3084,7 @@ async function buildDoctorGithubReport(config: BotConfig, credentials?: DoctorGi
       privateRepoDataStaysLocal: true
     },
     nextCommands: [
-      "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true --zcode false",
+      "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --expected-config-revision <verified-config-revision> --dry-run true --zcode true",
       "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff"
     ],
     troubleshooting: [
@@ -3313,7 +3333,8 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--pr", description: "Pull request number to review (required)." },
       { name: "--dry-run", description: "true (default) or false; false requires --confirm true." },
       { name: "--confirm", description: "Must be true to allow --dry-run false." },
-      { name: "--expected-config-revision", description: "Optional lowercase SHA-256 config revision pin for dry and live execution." }
+      { name: "--expected-config-revision", description: "Required lowercase SHA-256 config revision from provider verification for dry and live execution." },
+      { name: "--zcode", description: "Must be true so dry and live reviews execute the same provider path." }
     ]
   },
   "run-once": {
@@ -3498,7 +3519,7 @@ function buildHelp(command?: string) {
       "neondiff license deactivate --config config.local.json --json",
       "neondiff doctor --config config.local.json --json",
       "neondiff doctor github --config config.local.json --json",
-      "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true --zcode false",
+      "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --expected-config-revision <verified-config-revision> --dry-run true --zcode true",
       "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff",
       "neondiff daemon start --launchd-label com.example.neondiff --dry-run true",
       "neondiff daemon stop --launchd-label com.example.neondiff --dry-run true",

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -4,6 +4,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from "node:net";
 import { join, resolve } from "node:path";
 import type { BotConfig } from "./config.js";
+import { loadConfigAtRevision } from "./config-cli.js";
 import { getLicenseStatus, type LicenseStatusResult } from "./license.js";
 import { isAuthenticProductionLicenseAdmission, requireActiveProductionLicense } from "./license-admission.js";
 import { writeSecureFileSync } from "./temp-files.js";
@@ -145,7 +146,13 @@ export async function buildLocalDashboardStatus(input: {
     : buildProviderStatusItem(input.config.providers!, checkedAt);
   const items = { license, githubApp, daemon, provider };
   const ok = Object.values(items).every((item) => item.state === "healthy" || item.state === "degraded");
-  const verifiedConfigRevision = input.providerVerification?.configRevision;
+  const candidateConfigRevision = input.providerVerification?.ok
+    ? input.providerVerification.configRevision
+    : undefined;
+  const verifiedConfigRevision = candidateConfigRevision &&
+    /^[a-f0-9]{64}$/.test(candidateConfigRevision)
+    ? candidateConfigRevision
+    : undefined;
   const firstReviewCommand = verifiedConfigRevision
     ? "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 "
       + `--expected-config-revision ${verifiedConfigRevision} --zcode true --dry-run true`
@@ -721,12 +728,31 @@ export async function startLocalDashboardServer(input: {
           return;
         }
         const body = await readJsonBody(request);
-        latestVerification = await verifyProviderApiKey({
-          config: input.config,
+        const configSnapshot = input.configExists && existsSync(input.configPath)
+          ? loadConfigAtRevision(input.configPath)
+          : undefined;
+        const verification = await verifyProviderApiKey({
+          config: configSnapshot?.config ?? input.config,
           providerId: readOptionalString(body, "providerId"),
           apiKey: readOptionalString(body, "apiKey"),
           allowRemoteSmoke: readOptionalBoolean(body, "allowRemoteSmoke") || input.allowRemoteSmoke === true
         });
+        if (configSnapshot) {
+          const currentRevision = loadConfigAtRevision(input.configPath).revision;
+          latestVerification = currentRevision === configSnapshot.revision
+            ? { ...verification, configRevision: configSnapshot.revision }
+            : {
+                ...verification,
+                ok: false,
+                state: "blocked",
+                detail: "Configuration changed during provider verification. Reload and verify again.",
+                troubleshooting: [
+                  "Reload the dashboard and repeat provider verification against the current configuration."
+                ]
+              };
+        } else {
+          latestVerification = verification;
+        }
         writeResponse(response, latestVerification.ok ? 200 : 422, "application/json; charset=utf-8", stringifyRedactedJson(latestVerification));
         return;
       }

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -744,7 +744,7 @@ export async function startLocalDashboardServer(input: {
           return;
         }
         const body = await readJsonBody(request);
-        const configSnapshot = input.configExists && existsSync(input.configPath)
+        const configSnapshot = existsSync(input.configPath)
           ? loadConfigAtRevision(input.configPath)
           : undefined;
         const verification = await verifyProviderApiKey({

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -145,6 +145,8 @@ export async function buildLocalDashboardStatus(input: {
     : buildProviderStatusItem(input.config.providers!, checkedAt);
   const items = { license, githubApp, daemon, provider };
   const ok = Object.values(items).every((item) => item.state === "healthy" || item.state === "degraded");
+  const verifiedConfigRevision =
+    input.providerVerification?.configRevision ?? "<run-neondiff-providers-verify-first>";
 
   return redactedStatus({
     ok,
@@ -166,7 +168,9 @@ export async function buildLocalDashboardStatus(input: {
       detail: ok
         ? "Configuration looks ready for a dry-run PR review."
         : "Complete blocked setup items before running a review.",
-      command: "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true"
+      command:
+        "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 "
+        + `--expected-config-revision ${verifiedConfigRevision} --zcode true --dry-run true`
     },
     proofBoundary: "Local dashboard readiness only; this does not prove signed desktop release, appcast, notarization, or live review quality."
   });

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -145,8 +145,11 @@ export async function buildLocalDashboardStatus(input: {
     : buildProviderStatusItem(input.config.providers!, checkedAt);
   const items = { license, githubApp, daemon, provider };
   const ok = Object.values(items).every((item) => item.state === "healthy" || item.state === "degraded");
-  const verifiedConfigRevision =
-    input.providerVerification?.configRevision ?? "<run-neondiff-providers-verify-first>";
+  const verifiedConfigRevision = input.providerVerification?.configRevision;
+  const firstReviewCommand = verifiedConfigRevision
+    ? "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 "
+      + `--expected-config-revision ${verifiedConfigRevision} --zcode true --dry-run true`
+    : "neondiff providers doctor --config config.local.json --json";
 
   return redactedStatus({
     ok,
@@ -164,13 +167,13 @@ export async function buildLocalDashboardStatus(input: {
       options: buildProviderOptions(input.config.providers!)
     },
     firstReviewPreview: {
-      available: ok,
-      detail: ok
+      available: ok && Boolean(verifiedConfigRevision),
+      detail: ok && verifiedConfigRevision
         ? "Configuration looks ready for a dry-run PR review."
-        : "Complete blocked setup items before running a review.",
-      command:
-        "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 "
-        + `--expected-config-revision ${verifiedConfigRevision} --zcode true --dry-run true`
+        : ok
+          ? "Verify the provider configuration before running a review."
+          : "Complete blocked setup items before running a review.",
+      command: firstReviewCommand
     },
     proofBoundary: "Local dashboard readiness only; this does not prove signed desktop release, appcast, notarization, or live review quality."
   });

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -562,6 +562,7 @@ export function renderLocalDashboardHtml(status: LocalDashboardStatusContract): 
         });
         const json = await response.json();
         output.textContent = JSON.stringify(json, null, 2);
+        if (response.ok && json.ok) window.location.reload();
       } catch (error) {
         output.textContent = JSON.stringify({ ok: false, error: String(error) }, null, 2);
       } finally {
@@ -681,8 +682,9 @@ export async function startLocalDashboardServer(input: {
   requireActiveProductionLicense?: typeof requireActiveProductionLicense;
 }): Promise<LocalDashboardServerHandle> {
   let latestVerification: ProviderApiKeyVerificationResult | undefined;
+  let statusConfig = input.config;
   let status = await buildLocalDashboardStatus({
-    config: input.config,
+    config: statusConfig,
     configPath: input.configPath,
     configExists: input.configExists,
     launchdLabel: input.launchdLabel,
@@ -693,7 +695,7 @@ export async function startLocalDashboardServer(input: {
       const url = new URL(request.url ?? "/", `http://${input.host ?? "127.0.0.1"}`);
       if (request.method === "GET" && url.pathname === "/") {
         status = await buildLocalDashboardStatus({
-          config: input.config,
+          config: statusConfig,
           configPath: input.configPath,
           configExists: input.configExists,
           launchdLabel: input.launchdLabel,
@@ -704,7 +706,7 @@ export async function startLocalDashboardServer(input: {
       }
       if (request.method === "GET" && url.pathname === "/api/status") {
         status = await buildLocalDashboardStatus({
-          config: input.config,
+          config: statusConfig,
           configPath: input.configPath,
           configExists: input.configExists,
           launchdLabel: input.launchdLabel,
@@ -763,6 +765,9 @@ export async function startLocalDashboardServer(input: {
                   "Reload the dashboard and repeat provider verification against the current configuration."
                 ]
               };
+          if (currentRevision === configSnapshot.revision) {
+            statusConfig = configSnapshot.config;
+          }
         } else {
           latestVerification = verification;
         }

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -158,7 +158,8 @@ export async function buildLocalDashboardStatus(input: {
   const scopedReviewProviderReady =
     selectedProvider?.enabled === true &&
     selectedProvider.authMode === "zcode-app-config" &&
-    input.providerVerification?.providerId === selectedProviderId;
+    input.providerVerification?.providerId === selectedProviderId &&
+    input.config.zcode.providerId === selectedProviderId;
   const quotedConfigPath = shellQuoteCommandArg(input.configPath);
   const firstReviewCommand = verifiedConfigRevision && scopedReviewProviderReady
     ? `neondiff review-pr --config ${quotedConfigPath} --repo owner/repo --pr 123 `

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -153,10 +153,17 @@ export async function buildLocalDashboardStatus(input: {
     /^[a-f0-9]{64}$/.test(candidateConfigRevision)
     ? candidateConfigRevision
     : undefined;
-  const firstReviewCommand = verifiedConfigRevision
-    ? "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 "
+  const selectedProviderId = input.config.providers!.defaultProviderId;
+  const selectedProvider = input.config.providers!.providers[selectedProviderId];
+  const scopedReviewProviderReady =
+    selectedProvider?.enabled === true &&
+    selectedProvider.authMode === "zcode-app-config" &&
+    input.providerVerification?.providerId === selectedProviderId;
+  const quotedConfigPath = shellQuoteCommandArg(input.configPath);
+  const firstReviewCommand = verifiedConfigRevision && scopedReviewProviderReady
+    ? `neondiff review-pr --config ${quotedConfigPath} --repo owner/repo --pr 123 `
       + `--expected-config-revision ${verifiedConfigRevision} --zcode true --dry-run true`
-    : "neondiff providers doctor --config config.local.json --json";
+    : `neondiff providers doctor --config ${quotedConfigPath} --json`;
 
   return redactedStatus({
     ok,
@@ -174,8 +181,8 @@ export async function buildLocalDashboardStatus(input: {
       options: buildProviderOptions(input.config.providers!)
     },
     firstReviewPreview: {
-      available: ok && Boolean(verifiedConfigRevision),
-      detail: ok && verifiedConfigRevision
+      available: ok && Boolean(verifiedConfigRevision) && scopedReviewProviderReady,
+      detail: ok && verifiedConfigRevision && scopedReviewProviderReady
         ? "Configuration looks ready for a dry-run PR review."
         : ok
           ? "Verify the provider configuration before running a review."
@@ -184,6 +191,12 @@ export async function buildLocalDashboardStatus(input: {
     },
     proofBoundary: "Local dashboard readiness only; this does not prove signed desktop release, appcast, notarization, or live review quality."
   });
+}
+
+function shellQuoteCommandArg(value: string): string {
+  return /^[A-Za-z0-9_./:=@%+-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 export async function verifyProviderApiKey(input: ProviderApiKeyVerificationInput): Promise<ProviderApiKeyVerificationResult> {

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { join, resolve } from "node:path";
-import type { BotConfig } from "./config.js";
+import { loadConfigFromObject, type BotConfig } from "./config.js";
 import { loadConfigAtRevision } from "./config-cli.js";
 import { getLicenseStatus, type LicenseStatusResult } from "./license.js";
 import { isAuthenticProductionLicenseAdmission, requireActiveProductionLicense } from "./license-admission.js";
@@ -684,10 +684,11 @@ export async function startLocalDashboardServer(input: {
 }): Promise<LocalDashboardServerHandle> {
   let latestVerification: ProviderApiKeyVerificationResult | undefined;
   let statusConfig = input.config;
+  let statusConfigExists = input.configExists;
   let status = await buildLocalDashboardStatus({
     config: statusConfig,
     configPath: input.configPath,
-    configExists: input.configExists,
+    configExists: statusConfigExists,
     launchdLabel: input.launchdLabel,
     providerVerification: latestVerification
   });
@@ -698,7 +699,7 @@ export async function startLocalDashboardServer(input: {
         status = await buildLocalDashboardStatus({
           config: statusConfig,
           configPath: input.configPath,
-          configExists: input.configExists,
+          configExists: statusConfigExists,
           launchdLabel: input.launchdLabel,
           providerVerification: latestVerification
         });
@@ -709,7 +710,7 @@ export async function startLocalDashboardServer(input: {
         status = await buildLocalDashboardStatus({
           config: statusConfig,
           configPath: input.configPath,
-          configExists: input.configExists,
+          configExists: statusConfigExists,
           launchdLabel: input.launchdLabel,
           providerVerification: latestVerification
         });
@@ -747,15 +748,35 @@ export async function startLocalDashboardServer(input: {
         const configSnapshot = existsSync(input.configPath)
           ? loadConfigAtRevision(input.configPath)
           : undefined;
+        if (!configSnapshot) {
+          statusConfig = loadConfigFromObject({});
+          statusConfigExists = false;
+          latestVerification = redactedVerification({
+            ok: false,
+            command: "dashboard verify-provider",
+            checkedAt: new Date().toISOString(),
+            providerId: readOptionalString(body, "providerId")
+              ?? input.config.providers!.defaultProviderId,
+            state: "blocked",
+            mode: "metadata_only",
+            detail: "The NeonDiff config file is missing. Initialize or restore it before provider verification.",
+            redacted: true,
+            troubleshooting: [
+              "Initialize or restore the config file, reload the dashboard, and repeat provider verification."
+            ]
+          });
+          writeResponse(response, 422, "application/json; charset=utf-8", stringifyRedactedJson(latestVerification));
+          return;
+        }
         const verification = await verifyProviderApiKey({
-          config: configSnapshot?.config ?? input.config,
+          config: configSnapshot.config,
           providerId: readOptionalString(body, "providerId"),
           apiKey: readOptionalString(body, "apiKey"),
           allowRemoteSmoke: readOptionalBoolean(body, "allowRemoteSmoke") || input.allowRemoteSmoke === true
         });
-        if (configSnapshot) {
-          const currentRevision = loadConfigAtRevision(input.configPath).revision;
-          latestVerification = currentRevision === configSnapshot.revision
+        {
+          const currentSnapshot = loadConfigAtRevision(input.configPath);
+          latestVerification = currentSnapshot.revision === configSnapshot.revision
             ? { ...verification, configRevision: configSnapshot.revision }
             : {
                 ...verification,
@@ -766,11 +787,12 @@ export async function startLocalDashboardServer(input: {
                   "Reload the dashboard and repeat provider verification against the current configuration."
                 ]
               };
-          if (currentRevision === configSnapshot.revision) {
+          statusConfigExists = true;
+          if (currentSnapshot.revision === configSnapshot.revision) {
             statusConfig = configSnapshot.config;
+          } else {
+            statusConfig = currentSnapshot.config;
           }
-        } else {
-          latestVerification = verification;
         }
         writeResponse(response, latestVerification.ok ? 200 : 422, "application/json; charset=utf-8", stringifyRedactedJson(latestVerification));
         return;

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -63,7 +63,15 @@ export function buildRunOnceCliReport(input: {
 }
 
 export function runOnceCliExitCode(result: RunOnceResult, input: { dryRun?: boolean } = {}): 0 | 1 {
-  return result.failed > 0 || (!input.dryRun && Boolean(result.scopedPull) && (result.skippedLicenseGate ?? 0) > 0) ? 1 : 0;
+  const scopedLiveDidNotPost =
+    !input.dryRun &&
+    Boolean(result.scopedPull) &&
+    result.reviewed !== 1;
+  return result.failed > 0 ||
+    scopedLiveDidNotPost ||
+    (!input.dryRun && Boolean(result.scopedPull) && (result.skippedLicenseGate ?? 0) > 0)
+    ? 1
+    : 0;
 }
 
 export function serializeRunOnceCliReport(report: RunOnceCliReport): string {

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -47,9 +47,13 @@ export function buildRunOnceCliReport(input: {
   pullNumber?: number;
   commandName?: "run-once" | "review-pr";
 }): RunOnceCliReport {
+  const commandName = input.commandName ?? "run-once";
   return {
-    ok: runOnceCliExitCode(input.result, { dryRun: input.dryRun }) === 0,
-    command: input.commandName ?? "run-once",
+    ok: runOnceCliExitCode(input.result, {
+      dryRun: input.dryRun,
+      commandName
+    }) === 0,
+    command: commandName,
     dryRun: input.dryRun,
     useZCode: input.useZCode,
     scope: {
@@ -62,8 +66,15 @@ export function buildRunOnceCliReport(input: {
   };
 }
 
-export function runOnceCliExitCode(result: RunOnceResult, input: { dryRun?: boolean } = {}): 0 | 1 {
+export function runOnceCliExitCode(
+  result: RunOnceResult,
+  input: {
+    dryRun?: boolean;
+    commandName?: "run-once" | "review-pr";
+  } = {}
+): 0 | 1 {
   const scopedLiveDidNotPost =
+    input.commandName === "review-pr" &&
     !input.dryRun &&
     Boolean(result.scopedPull) &&
     result.reviewed !== 1;
@@ -119,7 +130,10 @@ export async function runOnceCliCommand(input: {
   return {
     report,
     output: serializeRunOnceCliReport(report),
-    exitCode: runOnceCliExitCode(result, { dryRun: input.options.dryRun })
+    exitCode: runOnceCliExitCode(result, {
+      dryRun: input.options.dryRun,
+      commandName: input.commandName ?? "run-once"
+    })
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -121,6 +121,13 @@ export const ACTIVATION_BASELINE_EXISTING_HEAD_ERROR = "activation_baseline_exis
 export const EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR = "exact_authorization_already_consumed";
 export const POST_REVIEW_HEAD_UNVERIFIED_ERROR = "post_review_head_unverified";
 export const APPROVED_DRY_RUN_LIVE_CLAIM_ERROR = "approved_dry_run_consumed_for_live_post";
+
+export function isRetryableApprovedDryRunPrePostFailure(
+  record: Pick<ProcessedReviewRecord, "status" | "error"> | undefined
+): boolean {
+  return record?.status === "skipped" &&
+    record.error?.startsWith(`${APPROVED_DRY_RUN_LIVE_CLAIM_ERROR}; post_error=`) === true;
+}
 export const REVIEW_POSTED_HEAD_CHANGED_ERROR = "review_posted_head_changed";
 
 export function isActivationBaselineProcessedReview(
@@ -958,10 +965,18 @@ export class ReviewStateStore {
         .get(record.repo, record.pullNumber, record.headSha);
       const processed = this.db
         .prepare(
-          "select status from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1"
+          "select status, error from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1"
         )
-        .get(record.repo, record.pullNumber, record.headSha) as { status: ProcessedStatus } | undefined;
-      if (activeClaim || (processed && processed.status !== "dry_run")) {
+        .get(record.repo, record.pullNumber, record.headSha) as Pick<
+          ProcessedReviewRecord,
+          "status" | "error"
+        > | undefined;
+      if (
+        activeClaim ||
+        (processed &&
+          processed.status !== "dry_run" &&
+          !isRetryableApprovedDryRunPrePostFailure(processed))
+      ) {
         this.db.exec("commit");
         return false;
       }

--- a/src/state.ts
+++ b/src/state.ts
@@ -932,6 +932,53 @@ export class ReviewStateStore {
     }
   }
 
+  tryRecordDryRun(
+    record: Omit<ProcessedReviewRecord, "status" | "reviewUrl" | "error">,
+    now: Date = new Date()
+  ): boolean {
+    this.db.exec("begin immediate");
+    try {
+      const recordedAt = now.toISOString();
+      this.db
+        .prepare(
+          "delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ? and expires_at <= ?"
+        )
+        .run(record.repo, record.pullNumber, record.headSha, recordedAt);
+      const activeClaim = this.db
+        .prepare(
+          "select 1 from review_head_claims where repo = ? and pull_number = ? and head_sha = ? limit 1"
+        )
+        .get(record.repo, record.pullNumber, record.headSha);
+      const processed = this.db
+        .prepare(
+          "select 1 from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1"
+        )
+        .get(record.repo, record.pullNumber, record.headSha);
+      if (activeClaim || processed) {
+        this.db.exec("commit");
+        return false;
+      }
+      this.db
+        .prepare(
+          `insert into processed_reviews
+            (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+           values (?, ?, ?, 'dry_run', ?, null, null, ?)`
+        )
+        .run(
+          record.repo,
+          record.pullNumber,
+          record.headSha,
+          record.event ?? null,
+          recordedAt
+        );
+      this.db.exec("commit");
+      return true;
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
   recordFindingOutcomeLabel(record: FindingOutcomeLabelRecord): void {
     this.writeFindingOutcomeLabel(record);
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -59,6 +59,7 @@ export interface ProcessedReviewRecord {
   pullNumber: number;
   headSha: string;
   status: ProcessedStatus;
+  configRevision?: string;
   event?: ReviewEvent;
   reviewUrl?: string;
   error?: string;
@@ -155,6 +156,7 @@ export interface ReviewHeadClaimInput {
   ownerPid?: number;
   allowProcessedOwnerSupersession?: boolean;
   requiredProcessedStatusForSupersession?: ProcessedStatus;
+  requiredProcessedConfigRevisionForSupersession?: string;
 }
 
 export type ReviewHeadClaimAttempt =
@@ -548,6 +550,7 @@ export class ReviewStateStore {
         pull_number integer not null,
         head_sha text not null,
         status text not null,
+        config_revision text,
         event text,
         review_url text,
         error text,
@@ -814,6 +817,7 @@ export class ReviewStateStore {
         owner_pid integer
       );
     `);
+    this.ensureProcessedReviewColumns();
     this.ensureIssueEnrichmentBodyHashColumn();
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
@@ -881,7 +885,7 @@ export class ReviewStateStore {
   getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined {
     const row = this.db
       .prepare(
-        `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+        `select repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at
          from processed_reviews
          where repo = ? and pull_number = ? and head_sha = ?
          limit 1`
@@ -893,7 +897,7 @@ export class ReviewStateStore {
   listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[] {
     const rows = this.db
       .prepare(
-        `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+        `select repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at
          from processed_reviews
          where repo = ? and pull_number = ?
          order by datetime(created_at) desc`
@@ -908,14 +912,15 @@ export class ReviewStateStore {
       this.db
         .prepare(
           `insert or replace into processed_reviews
-            (repo, pull_number, head_sha, status, event, review_url, error, created_at)
-           values (?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+            (repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at)
+           values (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
         )
         .run(
           record.repo,
           record.pullNumber,
           record.headSha,
           record.status,
+          record.configRevision ?? null,
           record.event ?? null,
           record.reviewUrl ?? null,
           record.error ?? null
@@ -951,23 +956,24 @@ export class ReviewStateStore {
         .get(record.repo, record.pullNumber, record.headSha);
       const processed = this.db
         .prepare(
-          "select 1 from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1"
+          "select status from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1"
         )
-        .get(record.repo, record.pullNumber, record.headSha);
-      if (activeClaim || processed) {
+        .get(record.repo, record.pullNumber, record.headSha) as { status: ProcessedStatus } | undefined;
+      if (activeClaim || (processed && processed.status !== "dry_run")) {
         this.db.exec("commit");
         return false;
       }
       this.db
         .prepare(
-          `insert into processed_reviews
-            (repo, pull_number, head_sha, status, event, review_url, error, created_at)
-           values (?, ?, ?, 'dry_run', ?, null, null, ?)`
+          `insert or replace into processed_reviews
+            (repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at)
+           values (?, ?, ?, 'dry_run', ?, ?, null, null, ?)`
         )
         .run(
           record.repo,
           record.pullNumber,
           record.headSha,
+          record.configRevision ?? null,
           record.event ?? null,
           recordedAt
         );
@@ -1617,13 +1623,22 @@ export class ReviewStateStore {
         return { status: "blocked", reason: "active_claim" };
       }
       const processed = this.db
-        .prepare("select status from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1")
-        .get(input.repo, input.pullNumber, input.headSha) as { status: ProcessedStatus } | undefined;
+        .prepare(
+          "select status, config_revision from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1"
+        )
+        .get(input.repo, input.pullNumber, input.headSha) as {
+          status: ProcessedStatus;
+          config_revision: string | null;
+        } | undefined;
       if (processed) {
         const allowed = input.allowProcessedOwnerSupersession &&
           (
             input.requiredProcessedStatusForSupersession === undefined ||
             processed.status === input.requiredProcessedStatusForSupersession
+          ) &&
+          (
+            input.requiredProcessedConfigRevisionForSupersession === undefined ||
+            processed.config_revision === input.requiredProcessedConfigRevisionForSupersession
           );
         if (!allowed) {
           this.db.exec("commit");
@@ -3521,6 +3536,15 @@ export class ReviewStateStore {
     this.db.close();
   }
 
+  private ensureProcessedReviewColumns(): void {
+    const columns = this.db
+      .prepare("pragma table_info(processed_reviews)")
+      .all() as unknown as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === "config_revision")) {
+      this.db.exec("alter table processed_reviews add column config_revision text");
+    }
+  }
+
   private ensureIssueEnrichmentBodyHashColumn(): void {
     const columns = this.db.prepare("pragma table_info(issue_enrichment_records)").all() as unknown as Array<{ name: string }>;
     if (!columns.some((column) => column.name === "body_hash")) {
@@ -3995,6 +4019,7 @@ interface ProcessedReviewRow {
   pull_number: number;
   head_sha: string;
   status: ProcessedStatus;
+  config_revision?: string | null;
   event: ReviewEvent | null;
   review_url: string | null;
   error: string | null;
@@ -4197,6 +4222,7 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     pullNumber: row.pull_number,
     headSha: row.head_sha,
     status: row.status,
+    ...(row.config_revision ? { configRevision: row.config_revision } : {}),
     ...(row.event ? { event: row.event } : {}),
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),

--- a/src/state.ts
+++ b/src/state.ts
@@ -120,6 +120,7 @@ export interface RepoActivationRecord {
 export const ACTIVATION_BASELINE_EXISTING_HEAD_ERROR = "activation_baseline_existing_head";
 export const EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR = "exact_authorization_already_consumed";
 export const POST_REVIEW_HEAD_UNVERIFIED_ERROR = "post_review_head_unverified";
+export const APPROVED_DRY_RUN_LIVE_CLAIM_ERROR = "approved_dry_run_consumed_for_live_post";
 export const REVIEW_POSTED_HEAD_CHANGED_ERROR = "review_posted_head_changed";
 
 export function isActivationBaselineProcessedReview(
@@ -157,6 +158,7 @@ export interface ReviewHeadClaimInput {
   allowProcessedOwnerSupersession?: boolean;
   requiredProcessedStatusForSupersession?: ProcessedStatus;
   requiredProcessedConfigRevisionForSupersession?: string;
+  consumeProcessedApprovalOnAcquire?: boolean;
 }
 
 export type ReviewHeadClaimAttempt =
@@ -1650,6 +1652,32 @@ export class ReviewStateStore {
           "insert into review_head_claims (repo, pull_number, head_sha, claim_id, owner_pid, claimed_at, expires_at) values (?, ?, ?, ?, ?, ?, ?)"
         )
         .run(input.repo, input.pullNumber, input.headSha, claimId, ownerPid, claimedAt, expiresAt);
+      if (input.consumeProcessedApprovalOnAcquire) {
+        if (
+          input.requiredProcessedStatusForSupersession === undefined ||
+          input.requiredProcessedConfigRevisionForSupersession === undefined
+        ) {
+          throw new Error("consuming a processed approval requires exact status and configuration revision");
+        }
+        const consumed = this.db
+          .prepare(
+            `update processed_reviews
+             set status = 'skipped', error = ?, created_at = datetime('now')
+             where repo = ? and pull_number = ? and head_sha = ?
+               and status = ? and config_revision = ?`
+          )
+          .run(
+            APPROVED_DRY_RUN_LIVE_CLAIM_ERROR,
+            input.repo,
+            input.pullNumber,
+            input.headSha,
+            input.requiredProcessedStatusForSupersession,
+            input.requiredProcessedConfigRevisionForSupersession
+          );
+        if (consumed.changes !== 1) {
+          throw new Error("processed approval changed before it could be consumed");
+        }
+      }
       this.db.exec("commit");
       return { status: "acquired", claim: { claimId, expiresAt, ownerPid } };
     } catch (error) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -154,6 +154,7 @@ export interface ReviewHeadClaimInput {
   now?: Date;
   ownerPid?: number;
   allowProcessedOwnerSupersession?: boolean;
+  requiredProcessedStatusForSupersession?: ProcessedStatus;
 }
 
 export type ReviewHeadClaimAttempt =
@@ -1568,11 +1569,16 @@ export class ReviewStateStore {
         this.db.exec("commit");
         return { status: "blocked", reason: "active_claim" };
       }
-      if (!input.allowProcessedOwnerSupersession) {
-        const processed = this.db
-          .prepare("select 1 from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1")
-          .get(input.repo, input.pullNumber, input.headSha);
-        if (processed) {
+      const processed = this.db
+        .prepare("select status from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1")
+        .get(input.repo, input.pullNumber, input.headSha) as { status: ProcessedStatus } | undefined;
+      if (processed) {
+        const allowed = input.allowProcessedOwnerSupersession &&
+          (
+            input.requiredProcessedStatusForSupersession === undefined ||
+            processed.status === input.requiredProcessedStatusForSupersession
+          );
+        if (!allowed) {
           this.db.exec("commit");
           return { status: "blocked", reason: "processed" };
         }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -199,7 +199,7 @@ export interface RunOnceOptions {
   pullNumber?: number;
   expectedHeadSha?: string;
   expectedConfigRevision?: string;
-  processedHeadPolicy?: "normal" | "approved_dry_run";
+  processedHeadPolicy?: "normal" | "approved_dry_run" | "refresh_dry_run";
   useZCode?: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
 }
@@ -1415,7 +1415,7 @@ export interface ReviewPullInput {
   configRevision?: string;
   sourceConfigRevision?: string;
   budget?: ReviewRunBudget;
-  processedHeadPolicy?: "normal" | "approved_dry_run" | "retry_failed_head";
+  processedHeadPolicy?: "normal" | "approved_dry_run" | "refresh_dry_run" | "retry_failed_head";
   commandCommentId?: number;
   allowActivationBaselineCommandLookup?: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
@@ -1451,7 +1451,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   const retryableApprovedDryRunPrePostFailure =
     input.dryRun && isRetryableApprovedDryRunPrePostFailure(processed);
   const refreshableDryRun =
-    input.dryRun && processed?.status === "dry_run";
+    input.dryRun &&
+    input.processedHeadPolicy === "refresh_dry_run" &&
+    processed?.status === "dry_run";
   const approvedDryRunTransition =
     input.processedHeadPolicy === "approved_dry_run" &&
     processed?.status === "dry_run" &&
@@ -1700,6 +1702,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     : undefined;
   if (activeCooldown && input.processedHeadPolicy !== "retry_failed_head") {
     if (
+      !retryableApprovedDryRunPrePostFailure &&
       !(
         processed?.status === "dry_run" &&
         (approvedDryRunTransition || refreshableDryRun)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -86,6 +86,7 @@ import { writeSecureFileSync } from "./temp-files.js";
 import {
   ACTIVATION_BASELINE_EXISTING_HEAD_ERROR,
   APPROVED_DRY_RUN_LIVE_CLAIM_ERROR,
+  isRetryableApprovedDryRunPrePostFailure,
   EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
   POST_REVIEW_HEAD_UNVERIFIED_ERROR,
   REVIEW_POSTED_HEAD_CHANGED_ERROR,
@@ -1423,6 +1424,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
+  const retryableApprovedDryRunPrePostFailure =
+    input.dryRun && isRetryableApprovedDryRunPrePostFailure(processed);
   const approvedDryRunTransition =
     input.processedHeadPolicy === "approved_dry_run" &&
     processed?.status === "dry_run" &&
@@ -1649,6 +1652,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     input.processedHeadPolicy !== "retry_failed_head" &&
     !manualReviewRequested &&
     !approvedDryRunTransition &&
+    !retryableApprovedDryRunPrePostFailure &&
     (processed || state.hasProcessed(repo, pull.number, pull.head.sha))
   ) {
     // This is a provider-free visibility repair for a GitHub review that is

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3398,6 +3398,21 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
     cooldownUntil,
     reason: classification.reason
   });
+  if (
+    input.preserveExistingDryRun &&
+    previous?.status === "skipped" &&
+    previous.error?.startsWith(APPROVED_DRY_RUN_LIVE_CLAIM_ERROR)
+  ) {
+    recordFailedReview({
+      config: input.config,
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      error: input.error,
+      preserveExistingDryRun: true
+    });
+    return true;
+  }
   if (!(input.preserveExistingDryRun && previous?.status === "dry_run")) {
     recordProviderCooldownSkip({
       state: input.state,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1936,9 +1936,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (input.dryRun) writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
 
     if (input.dryRun) {
-      // Dry-run posts nothing public, so it does NOT acquire a per-head claim (#295): claiming would
-      // add contention/TTL churn for a run that cannot violate the at-most-one-posted-review invariant.
-      state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event: plan.event });
+      // Dry-run posts nothing public, but its durable proof must not replace an
+      // active or completed live review. The state transaction admits this row
+      // only while the exact head remains unclaimed and unprocessed.
+      const recorded = state.tryRecordDryRun({
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        event: plan.event
+      });
+      if (!recorded) return "skipped_processed";
       return manualReviewRequested ? "reviewed_command" : "reviewed";
     }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
@@ -11,7 +12,7 @@ import {
   type CommandDecision
 } from "./commands.js";
 import { loadConfig, type BotConfig } from "./config.js";
-import { loadConfigAtRevision } from "./config-cli.js";
+import { loadConfigAtRevision, readConfigRevision } from "./config-cli.js";
 import { planContextBudget, type ContextBudgetPlan } from "./context-budget.js";
 import { assertGitClean, planPullWorktreePaths, preparePullWorktree } from "./git.js";
 import {
@@ -342,6 +343,23 @@ export function assertExpectedReviewPrHead(input: {
   );
 }
 
+export function buildReviewApprovalRevision(input: {
+  configRevision?: string;
+  useZCode: boolean;
+  zcodeAppConfigPath: string;
+}): string | undefined {
+  if (!input.configRevision) return undefined;
+  if (!input.useZCode) return input.configRevision;
+  const zcodeRevision = readConfigRevision(input.zcodeAppConfigPath);
+  return createHash("sha256")
+    .update("neondiff-review-approval-v1")
+    .update("\0")
+    .update(input.configRevision)
+    .update("\0")
+    .update(zcodeRevision)
+    .digest("hex");
+}
+
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   let config: BotConfig;
   if (options.expectedConfigRevision !== undefined) {
@@ -359,6 +377,11 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   } else {
     config = loadConfig(options.configPath);
   }
+  const reviewApprovalRevision = buildReviewApprovalRevision({
+    configRevision: options.expectedConfigRevision,
+    useZCode: options.useZCode ?? true,
+    zcodeAppConfigPath: config.zcode.appConfigPath
+  });
   const result: RunOnceResult = {
     reposScanned: 0,
     pullsSeen: 0,
@@ -437,8 +460,8 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             pull,
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
-            ...(options.expectedConfigRevision
-              ? { configRevision: options.expectedConfigRevision }
+            ...(reviewApprovalRevision
+              ? { configRevision: reviewApprovalRevision }
               : {}),
             budget,
             licenseAdmission,
@@ -448,7 +471,17 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             allowActivationBaselineCommandLookup: options.pullNumber !== undefined
           });
         } catch (error) {
-          if (recordProviderRateLimitCooldownIfNeeded({ config, state, repo, pull, error })) {
+          const preserveApprovedDryRun =
+            options.processedHeadPolicy === "approved_dry_run" &&
+            !reviewWasAlreadyPosted(error);
+          if (recordProviderRateLimitCooldownIfNeeded({
+            config,
+            state,
+            repo,
+            pull,
+            error,
+            preserveExistingDryRun: preserveApprovedDryRun
+          })) {
             result.skippedProviderCooldown += 1;
             continue;
           }
@@ -458,8 +491,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             repo,
             pull,
             error,
-            preserveExistingDryRun:
-              options.processedHeadPolicy === "approved_dry_run"
+            preserveExistingDryRun: preserveApprovedDryRun
           });
           result.failed += 1;
           continue;
@@ -1371,6 +1403,14 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     recordLicenseAdmissionBlock({ config, state, repo, pull, decision: visibilityDecision.decision });
     return "skipped_license_gate";
   }
+  if (
+    input.processedHeadPolicy === "approved_dry_run" &&
+    input.configRevision === undefined
+  ) {
+    throw new Error(
+      "approved dry-run transition requires an exact configuration revision"
+    );
+  }
 
   const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
   const approvedDryRunTransition =
@@ -2190,32 +2230,36 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       body: reviewBodyAfterWalkthroughPost(plan),
       comments
     });
-    if (reviewEventResolution.consumed) {
-      if (
-        reviewEventResolution.authorization.status !== "eligible" ||
-        !review.html_url
-      ) {
-        throw new Error("consumed owner authorization did not produce a durable review receipt");
+    try {
+      if (reviewEventResolution.consumed) {
+        if (
+          reviewEventResolution.authorization.status !== "eligible" ||
+          !review.html_url
+        ) {
+          throw new Error("consumed owner authorization did not produce a durable review receipt");
+        }
+        state.recordAuthorizedReviewPosted({
+          repo,
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          commentId: reviewEventResolution.authorization.commentId,
+          author: reviewEventResolution.authorization.author,
+          event: plan.event,
+          reviewUrl: review.html_url,
+          preserveExistingBlocking: preservedPriorBlockingRow
+        });
+      } else if (!preservedPriorBlockingRow) {
+        state.recordProcessed({
+          repo,
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          event: plan.event,
+          reviewUrl: review.html_url
+        });
       }
-      state.recordAuthorizedReviewPosted({
-        repo,
-        pullNumber: pull.number,
-        headSha: pull.head.sha,
-        commentId: reviewEventResolution.authorization.commentId,
-        author: reviewEventResolution.authorization.author,
-        event: plan.event,
-        reviewUrl: review.html_url,
-        preserveExistingBlocking: preservedPriorBlockingRow
-      });
-    } else if (!preservedPriorBlockingRow) {
-      state.recordProcessed({
-        repo,
-        pullNumber: pull.number,
-        headSha: pull.head.sha,
-        status: "posted",
-        event: plan.event,
-        reviewUrl: review.html_url
-      });
+    } catch (error) {
+      throw new ReviewPostPersistenceError(error);
     }
     writeRedactedJsonBestEffort(join(evidenceDir, "posted-review.json"), {
       event: plan.event,
@@ -3256,7 +3300,10 @@ export function recordFailedReview(input: {
       recordedAt: new Date().toISOString()
     });
   }
-  if (!(input.preserveExistingDryRun && previous?.status === "dry_run")) {
+  if (
+    previous?.status !== "posted" &&
+    !(input.preserveExistingDryRun && previous?.status === "dry_run")
+  ) {
     input.state.recordProcessed({
       repo: input.repo,
       pullNumber: input.pull.number,
@@ -3275,6 +3322,7 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
   pull: PullRequestSummary;
   error: unknown;
   now?: Date;
+  preserveExistingDryRun?: boolean;
 }): boolean {
   if (!input.config.providerCooldown.enabled) return false;
   const classification = classifyProviderError(input.error);
@@ -3291,17 +3339,42 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
     cooldownUntil,
     reason: classification.reason
   });
-  recordProviderCooldownSkip({
-    state: input.state,
-    repo: input.repo,
-    pull: input.pull,
-    cooldownUntil: cooldownUntil.toISOString(),
-    reason: classification.reason,
-    ...(classification.category === "overloaded" ? { retryAttempt } : {}),
-    ...(classification.category === "overloaded" && classification.providerCode ? { providerCode: classification.providerCode } : {}),
-    ...(classification.category === "overloaded" && classification.retryAfterMs ? { retryAfterMs: classification.retryAfterMs } : {})
-  });
+  if (!(input.preserveExistingDryRun && previous?.status === "dry_run")) {
+    recordProviderCooldownSkip({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      cooldownUntil: cooldownUntil.toISOString(),
+      reason: classification.reason,
+      ...(classification.category === "overloaded" ? { retryAttempt } : {}),
+      ...(classification.category === "overloaded" && classification.providerCode ? { providerCode: classification.providerCode } : {}),
+      ...(classification.category === "overloaded" && classification.retryAfterMs ? { retryAfterMs: classification.retryAfterMs } : {})
+    });
+  }
   return true;
+}
+
+class ReviewPostPersistenceError extends Error {
+  readonly reviewAlreadyPosted = true;
+
+  constructor(cause: unknown) {
+    super(
+      `review posted but its durable receipt could not be recorded: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      { cause }
+    );
+    this.name = "ReviewPostPersistenceError";
+  }
+}
+
+export function reviewWasAlreadyPosted(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "reviewAlreadyPosted" in error &&
+    (error as { reviewAlreadyPosted?: unknown }).reviewAlreadyPosted === true
+  );
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1426,6 +1426,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
   const retryableApprovedDryRunPrePostFailure =
     input.dryRun && isRetryableApprovedDryRunPrePostFailure(processed);
+  const refreshableDryRun =
+    input.dryRun && processed?.status === "dry_run";
   const approvedDryRunTransition =
     input.processedHeadPolicy === "approved_dry_run" &&
     processed?.status === "dry_run" &&
@@ -1653,6 +1655,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     !manualReviewRequested &&
     !approvedDryRunTransition &&
     !retryableApprovedDryRunPrePostFailure &&
+    !refreshableDryRun &&
     (processed || state.hasProcessed(repo, pull.number, pull.head.sha))
   ) {
     // This is a provider-free visibility repair for a GitHub review that is
@@ -1672,7 +1675,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     ? state.getActiveRepoProviderCooldown(repo)
     : undefined;
   if (activeCooldown && input.processedHeadPolicy !== "retry_failed_head") {
-    if (!(approvedDryRunTransition && processed?.status === "dry_run")) {
+    if (
+      !(
+        processed?.status === "dry_run" &&
+        (approvedDryRunTransition || refreshableDryRun)
+      )
+    ) {
       recordProviderCooldownSkip({
         state,
         repo,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -493,13 +493,16 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             allowActivationBaselineCommandLookup: options.pullNumber !== undefined
           });
         } catch (error) {
-          if (recoverPostedReviewReceipt({
+          const recoveredStatus = await recoverPostedReviewReceiptForCurrentHead({
+            config,
+            github,
             state,
             repo,
             pull,
             error
-          })) {
-            result.reviewed += 1;
+          });
+          if (recoveredStatus) {
+            applyReviewPullResultToRunOnceResult(result, recoveredStatus);
             continue;
           }
           const preserveApprovedDryRun =
@@ -3530,6 +3533,90 @@ export function recoverPostedReviewReceipt(input: {
     });
   }
   return true;
+}
+
+export async function recoverPostedReviewReceiptForCurrentHead(input: {
+  config: BotConfig;
+  github: Pick<GitHubApi, "getPull">;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  error: unknown;
+}): Promise<ReviewPullResult | undefined> {
+  if (!reviewWasAlreadyPosted(input.error)) return undefined;
+  const receipt = (input.error as { receipt?: PostedReviewReceipt }).receipt;
+  const priorPosted = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  const preservedPriorVerifiedBlockingRow = Boolean(
+    receipt?.preserveExistingBlocking &&
+    priorPosted?.status === "posted" &&
+    priorPosted.event === "REQUEST_CHANGES" &&
+    !priorPosted.error
+  );
+  recoverPostedReviewReceipt(input);
+
+  const evidenceDir = buildEvidenceDir(input.config, input.repo, input.pull, {
+    action: "none",
+    shouldReview: false
+  });
+  let liveHeadSha: string | undefined;
+  let lookupError: unknown;
+  try {
+    liveHeadSha = (await input.github.getPull(input.repo, input.pull.number)).head.sha;
+  } catch (error) {
+    lookupError = error;
+  }
+
+  const uncertaintyReason = lookupError
+    ? POST_REVIEW_HEAD_UNVERIFIED_ERROR
+    : liveHeadSha !== input.pull.head.sha
+      ? REVIEW_POSTED_HEAD_CHANGED_ERROR
+      : undefined;
+  if (!uncertaintyReason) return "reviewed";
+
+  if (lookupError) {
+    writeRedactedJsonBestEffort(join(evidenceDir, "post-receipt-recovery-head-lookup-failed.json"), {
+      reason: "post_receipt_recovery_head_lookup_failed",
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      expectedHeadSha: input.pull.head.sha,
+      reviewUrl: receipt?.reviewUrl,
+      error: redactSecrets(lookupError instanceof Error ? lookupError.message : String(lookupError)).slice(0, 300)
+    });
+  } else {
+    writeRedactedJsonBestEffort(join(evidenceDir, "head-changed-during-receipt-recovery.json"), {
+      reason: "head_changed_during_receipt_recovery",
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      expectedHeadSha: input.pull.head.sha,
+      liveHeadSha,
+      reviewUrl: receipt?.reviewUrl
+    });
+  }
+
+  if (!preservedPriorVerifiedBlockingRow) {
+    const durablePosted = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+    if (durablePosted?.status === "posted") {
+      input.state.recordProcessed({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        status: "posted",
+        ...(durablePosted.event ? { event: durablePosted.event } : {}),
+        ...(durablePosted.reviewUrl ? { reviewUrl: durablePosted.reviewUrl } : {}),
+        error: uncertaintyReason
+      });
+      input.state.recordReviewReadiness({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        state: lookupError ? "failed" : "stale",
+        reason: uncertaintyReason,
+        ...(durablePosted.event ? { event: durablePosted.event } : {}),
+        ...(durablePosted.reviewUrl ? { reviewUrl: durablePosted.reviewUrl } : {})
+      });
+    }
+  }
+  return lookupError ? "posted_head_unverified" : "posted_stale_head";
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -362,6 +362,23 @@ export function buildReviewApprovalRevision(input: {
     .digest("hex");
 }
 
+export function assertReviewApprovalRevisionCurrent(input: {
+  approvedRevision: string;
+  sourceConfigRevision: string;
+  useZCode: boolean;
+  zcodeAppConfigPath: string;
+}): void {
+  const currentRevision = buildReviewApprovalRevision({
+    configRevision: input.sourceConfigRevision,
+    useZCode: input.useZCode,
+    zcodeAppConfigPath: input.zcodeAppConfigPath
+  });
+  if (currentRevision === input.approvedRevision) return;
+  throw new Error(
+    "review-pr provider configuration changed; run a new dry review before posting"
+  );
+}
+
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   let config: BotConfig;
   if (options.expectedConfigRevision !== undefined) {
@@ -464,6 +481,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             useZCode: options.useZCode ?? true,
             ...(reviewApprovalRevision
               ? { configRevision: reviewApprovalRevision }
+              : {}),
+            ...(options.expectedConfigRevision
+              ? { sourceConfigRevision: options.expectedConfigRevision }
               : {}),
             budget,
             licenseAdmission,
@@ -1390,6 +1410,7 @@ export interface ReviewPullInput {
   dryRun: boolean;
   useZCode: boolean;
   configRevision?: string;
+  sourceConfigRevision?: string;
   budget?: ReviewRunBudget;
   processedHeadPolicy?: "normal" | "approved_dry_run" | "retry_failed_head";
   commandCommentId?: number;
@@ -1859,6 +1880,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       return "skipped_context_budget";
     }
 
+    const assertApprovedProviderConfigCurrent = (): void => {
+      if (!input.configRevision || !input.sourceConfigRevision) return;
+      assertReviewApprovalRevisionCurrent({
+        approvedRevision: input.configRevision,
+        sourceConfigRevision: input.sourceConfigRevision,
+        useZCode: input.useZCode,
+        zcodeAppConfigPath: config.zcode.appConfigPath
+      });
+    };
+    assertApprovedProviderConfigCurrent();
     const zcodeExecution = await runReviewWithContextBudget({
       config,
       github,
@@ -1872,6 +1903,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       useZCode: input.useZCode,
       evidenceDir
     });
+    assertApprovedProviderConfigCurrent();
     if (zcodeExecution.status === "skipped_stale_head") return "skipped_stale_head";
     if (zcodeExecution.status === "skipped_context_budget") return "skipped_context_budget";
     const zcodeResult = zcodeExecution.result;
@@ -1915,6 +1947,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       worktreePath: worktree.path,
       evidenceDir
     });
+    assertApprovedProviderConfigCurrent();
     if (selfConsistency.runtimeNote && Array.isArray(zcodeResult.runtime.notes)) {
       zcodeResult.runtime.notes.push(selfConsistency.runtimeNote);
     }
@@ -2019,6 +2052,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     }
     if (input.dryRun) writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
 
+    assertApprovedProviderConfigCurrent();
     if (input.dryRun) {
       // Dry-run posts nothing public, but its durable proof must not replace an
       // active or completed live review. The state transaction admits this row

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1427,6 +1427,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     processed?.status === "dry_run" &&
     input.configRevision !== undefined &&
     processed.configRevision === input.configRevision;
+  if (
+    input.processedHeadPolicy === "approved_dry_run" &&
+    !approvedDryRunTransition
+  ) {
+    return "skipped_processed";
+  }
   const reviewEventPolicyMode = config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only";
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -471,6 +471,15 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             allowActivationBaselineCommandLookup: options.pullNumber !== undefined
           });
         } catch (error) {
+          if (recoverPostedReviewReceipt({
+            state,
+            repo,
+            pull,
+            error
+          })) {
+            result.reviewed += 1;
+            continue;
+          }
           const preserveApprovedDryRun =
             options.processedHeadPolicy === "approved_dry_run" &&
             !reviewWasAlreadyPosted(error);
@@ -1652,13 +1661,15 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     ? state.getActiveRepoProviderCooldown(repo)
     : undefined;
   if (activeCooldown && input.processedHeadPolicy !== "retry_failed_head") {
-    recordProviderCooldownSkip({
-      state,
-      repo,
-      pull,
-      cooldownUntil: activeCooldown.cooldownUntil,
-      reason: activeCooldown.reason
-    });
+    if (!(approvedDryRunTransition && processed?.status === "dry_run")) {
+      recordProviderCooldownSkip({
+        state,
+        repo,
+        pull,
+        cooldownUntil: activeCooldown.cooldownUntil,
+        reason: activeCooldown.reason
+      });
+    }
     return "skipped_provider_cooldown";
   }
   if (input.processedHeadPolicy === "retry_failed_head") {
@@ -2259,7 +2270,20 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         });
       }
     } catch (error) {
-      throw new ReviewPostPersistenceError(error);
+      throw new ReviewPostPersistenceError(error, {
+        event: plan.event,
+        reviewUrl: review.html_url ?? `${pull.html_url}#pullrequestreview-${review.id}`,
+        preserveExistingBlocking: preservedPriorBlockingRow,
+        ...(reviewEventResolution.consumed &&
+          reviewEventResolution.authorization.status === "eligible"
+          ? {
+              authorization: {
+                commentId: reviewEventResolution.authorization.commentId,
+                author: reviewEventResolution.authorization.author
+              }
+            }
+          : {})
+      });
     }
     writeRedactedJsonBestEffort(join(evidenceDir, "posted-review.json"), {
       event: plan.event,
@@ -3354,10 +3378,21 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
   return true;
 }
 
+interface PostedReviewReceipt {
+  event: ReviewEvent;
+  reviewUrl: string;
+  preserveExistingBlocking: boolean;
+  authorization?: {
+    commentId: number;
+    author: string;
+  };
+}
+
 class ReviewPostPersistenceError extends Error {
   readonly reviewAlreadyPosted = true;
+  readonly receipt: PostedReviewReceipt;
 
-  constructor(cause: unknown) {
+  constructor(cause: unknown, receipt: PostedReviewReceipt) {
     super(
       `review posted but its durable receipt could not be recorded: ${
         cause instanceof Error ? cause.message : String(cause)
@@ -3365,6 +3400,7 @@ class ReviewPostPersistenceError extends Error {
       { cause }
     );
     this.name = "ReviewPostPersistenceError";
+    this.receipt = receipt;
   }
 }
 
@@ -3375,6 +3411,41 @@ export function reviewWasAlreadyPosted(error: unknown): boolean {
     "reviewAlreadyPosted" in error &&
     (error as { reviewAlreadyPosted?: unknown }).reviewAlreadyPosted === true
   );
+}
+
+export function recoverPostedReviewReceipt(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  error: unknown;
+}): boolean {
+  if (!reviewWasAlreadyPosted(input.error)) return false;
+  const receipt = (input.error as { receipt?: PostedReviewReceipt }).receipt;
+  if (!receipt?.reviewUrl || !receipt.event) {
+    throw new Error("review posted but its recovery receipt is incomplete");
+  }
+  if (receipt.authorization) {
+    input.state.recordAuthorizedReviewPosted({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      commentId: receipt.authorization.commentId,
+      author: receipt.authorization.author,
+      event: receipt.event,
+      reviewUrl: receipt.reviewUrl,
+      preserveExistingBlocking: receipt.preserveExistingBlocking
+    });
+  } else if (!receipt.preserveExistingBlocking) {
+    input.state.recordProcessed({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      status: "posted",
+      event: receipt.event,
+      reviewUrl: receipt.reviewUrl
+    });
+  }
+  return true;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11,6 +11,7 @@ import {
   type CommandDecision
 } from "./commands.js";
 import { loadConfig, type BotConfig } from "./config.js";
+import { loadConfigAtRevision } from "./config-cli.js";
 import { planContextBudget, type ContextBudgetPlan } from "./context-budget.js";
 import { assertGitClean, planPullWorktreePaths, preparePullWorktree } from "./git.js";
 import {
@@ -194,6 +195,8 @@ export interface RunOnceOptions {
   repo?: string;
   pullNumber?: number;
   expectedHeadSha?: string;
+  expectedConfigRevision?: string;
+  processedHeadPolicy?: "normal" | "approved_dry_run";
   useZCode?: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
 }
@@ -340,7 +343,22 @@ export function assertExpectedReviewPrHead(input: {
 }
 
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
-  const config = loadConfig(options.configPath);
+  let config: BotConfig;
+  if (options.expectedConfigRevision !== undefined) {
+    if (!/^[a-f0-9]{64}$/.test(options.expectedConfigRevision)) {
+      throw new Error("review-pr expected config revision must be a lowercase SHA-256 value");
+    }
+    if (!options.configPath) {
+      throw new Error("review-pr expected config revision requires a config path");
+    }
+    const loaded = loadConfigAtRevision(options.configPath);
+    if (loaded.revision !== options.expectedConfigRevision) {
+      throw new Error("review-pr config revision changed; run a new dry review before posting");
+    }
+    config = loaded.config;
+  } else {
+    config = loadConfig(options.configPath);
+  }
   const result: RunOnceResult = {
     reposScanned: 0,
     pullsSeen: 0,
@@ -421,6 +439,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             useZCode: options.useZCode ?? true,
             budget,
             licenseAdmission,
+            ...(options.processedHeadPolicy
+              ? { processedHeadPolicy: options.processedHeadPolicy }
+              : {}),
             allowActivationBaselineCommandLookup: options.pullNumber !== undefined
           });
         } catch (error) {
@@ -1315,7 +1336,7 @@ export interface ReviewPullInput {
   dryRun: boolean;
   useZCode: boolean;
   budget?: ReviewRunBudget;
-  processedHeadPolicy?: "normal" | "retry_failed_head";
+  processedHeadPolicy?: "normal" | "approved_dry_run" | "retry_failed_head";
   commandCommentId?: number;
   allowActivationBaselineCommandLookup?: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
@@ -1340,6 +1361,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
+  const approvedDryRunTransition =
+    input.processedHeadPolicy === "approved_dry_run" &&
+    processed?.status === "dry_run";
   const reviewEventPolicyMode = config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only";
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
@@ -1554,6 +1578,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !manualReviewRequested &&
+    !approvedDryRunTransition &&
     (processed || state.hasProcessed(repo, pull.number, pull.head.sha))
   ) {
     // This is a provider-free visibility repair for a GitHub review that is
@@ -1929,7 +1954,11 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       // be able to replace that failed/deferred row after a successful provider retry.
       allowProcessedOwnerSupersession: commandReviewRequested ||
         (exactOwnerReviewRequested && queuedOwnerRequestChanges) ||
-        input.processedHeadPolicy === "retry_failed_head"
+        input.processedHeadPolicy === "approved_dry_run" ||
+        input.processedHeadPolicy === "retry_failed_head",
+      ...(input.processedHeadPolicy === "approved_dry_run"
+        ? { requiredProcessedStatusForSupersession: "dry_run" as const }
+        : {})
     });
     if (headClaimAttempt.status === "blocked") {
       if (headClaimAttempt.reason === "active_claim") {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -85,6 +85,7 @@ import { buildSkillPackContextPacket, type SkillPackContextPacket } from "./skil
 import { writeSecureFileSync } from "./temp-files.js";
 import {
   ACTIVATION_BASELINE_EXISTING_HEAD_ERROR,
+  APPROVED_DRY_RUN_LIVE_CLAIM_ERROR,
   EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
   POST_REVIEW_HEAD_UNVERIFIED_ERROR,
   REVIEW_POSTED_HEAD_CHANGED_ERROR,
@@ -2038,7 +2039,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       ...(input.processedHeadPolicy === "approved_dry_run"
         ? {
             requiredProcessedStatusForSupersession: "dry_run" as const,
-            requiredProcessedConfigRevisionForSupersession: input.configRevision
+            requiredProcessedConfigRevisionForSupersession: input.configRevision,
+            consumeProcessedApprovalOnAcquire: true
           }
         : {})
     });
@@ -3320,6 +3322,21 @@ export function recordFailedReview(input: {
     previousError: previous?.error,
     timeoutMs: input.config.zcode.timeoutMs ?? 180_000
   }) ?? rawErrorMessage;
+  if (
+    previous?.status === "skipped" &&
+    previous.error?.startsWith(APPROVED_DRY_RUN_LIVE_CLAIM_ERROR)
+  ) {
+    input.state.recordProcessed({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      status: "skipped",
+      ...(previous.configRevision ? { configRevision: previous.configRevision } : {}),
+      ...(previous.event ? { event: previous.event } : {}),
+      error: `${APPROVED_DRY_RUN_LIVE_CLAIM_ERROR}; post_error=${errorMessage}`
+    });
+    return errorMessage;
+  }
   if (input.writeErrorEvidence !== false) {
     mkdirSync(evidenceDir, { recursive: true });
     writeRedactedJson(join(evidenceDir, "review-error.json"), {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3552,12 +3552,26 @@ export async function recoverPostedReviewReceiptForCurrentHead(input: {
     priorPosted.event === "REQUEST_CHANGES" &&
     !priorPosted.error
   );
-  recoverPostedReviewReceipt(input);
-
   const evidenceDir = buildEvidenceDir(input.config, input.repo, input.pull, {
     action: "none",
     shouldReview: false
   });
+  try {
+    recoverPostedReviewReceipt(input);
+  } catch (recoveryError) {
+    writeRedactedJsonBestEffort(join(evidenceDir, "post-receipt-recovery-persistence-failed.json"), {
+      reason: "post_receipt_recovery_persistence_failed",
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      expectedHeadSha: input.pull.head.sha,
+      reviewUrl: receipt?.reviewUrl,
+      error: redactSecrets(
+        recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
+      ).slice(0, 300)
+    });
+    return "posted_head_unverified";
+  }
+
   let liveHeadSha: string | undefined;
   let lookupError: unknown;
   try {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -437,6 +437,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             pull,
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
+            ...(options.expectedConfigRevision
+              ? { configRevision: options.expectedConfigRevision }
+              : {}),
             budget,
             licenseAdmission,
             ...(options.processedHeadPolicy
@@ -449,7 +452,15 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             result.skippedProviderCooldown += 1;
             continue;
           }
-          recordFailedReview({ config, state, repo, pull, error });
+          recordFailedReview({
+            config,
+            state,
+            repo,
+            pull,
+            error,
+            preserveExistingDryRun:
+              options.processedHeadPolicy === "approved_dry_run"
+          });
           result.failed += 1;
           continue;
         }
@@ -1335,6 +1346,7 @@ export interface ReviewPullInput {
   pull: PullRequestSummary;
   dryRun: boolean;
   useZCode: boolean;
+  configRevision?: string;
   budget?: ReviewRunBudget;
   processedHeadPolicy?: "normal" | "approved_dry_run" | "retry_failed_head";
   commandCommentId?: number;
@@ -1363,7 +1375,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
   const approvedDryRunTransition =
     input.processedHeadPolicy === "approved_dry_run" &&
-    processed?.status === "dry_run";
+    processed?.status === "dry_run" &&
+    input.configRevision !== undefined &&
+    processed.configRevision === input.configRevision;
   const reviewEventPolicyMode = config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only";
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
@@ -1943,6 +1957,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         repo,
         pullNumber: pull.number,
         headSha: pull.head.sha,
+        ...(input.configRevision ? { configRevision: input.configRevision } : {}),
         event: plan.event
       });
       if (!recorded) return "skipped_processed";
@@ -1964,7 +1979,10 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         input.processedHeadPolicy === "approved_dry_run" ||
         input.processedHeadPolicy === "retry_failed_head",
       ...(input.processedHeadPolicy === "approved_dry_run"
-        ? { requiredProcessedStatusForSupersession: "dry_run" as const }
+        ? {
+            requiredProcessedStatusForSupersession: "dry_run" as const,
+            requiredProcessedConfigRevisionForSupersession: input.configRevision
+          }
         : {})
     });
     if (headClaimAttempt.status === "blocked") {
@@ -3218,6 +3236,7 @@ export function recordFailedReview(input: {
   pull: PullRequestSummary;
   error: unknown;
   writeErrorEvidence?: boolean;
+  preserveExistingDryRun?: boolean;
 }): string {
   const evidenceDir = buildEvidenceDir(input.config, input.repo, input.pull, { action: "none", shouldReview: false });
   const previous = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
@@ -3237,13 +3256,15 @@ export function recordFailedReview(input: {
       recordedAt: new Date().toISOString()
     });
   }
-  input.state.recordProcessed({
-    repo: input.repo,
-    pullNumber: input.pull.number,
-    headSha: input.pull.head.sha,
-    status: "failed",
-    error: errorMessage
-  });
+  if (!(input.preserveExistingDryRun && previous?.status === "dry_run")) {
+    input.state.recordProcessed({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      status: "failed",
+      error: errorMessage
+    });
+  }
   return errorMessage;
 }
 

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -72,6 +72,10 @@ describe("local HTML dashboard", () => {
     expect(html).toContain("Daemon");
     expect(html).toContain("Provider");
     expect(html).toContain("openai-compatible");
+    expect(status.firstReviewPreview.command).toBe(
+      "neondiff providers doctor --config config.local.json --json"
+    );
+    expect(status.firstReviewPreview.command).not.toContain("<");
   });
 
   it("reports GitHub App client-id readiness without exposing user tokens", async () => {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -226,6 +226,104 @@ describe("local HTML dashboard", () => {
       })
     });
     expect(JSON.stringify(result)).not.toContain(fakeKey);
+  });
+
+  it("returns the stable config revision after browser provider verification", async () => {
+    const modelServer = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/v1/models") {
+        response.end(JSON.stringify({ data: [{ id: "local-review-model" }] }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: "not found" }));
+    });
+    servers.push(modelServer);
+    await listen(modelServer);
+    const address = modelServer.address() as AddressInfo;
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dashboard-config-revision-"));
+    const configPath = join(root, "config.local.json");
+    const configObject = {
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            adapter: "openai-compatible",
+            displayName: "Local Review",
+            baseUrl: `http://127.0.0.1:${address.port}/v1`,
+            model: "local-review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "LOCAL_REVIEW_API_KEY",
+            capabilities: { local: true }
+          }
+        }
+      }
+    };
+    writeFileSync(configPath, JSON.stringify(configObject));
+    const handle = await startLocalDashboardServer({
+      config: loadConfigFromObject(configObject),
+      configPath,
+      configExists: true,
+      openBrowser: false,
+      port: 0,
+      requireActiveProductionLicense: admittedProviderVerification
+    });
+    servers.push(handle.server);
+    const fakeKey = ["sk", "dashboard-revision-1234567890"].join("-");
+
+    const verifyResponse = await fetch(new URL("/api/provider/verify", handle.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        providerId: "openai-compatible",
+        apiKey: fakeKey,
+        allowRemoteSmoke: false
+      })
+    });
+    const verification = await verifyResponse.json() as {
+      ok: boolean;
+      configRevision?: string;
+    };
+    expect(verifyResponse.status).toBe(200);
+    expect(verification.ok).toBe(true);
+    expect(verification.configRevision).toMatch(/^[a-f0-9]{64}$/);
+
+    const statusResponse = await fetch(new URL("/api/status", handle.url));
+    const status = await statusResponse.json() as {
+      firstReviewPreview: { available: boolean; command: string };
+    };
+    expect(status.firstReviewPreview.available).toBe(false);
+    expect(status.firstReviewPreview.command).toContain(
+      `--expected-config-revision ${verification.configRevision}`
+    );
+    expect(JSON.stringify({ verification, status })).not.toContain(fakeKey);
+  });
+
+  it("withholds a review command for a malformed verification revision", async () => {
+    const status = await buildLocalDashboardStatus({
+      config: loadConfigFromObject({}),
+      configPath: "config.local.json",
+      configExists: true,
+      providerVerification: {
+        ok: true,
+        command: "providers verify",
+        checkedAt: "2026-07-27T00:00:00.000Z",
+        providerId: "zcode-glm",
+        state: "healthy",
+        mode: "metadata_only",
+        detail: "verified",
+        redacted: true,
+        troubleshooting: [],
+        configRevision: "not-a-sha"
+      }
+    });
+
+    expect(status.firstReviewPreview.available).toBe(false);
+    expect(status.firstReviewPreview.command).toBe(
+      "neondiff providers doctor --config config.local.json --json"
+    );
   });
 
   it("serves HTML status but blocks provider verification before activation", async () => {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -366,6 +366,14 @@ describe("local HTML dashboard", () => {
     expect(verification.ok).toBe(true);
     expect(verification.configRevision).toMatch(/^[a-f0-9]{64}$/);
     expect(JSON.stringify(verification)).not.toContain(fakeKey);
+
+    const statusResponse = await fetch(new URL("/api/status", handle.url));
+    const status = await statusResponse.json() as {
+      config: { exists: boolean; source: string };
+      providers: { defaultProviderId: string };
+    };
+    expect(status.config).toEqual({ path: configPath, exists: true, source: "file" });
+    expect(status.providers.defaultProviderId).toBe("openai-compatible");
   });
 
   it("renders status from the same changed config snapshot that provider verification accepted", async () => {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -302,6 +302,72 @@ describe("local HTML dashboard", () => {
     expect(JSON.stringify({ verification, status })).not.toContain(fakeKey);
   });
 
+  it("tracks a config created after the dashboard starts", async () => {
+    const modelServer = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/v1/models") {
+        response.end(JSON.stringify({ data: [{ id: "late-model" }] }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: "not found" }));
+    });
+    servers.push(modelServer);
+    await listen(modelServer);
+    const address = modelServer.address() as AddressInfo;
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dashboard-late-config-"));
+    const configPath = join(root, "config.local.json");
+    const startupConfig = loadConfigFromObject({});
+    const handle = await startLocalDashboardServer({
+      config: startupConfig,
+      configPath,
+      configExists: false,
+      openBrowser: false,
+      port: 0,
+      requireActiveProductionLicense: admittedProviderVerification
+    });
+    servers.push(handle.server);
+
+    const currentConfig = {
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            adapter: "openai-compatible",
+            displayName: "Late Provider",
+            baseUrl: `http://127.0.0.1:${address.port}/v1`,
+            model: "late-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "LATE_PROVIDER_API_KEY",
+            capabilities: { local: true }
+          }
+        }
+      }
+    };
+    writeFileSync(configPath, JSON.stringify(currentConfig));
+    const fakeKey = ["sk", "dashboard-late-config-1234567890"].join("-");
+    const verifyResponse = await fetch(new URL("/api/provider/verify", handle.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        providerId: "openai-compatible",
+        apiKey: fakeKey,
+        allowRemoteSmoke: false
+      })
+    });
+    const verification = await verifyResponse.json() as {
+      ok: boolean;
+      configRevision?: string;
+    };
+
+    expect(verifyResponse.status).toBe(200);
+    expect(verification.ok).toBe(true);
+    expect(verification.configRevision).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(verification)).not.toContain(fakeKey);
+  });
+
   it("renders status from the same changed config snapshot that provider verification accepted", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-dashboard-config-snapshot-"));
     const configPath = join(root, "config.local.json");

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -381,6 +381,12 @@ describe("local HTML dashboard", () => {
     const revision = "a".repeat(64);
     const status = await buildLocalDashboardStatus({
       config: loadConfigFromObject({
+        zcode: {
+          providerId: "zcode-glm",
+          cliPath: "zcode",
+          appConfigPath: "zcode.json",
+          model: "GLM-5.2"
+        },
         providers: {
           defaultProviderId: "zcode-glm",
           providers: {
@@ -390,7 +396,12 @@ describe("local HTML dashboard", () => {
               displayName: "GLM through ZCode",
               model: "GLM-5.2",
               authMode: "zcode-app-config",
-              capabilities: { review: true }
+              capabilities: {
+                review: true,
+                jsonOutput: true,
+                local: false,
+                streaming: false
+              }
             }
           }
         }
@@ -418,6 +429,67 @@ describe("local HTML dashboard", () => {
       `--expected-config-revision ${revision}`
     );
     expect(status.firstReviewPreview.command).toContain("--zcode true");
+  });
+
+  it("withholds review when the verified default provider differs from ZCode execution", async () => {
+    const status = await buildLocalDashboardStatus({
+      config: loadConfigFromObject({
+        zcode: {
+          providerId: "zcode-execution",
+          cliPath: "zcode",
+          appConfigPath: "zcode.json",
+          model: "GLM-5.2"
+        },
+        providers: {
+          defaultProviderId: "zcode-verified",
+          providers: {
+            "zcode-verified": {
+              enabled: true,
+              adapter: "zcode",
+              displayName: "Verified provider",
+              model: "GLM-5.2",
+              authMode: "zcode-app-config",
+              capabilities: {
+                review: true,
+                jsonOutput: true,
+                local: false,
+                streaming: false
+              }
+            },
+            "zcode-execution": {
+              enabled: true,
+              adapter: "zcode",
+              displayName: "Execution provider",
+              model: "GLM-5.2",
+              authMode: "zcode-app-config",
+              capabilities: {
+                review: true,
+                jsonOutput: true,
+                local: false,
+                streaming: false
+              }
+            }
+          }
+        }
+      }),
+      configPath: "config.local.json",
+      configExists: true,
+      providerVerification: {
+        ok: true,
+        command: "providers verify",
+        checkedAt: "2026-07-27T00:00:00.000Z",
+        providerId: "zcode-verified",
+        state: "healthy",
+        mode: "metadata_only",
+        detail: "verified",
+        redacted: true,
+        troubleshooting: [],
+        configRevision: "c".repeat(64)
+      }
+    });
+
+    expect(status.firstReviewPreview.available).toBe(false);
+    expect(status.firstReviewPreview.command).toContain("providers doctor");
   });
 
   it("automatically refreshes dashboard state after successful provider verification", async () => {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -73,7 +73,7 @@ describe("local HTML dashboard", () => {
     expect(html).toContain("Provider");
     expect(html).toContain("openai-compatible");
     expect(status.firstReviewPreview.command).toBe(
-      "neondiff providers doctor --config config.local.json --json"
+      "neondiff providers doctor --config /Volumes/LEXAR/Codex/neondiff/config.local.json --json"
     );
     expect(status.firstReviewPreview.command).not.toContain("<");
   });
@@ -295,10 +295,55 @@ describe("local HTML dashboard", () => {
       firstReviewPreview: { available: boolean; command: string };
     };
     expect(status.firstReviewPreview.available).toBe(false);
-    expect(status.firstReviewPreview.command).toContain(
-      `--expected-config-revision ${verification.configRevision}`
+    expect(status.firstReviewPreview.command).toBe(
+      `neondiff providers doctor --config ${configPath} --json`
     );
+    expect(status.firstReviewPreview.command).not.toContain("review-pr");
     expect(JSON.stringify({ verification, status })).not.toContain(fakeKey);
+  });
+
+  it("binds the ZCode review preview to the verified configured path", async () => {
+    const configPath = "/tmp/NeonDiff Config/config.local.json";
+    const revision = "a".repeat(64);
+    const status = await buildLocalDashboardStatus({
+      config: loadConfigFromObject({
+        providers: {
+          defaultProviderId: "zcode-glm",
+          providers: {
+            "zcode-glm": {
+              enabled: true,
+              adapter: "zcode",
+              displayName: "GLM through ZCode",
+              model: "GLM-5.2",
+              authMode: "zcode-app-config",
+              capabilities: { review: true }
+            }
+          }
+        }
+      }),
+      configPath,
+      configExists: true,
+      providerVerification: {
+        ok: true,
+        command: "providers verify",
+        checkedAt: "2026-07-27T00:00:00.000Z",
+        providerId: "zcode-glm",
+        state: "configured_unverified",
+        mode: "metadata_only",
+        detail: "verified ZCode app configuration",
+        redacted: true,
+        troubleshooting: [],
+        configRevision: revision
+      }
+    });
+
+    expect(status.firstReviewPreview.command).toContain(
+      "review-pr --config '/tmp/NeonDiff Config/config.local.json'"
+    );
+    expect(status.firstReviewPreview.command).toContain(
+      `--expected-config-revision ${revision}`
+    );
+    expect(status.firstReviewPreview.command).toContain("--zcode true");
   });
 
   it("withholds a review command for a malformed verification revision", async () => {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -302,6 +302,80 @@ describe("local HTML dashboard", () => {
     expect(JSON.stringify({ verification, status })).not.toContain(fakeKey);
   });
 
+  it("renders status from the same changed config snapshot that provider verification accepted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dashboard-config-snapshot-"));
+    const configPath = join(root, "config.local.json");
+    const startupConfig = {
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            adapter: "openai-compatible",
+            displayName: "Startup Provider",
+            baseUrl: "https://startup.example.test/v1",
+            model: "startup-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "STARTUP_API_KEY"
+          }
+        }
+      }
+    };
+    writeFileSync(configPath, JSON.stringify(startupConfig));
+    const handle = await startLocalDashboardServer({
+      config: loadConfigFromObject(startupConfig),
+      configPath,
+      configExists: true,
+      openBrowser: false,
+      port: 0,
+      requireActiveProductionLicense: admittedProviderVerification
+    });
+    servers.push(handle.server);
+
+    const currentConfig = {
+      zcode: {
+        providerId: "zcode-glm",
+        cliPath: "zcode",
+        appConfigPath: "zcode.json",
+        model: "GLM-5.2"
+      },
+      providers: {
+        defaultProviderId: "zcode-glm",
+        providers: {
+          "zcode-glm": {
+            enabled: true,
+            adapter: "zcode",
+            displayName: "Current ZCode Provider",
+            model: "GLM-5.2",
+            authMode: "zcode-app-config",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    };
+    writeFileSync(configPath, JSON.stringify(currentConfig));
+
+    const verifyResponse = await fetch(new URL("/api/provider/verify", handle.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ providerId: "zcode-glm" })
+    });
+    expect(verifyResponse.status).toBe(200);
+
+    const statusResponse = await fetch(new URL("/api/status", handle.url));
+    const status = await statusResponse.json() as {
+      providers: { defaultProviderId: string };
+      firstReviewPreview: { available: boolean; command: string };
+    };
+    expect(status.providers.defaultProviderId).toBe("zcode-glm");
+    expect(status.firstReviewPreview.command).toContain("review-pr");
+  });
+
   it("binds the ZCode review preview to the verified configured path", async () => {
     const configPath = "/tmp/NeonDiff Config/config.local.json";
     const revision = "a".repeat(64);
@@ -344,6 +418,16 @@ describe("local HTML dashboard", () => {
       `--expected-config-revision ${revision}`
     );
     expect(status.firstReviewPreview.command).toContain("--zcode true");
+  });
+
+  it("automatically refreshes dashboard state after successful provider verification", async () => {
+    const html = renderLocalDashboardHtml(await buildLocalDashboardStatus({
+      config: loadConfigFromObject({}),
+      configPath: "config.local.json",
+      configExists: true
+    }));
+
+    expect(html).toContain("if (response.ok && json.ok) window.location.reload();");
   });
 
   it("withholds a review command for a malformed verification revision", async () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -12,6 +12,7 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ProviderApiKeyVerificationInput } from "../src/local-dashboard.js";
 import { runProvidersVerifyCommand } from "../src/providers-verify-command.js";
+import { configRevision } from "../src/config-cli.js";
 import { ReviewStateStore } from "../src/state.js";
 import { createTestLicenseAdmission } from "./helpers/license-admission.js";
 import {
@@ -2731,6 +2732,65 @@ exit 1
       "false"
     ])).rejects.toMatchObject({
       stdout: expect.stringContaining("repo must be present in configured repos")
+    });
+  });
+
+  it("requires an exact config revision before review-pr can create an approval", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-revision-required-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "true"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --expected-config-revision")
+    });
+  });
+
+  it("rejects provider-disabled review-pr runs before they can authorize a live review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-provider-required-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const configText = `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`;
+    writeFileSync(configPath, configText);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--expected-config-revision",
+      configRevision(configText),
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --zcode true")
     });
   });
 

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -136,6 +136,32 @@ describe("run-once CLI reporting", () => {
     expect(runOnceCliExitCode(result)).toBe(1);
   });
 
+  it("fails a scoped live command that did not post exactly one review", () => {
+    const result = runOnceResult({
+      reposScanned: 1,
+      pullsSeen: 1,
+      reviewed: 0,
+      skippedProcessed: 1,
+      scopedPull: {
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-123",
+        title: "already processed",
+        url: "https://github.com/owner/repo/pull/123"
+      }
+    });
+
+    expect(runOnceCliExitCode(result, { dryRun: false })).toBe(1);
+    expect(buildRunOnceCliReport({
+      result,
+      dryRun: false,
+      useZCode: true,
+      repo: "owner/repo",
+      pullNumber: 123,
+      commandName: "review-pr"
+    }).ok).toBe(false);
+  });
+
   it.each([
     ["posted_stale_head", 0, true],
     ["posted_head_unverified", 1, false],
@@ -422,6 +448,47 @@ describe("run-once CLI reporting", () => {
           reviewed: 0,
           skippedPolicy: 1,
           policySkips: [{ repo: "owner/skipped", reason: "repo_profile_disabled" }]
+        }
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails before review work when the pinned config revision changed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "neondiff-review-pr-config-revision-"));
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["owner/skipped"],
+        workRoot: join(dir, "runtime"),
+        statePath: join(dir, "state.sqlite"),
+        evidenceDir: join(dir, "evidence"),
+        repoProfiles: {
+          repos: {
+            "owner/skipped": { enabled: false }
+          }
+        }
+      })}\n`);
+
+      const result = await runOnceCliCommand({
+        options: {
+          configPath,
+          repo: "owner/skipped",
+          pullNumber: 123,
+          expectedConfigRevision: "0".repeat(64),
+          dryRun: false,
+          useZCode: true
+        },
+        commandName: "review-pr"
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(JSON.parse(result.output)).toMatchObject({
+        ok: false,
+        command: "review-pr",
+        error: {
+          message: "review-pr config revision changed; run a new dry review before posting"
         }
       });
     } finally {

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -151,7 +151,10 @@ describe("run-once CLI reporting", () => {
       }
     });
 
-    expect(runOnceCliExitCode(result, { dryRun: false })).toBe(1);
+    expect(runOnceCliExitCode(result, {
+      dryRun: false,
+      commandName: "review-pr"
+    })).toBe(1);
     expect(buildRunOnceCliReport({
       result,
       dryRun: false,
@@ -160,6 +163,30 @@ describe("run-once CLI reporting", () => {
       pullNumber: 123,
       commandName: "review-pr"
     }).ok).toBe(false);
+  });
+
+  it("does not apply review-pr exact-one semantics to a broad run-once scan", () => {
+    const result = runOnceResult({
+      reposScanned: 2,
+      pullsSeen: 2,
+      reviewed: 2,
+      scopedPull: {
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-123",
+        title: "one pull in a broader sweep",
+        url: "https://github.com/owner/repo/pull/123"
+      }
+    });
+
+    expect(runOnceCliExitCode(result, {
+      dryRun: false,
+      commandName: "run-once"
+    })).toBe(0);
+    expect(runOnceCliExitCode(result, {
+      dryRun: false,
+      commandName: "review-pr"
+    })).toBe(1);
   });
 
   it.each([

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2424,6 +2424,38 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("allows an approved dry-to-live claim only while the processed row is still dry_run", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-head-claim-dry-to-live-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const dryHead = { repo: "r/x", pullNumber: 33, headSha: "sha-dry-to-live" };
+    store.recordProcessed({ ...dryHead, status: "dry_run", event: "COMMENT" });
+
+    expect(store.tryClaimReviewHead({
+      ...dryHead,
+      claimTtlMs: 900_000,
+      allowProcessedOwnerSupersession: true,
+      requiredProcessedStatusForSupersession: "dry_run",
+      now: new Date("2026-07-06T00:00:01.000Z")
+    })).toBeDefined();
+
+    const postedHead = { repo: "r/x", pullNumber: 34, headSha: "sha-already-posted" };
+    store.recordProcessed({
+      ...postedHead,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/r/x/pull/34#pullrequestreview-prior"
+    });
+    expect(store.tryClaimReviewHead({
+      ...postedHead,
+      claimTtlMs: 900_000,
+      allowProcessedOwnerSupersession: true,
+      requiredProcessedStatusForSupersession: "dry_run",
+      now: new Date("2026-07-06T00:00:02.000Z")
+    })).toBeUndefined();
+    store.close();
+  });
+
   it("retires the per-head claim and refuses ordinary re-claim after the review is recorded (#295)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-retire-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2495,6 +2495,48 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("binds dry-to-live claims to the exact config revision and permits a fresh dry proof after failure", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dry-proof-revision-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "r/x", pullNumber: 38, headSha: "sha-revision-bound" };
+    const revisionA = "a".repeat(64);
+    const revisionB = "b".repeat(64);
+
+    expect(store.tryRecordDryRun({
+      ...head,
+      event: "COMMENT",
+      configRevision: revisionA
+    })).toBe(true);
+    expect(store.tryClaimReviewHead({
+      ...head,
+      claimTtlMs: 900_000,
+      allowProcessedOwnerSupersession: true,
+      requiredProcessedStatusForSupersession: "dry_run",
+      requiredProcessedConfigRevisionForSupersession: revisionB
+    })).toBeUndefined();
+    const claim = store.tryClaimReviewHead({
+      ...head,
+      claimTtlMs: 900_000,
+      allowProcessedOwnerSupersession: true,
+      requiredProcessedStatusForSupersession: "dry_run",
+      requiredProcessedConfigRevisionForSupersession: revisionA
+    });
+    expect(claim).toBeDefined();
+
+    store.releaseReviewHeadClaim(claim!.claimId);
+    expect(store.tryRecordDryRun({
+      ...head,
+      event: "COMMENT",
+      configRevision: revisionB
+    })).toBe(true);
+    expect(store.getProcessedReview(head.repo, head.pullNumber, head.headSha)).toMatchObject({
+      status: "dry_run",
+      configRevision: revisionB
+    });
+    store.close();
+  });
+
   it("retires the per-head claim and refuses ordinary re-claim after the review is recorded (#295)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-retire-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2456,6 +2456,45 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("records a dry proof only while the head is unclaimed and unprocessed", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dry-proof-claim-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const openHead = { repo: "r/x", pullNumber: 35, headSha: "sha-open-dry" };
+    expect(store.tryRecordDryRun({ ...openHead, event: "COMMENT" })).toBe(true);
+    expect(store.getProcessedReview(openHead.repo, openHead.pullNumber, openHead.headSha)).toMatchObject({
+      status: "dry_run"
+    });
+
+    const claimedHead = { repo: "r/x", pullNumber: 36, headSha: "sha-claimed-before-dry" };
+    const claim = store.tryClaimReviewHead({
+      ...claimedHead,
+      claimTtlMs: 900_000,
+      now: new Date("2026-07-06T00:00:01.000Z")
+    });
+    expect(claim).toBeDefined();
+    expect(store.tryRecordDryRun(
+      { ...claimedHead, event: "COMMENT" },
+      new Date("2026-07-06T00:00:02.000Z")
+    )).toBe(false);
+    expect(store.getProcessedReview(
+      claimedHead.repo,
+      claimedHead.pullNumber,
+      claimedHead.headSha
+    )).toBeUndefined();
+
+    const postedHead = { repo: "r/x", pullNumber: 37, headSha: "sha-posted-before-dry" };
+    store.recordProcessed({ ...postedHead, status: "posted", event: "COMMENT" });
+    expect(store.tryRecordDryRun({ ...postedHead, event: "COMMENT" })).toBe(false);
+    expect(store.getProcessedReview(
+      postedHead.repo,
+      postedHead.pullNumber,
+      postedHead.headSha
+    )).toMatchObject({ status: "posted" });
+    store.close();
+  });
+
   it("retires the per-head claim and refuses ordinary re-claim after the review is recorded (#295)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-retire-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -416,6 +416,45 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("permits one exact live review to supersede its matching dry-run row", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-context-budget-dry-to-live-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(416, "f".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Approved dry-to-live finding")]);
+    const github = githubForPull(pull, files);
+
+    const dryResult = await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true
+    });
+    const liveResult = await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      processedHeadPolicy: "approved_dry_run"
+    });
+
+    expect(dryResult).toBe("reviewed");
+    expect(liveResult).toBe("reviewed");
+    expect(createdReviews).toHaveLength(1);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "posted"
+    });
+    state.close();
+  });
+
   it("uses the single-prompt path when overflow chunk is configured but the prompt fits", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-context-budget-within-chunk-config-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -120,7 +120,12 @@ vi.mock("../src/walkthrough.js", async (importOriginal) => {
   };
 });
 
-const { localDateFolder, prepareFailedHeadRetry, reviewPull: reviewPullImpl } = await import("../src/worker.js");
+const {
+  localDateFolder,
+  prepareFailedHeadRetry,
+  reviewPull: reviewPullImpl,
+  reviewWasAlreadyPosted
+} = await import("../src/worker.js");
 const reviewPull = (input: Parameters<typeof reviewPullImpl>[0]) => reviewPullImpl({
   ...input,
   pull: {
@@ -437,6 +442,19 @@ describe("worker context budget preflight", () => {
       useZCode: true,
       configRevision
     });
+    await expect(reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      processedHeadPolicy: "approved_dry_run"
+    })).rejects.toThrow(
+      "approved dry-run transition requires an exact configuration revision"
+    );
+    expect(createdReviews).toHaveLength(0);
     const liveResult = await reviewPull({
       config,
       github,
@@ -455,6 +473,59 @@ describe("worker context budget preflight", () => {
     expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
       status: "posted"
     });
+    state.close();
+  });
+
+  it("marks a post-success receipt persistence failure as already posted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-post-receipt-failure-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(417, "e".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    const configRevision = "c".repeat(64);
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Posted before receipt failure")]);
+    const github = githubForPull(pull, files);
+
+    await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true,
+      configRevision
+    });
+    const persistence = vi.spyOn(state, "recordProcessed")
+      .mockImplementationOnce(() => {
+        throw new Error("state receipt unavailable");
+      });
+
+    let caught: unknown;
+    try {
+      await reviewPull({
+        config,
+        github,
+        state,
+        repo: "electricsheephq/WorldOS",
+        pull,
+        dryRun: false,
+        useZCode: true,
+        configRevision,
+        processedHeadPolicy: "approved_dry_run"
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(createdReviews).toHaveLength(1);
+    expect(reviewWasAlreadyPosted(caught)).toBe(true);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain(
+      "review posted but its durable receipt could not be recorded"
+    );
+    persistence.mockRestore();
     state.close();
   });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -631,6 +631,86 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("permits a fresh dry proof after a consumed live approval fails before posting", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-consumed-live-failed-before-post-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(421, "7".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    const configRevision = "d".repeat(64);
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Fresh approval after failed live post")]);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      configRevision,
+      event: "COMMENT",
+      error: "approved_dry_run_consumed_for_live_post; post_error=provider transport failed before posting"
+    });
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true,
+      configRevision
+    })).toBe("reviewed");
+    expect(createdReviews).toHaveLength(0);
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "dry_run",
+      configRevision
+    });
+    state.close();
+  });
+
+  it("does not replace an uncertain post-success receipt with a fresh dry proof", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-consumed-live-post-uncertain-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(422, "6".repeat(40));
+    const configRevision = "e".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      configRevision,
+      event: "COMMENT",
+      error: "approved_dry_run_consumed_for_live_post"
+    });
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, [pullFile("src/a.ts", 200)]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true,
+      configRevision
+    })).toBe("skipped_processed");
+    expect(createdReviews).toHaveLength(0);
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "skipped",
+      error: "approved_dry_run_consumed_for_live_post"
+    });
+    state.close();
+  });
+
   it("preserves an approved dry-run receipt while the repository provider cooldown is active", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-approved-dry-run-active-cooldown-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -123,6 +123,7 @@ vi.mock("../src/walkthrough.js", async (importOriginal) => {
 const {
   localDateFolder,
   prepareFailedHeadRetry,
+  recoverPostedReviewReceipt,
   reviewPull: reviewPullImpl,
   reviewWasAlreadyPosted
 } = await import("../src/worker.js");
@@ -563,6 +564,65 @@ describe("worker context budget preflight", () => {
       "review posted but its durable receipt could not be recorded"
     );
     persistence.mockRestore();
+    expect(recoverPostedReviewReceipt({
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: caught
+    })).toBe(true);
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/417#pullrequestreview-1"
+    });
+    state.close();
+  });
+
+  it("preserves an approved dry-run receipt while the repository provider cooldown is active", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-approved-dry-run-active-cooldown-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.providerCooldown.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(419, "9".repeat(40));
+    const configRevision = "a".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "dry_run",
+      configRevision
+    });
+    state.recordRepoProviderCooldown({
+      repo: "electricsheephq/WorldOS",
+      cooldownUntil: new Date("2999-01-01T00:00:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, [pullFile("src/a.ts", 200)]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      configRevision,
+      processedHeadPolicy: "approved_dry_run"
+    })).toBe("skipped_provider_cooldown");
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "dry_run",
+      configRevision
+    });
+    expect(createdReviews).toHaveLength(0);
     state.close();
   });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -909,6 +909,80 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("preserves a retryable consumed approval while a replacement dry run is provider-cooled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retryable-approval-active-cooldown-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.providerCooldown.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(424, "6".repeat(40));
+    const configRevision = "c".repeat(64);
+    const retryableError = "approved_dry_run_consumed_for_live_post; post_error=provider transport failed before posting";
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      configRevision,
+      error: retryableError
+    });
+    state.recordRepoProviderCooldown({
+      repo: "electricsheephq/WorldOS",
+      cooldownUntil: new Date("2999-01-01T00:00:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, [pullFile("src/a.ts", 200)]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true,
+      configRevision,
+      processedHeadPolicy: "refresh_dry_run"
+    })).toBe("skipped_provider_cooldown");
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "skipped",
+      configRevision,
+      error: retryableError
+    });
+    expect(createdReviews).toHaveLength(0);
+    state.close();
+  });
+
+  it("deduplicates ordinary daemon dry runs for an unchanged processed head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-daemon-dry-run-dedup-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(425, "7".repeat(40));
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "dry_run"
+    });
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, [pullFile("src/a.ts", 200)]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true
+    })).toBe("skipped_processed");
+    expect(zcodePrompts).toHaveLength(0);
+    expect(createdReviews).toHaveLength(0);
+    state.close();
+  });
+
   it("admits a fresh dry proof after a pre-claim live failure leaves the prior dry receipt", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-refresh-approved-dry-run-"));
     roots.push(root);
@@ -933,7 +1007,8 @@ describe("worker context budget preflight", () => {
       pull,
       dryRun: true,
       useZCode: true,
-      configRevision: newRevision
+      configRevision: newRevision,
+      processedHeadPolicy: "refresh_dry_run"
     })).toBe("reviewed");
     expect(createdReviews).toHaveLength(0);
     expect(state.getProcessedReview(

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -423,6 +423,7 @@ describe("worker context budget preflight", () => {
     const state = new ReviewStateStore(config.statePath);
     const pull = pullSummary(416, "f".repeat(40));
     const files = [pullFile("src/a.ts", 200)];
+    const configRevision = "a".repeat(64);
     zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Approved dry-to-live finding")]);
     const github = githubForPull(pull, files);
 
@@ -433,7 +434,8 @@ describe("worker context budget preflight", () => {
       repo: "electricsheephq/WorldOS",
       pull,
       dryRun: true,
-      useZCode: true
+      useZCode: true,
+      configRevision
     });
     const liveResult = await reviewPull({
       config,
@@ -443,6 +445,7 @@ describe("worker context budget preflight", () => {
       pull,
       dryRun: false,
       useZCode: true,
+      configRevision,
       processedHeadPolicy: "approved_dry_run"
     });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -672,6 +672,62 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("fails closed without throwing when posted-review receipt recovery cannot persist", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-recovered-receipt-persistence-failed-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(420, "d".repeat(40));
+    mkdirSync(join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha
+    ), { recursive: true });
+    const error = Object.assign(new Error("receipt persistence failed"), {
+      reviewAlreadyPosted: true,
+      receipt: {
+        event: "COMMENT" as const,
+        reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/420#pullrequestreview-1",
+        preserveExistingBlocking: false
+      }
+    });
+    const getPull = vi.fn(async () => pullSummary(420, pull.head.sha));
+    const persistence = vi.spyOn(state, "recordProcessed").mockImplementation(() => {
+      throw new Error("state write still unavailable");
+    });
+
+    await expect(recoverPostedReviewReceiptForCurrentHead({
+      config,
+      github: { getPull },
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error
+    })).resolves.toBe("posted_head_unverified");
+    expect(getPull).not.toHaveBeenCalled();
+    expect(JSON.parse(readFileSync(join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha,
+      "post-receipt-recovery-persistence-failed.json"
+    ), "utf8"))).toMatchObject({
+      reason: "post_receipt_recovery_persistence_failed",
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 420,
+      expectedHeadSha: pull.head.sha,
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/420#pullrequestreview-1",
+      error: "state write still unavailable"
+    });
+    persistence.mockRestore();
+    state.close();
+  });
+
   it("withholds current-head success when recovered receipt head verification is unavailable", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-recovered-receipt-unverified-head-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -477,6 +477,34 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("refuses an approved live review when no matching dry-run receipt exists", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-approved-live-without-dry-run-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(420, "8".repeat(40));
+    const configRevision = "b".repeat(64);
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, [pullFile("src/a.ts", 200)]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      configRevision,
+      processedHeadPolicy: "approved_dry_run"
+    })).toBe("skipped_processed");
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toBeUndefined();
+    expect(createdReviews).toHaveLength(0);
+    state.close();
+  });
+
   it("does not let a daemon dry-run overwrite an already posted head", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-daemon-dry-posted-head-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -476,6 +476,43 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("does not let a daemon dry-run overwrite an already posted head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-daemon-dry-posted-head-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(418, "d".repeat(40));
+    const github = githubForPull(pull, [pullFile("src/a.ts", 200)]);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/418#pullrequestreview-1"
+    });
+
+    expect(await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true
+    })).toBe("skipped_processed");
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "posted",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/418#pullrequestreview-1"
+    });
+    expect(createdReviews).toHaveLength(0);
+    state.close();
+  });
+
   it("marks a post-success receipt persistence failure as already posted", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-post-receipt-failure-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -755,6 +755,44 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("admits a fresh dry proof after a pre-claim live failure leaves the prior dry receipt", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-refresh-approved-dry-run-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(423, "5".repeat(40));
+    const oldRevision = "a".repeat(64);
+    const newRevision = "b".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "dry_run",
+      configRevision: oldRevision
+    });
+
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, [pullFile("src/a.ts", 200)]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true,
+      configRevision: newRevision
+    })).toBe("reviewed");
+    expect(createdReviews).toHaveLength(0);
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "dry_run",
+      configRevision: newRevision
+    });
+    state.close();
+  });
+
   it("uses the single-prompt path when overflow chunk is configured but the prompt fits", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-context-budget-within-chunk-config-"));
     roots.push(root);

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -678,7 +678,7 @@ describe("worker context budget preflight", () => {
     const config = minimalConfig(root);
     const state = new ReviewStateStore(config.statePath);
     const pull = pullSummary(420, "c".repeat(40));
-    const lookupSecret = "ghp_recovery_lookup_secret";
+    const lookupSecret = ["ghp", "recovery", "lookup", "secret"].join("_");
     mkdirSync(join(
       root,
       "evidence",

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -591,6 +591,27 @@ describe("worker context budget preflight", () => {
     expect((caught as Error).message).toContain(
       "review posted but its durable receipt could not be recorded"
     );
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "skipped",
+      configRevision,
+      error: "approved_dry_run_consumed_for_live_post"
+    });
+    expect(await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      configRevision,
+      processedHeadPolicy: "approved_dry_run"
+    })).toBe("skipped_processed");
+    expect(createdReviews).toHaveLength(1);
     persistence.mockRestore();
     expect(recoverPostedReviewReceipt({
       state,

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -124,6 +124,7 @@ const {
   localDateFolder,
   prepareFailedHeadRetry,
   recoverPostedReviewReceipt,
+  recoverPostedReviewReceiptForCurrentHead,
   reviewPull: reviewPullImpl,
   reviewWasAlreadyPosted
 } = await import("../src/worker.js");
@@ -628,6 +629,103 @@ describe("worker context budget preflight", () => {
       event: "COMMENT",
       reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/417#pullrequestreview-1"
     });
+    state.close();
+  });
+
+  it("withholds current-head success when a recovered review receipt belongs to a stale head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-recovered-receipt-stale-head-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(419, "a".repeat(40));
+    const error = Object.assign(new Error("receipt persistence failed"), {
+      reviewAlreadyPosted: true,
+      receipt: {
+        event: "COMMENT" as const,
+        reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/419#pullrequestreview-1",
+        preserveExistingBlocking: false
+      }
+    });
+
+    const result = await recoverPostedReviewReceiptForCurrentHead({
+      config,
+      github: {
+        getPull: async () => pullSummary(419, "b".repeat(40))
+      },
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error
+    });
+
+    expect(result).toBe("posted_stale_head");
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/419#pullrequestreview-1",
+      error: "review_posted_head_changed"
+    });
+    state.close();
+  });
+
+  it("withholds current-head success when recovered receipt head verification is unavailable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-recovered-receipt-unverified-head-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(420, "c".repeat(40));
+    const lookupSecret = "ghp_recovery_lookup_secret";
+    mkdirSync(join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha
+    ), { recursive: true });
+    const error = Object.assign(new Error("receipt persistence failed"), {
+      reviewAlreadyPosted: true,
+      receipt: {
+        event: "COMMENT" as const,
+        reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/420#pullrequestreview-1",
+        preserveExistingBlocking: false
+      }
+    });
+
+    const result = await recoverPostedReviewReceiptForCurrentHead({
+      config,
+      github: {
+        getPull: async () => { throw new Error(`lookup failed ${lookupSecret}`); }
+      },
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error
+    });
+
+    expect(result).toBe("posted_head_unverified");
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "posted",
+      error: "post_review_head_unverified"
+    });
+    const incident = JSON.parse(readFileSync(join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha,
+      "post-receipt-recovery-head-lookup-failed.json"
+    ), "utf8"));
+    expect(JSON.stringify(incident)).not.toContain(lookupSecret);
     state.close();
   });
 

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -12,6 +12,7 @@ import { testLicenseAdmission } from "./helpers/license-admission.js";
 import {
   buildRepoMemoryContext,
   buildReviewApprovalRevision,
+  assertReviewApprovalRevisionCurrent,
   buildGitNexusContext,
   buildGitHubRelatedContext,
   buildSkillPackContext,
@@ -219,6 +220,34 @@ describe("worker review failures", () => {
       useZCode: false,
       zcodeAppConfigPath: zcodeConfigPath
     })).toBe(configRevision);
+  });
+
+  it("rejects a changed ZCode config before an approved review can continue", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-revision-current-"));
+    roots.push(root);
+    const zcodeConfigPath = join(root, "zcode.json");
+    const sourceConfigRevision = "b".repeat(64);
+    writeFileSync(zcodeConfigPath, "{\"provider\":\"glm\",\"endpoint\":\"one\"}\n");
+    const approvedRevision = buildReviewApprovalRevision({
+      configRevision: sourceConfigRevision,
+      useZCode: true,
+      zcodeAppConfigPath: zcodeConfigPath
+    })!;
+
+    expect(() => assertReviewApprovalRevisionCurrent({
+      approvedRevision,
+      sourceConfigRevision,
+      useZCode: true,
+      zcodeAppConfigPath: zcodeConfigPath
+    })).not.toThrow();
+
+    writeFileSync(zcodeConfigPath, "{\"provider\":\"glm\",\"endpoint\":\"two\"}\n");
+    expect(() => assertReviewApprovalRevisionCurrent({
+      approvedRevision,
+      sourceConfigRevision,
+      useZCode: true,
+      zcodeAppConfigPath: zcodeConfigPath
+    })).toThrow("review-pr provider configuration changed; run a new dry review before posting");
   });
 
   it("records ZCode hard timeouts with bounded retry metadata instead of anonymous failure text", () => {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -391,6 +391,52 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("keeps a consumed live approval recoverable when post rate limiting starts a cooldown", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-consumed-approved-provider-cooldown-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1236, "head-consumed-approved-rate-limit");
+    const revision = "c".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      configRevision: revision,
+      event: "COMMENT",
+      error: "approved_dry_run_consumed_for_live_post"
+    });
+
+    expect(recordProviderRateLimitCooldownIfNeeded({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("GitHub createReview rate limit reached"),
+      now: new Date("2026-07-01T00:00:00.000Z"),
+      preserveExistingDryRun: true
+    })).toBe(true);
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "skipped",
+      configRevision: revision,
+      error: expect.stringMatching(
+        /^approved_dry_run_consumed_for_live_post; post_error=/
+      )
+    });
+    expect(state.getActiveRepoProviderCooldown(
+      "electricsheephq/WorldOS",
+      new Date("2026-07-01T00:01:00.000Z")
+    )).toMatchObject({
+      reason: "provider_request_rate_limit"
+    });
+    state.close();
+  });
+
   it("degrades oversized repo-memory packets to no-memory context", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-repo-memory-budget-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -114,6 +114,51 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("keeps a consumed live approval non-retryable after post transport failure", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-consumed-live-failure-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1225, "head-consumed-approved-dry");
+    const revision = "b".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      configRevision: revision,
+      event: "COMMENT",
+      error: "approved_dry_run_consumed_for_live_post"
+    });
+
+    recordFailedReview({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("createReview transport failed"),
+      preserveExistingDryRun: true
+    });
+
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "skipped",
+      configRevision: revision,
+      error: expect.stringContaining("approved_dry_run_consumed_for_live_post")
+    });
+    expect(() => prepareFailedHeadRetry({
+      state,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      livePull: pull
+    })).toThrow("not failed/provider-cooldown");
+    state.close();
+  });
+
   it("never replaces a durable posted receipt with a generic failure row", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-posted-receipt-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -77,6 +77,42 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("preserves an approved dry proof after a live transport failure so a fresh dry run can replace it", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-approved-live-failure-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1223, "head-approved-dry");
+    const revision = "a".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "dry_run",
+      configRevision: revision,
+      event: "COMMENT"
+    });
+
+    recordFailedReview({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("createReview transport failed"),
+      preserveExistingDryRun: true
+    });
+
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "dry_run",
+      configRevision: revision
+    });
+    state.close();
+  });
+
   it("records ZCode hard timeouts with bounded retry metadata instead of anonymous failure text", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-zcode-timeout-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -11,6 +11,7 @@ import type { PullRequestSummary } from "../src/types.js";
 import { testLicenseAdmission } from "./helpers/license-admission.js";
 import {
   buildRepoMemoryContext,
+  buildReviewApprovalRevision,
   buildGitNexusContext,
   buildGitHubRelatedContext,
   buildSkillPackContext,
@@ -111,6 +112,68 @@ describe("worker review failures", () => {
       configRevision: revision
     });
     state.close();
+  });
+
+  it("never replaces a durable posted receipt with a generic failure row", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-posted-receipt-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1224, "head-posted");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1224#pullrequestreview-1"
+    });
+
+    recordFailedReview({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("later bookkeeping failed")
+    });
+
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "posted",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1224#pullrequestreview-1"
+    });
+    state.close();
+  });
+
+  it("binds approved ZCode reviews to both the NeonDiff and external provider configs", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-revision-"));
+    roots.push(root);
+    const zcodeConfigPath = join(root, "zcode.json");
+    const configRevision = "a".repeat(64);
+    writeFileSync(zcodeConfigPath, "{\"provider\":\"glm\",\"endpoint\":\"one\"}\n");
+    const first = buildReviewApprovalRevision({
+      configRevision,
+      useZCode: true,
+      zcodeAppConfigPath: zcodeConfigPath
+    });
+    writeFileSync(zcodeConfigPath, "{\"provider\":\"glm\",\"endpoint\":\"two\"}\n");
+    const second = buildReviewApprovalRevision({
+      configRevision,
+      useZCode: true,
+      zcodeAppConfigPath: zcodeConfigPath
+    });
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(second).toMatch(/^[a-f0-9]{64}$/);
+    expect(second).not.toBe(first);
+    expect(buildReviewApprovalRevision({
+      configRevision,
+      useZCode: false,
+      zcodeAppConfigPath: zcodeConfigPath
+    })).toBe(configRevision);
   });
 
   it("records ZCode hard timeouts with bounded retry metadata instead of anonymous failure text", () => {
@@ -236,6 +299,48 @@ describe("worker review failures", () => {
       error: "provider_rate_limit_cooldown_until=2026-07-01T00:01:30.000Z; reason=provider_request_rate_limit"
     });
     expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:01:00.000Z"))).toMatchObject({
+      reason: "provider_request_rate_limit"
+    });
+    state.close();
+  });
+
+  it("keeps the approved dry-run row retryable while recording a repository cooldown", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-approved-provider-cooldown-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1235, "head-approved-rate-limit");
+    const revision = "b".repeat(64);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "dry_run",
+      configRevision: revision,
+      event: "COMMENT"
+    });
+
+    expect(recordProviderRateLimitCooldownIfNeeded({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("ProviderBusinessError: [1302][Rate limit reached for requests]"),
+      now: new Date("2026-07-01T00:00:00.000Z"),
+      preserveExistingDryRun: true
+    })).toBe(true);
+    expect(state.getProcessedReview(
+      "electricsheephq/WorldOS",
+      pull.number,
+      pull.head.sha
+    )).toMatchObject({
+      status: "dry_run",
+      configRevision: revision
+    });
+    expect(state.getActiveRepoProviderCooldown(
+      "electricsheephq/WorldOS",
+      new Date("2026-07-01T00:01:00.000Z")
+    )).toMatchObject({
       reason: "provider_request_rate_limit"
     });
     state.close();


### PR DESCRIPTION
## Outcome

Supersedes the parked exact-head candidate #687 with only the two verified provider-binding blockers and the directly coupled no-hidden-reload usability fix for #686.

## Bounded acceptance criteria

- Native scoped review stays disabled unless `providers.defaultProviderId` exactly matches the `zcode.providerId` the worker will execute.
- The local dashboard renders status and first-review preview from the same stable config snapshot accepted by provider verification.
- Successful browser provider verification refreshes status automatically; no manual reload is required.
- Existing repository, entitlement, current-head, secret-custody, dry-run, and explicit live-confirmation boundaries remain unchanged.
- Current-head remote CI, hosted Mac smoke, CodeQL, review threads, top-level feedback, and annotations must pass before merge.

## Explicit non-goals

- No managed GitHub App or B1 OAuth work.
- No billing, checkout, website publication, signing, notarization, release, canary, daemon repair, allowlist rewrite, or Sparkle claim.
- No generalized dashboard framework or additional provider architecture.
- No closure of broader #517 or GA work.

## Failing-first proof

- Swift mismatch test failed because `scopedReviewProviderReady` was true for different selected and execution provider IDs.
- Dashboard snapshot test failed because status used the startup config after verification loaded a changed file.
- Browser refresh contract failed because successful verification left the stale preview visible.

Focused green proof after the fix:

- `ExistingLocalBotReconciliationTests`: 29 passed.
- Node dashboard/worker/state set: 200 passed.
- TypeScript build and `git diff --check`: passed.

Relates #686. Replaces #687; does not close broader release or GA work.