### PR TITLE
DO NOT MERGE: beta.30 native UI review canary

### DIFF
--- a/tests/canaries/beta30-ui-review.ts
+++ b/tests/canaries/beta30-ui-review.ts
@@ -5,6 +5,7 @@
  * signed/notarized NeonDiff candidate has one bounded defect to find when the
  * dry and live review sequence is initiated from the native app.
  * Beta 36 refreshes this disposable head without changing the canary defect.
+ * The installed-app pass runs while the background worker is briefly paused.
  */
 export function selectedRepository(
   repositories: Map<string, string>,

--- a/tests/canaries/beta30-ui-review.ts
+++ b/tests/canaries/beta30-ui-review.ts
@@ -1,0 +1,14 @@
+/**
+ * Disposable beta.30 installed-app UI review canary.
+ *
+ * This branch must not merge. The unchecked lookup below is deliberate so the
+ * signed/notarized NeonDiff candidate has one bounded defect to find when the
+ * dry and live review sequence is initiated from the native app.
+ */
+export function selectedRepository(
+  repositories: Map<string, string>,
+  repositoryId: string,
+): string {
+  // Deliberate canary: reject an unknown repository before dereferencing it.
+  return repositories.get(repositoryId)!.trim();
+}

--- a/tests/canaries/beta30-ui-review.ts
+++ b/tests/canaries/beta30-ui-review.ts
@@ -4,6 +4,7 @@
  * This branch must not merge. The unchecked lookup below is deliberate so the
  * signed/notarized NeonDiff candidate has one bounded defect to find when the
  * dry and live review sequence is initiated from the native app.
+ * Beta 36 refreshes this disposable head without changing the canary defect.
  */
 export function selectedRepository(
   repositories: Map<string, string>,

--- a/tests/canaries/beta30-ui-review.ts
+++ b/tests/canaries/beta30-ui-review.ts
@@ -4,7 +4,7 @@
  * This branch must not merge. The unchecked lookup below is deliberate so the
  * signed/notarized NeonDiff candidate has one bounded defect to find when the
  * dry and live review sequence is initiated from the native app.
- * Beta 36 refreshes this disposable head without changing the canary defect.
+ * Beta 37 refreshes this disposable head without changing the canary defect.
  * The installed-app pass runs while the background worker is briefly paused.
  */
 export function selectedRepository(


### PR DESCRIPTION
## Purpose

Disposable, never-merge canary for the signed/notarized beta.30 installed-app UI review path.

The one unchecked lookup is deliberate. NeonDiff should identify it when a dry review and the exact-head live review are initiated from the native app.

## Acceptance

- native app accepts this PR number
- native **Run Dry Review** completes against this exact head
- native **Post Live Review** then posts one App-authored review against the same head
- the review identifies the deliberate unchecked lookup
- no operator shell repair, credential edit, Keychain prompt, XCTest, or Accessibility reset is used

## Non-goals

- never merge this branch
- no product source change
- no billing, entitlement, release, appcast, or customer-readiness claim
- no generalized review harness or broader #517 matrix

Related: #699, #646, #610.
