### PR TITLE
fix(desktop): allow legacy agent GitHub verification

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3144,7 +3144,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     executablePath: executablePath,
                     arguments: arguments,
                     standardInput: nil,
-                    timeout: 30
+                    // Current agents honor --repo and return quickly. Older
+                    // compatible local agents may ignore that filter and scan
+                    // their full configured allowlist, so keep this read-only
+                    // existing-agent probe bounded without killing valid proof.
+                    timeout: 150
                 )
                 await MainActor.run {
                     self.applyBYOGitHubVerificationResult(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -677,6 +677,7 @@ import NeonDiffDesktopCore
             "--json"
         ])
         #expect(call.standardInput == nil)
+        #expect(call.timeout == 150)
         #expect(fixture.model.repos.filter(\.enabled).count == 2)
         #expect(fixture.model.byoGitHubCredentialsVerified)
         #expect(


### PR DESCRIPTION
## Outcome

Allow the installed Mac app to accept valid GitHub installation/repository proof from an older already-configured local NeonDiff agent that ignores the newer `doctor github --repo` filter and therefore needs longer than 30 seconds to finish its read-only full-allowlist scan.

Related to #686 and tracker #610. This PR does not close the broader installed B0 golden path.

## Reproduced installed failure

Private signed/notarized `v1.1.0-beta.21` build 11025 from protected main `8c63bef288392f809c63c9a13f88bfa3c8aad2a4` restored the ElectricSheep bot, 35 repositories, provider, entitlement, and selected review target as 4/4 ready. `Verify Existing App Access` then failed safely at the native 30-second boundary.

The exact launchd-owned CLI eventually returned authoritative App-installation proof for all 35 repos, but only after roughly 90 seconds because its source head `c1bbdbb986e4b91b604a328bfa44f64026f86c93` predates the `--repo` optimization. Current protected-main source honored `--repo`, checked exactly one repo, and passed in 4.1 seconds.

## Acceptance criteria

- Keep the exact `doctor github --config ... --repo <selected> --json` request.
- Keep credentials in the launchd-owned execution context; no stdin, copying, printing, or Keychain migration.
- Bound only existing-local-agent GitHub verification at 150 seconds so older valid agents can finish.
- Preserve fast completion for current agents and fail closed on timeout or invalid proof.
- Preserve repository/activation binding and all scoped dry/live review gates.

## Non-goals

- No worker, launchd, config, repository allowlist, queue, credential, activation, review-posting, billing, website, signing, tag, or publication change.
- No generalized compatibility harness or wider timeout changes.
- No beta/release/customer-readiness claim.

## Failing-first and local proof

- RED: exact existing-agent test failed because recorded timeout was `30.0`, expected `150.0`.
- GREEN: focused exact test 1/1 passed.
- GREEN: complete `ExistingLocalBotReconciliationTests` 30/30 passed.
- `git diff --check` passed.

Remote CI, hosted Mac proof, current-head review surfaces, and one bounded independent review remain required before merge. beta.21 remains private and superseded pending this source fix.