### PR TITLE
fix(desktop): reconcile config through installed agent CLI

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -351,7 +351,8 @@ package enum DesktopLocalBotExecutionContextResolver {
         matchingContext(
             executablePath: executablePath,
             arguments: arguments,
-            executionContexts: executionContexts
+            executionContexts: executionContexts,
+            commandAccess: .credentialEnvironment
         )?.environmentOverrides ?? [:]
     }
 
@@ -363,7 +364,8 @@ package enum DesktopLocalBotExecutionContextResolver {
         matchingContext(
             executablePath: executablePath,
             arguments: arguments,
-            executionContexts: executionContexts
+            executionContexts: executionContexts,
+            commandAccess: .executableReuse
         )?.executablePath
     }
 
@@ -375,22 +377,39 @@ package enum DesktopLocalBotExecutionContextResolver {
         guard let context = matchingContext(
             executablePath: executablePath,
             arguments: arguments,
-            executionContexts: executionContexts
+            executionContexts: executionContexts,
+            commandAccess: .executableReuse
         ) else {
             return arguments
         }
         return context.argumentPrefix + arguments
     }
 
+    private enum CommandAccess {
+        case credentialEnvironment
+        case executableReuse
+
+        func allows(_ arguments: [String]) -> Bool {
+            let credentialCommand = arguments.first == "review-pr"
+                || Array(arguments.prefix(2)) == ["doctor", "github"]
+            switch self {
+            case .credentialEnvironment:
+                return credentialCommand
+            case .executableReuse:
+                return credentialCommand
+                    || Array(arguments.prefix(2)) == ["config", "inspect"]
+            }
+        }
+    }
+
     private static func matchingContext(
         executablePath: String,
         arguments: [String],
-        executionContexts: [DesktopLocalBotExecutionContext]
+        executionContexts: [DesktopLocalBotExecutionContext],
+        commandAccess: CommandAccess
     ) -> DesktopLocalBotExecutionContext? {
         guard executablePath == "neondiff" else { return nil }
-        let commandIsAllowed = arguments.first == "review-pr"
-            || Array(arguments.prefix(2)) == ["doctor", "github"]
-        guard commandIsAllowed else { return nil }
+        guard commandAccess.allows(arguments) else { return nil }
         let configIndexes = arguments.indices.filter {
             arguments[$0] == "--config"
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -329,6 +329,61 @@ import Testing
         ) == [sourceRunner, "src/cli.ts", "review-pr", "--config", configPath])
     }
 
+    @Test func reusesTheExactSourceRunnerForCredentialFreeConfigInspection() throws {
+        let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let nodePath = "/opt/homebrew/bin/node"
+        let sourceRunner = "\(workingDirectory)/node_modules/tsx/dist/cli.mjs"
+        let arguments = ["config", "inspect", "--config", configPath]
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: try propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: [
+                    "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                    "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                ],
+                arguments: [
+                    nodePath,
+                    sourceRunner,
+                    "src/cli.ts",
+                    "daemon",
+                    "--config",
+                    configPath
+                ],
+                workingDirectory: workingDirectory
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        )
+
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context!]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context!]
+        ) == nodePath)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context!]
+        ) == [sourceRunner, "src/cli.ts"] + arguments)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: ["config", "inspect", "--config", "/other/config.json"],
+            executionContexts: [context!]
+        ) == nil)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "/tmp/custom-neondiff",
+            arguments: arguments,
+            executionContexts: [context!]
+        ) == nil)
+    }
+
     @Test func rejectsUnsafeOrConflictingExistingWorkerCredentialCoordinates() throws {
         let configPath = "/tmp/neondiff.json"
         let baseEnvironment = [


### PR DESCRIPTION
## Acceptance criteria

- Route desktop `config inspect` through the exact executable and argument prefix parsed from the verified, exact-config launch agent.
- Keep GitHub App ID/private-key path environment overrides unavailable to `config inspect`.
- Preserve existing exact-config credential forwarding for `review-pr` and `doctor github`.
- Refuse launch-context reuse for custom executable settings, duplicate/missing `--config`, and unmatched config paths.
- Pass current-head Swift CI and hosted desktop proof.

## Failing-first proof

Before the production change, `LaunchAgentLocalBotConfigurationTests.reusesTheExactSourceRunnerForCredentialFreeConfigInspection` failed because the resolved executable was `nil` and the source-runner prefix was absent. After the change:

- `LaunchAgentLocalBotConfigurationTests`: 11/11 pass.
- `ProductionBoundaryContractTests`: 18/18 pass.
- `git diff --check`: pass.

## Non-goals

- No live config migration, daemon restart, global npm mutation, Keychain copy, private-key exposure, billing, checkout, website publish, update feed, release, managed GitHub App change, generalized CLI compatibility layer, or broader desktop matrix.
- This PR does not close #696; exact signed/notarized installed-app reconciliation and relaunch proof remain required.

Related to #696, #646, and #610.