### PR TITLE
fix: retry transient launchd worker bootstrap

### DIFF
--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -24,6 +24,7 @@ import {
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
+  retryTransientLaunchdBootstrap,
   validateWorkerCandidate
 } from "./lib/b0-worker-installer.mjs";
 
@@ -309,10 +310,10 @@ function launchdState(label) {
   const domain = `gui/${process.getuid()}`;
   const target = `${domain}/${label}`;
   const result = spawnSync("/bin/launchctl", ["print", target], CHILD_PROCESS_OPTIONS);
-  if (result.status === 0) return { loaded: true, domain, target };
+  if (result.status === 0) return { loaded: true, domain, target, label };
   const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   if (/could not find service|service not found/i.test(detail)) {
-    return { loaded: false, domain, target };
+    return { loaded: false, domain, target, label };
   }
   fail("launchd service state is ambiguous");
 }
@@ -326,8 +327,18 @@ function stopIfLoaded(state) {
 
 function startIfPreviouslyLoaded(state, plistPath) {
   if (!state.loaded) return;
-  execFileSync("/bin/launchctl", ["bootstrap", state.domain, plistPath], {
-    ...CHILD_PROCESS_OPTIONS
+  retryTransientLaunchdBootstrap({
+    bootstrap() {
+      execFileSync("/bin/launchctl", ["bootstrap", state.domain, plistPath], {
+        ...CHILD_PROCESS_OPTIONS
+      });
+    },
+    isLoaded() {
+      return launchdState(state.label).loaded;
+    },
+    wait(milliseconds) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+    }
   });
   execFileSync("/bin/launchctl", ["kickstart", "-k", state.target], {
     ...CHILD_PROCESS_OPTIONS

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -11,6 +11,7 @@ const PRIVATE_KEY_KEYS = [
   "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
   "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH"
 ];
+const LAUNCHD_BOOTSTRAP_RETRY_DELAYS_MS = [250, 750, 2_000, 5_000, 10_000];
 
 function fail(message) {
   throw new Error(message);
@@ -324,4 +325,43 @@ export function recoverPreviouslyLoadedWorker({
   stopReplacement();
   startOriginal();
   return true;
+}
+
+export function retryTransientLaunchdBootstrap({
+  bootstrap,
+  isLoaded,
+  wait,
+  delays = LAUNCHD_BOOTSTRAP_RETRY_DELAYS_MS
+}) {
+  if (
+    typeof bootstrap !== "function"
+    || typeof isLoaded !== "function"
+    || typeof wait !== "function"
+    || !Array.isArray(delays)
+    || !delays.every((value) => Number.isInteger(value) && value >= 0)
+  ) {
+    fail("launchd bootstrap retry dependencies are invalid");
+  }
+  let attempts = 0;
+  while (true) {
+    attempts += 1;
+    try {
+      bootstrap();
+      return attempts;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const delay = delays[attempts - 1];
+      if (
+        delay === undefined
+        || !/bootstrap failed:\s*5:\s*input\/output error/i.test(detail)
+      ) {
+        throw error;
+      }
+      const loaded = isLoaded();
+      if (loaded !== true && loaded !== false) {
+        fail("launchd service state is ambiguous during bootstrap retry");
+      }
+      wait(delay);
+    }
+  }
 }

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -6,6 +6,7 @@ import {
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
+  retryTransientLaunchdBootstrap,
   validateWorkerCandidate
 } from "../scripts/lib/b0-worker-installer.mjs";
 
@@ -319,6 +320,58 @@ describe("B0 worker installer", () => {
         throw new Error("original restart failed");
       }
     })).toThrow("original restart failed");
+  });
+
+  it("retries the bounded launchd bootstrap I/O race before activating the worker", () => {
+    let attempts = 0;
+    const waits: number[] = [];
+    const loadedStates = [true, false];
+    const observedAttempts = retryTransientLaunchdBootstrap({
+      bootstrap() {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("Bootstrap failed: 5: Input/output error");
+        }
+      },
+      isLoaded() {
+        return loadedStates.shift() ?? false;
+      },
+      wait(milliseconds) {
+        waits.push(milliseconds);
+      }
+    });
+
+    expect(observedAttempts).toBe(3);
+    expect(waits).toEqual([250, 750]);
+
+    let unrelatedAttempts = 0;
+    expect(() => retryTransientLaunchdBootstrap({
+      bootstrap() {
+        unrelatedAttempts += 1;
+        throw new Error("Bootstrap failed: 1: Operation not permitted");
+      },
+      isLoaded() {
+        throw new Error("must not inspect unrelated failures");
+      },
+      wait() {
+        throw new Error("must not wait on unrelated failures");
+      }
+    })).toThrow("Operation not permitted");
+    expect(unrelatedAttempts).toBe(1);
+
+    let boundedAttempts = 0;
+    expect(() => retryTransientLaunchdBootstrap({
+      bootstrap() {
+        boundedAttempts += 1;
+        throw new Error("Bootstrap failed: 5: Input/output error");
+      },
+      isLoaded() {
+        return false;
+      },
+      wait() {},
+      delays: [1]
+    })).toThrow("Input/output error");
+    expect(boundedAttempts).toBe(2);
   });
 
   it("fails closed when rollback is requested after the original worker is already active", () => {


### PR DESCRIPTION
## Outcome

Fixes the real installed-worker update/rollback activation failure observed under #699 when macOS returns transient `launchctl bootstrap` error 5 while the prior exact service is still tearing down.

The installer now retries only that exact transient error on a bounded schedule (250 ms, 750 ms, 2 s, 5 s, 10 s). It still stops immediately for every other bootstrap error, ambiguous service inspection, or exhaustion.

## Acceptance criteria

- failing-first test reproduces transient bootstrap I/O errors while the exact prior service transitions from loaded to unloaded
- update and recovery use the same bounded retry
- unrelated bootstrap errors are never retried
- retry exhaustion fails closed
- existing LaunchAgent label, working directory, config path, environment, credentials, provider state, repository allowlist, worker pointer, and rollback state remain governed by the existing installer contract
- real owner-path update → rollback → reupdate succeeds against the immutable beta.27 payload

## Evidence

- RED: focused installer suite failed because the retry seam did not exist; after the first correction, it failed again when the real service still reported loaded during teardown
- GREEN: `npx vitest run tests/b0-worker-installer.test.ts` — 10/10
- `node --check scripts/install-b0-worker-candidate.mjs`
- `node --check scripts/lib/b0-worker-installer.mjs`
- `git diff --check`
- real installed path:
  - original source-checkout worker restored after the observed failed activation
  - live beta.27 update passed with `restarted:true`
  - live rollback to the original worker passed with `restarted:true`
  - live beta.27 reupdate passed with `restarted:true`
  - final worker: `1.1.0-beta.27`, candidate `089c4e5f7e95c5edbf089f465781956e8a8f1702`
  - original LaunchAgent label, working directory, config path, and credential references were preserved

## Non-goals

No billing, checkout, website, public download, npm publication, tag, GitHub Release, app signing/notarization, Sparkle/appcast, B1 managed GitHub App, broader #517 work, or beta/release/customer-readiness claim. This does not close #699; installed-app Retry Worker Check and UI dry/live review remain.

Related to #699.
