### PR TITLE
Fix installed worker discovery after B0 update

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -18,12 +18,20 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
             .appendingPathComponent("\(label).plist")
             .standardizedFileURL
+        let installedWorkerRoot = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(
+                "Library/Application Support/NeonDiffDesktop/Workers",
+                isDirectory: true
+            )
+            .appendingPathComponent(label, isDirectory: true)
+            .standardizedFileURL
         guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe) else {
             return Snapshot(configurations: [], executionContexts: [])
         }
         let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
             data: data,
             expectedLabel: label,
+            installedWorkerRoot: installedWorkerRoot,
             configExists: { fileManager.fileExists(atPath: $0.path) },
             workingDirectoryExists: {
                 var isDirectory: ObjCBool = false
@@ -36,6 +44,7 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
         let context = DesktopLaunchAgentExecutionContextParser.parse(
             data: data,
             expectedLabel: label,
+            installedWorkerRoot: installedWorkerRoot,
             privateKeyPathIsSafe: { url in
                 isSafePrivateKeyFile(url, fileManager: fileManager)
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -105,6 +105,7 @@ package enum DesktopLaunchAgentBotConfigurationParser {
     package static func parse(
         data: Data,
         expectedLabel: String,
+        installedWorkerRoot: URL? = nil,
         configExists: (URL) -> Bool,
         workingDirectoryExists: (URL) -> Bool
     ) -> DesktopLocalBotConfiguration? {
@@ -126,7 +127,8 @@ package enum DesktopLaunchAgentBotConfigurationParser {
             .standardizedFileURL
         guard approvedNeonDiffDaemonInvocation(
             arguments,
-            workingDirectory: workingDirectoryURL
+            workingDirectory: workingDirectoryURL,
+            installedWorkerRoot: installedWorkerRoot
         ) else {
             return nil
         }
@@ -197,6 +199,7 @@ package enum DesktopLaunchAgentExecutionContextParser {
     package static func parse(
         data: Data,
         expectedLabel: String,
+        installedWorkerRoot: URL? = nil,
         privateKeyPathIsSafe: (URL) -> Bool
     ) -> DesktopLocalBotExecutionContext? {
         guard let propertyList = try? PropertyListSerialization.propertyList(
@@ -217,7 +220,8 @@ package enum DesktopLaunchAgentExecutionContextParser {
             .standardizedFileURL
         guard approvedNeonDiffDaemonInvocation(
             arguments,
-            workingDirectory: workingDirectoryURL
+            workingDirectory: workingDirectoryURL,
+            installedWorkerRoot: installedWorkerRoot
         ) else {
             return nil
         }
@@ -329,7 +333,8 @@ package enum DesktopLaunchAgentExecutionContextParser {
 
 private func approvedNeonDiffDaemonInvocation(
     _ arguments: [String],
-    workingDirectory: URL
+    workingDirectory: URL,
+    installedWorkerRoot: URL?
 ) -> Bool {
     guard !arguments.isEmpty else { return false }
     let executableName = URL(filePath: arguments[0]).lastPathComponent
@@ -357,8 +362,16 @@ private func approvedNeonDiffDaemonInvocation(
     let bundledCLI = workingDirectory
         .appendingPathComponent("dist/src/cli.js")
         .standardizedFileURL.path
-    return URL(filePath: arguments[1]).standardizedFileURL.path == bundledCLI
-        && arguments[2] == "daemon"
+    let candidateCLI = URL(filePath: arguments[1]).standardizedFileURL
+    guard arguments[2] == "daemon" else { return false }
+    if candidateCLI.path == bundledCLI {
+        return true
+    }
+    guard let installedWorkerRoot else { return false }
+    let installedCLI = installedWorkerRoot
+        .appendingPathComponent("current/node_modules/neondiff/dist/src/cli.js")
+        .standardizedFileURL
+    return candidateCLI == installedCLI
 }
 
 package enum DesktopLocalBotWorkingDirectoryResolver {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -293,6 +293,70 @@ import Testing
         ) == nil)
     }
 
+    @Test func acceptsOnlyTheExactInstallerManagedWorkerForTheKnownLabel() throws {
+        let label = "com.electricsheephq.evaos-code-review-bot"
+        let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let workerRoot = URL(filePath: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers")
+            .appendingPathComponent(label, isDirectory: true)
+            .standardizedFileURL
+        let workerCLI = workerRoot
+            .appendingPathComponent("current/node_modules/neondiff/dist/src/cli.js")
+            .standardizedFileURL
+        let arguments = [
+            "/opt/homebrew/bin/node",
+            workerCLI.path,
+            "daemon",
+            "--config",
+            configPath
+        ]
+        let data = try propertyList(
+            label: label,
+            environment: [
+                "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+            ],
+            arguments: arguments,
+            workingDirectory: workingDirectory
+        )
+
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: data,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot,
+            configExists: { $0.path == configPath },
+            workingDirectoryExists: { $0.path == workingDirectory }
+        ) == DesktopLocalBotConfiguration(
+            appID: 4_184_532,
+            configPath: configPath,
+            workingDirectory: workingDirectory
+        ))
+
+        let context = DesktopLaunchAgentExecutionContextParser.parse(
+            data: data,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot,
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        )
+        #expect(context?.executablePath == "/opt/homebrew/bin/node")
+        #expect(context?.argumentPrefix == [workerCLI.path])
+
+        #expect(DesktopLaunchAgentBotConfigurationParser.parse(
+            data: data,
+            expectedLabel: label,
+            configExists: { _ in true },
+            workingDirectoryExists: { _ in true }
+        ) == nil)
+        #expect(DesktopLaunchAgentExecutionContextParser.parse(
+            data: data,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot.deletingLastPathComponent()
+                .appendingPathComponent("other-label", isDirectory: true),
+            privateKeyPathIsSafe: { _ in true }
+        ) == nil)
+    }
+
     @Test func preservesTheAcceptedSourceRunnerInvocationForDesktopCommands() throws {
         let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
         let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"


### PR DESCRIPTION
Related: #699

Acceptance criteria:
- recognize only the exact installer-managed worker CLI beneath the known LaunchAgent labels private worker root
- preserve the existing config path, working directory, environment-backed App identity, and private-key safety checks
- restore the saved verified bot as THIS MAC after an update and app relaunch
- keep unsupported or sibling worker paths fail closed

Failing-first evidence:
- the new focused test initially failed to compile because installedWorkerRoot was not part of either parser contract
- after the bounded implementation, LaunchAgentLocalBotConfigurationTests passes 14 of 14
- git diff --check passes

Non-goals:
- no new onboarding or account design
- no credential migration or key access
- no broader LaunchAgent command acceptance
- no billing, signing, publication, release, or customer-readiness claim

Agent-authored change. Broad Swift and hosted app validation remains remote-CI owned.