### PR TITLE
fix(ci): avoid fresh Phase 1 lease port collisions

### DIFF
--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import {
+  constants as fsConstants,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -990,7 +991,7 @@ async function acquireRunLease(path: string): Promise<number> {
       return fd;
     } catch (error) {
       if (!isAlreadyExistsError(error)) throw error;
-      const prior = parseJson<{ pid?: number }>(path);
+      const prior = parseOpenedRunLease(path);
       if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
       // Every conforming stale-lock recovery writer must own the crash-released
       // loopback coordinator before replacing the canonical lease. Fresh writers
@@ -1321,6 +1322,15 @@ function finalizeRun(outputDir: string, summary: Phase1RunSummary): Phase1RunSum
 
 function parseJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function parseOpenedRunLease(path: string): { pid?: number } {
+  const fd = openSync(path, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+  try {
+    return JSON.parse(readFileSync(fd, "utf8")) as { pid?: number };
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function fingerprint(value: unknown): string {

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -958,31 +958,36 @@ function canonicalProspectivePath(path: string): string {
 }
 
 async function acquireRunLease(path: string): Promise<number> {
-  try {
-    const fd = openSync(path, "wx", 0o600);
-    writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
-    return fd;
-  } catch (error) {
-    if (!isAlreadyExistsError(error)) throw error;
-  }
-
   const coordinator = createServer((socket) => socket.destroy());
   const coordinationPort = phase1LeaseCoordinationPort(path);
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    const fail = (error: Error & { code?: string }) => {
-      coordinator.removeListener("listening", ready);
-      rejectPromise(new Error(error.code === "EADDRINUSE"
-        ? "Phase 1 lease acquisition is already coordinated by another writer"
-        : `Phase 1 lease coordination failed: ${errorMessage(error)}`));
-    };
-    const ready = () => {
-      coordinator.removeListener("error", fail);
-      resolvePromise();
-    };
-    coordinator.once("error", fail);
-    coordinator.once("listening", ready);
-    coordinator.listen({ host: "127.0.0.1", port: coordinationPort, exclusive: true });
-  });
+  try {
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      const fail = (error: Error & { code?: string }) => {
+        coordinator.removeListener("listening", ready);
+        rejectPromise(error);
+      };
+      const ready = () => {
+        coordinator.removeListener("error", fail);
+        resolvePromise();
+      };
+      coordinator.once("error", fail);
+      coordinator.once("listening", ready);
+      coordinator.listen({ host: "127.0.0.1", port: coordinationPort, exclusive: true });
+    });
+  } catch (error) {
+    const coordinationError = error as Error & { code?: string };
+    if (coordinationError.code !== "EADDRINUSE") {
+      throw new Error(`Phase 1 lease coordination failed: ${errorMessage(coordinationError)}`);
+    }
+    try {
+      const fd = openSync(path, "wx", 0o600);
+      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
+      return fd;
+    } catch (leaseError) {
+      if (!isAlreadyExistsError(leaseError)) throw leaseError;
+      throw new Error("Phase 1 lease acquisition is already coordinated by another writer");
+    }
+  }
   try {
     try {
       const fd = openSync(path, "wx", 0o600);

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -958,6 +958,14 @@ function canonicalProspectivePath(path: string): string {
 }
 
 async function acquireRunLease(path: string): Promise<number> {
+  try {
+    const fd = openSync(path, "wx", 0o600);
+    writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
+    return fd;
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+  }
+
   const coordinator = createServer((socket) => socket.destroy());
   const coordinationPort = phase1LeaseCoordinationPort(path);
   await new Promise<void>((resolvePromise, rejectPromise) => {
@@ -982,23 +990,22 @@ async function acquireRunLease(path: string): Promise<number> {
       return fd;
     } catch (error) {
       if (!isAlreadyExistsError(error)) throw error;
-      const prior = parseJson<{ pid?: number }>(path);
-      if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
-      // Every conforming writer must own the crash-released loopback
-      // coordinator before replacing the canonical lease. Build the new lease
-      // under a unique name, then atomically replace the verified-stale path;
-      // there is no check/remove/reopen window on the canonical path.
-      const replacementPath = `${path}.${process.pid}.${randomUUID()}.replacement`;
-      const fd = openSync(replacementPath, "wx", 0o600);
-      try {
-        writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
-        renameSync(replacementPath, path);
-        return fd;
-      } catch (replacementError) {
-        closeSync(fd);
-        rmSync(replacementPath, { force: true });
-        throw replacementError;
-      }
+    }
+    const prior = parseJson<{ pid?: number }>(path);
+    if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
+    // Every conforming stale-lock recovery writer must own the crash-released
+    // loopback coordinator before replacing the canonical lease. Fresh writers
+    // are already serialized by the initial O_EXCL create above.
+    const replacementPath = `${path}.${process.pid}.${randomUUID()}.replacement`;
+    const fd = openSync(replacementPath, "wx", 0o600);
+    try {
+      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
+      renameSync(replacementPath, path);
+      return fd;
+    } catch (replacementError) {
+      closeSync(fd);
+      rmSync(replacementPath, { force: true });
+      throw replacementError;
     }
   } finally {
     await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -990,22 +990,22 @@ async function acquireRunLease(path: string): Promise<number> {
       return fd;
     } catch (error) {
       if (!isAlreadyExistsError(error)) throw error;
-    }
-    const prior = parseJson<{ pid?: number }>(path);
-    if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
-    // Every conforming stale-lock recovery writer must own the crash-released
-    // loopback coordinator before replacing the canonical lease. Fresh writers
-    // are already serialized by the initial O_EXCL create above.
-    const replacementPath = `${path}.${process.pid}.${randomUUID()}.replacement`;
-    const fd = openSync(replacementPath, "wx", 0o600);
-    try {
-      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
-      renameSync(replacementPath, path);
-      return fd;
-    } catch (replacementError) {
-      closeSync(fd);
-      rmSync(replacementPath, { force: true });
-      throw replacementError;
+      const prior = parseJson<{ pid?: number }>(path);
+      if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
+      // Every conforming stale-lock recovery writer must own the crash-released
+      // loopback coordinator before replacing the canonical lease. Fresh writers
+      // are already serialized by the initial O_EXCL create above.
+      const replacementPath = `${path}.${process.pid}.${randomUUID()}.replacement`;
+      const fd = openSync(replacementPath, "wx", 0o600);
+      try {
+        writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
+        renameSync(replacementPath, path);
+        return fd;
+      } catch (replacementError) {
+        closeSync(fd);
+        rmSync(replacementPath, { force: true });
+        throw replacementError;
+      }
     }
   } finally {
     await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -1,7 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import {
-  constants as fsConstants,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -991,11 +990,12 @@ async function acquireRunLease(path: string): Promise<number> {
       return fd;
     } catch (error) {
       if (!isAlreadyExistsError(error)) throw error;
-      const prior = parseOpenedRunLease(path);
+      const prior = parseJson<{ pid?: number }>(path);
       if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
-      // Every conforming stale-lock recovery writer must own the crash-released
-      // loopback coordinator before replacing the canonical lease. Fresh writers
-      // are already serialized by the initial O_EXCL create above.
+      // Every conforming writer must own the crash-released loopback
+      // coordinator before replacing the canonical lease. Build the new lease
+      // under a unique name, then atomically replace the verified-stale path;
+      // there is no check/remove/reopen window on the canonical path.
       const replacementPath = `${path}.${process.pid}.${randomUUID()}.replacement`;
       const fd = openSync(replacementPath, "wx", 0o600);
       try {
@@ -1322,15 +1322,6 @@ function finalizeRun(outputDir: string, summary: Phase1RunSummary): Phase1RunSum
 
 function parseJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, "utf8")) as T;
-}
-
-function parseOpenedRunLease(path: string): { pid?: number } {
-  const fd = openSync(path, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
-  try {
-    return JSON.parse(readFileSync(fd, "utf8")) as { pid?: number };
-  } finally {
-    closeSync(fd);
-  }
 }
 
 function fingerprint(value: unknown): string {

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -776,6 +776,22 @@ describe("Phase 1 screening runner", () => {
     await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/active exclusive run lease/i);
   });
 
+  it("does not require the stale-recovery coordinator for a fresh output lease", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-fresh-lease-"));
+    const coordinator = createNetServer();
+    await new Promise<void>((resolvePromise) => coordinator.listen({
+      host: "127.0.0.1",
+      port: phase1LeaseCoordinationPort(join(outputDir, ".phase1-run.lock")),
+      exclusive: true
+    }, resolvePromise));
+    try {
+      const result = await runPhase1Screen(spec(outputDir), adapter());
+      expect(result.status).toBe("completed");
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
   it("serializes stale lease recovery through a crash-released loopback coordinator", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-stale-lease-"));
     writeFileSync(join(outputDir, ".phase1-run.lock"), JSON.stringify({ pid: 999_999_999 }));
@@ -783,6 +799,7 @@ describe("Phase 1 screening runner", () => {
     expect(result.status).toBe("completed");
 
     const blockedDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-coordinated-lease-"));
+    writeFileSync(join(blockedDir, ".phase1-run.lock"), JSON.stringify({ pid: 999_999_999 }));
     const coordinator = createNetServer();
     await new Promise<void>((resolvePromise) => coordinator.listen({
       host: "127.0.0.1",


### PR DESCRIPTION
Relates to #692 and unblocks #610.

Acceptance
- failing-first test proves a fresh output lease does not require the stale-recovery coordinator even when its derived TCP port is occupied;
- fresh writers use the atomic O_EXCL lock create first;
- only EEXIST/stale-recovery paths bind the deterministic coordinator;
- active live-PID leases and concurrent stale recovery remain fail closed;
- focused Phase 1 suite, build, secret scan, exact-head remote CI, and one bounded independent review pass.

Evidence before push
- failing-first new test: failed with Phase 1 lease acquisition is already coordinated by another writer;
- new test after fix: 1/1 passed;
- lease-focused tests: 4/4 passed;
- full phase1-screening-runner test file: 79/79 passed;
- npm run build: passed;
- secret scan: 848 tracked files passed;
- git diff --check: passed.

Non-goals
- no Phase 1 evidence-format or product redesign;
- no weakening of active-writer or stale-recovery exclusivity;
- no broad CI refactor, Mac-app behavior change, billing, release, or unrelated hardening.