### PR TITLE
feat(desktop): enable license-aware signed updates

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -42,9 +42,15 @@ jobs:
         run: swift run NeonDiffDesktopAppcastChecks
 
       - name: Build unsigned Release app bundle
+        env:
+          NEONDIFF_SPARKLE_FEED_URL: https://ci.invalid/neondiff/appcast-beta.xml
+          NEONDIFF_SPARKLE_PUBLIC_ED_KEY: CI_ONLY_NOT_A_RELEASE_KEY
         run: script/build_and_run.sh release-build
 
       - name: Check unsigned Release app bundle
+        env:
+          NEONDIFF_SPARKLE_FEED_URL: https://ci.invalid/neondiff/appcast-beta.xml
+          NEONDIFF_SPARKLE_PUBLIC_ED_KEY: CI_ONLY_NOT_A_RELEASE_KEY
         run: script/build_and_run.sh release-bundle-check
 
       - name: Enforce release-only fixture boundary

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -408,6 +408,8 @@ jobs:
         timeout-minutes: 5
         env:
           RELEASE_ARCHIVE: ${{ runner.temp }}/NeonDiffDesktop-release.xcarchive
+          NEONDIFF_SPARKLE_FEED_URL: https://ci.invalid/neondiff/appcast-beta.xml
+          NEONDIFF_SPARKLE_PUBLIC_ED_KEY: CI_ONLY_NOT_A_RELEASE_KEY
         run: |
           set -euo pipefail
           NEONDIFF_DESKTOP_DIST_DIR="$PWD/apps/neondiff-desktop/dist-release" \

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -50,10 +50,10 @@ struct NeonDiffDesktopApp: App {
         }
         let initialModel = context.map(DesktopEvaluationModelAdapter.makeModel(context:))
             ?? NeonDiffDesktopCompositionRoot.makeModel()
-        let initialUpdateController = NeonUpdateController()
+        let initialUpdateController = NeonUpdateController(model: initialModel)
 #else
         let initialModel = NeonDiffDesktopCompositionRoot.makeModel()
-        let initialUpdateController = NeonUpdateController()
+        let initialUpdateController = NeonUpdateController(model: initialModel)
 #endif
         _model = StateObject(wrappedValue: initialModel)
         _updateController = StateObject(wrappedValue: initialUpdateController)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
@@ -54,6 +54,7 @@ final class NeonUpdateController: NSObject, ObservableObject, SPUUpdaterDelegate
         case .checking: "CHECKING"
         case .updateAvailable: "UPDATE AVAILABLE"
         case .upToDate: "UP TO DATE"
+        case .feedInvalid: "FEED ERROR"
         case .networkError: "NETWORK ERROR"
         case .signatureError: "SIGNATURE ERROR"
         case .failed: "UPDATE ERROR"
@@ -74,6 +75,8 @@ final class NeonUpdateController: NSObject, ObservableObject, SPUUpdaterDelegate
             "A signed NeonDiff update is available."
         case .upToDate:
             "This Mac has the newest eligible NeonDiff beta."
+        case .feedInvalid:
+            "The signed NeonDiff update feed is invalid. No update was installed."
         case .networkError:
             "NeonDiff could not reach the update feed. Check your connection and try again."
         case .signatureError:
@@ -176,6 +179,9 @@ final class NeonUpdateController: NSObject, ObservableObject, SPUUpdaterDelegate
         case .signatureError:
             runtimeStatus = .signatureError
             lastAction = "Update rejected: signature verification failed"
+        case .feedInvalid:
+            runtimeStatus = .feedInvalid
+            lastAction = "Update check failed: signed feed is invalid"
         case .networkError:
             runtimeStatus = .networkError
             lastAction = "Update check failed: feed unavailable"
@@ -253,6 +259,7 @@ private enum RuntimeStatus {
     case checking
     case updateAvailable
     case upToDate
+    case feedInvalid
     case networkError
     case signatureError
     case failed(String)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
@@ -171,6 +171,12 @@ final class NeonUpdateController: NSObject, ObservableObject, SPUUpdaterDelegate
         didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
         error: Error?
     ) {
+        if case .blocked(let reason) = model.desktopUpdateAccess {
+            runtimeStatus = .blocked(reason.customerMessage)
+            lastAction = "Update remained blocked after the current cycle"
+            objectWillChange.send()
+            return
+        }
         guard let error = error as NSError? else { return }
         switch DesktopUpdateCycleResult.classify(sparkleErrorCode: error.code) {
         case .noUpdate:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
@@ -1,30 +1,259 @@
+import Combine
 import Foundation
+import NeonDiffDesktopAppCore
+import Sparkle
 
 @MainActor
-final class NeonUpdateController: ObservableObject {
-    @Published private(set) var lastAction = "Updates blocked pending native activation proof"
+final class NeonUpdateController: NSObject, ObservableObject, SPUUpdaterDelegate {
+    @Published private(set) var lastAction: String
 
-    init(bundle: Bundle = .main) {
-        _ = bundle
+    private let bundle: Bundle
+    private let model: NeonDiffDesktopModel
+    private var updaterController: SPUStandardUpdaterController?
+    private var modelObservation: AnyCancellable?
+    private var runtimeStatus: RuntimeStatus
+
+    init(bundle: Bundle = .main, model: NeonDiffDesktopModel) {
+        self.bundle = bundle
+        self.model = model
+        if Self.hasSignedFeedConfiguration(bundle: bundle) {
+            runtimeStatus = .blocked(model.desktopUpdateAccess.customerMessage)
+            lastAction = "Ready to verify update access"
+        } else {
+            runtimeStatus = .notConfigured
+            lastAction = "Signed update feed is not configured in this build"
+        }
+        super.init()
+
+        modelObservation = model.objectWillChange.sink { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.modelDidChange()
+            }
+        }
+        modelDidChange()
     }
 
     var isConfigured: Bool {
-        false
+        Self.hasSignedFeedConfiguration(bundle: bundle)
     }
 
     var canCheckForUpdates: Bool {
-        false
+        guard isConfigured,
+              model.desktopUpdateAccess.allowedChannel != nil
+        else {
+            return false
+        }
+        return updaterController?.updater.canCheckForUpdates ?? false
     }
 
     var badgeText: String {
-        "UPDATES BLOCKED"
+        switch runtimeStatus {
+        case .notConfigured: "NOT CONFIGURED"
+        case .blocked: "ENTITLEMENT REQUIRED"
+        case .ready: "READY"
+        case .checking: "CHECKING"
+        case .updateAvailable: "UPDATE AVAILABLE"
+        case .upToDate: "UP TO DATE"
+        case .networkError: "NETWORK ERROR"
+        case .signatureError: "SIGNATURE ERROR"
+        case .failed: "UPDATE ERROR"
+        }
     }
 
     var statusText: String {
-        "Sparkle startup and manual checks are disabled until the native app proves API-backed activation and update entitlement."
+        switch runtimeStatus {
+        case .notConfigured:
+            "This build has no signed NeonDiff update feed."
+        case .blocked(let reason):
+            reason
+        case .ready:
+            "Signed beta updates are enabled for this verified account."
+        case .checking:
+            "Checking the signed NeonDiff beta feed."
+        case .updateAvailable:
+            "A signed NeonDiff update is available."
+        case .upToDate:
+            "This Mac has the newest eligible NeonDiff beta."
+        case .networkError:
+            "NeonDiff could not reach the update feed. Check your connection and try again."
+        case .signatureError:
+            "The downloaded update failed signature verification and was not installed."
+        case .failed(let message):
+            message
+        }
     }
 
     func checkForUpdates() {
-        lastAction = "Updates blocked pending native activation proof"
+        startUpdaterIfEligible()
+        guard isConfigured else {
+            runtimeStatus = .notConfigured
+            lastAction = "Signed update feed is not configured in this build"
+            objectWillChange.send()
+            return
+        }
+        guard case .allowed = model.desktopUpdateAccess else {
+            runtimeStatus = .blocked(model.desktopUpdateAccess.customerMessage)
+            lastAction = "Update check blocked until entitlement is verified"
+            objectWillChange.send()
+            return
+        }
+        guard let updaterController, updaterController.updater.canCheckForUpdates else {
+            lastAction = "The updater is busy; try again in a moment"
+            objectWillChange.send()
+            return
+        }
+
+        runtimeStatus = .checking
+        lastAction = "Checking for signed updates"
+        objectWillChange.send()
+        updaterController.checkForUpdates(nil)
     }
+
+    func updater(
+        _ updater: SPUUpdater,
+        mayPerform updateCheck: SPUUpdateCheck
+    ) throws {
+        guard case .allowed = model.desktopUpdateAccess else {
+            let message = model.desktopUpdateAccess.customerMessage
+            runtimeStatus = .blocked(message)
+            lastAction = "Update check blocked until entitlement is verified"
+            objectWillChange.send()
+            throw NSError(
+                domain: "com.electricsheephq.NeonDiffDesktop.UpdateAccess",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        guard let channel = model.desktopUpdateAccess.allowedChannel else {
+            return []
+        }
+        return [channel.rawValue]
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        shouldProceedWithUpdate updateItem: SUAppcastItem,
+        updateCheck: SPUUpdateCheck
+    ) throws {
+        guard case .allowed = model.desktopUpdateAccess else {
+            let message = model.desktopUpdateAccess.customerMessage
+            runtimeStatus = .blocked(message)
+            lastAction = "Update download blocked until entitlement is verified"
+            objectWillChange.send()
+            throw NSError(
+                domain: "com.electricsheephq.NeonDiffDesktop.UpdateAccess",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+    }
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        runtimeStatus = .updateAvailable
+        lastAction = "Signed update available"
+        objectWillChange.send()
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+        runtimeStatus = .upToDate
+        lastAction = "NeonDiff is up to date"
+        objectWillChange.send()
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: Error?
+    ) {
+        guard let error = error as NSError? else { return }
+        switch DesktopUpdateCycleResult.classify(sparkleErrorCode: error.code) {
+        case .noUpdate:
+            runtimeStatus = .upToDate
+            lastAction = "NeonDiff is up to date"
+        case .signatureError:
+            runtimeStatus = .signatureError
+            lastAction = "Update rejected: signature verification failed"
+        case .networkError:
+            runtimeStatus = .networkError
+            lastAction = "Update check failed: feed unavailable"
+        case .cancelled:
+            runtimeStatus = .ready
+            lastAction = "Update cancelled"
+        case .failed:
+            runtimeStatus = .failed("The update could not be completed. Try again or contact support.")
+            lastAction = "Update failed safely"
+        }
+        objectWillChange.send()
+    }
+
+    private func modelDidChange() {
+        guard isConfigured else {
+            runtimeStatus = .notConfigured
+            objectWillChange.send()
+            return
+        }
+
+        switch model.desktopUpdateAccess {
+        case .allowed:
+            startUpdaterIfEligible()
+            if case .blocked = runtimeStatus {
+                runtimeStatus = .ready
+                lastAction = "Ready to check for signed updates"
+            } else if case .notConfigured = runtimeStatus {
+                runtimeStatus = .ready
+                lastAction = "Ready to check for signed updates"
+            }
+        case .blocked(let reason):
+            runtimeStatus = .blocked(reason.customerMessage)
+            lastAction = "Update access needs verification"
+        }
+        objectWillChange.send()
+    }
+
+    private func startUpdaterIfEligible() {
+        guard updaterController == nil,
+              isConfigured,
+              case .allowed = model.desktopUpdateAccess
+        else {
+            return
+        }
+
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: self,
+            userDriverDelegate: nil
+        )
+        controller.startUpdater()
+        updaterController = controller
+        runtimeStatus = .ready
+        lastAction = "Ready to check for signed updates"
+    }
+
+    private static func hasSignedFeedConfiguration(bundle: Bundle) -> Bool {
+        guard let feed = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String,
+              let feedURL = URL(string: feed),
+              feedURL.scheme?.lowercased() == "https",
+              feedURL.host?.isEmpty == false,
+              let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
+              !publicKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return false
+        }
+        return true
+    }
+}
+
+private enum RuntimeStatus {
+    case notConfigured
+    case blocked(String)
+    case ready
+    case checking
+    case updateAvailable
+    case upToDate
+    case networkError
+    case signatureError
+    case failed(String)
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -46,7 +46,7 @@ struct SettingsPane: View {
                             Text(updateController.statusText)
                                 .operatorBodyText()
                                 .fixedSize(horizontal: false, vertical: true)
-                            Text("Automatic updates are not configured for this candidate. Signed update, rollback, and installed-app proof remain required under #116 before release.")
+                            Text("NeonDiff revalidates update access before every signed beta feed check. A failed entitlement or signature check never installs an update.")
                                 .font(.caption)
                                 .foregroundStyle(NeonDiffTheme.textSecondary)
                                 .fixedSize(horizontal: false, vertical: true)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
@@ -1,0 +1,97 @@
+package enum DesktopUpdateChannel: String, Equatable, Sendable {
+    case beta
+    case stable
+}
+
+package enum DesktopUpdateBlockReason: String, Equatable, Sendable {
+    case productionUnavailable
+    case verificationRequired
+    case entitlementRequired
+
+    package var customerMessage: String {
+        switch self {
+        case .productionUnavailable:
+            "Updates are unavailable in this build. Install a signed NeonDiff release with production activation enabled."
+        case .verificationRequired:
+            "Verify your current NeonDiff account or activation before checking for updates."
+        case .entitlementRequired:
+            "An active NeonDiff entitlement is required for this update channel."
+        }
+    }
+}
+
+package enum DesktopUpdateAccess: Equatable, Sendable {
+    case allowed(channel: DesktopUpdateChannel)
+    case blocked(reason: DesktopUpdateBlockReason)
+
+    package var allowedChannel: DesktopUpdateChannel? {
+        guard case .allowed(let channel) = self else { return nil }
+        return channel
+    }
+
+    package var customerMessage: String {
+        switch self {
+        case .allowed:
+            "Signed NeonDiff updates are available for this account."
+        case .blocked(let reason):
+            reason.customerMessage
+        }
+    }
+}
+
+package enum DesktopUpdateAccessPolicy {
+    package static func evaluate(
+        productionBoundaryVerified: Bool,
+        accountCatalogCurrent: Bool,
+        accountEntitlement: DesktopAccountEntitlement?,
+        activationVerifiedThisLaunch: Bool,
+        activationIsActive: Bool,
+        managedPublicRepositoryVerified: Bool
+    ) -> DesktopUpdateAccess {
+        guard productionBoundaryVerified else {
+            return .blocked(reason: .productionUnavailable)
+        }
+
+        if activationVerifiedThisLaunch && activationIsActive {
+            return .allowed(channel: .beta)
+        }
+
+        guard accountCatalogCurrent else {
+            return .blocked(reason: .verificationRequired)
+        }
+
+        switch accountEntitlement {
+        case .internalAdmin:
+            return .allowed(channel: .beta)
+        case .paid, .trial:
+            return .blocked(reason: .verificationRequired)
+        case .publicFree where managedPublicRepositoryVerified:
+            return .allowed(channel: .beta)
+        case .publicFree, .some(.none), nil:
+            return .blocked(reason: .entitlementRequired)
+        }
+    }
+}
+
+package enum DesktopUpdateCycleResult: Equatable, Sendable {
+    case noUpdate
+    case networkError
+    case signatureError
+    case cancelled
+    case failed
+
+    package static func classify(sparkleErrorCode: Int) -> DesktopUpdateCycleResult {
+        switch sparkleErrorCode {
+        case 1001:
+            .noUpdate
+        case 1000, 1002, 2001:
+            .networkError
+        case 3001, 3002:
+            .signatureError
+        case 4007:
+            .cancelled
+        default:
+            .failed
+        }
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 package enum DesktopUpdateChannel: String, Equatable, Sendable {
     case beta
     case stable
@@ -46,6 +48,7 @@ package enum DesktopUpdateAccessPolicy {
         accountEntitlement: DesktopAccountEntitlement?,
         activationVerifiedThisLaunch: Bool,
         activationIsActive: Bool,
+        activationUpdateEntitlement: Bool = false,
         managedPublicRepositoryVerified: Bool
     ) -> DesktopUpdateAccess {
         guard productionBoundaryVerified else {
@@ -53,7 +56,9 @@ package enum DesktopUpdateAccessPolicy {
         }
 
         if activationVerifiedThisLaunch && activationIsActive {
-            return .allowed(channel: .beta)
+            return activationUpdateEntitlement
+                ? .allowed(channel: .beta)
+                : .blocked(reason: .entitlementRequired)
         }
 
         guard accountCatalogCurrent else {
@@ -70,6 +75,16 @@ package enum DesktopUpdateAccessPolicy {
         case .publicFree, .some(.none), nil:
             return .blocked(reason: .entitlementRequired)
         }
+    }
+
+    package static func accountCatalogIsCurrent(
+        verifiedAt: Date?,
+        now: Date,
+        maximumAge: TimeInterval = 300
+    ) -> Bool {
+        guard let verifiedAt else { return false }
+        let age = now.timeIntervalSince(verifiedAt)
+        return age >= 0 && age <= maximumAge
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
@@ -49,6 +49,7 @@ package enum DesktopUpdateAccessPolicy {
         activationVerifiedThisLaunch: Bool,
         activationIsActive: Bool,
         activationUpdateEntitlement: Bool = false,
+        activationAuthorityCurrent: Bool = false,
         managedPublicRepositoryVerified: Bool
     ) -> DesktopUpdateAccess {
         guard productionBoundaryVerified else {
@@ -56,6 +57,9 @@ package enum DesktopUpdateAccessPolicy {
         }
 
         if activationVerifiedThisLaunch && activationIsActive {
+            guard activationAuthorityCurrent else {
+                return .blocked(reason: .verificationRequired)
+            }
             return activationUpdateEntitlement
                 ? .allowed(channel: .beta)
                 : .blocked(reason: .entitlementRequired)
@@ -85,6 +89,14 @@ package enum DesktopUpdateAccessPolicy {
         guard let verifiedAt else { return false }
         let age = now.timeIntervalSince(verifiedAt)
         return age >= 0 && age <= maximumAge
+    }
+
+    package static func managedPublicRepositoryIsEligible(
+        isPublic: Bool,
+        verifiedAt: Date?,
+        now: Date
+    ) -> Bool {
+        isPublic && accountCatalogIsCurrent(verifiedAt: verifiedAt, now: now)
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopUpdateAccess.swift
@@ -75,6 +75,7 @@ package enum DesktopUpdateAccessPolicy {
 
 package enum DesktopUpdateCycleResult: Equatable, Sendable {
     case noUpdate
+    case feedInvalid
     case networkError
     case signatureError
     case cancelled
@@ -84,7 +85,9 @@ package enum DesktopUpdateCycleResult: Equatable, Sendable {
         switch sparkleErrorCode {
         case 1001:
             .noUpdate
-        case 1000, 1002, 2001:
+        case 1000, 1002:
+            .feedInvalid
+        case 2001:
             .networkError
         case 3001, 3002:
             .signatureError

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -139,6 +139,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var isGitHubRepositoryRefreshInProgress = false
     @Published package var managedGitHubConnectionState: ManagedGitHubConnectionState = .quarantined
     @Published package var managedGitHubRepositories: [GitHubBrokerRepository] = []
+    private var managedGitHubRepositoriesVerifiedAt: Date?
     @Published package var managedGitHubInstallationCandidates: [ManagedGitHubInstallationCandidate] = []
     @Published package var selectedManagedGitHubRepository: String?
     @Published package private(set) var selectedBYOReviewRepository: String?
@@ -192,10 +193,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         didSet {
             if !activationVerifiedThisLaunch {
                 activationUpdateEntitlementThisLaunch = false
+                activationUpdateAuthorityVerifiedAt = nil
+                activationUpdateAuthorityValidUntil = nil
             }
         }
     }
     private var activationUpdateEntitlementThisLaunch = false
+    private var activationUpdateAuthorityVerifiedAt: Date?
+    private var activationUpdateAuthorityValidUntil: Date?
     private var accountWorkspaceCatalogVerifiedAt: Date?
     private var activationVerifiedRepositoryThisLaunch: String?
     private var appliedRepoSelection: AppliedRepoSelection?
@@ -851,9 +856,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
            let repository = managedGitHubRepositories.first(where: {
                $0.fullName == selectedManagedGitHubRepository
            }) {
-            managedPublicRepositoryVerified = repository.visibility == .public
+            managedPublicRepositoryVerified = DesktopUpdateAccessPolicy
+                .managedPublicRepositoryIsEligible(
+                    isPublic: repository.visibility == .public,
+                    verifiedAt: managedGitHubRepositoriesVerifiedAt,
+                    now: dependencies.clock.now
+                )
         } else {
             managedPublicRepositoryVerified = false
+        }
+
+        let activationAuthorityCurrent: Bool
+        if let validUntil = activationUpdateAuthorityValidUntil {
+            activationAuthorityCurrent = DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+                verifiedAt: activationUpdateAuthorityVerifiedAt,
+                now: dependencies.clock.now
+            ) && dependencies.clock.now < validUntil
+        } else {
+            activationAuthorityCurrent = false
         }
 
         return DesktopUpdateAccessPolicy.evaluate(
@@ -863,6 +883,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             activationVerifiedThisLaunch: activationVerifiedThisLaunch,
             activationIsActive: activationState == .active,
             activationUpdateEntitlement: activationUpdateEntitlementThisLaunch,
+            activationAuthorityCurrent: activationAuthorityCurrent,
             managedPublicRepositoryVerified: managedPublicRepositoryVerified
         )
     }
@@ -1610,6 +1631,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         github = GitHubConnectionStatus()
         discoveredGitHubRepos = []
         managedGitHubRepositories = []
+        managedGitHubRepositoriesVerifiedAt = nil
         managedGitHubInstallationCandidates = []
         selectedManagedGitHubRepository = nil
         selectedBYOReviewRepository = nil
@@ -2658,6 +2680,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubConnectionState = .connecting
         managedGitHubRecovery = nil
         managedGitHubRepositories = []
+        managedGitHubRepositoriesVerifiedAt = nil
         managedGitHubInstallationCandidates = []
         pendingManagedGitHubAuthorization = nil
         githubAuthorizationCode = nil
@@ -2809,6 +2832,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         invalidateRepoApplicationProof()
         managedGitHubRecovery = nil
         managedGitHubRepositories = []
+        managedGitHubRepositoriesVerifiedAt = nil
         selectedManagedGitHubRepository = nil
         lastError = nil
 
@@ -3819,6 +3843,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
     ) {
         switch outcome {
         case .active(let summary):
+            let now = dependencies.clock.now
+            activationUpdateAuthorityVerifiedAt = now
+            let freshnessDeadline = now.addingTimeInterval(300)
+            if let rawExpiry = summary.expiresAt {
+                activationUpdateAuthorityValidUntil = ISO8601DateFormatter()
+                    .date(from: rawExpiry)
+                    .map { min($0, freshnessDeadline) }
+            } else {
+                activationUpdateAuthorityValidUntil = freshnessDeadline
+            }
             activationUpdateEntitlementThisLaunch = summary.updateEntitlement
             activationVerifiedThisLaunch = true
             lastError = nil
@@ -4757,6 +4791,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubRepositories = repositories.sorted {
             $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending
         }
+        managedGitHubRepositoriesVerifiedAt = dependencies.clock.now
         managedGitHubConnectionState = .bound(installationId: installationId)
         managedGitHubRecovery = nil
         lastError = nil
@@ -4774,6 +4809,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         githubAuthorizationCode = nil
         managedGitHubConnectionState = .failed
         managedGitHubRepositories = []
+        managedGitHubRepositoriesVerifiedAt = nil
         selectedManagedGitHubRepository = nil
         let recovery: GitHubConnectionRecovery
         if let brokerError = error as? GitHubBrokerClientError {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -188,7 +188,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var activationState: ActivationState = ActivationStateMachine.initialState
     @Published package private(set) var activationKeyRedactedPrefix: String?
     @Published package var pendingActivationKey = ""
-    @Published package private(set) var activationVerifiedThisLaunch = false
+    @Published package private(set) var activationVerifiedThisLaunch = false {
+        didSet {
+            if !activationVerifiedThisLaunch {
+                activationUpdateEntitlementThisLaunch = false
+            }
+        }
+    }
+    private var activationUpdateEntitlementThisLaunch = false
+    private var accountWorkspaceCatalogVerifiedAt: Date?
     private var activationVerifiedRepositoryThisLaunch: String?
     private var appliedRepoSelection: AppliedRepoSelection?
     private var scopedReviewTask: Task<Void, Never>?
@@ -829,7 +837,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var desktopUpdateAccess: DesktopUpdateAccess {
         let accountCatalogCurrent: Bool
         if case .loaded = accountWorkspaceCatalog {
-            accountCatalogCurrent = true
+            accountCatalogCurrent = DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+                verifiedAt: accountWorkspaceCatalogVerifiedAt,
+                now: dependencies.clock.now
+            )
         } else {
             accountCatalogCurrent = false
         }
@@ -851,6 +862,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             accountEntitlement: selectedAccountWorkspace?.entitlement,
             activationVerifiedThisLaunch: activationVerifiedThisLaunch,
             activationIsActive: activationState == .active,
+            activationUpdateEntitlement: activationUpdateEntitlementThisLaunch,
             managedPublicRepositoryVerified: managedPublicRepositoryVerified
         )
     }
@@ -1386,6 +1398,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func applyAccountWorkspaceCatalog(_ catalog: DesktopAccountWorkspaceCatalog) {
         let previousSelectedAccount = selectedAccountWorkspace
         let previousSelectedBot = selectedBotInstallation
+        if case .loaded = catalog {
+            accountWorkspaceCatalogVerifiedAt = dependencies.clock.now
+        } else {
+            accountWorkspaceCatalogVerifiedAt = nil
+        }
         accountWorkspaceCatalog = catalog
         guard !catalog.accounts.isEmpty else {
             accountWorkspaceSelection = DesktopAccountWorkspaceSelection()
@@ -3802,6 +3819,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     ) {
         switch outcome {
         case .active(let summary):
+            activationUpdateEntitlementThisLaunch = summary.updateEntitlement
             activationVerifiedThisLaunch = true
             lastError = nil
             let scope = summary.repoVisibilityScope

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -821,6 +821,40 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
+    /// Update access is evaluated at the moment Sparkle starts a check. A
+    /// current launch activation can authorize the paid beta channel directly.
+    /// Otherwise the account catalog must be a current server response; stale
+    /// or failed account state never unlocks an update. Public-free access is
+    /// limited to a verified managed public repository.
+    package var desktopUpdateAccess: DesktopUpdateAccess {
+        let accountCatalogCurrent: Bool
+        if case .loaded = accountWorkspaceCatalog {
+            accountCatalogCurrent = true
+        } else {
+            accountCatalogCurrent = false
+        }
+
+        let managedPublicRepositoryVerified: Bool
+        if hasVerifiedManagedGitHubSelection,
+           let selectedManagedGitHubRepository,
+           let repository = managedGitHubRepositories.first(where: {
+               $0.fullName == selectedManagedGitHubRepository
+           }) {
+            managedPublicRepositoryVerified = repository.visibility == .public
+        } else {
+            managedPublicRepositoryVerified = false
+        }
+
+        return DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: dependencies.productionBoundary.nativeActivationBrokerVerified,
+            accountCatalogCurrent: accountCatalogCurrent,
+            accountEntitlement: selectedAccountWorkspace?.entitlement,
+            activationVerifiedThisLaunch: activationVerifiedThisLaunch,
+            activationIsActive: activationState == .active,
+            managedPublicRepositoryVerified: managedPublicRepositoryVerified
+        )
+    }
+
     /// Successful config inspection proves that the selected local config
     /// already contains and read back its repository allowlist. BYO credential
     /// verification remains a separate current-launch work gate.

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -95,10 +95,11 @@ import NeonDiffDesktopCore
     private func activeSummary(
         scope: String = "private",
         privateAllowed: Bool? = true,
-        updateEntitlement: Bool = true
+        updateEntitlement: Bool = true,
+        expiresAt: String? = nil
     ) -> ActivationClientOutcome {
         .active(.init(status: .active, repoVisibilityScope: scope, privateRepoAllowed: privateAllowed,
-                      updateEntitlement: updateEntitlement, expiresAt: nil, plan: "team", seats: 3))
+                      updateEntitlement: updateEntitlement, expiresAt: expiresAt, plan: "team", seats: 3))
     }
 
     private let activationKeyAccount = "license/default"
@@ -207,6 +208,27 @@ import NeonDiffDesktopCore
 
         #expect(model.desktopUpdateAccess == .allowed(channel: .beta))
         clock.advance(by: 301)
+        #expect(model.desktopUpdateAccess == .blocked(reason: .verificationRequired))
+    }
+
+    @Test func activationUpdateAuthorityHonorsServerExpiry() async {
+        let clock = TestClock(now: Date(timeIntervalSince1970: 10_000))
+        let expiry = ISO8601DateFormatter().string(
+            from: Date(timeIntervalSince1970: 10_010)
+        )
+        let keychain = RecordingKeychain()
+        let model = makeModel(
+            secretStore: keychain,
+            clock: clock,
+            client: FakeActivationClient(activeSummary(expiresAt: expiry))
+        )
+        model.activationState = .checkoutPaused
+        model.pendingActivationKey = "NDL-EXPIRING-0123456789"
+        model.provideExistingActivationKey()
+        await model.submitActivation()
+
+        #expect(model.desktopUpdateAccess == .allowed(channel: .beta))
+        clock.advance(by: 11)
         #expect(model.desktopUpdateAccess == .blocked(reason: .verificationRequired))
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -72,6 +72,7 @@ import NeonDiffDesktopCore
         preferences: MemoryPreferences = MemoryPreferences(),
         secretStore: RecordingKeychain = RecordingKeychain(),
         cli: RecordingCLIExecutor = RecordingCLIExecutor(),
+        clock: TestClock = TestClock(),
         client: (any ActivationLicenseClienting)? = nil
     ) -> NeonDiffDesktopModel {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -81,7 +82,7 @@ import NeonDiffDesktopCore
             cli: cli,
             dashboard: RecordingDashboardLauncher(),
             preferences: preferences,
-            clock: TestClock(),
+            clock: clock,
             fileWriter: TemporaryFileWriter(root: root),
             providerVerifier: RecordingProviderVerifier(),
             secretStore: secretStore,
@@ -91,9 +92,13 @@ import NeonDiffDesktopCore
         return NeonDiffDesktopModel(dependencies: dependencies, activationLicenseClient: client)
     }
 
-    private func activeSummary(scope: String = "private", privateAllowed: Bool? = true) -> ActivationClientOutcome {
+    private func activeSummary(
+        scope: String = "private",
+        privateAllowed: Bool? = true,
+        updateEntitlement: Bool = true
+    ) -> ActivationClientOutcome {
         .active(.init(status: .active, repoVisibilityScope: scope, privateRepoAllowed: privateAllowed,
-                      updateEntitlement: true, expiresAt: nil, plan: "team", seats: 3))
+                      updateEntitlement: updateEntitlement, expiresAt: nil, plan: "team", seats: 3))
     }
 
     private let activationKeyAccount = "license/default"
@@ -169,6 +174,40 @@ import NeonDiffDesktopCore
         #expect(model.license.entitlement.contains("active"))
         #expect(prefs.string(forKey: activationStateKey) == ActivationState.active.rawValue,
                 "active state must be persisted for resume-exact")
+    }
+
+    @Test func activeActivationWithoutUpdateEntitlementCannotUseBetaChannel() async {
+        let keychain = RecordingKeychain()
+        let model = makeModel(
+            secretStore: keychain,
+            client: FakeActivationClient(activeSummary(updateEntitlement: false))
+        )
+        model.activationState = .checkoutPaused
+        model.pendingActivationKey = "NDL-NO-UPDATES-0123456789"
+        model.provideExistingActivationKey()
+        await model.submitActivation()
+
+        #expect(model.activationState == .active)
+        #expect(model.desktopUpdateAccess == .blocked(reason: .entitlementRequired))
+    }
+
+    @Test func serverAccountUpdateAuthorityExpiresAfterFiveMinutes() {
+        let clock = TestClock(now: Date(timeIntervalSince1970: 10_000))
+        let model = makeModel(clock: clock)
+        model.applyAccountWorkspaceCatalog(.loaded([
+            DesktopAccountWorkspace(
+                id: "account-admin",
+                kind: .organization,
+                name: "ElectricSheep",
+                role: .admin,
+                entitlement: .internalAdmin,
+                bots: []
+            )
+        ]))
+
+        #expect(model.desktopUpdateAccess == .allowed(channel: .beta))
+        clock.advance(by: 301)
+        #expect(model.desktopUpdateAccess == .blocked(reason: .verificationRequired))
     }
 
     @Test func offlineThenRetrySucceeds() async {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import NeonDiffDesktopAppCore
 
@@ -9,10 +10,25 @@ import Testing
             accountEntitlement: nil,
             activationVerifiedThisLaunch: true,
             activationIsActive: true,
+            activationUpdateEntitlement: true,
             managedPublicRepositoryVerified: false
         )
 
         #expect(access == .allowed(channel: .beta))
+    }
+
+    @Test func activeActivationWithoutUpdateEntitlementFailsClosed() {
+        let access = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: false,
+            accountEntitlement: nil,
+            activationVerifiedThisLaunch: true,
+            activationIsActive: true,
+            activationUpdateEntitlement: false,
+            managedPublicRepositoryVerified: false
+        )
+
+        #expect(access == .blocked(reason: .entitlementRequired))
     }
 
     @Test func currentServerInternalAdminEntitlementAllowsBetaUpdates() {
@@ -100,5 +116,22 @@ import Testing
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 3002) == .signatureError)
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 4007) == .cancelled)
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 9999) == .failed)
+    }
+
+    @Test func accountCatalogFreshnessIsBoundedAndRejectsFutureProof() {
+        let now = Date(timeIntervalSince1970: 10_000)
+
+        #expect(DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+            verifiedAt: now.addingTimeInterval(-299),
+            now: now
+        ))
+        #expect(!DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+            verifiedAt: now.addingTimeInterval(-301),
+            now: now
+        ))
+        #expect(!DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+            verifiedAt: now.addingTimeInterval(1),
+            now: now
+        ))
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
@@ -93,6 +93,8 @@ import Testing
 
     @Test func sparkleErrorsMapToDistinctCustomerStates() {
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 1001) == .noUpdate)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 1000) == .feedInvalid)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 1002) == .feedInvalid)
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 2001) == .networkError)
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 3001) == .signatureError)
         #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 3002) == .signatureError)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
@@ -1,0 +1,102 @@
+import Testing
+@testable import NeonDiffDesktopAppCore
+
+@Suite struct DesktopUpdateAccessPolicyTests {
+    @Test func currentLaunchPaidActivationAllowsBetaUpdates() {
+        let access = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: false,
+            accountEntitlement: nil,
+            activationVerifiedThisLaunch: true,
+            activationIsActive: true,
+            managedPublicRepositoryVerified: false
+        )
+
+        #expect(access == .allowed(channel: .beta))
+    }
+
+    @Test func currentServerInternalAdminEntitlementAllowsBetaUpdates() {
+        let access = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: true,
+            accountEntitlement: .internalAdmin,
+            activationVerifiedThisLaunch: false,
+            activationIsActive: false,
+            managedPublicRepositoryVerified: false
+        )
+
+        #expect(access == .allowed(channel: .beta))
+    }
+
+    @Test func paidAndTrialSnapshotsRequireCurrentActivation() {
+        for entitlement in [DesktopAccountEntitlement.paid, .trial] {
+            let access = DesktopUpdateAccessPolicy.evaluate(
+                productionBoundaryVerified: true,
+                accountCatalogCurrent: true,
+                accountEntitlement: entitlement,
+                activationVerifiedThisLaunch: false,
+                activationIsActive: false,
+                managedPublicRepositoryVerified: false
+            )
+
+            #expect(access == .blocked(reason: .verificationRequired))
+        }
+    }
+
+    @Test func staleAccountSnapshotFailsClosedWithoutCurrentActivation() {
+        let access = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: false,
+            accountEntitlement: .paid,
+            activationVerifiedThisLaunch: false,
+            activationIsActive: false,
+            managedPublicRepositoryVerified: false
+        )
+
+        #expect(access == .blocked(reason: .verificationRequired))
+    }
+
+    @Test func publicFreeRequiresVerifiedManagedPublicRepository() {
+        let allowed = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: true,
+            accountEntitlement: .publicFree,
+            activationVerifiedThisLaunch: false,
+            activationIsActive: false,
+            managedPublicRepositoryVerified: true
+        )
+        let blocked = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: true,
+            accountEntitlement: .publicFree,
+            activationVerifiedThisLaunch: false,
+            activationIsActive: false,
+            managedPublicRepositoryVerified: false
+        )
+
+        #expect(allowed == .allowed(channel: .beta))
+        #expect(blocked == .blocked(reason: .entitlementRequired))
+    }
+
+    @Test func missingProductionBoundaryFailsClosed() {
+        let access = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: false,
+            accountCatalogCurrent: true,
+            accountEntitlement: .internalAdmin,
+            activationVerifiedThisLaunch: true,
+            activationIsActive: true,
+            managedPublicRepositoryVerified: true
+        )
+
+        #expect(access == .blocked(reason: .productionUnavailable))
+    }
+
+    @Test func sparkleErrorsMapToDistinctCustomerStates() {
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 1001) == .noUpdate)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 2001) == .networkError)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 3001) == .signatureError)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 3002) == .signatureError)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 4007) == .cancelled)
+        #expect(DesktopUpdateCycleResult.classify(sparkleErrorCode: 9999) == .failed)
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopUpdateAccessPolicyTests.swift
@@ -11,6 +11,7 @@ import Testing
             activationVerifiedThisLaunch: true,
             activationIsActive: true,
             activationUpdateEntitlement: true,
+            activationAuthorityCurrent: true,
             managedPublicRepositoryVerified: false
         )
 
@@ -25,10 +26,26 @@ import Testing
             activationVerifiedThisLaunch: true,
             activationIsActive: true,
             activationUpdateEntitlement: false,
+            activationAuthorityCurrent: true,
             managedPublicRepositoryVerified: false
         )
 
         #expect(access == .blocked(reason: .entitlementRequired))
+    }
+
+    @Test func staleActivationAuthorityFailsClosed() {
+        let access = DesktopUpdateAccessPolicy.evaluate(
+            productionBoundaryVerified: true,
+            accountCatalogCurrent: false,
+            accountEntitlement: nil,
+            activationVerifiedThisLaunch: true,
+            activationIsActive: true,
+            activationUpdateEntitlement: true,
+            activationAuthorityCurrent: false,
+            managedPublicRepositoryVerified: false
+        )
+
+        #expect(access == .blocked(reason: .verificationRequired))
     }
 
     @Test func currentServerInternalAdminEntitlementAllowsBetaUpdates() {
@@ -131,6 +148,26 @@ import Testing
         ))
         #expect(!DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
             verifiedAt: now.addingTimeInterval(1),
+            now: now
+        ))
+    }
+
+    @Test func managedPublicRepositoryRequiresCurrentVisibilityProof() {
+        let now = Date(timeIntervalSince1970: 10_000)
+
+        #expect(DesktopUpdateAccessPolicy.managedPublicRepositoryIsEligible(
+            isPublic: true,
+            verifiedAt: now.addingTimeInterval(-299),
+            now: now
+        ))
+        #expect(!DesktopUpdateAccessPolicy.managedPublicRepositoryIsEligible(
+            isPublic: true,
+            verifiedAt: now.addingTimeInterval(-301),
+            now: now
+        ))
+        #expect(!DesktopUpdateAccessPolicy.managedPublicRepositoryIsEligible(
+            isPublic: false,
+            verifiedAt: now,
             now: now
         ))
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -256,7 +256,7 @@ import Testing
         #expect(model.contains("Review worker needs attention — open Advanced Diagnostics"))
         #expect(activity.contains("DisclosureGroup"))
         #expect(activity.contains("// ADVANCED DIAGNOSTICS"))
-        #expect(settings.contains("Signed update, rollback, and installed-app proof"))
+        #expect(settings.contains("NeonDiff revalidates update access before every signed beta feed check"))
         #expect(!settings.contains("This dev build"))
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -192,14 +192,28 @@ import Testing
         }
     }
 
-    @Test func updaterCannotStartBeforeNativeActivationBrokerProof() throws {
+    @Test func updaterUsesSignedFeedAndRevalidatesEntitlementBeforeEachCheck() throws {
         let updaterSource = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Support/NeonUpdateController.swift")
+        let bundleScript = sourceBoundaryPackageRoot()
+            .appendingPathComponent("script/build_and_run.sh")
         let source = try sourceBoundaryText(at: updaterSource)
+        let bundler = try sourceBoundaryText(at: bundleScript)
 
-        #expect(!source.contains("SPUStandardUpdaterController"))
-        #expect(!source.contains("startingUpdater"))
-        #expect(source.contains("Updates blocked pending native activation proof"))
+        #expect(source.contains("import Sparkle"))
+        #expect(source.contains("SPUStandardUpdaterController"))
+        #expect(source.contains("startingUpdater: false"))
+        #expect(source.contains("mayPerform updateCheck"))
+        #expect(source.contains("shouldProceedWithUpdate"))
+        #expect(source.contains("allowedChannels(for updater"))
+        #expect(source.contains("model.desktopUpdateAccess"))
+        #expect(!source.contains("Updates blocked pending native activation proof"))
+        #expect(bundler.contains("NEONDIFF_SPARKLE_REQUIRED"))
+        #expect(bundler.contains("Sparkle feed and public key must be configured together"))
+        #expect(bundler.contains("A signed Sparkle feed is required for this release build"))
+        #expect(bundler.contains("SUEnableAutomaticChecks"))
+        #expect(bundler.contains("SUScheduledCheckInterval"))
+        #expect(bundler.contains("SUAutomaticallyUpdate"))
     }
 
     @Test func productionCompositionRootResolvesOnlyTheSignedBuildBoundary() throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -209,6 +209,8 @@ import Testing
         #expect(source.contains("model.desktopUpdateAccess"))
         #expect(!source.contains("Updates blocked pending native activation proof"))
         #expect(bundler.contains("NEONDIFF_SPARKLE_REQUIRED"))
+        #expect(bundler.contains("Release builds require NEONDIFF_SPARKLE_REQUIRED=1"))
+        #expect(bundler.contains("Sparkle feed and public key must not contain surrounding whitespace"))
         #expect(bundler.contains("Sparkle feed and public key must be configured together"))
         #expect(bundler.contains("A signed Sparkle feed is required for this release build"))
         #expect(bundler.contains("SUEnableAutomaticChecks"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -207,6 +207,7 @@ import Testing
         #expect(source.contains("shouldProceedWithUpdate"))
         #expect(source.contains("allowedChannels(for updater"))
         #expect(source.contains("model.desktopUpdateAccess"))
+        #expect(source.contains("Update remained blocked after the current cycle"))
         #expect(!source.contains("Updates blocked pending native activation proof"))
         #expect(bundler.contains("NEONDIFF_SPARKLE_REQUIRED"))
         #expect(bundler.contains("Release builds require NEONDIFF_SPARKLE_REQUIRED=1"))

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -42,10 +42,10 @@ The appcast core models these update outcomes for fixtures and release evidence:
 - `feed_invalid`
 - `unsupported_channel`
 
-These statuses are evidence taxonomy for dry-run planning and tests. Mapping
-real Sparkle delegate errors into the desktop UI requires signed/notarized
-artifacts and hosted appcasts, so that runtime proof remains in the owner/Codex
-release lane.
+These statuses back both dry-run planning and the native updater UI. The source
+maps real Sparkle no-update, network/feed, signature/validation, cancellation,
+and generic failures into distinct customer states. A hosted signed appcast and
+installed-app run are still required before claiming runtime proof.
 
 ## Fixtures
 
@@ -62,9 +62,8 @@ Fixtures live under `apps/neondiff-desktop/fixtures/appcast/`:
 
 ## Signing Seam
 
-Real appcast signing is parked until the signed/notarized artifact and owner
-credentials are available. The future signing step should fill `ed_signature`
-from Sparkle's `sign_update` output using owner-custodied private key material.
+Real appcast signing remains a release-time step. It fills `ed_signature` from
+Sparkle's `sign_update` output using owner-custodied private key material.
 Private key values must never be committed, logged, or written to evidence.
 
 The public key and feed URL are build-time inputs documented in

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -82,9 +82,16 @@ if { [ -n "$SPARKLE_FEED_URL" ] && [ -z "$SPARKLE_PUBLIC_KEY" ]; } \
 fi
 if [ -n "$SPARKLE_FEED_URL" ]; then
   case "$SPARKLE_FEED_URL" in
-    https://*) ;;
+    https://*)
+      SPARKLE_FEED_AUTHORITY="${SPARKLE_FEED_URL#https://}"
+      SPARKLE_FEED_HOST="${SPARKLE_FEED_AUTHORITY%%[/?#]*}"
+      if [ -z "$SPARKLE_FEED_HOST" ]; then
+        echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a host" >&2
+        exit 2
+      fi
+      ;;
     *)
-      echo "NEONDIFF_SPARKLE_FEED_URL must use https" >&2
+      echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a host" >&2
       exit 2
       ;;
   esac

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -41,10 +41,34 @@ SHORT_VERSION="${NEONDIFF_DESKTOP_VERSION:-0.1.0}"
 BUILD_VERSION="${NEONDIFF_DESKTOP_BUILD:-1}"
 SPARKLE_FEED_URL="${NEONDIFF_SPARKLE_FEED_URL:-}"
 SPARKLE_PUBLIC_KEY="${NEONDIFF_SPARKLE_PUBLIC_ED_KEY:-}"
+SPARKLE_REQUIRED="${NEONDIFF_SPARKLE_REQUIRED:-0}"
 PAID_BETA_CONTRACT="${NEONDIFF_DESKTOP_PAID_BETA_CONTRACT:-}"
 MANAGED_GITHUB_BROKER_ENABLED="${NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED:-}"
 GITHUB_BROKER_ORIGIN="${NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN:-}"
 BYO_GITHUB_ENABLED="${NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED:-}"
+
+if [ "$SPARKLE_REQUIRED" != "0" ] && [ "$SPARKLE_REQUIRED" != "1" ]; then
+  echo "NEONDIFF_SPARKLE_REQUIRED must be 0 or 1" >&2
+  exit 2
+fi
+if { [ -n "$SPARKLE_FEED_URL" ] && [ -z "$SPARKLE_PUBLIC_KEY" ]; } \
+  || { [ -z "$SPARKLE_FEED_URL" ] && [ -n "$SPARKLE_PUBLIC_KEY" ]; }; then
+  echo "Sparkle feed and public key must be configured together" >&2
+  exit 2
+fi
+if [ -n "$SPARKLE_FEED_URL" ]; then
+  case "$SPARKLE_FEED_URL" in
+    https://*) ;;
+    *)
+      echo "NEONDIFF_SPARKLE_FEED_URL must use https" >&2
+      exit 2
+      ;;
+  esac
+fi
+if [ "$SPARKLE_REQUIRED" = "1" ] && [ -z "$SPARKLE_FEED_URL" ]; then
+  echo "A signed Sparkle feed is required for this release build" >&2
+  exit 2
+fi
 
 resolve_production_contract_mode() {
   if [ -z "$PAID_BETA_CONTRACT" ] \
@@ -189,6 +213,9 @@ esac
 if [ -n "$SPARKLE_FEED_URL" ] && [ -n "$SPARKLE_PUBLIC_KEY" ]; then
   /usr/libexec/PlistBuddy -c "Add :SUFeedURL string $SPARKLE_FEED_URL" "$INFO_PLIST"
   /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string $SPARKLE_PUBLIC_KEY" "$INFO_PLIST"
+  /usr/libexec/PlistBuddy -c "Add :SUEnableAutomaticChecks bool true" "$INFO_PLIST"
+  /usr/libexec/PlistBuddy -c "Add :SUScheduledCheckInterval real 21600" "$INFO_PLIST"
+  /usr/libexec/PlistBuddy -c "Add :SUAutomaticallyUpdate bool false" "$INFO_PLIST"
 fi
 
 open_app() {
@@ -239,6 +266,13 @@ case "$MODE" in
     if otool -L "$APP_BINARY" | grep -q "Sparkle.framework"; then
       test -d "$APP_FRAMEWORKS/Sparkle.framework"
       otool -l "$APP_BINARY" | grep -q "@executable_path/../Frameworks"
+    fi
+    if [ "$SPARKLE_REQUIRED" = "1" ]; then
+      test "$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$INFO_PLIST")" = "$SPARKLE_FEED_URL"
+      test "$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$INFO_PLIST")" = "$SPARKLE_PUBLIC_KEY"
+      test "$(/usr/libexec/PlistBuddy -c 'Print :SUEnableAutomaticChecks' "$INFO_PLIST")" = "true"
+      test "$(/usr/libexec/PlistBuddy -c 'Print :SUScheduledCheckInterval' "$INFO_PLIST")" = "21600.000000"
+      test "$(/usr/libexec/PlistBuddy -c 'Print :SUAutomaticallyUpdate' "$INFO_PLIST")" = "false"
     fi
     ;;
   *)

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -41,7 +41,16 @@ SHORT_VERSION="${NEONDIFF_DESKTOP_VERSION:-0.1.0}"
 BUILD_VERSION="${NEONDIFF_DESKTOP_BUILD:-1}"
 SPARKLE_FEED_URL="${NEONDIFF_SPARKLE_FEED_URL:-}"
 SPARKLE_PUBLIC_KEY="${NEONDIFF_SPARKLE_PUBLIC_ED_KEY:-}"
-SPARKLE_REQUIRED="${NEONDIFF_SPARKLE_REQUIRED:-0}"
+if [ "$BUILD_CONFIGURATION" = "release" ]; then
+  if [ "${NEONDIFF_SPARKLE_REQUIRED+x}" = "x" ] \
+    && [ "$NEONDIFF_SPARKLE_REQUIRED" != "1" ]; then
+    echo "Release builds require NEONDIFF_SPARKLE_REQUIRED=1" >&2
+    exit 2
+  fi
+  SPARKLE_REQUIRED=1
+else
+  SPARKLE_REQUIRED="${NEONDIFF_SPARKLE_REQUIRED:-0}"
+fi
 PAID_BETA_CONTRACT="${NEONDIFF_DESKTOP_PAID_BETA_CONTRACT:-}"
 MANAGED_GITHUB_BROKER_ENABLED="${NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED:-}"
 GITHUB_BROKER_ORIGIN="${NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN:-}"
@@ -49,6 +58,21 @@ BYO_GITHUB_ENABLED="${NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED:-}"
 
 if [ "$SPARKLE_REQUIRED" != "0" ] && [ "$SPARKLE_REQUIRED" != "1" ]; then
   echo "NEONDIFF_SPARKLE_REQUIRED must be 0 or 1" >&2
+  exit 2
+fi
+
+trim_surrounding_whitespace() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+SPARKLE_FEED_URL_TRIMMED="$(trim_surrounding_whitespace "$SPARKLE_FEED_URL")"
+SPARKLE_PUBLIC_KEY_TRIMMED="$(trim_surrounding_whitespace "$SPARKLE_PUBLIC_KEY")"
+if [ "$SPARKLE_FEED_URL" != "$SPARKLE_FEED_URL_TRIMMED" ] \
+  || [ "$SPARKLE_PUBLIC_KEY" != "$SPARKLE_PUBLIC_KEY_TRIMMED" ]; then
+  echo "Sparkle feed and public key must not contain surrounding whitespace" >&2
   exit 2
 fi
 if { [ -n "$SPARKLE_FEED_URL" ] && [ -z "$SPARKLE_PUBLIC_KEY" ]; } \

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -84,14 +84,31 @@ if [ -n "$SPARKLE_FEED_URL" ]; then
   case "$SPARKLE_FEED_URL" in
     https://*)
       SPARKLE_FEED_AUTHORITY="${SPARKLE_FEED_URL#https://}"
-      SPARKLE_FEED_HOST="${SPARKLE_FEED_AUTHORITY%%[/?#]*}"
-      if [ -z "$SPARKLE_FEED_HOST" ]; then
-        echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a host" >&2
+      SPARKLE_FEED_HOSTPORT="${SPARKLE_FEED_AUTHORITY%%[/?#]*}"
+      SPARKLE_FEED_HOST="$SPARKLE_FEED_HOSTPORT"
+      if [[ "$SPARKLE_FEED_HOSTPORT" == *:* ]]; then
+        SPARKLE_FEED_HOST="${SPARKLE_FEED_HOSTPORT%%:*}"
+        SPARKLE_FEED_PORT="${SPARKLE_FEED_HOSTPORT#*:}"
+        if [ -z "$SPARKLE_FEED_PORT" ] \
+          || [[ "$SPARKLE_FEED_PORT" == *[!0-9]* ]] \
+          || [ "$SPARKLE_FEED_PORT" -lt 1 ] \
+          || [ "$SPARKLE_FEED_PORT" -gt 65535 ]; then
+          echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a DNS host" >&2
+          exit 2
+        fi
+      fi
+      if [ -z "$SPARKLE_FEED_HOST" ] \
+        || [[ "$SPARKLE_FEED_HOSTPORT" == *@* ]] \
+        || [[ "$SPARKLE_FEED_HOST" == .* ]] \
+        || [[ "$SPARKLE_FEED_HOST" == *. ]] \
+        || [[ "$SPARKLE_FEED_HOST" == *..* ]] \
+        || [[ "$SPARKLE_FEED_HOST" == *[!A-Za-z0-9.-]* ]]; then
+        echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a DNS host" >&2
         exit 2
       fi
       ;;
     *)
-      echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a host" >&2
+      echo "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a DNS host" >&2
       exit 2
       ;;
   esac

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -1,10 +1,35 @@
-# Desktop Auto-Update Channel Plan
+# Desktop Auto-Update Channel
 
-Issue #116 tracks the future NeonDiff Desktop auto-update channel with signed
-artifacts, rollback, and license-aware entitlement checks. This document is a
-planning and governance contract only. It does not ship an updater, publish an
-appcast, enable artifact downloads, change live runtime config, or prove desktop
-release readiness.
+Issue #116 tracks NeonDiff Desktop's Sparkle 2 update channel with signed
+artifacts, rollback, and license-aware entitlement checks. The native source now
+contains the real Sparkle controller and release-build configuration gate. No
+hosted appcast, signed update, installed update, rollback, or public release is
+proven by source alone.
+
+## Current Implementation — 2026-07-28
+
+- The native SwiftUI executable uses the existing Sparkle 2 dependency and
+  standard updater UI.
+- Release builds can require a paired HTTPS `SUFeedURL` and `SUPublicEDKey`;
+  partial or missing required configuration fails before the bundle is built.
+- Configured builds check the beta feed every six hours and also expose a
+  manual Check for Updates action. Downloads remain user-confirmed.
+- Every check and every selected update re-evaluates update access. A current
+  paid/trial activation, a current server `internal_admin` entitlement, or a
+  verified managed public-free repository can authorize the beta channel.
+  Missing production composition, stale account state, or missing entitlement
+  fails closed.
+- The customer UI distinguishes ready, checking, update available, up to date,
+  entitlement required, network error, signature error, and generic safe
+  failure.
+- Failing-first tests cover access policy, public-free bounds, stale paid/trial
+  state, and Sparkle error classification. The existing appcast generator and
+  rollback/signature fixtures remain the publishing seam.
+
+Proof boundary: source composition and unsigned Release-configuration bundle
+proof only. #116 remains open for real public-key/feed identity, EdDSA-signed
+appcast, exact signed/notarized installed update, state-preserving rollback and
+re-update, immutable release assets, and live customer evidence.
 
 ## Durable Plan Contract
 
@@ -106,8 +131,8 @@ notes URL, and rollback target.
 
 ## Signed Artifact Rules
 
-Future implementation may use Sparkle, Tauri updater, or another updater only if
-it provides equivalent guarantees:
+The native SwiftUI path uses Sparkle 2. Any future replacement must provide
+equivalent guarantees:
 
 - artifacts are signed and verified before install
 - public verification material may live in the repo, but private signing keys
@@ -119,10 +144,9 @@ it provides equivalent guarantees:
 - signing, notarization, and updater keys are rotated or revoked through a
   documented operator path
 
-If the final shell is the SwiftUI desktop path, Sparkle-style appcast and EdDSA
-signatures are the likely default. If the final shell is Tauri, the Tauri updater
-contract may replace Sparkle if it preserves signature verification, channel
-metadata, rollback, and entitlement checks.
+Sparkle appcasts and EdDSA signatures are the selected production path. The
+private signing key remains outside source control; only the public key may be
+embedded in the app bundle.
 
 ## License-Aware Entitlement Checks
 
@@ -147,8 +171,8 @@ The desktop UI and any CLI status surface should use the same state names:
 
 ## Release Governance Gates
 
-Before any desktop updater can be marked required in
-`docs/public-release-manifest.json`, a future PR must provide evidence for:
+Before #116 can close and the public manifest can claim a working desktop update
+channel, the release lane must provide evidence for:
 
 - desktop shell choice and updater technology
 - signed artifact creation and public verification material

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -15,6 +15,8 @@ proven by source alone.
   `SUPublicEDKey`; partial, hostless, whitespace-only, missing, or explicitly
   disabled configuration fails in
   `apps/neondiff-desktop/script/build_and_run.sh` before the bundle is built.
+  This gate proves configuration shape and presence only; CI placeholders are
+  never proof of the real release key or appcast identity.
 - Configured builds check the beta feed every six hours and also expose a
   manual Check for Updates action. Downloads remain user-confirmed.
 - Every check and every selected update re-evaluates update access. A current

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -19,12 +19,14 @@ proven by source alone.
   never proof of the real release key or appcast identity.
 - Configured builds check the beta feed every six hours and also expose a
   manual Check for Updates action. Downloads remain user-confirmed.
-- Every check and every selected update re-evaluates update access. A current
-  paid/trial activation must explicitly include `updateEntitlement=true`.
+- Every check and every selected update re-evaluates update access. A paid/trial
+  activation must explicitly include `updateEntitlement=true`, remain inside
+  its server expiry, and have been verified within five minutes.
   A server `internal_admin` entitlement or verified managed public-free
-  repository is accepted only from an account catalog verified within five
-  minutes. Missing production composition, stale account state, or missing
-  update entitlement fails closed. The policy and focused tests live in
+  repository is accepted only when both the account catalog and authoritative
+  repository visibility were verified within five minutes. Missing production
+  composition, stale authority, or missing update entitlement fails closed. The
+  policy and focused tests live in
   `DesktopUpdateAccess.swift` and `DesktopUpdateAccessPolicyTests.swift`.
 - The customer UI distinguishes ready, checking, update available, up to date,
   entitlement required, invalid feed, network error, signature error, and

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -9,22 +9,28 @@ proven by source alone.
 ## Current Implementation — 2026-07-28
 
 - The native SwiftUI executable uses the existing Sparkle 2 dependency and
-  standard updater UI.
-- Release builds can require a paired HTTPS `SUFeedURL` and `SUPublicEDKey`;
-  partial or missing required configuration fails before the bundle is built.
+  standard updater UI in
+  `apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift`.
+- Every Release build requires a paired, nonblank HTTPS `SUFeedURL` and
+  `SUPublicEDKey`; partial, hostless, whitespace-only, missing, or explicitly
+  disabled configuration fails in
+  `apps/neondiff-desktop/script/build_and_run.sh` before the bundle is built.
 - Configured builds check the beta feed every six hours and also expose a
   manual Check for Updates action. Downloads remain user-confirmed.
 - Every check and every selected update re-evaluates update access. A current
-  paid/trial activation, a current server `internal_admin` entitlement, or a
-  verified managed public-free repository can authorize the beta channel.
-  Missing production composition, stale account state, or missing entitlement
-  fails closed.
+  paid/trial activation must explicitly include `updateEntitlement=true`.
+  A server `internal_admin` entitlement or verified managed public-free
+  repository is accepted only from an account catalog verified within five
+  minutes. Missing production composition, stale account state, or missing
+  update entitlement fails closed. The policy and focused tests live in
+  `DesktopUpdateAccess.swift` and `DesktopUpdateAccessPolicyTests.swift`.
 - The customer UI distinguishes ready, checking, update available, up to date,
-  entitlement required, network error, signature error, and generic safe
-  failure.
-- Failing-first tests cover access policy, public-free bounds, stale paid/trial
-  state, and Sparkle error classification. The existing appcast generator and
-  rollback/signature fixtures remain the publishing seam.
+  entitlement required, invalid feed, network error, signature error, and
+  generic safe failure.
+- Failing-first tests in `DesktopUpdateAccessPolicyTests.swift` cover access
+  policy, public-free bounds, stale paid/trial state, bounded account authority,
+  update-specific entitlement, and Sparkle error classification. The existing
+  appcast generator and rollback/signature fixtures remain the publishing seam.
 
 Proof boundary: source composition and unsigned Release-configuration bundle
 proof only. #116 remains open for real public-key/feed identity, EdDSA-signed

--- a/tests/desktop-byo-production-contract.test.ts
+++ b/tests/desktop-byo-production-contract.test.ts
@@ -102,8 +102,23 @@ describe("NeonDiff desktop B0 production bundle contract", () => {
     });
     expect(hostlessFeed.status).toBe(2);
     expect(hostlessFeed.stderr).toContain(
-      "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a host"
+      "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a DNS host"
     );
+
+    for (const malformedFeed of [
+      "https://:443/appcast.xml",
+      "https://user@/appcast.xml"
+    ]) {
+      const malformedAuthority = checkContract({
+        NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+        NEONDIFF_SPARKLE_FEED_URL: malformedFeed,
+        NEONDIFF_SPARKLE_PUBLIC_ED_KEY: "CI_ONLY_NOT_A_RELEASE_KEY"
+      });
+      expect(malformedAuthority.status).toBe(2);
+      expect(malformedAuthority.stderr).toContain(
+        "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a DNS host"
+      );
+    }
 
     const disabled = checkContract({
       NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",

--- a/tests/desktop-byo-production-contract.test.ts
+++ b/tests/desktop-byo-production-contract.test.ts
@@ -2,6 +2,10 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 const script = "apps/neondiff-desktop/script/build_and_run.sh";
+const signedUpdateBoundary = {
+  NEONDIFF_SPARKLE_FEED_URL: "https://www.neondiff.com/appcast-beta.xml",
+  NEONDIFF_SPARKLE_PUBLIC_ED_KEY: "CI_ONLY_NOT_A_RELEASE_KEY"
+};
 
 function checkContract(overrides: Record<string, string> = {}) {
   return spawnSync(script, ["production-contract-check"], {
@@ -25,7 +29,8 @@ describe("NeonDiff desktop B0 production bundle contract", () => {
       NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
       NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-v1",
       NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED: "true",
-      NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN: "https://neondiff-license.fly.dev"
+      NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN: "https://neondiff-license.fly.dev",
+      ...signedUpdateBoundary
     });
     expect(managed.status).toBe(0);
     expect(managed.stdout.trim()).toBe("managed");
@@ -35,7 +40,8 @@ describe("NeonDiff desktop B0 production bundle contract", () => {
     const result = checkContract({
       NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
       NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1",
-      NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true"
+      NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true",
+      ...signedUpdateBoundary
     });
 
     expect(result.status).toBe(0);
@@ -52,14 +58,16 @@ describe("NeonDiff desktop B0 production bundle contract", () => {
       },
       {
         NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
-        NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1"
+        NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1",
+        ...signedUpdateBoundary
       },
       {
         NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
         NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: "paid-mac-beta-byo-v1",
         NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true",
         NEONDIFF_DESKTOP_MANAGED_GITHUB_BROKER_ENABLED: "true",
-        NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN: "https://neondiff-license.fly.dev"
+        NEONDIFF_DESKTOP_GITHUB_BROKER_ORIGIN: "https://neondiff-license.fly.dev",
+        ...signedUpdateBoundary
       }
     ];
 
@@ -68,5 +76,31 @@ describe("NeonDiff desktop B0 production bundle contract", () => {
       expect(result.status).not.toBe(0);
       expect(result.stdout).toBe("");
     }
+  });
+
+  it("requires a nonblank signed update boundary for every Release configuration", () => {
+    const missing = checkContract({
+      NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release"
+    });
+    expect(missing.status).toBe(2);
+    expect(missing.stderr).toContain("A signed Sparkle feed is required for this release build");
+
+    const whitespaceKey = checkContract({
+      NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+      NEONDIFF_SPARKLE_FEED_URL: "https://www.neondiff.com/appcast-beta.xml",
+      NEONDIFF_SPARKLE_PUBLIC_ED_KEY: "   "
+    });
+    expect(whitespaceKey.status).toBe(2);
+    expect(whitespaceKey.stderr).toContain(
+      "Sparkle feed and public key must not contain surrounding whitespace"
+    );
+
+    const disabled = checkContract({
+      NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+      NEONDIFF_SPARKLE_REQUIRED: "0",
+      ...signedUpdateBoundary
+    });
+    expect(disabled.status).toBe(2);
+    expect(disabled.stderr).toContain("Release builds require NEONDIFF_SPARKLE_REQUIRED=1");
   });
 });

--- a/tests/desktop-byo-production-contract.test.ts
+++ b/tests/desktop-byo-production-contract.test.ts
@@ -95,6 +95,16 @@ describe("NeonDiff desktop B0 production bundle contract", () => {
       "Sparkle feed and public key must not contain surrounding whitespace"
     );
 
+    const hostlessFeed = checkContract({
+      NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
+      NEONDIFF_SPARKLE_FEED_URL: "https:///appcast.xml",
+      NEONDIFF_SPARKLE_PUBLIC_ED_KEY: "CI_ONLY_NOT_A_RELEASE_KEY"
+    });
+    expect(hostlessFeed.status).toBe(2);
+    expect(hostlessFeed.stderr).toContain(
+      "NEONDIFF_SPARKLE_FEED_URL must be an absolute https URL with a host"
+    );
+
     const disabled = checkContract({
       NEONDIFF_DESKTOP_BUILD_CONFIGURATION: "release",
       NEONDIFF_SPARKLE_REQUIRED: "0",

--- a/tests/desktop-evaluation-boundary.test.ts
+++ b/tests/desktop-evaluation-boundary.test.ts
@@ -171,8 +171,12 @@ describe("desktop evaluation production boundary", () => {
     expect(app).toContain('keyEquivalent == "n"');
     expect(app).not.toContain('item(withTitle: "File")');
     expect(app).not.toContain('hasPrefix("New NeonDiff Desktop Window")');
-    expect(updater).toContain("Updates blocked pending native activation proof");
-    expect(updater).not.toContain("SPUStandardUpdaterController");
+    expect(updater).toContain("SPUStandardUpdaterController");
+    expect(updater).toContain("startingUpdater: false");
+    expect(updater).toContain("model.desktopUpdateAccess");
+    expect(updater).toContain("mayPerform updateCheck");
+    expect(updater).toContain("shouldProceedWithUpdate");
+    expect(updater).not.toContain("Updates blocked pending native activation proof");
     expect(manifestBuilder).toContain('visualBaseline: { status: "captured-no-reference" }');
     expect(manifestBuilder).not.toContain("goldenMetrics");
     expect(runner).toContain("kill -KILL");


### PR DESCRIPTION
## Outcome

Enable the existing Sparkle 2 scaffold as the bounded, license-aware NeonDiff beta update client.

Related to #116. This PR does not close #116.

## Acceptance criteria

- A configured native release uses the standard Sparkle updater UI and beta channel.
- A current API-backed activation authorizes paid/trial update checks only when
  the server explicitly returns `updateEntitlement=true`.
- Activation update authority is bounded to five minutes; when the optional
  server `expiresAt` is present it must parse and the earlier of server expiry
  and freshness wins.
- A server internal-admin entitlement authorizes the owner/admin path only from
  an account catalog verified within five minutes.
- Public-free is allowed only for a verified managed public repository backed
  by both current account authority and an independently current authoritative
  repository-visibility snapshot.
- Missing production composition, stale account state, or missing entitlement fails closed.
- Entitlement is rechecked before an update check and before Sparkle proceeds with the selected download.
- Customer states distinguish ready, checking, update available, up to date, entitlement required, malformed feed, network error, signature error, cancellation, and generic safe failure.
- Every Release configuration requires a paired, nonblank, whitespace-clean absolute HTTPS feed with a host plus a public key, and rejects an explicit opt-out before packaging.
- Release feed validation rejects hostless, credential-bearing, malformed-host,
  and invalid-port authorities while accepting a valid DNS host with an
  optional numeric port.
- Configured bundles schedule six-hour checks, retain a manual check action, and keep installation user-confirmed.

## Failing-first and focused proof

- RED: update access policy types absent; focused Swift test failed to compile.
- RED: Sparkle result classifier absent; focused test failed to compile.
- RED: paid/trial account snapshots incorrectly authorized updates; focused test reproduced both failures.
- RED: required release feed/key and automatic-check bundle keys absent; source contract failed.
- RED at `f675607`: Release configuration with missing metadata, a whitespace-only key, and an explicit opt-out each exited successfully; appcast parse cases had no distinct state.
- RED at `349b243`: `updateEntitlement=false` still authorized a current activation; loaded account authority had no expiry; `https:///appcast.xml` passed packaging; a vetoed cycle could overwrite its entitlement status.
- RED at `e95288b`: cached activation update authority ignored freshness and
  optional server expiry; managed public eligibility did not independently
  expire repository-visibility authority; `https://:443/appcast.xml` and
  `https://user@/appcast.xml` passed the release-feed preflight.
- PASS at `da35231`: `DesktopUpdateAccessPolicyTests` — 11/11.
- PASS at `da35231`: `ActivationHandoffModelTests` — 21/21, including
  update-specific entitlement, activation freshness/server-expiry behavior,
  five-minute account authority, and independent repository-visibility
  freshness.
- PASS at `349b243`: `ProductionBoundaryContractTests` — 18/18.
- PASS at `6af2a60`: missing Release metadata, whitespace-only metadata, hostless HTTPS metadata, and explicit opt-out each fail before build; a paired non-secret test boundary passes.
- PASS at `349b243`: `NeonDiffDesktopAppcastChecks` and Bash syntax check.
- PASS at `6af2a60`: unsigned Release-configuration bundle check with obvious non-release CI metadata; Sparkle 2.9.4 and required Info.plist keys packaged.
- PASS at `da35231`: malformed host/credential feed probes fail closed; valid
  DNS-host probes with and without numeric port 443 pass.
- PASS at exact head `da352314746b7eef2c213b12317f902cf1f71af8`:
  independent bounded delta review covering activation expiry/freshness,
  repository-visibility freshness, and feed authority.
- PASS: current-head PR CI, Swift fast gate, CodeQL, Socket, CodeRabbit, and
  evaOS review are terminal green; all 13 review threads are resolved with
  complete pagination.
- PASS: full-candidate run `30347770899` on exact head `da352314...`: Swift
  fast, Release boundaries, hosted XCUITest, candidate gate, and aggregate gate
  all green.
- PASS: hosted xcresult artifact `8684044010`, GitHub digest
  `sha256:e400dfbeeabc7cd638be40c7df15dc8fc3bad5287a876adc5d2ee2a6d9705bd0`;
  inspected result is Passed with 9 passed, 0 failed, and 2 existing #516
  harness skips.

## Non-goals / proof boundary

- No private signing key or credential creation/rotation.
- No real public key, hosted appcast, artifact URL, deploy, tag, GitHub Release, checkout, or website publication.
- CI-only feed/key placeholders are not release credentials and must never be used for a distributed build.
- No signed installed update, rollback, re-update, or customer canary claim.
- No change to broader #517 or GA scope.
- #116 remains open until exact signed/notarized installed update, rollback, immutable asset/feed, and customer evidence pass.
