### PR TITLE
fix: scope existing-agent GitHub access proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ entitlement, and repository setup as configured while still requiring fresh,
 repository-scoped GitHub and activation verification before new review work.
 If that existing worker monitors more than one repository, the native app keeps
 the full allowlist intact and asks the user to choose one **Review Target**.
-Native activation binds to that exact target; selecting it does not remove,
+Native activation and current-access verification bind to that exact target;
+the app uses the bounded `doctor github --repo owner/repo` form rather than
+rescanning the worker's complete allowlist. Selecting it does not remove,
 disable, or rewrite the worker's other repositories. The app may reuse the
 exact matched LaunchAgent's App ID and private-key file coordinate only inside
 the child process for that config; it never copies the key into the app,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3101,9 +3101,22 @@ package final class NeonDiffDesktopModel: ObservableObject {
             byoGitHubCredentialStatus = lastError ?? "Local agent unavailable"
             return
         }
+        guard let targetRepository = selectedBYOReviewRepository,
+              repos.contains(where: {
+                  $0.enabled
+                      && $0.name.caseInsensitiveCompare(targetRepository)
+                          == .orderedSame
+              })
+        else {
+            lastError =
+                "Select one configured review target before verifying current App access."
+            byoGitHubCredentialStatus = lastError ?? "Review target required"
+            return
+        }
         let arguments = [
             "doctor", "github",
             "--config", configPath,
+            "--repo", targetRepository,
             "--json"
         ]
         let verificationContext = BYOGitHubVerificationContext(
@@ -3112,7 +3125,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
-            repositories: repos.filter(\.enabled).map(\.name).sorted(),
+            repositories: [targetRepository],
             workspaceGeneration: workspaceContextGeneration
         )
         let executablePath = cliPath
@@ -3120,7 +3133,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         isBYOGitHubVerificationInProgress = true
         byoGitHubCredentialsVerified = false
         lastError = nil
-        lastCommandLine = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --json"
+        lastCommandLine =
+            "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --repo \(shellQuote(targetRepository)) --json"
         byoGitHubCredentialStatus =
             "Verifying current App installation access through the exact existing local agent…"
 
@@ -3178,16 +3192,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
             }
         case .existingLocalAgent:
             currentContext = existingLocalAgentAccessAvailable
-                ? selectedBotInstallation.map { bot in
-                    BYOGitHubVerificationContext(
-                        appId: String(bot.appID),
-                        source: .existingLocalAgent,
-                        credentialRevision: byoGitHubCredentialRevision,
-                        cliPath: cliPath,
-                        configPath: configPath,
-                        repositories: repos.filter(\.enabled).map(\.name).sorted(),
-                        workspaceGeneration: workspaceContextGeneration
-                    )
+                ? selectedBotInstallation.flatMap { bot in
+                    selectedBYOReviewRepository.map { targetRepository in
+                        BYOGitHubVerificationContext(
+                            appId: String(bot.appID),
+                            source: .existingLocalAgent,
+                            credentialRevision: byoGitHubCredentialRevision,
+                            cliPath: cliPath,
+                            configPath: configPath,
+                            repositories: [targetRepository],
+                            workspaceGeneration: workspaceContextGeneration
+                        )
+                    }
                 }
                 : nil
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -762,7 +762,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"electricsheephq/WorldOS","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true},{"repo":"electricsheephq/evaos-code-review-bot-neondiff","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
                 .success(CLIRunResult(
@@ -831,6 +831,12 @@ import NeonDiffDesktopCore
             await Task.yield()
         }
 
+        #expect(fixture.cli.calls[1].arguments == [
+            "doctor", "github",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--json"
+        ])
         #expect(fixture.model.productionUsefulWorkAvailable)
         #expect(!fixture.model.productionDaemonStartAvailable)
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -604,13 +604,15 @@ import NeonDiffDesktopCore
 
     @MainActor
     @Test func selectedExistingBYOBotPrefersItsExactLocalAgentOverStoredKeychainMaterial() async throws {
-        let repositories = [
-            "electricsheephq/WorldOS",
+        let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"
+        let otherRepository = "electricsheephq/WorldOS"
+        let repositories = [
+            otherRepository,
+            targetRepository
         ]
-        let readChecks = repositories.map { repository in
-            #"{"repo":"\#(repository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
-        }.joined(separator: ",")
+        let readChecks =
+            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
                 .success(CLIRunResult(
@@ -651,6 +653,7 @@ import NeonDiffDesktopCore
             authMode: "zcode-app-config",
             repositories: repositories
         ))
+        fixture.model.selectBYOReviewRepository(fullName: targetRepository)
         fixture.model.pendingBYOGitHubAppId = "4184532"
         fixture.model.pendingBYOGitHubAppPrivateKey = existingBotFixturePrivateKey
         fixture.model.storeBYOGitHubAppCredentials()
@@ -670,9 +673,11 @@ import NeonDiffDesktopCore
         #expect(call.arguments == [
             "doctor", "github",
             "--config", configPath,
+            "--repo", targetRepository,
             "--json"
         ])
         #expect(call.standardInput == nil)
+        #expect(fixture.model.repos.filter(\.enabled).count == 2)
         #expect(fixture.model.byoGitHubCredentialsVerified)
         #expect(
             fixture.model.existingLocalBotBYOGitHubVerificationStatus

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -373,10 +373,12 @@ Keychain, select and apply one repository, and verify that installation without
 an operator editing local files. For a reconciled existing worker with a
 multi-repository allowlist, choose one **Review Target** in the repository
 table; this binds activation without changing the worker's other configured
-repositories. The native app can run one scoped dry review through the exact
-matched local agent, then offer a confirmed live post pinned to that dry-run
-head. It still does not start the multi-repository daemon or rewrite its
-allowlist. The managed B1 broker remains a separate path.
+repositories. Current-access verification uses `doctor github --repo` for that
+one selected target, while the default CLI command without `--repo` continues
+to inspect the complete configured allowlist. The native app can run one scoped
+dry review through the exact matched local agent, then offer a confirmed live
+post pinned to that dry-run head. It still does not start the multi-repository
+daemon or rewrite its allowlist. The managed B1 broker remains a separate path.
 The dashboard shows license status, GitHub App status, daemon status, and
 provider readiness with redacted output. Use the provider card's `Verify API Key` button before launch/use; the
 button checks the selected provider path and reports pass/fail without printing

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -155,7 +155,7 @@ directory:
 
 ```bash
 NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
-neondiff doctor github --config "$NATIVE_CONFIG" --json
+neondiff doctor github --config "$NATIVE_CONFIG" --repo owner/repo --json
 ```
 
 CLI-first and non-Mac setups may instead use the checkout-local path documented
@@ -165,10 +165,13 @@ in [SETUP.md](SETUP.md):
 neondiff doctor github --config config.local.json --json
 ```
 
-The command verifies App credential presence, App installation visibility, and
-repo read access for the enabled repos in your local config. It does not run
-ZCode, call a model provider, post comments, print tokens, or print the private
-key path.
+The scoped command verifies App credential presence, App installation
+visibility, and repo read access for that exact configured repository. The
+native app uses this form when a reconciled existing worker has a larger
+allowlist, so current-access proof remains bounded to the selected Review Target
+without rewriting the worker. Omit `--repo` for the CLI-first full-allowlist
+doctor. Neither form runs ZCode, calls a model provider, posts comments, prints
+tokens, or prints the private key path.
 
 Before starting a long-running daemon, also follow the worktree-cleanup setup in
 [SETUP.md](SETUP.md): install the full `lsof` utility, and keep the configured

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,7 +400,8 @@ async function main(): Promise<void> {
     const config = loadConfig(args.config);
     if (args._[1] === "github") {
       const credentials = await resolveDoctorGitHubCredentials(args, process.stdin);
-      const result = await buildDoctorGithubReport(config, credentials);
+      const requestedRepo = args.repo ? parseSingleArg(args.repo, "--repo") : undefined;
+      const result = await buildDoctorGithubReport(config, credentials, requestedRepo);
       console.log(stringifyRedactedJson(result));
       if (!result.ok) process.exitCode = 1;
       return;
@@ -2963,7 +2964,11 @@ type DoctorGitHubCredentialOverride = {
   source: "stdin";
 };
 
-async function buildDoctorGithubReport(config: BotConfig, credentials?: DoctorGitHubCredentialOverride) {
+async function buildDoctorGithubReport(
+  config: BotConfig,
+  credentials?: DoctorGitHubCredentialOverride,
+  requestedRepo?: string
+) {
   const github = new GitHubApi(credentials
     ? {
         ...config.github,
@@ -2972,7 +2977,7 @@ async function buildDoctorGithubReport(config: BotConfig, credentials?: DoctorGi
         privateKeyPath: undefined
       }
     : config.github);
-  const monitoredRepos = listReposToScan(config);
+  const monitoredRepos = resolveDoctorGitHubRepos(config, requestedRepo);
   const readChecks = [];
   let activeRepoChecks = 0;
   const appCredentialsConfigured = github.canPostAsApp();
@@ -3040,7 +3045,11 @@ async function buildDoctorGithubReport(config: BotConfig, credentials?: DoctorGi
     }
   }
 
-  const issueReadChecks = await collectIssueEnrichmentReadChecks(config, github);
+  const issueReadChecks = await collectIssueEnrichmentReadChecks(
+    config,
+    github,
+    requestedRepo ? monitoredRepos : undefined
+  );
   const issueEnrichment = buildIssueEnrichmentStatus({
     config,
     canPostAsApp: appCredentialsConfigured,
@@ -3095,6 +3104,26 @@ async function buildDoctorGithubReport(config: BotConfig, credentials?: DoctorGi
       ...(readChecks.some((check) => !check.ok) ? ["Confirm the GitHub App is installed on selected repositories with the required repository permissions."] : [])
     ]
   };
+}
+
+function resolveDoctorGitHubRepos(config: BotConfig, requestedRepo?: string): string[] {
+  const configuredRepos = listReposToScan(config);
+  if (!requestedRepo) return configuredRepos;
+
+  const requestedCanonical = canonicalRepoNameForCli(requestedRepo);
+  const configuredRepo = configuredRepos.find(
+    (repo) => canonicalRepoNameForCli(repo) === requestedCanonical
+  );
+  if (!configuredRepo) {
+    throw new Error(
+      `doctor github --repo must be present in configured repos: ${configuredRepos.join(", ") || "(none)"}`
+    );
+  }
+  const policy = resolveRepoProfile(config, configuredRepo);
+  if (!policy.allowed) {
+    throw new Error(`doctor github --repo is blocked by repo policy: ${policy.reason}`);
+  }
+  return [configuredRepo];
 }
 
 async function resolveDoctorGitHubCredentials(
@@ -3204,13 +3233,16 @@ function licenseGateDecisionForVisibility(
 
 async function collectIssueEnrichmentReadChecks(
   config: BotConfig,
-  github: GitHubApi
+  github: GitHubApi,
+  repoScope?: string[]
 ): Promise<IssueEnrichmentRepoReadCheck[]> {
   const issueConfig = config.issueEnrichment;
   if (!issueConfig || issueConfig.allowlist.length === 0) return [];
   const canRead = github.canPostAsApp() || Boolean(config.github.token);
   const checks: IssueEnrichmentRepoReadCheck[] = [];
+  const scopedRepos = repoScope?.map(canonicalRepoNameForCli);
   for (const repo of issueConfig.allowlist) {
+    if (scopedRepos && !scopedRepos.includes(canonicalRepoNameForCli(repo))) continue;
     const policy = resolveIssueEnrichmentRepoPolicy(issueConfig, repo);
     if (!policy.allowed) {
       checks.push({ repo, ok: true, skippedByPolicy: policy.reason });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2500,8 +2500,9 @@ function validateReviewPrRepoAllowed(config: ReturnType<typeof loadConfig>, repo
 }
 
 function canonicalRepoNameForCli(repo: string): string {
-  const [owner, name] = repo.split("/");
-  return `${owner?.toLowerCase() ?? ""}/${name?.toLowerCase() ?? ""}`;
+  const [owner, name, extra] = repo.trim().split("/");
+  if (extra !== undefined || !owner || !name) return "";
+  return `${owner.toLowerCase()}/${name.toLowerCase()}`;
 }
 
 function validateInitForceTarget(configPath: string): string | undefined {
@@ -3051,7 +3052,9 @@ async function buildDoctorGithubReport(
     requestedRepo ? monitoredRepos : undefined
   );
   const issueEnrichment = buildIssueEnrichmentStatus({
-    config,
+    config: requestedRepo
+      ? scopeDoctorIssueEnrichmentConfig(config, monitoredRepos)
+      : config,
     canPostAsApp: appCredentialsConfigured,
     issueReadChecks
   });
@@ -3111,6 +3114,9 @@ function resolveDoctorGitHubRepos(config: BotConfig, requestedRepo?: string): st
   if (!requestedRepo) return configuredRepos;
 
   const requestedCanonical = canonicalRepoNameForCli(requestedRepo);
+  if (!requestedCanonical) {
+    throw new Error("doctor github --repo must be exactly one GitHub owner/repo name");
+  }
   const configuredRepo = configuredRepos.find(
     (repo) => canonicalRepoNameForCli(repo) === requestedCanonical
   );
@@ -3124,6 +3130,41 @@ function resolveDoctorGitHubRepos(config: BotConfig, requestedRepo?: string): st
     throw new Error(`doctor github --repo is blocked by repo policy: ${policy.reason}`);
   }
   return [configuredRepo];
+}
+
+function scopeDoctorIssueEnrichmentConfig(config: BotConfig, monitoredRepos: string[]): BotConfig {
+  const issueEnrichment = config.issueEnrichment;
+  if (!issueEnrichment) return config;
+
+  const monitored = new Set(monitoredRepos.map(canonicalRepoNameForCli));
+  const allowlist = issueEnrichment.allowlist.filter((repo) =>
+    monitored.has(canonicalRepoNameForCli(repo))
+  );
+  if (allowlist.length === 0) {
+    return {
+      ...config,
+      issueEnrichment: {
+        ...issueEnrichment,
+        enabled: false,
+        allowlist: [],
+        repos: {}
+      }
+    };
+  }
+
+  const repos = Object.fromEntries(
+    Object.entries(issueEnrichment.repos ?? {}).filter(([repo]) =>
+      monitored.has(canonicalRepoNameForCli(repo))
+    )
+  );
+  return {
+    ...config,
+    issueEnrichment: {
+      ...issueEnrichment,
+      allowlist,
+      repos
+    }
+  };
 }
 
 async function resolveDoctorGitHubCredentials(

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1320,7 +1320,7 @@ exit 1
     });
   });
 
-  it("doctor github proves App installation reads without printing secrets", async () => {
+  it("doctor github can scope App installation proof to one configured repo", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-"));
     roots.push(root);
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
@@ -1365,7 +1365,7 @@ exit 1
       const address = server.address() as AddressInfo;
       const configPath = join(root, "config.json");
       writeFileSync(configPath, `${JSON.stringify({
-        pilotRepos: ["acme/demo"],
+        pilotRepos: ["acme/demo", "acme/other"],
         workRoot: join(root, "runtime"),
         statePath: join(root, "state.sqlite"),
         evidenceDir: join(root, "evidence"),
@@ -1396,7 +1396,9 @@ exit 1
         }
       })}\n`);
 
-      const { stdout } = await runCli(["doctor", "github", "--config", configPath], {
+      const { stdout } = await runCli([
+        "doctor", "github", "--config", configPath, "--repo", "acme/demo"
+      ], {
         env: {
           NEONDIFF_GITHUB_APP_ID: "12345",
           NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: privateKeyPath
@@ -1407,6 +1409,7 @@ exit 1
       expect(output).toMatchObject({
         ok: true,
         command: "doctor github",
+        monitoredRepos: ["acme/demo"],
         activeRepoChecks: 1,
         appCredentials: {
           appIdConfigured: true,
@@ -1461,6 +1464,8 @@ exit 1
         "github",
         "--config",
         configPath,
+        "--repo",
+        "acme/demo",
         "--github-app-id",
         "12345",
         "--github-app-private-key-stdin",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1384,15 +1384,25 @@ exit 1
         },
         issueEnrichment: {
           enabled: true,
-          postIssueComment: false,
-          allowlist: ["acme/demo"],
+          postIssueComment: true,
+          allowlist: ["acme/demo", "acme/other"],
           maxIssuesPerCycle: 1,
-          maxCommentsPerCycle: 0,
+          maxCommentsPerCycle: 1,
           cooldownMs: 3_600_000,
           burstWindowMs: 3_600_000,
           maxIssuesPerBurst: 3,
           lookbackMs: 600_000,
-          processExistingOpenIssuesOnActivation: false
+          processExistingOpenIssuesOnActivation: false,
+          repos: {
+            "acme/demo": {
+              maxIssuesPerCycle: 1,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 1,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
 
@@ -1437,7 +1447,9 @@ exit 1
         }
       });
       expect(output.issueEnrichment).toMatchObject({
-        state: "dry_run_only",
+        state: "ready",
+        allowlist: ["acme/demo"],
+        liveThresholdsMissingRepos: [],
         readChecks: [
           {
             repo: "acme/demo",
@@ -1500,6 +1512,39 @@ exit 1
     } finally {
       await closeServer(server);
     }
+  });
+
+  it("doctor github rejects malformed, unconfigured, and policy-disabled repository scopes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-scope-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/demo", "acme/disabled"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      repoProfiles: {
+        repos: {
+          "acme/disabled": { enabled: false }
+        }
+      }
+    })}\n`);
+
+    await expect(runCli([
+      "doctor", "github", "--config", configPath, "--repo", "acme/demo/extra"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("must be exactly one GitHub owner/repo name")
+    });
+    await expect(runCli([
+      "doctor", "github", "--config", configPath, "--repo", "acme/unconfigured"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("must be present in configured repos")
+    });
+    await expect(runCli([
+      "doctor", "github", "--config", configPath, "--repo", "acme/disabled"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("is blocked by repo policy")
+    });
   });
 
   it("doctor github rejects an invalid App ID before consuming an open secret stdin", async () => {


### PR DESCRIPTION
Related: #686

## Bounded outcome

Make the installed B0 app reverify the selected Review Target through the exact matched local agent without rescanning or rewriting the worker's full repository allowlist.

## Acceptance criteria

- `doctor github --repo owner/repo` verifies exactly one configured, policy-allowed repository.
- The default command without `--repo` retains the full-allowlist doctor.
- Existing-agent native verification passes the selected target and requires an exact one-repository report.
- The matched LaunchAgent credential overlay remains child-process-only; no key is copied, printed, placed in argv, or stored by the app.
- The worker's existing allowlist remains unchanged.

## Non-goals

- No managed GitHub App or B1 OAuth work.
- No daemon restart, allowlist rewrite, credential migration, billing, checkout, publication, tag, or release.
- No broader #517 or GA closure.

## Reproduction and proof

- Installed signed build 11024 reproduced the blocker: the full 35-repository doctor exceeded the native 30-second deadline and returned a safe failure after roughly 102 seconds.
- Failing-first CLI test: the scoped command initially scanned the second configured repository and failed.
- Failing-first Swift test: the model omitted `--repo` and rejected the selected-only proof.
- Focused CLI test now passes: 1/1.
- Focused Swift test now passes: 1/1.
- Live authorized source probe on the same selected repository passed in 5.41 seconds with `readMode=app_installation`, one monitored repository, and all read checks healthy.
- TypeScript build, secret scan (848 tracked files), and `git diff --check` pass.

The previously signed private beta.20 artifact remains unpublished and is superseded for release purposes by this source fix. A new signed candidate is required after merge and exact-main CI.
