### PR TITLE
canary: prove installed beta.30 dry and live review

### DIFF
--- a/tests/canaries/beta30-installed-review.ts
+++ b/tests/canaries/beta30-installed-review.ts
@@ -1,0 +1,14 @@
+/**
+ * Disposable beta.30 installed-app review canary.
+ *
+ * This branch must not merge. The unchecked lookup below is deliberate so the
+ * signed/notarized NeonDiff candidate has one bounded defect to find during the
+ * dry-review and exact-head live-review proof.
+ */
+export function selectedRepository(
+  repositories: Map<string, string>,
+  repositoryId: string,
+): string {
+  // Deliberate canary: reject an unknown repository before dereferencing it.
+  return repositories.get(repositoryId)!.trim();
+}


### PR DESCRIPTION
Disposable, non-merge canary for the exact signed/notarized NeonDiff 1.1.0 beta.30 build 11032 candidate.

Acceptance gate:
- installed `/Applications/NeonDiff.app` restores the existing local bot and 4/4 readiness;
- the app runs a dry review against this PR and returns this exact PR head;
- live posting is enabled only for that exact dry-reviewed head;
- the app posts one App/worker-authored live review that identifies the deliberate unchecked repository lookup;
- evidence records exact app identity, PR head, dry result, and live GitHub review.

Non-goals:
- do not merge this branch;
- do not expand product source, CI, schema, fixtures, or hardening;
- do not claim public/private matrix, billing, publication, customer canaries, or GA.

This PR will be closed unmerged after the bounded proof.