### PR TITLE
fix(desktop): gate reviews on worker capabilities

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -38,8 +38,7 @@ struct DesktopSetupReadiness {
                 ? "Choose review target"
                 : model.repos.first(where: \.enabled)?.name)
             ?? "owner/repository"
-        canRunDryRun = model.productionUsefulWorkAvailable
-            && model.providerSetupReady
+        canRunDryRun = model.scopedReviewExecutionAvailable
     }
 
     private var gates: [Bool] { [github, provider, license, repository] }
@@ -389,6 +388,17 @@ struct OverviewView: View {
                 .font(.callout)
                 .foregroundStyle(palette.textSecondary)
 
+            if model.localWorkerReviewUpdateRequired
+                || (model.localWorkerReviewCompatibilityCheckAvailable
+                    && !model.localWorkerReviewCompatibility.isCompatible) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 10) { localWorkerRecoveryControls }
+                    VStack(alignment: .leading, spacing: 10) {
+                        localWorkerRecoveryControls
+                    }
+                }
+            }
+
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 10) { scopedReviewControls }
                 VStack(alignment: .leading, spacing: 10) { scopedReviewControls }
@@ -401,6 +411,30 @@ struct OverviewView: View {
                 )
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityIdentifier("neondiff-scoped-review-status")
+        }
+    }
+
+    @ViewBuilder
+    private var localWorkerRecoveryControls: some View {
+        if model.localWorkerReviewUpdateRequired {
+            Button {
+                model.openLocalWorkerUpdateGuide()
+            } label: {
+                Label("View Worker Update Steps", systemImage: "arrow.down.circle")
+            }
+            .buttonStyle(ReferenceOutlineButtonStyle())
+            .accessibilityIdentifier("neondiff-worker-update-guide")
+        }
+
+        if model.localWorkerReviewCompatibilityCheckAvailable
+            && !model.localWorkerReviewCompatibility.isCompatible {
+            Button {
+                model.checkLocalWorkerReviewCompatibility()
+            } label: {
+                Label("Retry Worker Check", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(ReferenceOutlineButtonStyle())
+            .accessibilityIdentifier("neondiff-worker-retry-check")
         }
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -45,6 +45,57 @@ package struct DesktopLocalBotExecutionContext: Equatable, Sendable {
     }
 }
 
+package enum DesktopLocalWorkerReviewCompatibility: Equatable, Sendable {
+    case unknown
+    case checking
+    case compatible(packageVersion: String?)
+    case incompatible
+
+    package var isCompatible: Bool {
+        if case .compatible = self { return true }
+        return false
+    }
+}
+
+package struct DesktopLocalWorkerReviewCapabilityReport: Decodable, Equatable, Sendable {
+    package struct LicenseBoundary: Decodable, Equatable, Sendable {
+        package let packageVersion: String?
+    }
+
+    package struct Usage: Decodable, Equatable, Sendable {
+        package struct Flag: Decodable, Equatable, Sendable {
+            package let name: String
+        }
+
+        package let command: String
+        package let flags: [Flag]
+    }
+
+    package let ok: Bool
+    package let command: String
+    package let licenseBoundary: LicenseBoundary?
+    package let usage: Usage
+
+    package var supportsExactDryToLiveReview: Bool {
+        guard ok,
+              command == "review-pr",
+              usage.command == "review-pr"
+        else {
+            return false
+        }
+        let names = Set(usage.flags.map(\.name))
+        return names.isSuperset(of: [
+            "--expected-config-revision",
+            "--zcode"
+        ])
+    }
+
+    package static func parse(_ stdout: String) -> Self? {
+        guard let data = stdout.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(Self.self, from: data)
+    }
+}
+
 package enum DesktopLaunchAgentBotConfigurationParser {
     private static let supportedAppIDKeys = [
         "NEONDIFF_GITHUB_APP_ID",
@@ -390,13 +441,18 @@ package enum DesktopLocalBotExecutionContextResolver {
         case executableReuse
 
         func allows(_ arguments: [String]) -> Bool {
-            let credentialCommand = arguments.first == "review-pr"
+            let reviewHelpCommand = arguments.first == "review-pr"
+                && arguments.contains("--help")
+            let credentialCommand = (
+                arguments.first == "review-pr" && !reviewHelpCommand
+            )
                 || Array(arguments.prefix(2)) == ["doctor", "github"]
             switch self {
             case .credentialEnvironment:
                 return credentialCommand
             case .executableReuse:
                 return credentialCommand
+                    || reviewHelpCommand
                     || Array(arguments.prefix(2)) == ["config", "inspect"]
             }
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -664,6 +664,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var githubRepositoryRefreshTask: Task<Void, Never>?
     private var managedGitHubConnectionTask: Task<Void, Never>?
     private var localWorkerCompatibilityTask: Task<Void, Never>?
+    private var localWorkerReviewCompatibilityGeneration: UInt64 = 0
     private var accountLinkTask: Task<Void, Never>?
     private var mostRecentAccountLinkTask: Task<Void, Never>?
     private var accountLinkGeneration: UInt64 = 0
@@ -2163,7 +2164,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             headSHA: "",
             configPath: configPath,
             configRevision: configRevision,
-            workspaceGeneration: workspaceContextGeneration
+            workspaceGeneration: workspaceContextGeneration,
+            workerCompatibilityGeneration:
+                localWorkerReviewCompatibilityGeneration
         )
         let arguments = [
             "review-pr",
@@ -4173,7 +4176,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             headSHA: report.scope.headSha.lowercased(),
             configPath: expectedContext.configPath,
             configRevision: expectedContext.configRevision,
-            workspaceGeneration: expectedContext.workspaceGeneration
+            workspaceGeneration: expectedContext.workspaceGeneration,
+            workerCompatibilityGeneration:
+                expectedContext.workerCompatibilityGeneration
         )
         scopedDryRunApproval = approval
         scopedDryRunHeadSHA = approval.headSHA
@@ -4229,6 +4234,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         _ approval: ScopedReviewApproval
     ) -> Bool {
         guard approval.workspaceGeneration == workspaceContextGeneration,
+              approval.workerCompatibilityGeneration
+                == localWorkerReviewCompatibilityGeneration,
+              localWorkerReviewCompatibility.isCompatible,
               approval.configPath == configPath,
               let selectedReviewRepository,
               selectedReviewRepository.caseInsensitiveCompare(approval.repo)
@@ -4264,6 +4272,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private func invalidateLocalWorkerReviewCompatibility() {
         localWorkerCompatibilityTask?.cancel()
         localWorkerCompatibilityTask = nil
+        localWorkerReviewCompatibilityGeneration &+= 1
         localWorkerReviewCompatibility = .unknown
         invalidateScopedReviewApproval()
     }
@@ -5704,6 +5713,7 @@ private struct ScopedReviewApproval: Equatable, Sendable {
     let configPath: String
     let configRevision: String
     let workspaceGeneration: UInt64
+    let workerCompatibilityGeneration: UInt64
 }
 
 private struct ScopedReviewCommandReport: Decodable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -88,6 +88,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             invalidateProviderConfigAuthorization()
             invalidateProviderVerificationContext()
             invalidateBYOGitHubVerificationContext()
+            invalidateLocalWorkerReviewCompatibility()
             invalidateActivationForRepositoryChange()
         }
     }
@@ -96,6 +97,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             guard cliPath != oldValue else { return }
             invalidateProviderVerificationContext()
             invalidateBYOGitHubVerificationContext()
+            invalidateLocalWorkerReviewCompatibility()
         }
     }
     @Published package var launchdLabel: String
@@ -160,6 +162,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var isScopedReviewInProgress = false
     @Published package private(set) var scopedDryRunHeadSHA: String?
     @Published package private(set) var scopedReviewStatus = "Verify current access before running a dry review."
+    @Published package private(set) var localWorkerReviewCompatibility: DesktopLocalWorkerReviewCompatibility = .unknown
     @Published package var logText = "No logs loaded."
     @Published package var lastError: String?
     @Published package var lastCommandLine = ""
@@ -435,7 +438,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var scopedReviewExecutionAvailable: Bool {
         productionUsefulWorkAvailable
             && existingLocalAgentAccessAvailable
+            && localWorkerReviewCompatibility.isCompatible
             && scopedReviewProviderReady
+    }
+
+    package var localWorkerReviewUpdateRequired: Bool {
+        localWorkerReviewCompatibility == .incompatible
+    }
+
+    package var localWorkerReviewCompatibilityCheckAvailable: Bool {
+        existingLocalAgentAccessAvailable
+            && localWorkerReviewCompatibility != .checking
+            && !isScopedReviewInProgress
     }
 
     /// Stopping an already-running daemon is a safety remediation, not useful
@@ -649,6 +663,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var githubAuthorizationTask: Task<Void, Never>?
     private var githubRepositoryRefreshTask: Task<Void, Never>?
     private var managedGitHubConnectionTask: Task<Void, Never>?
+    private var localWorkerCompatibilityTask: Task<Void, Never>?
     private var accountLinkTask: Task<Void, Never>?
     private var mostRecentAccountLinkTask: Task<Void, Never>?
     private var accountLinkGeneration: UInt64 = 0
@@ -1598,6 +1613,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         _ = githubRepositoryRefreshGate.begin()
         managedGitHubConnectionTask?.cancel()
         managedGitHubConnectionTask = nil
+        invalidateLocalWorkerReviewCompatibility()
         scopedReviewTask?.cancel()
         scopedReviewTask = nil
         pendingManagedGitHubAuthorization = nil
@@ -2037,6 +2053,94 @@ package final class NeonDiffDesktopModel: ObservableObject {
             arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
             displayCommand: startDaemonCommand
         )
+    }
+
+    package func checkLocalWorkerReviewCompatibility() {
+        guard existingLocalAgentAccessAvailable else {
+            invalidateLocalWorkerReviewCompatibility()
+            scopedReviewStatus =
+                "Connect a verified local NeonDiff agent before checking review compatibility."
+            return
+        }
+
+        localWorkerCompatibilityTask?.cancel()
+        let expectedConfigPath = configPath
+        let expectedCLIPath = cliPath
+        let expectedWorkspaceGeneration = workspaceContextGeneration
+        let cli = dependencies.cli
+        localWorkerReviewCompatibility = .checking
+        scopedReviewStatus =
+            "Checking whether the selected local worker supports exact dry-to-live review…"
+
+        localWorkerCompatibilityTask = Task { [weak self] in
+            do {
+                let result = try await cli.run(
+                    executablePath: expectedCLIPath,
+                    arguments: [
+                        "review-pr",
+                        "--help",
+                        "--config",
+                        expectedConfigPath
+                    ],
+                    standardInput: nil,
+                    timeout: 15
+                )
+                guard let self, !Task.isCancelled,
+                      self.workspaceContextGeneration == expectedWorkspaceGeneration,
+                      self.configPath == expectedConfigPath,
+                      self.cliPath == expectedCLIPath
+                else {
+                    return
+                }
+                self.localWorkerCompatibilityTask = nil
+                let report = result.exitCode == 0
+                    ? DesktopLocalWorkerReviewCapabilityReport.parse(
+                        result.stdout
+                    )
+                    : nil
+                if let report, report.supportsExactDryToLiveReview {
+                    self.localWorkerReviewCompatibility = .compatible(
+                        packageVersion: report.licenseBoundary?.packageVersion
+                    )
+                    self.lastError = nil
+                    self.scopedReviewStatus =
+                        "Local worker supports exact config-revision dry and live review."
+                } else {
+                    self.localWorkerReviewCompatibility = .incompatible
+                    self.invalidateScopedReviewApproval(preserveStatus: true)
+                    self.lastError =
+                        "This local NeonDiff worker must be updated before reviews can run."
+                    self.scopedReviewStatus =
+                        "Worker update required. View the update steps, then retry this check."
+                }
+            } catch {
+                guard let self, !Task.isCancelled,
+                      self.workspaceContextGeneration == expectedWorkspaceGeneration,
+                      self.configPath == expectedConfigPath,
+                      self.cliPath == expectedCLIPath
+                else {
+                    return
+                }
+                self.localWorkerCompatibilityTask = nil
+                self.localWorkerReviewCompatibility = .incompatible
+                self.invalidateScopedReviewApproval(preserveStatus: true)
+                self.lastError =
+                    "The local worker compatibility check failed safely."
+                self.scopedReviewStatus =
+                    "Worker check failed. View the update steps or retry the check."
+            }
+        }
+    }
+
+    package func openLocalWorkerUpdateGuide() {
+        let url = URL(
+            string: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/blob/main/docs/SETUP.md#update-an-existing-local-worker"
+        )!
+        guard dependencies.urlOpener.open(url) else {
+            lastError = "NeonDiff could not open the local worker update guide."
+            return
+        }
+        lastError = nil
     }
 
     package func runScopedDryReview() {
@@ -4012,6 +4116,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
             scopedReviewStatus = lastError ?? "Local agent required"
             return false
         }
+        guard localWorkerReviewCompatibility.isCompatible else {
+            lastError = localWorkerReviewCompatibility == .checking
+                ? "Wait for the local worker compatibility check to finish."
+                : "Update or recheck the selected local worker before running a review."
+            scopedReviewStatus = lastError ?? "Worker compatibility required"
+            return false
+        }
         return true
     }
 
@@ -4148,6 +4259,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
             scopedReviewStatus =
                 "Run a dry review before posting an exact pull request head."
         }
+    }
+
+    private func invalidateLocalWorkerReviewCompatibility() {
+        localWorkerCompatibilityTask?.cancel()
+        localWorkerCompatibilityTask = nil
+        localWorkerReviewCompatibility = .unknown
+        invalidateScopedReviewApproval()
     }
 
     @discardableResult
@@ -5155,6 +5273,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         controlCenterStatus = "Current config loaded. Edit settings, then Preview."
                     } else {
                         controlCenterStatus = "Config loaded from a previous path. Reload the current config before editing."
+                    }
+                    if existingLocalAgentAccessAvailable {
+                        checkLocalWorkerReviewCompatibility()
+                    } else {
+                        invalidateLocalWorkerReviewCompatibility()
                     }
                 }
             }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -672,6 +672,85 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func workerChangeWhileDryReviewIsRunningCannotRecreateApproval() async throws {
+        let repository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let headSHA = String(repeating: "c", count: 40)
+        let boundary = DesktopProductionBoundary.resolve(infoDictionary: [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ])
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [repository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"electricsheephq/evaos-code-review-bot-neondiff","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":699,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/699"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
+                    stderr: ""
+                ))
+            ],
+            activationLicenseClient: ExistingBotActiveActivationClient(),
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            localBotExecutionConfigPaths: [configPath],
+            productionBoundary: boundary
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
+        fixture.model.selectBYOReviewRepository(fullName: repository)
+        fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(3)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+        #expect(fixture.model.scopedReviewExecutionAvailable)
+
+        fixture.cli.suspendFutureRuns()
+        fixture.model.pendingReviewPullNumber = "699"
+        fixture.model.runScopedDryReview()
+        await fixture.cli.waitUntilCallCount(4)
+        fixture.model.cliPath = "/fixture/bin/neondiff-updated"
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.scopedDryRunHeadSHA == nil)
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+        #expect(fixture.model.localWorkerReviewCompatibility == .unknown)
+    }
+
+    @MainActor
     @Test func selectedExistingBYOBotPrefersItsExactLocalAgentOverStoredKeychainMaterial() async throws {
         let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -603,6 +603,75 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func incompatibleLocalWorkerBlocksReviewAndOffersVisibleRecovery() async throws {
+        let repository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let staleHelp = #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"},{"name":"--repo"},{"name":"--pr"},{"name":"--dry-run"},{"name":"--confirm"}]}}"#
+        let compatibleHelp = #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"},{"name":"--repo"},{"name":"--pr"},{"name":"--dry-run"},{"name":"--confirm"},{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [repository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: staleHelp,
+                    stderr: ""
+                ))
+            ],
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            localBotExecutionConfigPaths: [configPath],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
+
+        #expect(fixture.cli.calls[1].arguments == [
+            "review-pr", "--help", "--config", configPath
+        ])
+        #expect(fixture.cli.calls[1].standardInput == nil)
+        #expect(fixture.model.localWorkerReviewUpdateRequired)
+        #expect(!fixture.model.scopedReviewExecutionAvailable)
+        #expect(fixture.model.scopedReviewStatus.contains("update required"))
+
+        fixture.model.openLocalWorkerUpdateGuide()
+        #expect(fixture.urlOpener.urls.last?.absoluteString.contains(
+            "docs/SETUP.md#update-an-existing-local-worker"
+        ) == true)
+
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 0,
+            stdout: compatibleHelp,
+            stderr: ""
+        )))
+        fixture.model.checkLocalWorkerReviewCompatibility()
+        await fixture.cli.waitUntilCallCount(3)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.localWorkerReviewCompatibility.isCompatible)
+        #expect(!fixture.model.localWorkerReviewUpdateRequired)
+        #expect(fixture.model.scopedReviewStatus.contains("supports exact"))
+    }
+
+    @MainActor
     @Test func selectedExistingBYOBotPrefersItsExactLocalAgentOverStoredKeychainMaterial() async throws {
         let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"
@@ -621,6 +690,11 @@ import NeonDiffDesktopCore
                         authMode: "zcode-app-config",
                         repositories: repositories
                     ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
                     stderr: ""
                 )),
                 .success(CLIRunResult(
@@ -649,10 +723,10 @@ import NeonDiffDesktopCore
         for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
             await Task.yield()
         }
-        fixture.loadConfig(existingBotConfig(
-            authMode: "zcode-app-config",
-            repositories: repositories
-        ))
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
         fixture.model.selectBYOReviewRepository(fullName: targetRepository)
         fixture.model.pendingBYOGitHubAppId = "4184532"
         fixture.model.pendingBYOGitHubAppPrivateKey = existingBotFixturePrivateKey
@@ -664,7 +738,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.byoGitHubPrivateKeyStored)
 
         fixture.model.verifyExistingLocalBotGitHubAccess()
-        await fixture.cli.waitUntilCallCount(2)
+        await fixture.cli.waitUntilCallCount(3)
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
@@ -763,6 +837,11 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
@@ -784,6 +863,16 @@ import NeonDiffDesktopCore
                 .success(CLIRunResult(
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":685,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/685"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
                     stderr: ""
                 )),
                 .success(CLIRunResult(
@@ -818,21 +907,21 @@ import NeonDiffDesktopCore
         for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
             await Task.yield()
         }
-        fixture.loadConfig(existingBotConfig(
-            authMode: "zcode-app-config",
-            repositories: [otherRepository, targetRepository]
-        ))
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
         fixture.model.selectBYOReviewRepository(fullName: targetRepository)
         fixture.model.pendingActivationKey = "NDL-BYO-0123456789"
         fixture.model.provideExistingActivationKey()
         await fixture.model.submitActivation()
         fixture.model.verifyExistingLocalBotGitHubAccess()
-        await fixture.cli.waitUntilCallCount(2)
+        await fixture.cli.waitUntilCallCount(3)
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
 
-        #expect(fixture.cli.calls[1].arguments == [
+        #expect(fixture.cli.calls[2].arguments == [
             "doctor", "github",
             "--config", configPath,
             "--repo", targetRepository,
@@ -843,7 +932,7 @@ import NeonDiffDesktopCore
 
         fixture.model.pendingReviewPullNumber = "685"
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(3)
+        await fixture.cli.waitUntilCallCount(4)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -852,7 +941,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
 
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(4)
+        await fixture.cli.waitUntilCallCount(5)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -861,7 +950,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedLiveReviewConfirmationAvailable)
 
         fixture.model.runScopedLiveReview()
-        await fixture.cli.waitUntilCallCount(5)
+        await fixture.cli.waitUntilCallCount(6)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -870,7 +959,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
 
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(6)
+        await fixture.cli.waitUntilCallCount(7)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -880,22 +969,30 @@ import NeonDiffDesktopCore
             repositories: [otherRepository, targetRepository],
             revision: String(repeating: "b", count: 64)
         ))
+        await fixture.cli.waitUntilCallCount(8)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
         #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
         fixture.model.runScopedLiveReview()
         await Task.yield()
-        #expect(fixture.cli.calls.count == 6)
+        #expect(fixture.cli.calls.count == 8)
 
         fixture.loadConfig(existingBotConfig(
             authMode: "zcode-app-config",
             repositories: [otherRepository, targetRepository]
         ))
+        await fixture.cli.waitUntilCallCount(9)
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(7)
+        await fixture.cli.waitUntilCallCount(10)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
         fixture.model.runScopedLiveReview()
-        await fixture.cli.waitUntilCallCount(8)
+        await fixture.cli.waitUntilCallCount(11)
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -384,6 +384,70 @@ import Testing
         ) == nil)
     }
 
+    @Test func reusesTheExactSourceRunnerForCredentialFreeReviewCapabilityHelp() throws {
+        let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let nodePath = "/opt/homebrew/bin/node"
+        let sourceRunner = "\(workingDirectory)/node_modules/tsx/dist/cli.mjs"
+        let arguments = ["review-pr", "--help", "--config", configPath]
+        let context = try #require(DesktopLaunchAgentExecutionContextParser.parse(
+            data: propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: [
+                    "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                    "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                ],
+                arguments: [
+                    nodePath,
+                    sourceRunner,
+                    "src/cli.ts",
+                    "daemon",
+                    "--config",
+                    configPath
+                ],
+                workingDirectory: workingDirectory
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        ))
+
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ) == nodePath)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ) == [sourceRunner, "src/cli.ts"] + arguments)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: ["review-pr", "--help", "--config", "/other/config.json"],
+            executionContexts: [context]
+        ) == nil)
+    }
+
+    @Test func reviewCapabilityRequiresTheExactDryToLiveFlagContract() throws {
+        let compatible = try #require(DesktopLocalWorkerReviewCapabilityReport.parse(
+            #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"},{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#
+        ))
+        #expect(compatible.supportsExactDryToLiveReview)
+        #expect(compatible.licenseBoundary?.packageVersion == "1.0.4")
+
+        let stale = try #require(DesktopLocalWorkerReviewCapabilityReport.parse(
+            #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"}]}}"#
+        ))
+        #expect(!stale.supportsExactDryToLiveReview)
+        #expect(DesktopLocalWorkerReviewCapabilityReport.parse("not json") == nil)
+    }
+
     @Test func rejectsUnsafeOrConflictingExistingWorkerCredentialCoordinates() throws {
         let configPath = "/tmp/neondiff.json"
         let baseEnvironment = [

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -301,6 +301,11 @@ import Testing
         #expect(chrome.contains("WindowDragRegion"))
         #expect(!chrome.contains("ChromeCircuitBackdrop"))
         #expect(overview.contains("Ready for a dry run"))
+        #expect(overview.contains("canRunDryRun = model.scopedReviewExecutionAvailable"))
+        #expect(overview.contains("View Worker Update Steps"))
+        #expect(overview.contains("Retry Worker Check"))
+        #expect(overview.contains("neondiff-worker-update-guide"))
+        #expect(overview.contains("neondiff-worker-retry-check"))
         #expect(overview.contains("Existing bot configured"))
         #expect(overview.contains("Restoring this Mac"))
         #expect(overview.contains("CHECKING LOCAL SETUP"))
@@ -325,11 +330,7 @@ import Testing
         #expect(overview.contains("readiness.licenseStatus"))
         #expect(overview.contains(#""PUBLIC · FREE""#))
         #expect(overview.contains("model.licenseSetupReady"))
-        #expect(overview.contains("model.productionUsefulWorkAvailable"))
-        #expect(overview.contains(
-            "canRunDryRun = model.productionUsefulWorkAvailable\n"
-                + "            && model.providerSetupReady"
-        ))
+        #expect(overview.contains("canRunDryRun = model.scopedReviewExecutionAvailable"))
         #expect(overview.contains("Config and secrets stay on this Mac"))
         #expect(overview.contains("Model context follows your selected provider"))
         #expect(overview.contains("model.providerSetupReady"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -72,6 +72,10 @@ final class ScriptedDesktopCLIExecutor: DesktopCLIExecuting, @unchecked Sendable
         continuations.forEach { $0.resume() }
     }
 
+    func suspendFutureRuns() {
+        state.update { $0.suspendRuns = true }
+    }
+
     func run(
         executablePath: String,
         arguments: [String],

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -315,6 +315,32 @@ A local config path, launchd label, App ID, or repository name by itself is not
 authority. Suspended, revoked, pending, mismatched, or server-unrecognized bots
 remain in setup/recovery and fail closed.
 
+### Update an existing local worker
+
+The Mac app checks the exact discovered worker's `review-pr` help contract
+before enabling **Run Dry Review**. A package version alone is not sufficient:
+older and compatible technical-beta workers may both report `1.0.4`.
+
+If Overview shows **Worker update required**:
+
+1. Do not run or retry a live review from another terminal. The dry-to-live
+   approval contract is not proven for that worker.
+2. Use only the exact worker artifact or source commit named in the current
+   invite/release notes, and verify its published checksum or commit before
+   replacing the executable. Do not treat an unpinned `main` checkout or an npm
+   version string as release proof.
+3. Preserve the existing config, LaunchAgent label, GitHub App key file,
+   Keychain entries, provider configuration, and repository allowlist. Updating
+   the worker must not migrate or copy those secrets.
+4. Restart the same LaunchAgent using the release's documented command, return
+   to Overview, and choose **Retry Worker Check**. Dry review stays disabled
+   until the exact executable advertises both config-revision approval and the
+   matching ZCode provider path.
+
+Until an invite or immutable release names a compatible worker artifact, this
+state is a release blocker rather than a prompt to repair source files manually.
+The app's own Sparkle update does not update an external local worker.
+
 ## 4. Check Readiness
 
 Run the GitHub-only doctor first. It verifies App installation visibility and

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -99,6 +99,12 @@ describe("public NeonDiff CLI surface", () => {
       expect.objectContaining({ name: "--expected-config-revision" })
     ]));
     expect(output.examples).toContain("neondiff doctor github --config config.local.json --json");
+    const reviewHelp = JSON.parse((await runCli(["review-pr", "--help"])).stdout);
+    expect(reviewHelp).toMatchObject({ ok: true, command: "review-pr" });
+    expect(reviewHelp.usage.flags).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "--expected-config-revision" }),
+      expect.objectContaining({ name: "--zcode" })
+    ]));
     const doctorHelp = JSON.parse((await runCli(["doctor", "--help"])).stdout);
     expect(doctorHelp.usage.flags).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: "--github-app-id" }),


### PR DESCRIPTION
Related: #699

## Outcome

Prevent the native Mac app from presenting Dry Review or Live Review as ready when the exact discovered local worker lacks the config-revision dry-to-live contract.

This is the bounded detection and visible-recovery slice of #699. It does not close the broader customer update/install and old-to-current installed-worker canary gate.

## Acceptance criteria

- inspect the exact discovered worker with `review-pr --help --config <exact-config>`
- require the JSON help contract to advertise both `--expected-config-revision` and `--zcode`; do not trust the ambiguous `1.0.4` package version
- reuse the matched worker executable/runner for the help probe without injecting GitHub App credential environment
- keep Dry Review and Live Review disabled for missing, malformed, nonzero, stale, cancelled, or incompatible results
- invalidate compatibility and any scoped live approval when the selected config, CLI, or account workspace changes
- show customer-visible update guidance and a retry action without mutating the worker, LaunchAgent, config, Keychain, provider, or repository allowlist

## Non-goals

- no automatic updater, package install, `git pull`, `curl`, npm publication, or immutable worker release
- no LaunchAgent restart or local credential/config mutation
- no billing, appcast, managed GitHub App/B1, broader #517, or public release work
- no claim that #699 or #646 is complete

## Failing-first and focused proof

- RED: `swift test --filter LaunchAgentLocalBotConfigurationTests.reusesTheExactSourceRunnerForCredentialFreeReviewCapabilityHelp` failed because `review-pr --help` inherited the matched App ID/private-key-path environment
- GREEN: the same test passes after separating exact executable reuse from credential-environment authorization
- `swift test --filter LaunchAgentLocalBotConfigurationTests` — 13/13 passed
- `swift test --filter ExistingLocalBotReconciliationTests` — 31/31 passed
- `swift test --filter OwnerReferenceUXContractTests` — 7/7 passed
- `npx vitest run tests/public-cli.test.ts -t "shows public commands in help output"` — 1 passed
- `git diff --check` — passed

Broad build, test, package, security, and hosted desktop validation remain GitHub CI gates for this exact head.

## Safety boundary

The capability probe receives no stdin and no GitHub App credential environment. Actual credential-backed `doctor github` and `review-pr` operations keep their existing exact-config resolver boundary. The patch does not read, copy, store, display, or change private keys, provider credentials, activation material, or Keychain items.

Agent-authored with owner-approved release authority.
