### PR TITLE
feat: add checksum-bound B0 worker install and rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ package. To preview without changing your machine:
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
+Invite-only B0 Mac candidates use a separate checksum-bound private worker
+bundle rather than an unpublished npm version or an unpinned source checkout.
+When the app reports **Worker update required**, choose **Install / Update Local
+Worker** and follow the exact invite checksums plus the dry-run-first update and
+rollback commands in [docs/SETUP.md](docs/SETUP.md#update-an-existing-local-worker).
+This preserves the existing config, LaunchAgent identity/environment, provider
+state, repository allowlist, and credential stores. It is not a public npm,
+GitHub Release, Sparkle, or automatic worker-update claim.
+
 Source checkout fallback:
 
 ```bash

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -420,7 +420,7 @@ struct OverviewView: View {
             Button {
                 model.openLocalWorkerUpdateGuide()
             } label: {
-                Label("View Worker Update Steps", systemImage: "arrow.down.circle")
+                Label("Install / Update Local Worker", systemImage: "arrow.down.circle")
             }
             .buttonStyle(ReferenceOutlineButtonStyle())
             .accessibilityIdentifier("neondiff-worker-update-guide")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2138,7 +2138,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             string: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/blob/main/docs/SETUP.md#update-an-existing-local-worker"
         )!
         guard dependencies.urlOpener.open(url) else {
-            lastError = "NeonDiff could not open the local worker update guide."
+            lastError = "NeonDiff could not open the local worker installer guide."
             return
         }
         lastError = nil

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -302,7 +302,7 @@ import Testing
         #expect(!chrome.contains("ChromeCircuitBackdrop"))
         #expect(overview.contains("Ready for a dry run"))
         #expect(overview.contains("canRunDryRun = model.scopedReviewExecutionAvailable"))
-        #expect(overview.contains("View Worker Update Steps"))
+        #expect(overview.contains("Install / Update Local Worker"))
         #expect(overview.contains("Retry Worker Check"))
         #expect(overview.contains("neondiff-worker-update-guide"))
         #expect(overview.contains("neondiff-worker-retry-check"))

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -325,17 +325,45 @@ If Overview shows **Worker update required**:
 
 1. Do not run or retry a live review from another terminal. The dry-to-live
    approval contract is not proven for that worker.
-2. Use only the exact worker artifact or source commit named in the current
-   invite/release notes, and verify its published checksum or commit before
-   replacing the executable. Do not treat an unpinned `main` checkout or an npm
-   version string as release proof.
-3. Preserve the existing config, LaunchAgent label, GitHub App key file,
-   Keychain entries, provider configuration, and repository allowlist. Updating
-   the worker must not migrate or copy those secrets.
-4. Restart the same LaunchAgent using the release's documented command, return
-   to Overview, and choose **Retry Worker Check**. Dry review stays disabled
-   until the exact executable advertises both config-revision approval and the
-   matching ZCode provider path.
+2. Choose **Install / Update Local Worker**. For the invite-only B0 beta, use
+   only the private worker ZIP named in the invite. Compare both its ZIP
+   SHA-256 and the manifest SHA-256 with the values supplied separately in the
+   invite before extracting it. Do not use an unpinned `main` checkout or trust
+   the ambiguous `1.0.4` version string.
+3. In the extracted directory, preview the checksum-bound migration using the
+   exact LaunchAgent label shown in NeonDiff Settings:
+
+   ```bash
+   node install-b0-worker-candidate.mjs update \
+     --manifest neondiff-1.1.0-beta.N-b0-candidate-manifest.json \
+     --manifest-sha256 <manifest-sha256-from-invite> \
+     --tarball neondiff-1.1.0-beta.N.tgz \
+     --launchd-label <existing-label> \
+     --dry-run true
+   ```
+
+4. Inspect the public-safe preview, then repeat it with
+   `--dry-run false --confirm true`. The installer verifies the tarball before
+   mutation, installs into a versioned user-owned Application Support prefix,
+   preserves the existing config, LaunchAgent label/environment, GitHub App key
+   file, Keychain entries, provider state, and repository allowlist, and
+   restarts the same LaunchAgent only when it was already loaded. It never reads
+   or copies private-key bytes.
+5. Return to Overview and choose **Retry Worker Check**. Dry review stays
+   disabled until the exact installed worker advertises both config-revision
+   approval and the matching ZCode provider path.
+
+Preview rollback before changing the active worker:
+
+```bash
+node install-b0-worker-candidate.mjs rollback \
+  --launchd-label <existing-label> \
+  --dry-run true
+```
+
+Rollback also requires `--dry-run false --confirm true`. It restores the
+previous versioned worker, or the original LaunchAgent invocation on the first
+migration, without deleting either candidate or touching customer secrets.
 
 Until an invite or immutable release names a compatible worker artifact, this
 state is a release blocker rather than a prompt to repair source files manually.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -330,14 +330,17 @@ If Overview shows **Worker update required**:
    SHA-256 and the manifest SHA-256 with the values supplied separately in the
    invite before extracting it. Do not use an unpinned `main` checkout or trust
    the ambiguous `1.0.4` version string.
-3. In the extracted directory, preview the checksum-bound migration using the
-   exact LaunchAgent label shown in NeonDiff Settings:
+3. Confirm `node --version` reports Node.js 26 or newer. From the extracted
+   directory, preview the checksum-bound migration using the exact LaunchAgent
+   label shown in NeonDiff Settings. The installer requires absolute artifact
+   paths:
 
    ```bash
+   BUNDLE_DIR="$(pwd -P)"
    node install-b0-worker-candidate.mjs update \
-     --manifest neondiff-1.1.0-beta.N-b0-candidate-manifest.json \
+     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
      --manifest-sha256 <manifest-sha256-from-invite> \
-     --tarball neondiff-1.1.0-beta.N.tgz \
+     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
      --launchd-label <existing-label> \
      --dry-run true
    ```
@@ -348,7 +351,10 @@ If Overview shows **Worker update required**:
    preserves the existing config, LaunchAgent label/environment, GitHub App key
    file, Keychain entries, provider state, and repository allowlist, and
    restarts the same LaunchAgent only when it was already loaded. It never reads
-   or copies private-key bytes.
+   or copies private-key bytes. Each LaunchAgent label has an isolated worker
+   version, rollback state, and install lock. A lock owned by a process that no
+   longer exists is recovered automatically; a lock with missing or invalid
+   owner metadata fails closed and must be handled with NeonDiff support.
 5. Return to Overview and choose **Retry Worker Check**. Dry review stays
    disabled until the exact installed worker advertises both config-revision
    approval and the matching ZCode provider path.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -128,6 +128,14 @@ returned head SHA, and requires explicit confirmation before a live post pinned
 to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
+If this matched local worker reports **Worker update required**, choose
+**Install / Update Local Worker** and use only the checksum-bound private B0
+bundle named in the invite. Follow the Node.js 26+, absolute-path, dry-run, and
+confirmed-mutation steps in [SETUP.md](./SETUP.md#update-an-existing-local-worker).
+The label-isolated installer preserves the existing App environment, config,
+provider state, repository allowlist, and private-key file coordinate. Preview
+rollback before confirmed rollback; neither path reads or copies key bytes.
+
 Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -56,6 +56,16 @@ Use the JSON-first CLI instead of choosing `bootstrap` or `kickstart` from
 plist existence alone. The executable stop/start sequence and confirmation
 requirements live in [the operator CLI guide](operator-cli.md#common-operator-flows).
 
+For an invited B0 Mac worker update, do not edit `ProgramArguments`,
+`WorkingDirectory`, or credential environment entries by hand. Use the
+checksum-bound private bundle described in
+[SETUP.md](SETUP.md#update-an-existing-local-worker). Its installer validates
+the existing NeonDiff invocation, preserves the label and environment, stages a
+versioned user-owned worker, and changes the plist atomically only after
+`--dry-run false --confirm true`. If the LaunchAgent was loaded it is restarted;
+an unloaded service stays unloaded. The paired rollback command restores the
+previous worker or the original invocation without deleting customer state.
+
 After `bootout`, the plist normally remains at
 `~/Library/LaunchAgents/<label>.plist` while the service is absent from the
 launchd domain. `daemon start` detects that state, plans `bootstrap` followed by

--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -237,6 +237,11 @@ function main() {
       ["--github-app-id", "--github-app-private-key-stdin"],
       "BYO GitHub verification"
     );
+    const reviewFlags = requireFlags(
+      parseHelp(installedBinary, "review-pr"),
+      ["--expected-config-revision", "--zcode"],
+      "dry-to-live review"
+    );
 
     manifest = {
       schemaVersion: 1,
@@ -265,6 +270,7 @@ function main() {
         reportedVersion,
         activationFlags,
         githubDoctorFlags,
+        reviewFlags,
         isolatedInstallPassed: true
       },
       distribution: {
@@ -280,7 +286,7 @@ function main() {
       proofBoundary: {
         allows: [
           "exact clean protected-main source was packed with version-only ephemeral metadata",
-          "isolated installed CLI exposes the B0 native activation and BYO GitHub verification flags"
+          "isolated installed CLI exposes the B0 native activation, BYO GitHub verification, and exact dry-to-live review flags"
         ],
         excludes: [
           "private bucket upload or authenticated readback",

--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -175,6 +175,23 @@ function main() {
       stdio: ["ignore", "pipe", "pipe"]
     });
 
+    const productionDependencyPath = join(
+      repoRoot,
+      "node_modules",
+      "validate-npm-package-license",
+      "package.json"
+    );
+    if (!existsSync(productionDependencyPath)) {
+      fail("exact production dependency is missing from the reviewed install");
+    }
+    const productionDependency = JSON.parse(readFileSync(productionDependencyPath, "utf8"));
+    if (productionDependency.name !== "validate-npm-package-license" || productionDependency.version !== "3.0.4") {
+      fail("reviewed production dependency version is not validate-npm-package-license@3.0.4");
+    }
+    const candidatePackage = JSON.parse(readFileSync(packagePath, "utf8"));
+    candidatePackage.bundledDependencies = ["validate-npm-package-license"];
+    writeFileSync(packagePath, `${JSON.stringify(candidatePackage, null, 2)}\n`);
+
     const packOutput = execFileSync("npm", [
       "pack",
       "--json",
@@ -189,6 +206,11 @@ function main() {
     const pack = parsedPack[0];
     if (!pack || parsedPack.length !== 1 || pack.name !== "neondiff" || pack.version !== packageVersion) {
       fail("npm pack did not emit the exact requested neondiff candidate");
+    }
+    if (!Array.isArray(pack.files) || !pack.files.some(
+      (entry) => entry?.path === "node_modules/validate-npm-package-license/package.json"
+    )) {
+      fail("npm pack did not bundle the exact production dependency closure");
     }
 
     packJsonPath = join(outputDirectory, "pack.json");
@@ -206,6 +228,10 @@ function main() {
 
     execFileSync("npm", [
       "install",
+      "--offline",
+      "--cache",
+      join(installRoot, "empty-npm-cache"),
+      "--omit=dev",
       "--ignore-scripts",
       "--no-audit",
       "--no-fund",
@@ -251,7 +277,7 @@ function main() {
         candidateHead,
         protectedMainVerified: true,
         sourceTreeCleanBeforePackaging: true,
-        packageMetadataMutation: "version-only-ephemeral-restored"
+        packageMetadataMutation: "version-and-bundled-dependency-only-ephemeral-restored"
       },
       package: {
         name: "neondiff",
@@ -271,7 +297,9 @@ function main() {
         activationFlags,
         githubDoctorFlags,
         reviewFlags,
-        isolatedInstallPassed: true
+        isolatedInstallPassed: true,
+        offlineInstallPassed: true,
+        bundledProductionDependencies: ["validate-npm-package-license@3.0.4"]
       },
       distribution: {
         privateBucketTarget: PRIVATE_BUCKET_TARGET,
@@ -285,8 +313,9 @@ function main() {
       },
       proofBoundary: {
         allows: [
-          "exact clean protected-main source was packed with version-only ephemeral metadata",
-          "isolated installed CLI exposes the B0 native activation, BYO GitHub verification, and exact dry-to-live review flags"
+          "exact clean protected-main source was packed with version and bundled-dependency metadata only, then restored",
+          "the complete production dependency closure is bundled into and bound by the top-level tarball SHA-256",
+          "isolated offline-installed CLI exposes the B0 native activation, BYO GitHub verification, and exact dry-to-live review flags"
         ],
         excludes: [
           "private bucket upload or authenticated readback",

--- a/scripts/build-b0-worker-bundle.mjs
+++ b/scripts/build-b0-worker-bundle.mjs
@@ -46,6 +46,26 @@ function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function git(repoRoot, args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function assertExactCandidateCheckout(repoRoot, candidateHead) {
+  if (git(repoRoot, ["rev-parse", "HEAD"]) !== candidateHead) {
+    fail("bundle checkout does not match the candidate head");
+  }
+  if (git(repoRoot, ["rev-parse", "refs/remotes/origin/main"]) !== candidateHead) {
+    fail("bundle candidate is not the fetched protected-main head");
+  }
+  if (git(repoRoot, ["status", "--porcelain", "--untracked-files=all"])) {
+    fail("bundle checkout must be clean");
+  }
+}
+
 function requireRegularFile(path, maximumSize, label) {
   if (!isAbsolute(path) || !existsSync(path)) fail(`${label} must be an existing absolute path`);
   const entry = lstatSync(path);
@@ -88,15 +108,17 @@ Before continuing, compare this manifest SHA-256 with the value in your invite:
 From this extracted directory, preview the exact migration:
 
 \`\`\`sh
+BUNDLE_DIR="$(pwd -P)"
 node install-b0-worker-candidate.mjs update \\
-  --manifest ${manifestFilename} \\
+  --manifest "$BUNDLE_DIR/${manifestFilename}" \\
   --manifest-sha256 ${manifestSHA256} \\
-  --tarball ${tarballFilename} \\
+  --tarball "$BUNDLE_DIR/${tarballFilename}" \\
   --launchd-label YOUR_INVITED_LAUNCHD_LABEL \\
   --dry-run true
 \`\`\`
 
-After the preview reports the expected label/version, run the same command with
+Node.js 26 or newer is required for preview, install, and rollback. After the
+preview reports the expected label/version, run the same command with
 \`--dry-run false --confirm true\`. Return to NeonDiff and choose **Retry
 Worker Check**. The existing config, GitHub App environment, provider state,
 repository allowlist, and private-key file are preserved; private-key bytes are
@@ -135,6 +157,7 @@ function main() {
     tarballBytes,
     tarballFilename: basename(tarballPath)
   });
+  assertExactCandidateCheckout(repoRoot, candidate.candidateHead);
 
   const bundleName = `neondiff-worker-${candidate.packageVersion}-${candidate.candidateHead.slice(0, 12)}`;
   const temporaryRoot = mkdtempSync(join(tmpdir(), "neondiff-b0-worker-bundle-"));
@@ -147,11 +170,13 @@ function main() {
     mkdirSync(join(bundleRoot, "lib"), { recursive: true, mode: 0o700 });
     const bundledManifest = join(bundleRoot, basename(manifestPath));
     const bundledTarball = join(bundleRoot, basename(tarballPath));
+    const bundledInstaller = join(bundleRoot, "install-b0-worker-candidate.mjs");
+    const bundledLibrary = join(bundleRoot, "lib", "b0-worker-installer.mjs");
     copyFileSync(manifestPath, bundledManifest);
     copyFileSync(tarballPath, bundledTarball);
-    copyFileSync(installerSource, join(bundleRoot, "install-b0-worker-candidate.mjs"));
-    copyFileSync(librarySource, join(bundleRoot, "lib", "b0-worker-installer.mjs"));
-    chmodSync(join(bundleRoot, "install-b0-worker-candidate.mjs"), 0o700);
+    copyFileSync(installerSource, bundledInstaller);
+    copyFileSync(librarySource, bundledLibrary);
+    chmodSync(bundledInstaller, 0o700);
     writeFileSync(
       join(bundleRoot, "INSTALL.md"),
       installGuide(candidate, basename(manifestPath), basename(tarballPath), manifestSHA256),
@@ -167,6 +192,8 @@ function main() {
       packageVersion: candidate.packageVersion,
       manifestSHA256,
       tarballSHA256: candidate.tarballSHA256,
+      installerSHA256: sha256(readFileSync(bundledInstaller)),
+      installerLibrarySHA256: sha256(readFileSync(bundledLibrary)),
       bundleFilename: basename(zipPath),
       bundleSHA256,
       privateBucketTarget: "neondiff-beta-canary",

--- a/scripts/build-b0-worker-bundle.mjs
+++ b/scripts/build-b0-worker-bundle.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateWorkerCandidate } from "./lib/b0-worker-installer.mjs";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(values) {
+  const args = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index];
+    const value = values[index + 1];
+    if (!key?.startsWith("--") || value === undefined) fail("invalid argument list");
+    args.set(key.slice(2), value);
+  }
+  return args;
+}
+
+function required(args, name) {
+  const value = args.get(name);
+  if (!value) fail(`--${name} is required`);
+  return value;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requireRegularFile(path, maximumSize, label) {
+  if (!isAbsolute(path) || !existsSync(path)) fail(`${label} must be an existing absolute path`);
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isFile() || entry.size <= 0 || entry.size > maximumSize) {
+    fail(`${label} must be a bounded regular non-symlink file`);
+  }
+  return resolve(path);
+}
+
+function assertOutputDirectory(repoRoot, requested) {
+  if (!isAbsolute(requested)) fail("output directory must be absolute");
+  const output = resolve(requested);
+  if (existsSync(output)) {
+    const entry = lstatSync(output);
+    if (entry.isSymbolicLink() || !entry.isDirectory()) fail("output path must be a real directory");
+    if (readdirSync(output).length > 0) fail("output directory must be empty");
+  } else {
+    mkdirSync(output, { recursive: true, mode: 0o700 });
+  }
+  const realOutput = realpathSync(output);
+  const realRepo = realpathSync(repoRoot);
+  const rel = relative(realRepo, realOutput);
+  if (rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`))) {
+    fail("output directory must resolve outside the repository");
+  }
+  if ((statSync(realOutput).mode & 0o077) !== 0) fail("output directory must be private (0700)");
+  return realOutput;
+}
+
+function installGuide(candidate, manifestFilename, tarballFilename, manifestSHA256) {
+  return `# Install the NeonDiff ${candidate.packageVersion} B0 worker
+
+This private bundle is for the invited B0 technical beta. It is not a public
+npm package, GitHub Release, or automatic update.
+
+Before continuing, compare this manifest SHA-256 with the value in your invite:
+
+\`${manifestSHA256}\`
+
+From this extracted directory, preview the exact migration:
+
+\`\`\`sh
+node install-b0-worker-candidate.mjs update \\
+  --manifest ${manifestFilename} \\
+  --manifest-sha256 ${manifestSHA256} \\
+  --tarball ${tarballFilename} \\
+  --launchd-label YOUR_INVITED_LAUNCHD_LABEL \\
+  --dry-run true
+\`\`\`
+
+After the preview reports the expected label/version, run the same command with
+\`--dry-run false --confirm true\`. Return to NeonDiff and choose **Retry
+Worker Check**. The existing config, GitHub App environment, provider state,
+repository allowlist, and private-key file are preserved; private-key bytes are
+never read by the installer.
+
+Rollback preview:
+
+\`\`\`sh
+node install-b0-worker-candidate.mjs rollback \\
+  --launchd-label YOUR_INVITED_LAUNCHD_LABEL \\
+  --dry-run true
+\`\`\`
+
+Rollback mutation also requires \`--dry-run false --confirm true\`.
+
+Candidate source: \`${candidate.candidateHead}\`
+
+Package: \`neondiff@${candidate.packageVersion}\`
+
+Tarball SHA-256: \`${candidate.tarballSHA256}\`
+`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const manifestPath = requireRegularFile(required(args, "manifest"), 1024 * 1024, "manifest");
+  const tarballPath = requireRegularFile(required(args, "tarball"), 100 * 1024 * 1024, "tarball");
+  const outputDirectory = assertOutputDirectory(repoRoot, required(args, "output-dir"));
+  const manifestBytes = readFileSync(manifestPath);
+  const tarballBytes = readFileSync(tarballPath);
+  const manifestSHA256 = sha256(manifestBytes);
+  const candidate = validateWorkerCandidate({
+    manifestBytes,
+    manifestSHA256,
+    tarballBytes,
+    tarballFilename: basename(tarballPath)
+  });
+
+  const bundleName = `neondiff-worker-${candidate.packageVersion}-${candidate.candidateHead.slice(0, 12)}`;
+  const temporaryRoot = mkdtempSync(join(tmpdir(), "neondiff-b0-worker-bundle-"));
+  const bundleRoot = join(temporaryRoot, bundleName);
+  const zipPath = join(outputDirectory, `${bundleName}.zip`);
+  const receiptPath = join(outputDirectory, `${bundleName}-receipt.json`);
+  const installerSource = join(repoRoot, "scripts", "install-b0-worker-candidate.mjs");
+  const librarySource = join(repoRoot, "scripts", "lib", "b0-worker-installer.mjs");
+  try {
+    mkdirSync(join(bundleRoot, "lib"), { recursive: true, mode: 0o700 });
+    const bundledManifest = join(bundleRoot, basename(manifestPath));
+    const bundledTarball = join(bundleRoot, basename(tarballPath));
+    copyFileSync(manifestPath, bundledManifest);
+    copyFileSync(tarballPath, bundledTarball);
+    copyFileSync(installerSource, join(bundleRoot, "install-b0-worker-candidate.mjs"));
+    copyFileSync(librarySource, join(bundleRoot, "lib", "b0-worker-installer.mjs"));
+    chmodSync(join(bundleRoot, "install-b0-worker-candidate.mjs"), 0o700);
+    writeFileSync(
+      join(bundleRoot, "INSTALL.md"),
+      installGuide(candidate, basename(manifestPath), basename(tarballPath), manifestSHA256),
+      { mode: 0o600 }
+    );
+    execFileSync("/usr/bin/ditto", [
+      "-c", "-k", "--sequesterRsrc", "--keepParent", bundleRoot, zipPath
+    ], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    const bundleSHA256 = sha256(readFileSync(zipPath));
+    const receipt = {
+      schemaVersion: 1,
+      candidateHead: candidate.candidateHead,
+      packageVersion: candidate.packageVersion,
+      manifestSHA256,
+      tarballSHA256: candidate.tarballSHA256,
+      bundleFilename: basename(zipPath),
+      bundleSHA256,
+      privateBucketTarget: "neondiff-beta-canary",
+      uploaded: false,
+      authenticatedReadbackPassed: false,
+      publicDownloadEnabled: false,
+      includedFiles: [
+        basename(manifestPath),
+        basename(tarballPath),
+        "install-b0-worker-candidate.mjs",
+        "lib/b0-worker-installer.mjs",
+        "INSTALL.md"
+      ],
+      proofBoundary: "Private customer bundle assembly only; no upload, publication, install, rollback, review, beta, release, or customer-readiness claim."
+    };
+    writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+    console.log(JSON.stringify({
+      ok: true,
+      candidateHead: candidate.candidateHead,
+      packageVersion: candidate.packageVersion,
+      manifestSHA256,
+      bundlePath: zipPath,
+      bundleSHA256,
+      receiptPath,
+      uploaded: false
+    }));
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -23,6 +23,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "nod
 import {
   planWorkerRollback,
   planWorkerUpdate,
+  recoverPreviouslyLoadedWorker,
   validateWorkerCandidate
 } from "./lib/b0-worker-installer.mjs";
 
@@ -303,6 +304,15 @@ function startIfPreviouslyLoaded(state, plistPath) {
   });
 }
 
+function stopReplacementForRecovery(state) {
+  if (!state.loaded) return;
+  const result = spawnSync("/bin/launchctl", ["bootout", state.target], { encoding: "utf8" });
+  if (result.status === 0) return;
+  const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  if (/could not find service|service not found/i.test(detail)) return;
+  fail("replacement launchd job could not be stopped during recovery");
+}
+
 function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget, nextState, statePath }) {
   const originalBytes = readFileSync(plistPath);
   const oldCurrentTarget = currentTarget(currentLink, join(dirname(currentLink), "versions"));
@@ -316,7 +326,11 @@ function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget
     stopIfLoaded(service);
     renameSync(stagedPlist, plistPath);
     plistReplaced = true;
-    if (nextTarget) switchCurrent(currentLink, nextTarget);
+    if (nextTarget) {
+      switchCurrent(currentLink, nextTarget);
+    } else if (existsSync(currentLink) && lstatSync(currentLink).isSymbolicLink()) {
+      unlinkSync(currentLink);
+    }
     startIfPreviouslyLoaded(service, plistPath);
   } catch (error) {
     if (plistReplaced) {
@@ -333,10 +347,26 @@ function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget
     }
     if (priorState) writeState(statePath, priorState);
     else safeUnlink(statePath);
+    let recoveryError = null;
     try {
-      startIfPreviouslyLoaded(service, plistPath);
-    } catch {
-      // The original plist/current pointer were restored; surface the primary failure.
+      recoverPreviouslyLoadedWorker({
+        wasLoaded: service.loaded,
+        stopReplacement() {
+          stopReplacementForRecovery(service);
+        },
+        startOriginal() {
+          startIfPreviouslyLoaded(service, plistPath);
+        }
+      });
+    } catch (caught) {
+      recoveryError = caught;
+    }
+    if (recoveryError) {
+      fail(
+        `worker activation failed; disk state was restored but launchd recovery failed: ${
+          recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
+        }`
+      );
     }
     fail(`worker activation failed and the prior worker was restored: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  planWorkerRollback,
+  planWorkerUpdate,
+  validateWorkerCandidate
+} from "./lib/b0-worker-installer.mjs";
+
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_TARBALL_BYTES = 100 * 1024 * 1024;
+const MAX_PLIST_BYTES = 1024 * 1024;
+const STATE_FILENAME = "state.json";
+const LOCK_DIRECTORY = ".install-lock";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function usage() {
+  console.log(`Install or roll back one checksum-bound NeonDiff B0 worker.
+
+Usage:
+  node install-b0-worker-candidate.mjs update \\
+    --manifest /absolute/path/manifest.json \\
+    --manifest-sha256 <64-lowercase-hex> \\
+    --tarball /absolute/path/neondiff-1.1.0-beta.N.tgz \\
+    --launchd-label <label> [--dry-run true]
+
+  node install-b0-worker-candidate.mjs update ... --dry-run false --confirm true
+  node install-b0-worker-candidate.mjs rollback --launchd-label <label> [--dry-run true]
+  node install-b0-worker-candidate.mjs rollback --launchd-label <label> --dry-run false --confirm true
+
+The installer uses a user-owned versioned prefix, preserves the existing
+config and LaunchAgent environment, and never reads or copies private-key bytes.
+Dry-run is the default. Live mutation requires --dry-run false --confirm true.`);
+}
+
+function parseArgs(values) {
+  const args = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index];
+    const value = values[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      fail(`invalid argument list near ${key ?? "(missing)"}`);
+    }
+    const name = key.slice(2);
+    if (args.has(name)) fail(`duplicate --${name}`);
+    args.set(name, value);
+  }
+  return args;
+}
+
+function required(args, name) {
+  const value = args.get(name);
+  if (!value) fail(`--${name} is required`);
+  return value;
+}
+
+function parseBoolean(args, name, fallback) {
+  const value = args.get(name);
+  if (value === undefined) return fallback;
+  if (value !== "true" && value !== "false") fail(`--${name} must be true or false`);
+  return value === "true";
+}
+
+function requireLiveConfirmation(args) {
+  const dryRun = parseBoolean(args, "dry-run", true);
+  const confirm = parseBoolean(args, "confirm", false);
+  if (!dryRun && !confirm) fail("live worker mutation requires --dry-run false --confirm true");
+  return dryRun;
+}
+
+function requireAbsoluteRegularFile(path, maximumSize, label, requireOwner = true) {
+  if (!isAbsolute(path)) fail(`${label} path must be absolute`);
+  if (!existsSync(path)) fail(`${label} file is missing`);
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isFile()) fail(`${label} must be a regular non-symlink file`);
+  if (entry.size <= 0 || entry.size > maximumSize) fail(`${label} size is invalid`);
+  if (requireOwner && typeof process.getuid === "function" && entry.uid !== process.getuid()) {
+    fail(`${label} must be owned by the current user`);
+  }
+  return resolve(path);
+}
+
+function ensurePrivateDirectory(path) {
+  if (!existsSync(path)) mkdirSync(path, { recursive: true, mode: 0o700 });
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isDirectory()) fail("worker directory must be a real directory");
+  if (typeof process.getuid === "function" && entry.uid !== process.getuid()) {
+    fail("worker directory must be owned by the current user");
+  }
+  if ((entry.mode & 0o077) !== 0) fail("worker directory must be private to the current user (0700)");
+  return realpathSync(path);
+}
+
+function pathIsInside(root, candidate) {
+  const rel = relative(root, candidate);
+  return rel !== "" && rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function standardPaths(label) {
+  const home = homedir();
+  const workerRoot = join(home, "Library", "Application Support", "NeonDiffDesktop", "Workers");
+  return {
+    workerRoot,
+    versionsRoot: join(workerRoot, "versions"),
+    currentLink: join(workerRoot, "current"),
+    statePath: join(workerRoot, STATE_FILENAME),
+    lockPath: join(workerRoot, LOCK_DIRECTORY),
+    plistPath: join(home, "Library", "LaunchAgents", `${label}.plist`)
+  };
+}
+
+function parsePlist(path) {
+  const output = execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", path], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  try {
+    return JSON.parse(output);
+  } catch {
+    fail("LaunchAgent plist could not be parsed");
+  }
+}
+
+function writePlistFromTemplate(templatePath, destinationPath, launchAgent) {
+  copyFileSync(templatePath, destinationPath);
+  chmodSync(destinationPath, 0o600);
+  execFileSync("/usr/bin/plutil", [
+    "-replace", "ProgramArguments", "-json", JSON.stringify(launchAgent.ProgramArguments), destinationPath
+  ], { stdio: ["ignore", "pipe", "pipe"] });
+  execFileSync("/usr/bin/plutil", [
+    "-replace", "WorkingDirectory", "-string", launchAgent.WorkingDirectory, destinationPath
+  ], { stdio: ["ignore", "pipe", "pipe"] });
+  const readback = parsePlist(destinationPath);
+  if (
+    readback.Label !== launchAgent.Label
+    || JSON.stringify(readback.ProgramArguments) !== JSON.stringify(launchAgent.ProgramArguments)
+    || readback.WorkingDirectory !== launchAgent.WorkingDirectory
+    || JSON.stringify(readback.EnvironmentVariables) !== JSON.stringify(launchAgent.EnvironmentVariables)
+  ) {
+    fail("LaunchAgent staged readback mismatch");
+  }
+}
+
+function readState(path) {
+  if (!existsSync(path)) return null;
+  requireAbsoluteRegularFile(path, MAX_MANIFEST_BYTES, "worker state");
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    fail("worker state is invalid JSON");
+  }
+}
+
+function writeState(path, state) {
+  const temporary = `${path}.next-${process.pid}-${randomUUID()}`;
+  writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+}
+
+function safeUnlink(path) {
+  if (!existsSync(path)) return;
+  const entry = lstatSync(path);
+  if (!entry.isFile() && !entry.isSymbolicLink()) fail("refusing to unlink a non-file recovery path");
+  unlinkSync(path);
+}
+
+function resolveNpmPath() {
+  const candidates = [
+    join(dirname(process.execPath), "npm"),
+    "/opt/homebrew/bin/npm",
+    "/usr/local/bin/npm"
+  ];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const resolved = realpathSync(candidate);
+    if (statSync(resolved).isFile()) return resolved;
+  }
+  fail("npm was not found beside Node or in an approved install location");
+}
+
+function verifyInstalledWorker(versionRoot, expectedVersion) {
+  const cliPath = join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js");
+  requireAbsoluteRegularFile(cliPath, 50 * 1024 * 1024, "installed worker CLI", false);
+  const version = execFileSync(process.execPath, [cliPath, "--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+  if (version !== expectedVersion) fail("installed worker version mismatch");
+  const help = JSON.parse(execFileSync(process.execPath, [cliPath, "review-pr", "--help"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }));
+  const flags = new Set(help?.usage?.flags?.map((entry) => entry?.name));
+  if (
+    help?.ok !== true
+    || help?.command !== "review-pr"
+    || !flags.has("--expected-config-revision")
+    || !flags.has("--zcode")
+  ) {
+    fail("installed worker review capability mismatch");
+  }
+}
+
+function installVersion({ versionsRoot, versionID, tarballPath, manifestBytes, manifestSHA256, packageVersion }) {
+  const versionRoot = join(versionsRoot, versionID);
+  if (!pathIsInside(versionsRoot, versionRoot)) fail("worker version path escaped the version root");
+  if (existsSync(versionRoot)) {
+    const embeddedManifest = join(versionRoot, ".neondiff-candidate-manifest.json");
+    requireAbsoluteRegularFile(embeddedManifest, MAX_MANIFEST_BYTES, "installed candidate manifest");
+    const embeddedBytes = readFileSync(embeddedManifest);
+    if (Buffer.compare(embeddedBytes, manifestBytes) !== 0) fail("installed candidate manifest mismatch");
+    verifyInstalledWorker(versionRoot, packageVersion);
+    return versionRoot;
+  }
+
+  const staging = join(versionsRoot, `.staging-${process.pid}-${randomUUID()}`);
+  mkdirSync(staging, { mode: 0o700 });
+  const npmPath = resolveNpmPath();
+  try {
+    execFileSync(npmPath, [
+      "install", "--ignore-scripts", "--no-audit", "--no-fund", "--prefix", staging, tarballPath
+    ], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    verifyInstalledWorker(staging, packageVersion);
+    writeFileSync(join(staging, ".neondiff-candidate-manifest.json"), manifestBytes, { mode: 0o600 });
+    writeFileSync(join(staging, ".neondiff-candidate-manifest.sha256"), `${manifestSHA256}\n`, { mode: 0o600 });
+    renameSync(staging, versionRoot);
+  } catch (error) {
+    fail(`worker package installation failed before activation: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return versionRoot;
+}
+
+function currentTarget(currentLink, versionsRoot) {
+  if (!existsSync(currentLink)) return null;
+  const entry = lstatSync(currentLink);
+  if (!entry.isSymbolicLink()) fail("worker current pointer must be a symbolic link");
+  const target = readlinkSync(currentLink);
+  if (isAbsolute(target) || !target.startsWith(`versions${sep}`)) {
+    fail("worker current pointer escaped the version root");
+  }
+  const resolved = resolve(dirname(currentLink), target);
+  if (!pathIsInside(versionsRoot, resolved)) fail("worker current pointer escaped the version root");
+  return target;
+}
+
+function switchCurrent(currentLink, relativeTarget) {
+  const temporary = `${currentLink}.next-${process.pid}-${randomUUID()}`;
+  symlinkSync(relativeTarget, temporary);
+  renameSync(temporary, currentLink);
+}
+
+function launchdState(label) {
+  const domain = `gui/${process.getuid()}`;
+  const target = `${domain}/${label}`;
+  const result = spawnSync("/bin/launchctl", ["print", target], { encoding: "utf8" });
+  if (result.status === 0) return { loaded: true, domain, target };
+  const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  if (/could not find service|service not found/i.test(detail)) {
+    return { loaded: false, domain, target };
+  }
+  fail("launchd service state is ambiguous");
+}
+
+function stopIfLoaded(state) {
+  if (!state.loaded) return;
+  execFileSync("/bin/launchctl", ["bootout", state.target], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+function startIfPreviouslyLoaded(state, plistPath) {
+  if (!state.loaded) return;
+  execFileSync("/bin/launchctl", ["bootstrap", state.domain, plistPath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  execFileSync("/bin/launchctl", ["kickstart", "-k", state.target], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget, nextState, statePath }) {
+  const originalBytes = readFileSync(plistPath);
+  const oldCurrentTarget = currentTarget(currentLink, join(dirname(currentLink), "versions"));
+  const priorState = readState(statePath);
+  const stagedPlist = `${plistPath}.next-${process.pid}-${randomUUID()}`;
+  writePlistFromTemplate(plistPath, stagedPlist, nextLaunchAgent);
+  const service = launchdState(nextLaunchAgent.Label);
+  writeState(statePath, nextState);
+  let plistReplaced = false;
+  try {
+    stopIfLoaded(service);
+    renameSync(stagedPlist, plistPath);
+    plistReplaced = true;
+    if (nextTarget) switchCurrent(currentLink, nextTarget);
+    startIfPreviouslyLoaded(service, plistPath);
+  } catch (error) {
+    if (plistReplaced) {
+      const restorePlist = `${plistPath}.restore-${process.pid}-${randomUUID()}`;
+      writeFileSync(restorePlist, originalBytes, { mode: 0o600 });
+      renameSync(restorePlist, plistPath);
+    } else {
+      safeUnlink(stagedPlist);
+    }
+    if (oldCurrentTarget) {
+      switchCurrent(currentLink, oldCurrentTarget);
+    } else if (existsSync(currentLink) && lstatSync(currentLink).isSymbolicLink()) {
+      unlinkSync(currentLink);
+    }
+    if (priorState) writeState(statePath, priorState);
+    else safeUnlink(statePath);
+    try {
+      startIfPreviouslyLoaded(service, plistPath);
+    } catch {
+      // The original plist/current pointer were restored; surface the primary failure.
+    }
+    fail(`worker activation failed and the prior worker was restored: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return service.loaded;
+}
+
+function withWorkerLock(paths, operation) {
+  ensurePrivateDirectory(paths.workerRoot);
+  ensurePrivateDirectory(paths.versionsRoot);
+  try {
+    mkdirSync(paths.lockPath, { mode: 0o700 });
+  } catch {
+    fail("another NeonDiff worker install or rollback is active");
+  }
+  try {
+    return operation();
+  } finally {
+    rmdirSync(paths.lockPath);
+  }
+}
+
+function update(args) {
+  const dryRun = requireLiveConfirmation(args);
+  const manifestPath = requireAbsoluteRegularFile(
+    required(args, "manifest"),
+    MAX_MANIFEST_BYTES,
+    "candidate manifest"
+  );
+  const tarballPath = requireAbsoluteRegularFile(
+    required(args, "tarball"),
+    MAX_TARBALL_BYTES,
+    "candidate tarball"
+  );
+  const manifestSHA256 = required(args, "manifest-sha256");
+  const label = required(args, "launchd-label");
+  const paths = standardPaths(label);
+  const plistPath = requireAbsoluteRegularFile(paths.plistPath, MAX_PLIST_BYTES, "LaunchAgent plist");
+  const manifestBytes = readFileSync(manifestPath);
+  const tarballBytes = readFileSync(tarballPath);
+  const candidate = validateWorkerCandidate({
+    manifestBytes,
+    manifestSHA256,
+    tarballBytes,
+    tarballFilename: basename(tarballPath)
+  });
+  const launchAgent = parsePlist(plistPath);
+  const priorState = readState(paths.statePath);
+  const plan = planWorkerUpdate({
+    launchAgent,
+    expectedLabel: label,
+    workerRoot: paths.workerRoot,
+    nodePath: process.execPath,
+    candidateHead: candidate.candidateHead,
+    packageVersion: candidate.packageVersion,
+    manifestSHA256,
+    previousState: priorState
+  });
+  if (dryRun) {
+    console.log(JSON.stringify({ ok: true, dryRun: true, ...plan.publicSummary }));
+    return;
+  }
+  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+  if (!Number.isInteger(nodeMajor) || nodeMajor < 26) fail("worker installation requires Node.js 26 or newer");
+  const result = withWorkerLock(paths, () => {
+    installVersion({
+      versionsRoot: paths.versionsRoot,
+      versionID: plan.versionID,
+      tarballPath,
+      manifestBytes,
+      manifestSHA256,
+      packageVersion: candidate.packageVersion
+    });
+    const relativeTarget = join("versions", plan.versionID);
+    const restarted = mutateLaunchAgent({
+      plistPath,
+      nextLaunchAgent: plan.nextLaunchAgent,
+      currentLink: paths.currentLink,
+      nextTarget: relativeTarget,
+      nextState: plan.nextState,
+      statePath: paths.statePath
+    });
+    return { restarted };
+  });
+  console.log(JSON.stringify({ ok: true, dryRun: false, ...plan.publicSummary, ...result }));
+}
+
+function rollback(args) {
+  const dryRun = requireLiveConfirmation(args);
+  const label = required(args, "launchd-label");
+  const paths = standardPaths(label);
+  const plistPath = requireAbsoluteRegularFile(paths.plistPath, MAX_PLIST_BYTES, "LaunchAgent plist");
+  const state = readState(paths.statePath);
+  if (!state) fail("no NeonDiff worker rollback state exists");
+  const launchAgent = parsePlist(plistPath);
+  const plan = planWorkerRollback({ state, currentLaunchAgent: launchAgent, expectedLabel: label });
+  if (dryRun) {
+    console.log(JSON.stringify({ ok: true, dryRun: true, ...plan.publicSummary }));
+    return;
+  }
+  const result = withWorkerLock(paths, () => {
+    let target = null;
+    if (plan.nextState.currentVersionID) {
+      const versionRoot = join(paths.versionsRoot, plan.nextState.currentVersionID);
+      if (!existsSync(versionRoot) || !pathIsInside(paths.versionsRoot, realpathSync(versionRoot))) {
+        fail("rollback worker version is missing or outside the version root");
+      }
+      verifyInstalledWorker(versionRoot, plan.nextState.packageVersion);
+      target = join("versions", plan.nextState.currentVersionID);
+    }
+    const restarted = mutateLaunchAgent({
+      plistPath,
+      nextLaunchAgent: plan.nextLaunchAgent,
+      currentLink: paths.currentLink,
+      nextTarget: target,
+      nextState: plan.nextState,
+      statePath: paths.statePath
+    });
+    return { restarted };
+  });
+  console.log(JSON.stringify({ ok: true, dryRun: false, ...plan.publicSummary, ...result }));
+}
+
+function main() {
+  const [action, ...values] = process.argv.slice(2);
+  if (!action || action === "--help" || action === "-h") {
+    usage();
+    return;
+  }
+  const args = parseArgs(values);
+  if (action === "update") update(args);
+  else if (action === "rollback") rollback(args);
+  else fail("action must be update or rollback");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -12,7 +12,7 @@ import {
   readlinkSync,
   realpathSync,
   renameSync,
-  rmdirSync,
+  rmSync,
   statSync,
   symlinkSync,
   unlinkSync,
@@ -32,6 +32,15 @@ const MAX_TARBALL_BYTES = 100 * 1024 * 1024;
 const MAX_PLIST_BYTES = 1024 * 1024;
 const STATE_FILENAME = "state.json";
 const LOCK_DIRECTORY = ".install-lock";
+const LOCK_OWNER_FILENAME = "owner.json";
+const LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const CHILD_PROCESS_OPTIONS = Object.freeze({
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+  timeout: 120_000,
+  killSignal: "SIGKILL",
+  maxBuffer: 10 * 1024 * 1024
+});
 
 function fail(message) {
   throw new Error(message);
@@ -91,6 +100,13 @@ function requireLiveConfirmation(args) {
   return dryRun;
 }
 
+function requireSupportedRuntime() {
+  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+  if (!Number.isInteger(nodeMajor) || nodeMajor < 26) {
+    fail("worker installation requires Node.js 26 or newer");
+  }
+}
+
 function requireAbsoluteRegularFile(path, maximumSize, label, requireOwner = true) {
   if (!isAbsolute(path)) fail(`${label} path must be absolute`);
   if (!existsSync(path)) fail(`${label} file is missing`);
@@ -120,8 +136,16 @@ function pathIsInside(root, candidate) {
 }
 
 function standardPaths(label) {
+  if (!LABEL_PATTERN.test(label)) fail("launchd label is invalid");
   const home = homedir();
-  const workerRoot = join(home, "Library", "Application Support", "NeonDiffDesktop", "Workers");
+  const workerRoot = join(
+    home,
+    "Library",
+    "Application Support",
+    "NeonDiffDesktop",
+    "Workers",
+    label
+  );
   return {
     workerRoot,
     versionsRoot: join(workerRoot, "versions"),
@@ -133,10 +157,11 @@ function standardPaths(label) {
 }
 
 function parsePlist(path) {
-  const output = execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", path], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
+  const output = execFileSync(
+    "/usr/bin/plutil",
+    ["-convert", "json", "-o", "-", path],
+    CHILD_PROCESS_OPTIONS
+  );
   try {
     return JSON.parse(output);
   } catch {
@@ -149,10 +174,10 @@ function writePlistFromTemplate(templatePath, destinationPath, launchAgent) {
   chmodSync(destinationPath, 0o600);
   execFileSync("/usr/bin/plutil", [
     "-replace", "ProgramArguments", "-json", JSON.stringify(launchAgent.ProgramArguments), destinationPath
-  ], { stdio: ["ignore", "pipe", "pipe"] });
+  ], CHILD_PROCESS_OPTIONS);
   execFileSync("/usr/bin/plutil", [
     "-replace", "WorkingDirectory", "-string", launchAgent.WorkingDirectory, destinationPath
-  ], { stdio: ["ignore", "pipe", "pipe"] });
+  ], CHILD_PROCESS_OPTIONS);
   const readback = parsePlist(destinationPath);
   if (
     readback.Label !== launchAgent.Label
@@ -176,8 +201,13 @@ function readState(path) {
 
 function writeState(path, state) {
   const temporary = `${path}.next-${process.pid}-${randomUUID()}`;
-  writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
-  renameSync(temporary, path);
+  try {
+    writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+    renameSync(temporary, path);
+  } catch (error) {
+    safeUnlink(temporary);
+    throw error;
+  }
 }
 
 function safeUnlink(path) {
@@ -205,13 +235,11 @@ function verifyInstalledWorker(versionRoot, expectedVersion) {
   const cliPath = join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js");
   requireAbsoluteRegularFile(cliPath, 50 * 1024 * 1024, "installed worker CLI", false);
   const version = execFileSync(process.execPath, [cliPath, "--version"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    ...CHILD_PROCESS_OPTIONS
   }).trim();
   if (version !== expectedVersion) fail("installed worker version mismatch");
   const help = JSON.parse(execFileSync(process.execPath, [cliPath, "review-pr", "--help"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    ...CHILD_PROCESS_OPTIONS
   }));
   const flags = new Set(help?.usage?.flags?.map((entry) => entry?.name));
   if (
@@ -241,13 +269,18 @@ function installVersion({ versionsRoot, versionID, tarballPath, manifestBytes, m
   const npmPath = resolveNpmPath();
   try {
     execFileSync(npmPath, [
-      "install", "--ignore-scripts", "--no-audit", "--no-fund", "--prefix", staging, tarballPath
-    ], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+      "install", "--offline", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund", "--prefix", staging, tarballPath
+    ], CHILD_PROCESS_OPTIONS);
     verifyInstalledWorker(staging, packageVersion);
     writeFileSync(join(staging, ".neondiff-candidate-manifest.json"), manifestBytes, { mode: 0o600 });
     writeFileSync(join(staging, ".neondiff-candidate-manifest.sha256"), `${manifestSHA256}\n`, { mode: 0o600 });
     renameSync(staging, versionRoot);
   } catch (error) {
+    try {
+      rmSync(staging, { recursive: true, force: true });
+    } catch {
+      fail("worker package installation failed and its staging directory could not be removed");
+    }
     fail(`worker package installation failed before activation: ${error instanceof Error ? error.message : String(error)}`);
   }
   return versionRoot;
@@ -275,7 +308,7 @@ function switchCurrent(currentLink, relativeTarget) {
 function launchdState(label) {
   const domain = `gui/${process.getuid()}`;
   const target = `${domain}/${label}`;
-  const result = spawnSync("/bin/launchctl", ["print", target], { encoding: "utf8" });
+  const result = spawnSync("/bin/launchctl", ["print", target], CHILD_PROCESS_OPTIONS);
   if (result.status === 0) return { loaded: true, domain, target };
   const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   if (/could not find service|service not found/i.test(detail)) {
@@ -287,30 +320,35 @@ function launchdState(label) {
 function stopIfLoaded(state) {
   if (!state.loaded) return;
   execFileSync("/bin/launchctl", ["bootout", state.target], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    ...CHILD_PROCESS_OPTIONS
   });
 }
 
 function startIfPreviouslyLoaded(state, plistPath) {
   if (!state.loaded) return;
   execFileSync("/bin/launchctl", ["bootstrap", state.domain, plistPath], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    ...CHILD_PROCESS_OPTIONS
   });
   execFileSync("/bin/launchctl", ["kickstart", "-k", state.target], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    ...CHILD_PROCESS_OPTIONS
   });
 }
 
 function stopReplacementForRecovery(state) {
   if (!state.loaded) return;
-  const result = spawnSync("/bin/launchctl", ["bootout", state.target], { encoding: "utf8" });
+  const result = spawnSync("/bin/launchctl", ["bootout", state.target], CHILD_PROCESS_OPTIONS);
   if (result.status === 0) return;
   const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   if (/could not find service|service not found/i.test(detail)) return;
   fail("replacement launchd job could not be stopped during recovery");
+}
+
+function attemptRecoveryStep(errors, label, operation) {
+  try {
+    operation();
+  } catch (error) {
+    errors.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget, nextState, statePath }) {
@@ -318,11 +356,11 @@ function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget
   const oldCurrentTarget = currentTarget(currentLink, join(dirname(currentLink), "versions"));
   const priorState = readState(statePath);
   const stagedPlist = `${plistPath}.next-${process.pid}-${randomUUID()}`;
-  writePlistFromTemplate(plistPath, stagedPlist, nextLaunchAgent);
-  const service = launchdState(nextLaunchAgent.Label);
-  writeState(statePath, nextState);
+  let service = null;
   let plistReplaced = false;
   try {
+    writePlistFromTemplate(plistPath, stagedPlist, nextLaunchAgent);
+    service = launchdState(nextLaunchAgent.Label);
     stopIfLoaded(service);
     renameSync(stagedPlist, plistPath);
     plistReplaced = true;
@@ -332,40 +370,51 @@ function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget
       unlinkSync(currentLink);
     }
     startIfPreviouslyLoaded(service, plistPath);
+    writeState(statePath, nextState);
   } catch (error) {
+    const recoveryErrors = [];
+    attemptRecoveryStep(recoveryErrors, "remove staged plist", () => safeUnlink(stagedPlist));
     if (plistReplaced) {
-      const restorePlist = `${plistPath}.restore-${process.pid}-${randomUUID()}`;
-      writeFileSync(restorePlist, originalBytes, { mode: 0o600 });
-      renameSync(restorePlist, plistPath);
-    } else {
-      safeUnlink(stagedPlist);
-    }
-    if (oldCurrentTarget) {
-      switchCurrent(currentLink, oldCurrentTarget);
-    } else if (existsSync(currentLink) && lstatSync(currentLink).isSymbolicLink()) {
-      unlinkSync(currentLink);
-    }
-    if (priorState) writeState(statePath, priorState);
-    else safeUnlink(statePath);
-    let recoveryError = null;
-    try {
-      recoverPreviouslyLoadedWorker({
-        wasLoaded: service.loaded,
-        stopReplacement() {
-          stopReplacementForRecovery(service);
-        },
-        startOriginal() {
-          startIfPreviouslyLoaded(service, plistPath);
+      attemptRecoveryStep(recoveryErrors, "restore LaunchAgent plist", () => {
+        const restorePlist = `${plistPath}.restore-${process.pid}-${randomUUID()}`;
+        try {
+          writeFileSync(restorePlist, originalBytes, { mode: 0o600 });
+          renameSync(restorePlist, plistPath);
+        } catch (caught) {
+          safeUnlink(restorePlist);
+          throw caught;
         }
       });
-    } catch (caught) {
-      recoveryError = caught;
     }
-    if (recoveryError) {
+    attemptRecoveryStep(recoveryErrors, "restore worker pointer", () => {
+      if (oldCurrentTarget) {
+        switchCurrent(currentLink, oldCurrentTarget);
+      } else if (existsSync(currentLink) && lstatSync(currentLink).isSymbolicLink()) {
+        unlinkSync(currentLink);
+      }
+    });
+    attemptRecoveryStep(recoveryErrors, "restore rollback state", () => {
+      if (priorState) writeState(statePath, priorState);
+      else safeUnlink(statePath);
+    });
+    if (service && plistReplaced) {
+      attemptRecoveryStep(recoveryErrors, "restore launchd service", () => {
+        recoverPreviouslyLoadedWorker({
+          wasLoaded: service.loaded,
+          stopReplacement() {
+            stopReplacementForRecovery(service);
+          },
+          startOriginal() {
+            startIfPreviouslyLoaded(service, plistPath);
+          }
+        });
+      });
+    }
+    if (recoveryErrors.length > 0) {
       fail(
-        `worker activation failed; disk state was restored but launchd recovery failed: ${
-          recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
-        }`
+        `worker activation failed and recovery was incomplete: ${
+          error instanceof Error ? error.message : String(error)
+        }; ${recoveryErrors.join("; ")}`
       );
     }
     fail(`worker activation failed and the prior worker was restored: ${error instanceof Error ? error.message : String(error)}`);
@@ -376,15 +425,47 @@ function mutateLaunchAgent({ plistPath, nextLaunchAgent, currentLink, nextTarget
 function withWorkerLock(paths, operation) {
   ensurePrivateDirectory(paths.workerRoot);
   ensurePrivateDirectory(paths.versionsRoot);
+  const ownerPath = join(paths.lockPath, LOCK_OWNER_FILENAME);
+  const owner = {
+    schemaVersion: 1,
+    pid: process.pid,
+    createdAt: new Date().toISOString()
+  };
   try {
     mkdirSync(paths.lockPath, { mode: 0o700 });
-  } catch {
-    fail("another NeonDiff worker install or rollback is active");
+  } catch (error) {
+    if (!error || typeof error !== "object" || error.code !== "EEXIST") {
+      fail(`worker lock could not be created: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    let existingOwner;
+    try {
+      existingOwner = JSON.parse(readFileSync(ownerPath, "utf8"));
+    } catch {
+      fail("worker lock exists without valid owner metadata; contact NeonDiff support before removing it");
+    }
+    if (!Number.isInteger(existingOwner?.pid) || existingOwner.pid <= 0) {
+      fail("worker lock owner metadata is invalid; contact NeonDiff support before removing it");
+    }
+    let ownerIsAlive = true;
+    try {
+      process.kill(existingOwner.pid, 0);
+    } catch (caught) {
+      if (caught && typeof caught === "object" && caught.code === "ESRCH") ownerIsAlive = false;
+    }
+    if (ownerIsAlive) fail("another NeonDiff worker install or rollback is active");
+    rmSync(paths.lockPath, { recursive: true, force: true });
+    mkdirSync(paths.lockPath, { mode: 0o700 });
+  }
+  try {
+    writeFileSync(ownerPath, `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+  } catch (error) {
+    rmSync(paths.lockPath, { recursive: true, force: true });
+    fail(`worker lock owner metadata could not be written: ${error instanceof Error ? error.message : String(error)}`);
   }
   try {
     return operation();
   } finally {
-    rmdirSync(paths.lockPath);
+    rmSync(paths.lockPath, { recursive: true, force: true });
   }
 }
 
@@ -428,8 +509,6 @@ function update(args) {
     console.log(JSON.stringify({ ok: true, dryRun: true, ...plan.publicSummary }));
     return;
   }
-  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
-  if (!Number.isInteger(nodeMajor) || nodeMajor < 26) fail("worker installation requires Node.js 26 or newer");
   const result = withWorkerLock(paths, () => {
     installVersion({
       versionsRoot: paths.versionsRoot,
@@ -495,6 +574,7 @@ function main() {
     usage();
     return;
   }
+  requireSupportedRuntime();
   const args = parseArgs(values);
   if (action === "update") update(args);
   else if (action === "rollback") rollback(args);

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -252,6 +252,9 @@ export function planWorkerRollback({ state, currentLaunchAgent, expectedLabel })
   ) {
     fail("worker rollback state is invalid");
   }
+  if (state.currentVersionID === null) {
+    fail("original worker is already active; run update to reactivate a candidate");
+  }
   if (state.previousVersionID) {
     return {
       nextLaunchAgent: clone(currentLaunchAgent),
@@ -288,4 +291,15 @@ export function planWorkerRollback({ state, currentLaunchAgent, expectedLabel })
       launchdLabel: expectedLabel
     }
   };
+}
+
+export function recoverPreviouslyLoadedWorker({
+  wasLoaded,
+  stopReplacement,
+  startOriginal
+}) {
+  if (!wasLoaded) return false;
+  stopReplacement();
+  startOriginal();
+  return true;
 }

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -1,0 +1,291 @@
+import { createHash } from "node:crypto";
+import { basename, isAbsolute, join } from "node:path";
+
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const PACKAGE_VERSION_PATTERN = /^1\.1\.0-beta\.[1-9][0-9]{0,3}$/;
+const LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const REQUIRED_REVIEW_FLAGS = ["--expected-config-revision", "--zcode"];
+const APP_ID_KEYS = ["NEONDIFF_GITHUB_APP_ID", "EVAOS_REVIEW_BOT_APP_ID"];
+const PRIVATE_KEY_KEYS = [
+  "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
+  "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH"
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function consistentEnvironmentValue(environment, keys, validator, label) {
+  const present = keys.filter((key) => environment[key] !== undefined);
+  if (present.length === 0) fail(`LaunchAgent is missing ${label}`);
+  const values = present.map((key) => environment[key]);
+  if (!values.every((value) => typeof value === "string" && validator(value))) {
+    fail(`LaunchAgent has invalid ${label}`);
+  }
+  if (new Set(values).size !== 1) fail(`LaunchAgent has conflicting ${label}`);
+  return values[0];
+}
+
+function daemonIndexFor(argumentsList, workingDirectory) {
+  if (argumentsList.length < 2 || !isAbsolute(workingDirectory)) {
+    fail("LaunchAgent is not an approved NeonDiff daemon invocation");
+  }
+  const executable = basename(argumentsList[0]);
+  if (executable === "neondiff" && argumentsList[1] === "daemon") return 1;
+  if (executable !== "node") fail("LaunchAgent is not an approved NeonDiff daemon invocation");
+  if (
+    argumentsList[2] === "daemon"
+    && isAbsolute(argumentsList[1])
+    && argumentsList[1].endsWith("/dist/src/cli.js")
+  ) {
+    return 2;
+  }
+  if (
+    argumentsList[3] === "daemon"
+    && isAbsolute(argumentsList[1])
+    && argumentsList[1].endsWith("/node_modules/tsx/dist/cli.mjs")
+    && argumentsList[2] === "src/cli.ts"
+  ) {
+    return 3;
+  }
+  fail("LaunchAgent is not an approved NeonDiff daemon invocation");
+}
+
+function validateLaunchAgent(launchAgent, expectedLabel) {
+  if (!LABEL_PATTERN.test(expectedLabel)) fail("launchd label is invalid");
+  if (!launchAgent || typeof launchAgent !== "object" || Array.isArray(launchAgent)) {
+    fail("LaunchAgent root must be a dictionary");
+  }
+  if (launchAgent.Label !== expectedLabel) fail("LaunchAgent label mismatch");
+  if (
+    !Array.isArray(launchAgent.ProgramArguments)
+    || launchAgent.ProgramArguments.length === 0
+    || !launchAgent.ProgramArguments.every((value) => typeof value === "string" && value.length > 0)
+  ) {
+    fail("LaunchAgent ProgramArguments are invalid");
+  }
+  if (typeof launchAgent.WorkingDirectory !== "string" || !isAbsolute(launchAgent.WorkingDirectory)) {
+    fail("LaunchAgent WorkingDirectory must be absolute");
+  }
+  const environment = launchAgent.EnvironmentVariables;
+  if (!environment || typeof environment !== "object" || Array.isArray(environment)) {
+    fail("LaunchAgent EnvironmentVariables are invalid");
+  }
+  consistentEnvironmentValue(
+    environment,
+    APP_ID_KEYS,
+    (value) => /^[1-9][0-9]*$/.test(value),
+    "GitHub App ID"
+  );
+  consistentEnvironmentValue(
+    environment,
+    PRIVATE_KEY_KEYS,
+    (value) => isAbsolute(value),
+    "GitHub App private-key path"
+  );
+
+  const daemonIndex = daemonIndexFor(launchAgent.ProgramArguments, launchAgent.WorkingDirectory);
+  const daemonArguments = launchAgent.ProgramArguments.slice(daemonIndex + 1);
+  const configIndexes = daemonArguments
+    .map((value, index) => value === "--config" ? index : -1)
+    .filter((index) => index >= 0);
+  if (
+    configIndexes.length !== 1
+    || configIndexes[0] + 1 >= daemonArguments.length
+    || !isAbsolute(daemonArguments[configIndexes[0] + 1])
+  ) {
+    fail("LaunchAgent must contain exactly one absolute --config path");
+  }
+  return {
+    daemonArguments,
+    configPath: daemonArguments[configIndexes[0] + 1]
+  };
+}
+
+export function validateWorkerCandidate({
+  manifestBytes,
+  manifestSHA256,
+  tarballBytes,
+  tarballFilename
+}) {
+  if (!Buffer.isBuffer(manifestBytes) || !Buffer.isBuffer(tarballBytes)) {
+    fail("candidate inputs must be buffers");
+  }
+  if (!SHA256_PATTERN.test(manifestSHA256) || sha256(manifestBytes) !== manifestSHA256) {
+    fail("manifest SHA-256 mismatch");
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestBytes.toString("utf8"));
+  } catch {
+    fail("candidate manifest is invalid JSON");
+  }
+  if (
+    manifest?.schemaVersion !== 1
+    || manifest?.candidateClass !== "b0-access-controlled-cli"
+    || manifest?.source?.repository !== "electricsheephq/evaos-code-review-bot-neondiff"
+    || manifest?.source?.protectedMainVerified !== true
+    || !FULL_SHA_PATTERN.test(manifest?.source?.candidateHead ?? "")
+  ) {
+    fail("candidate manifest source identity is invalid");
+  }
+  const packageVersion = manifest?.package?.packageVersion;
+  if (
+    manifest?.package?.name !== "neondiff"
+    || !PACKAGE_VERSION_PATTERN.test(packageVersion ?? "")
+    || manifest?.installedCompatibility?.reportedVersion !== packageVersion
+    || manifest?.installedCompatibility?.isolatedInstallPassed !== true
+  ) {
+    fail("candidate manifest package identity is invalid");
+  }
+  if (
+    basename(tarballFilename) !== tarballFilename
+    || manifest?.package?.filename !== tarballFilename
+    || !SHA256_PATTERN.test(manifest?.package?.sha256 ?? "")
+    || sha256(tarballBytes) !== manifest.package.sha256
+  ) {
+    fail("candidate tarball SHA-256 mismatch");
+  }
+  const reviewFlags = manifest?.installedCompatibility?.reviewFlags;
+  if (!Array.isArray(reviewFlags)) fail("candidate review capability is missing");
+  for (const flag of REQUIRED_REVIEW_FLAGS) {
+    if (!reviewFlags.includes(flag)) fail(`missing review capability ${flag}`);
+  }
+  if (
+    manifest?.distribution?.privateBucketTarget !== "neondiff-beta-canary"
+    || manifest?.distribution?.publicNpmPublished !== false
+    || manifest?.distribution?.tagCreated !== false
+    || manifest?.distribution?.githubReleaseCreated !== false
+    || manifest?.distribution?.publicDownloadEnabled !== false
+  ) {
+    fail("candidate distribution boundary is invalid");
+  }
+  return {
+    candidateHead: manifest.source.candidateHead,
+    packageVersion,
+    tarballSHA256: manifest.package.sha256,
+    reviewFlags: [...REQUIRED_REVIEW_FLAGS]
+  };
+}
+
+export function planWorkerUpdate({
+  launchAgent,
+  expectedLabel,
+  workerRoot,
+  nodePath,
+  candidateHead,
+  packageVersion,
+  manifestSHA256,
+  previousState = null
+}) {
+  if (!isAbsolute(workerRoot) || !isAbsolute(nodePath)) fail("worker and Node paths must be absolute");
+  if (!FULL_SHA_PATTERN.test(candidateHead)) fail("candidate head is invalid");
+  if (!PACKAGE_VERSION_PATTERN.test(packageVersion)) fail("candidate package version is invalid");
+  if (!SHA256_PATTERN.test(manifestSHA256)) fail("candidate manifest SHA-256 is invalid");
+  const { daemonArguments, configPath } = validateLaunchAgent(launchAgent, expectedLabel);
+  const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
+  const currentPackageRoot = join(workerRoot, "current", "node_modules", "neondiff");
+  const nextLaunchAgent = clone(launchAgent);
+  nextLaunchAgent.ProgramArguments = [
+    nodePath,
+    join(currentPackageRoot, "dist", "src", "cli.js"),
+    "daemon",
+    ...daemonArguments
+  ];
+  nextLaunchAgent.WorkingDirectory = currentPackageRoot;
+
+  const originalProgramArguments = previousState?.originalProgramArguments
+    ?? clone(launchAgent.ProgramArguments);
+  const originalWorkingDirectory = previousState?.originalWorkingDirectory
+    ?? launchAgent.WorkingDirectory;
+  const previousVersionID = previousState?.currentVersionID ?? null;
+  const previousPackageVersion = previousVersionID
+    ? previousState?.packageVersion ?? null
+    : null;
+  const nextState = {
+    schemaVersion: 1,
+    launchdLabel: expectedLabel,
+    currentVersionID: versionID,
+    previousVersionID,
+    previousPackageVersion,
+    originalProgramArguments,
+    originalWorkingDirectory,
+    candidateHead,
+    packageVersion,
+    manifestSHA256
+  };
+  return {
+    versionID,
+    configPath,
+    nextLaunchAgent,
+    nextState,
+    publicSummary: {
+      action: previousVersionID ? "update" : "install",
+      launchdLabel: expectedLabel,
+      packageVersion,
+      candidateHead,
+      preservesConfiguration: true,
+      preservesCredentials: true,
+      preservesProviderState: true,
+      preservesRepositoryAllowlist: true
+    }
+  };
+}
+
+export function planWorkerRollback({ state, currentLaunchAgent, expectedLabel }) {
+  validateLaunchAgent(currentLaunchAgent, expectedLabel);
+  if (
+    state?.schemaVersion !== 1
+    || state?.launchdLabel !== expectedLabel
+    || !Array.isArray(state?.originalProgramArguments)
+    || typeof state?.originalWorkingDirectory !== "string"
+    || !isAbsolute(state.originalWorkingDirectory)
+  ) {
+    fail("worker rollback state is invalid");
+  }
+  if (state.previousVersionID) {
+    return {
+      nextLaunchAgent: clone(currentLaunchAgent),
+      nextState: {
+        ...state,
+        currentVersionID: state.previousVersionID,
+        previousVersionID: state.currentVersionID,
+        packageVersion: state.previousPackageVersion,
+        previousPackageVersion: state.packageVersion
+      },
+      publicSummary: {
+        action: "rollback",
+        target: "previous-worker",
+        launchdLabel: expectedLabel
+      }
+    };
+  }
+  const nextLaunchAgent = clone(currentLaunchAgent);
+  nextLaunchAgent.ProgramArguments = clone(state.originalProgramArguments);
+  nextLaunchAgent.WorkingDirectory = state.originalWorkingDirectory;
+  validateLaunchAgent(nextLaunchAgent, expectedLabel);
+  return {
+    nextLaunchAgent,
+    nextState: {
+      ...state,
+      currentVersionID: null,
+      previousVersionID: state.currentVersionID,
+      packageVersion: null,
+      previousPackageVersion: state.packageVersion
+    },
+    publicSummary: {
+      action: "rollback",
+      target: "original-worker",
+      launchdLabel: expectedLabel
+    }
+  };
+}

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { basename, isAbsolute, join } from "node:path";
+import { basename, isAbsolute, join, relative, sep } from "node:path";
 
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
@@ -22,6 +22,11 @@ function sha256(value) {
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function isPathAtOrInside(root, candidate) {
+  const rel = relative(root, candidate);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
 }
 
 function consistentEnvironmentValue(environment, keys, validator, label) {
@@ -144,6 +149,9 @@ export function validateWorkerCandidate({
     || !PACKAGE_VERSION_PATTERN.test(packageVersion ?? "")
     || manifest?.installedCompatibility?.reportedVersion !== packageVersion
     || manifest?.installedCompatibility?.isolatedInstallPassed !== true
+    || manifest?.installedCompatibility?.offlineInstallPassed !== true
+    || JSON.stringify(manifest?.installedCompatibility?.bundledProductionDependencies)
+      !== JSON.stringify(["validate-npm-package-license@3.0.4"])
   ) {
     fail("candidate manifest package identity is invalid");
   }
@@ -194,6 +202,20 @@ export function planWorkerUpdate({
   const { daemonArguments, configPath } = validateLaunchAgent(launchAgent, expectedLabel);
   const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
   const currentPackageRoot = join(workerRoot, "current", "node_modules", "neondiff");
+  if (previousState && previousState.launchdLabel !== expectedLabel) {
+    fail("worker state label mismatch");
+  }
+  if (
+    !previousState
+    && (
+      isPathAtOrInside(currentPackageRoot, launchAgent.WorkingDirectory)
+      || launchAgent.ProgramArguments.some(
+        (value) => isAbsolute(value) && isPathAtOrInside(currentPackageRoot, value)
+      )
+    )
+  ) {
+    fail("managed worker has no rollback state");
+  }
   const nextLaunchAgent = clone(launchAgent);
   nextLaunchAgent.ProgramArguments = [
     nodePath,
@@ -201,7 +223,7 @@ export function planWorkerUpdate({
     "daemon",
     ...daemonArguments
   ];
-  nextLaunchAgent.WorkingDirectory = currentPackageRoot;
+  nextLaunchAgent.WorkingDirectory = launchAgent.WorkingDirectory;
 
   const originalProgramArguments = previousState?.originalProgramArguments
     ?? clone(launchAgent.ProgramArguments);

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -54,6 +54,7 @@ describe("B0 access-controlled CLI candidate", () => {
       "nodeVersion",
       "activationFlags",
       "githubDoctorFlags",
+      "reviewFlags",
       "publicNpmPublished",
       "tagCreated",
       "githubReleaseCreated",
@@ -73,6 +74,8 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).toContain("--license-machine-id");
     expect(script).toContain("--github-app-id");
     expect(script).toContain("--github-app-private-key-stdin");
+    expect(script).toContain("--expected-config-revision");
+    expect(script).toContain("--zcode");
     expect(script).toContain("git status --porcelain");
     expect(script).toContain("must not be a symbolic link");
     expect(script).toContain("must be private to the current user (0700)");

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -55,6 +55,8 @@ describe("B0 access-controlled CLI candidate", () => {
       "activationFlags",
       "githubDoctorFlags",
       "reviewFlags",
+      "offlineInstallPassed",
+      "bundledProductionDependencies",
       "publicNpmPublished",
       "tagCreated",
       "githubReleaseCreated",
@@ -76,6 +78,7 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).toContain("--github-app-private-key-stdin");
     expect(script).toContain("--expected-config-revision");
     expect(script).toContain("--zcode");
+    expect(script).toContain("empty-npm-cache");
     expect(script).toContain("git status --porcelain");
     expect(script).toContain("must not be a symbolic link");
     expect(script).toContain("must be private to the current user (0700)");

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -33,7 +33,9 @@ function candidateManifest() {
     installedCompatibility: {
       reportedVersion: packageVersion,
       reviewFlags: ["--expected-config-revision", "--zcode"],
-      isolatedInstallPassed: true
+      isolatedInstallPassed: true,
+      offlineInstallPassed: true,
+      bundledProductionDependencies: ["validate-npm-package-license@3.0.4"]
     },
     distribution: {
       privateBucketTarget: "neondiff-beta-canary",
@@ -87,6 +89,8 @@ describe("B0 worker installer", () => {
     expect(script).toContain("INSTALL.md");
     expect(script).toContain("bundleSHA256");
     expect(script).toContain("manifestSHA256");
+    expect(script).toContain("assertExactCandidateCheckout");
+    expect(script).toContain('BUNDLE_DIR="$(pwd -P)"');
     expect(script).not.toMatch(/npm publish|npm dist-tag|gh release|git tag/);
   });
 
@@ -123,6 +127,36 @@ describe("B0 worker installer", () => {
       tarballBytes: tarball,
       tarballFilename: `neondiff-${packageVersion}.tgz`
     })).toThrow("missing review capability --expected-config-revision");
+
+    const unboundDependencies = candidateManifest();
+    unboundDependencies.installedCompatibility.offlineInstallPassed = false;
+    const unboundDependencyBytes = Buffer.from(`${JSON.stringify(unboundDependencies)}\n`);
+    expect(() => validateWorkerCandidate({
+      manifestBytes: unboundDependencyBytes,
+      manifestSHA256: createHash("sha256").update(unboundDependencyBytes).digest("hex"),
+      tarballBytes: tarball,
+      tarballFilename: `neondiff-${packageVersion}.tgz`
+    })).toThrow("candidate manifest package identity is invalid");
+
+    const published = candidateManifest();
+    published.distribution.publicNpmPublished = true;
+    const publishedBytes = Buffer.from(`${JSON.stringify(published)}\n`);
+    expect(() => validateWorkerCandidate({
+      manifestBytes: publishedBytes,
+      manifestSHA256: createHash("sha256").update(publishedBytes).digest("hex"),
+      tarballBytes: tarball,
+      tarballFilename: `neondiff-${packageVersion}.tgz`
+    })).toThrow("candidate distribution boundary is invalid");
+
+    const traversal = candidateManifest();
+    traversal.package.filename = `../neondiff-${packageVersion}.tgz`;
+    const traversalBytes = Buffer.from(`${JSON.stringify(traversal)}\n`);
+    expect(() => validateWorkerCandidate({
+      manifestBytes: traversalBytes,
+      manifestSHA256: createHash("sha256").update(traversalBytes).digest("hex"),
+      tarballBytes: tarball,
+      tarballFilename: `../neondiff-${packageVersion}.tgz`
+    })).toThrow("candidate tarball SHA-256 mismatch");
   });
 
   it("plans one state-preserving LaunchAgent migration without copying secrets", () => {
@@ -149,6 +183,7 @@ describe("B0 worker installer", () => {
       "--dry-run",
       "true"
     ]);
+    expect(plan.nextLaunchAgent.WorkingDirectory).toBe(launchAgent().WorkingDirectory);
     expect(JSON.stringify(plan.publicSummary)).not.toContain("app.pem");
     expect(JSON.stringify(plan.publicSummary)).not.toContain("config.local.json");
   });
@@ -183,6 +218,48 @@ describe("B0 worker installer", () => {
     expect(rollback.nextLaunchAgent.ProgramArguments).toEqual(launchAgent().ProgramArguments);
     expect(rollback.nextLaunchAgent.WorkingDirectory).toBe(launchAgent().WorkingDirectory);
     expect(rollback.publicSummary).toMatchObject({ action: "rollback", target: "original-worker" });
+  });
+
+  it("fails closed when managed worker state is missing or belongs to another label", () => {
+    const managed = launchAgent();
+    managed.ProgramArguments = [
+      "/opt/homebrew/bin/node",
+      "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/current/node_modules/neondiff/dist/src/cli.js",
+      "daemon",
+      "--config",
+      "/Users/test/.config/neondiff/config.local.json"
+    ];
+    expect(() => planWorkerUpdate({
+      launchAgent: managed,
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    })).toThrow("managed worker has no rollback state");
+
+    const first = planWorkerUpdate({
+      launchAgent: launchAgent(),
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+    const otherLabelLaunchAgent = launchAgent();
+    otherLabelLaunchAgent.Label = "com.electricsheephq.neondiff.other";
+    expect(() => planWorkerUpdate({
+      launchAgent: otherLabelLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff.other",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "b".repeat(64),
+      previousState: first.nextState
+    })).toThrow("worker state label mismatch");
   });
 
   it("carries the previous package identity through update and rollback", () => {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   planWorkerRollback,
   planWorkerUpdate,
+  recoverPreviouslyLoadedWorker,
   validateWorkerCandidate
 } from "../scripts/lib/b0-worker-installer.mjs";
 
@@ -217,5 +218,51 @@ describe("B0 worker installer", () => {
     expect(rollback.nextState.packageVersion).toBe("1.1.0-beta.26");
     expect(rollback.nextState.previousVersionID).toBe(second.versionID);
     expect(rollback.nextState.previousPackageVersion).toBe("1.1.0-beta.27");
+  });
+
+  it("boots out a partially activated replacement before restarting the original worker", () => {
+    const calls: string[] = [];
+    recoverPreviouslyLoadedWorker({
+      wasLoaded: true,
+      stopReplacement() {
+        calls.push("stop-replacement");
+      },
+      startOriginal() {
+        calls.push("start-original");
+      }
+    });
+    expect(calls).toEqual(["stop-replacement", "start-original"]);
+
+    expect(() => recoverPreviouslyLoadedWorker({
+      wasLoaded: true,
+      stopReplacement() {
+        calls.push("stop-again");
+      },
+      startOriginal() {
+        throw new Error("original restart failed");
+      }
+    })).toThrow("original restart failed");
+  });
+
+  it("fails closed when rollback is requested after the original worker is already active", () => {
+    const update = planWorkerUpdate({
+      launchAgent: launchAgent(),
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+    const firstRollback = planWorkerRollback({
+      state: update.nextState,
+      currentLaunchAgent: update.nextLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff"
+    });
+    expect(() => planWorkerRollback({
+      state: firstRollback.nextState,
+      currentLaunchAgent: firstRollback.nextLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff"
+    })).toThrow("original worker is already active");
   });
 });

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -1,0 +1,221 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  planWorkerRollback,
+  planWorkerUpdate,
+  validateWorkerCandidate
+} from "../scripts/lib/b0-worker-installer.mjs";
+
+const candidateHead = "7".repeat(40);
+const packageVersion = "1.1.0-beta.27";
+const tarball = Buffer.from("exact candidate bytes");
+const tarballSHA256 = createHash("sha256").update(tarball).digest("hex");
+
+function candidateManifest() {
+  return {
+    schemaVersion: 1,
+    candidateClass: "b0-access-controlled-cli",
+    source: {
+      repository: "electricsheephq/evaos-code-review-bot-neondiff",
+      candidateHead,
+      protectedMainVerified: true
+    },
+    package: {
+      name: "neondiff",
+      packageVersion,
+      filename: `neondiff-${packageVersion}.tgz`,
+      sha256: tarballSHA256,
+      integrity: "sha512-public-safe-placeholder"
+    },
+    installedCompatibility: {
+      reportedVersion: packageVersion,
+      reviewFlags: ["--expected-config-revision", "--zcode"],
+      isolatedInstallPassed: true
+    },
+    distribution: {
+      privateBucketTarget: "neondiff-beta-canary",
+      publicNpmPublished: false,
+      tagCreated: false,
+      githubReleaseCreated: false,
+      publicDownloadEnabled: false
+    }
+  };
+}
+
+function launchAgent() {
+  return {
+    Label: "com.electricsheephq.neondiff",
+    ProgramArguments: [
+      "/opt/homebrew/bin/node",
+      "/Users/test/neondiff/node_modules/tsx/dist/cli.mjs",
+      "src/cli.ts",
+      "daemon",
+      "--config",
+      "/Users/test/.config/neondiff/config.local.json",
+      "--dry-run",
+      "true"
+    ],
+    WorkingDirectory: "/Users/test/neondiff",
+    EnvironmentVariables: {
+      NEONDIFF_GITHUB_APP_ID: "123456",
+      NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: "/Users/test/.config/neondiff/app.pem"
+    }
+  };
+}
+
+describe("B0 worker installer", () => {
+  it("exposes an explicit dry-run, confirmed update, and rollback command", () => {
+    const scriptPath = "scripts/install-b0-worker-candidate.mjs";
+    expect(existsSync(scriptPath)).toBe(true);
+    const help = spawnSync(process.execPath, [scriptPath, "--help"], { encoding: "utf8" });
+    expect(help.status).toBe(0);
+    expect(help.stdout).toContain("update");
+    expect(help.stdout).toContain("rollback");
+    expect(help.stdout).toContain("--manifest-sha256");
+    expect(help.stdout).toContain("--dry-run false --confirm true");
+  });
+
+  it("provides a private customer bundle builder without public publication commands", () => {
+    const scriptPath = "scripts/build-b0-worker-bundle.mjs";
+    expect(existsSync(scriptPath)).toBe(true);
+    const script = readFileSync(scriptPath, "utf8");
+    expect(script).toContain("install-b0-worker-candidate.mjs");
+    expect(script).toContain("b0-worker-installer.mjs");
+    expect(script).toContain("INSTALL.md");
+    expect(script).toContain("bundleSHA256");
+    expect(script).toContain("manifestSHA256");
+    expect(script).not.toMatch(/npm publish|npm dist-tag|gh release|git tag/);
+  });
+
+  it("requires an out-of-band manifest digest and exact review capability", () => {
+    const manifestBytes = Buffer.from(`${JSON.stringify(candidateManifest())}\n`);
+    const manifestSHA256 = createHash("sha256").update(manifestBytes).digest("hex");
+    const result = validateWorkerCandidate({
+      manifestBytes,
+      manifestSHA256,
+      tarballBytes: tarball,
+      tarballFilename: `neondiff-${packageVersion}.tgz`
+    });
+
+    expect(result).toMatchObject({
+      candidateHead,
+      packageVersion,
+      tarballSHA256,
+      reviewFlags: ["--expected-config-revision", "--zcode"]
+    });
+
+    expect(() => validateWorkerCandidate({
+      manifestBytes,
+      manifestSHA256: "0".repeat(64),
+      tarballBytes: tarball,
+      tarballFilename: `neondiff-${packageVersion}.tgz`
+    })).toThrow("manifest SHA-256 mismatch");
+
+    const missingCapability = candidateManifest();
+    missingCapability.installedCompatibility.reviewFlags = ["--zcode"];
+    const missingCapabilityBytes = Buffer.from(`${JSON.stringify(missingCapability)}\n`);
+    expect(() => validateWorkerCandidate({
+      manifestBytes: missingCapabilityBytes,
+      manifestSHA256: createHash("sha256").update(missingCapabilityBytes).digest("hex"),
+      tarballBytes: tarball,
+      tarballFilename: `neondiff-${packageVersion}.tgz`
+    })).toThrow("missing review capability --expected-config-revision");
+  });
+
+  it("plans one state-preserving LaunchAgent migration without copying secrets", () => {
+    const plan = planWorkerUpdate({
+      launchAgent: launchAgent(),
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+
+    expect(plan.versionID).toBe(`1.1.0-beta.27-${candidateHead.slice(0, 12)}`);
+    expect(plan.configPath).toBe("/Users/test/.config/neondiff/config.local.json");
+    expect(plan.nextLaunchAgent.Label).toBe("com.electricsheephq.neondiff");
+    expect(plan.nextLaunchAgent.EnvironmentVariables).toEqual(launchAgent().EnvironmentVariables);
+    expect(plan.nextLaunchAgent.ProgramArguments).toEqual([
+      "/opt/homebrew/bin/node",
+      "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/current/node_modules/neondiff/dist/src/cli.js",
+      "daemon",
+      "--config",
+      "/Users/test/.config/neondiff/config.local.json",
+      "--dry-run",
+      "true"
+    ]);
+    expect(JSON.stringify(plan.publicSummary)).not.toContain("app.pem");
+    expect(JSON.stringify(plan.publicSummary)).not.toContain("config.local.json");
+  });
+
+  it("rejects ambiguous or non-NeonDiff LaunchAgents and plans reversible state", () => {
+    const ambiguous = launchAgent();
+    ambiguous.ProgramArguments.push("--config", "/tmp/other.json");
+    expect(() => planWorkerUpdate({
+      launchAgent: ambiguous,
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    })).toThrow("exactly one absolute --config path");
+
+    const update = planWorkerUpdate({
+      launchAgent: launchAgent(),
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+    const rollback = planWorkerRollback({
+      state: update.nextState,
+      currentLaunchAgent: update.nextLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff"
+    });
+    expect(rollback.nextLaunchAgent.ProgramArguments).toEqual(launchAgent().ProgramArguments);
+    expect(rollback.nextLaunchAgent.WorkingDirectory).toBe(launchAgent().WorkingDirectory);
+    expect(rollback.publicSummary).toMatchObject({ action: "rollback", target: "original-worker" });
+  });
+
+  it("carries the previous package identity through update and rollback", () => {
+    const first = planWorkerUpdate({
+      launchAgent: launchAgent(),
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion: "1.1.0-beta.26",
+      manifestSHA256: "a".repeat(64)
+    });
+    const secondHead = "8".repeat(40);
+    const second = planWorkerUpdate({
+      launchAgent: first.nextLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead: secondHead,
+      packageVersion: "1.1.0-beta.27",
+      manifestSHA256: "b".repeat(64),
+      previousState: first.nextState
+    });
+    expect(second.nextState.previousVersionID).toBe(first.versionID);
+    expect(second.nextState.previousPackageVersion).toBe("1.1.0-beta.26");
+
+    const rollback = planWorkerRollback({
+      state: second.nextState,
+      currentLaunchAgent: second.nextLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff"
+    });
+    expect(rollback.nextState.currentVersionID).toBe(first.versionID);
+    expect(rollback.nextState.packageVersion).toBe("1.1.0-beta.26");
+    expect(rollback.nextState.previousVersionID).toBe(second.versionID);
+    expect(rollback.nextState.previousPackageVersion).toBe("1.1.0-beta.27");
+  });
+});


### PR DESCRIPTION
Related: #699

## Customer-visible outcome

An invited B0 customer with an existing package or source worker gets one
checksum-bound private bundle with a dry-run-first installer and rollback path.
The migration installs the exact worker in a versioned user-owned prefix,
preserves the existing LaunchAgent label/environment and customer configuration,
and restarts only a service that was already loaded. NeonDiff then re-runs the
exact `review-pr` capability gate before Dry or Live Review is enabled.

## Bounded acceptance criteria

- The exact protected-main worker manifest records `--expected-config-revision`
  and `--zcode` from the isolated installed tarball.
- The bundle includes the exact TGZ, manifest, installer, pure validation/planning
  library, rollback instructions, and a separate ZIP receipt/checksum.
- The installer requires the manifest SHA-256 supplied out of band, verifies the
  tarball SHA-256, and defaults to dry-run.
- Live install/update/rollback requires `--dry-run false --confirm true`.
- The existing config, LaunchAgent label/environment, GitHub App private-key
  file, Keychain entries, provider state, and repository allowlist are preserved;
  private-key bytes are never read or copied.
- Install/update uses a versioned user-owned Application Support prefix and an
  atomic current pointer. Rollback restores the previous candidate or original
  LaunchAgent invocation without deleting customer state.
- An unloaded service remains unloaded; a loaded service is restarted only after
  the staged plist and installed worker read back successfully.
- The app exposes **Install / Update Local Worker** and keeps review blocked until
  **Retry Worker Check** proves the exact capability.

## Failing-first evidence

- `tests/b0-cli-candidate.test.ts` failed because the candidate manifest did not
  record the review capability.
- `tests/b0-worker-installer.test.ts` first failed because the installer/library
  did not exist, then failed on missing previous-package rollback identity.

## Focused validation

- `npx vitest run tests/b0-cli-candidate.test.ts tests/b0-worker-installer.test.ts --pool=forks --maxWorkers=1` — 9/9 passed.
- `swift test --package-path apps/neondiff-desktop --filter OwnerReferenceUXContractTests` — 7/7 passed.
- `node --check` passed for the installer, bundle builder, and pure library.
- `git diff --check` passed.

## Explicit non-goals

- No public npm publication or dist-tag mutation.
- No Git tag, GitHub Release, public download, signed URL, or website publication.
- No live owner LaunchAgent, customer config, Keychain, provider, or daemon mutation
  in this PR.
- No app signing/notarization, Sparkle/appcast, automatic worker updater, billing,
  checkout, activation canary, customer send, or beta/release claim.
- No B1 managed GitHub App, #613/#630 work, broader #517 matrix, daemon redesign,
  or generalized compatibility harness.

## Post-merge proof boundary

After exact-head CI and one bounded security/recovery review, merge may establish
the source contract only. Exact clean main must then build the worker bundle;
private upload/authenticated byte readback, a disposable old-to-current
install/rollback/reupdate canary, beta.26+ UI dry/live review, and customer proof
remain separate gates. #699 stays open until those execution gates pass.

Agent-authored change. No secrets, raw private paths, customer data, or live
configuration are included in this PR.
