### PR TITLE
fix: allow the locked B0 dependency closure

### DIFF
--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -137,6 +137,14 @@ function main() {
   }
   ensureClean(repoRoot, "preflight");
   execFileSync("npm", [
+    "ci",
+    "--ignore-scripts"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  execFileSync("npm", [
     "run",
     "build"
   ], {
@@ -215,7 +223,11 @@ function main() {
 
     packJsonPath = join(outputDirectory, "pack.json");
     writeFileSync(packJsonPath, `${JSON.stringify(parsedPack, null, 2)}\n`, { mode: 0o600 });
-    execFileSync(process.execPath, [join(repoRoot, "scripts", "check-packlist.mjs"), packJsonPath], {
+    execFileSync(process.execPath, [
+      join(repoRoot, "scripts", "check-packlist.mjs"),
+      packJsonPath,
+      "--allow-b0-bundled-production-closure"
+    ], {
       cwd: repoRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]

--- a/scripts/check-packlist.mjs
+++ b/scripts/check-packlist.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 const raw = readFileSync(process.argv[2] ?? "pack.json", "utf8");
 const [pack] = JSON.parse(raw);
 const files = new Set(pack.files.map((file) => file.path));
+const allowB0BundledProductionClosure = process.argv.includes(
+  "--allow-b0-bundled-production-closure"
+);
 const allowedBundledProductionRoots = [
   "node_modules/spdx-correct/",
   "node_modules/spdx-exceptions/",
@@ -18,7 +21,9 @@ function isAllowedBundledProductionFile(path) {
 const forbidden = [...files].filter((path) =>
   path.startsWith("tests/") ||
   path.startsWith("dist/tests/") ||
-  (path.startsWith("node_modules/") && !isAllowedBundledProductionFile(path)) ||
+  (path.startsWith("node_modules/") && (
+    !allowB0BundledProductionClosure || !isAllowedBundledProductionFile(path)
+  )) ||
   path.startsWith("apps/") ||
   path.startsWith(".git") ||
   path.includes(".env") ||

--- a/scripts/check-packlist.mjs
+++ b/scripts/check-packlist.mjs
@@ -3,11 +3,22 @@ import { readFileSync } from "node:fs";
 const raw = readFileSync(process.argv[2] ?? "pack.json", "utf8");
 const [pack] = JSON.parse(raw);
 const files = new Set(pack.files.map((file) => file.path));
+const allowedBundledProductionRoots = [
+  "node_modules/spdx-correct/",
+  "node_modules/spdx-exceptions/",
+  "node_modules/spdx-expression-parse/",
+  "node_modules/spdx-license-ids/",
+  "node_modules/validate-npm-package-license/"
+];
+
+function isAllowedBundledProductionFile(path) {
+  return allowedBundledProductionRoots.some((root) => path.startsWith(root));
+}
 
 const forbidden = [...files].filter((path) =>
   path.startsWith("tests/") ||
   path.startsWith("dist/tests/") ||
-  path.startsWith("node_modules/") ||
+  (path.startsWith("node_modules/") && !isAllowedBundledProductionFile(path)) ||
   path.startsWith("apps/") ||
   path.startsWith(".git") ||
   path.includes(".env") ||

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -81,6 +81,8 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).toContain("--expected-config-revision");
     expect(script).toContain("--zcode");
     expect(script).toContain("empty-npm-cache");
+    expect(script).toMatch(/execFileSync\("npm", \[\s*"ci",\s*"--ignore-scripts"/);
+    expect(script).toContain("--allow-b0-bundled-production-closure");
     expect(script).toContain("git status --porcelain");
     expect(script).toContain("must not be a symbolic link");
     expect(script).toContain("must be private to the current user (0700)");
@@ -124,14 +126,42 @@ describe("B0 access-controlled CLI candidate", () => {
     ];
     try {
       writeFileSync(packPath, JSON.stringify([{ files: [...required, ...allowedClosure].map((path) => ({ path })) }]));
-      const allowed = spawnSync(process.execPath, ["scripts/check-packlist.mjs", packPath], { encoding: "utf8" });
+      const deniedByDefault = spawnSync(
+        process.execPath,
+        ["scripts/check-packlist.mjs", packPath],
+        { encoding: "utf8" }
+      );
+      expect(deniedByDefault.status).not.toBe(0);
+      expect(deniedByDefault.stderr).toContain("node_modules/validate-npm-package-license/package.json");
+
+      const allowed = spawnSync(process.execPath, [
+        "scripts/check-packlist.mjs",
+        packPath,
+        "--allow-b0-bundled-production-closure"
+      ], { encoding: "utf8" });
       expect(allowed.status, `${allowed.stdout}\n${allowed.stderr}`).toBe(0);
+      expect(allowed.stdout).toContain(`packlist ok: ${required.length + allowedClosure.length} files`);
+
+      writeFileSync(packPath, JSON.stringify([{
+        files: [...required.slice(1), ...allowedClosure].map((path) => ({ path }))
+      }]));
+      const missingRequired = spawnSync(process.execPath, [
+        "scripts/check-packlist.mjs",
+        packPath,
+        "--allow-b0-bundled-production-closure"
+      ], { encoding: "utf8" });
+      expect(missingRequired.status).not.toBe(0);
+      expect(missingRequired.stderr).toContain(`Missing required package file: ${required[0]}`);
 
       writeFileSync(packPath, JSON.stringify([{
         files: [...required, ...allowedClosure, "node_modules/unreviewed-package/index.js"]
           .map((path) => ({ path }))
       }]));
-      const rejected = spawnSync(process.execPath, ["scripts/check-packlist.mjs", packPath], { encoding: "utf8" });
+      const rejected = spawnSync(process.execPath, [
+        "scripts/check-packlist.mjs",
+        packPath,
+        "--allow-b0-bundled-production-closure"
+      ], { encoding: "utf8" });
       expect(rejected.status).not.toBe(0);
       expect(rejected.stderr).toContain("node_modules/unreviewed-package/index.js");
     } finally {

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -1,5 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 const workflowPath = ".github/workflows/b0-cli-candidate.yml";
 const scriptPath = "scripts/build-b0-cli-candidate.mjs";
@@ -87,5 +89,53 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).not.toMatch(/\bnpm dist-tag\b/);
     expect(script).not.toMatch(/\bgh release\b/);
     expect(script).not.toMatch(/\bgit tag\b/);
+  });
+
+  it("allows only the locked bundled B0 production dependency closure", () => {
+    const temporary = mkdtempSync(join(tmpdir(), "neondiff-b0-packlist-"));
+    const packPath = join(temporary, "pack.json");
+    const required = [
+      "dist/src/cli.js",
+      "README.md",
+      "LICENSE.md",
+      "SECURITY.md",
+      "CODE_OF_CONDUCT.md",
+      "config.example.json",
+      "docs/SETUP.md",
+      "docs/ci-runner.md",
+      "docs/docker.md",
+      "docs/github-app-setup.md",
+      "docs/providers.md",
+      "docs/license-boundary.md",
+      "docs/pricing.md",
+      "docs/schema/neondiff-config.schema.json",
+      "docs/systemd.md",
+      "systemd/neondiff.service.example",
+      "systemd/neondiff.user.service.example",
+      "Dockerfile",
+      "docker-compose.example.yml"
+    ];
+    const allowedClosure = [
+      "node_modules/spdx-correct/package.json",
+      "node_modules/spdx-exceptions/package.json",
+      "node_modules/spdx-expression-parse/package.json",
+      "node_modules/spdx-license-ids/package.json",
+      "node_modules/validate-npm-package-license/package.json"
+    ];
+    try {
+      writeFileSync(packPath, JSON.stringify([{ files: [...required, ...allowedClosure].map((path) => ({ path })) }]));
+      const allowed = spawnSync(process.execPath, ["scripts/check-packlist.mjs", packPath], { encoding: "utf8" });
+      expect(allowed.status, `${allowed.stdout}\n${allowed.stderr}`).toBe(0);
+
+      writeFileSync(packPath, JSON.stringify([{
+        files: [...required, ...allowedClosure, "node_modules/unreviewed-package/index.js"]
+          .map((path) => ({ path }))
+      }]));
+      const rejected = spawnSync(process.execPath, ["scripts/check-packlist.mjs", packPath], { encoding: "utf8" });
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stderr).toContain("node_modules/unreviewed-package/index.js");
+    } finally {
+      rmSync(temporary, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Relates to #699. This is the smallest follow-up to the exact merged-main
artifact-build failure after #701.

## Acceptance criteria

- `scripts/check-packlist.mjs` permits only the five lock-resolved package roots
  in the intentionally bundled `validate-npm-package-license@3.0.4` production
  closure.
- Every other `node_modules/**` path remains forbidden.
- Existing secret, key, database, test, app, and Git metadata exclusions remain
  unchanged.
- The focused executable packlist test accepts the named closure and rejects an
  unreviewed package.
- Current-head CI, review threads, top-level feedback, and annotations are
  inspected before merge.

## Non-goals

- No customer install, LaunchAgent, Keychain, config, provider, or repository
  mutation.
- No artifact upload, npm publication, tag, GitHub Release, checkout change, or
  beta/release claim.
- No general `node_modules` allowance and no dependency upgrade.

## Failing-first evidence

Exact merged main `f1116acbcaad6984bca61fd3bb87d6b7e7589b32` built the
`1.1.0-beta.27` candidate, then failed before upload/install because the
existing packlist gate rejected the intentionally bundled locked dependency
closure. The failed local evidence packet is preserved under issue #699.

## Focused proof

- `npx vitest run tests/b0-cli-candidate.test.ts --pool=forks --maxWorkers=1`
  - 4/4 passed
- `git diff --check`
  - passed

Proof boundary: source correction only. Candidate packaging, private upload,
installation, rollback, live review, beta, and release remain unproven.
