### PR TITLE
Fix existing local-agent entitlement revalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ failure revokes that approval instead of permitting a blind retry. For that
 multi-repository worker, daemon-wide start remains blocked. The selection and
 dry-run approval fail closed if the config, target, pull request, workspace, or
 head changes.
+The same **Verify existing access** action then runs credential-free
+`license status --refresh true` through that exact matched worker and config.
+It does not read, copy, migrate, or prompt for the worker's Activation Key.
+Useful work unlocks only when GitHub reports the exact repository visibility
+and the live API response returns an active entitlement covering that
+visibility; missing, unknown, expired, revoked, malformed, or offline proof
+fails closed.
 During launch it shows a bounded restoring state while that authorized
 account/bot/config intersection is checked; it does not flash empty first-run
 setup or claim that the existing configuration is missing.

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -135,15 +135,24 @@ struct ActivationStateView: View {
                 .font(NDFont.label)
                 .foregroundStyle(palette.warning)
 
-            Text("NeonDiff still blocks new work until the exact GitHub App and repository access are reverified for this launch.")
+            Text("NeonDiff still blocks new work until the exact GitHub App, repository, and API-backed entitlement are reverified for this launch.")
                 .font(NDFont.mono)
                 .foregroundStyle(palette.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Button("Review repository access") {
-                model.reviewExistingBotRepositoryAccess()
+            Button(
+                model.existingLocalAgentAccessAvailable
+                    ? "Verify existing access"
+                    : "Review repository access"
+            ) {
+                if model.existingLocalAgentAccessAvailable {
+                    model.verifyExistingLocalBotGitHubAccess()
+                } else {
+                    model.reviewExistingBotRepositoryAccess()
+                }
             }
             .buttonStyle(NDBracketButtonStyle())
+            .disabled(model.isBYOGitHubVerificationInProgress)
             .accessibilityIdentifier("neondiff.activation.existing-account-reverify")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -167,7 +176,9 @@ struct ActivationStateView: View {
             )
             switch model.activationState {
             case .purchaseRequired:
-                existingAccountActivationRecovery(palette: palette)
+                if !model.existingLocalAgentAccessAvailable {
+                    existingAccountActivationRecovery(palette: palette)
+                }
             case .active:
                 EmptyView()
             default:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -182,7 +182,9 @@ struct ActivationStateView: View {
             case .active:
                 EmptyView()
             default:
-                activationFlow(palette: palette)
+                if !model.existingLocalAgentAccessAvailable {
+                    activationFlow(palette: palette)
+                }
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -379,10 +379,10 @@ struct ReposView: View {
                 if model.byoGitHubCredentialOnboardingAvailable {
                     HStack(spacing: 10) {
                         OperatorBadge(
-                            text: model.byoGitHubCredentialsVerified
+                            text: model.existingLocalBotCurrentAccessVerified
                                 ? "CURRENT ACCESS VERIFIED"
                                 : "CURRENT ACCESS REQUIRED",
-                            color: model.byoGitHubCredentialsVerified
+                            color: model.existingLocalBotCurrentAccessVerified
                                 ? NeonDiffTheme.accent
                                 : NeonDiffTheme.warning
                         )
@@ -390,7 +390,7 @@ struct ReposView: View {
                             Label(
                                 model.isBYOGitHubVerificationInProgress
                                     ? "Verifying…"
-                                    : "Verify Existing App Access",
+                                    : "Verify Existing Access",
                                 systemImage: "checkmark.shield"
                             )
                         }
@@ -404,7 +404,7 @@ struct ReposView: View {
                     Text(model.existingLocalBotBYOGitHubVerificationStatus)
                     .font(.caption)
                     .foregroundStyle(
-                        model.byoGitHubCredentialsVerified
+                        model.existingLocalBotCurrentAccessVerified
                             ? NeonDiffTheme.accent
                             : NeonDiffTheme.warning
                     )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -467,6 +467,7 @@ package enum DesktopLocalBotExecutionContextResolver {
                 return credentialCommand
                     || reviewHelpCommand
                     || Array(arguments.prefix(2)) == ["config", "inspect"]
+                    || Array(arguments.prefix(2)) == ["license", "status"]
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -360,7 +360,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
-            guard byoGitHubCredentialOnboardingAvailable,
+            guard existingLocalBotIdentityReady,
+                  selectedAccountEntitlementSupportsCurrentPath,
+                  byoGitHubCredentialOnboardingAvailable,
                   byoGitHubCredentialsVerified,
                   repositoryConfigurationReady,
                   currentRepositoryActivationReady,
@@ -1456,6 +1458,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
         if let selectedAccountID = accountWorkspaceSelection.accountID,
            let selectedAccount = catalog.accounts.first(where: { $0.id == selectedAccountID }) {
+            let selectedAuthorityChanged =
+                previousSelectedAccount?.hasSameAuthority(as: selectedAccount)
+                    != true
+            if selectedAuthorityChanged {
+                resetWorkspaceBoundRuntimeState()
+            }
             if let selectedBotID = accountWorkspaceSelection.botID {
                 if let pendingNewBotPlan,
                    pendingNewBotPlan.accountID == selectedAccountID,
@@ -1475,8 +1483,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     accountWorkspaceStatus = "The selected bot is no longer authorized. Choose another bot or create a new one."
                     return
                 }
-                if previousSelectedBot?.localConfigPath != selectedBot.localConfigPath {
-                    resetWorkspaceBoundRuntimeState()
+                if selectedAuthorityChanged
+                    || previousSelectedBot?.localConfigPath
+                        != selectedBot.localConfigPath
+                {
+                    if !selectedAuthorityChanged {
+                        resetWorkspaceBoundRuntimeState()
+                    }
                     if let localConfigPath = selectedBot.localConfigPath {
                         configPath = localConfigPath
                         inspectConfig(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -360,9 +360,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
-            guard existingLocalBotIdentityReady,
-                  selectedAccountEntitlementSupportsCurrentPath,
-                  byoGitHubCredentialOnboardingAvailable,
+            if existingLocalBotReconciliationMode {
+                guard selectedAccountEntitlementSupportsCurrentPath else {
+                    return false
+                }
+            }
+            guard byoGitHubCredentialOnboardingAvailable,
                   byoGitHubCredentialsVerified,
                   repositoryConfigurationReady,
                   currentRepositoryActivationReady,
@@ -3498,13 +3501,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 "GitHub access was verified, but current entitlement verification was cancelled safely."
             return
         }
-        if currentRepositoryActivationReady {
-            isBYOGitHubVerificationInProgress = false
-            byoGitHubCredentialStatus =
-                "Verified existing local agent App access and API-backed entitlement for \(repository)."
-            return
-        }
-
         applyActivationEvent(.verifyExistingEntitlement)
         guard activationState == .activationPending else {
             isBYOGitHubVerificationInProgress = false
@@ -3544,9 +3540,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     standardInput: nil,
                     timeout: 20
                 )
-                outcome = result.exitCode == 0
-                    ? CLIActivationLicenseClient.classify(stdout: result.stdout)
-                    : .serviceError
+                outcome = result.stdout.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                ).isEmpty
+                    ? .serviceError
+                    : CLIActivationLicenseClient.classify(
+                        stdout: result.stdout
+                    )
             } catch let error as NeonDiffCLIError {
                 switch error {
                 case .timedOut, .cancelled, .cleanupTimedOut:
@@ -3560,14 +3560,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
             await MainActor.run {
                 guard activationGeneration
-                        == self.activationRequestGeneration,
-                      self.workspaceContextGeneration
+                        == self.activationRequestGeneration
+                else {
+                    return
+                }
+                guard self.workspaceContextGeneration
                         == expectedWorkspaceGeneration,
                       self.cliPath == expectedCLIPath,
                       self.configPath == expectedConfigPath,
                       self.selectedReviewRepository?
                         .caseInsensitiveCompare(repository) == .orderedSame
                 else {
+                    self.isBYOGitHubVerificationInProgress = false
+                    self.applyActivationEvent(.activationServiceError)
+                    self.lastError =
+                        "The local worker, config, or Review Target changed before entitlement verification finished."
+                    self.byoGitHubCredentialStatus =
+                        "GitHub access was verified, but stale entitlement proof was discarded. Verify existing access again."
                     return
                 }
                 self.isBYOGitHubVerificationInProgress = false
@@ -3606,6 +3615,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case "public":
             guard summary.repoVisibilityScope == "all"
                     || summary.repoVisibilityScope == "public"
+                    || summary.repoVisibilityScope == "private"
             else {
                 return .scopeConflict
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -536,6 +536,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return storedAppID == String(bot.appID)
     }
 
+    package var existingLocalBotCurrentAccessVerified: Bool {
+        existingLocalAgentAccessAvailable
+            && byoGitHubCredentialsVerified
+            && currentRepositoryActivationReady
+    }
+
     package var existingLocalAgentAccessAvailable: Bool {
         guard existingLocalBotIdentityReady,
               byoGitHubCredentialOnboardingAvailable,
@@ -566,7 +572,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         if existingLocalAgentAccessAvailable {
             return byoGitHubCredentialsVerified
-                ? "Verified through the existing local agent for this launch."
+                ? byoGitHubCredentialStatus
                 : "The exact existing local agent is ready for current-access verification. Its private key will not be copied or printed."
         }
         if cliPath != "neondiff" {
@@ -3448,6 +3454,156 @@ package final class NeonDiffDesktopModel: ObservableObject {
         logText = expectedContext.source == .existingLocalAgent
             ? "Existing local agent GitHub App installation and repository access verified. No credential was copied and no review was executed or posted."
             : "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
+
+        if expectedContext.source == .existingLocalAgent,
+           let readCheck = report.github.readChecks.first
+        {
+            verifyExistingLocalAgentEntitlement(
+                expectedContext: expectedContext,
+                visibility: readCheck.visibilityResult
+            )
+        }
+    }
+
+    private func verifyExistingLocalAgentEntitlement(
+        expectedContext: BYOGitHubVerificationContext,
+        visibility: String?
+    ) {
+        guard existingLocalAgentAccessAvailable,
+              existingLocalBotIdentityReady,
+              selectedAccountEntitlementSupportsCurrentPath,
+              expectedContext.source == .existingLocalAgent,
+              expectedContext.repositories.count == 1,
+              let repository = expectedContext.repositories.first,
+              selectedReviewRepository?.caseInsensitiveCompare(repository)
+                  == .orderedSame
+        else {
+            isBYOGitHubVerificationInProgress = false
+            lastError =
+                "The existing account, local agent, or Review Target changed before entitlement verification."
+            byoGitHubCredentialStatus =
+                "GitHub access was verified, but current entitlement verification was cancelled safely."
+            return
+        }
+        if currentRepositoryActivationReady {
+            isBYOGitHubVerificationInProgress = false
+            byoGitHubCredentialStatus =
+                "Verified existing local agent App access and API-backed entitlement for \(repository)."
+            return
+        }
+
+        applyActivationEvent(.verifyExistingEntitlement)
+        guard activationState == .activationPending else {
+            isBYOGitHubVerificationInProgress = false
+            lastError =
+                "Finish or cancel the current activation attempt before verifying the existing local agent."
+            byoGitHubCredentialStatus =
+                "GitHub access was verified, but entitlement verification could not start."
+            return
+        }
+
+        activationRequestGeneration &+= 1
+        let activationGeneration = activationRequestGeneration
+        let expectedWorkspaceGeneration = workspaceContextGeneration
+        let expectedCLIPath = cliPath
+        let expectedConfigPath = configPath
+        let executablePath = cliPath
+        let cli = dependencies.cli
+        let arguments = [
+            "license", "status",
+            "--config", configPath,
+            "--repo", repository,
+            "--refresh", "true",
+            "--json"
+        ]
+        isBYOGitHubVerificationInProgress = true
+        byoGitHubCredentialStatus =
+            "GitHub access verified. Checking the existing local agent's API-backed entitlement…"
+        lastCommandLine =
+            "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true --json"
+
+        Task.detached {
+            let outcome: ActivationClientOutcome
+            do {
+                let result = try await cli.run(
+                    executablePath: executablePath,
+                    arguments: arguments,
+                    standardInput: nil,
+                    timeout: 20
+                )
+                outcome = result.exitCode == 0
+                    ? CLIActivationLicenseClient.classify(stdout: result.stdout)
+                    : .serviceError
+            } catch let error as NeonDiffCLIError {
+                switch error {
+                case .timedOut, .cancelled, .cleanupTimedOut:
+                    outcome = .offline
+                case .launchFailed, .standardInputTooLarge, .outputTooLarge:
+                    outcome = .serviceError
+                }
+            } catch {
+                outcome = .offline
+            }
+
+            await MainActor.run {
+                guard activationGeneration
+                        == self.activationRequestGeneration,
+                      self.workspaceContextGeneration
+                        == expectedWorkspaceGeneration,
+                      self.cliPath == expectedCLIPath,
+                      self.configPath == expectedConfigPath,
+                      self.selectedReviewRepository?
+                        .caseInsensitiveCompare(repository) == .orderedSame
+                else {
+                    return
+                }
+                self.isBYOGitHubVerificationInProgress = false
+                let resolved =
+                    self.resolveExistingLocalAgentEntitlementOutcome(
+                        outcome,
+                        visibility: visibility
+                    )
+                self.applyActivationEvent(
+                    ActivationLicenseOutcomeMapping.event(for: resolved)
+                )
+                self.applyActivationOutcomeSideEffects(
+                    resolved,
+                    repository: repository,
+                    activeLogMessage:
+                        "Current repository entitlement verified through the existing local agent. No Activation Key was copied."
+                )
+                switch resolved {
+                case .active:
+                    self.byoGitHubCredentialStatus =
+                        "Verified existing local agent App access and API-backed entitlement for \(repository)."
+                default:
+                    self.byoGitHubCredentialStatus =
+                        "GitHub access is verified, but the existing local agent did not return an active entitlement for \(repository)."
+                }
+            }
+        }
+    }
+
+    private func resolveExistingLocalAgentEntitlementOutcome(
+        _ outcome: ActivationClientOutcome,
+        visibility: String?
+    ) -> ActivationClientOutcome {
+        guard case let .active(summary) = outcome else { return outcome }
+        switch visibility?.lowercased() {
+        case "public":
+            guard summary.repoVisibilityScope == "all"
+                    || summary.repoVisibilityScope == "public"
+            else {
+                return .scopeConflict
+            }
+        case "private", "internal":
+            guard summary.coversPrivateRepos else {
+                return .scopeConflict
+            }
+        default:
+            return .scopeConflict
+        }
+        return outcome
     }
 
     private func invalidateBYOGitHubVerificationContext() {
@@ -3946,7 +4102,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func applyActivationOutcomeSideEffects(
         _ outcome: ActivationClientOutcome,
-        repository: String?
+        repository: String?,
+        activeLogMessage: String? = nil
     ) {
         switch outcome {
         case .active(let summary):
@@ -3966,7 +4123,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             let scope = summary.repoVisibilityScope
             let plan = summary.plan.map { " · \($0)" } ?? ""
             license.entitlement = "active (\(scope)\(plan))"
-            logText = "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
+            logText = activeLogMessage
+                ?? "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
             activationVerifiedRepositoryThisLaunch = repository
             if let repository {
                 dependencies.preferences.set(repository, forKey: activationRepositoryKey)
@@ -5675,6 +5833,7 @@ private struct BYOGitHubDoctorReport: Decodable {
     struct ReadCheck: Decodable {
         let repo: String
         let ok: Bool
+        let visibilityResult: String?
         let skippedByPolicy: String?
         let installationIdPresent: Bool
         let appCanReadMetadata: Bool
@@ -5683,6 +5842,7 @@ private struct BYOGitHubDoctorReport: Decodable {
         enum CodingKeys: String, CodingKey {
             case repo
             case ok
+            case visibilityResult = "visibility_result"
             case skippedByPolicy
             case installationIdPresent = "installation_id_present"
             case appCanReadMetadata = "app_can_read_metadata"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -58,6 +58,9 @@ public enum ActivationEvent: String, CaseIterable, Sendable, Hashable {
     case checkoutCompleted
     case checkoutCancelled
     case provideExistingKey
+    /// Revalidate an exact existing local agent's stored entitlement without
+    /// copying its Activation Key into the native app.
+    case verifyExistingEntitlement
     case submitActivation
     case activationSucceeded
     case activationInvalid
@@ -114,9 +117,11 @@ public enum ActivationStateMachine {
         case (.purchaseRequired, .beginCheckout): return .checkoutPending
         case (.purchaseRequired, .checkoutUnavailable): return .checkoutPaused
         case (.purchaseRequired, .provideExistingKey): return .keyReady
+        case (.purchaseRequired, .verifyExistingEntitlement): return .activationPending
         case (.purchaseRequired, .choosePublicPath): return .publicFreeSkip
 
         case (.checkoutPaused, .provideExistingKey): return .keyReady
+        case (.checkoutPaused, .verifyExistingEntitlement): return .activationPending
         case (.checkoutPaused, .checkoutCompleted): return .keyReady
         case (.checkoutPaused, .checkoutCancelled): return .purchaseRequired
         case (.checkoutPaused, .resetToPurchase): return .purchaseRequired
@@ -127,6 +132,7 @@ public enum ActivationStateMachine {
         case (.checkoutPending, .activationOffline): return .offline
 
         case (.keyReady, .submitActivation): return .activationPending
+        case (.keyReady, .verifyExistingEntitlement): return .activationPending
         case (.keyReady, .resetToPurchase): return .purchaseRequired
 
         case (.activationPending, .activationSucceeded): return .active
@@ -145,20 +151,26 @@ public enum ActivationStateMachine {
         case (.active, .activationRevoked): return .revoked
         case (.active, .activationInvalid): return .invalid
         case (.active, .activationOffline): return .offline
+        case (.active, .verifyExistingEntitlement): return .activationPending
 
         case (.invalid, .reenterKey): return .keyReady
+        case (.invalid, .verifyExistingEntitlement): return .activationPending
         case (.invalid, .resetToPurchase): return .purchaseRequired
 
         case (.expired, .renew): return .purchaseRequired
         case (.expired, .provideExistingKey): return .keyReady
+        case (.expired, .verifyExistingEntitlement): return .activationPending
 
         case (.revoked, .renew): return .purchaseRequired
+        case (.revoked, .verifyExistingEntitlement): return .activationPending
 
         case (.offline, .retry): return .activationPending
         case (.offline, .reenterKey): return .keyReady
+        case (.offline, .verifyExistingEntitlement): return .activationPending
 
         case (.serviceError, .retry): return .activationPending
         case (.serviceError, .reenterKey): return .keyReady
+        case (.serviceError, .verifyExistingEntitlement): return .activationPending
 
         case (.publicFreeSkip, .choosePrivatePath): return .purchaseRequired
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ActivationLicenseClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ActivationLicenseClient.swift
@@ -204,10 +204,13 @@ public final class CLIActivationLicenseClient: ActivationLicenseClienting, @unch
 
         switch status {
         case "active":
-            let summary = parseEntitlement(root["entitlement"]) ?? ActivationEntitlementSummary(
-                status: .active, repoVisibilityScope: "all", privateRepoAllowed: nil,
-                updateEntitlement: false, expiresAt: nil, plan: nil, seats: nil
-            )
+            guard root["ok"] as? Bool == true,
+                  root["source"] as? String == "api",
+                  let summary = parseEntitlement(root["entitlement"]),
+                  summary.status == .active
+            else {
+                return .serviceError
+            }
             return .active(summary)
         case "expired":
             return .expired(parseEntitlement(root["entitlement"]))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -217,6 +217,41 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
+    @Test func cleanInstallBYOUnlocksAfterExactSetupAndActivation() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(doctorResult(
+                    readChecks: doctorReadCheck(repo: "acme/demo")
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: byoRepoPatchJSON(repository: "acme/demo"),
+                    stderr: ""
+                ))
+            ],
+            activationLicenseClient: ActiveBYOActivationClient(),
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.selectBYOReviewRepository(fullName: "acme/demo")
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+
+        #expect(fixture.model.selectedAccountWorkspace == nil)
+        #expect(fixture.model.selectedBotInstallation == nil)
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.productionUsefulWorkAvailable)
+    }
+
     @Test func verificationFailsClosedUnlessDoctorChecksExactlyMatchEnabledRepositories() async throws {
         struct Scenario {
             let name: String
@@ -456,6 +491,24 @@ private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: 
     "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
     "NeonDiffBYOGitHubEnabled": true
 ])
+
+private struct ActiveBYOActivationClient: ActivationLicenseClienting {
+    func activate(key _: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        .active(ActivationEntitlementSummary(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "fixture-paid",
+            seats: 1
+        ))
+    }
+
+    func revalidate(key _: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
+        .serviceError
+    }
+}
 
 private let fixturePrivateKeyLabel = "PRIVATE" + " KEY"
 private let fixturePrivateKey = """

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -780,6 +780,17 @@ import NeonDiffDesktopCore
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
                     stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: """
+                    {"command":"license status","ok":true,"status":"active","source":"api",
+                     "checkedAt":"2026-07-29T00:00:00.000Z",
+                     "entitlement":{"status":"active","repoVisibilityScope":"all",
+                     "privateRepoAllowed":true,"updateEntitlement":true,
+                     "plan":"internal-owner-recovery","seats":1}}
+                    """,
+                    stderr: ""
                 ))
             ],
             suspendCLIRuns: true,
@@ -816,26 +827,44 @@ import NeonDiffDesktopCore
         #expect(fixture.model.byoGitHubAppIdStored)
         #expect(fixture.model.byoGitHubPrivateKeyStored)
 
+        // Relaunch restores the persisted state but not this launch's live
+        // entitlement proof. Existing-agent verification must refresh it.
+        fixture.model.activationState = .active
+        #expect(!fixture.model.currentRepositoryActivationReady)
+
         fixture.model.verifyExistingLocalBotGitHubAccess()
         await fixture.cli.waitUntilCallCount(3)
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
 
-        let call = try #require(fixture.cli.calls.last)
-        #expect(call.arguments == [
+        #expect(fixture.cli.calls.count == 4)
+        let githubCall = fixture.cli.calls[2]
+        #expect(githubCall.arguments == [
             "doctor", "github",
             "--config", configPath,
             "--repo", targetRepository,
             "--json"
         ])
-        #expect(call.standardInput == nil)
-        #expect(call.timeout == 150)
+        #expect(githubCall.standardInput == nil)
+        #expect(githubCall.timeout == 150)
+        let entitlementCall = try #require(fixture.cli.calls.last)
+        #expect(entitlementCall.arguments == [
+            "license", "status",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--refresh", "true",
+            "--json"
+        ])
+        #expect(entitlementCall.standardInput == nil)
         #expect(fixture.model.repos.filter(\.enabled).count == 2)
         #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.activationState == .active)
+        #expect(fixture.model.productionUsefulWorkAvailable)
         #expect(
             fixture.model.existingLocalBotBYOGitHubVerificationStatus
-                .contains("existing local agent")
+                .contains("entitlement")
         )
 
         fixture.model.cliPath = "/tmp/untrusted-neondiff"
@@ -892,6 +921,87 @@ import NeonDiffDesktopCore
         fixture.model.verifyExistingLocalBotGitHubAccess()
         #expect(fixture.model.lastError == diagnosis)
         #expect(fixture.model.byoGitHubCredentialStatus == diagnosis)
+    }
+
+    @MainActor
+    @Test func privateRepositoryRejectsPublicOnlyExistingAgentEntitlement() async throws {
+        let targetRepository =
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [targetRepository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: """
+                    {"command":"license status","ok":true,"status":"active","source":"api",
+                     "checkedAt":"2026-07-29T00:00:00.000Z",
+                     "entitlement":{"status":"active","repoVisibilityScope":"public",
+                     "privateRepoAllowed":false,"updateEntitlement":false,
+                     "plan":"public-free","seats":1}}
+                    """,
+                    stderr: ""
+                ))
+            ],
+            suspendCLIRuns: true,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            localBotExecutionConfigPaths: [configPath],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(1)
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20
+            where fixture.model.localWorkerReviewCompatibility == .checking
+        {
+            await Task.yield()
+        }
+        fixture.model.selectBYOReviewRepository(fullName: targetRepository)
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(4)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+        #expect(!fixture.model.existingLocalBotCurrentAccessVerified)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.activationState == .invalid)
+        #expect(
+            fixture.model.lastError?.contains("does not cover private")
+                == true
+        )
     }
 
     @MainActor

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -867,6 +867,16 @@ import NeonDiffDesktopCore
                 .contains("entitlement")
         )
 
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .none)
+        ]))
+        #expect(!fixture.model.currentRepositoryActivationReady)
+        #expect(!fixture.model.existingLocalBotCurrentAccessVerified)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
         fixture.model.cliPath = "/tmp/untrusted-neondiff"
         #expect(!fixture.model.existingLocalAgentAccessAvailable)
         #expect(!fixture.model.byoGitHubCredentialsVerified)
@@ -921,6 +931,102 @@ import NeonDiffDesktopCore
         fixture.model.verifyExistingLocalBotGitHubAccess()
         #expect(fixture.model.lastError == diagnosis)
         #expect(fixture.model.byoGitHubCredentialStatus == diagnosis)
+    }
+
+    @MainActor
+    @Test func authorityDowngradeDropsInFlightExistingAgentEntitlement() async throws {
+        let targetRepository =
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [targetRepository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: """
+                    {"command":"license status","ok":true,"status":"active","source":"api",
+                     "checkedAt":"2026-07-29T00:00:00.000Z",
+                     "entitlement":{"status":"active","repoVisibilityScope":"all",
+                     "privateRepoAllowed":true,"updateEntitlement":true,
+                     "plan":"internal-owner-recovery","seats":1}}
+                    """,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [targetRepository]
+                    ),
+                    stderr: ""
+                ))
+            ],
+            suspendCLIRuns: true,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            localBotExecutionConfigPaths: [configPath],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(1)
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20
+            where fixture.model.localWorkerReviewCompatibility == .checking
+        {
+            await Task.yield()
+        }
+        fixture.model.selectBYOReviewRepository(fullName: targetRepository)
+        fixture.model.activationState = .active
+
+        fixture.cli.suspendFutureRuns()
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(3)
+        fixture.cli.resumeNextSuspendedRun()
+        await fixture.cli.waitUntilCallCount(4)
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .none)
+        ]))
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20
+            where fixture.model.isBYOGitHubVerificationInProgress
+                || fixture.model.isConfigInspectInProgress
+        {
+            await Task.yield()
+        }
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+        #expect(!fixture.model.existingLocalBotCurrentAccessVerified)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
     @MainActor

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -699,6 +699,10 @@ import NeonDiffDesktopCore
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"electricsheephq/evaos-code-review-bot-neondiff","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
+                .success(existingAgentLicenseStatus(
+                    scope: "private",
+                    privateRepoAllowed: true
+                )),
                 .success(CLIRunResult(
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff","pullNumber":699,"headSha":"\#(headSHA)","url":"https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/699"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
@@ -729,7 +733,7 @@ import NeonDiffDesktopCore
         fixture.model.provideExistingActivationKey()
         await fixture.model.submitActivation()
         fixture.model.verifyExistingLocalBotGitHubAccess()
-        await fixture.cli.waitUntilCallCount(3)
+        #expect(await reachesCallCount(fixture, 4))
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
@@ -738,7 +742,7 @@ import NeonDiffDesktopCore
         fixture.cli.suspendFutureRuns()
         fixture.model.pendingReviewPullNumber = "699"
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(4)
+        await fixture.cli.waitUntilCallCount(5)
         fixture.model.cliPath = "/fixture/bin/neondiff-updated"
         fixture.cli.resumeSuspendedRuns()
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
@@ -957,6 +961,10 @@ import NeonDiffDesktopCore
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
+                .success(existingAgentLicenseStatus(
+                    scope: "private",
+                    privateRepoAllowed: true
+                )),
                 .success(CLIRunResult(
                     exitCode: 0,
                     stdout: """
@@ -1111,6 +1119,108 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func publicRepositoryAcceptsPrivateExistingAgentEntitlement() async throws {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "public",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            )
+        )
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(4)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func nonzeroStructuredExistingAgentStatusKeepsTypedExpiredState() async throws {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: CLIRunResult(
+                exitCode: 1,
+                stdout: """
+                {"command":"license status","ok":false,"status":"expired","source":"api",
+                 "checkedAt":"2026-07-29T00:00:00.000Z",
+                 "entitlement":{"status":"expired","repoVisibilityScope":"private",
+                 "privateRepoAllowed":true,"updateEntitlement":false,
+                 "plan":"fixture-paid","seats":1}}
+                """,
+                stderr: ""
+            )
+        )
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(4)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.model.activationState == .expired)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+    }
+
+    @MainActor
+    @Test func exactWorkerStatusRefreshRunsEvenAfterNativeActivation() async throws {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            ),
+            activationLicenseClient: ExistingBotActiveActivationClient()
+        )
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+        #expect(fixture.model.currentRepositoryActivationReady)
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        for _ in 0..<20 where fixture.cli.calls.count < 4 {
+            await Task.yield()
+        }
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(fixture.cli.calls.count == 4)
+        #expect(fixture.cli.calls.last?.arguments.first == "license")
+        #expect(fixture.model.currentRepositoryActivationReady)
+    }
+
+    @MainActor
+    @Test func staleExactWorkerStatusClearsOwnedProgressState() async throws {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            )
+        )
+        fixture.cli.suspendFutureRuns()
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(3)
+        fixture.cli.resumeNextSuspendedRun()
+        await fixture.cli.waitUntilCallCount(4)
+        #expect(fixture.model.isBYOGitHubVerificationInProgress)
+
+        fixture.model.cliPath = "/fixture/bin/replaced-neondiff"
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(!fixture.model.isBYOGitHubVerificationInProgress)
+        #expect(fixture.model.activationState != .activationPending)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+    }
+
+    @MainActor
     @Test func selectedTargetUnlocksScopedReviewButNotMultiRepoDaemonStart() async throws {
         let targetRepository = "electricsheephq/evaos-code-review-bot-neondiff"
         let otherRepository = "electricsheephq/WorldOS"
@@ -1139,6 +1249,10 @@ import NeonDiffDesktopCore
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
+                )),
+                .success(existingAgentLicenseStatus(
+                    scope: "private",
+                    privateRepoAllowed: true
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
@@ -1211,7 +1325,7 @@ import NeonDiffDesktopCore
         fixture.model.provideExistingActivationKey()
         await fixture.model.submitActivation()
         fixture.model.verifyExistingLocalBotGitHubAccess()
-        await fixture.cli.waitUntilCallCount(3)
+        await fixture.cli.waitUntilCallCount(4)
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
@@ -1227,7 +1341,7 @@ import NeonDiffDesktopCore
 
         fixture.model.pendingReviewPullNumber = "685"
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(4)
+        #expect(await reachesCallCount(fixture, 5))
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -1236,7 +1350,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
 
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(5)
+        #expect(await reachesCallCount(fixture, 6))
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -1245,7 +1359,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedLiveReviewConfirmationAvailable)
 
         fixture.model.runScopedLiveReview()
-        await fixture.cli.waitUntilCallCount(6)
+        #expect(await reachesCallCount(fixture, 7))
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -1254,7 +1368,7 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
 
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(7)
+        #expect(await reachesCallCount(fixture, 8))
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -1264,30 +1378,30 @@ import NeonDiffDesktopCore
             repositories: [otherRepository, targetRepository],
             revision: String(repeating: "b", count: 64)
         ))
-        await fixture.cli.waitUntilCallCount(8)
+        #expect(await reachesCallCount(fixture, 9))
         for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
             await Task.yield()
         }
         #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
         fixture.model.runScopedLiveReview()
         await Task.yield()
-        #expect(fixture.cli.calls.count == 8)
+        #expect(fixture.cli.calls.count == 9)
 
         fixture.loadConfig(existingBotConfig(
             authMode: "zcode-app-config",
             repositories: [otherRepository, targetRepository]
         ))
-        await fixture.cli.waitUntilCallCount(9)
+        #expect(await reachesCallCount(fixture, 10))
         for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
             await Task.yield()
         }
         fixture.model.runScopedDryReview()
-        await fixture.cli.waitUntilCallCount(10)
+        #expect(await reachesCallCount(fixture, 11))
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
         fixture.model.runScopedLiveReview()
-        await fixture.cli.waitUntilCallCount(11)
+        #expect(await reachesCallCount(fixture, 12))
         for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
             await Task.yield()
         }
@@ -1589,6 +1703,93 @@ import NeonDiffDesktopCore
         #expect(!fixture.model.licenseSetupReady)
         #expect(!fixture.model.existingLocalBotSetupReady)
         #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    private func preparedExistingAgentVerificationFixture(
+        visibility: String,
+        licenseResult: CLIRunResult,
+        activationLicenseClient: (any ActivationLicenseClienting)? = nil
+    ) async -> ModelDependencyFixture {
+        let targetRepository =
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [targetRepository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"\#(visibility)","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stderr: ""
+                )),
+                .success(licenseResult)
+            ],
+            activationLicenseClient: activationLicenseClient,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            localBotExecutionConfigPaths: [configPath],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        await fixture.cli.waitUntilCallCount(2)
+        for _ in 0..<20
+            where fixture.model.localWorkerReviewCompatibility == .checking
+        {
+            await Task.yield()
+        }
+        fixture.model.selectBYOReviewRepository(fullName: targetRepository)
+        return fixture
+    }
+
+    private func existingAgentLicenseStatus(
+        scope: String,
+        privateRepoAllowed: Bool
+    ) -> CLIRunResult {
+        CLIRunResult(
+            exitCode: 0,
+            stdout: """
+            {"command":"license status","ok":true,"status":"active","source":"api",
+             "checkedAt":"2026-07-29T00:00:00.000Z",
+             "entitlement":{"status":"active","repoVisibilityScope":"\(scope)",
+             "privateRepoAllowed":\(privateRepoAllowed),"updateEntitlement":true,
+             "plan":"fixture-paid","seats":1}}
+            """,
+            stderr: ""
+        )
+    }
+
+    @MainActor
+    private func reachesCallCount(
+        _ fixture: ModelDependencyFixture,
+        _ expected: Int
+    ) async -> Bool {
+        for _ in 0..<100 where fixture.cli.calls.count < expected {
+            await Task.yield()
+        }
+        return fixture.cli.calls.count >= expected
     }
 
     private func workspace(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -498,6 +498,58 @@ import Testing
         ) == nil)
     }
 
+    @Test func reusesExactWorkerForCredentialFreeLiveEntitlementStatus() throws {
+        let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
+        let configPath =
+            "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let nodePath = "/opt/homebrew/bin/node"
+        let sourceRunner = "\(workingDirectory)/node_modules/tsx/dist/cli.mjs"
+        let arguments = [
+            "license", "status",
+            "--config", configPath,
+            "--repo", "electricsheephq/evaos-code-review-bot-neondiff",
+            "--refresh", "true",
+            "--json"
+        ]
+        let context = try #require(DesktopLaunchAgentExecutionContextParser.parse(
+            data: propertyList(
+                label: "com.electricsheephq.evaos-code-review-bot",
+                environment: [
+                    "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                    "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                ],
+                arguments: [
+                    nodePath,
+                    sourceRunner,
+                    "src/cli.ts",
+                    "daemon",
+                    "--config",
+                    configPath
+                ],
+                workingDirectory: workingDirectory
+            ),
+            expectedLabel: "com.electricsheephq.evaos-code-review-bot",
+            privateKeyPathIsSafe: { $0.path == privateKeyPath }
+        ))
+
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ) == nodePath)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ) == [sourceRunner, "src/cli.ts"] + arguments)
+    }
+
     @Test func reviewCapabilityRequiresTheExactDryToLiveFlagContract() throws {
         let compatible = try #require(DesktopLocalWorkerReviewCapabilityReport.parse(
             #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"},{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -247,6 +247,10 @@ import Testing
         #expect(activation.contains("existing local worker stays in place"))
         #expect(activation.contains("Use existing activation key"))
         #expect(activation.contains("model.applyActivationEvent(.checkoutUnavailable)"))
+        #expect(activation.contains(
+            "default:\n"
+                + "                if !model.existingLocalAgentAccessAvailable"
+        ))
         #expect(activity.contains("OperatorSection(\"Current Activity\")"))
         #expect(activity.contains("model.githubSetupReady"))
         #expect(activity.contains("GitHub connection ready"))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -72,6 +72,15 @@ final class ScriptedDesktopCLIExecutor: DesktopCLIExecuting, @unchecked Sendable
         continuations.forEach { $0.resume() }
     }
 
+    func resumeNextSuspendedRun() {
+        let continuation = state.update {
+            $0.suspendedRunContinuations.isEmpty
+                ? nil
+                : $0.suspendedRunContinuations.removeFirst()
+        }
+        continuation?.resume()
+    }
+
     func suspendFutureRuns() {
         state.update { $0.suspendRuns = true }
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationLicenseClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationLicenseClientTests.swift
@@ -70,6 +70,18 @@ import Testing
         #expect(summary.seats == 3)
     }
 
+    @Test func activeWithoutLiveAPISourceFailsClosed() {
+        let cached = activeJSON.replacingOccurrences(
+            of: #""source":"api""#,
+            with: #""source":"local""#
+        )
+
+        #expect(
+            CLIActivationLicenseClient.classify(stdout: cached)
+                == .serviceError
+        )
+    }
+
     @Test func keyIsPassedOverStdinNeverArgv() async throws {
         let (client, stub) = client(success(activeJSON))
         let key = ActivationKeyMaterial("NDL-REALKEY-0123456789")

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationStateMachineTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationStateMachineTests.swift
@@ -11,9 +11,11 @@ import Testing
         (.purchaseRequired, .beginCheckout, .checkoutPending),
         (.purchaseRequired, .checkoutUnavailable, .checkoutPaused),
         (.purchaseRequired, .provideExistingKey, .keyReady),
+        (.purchaseRequired, .verifyExistingEntitlement, .activationPending),
         (.purchaseRequired, .choosePublicPath, .publicFreeSkip),
 
         (.checkoutPaused, .provideExistingKey, .keyReady),
+        (.checkoutPaused, .verifyExistingEntitlement, .activationPending),
         (.checkoutPaused, .checkoutCompleted, .keyReady),
         (.checkoutPaused, .checkoutCancelled, .purchaseRequired),
         (.checkoutPaused, .resetToPurchase, .purchaseRequired),
@@ -24,6 +26,7 @@ import Testing
         (.checkoutPending, .activationOffline, .offline),
 
         (.keyReady, .submitActivation, .activationPending),
+        (.keyReady, .verifyExistingEntitlement, .activationPending),
         (.keyReady, .resetToPurchase, .purchaseRequired),
 
         (.activationPending, .activationSucceeded, .active),
@@ -40,20 +43,26 @@ import Testing
         (.active, .activationRevoked, .revoked),
         (.active, .activationInvalid, .invalid),
         (.active, .activationOffline, .offline),
+        (.active, .verifyExistingEntitlement, .activationPending),
 
         (.invalid, .reenterKey, .keyReady),
+        (.invalid, .verifyExistingEntitlement, .activationPending),
         (.invalid, .resetToPurchase, .purchaseRequired),
 
         (.expired, .renew, .purchaseRequired),
         (.expired, .provideExistingKey, .keyReady),
+        (.expired, .verifyExistingEntitlement, .activationPending),
 
         (.revoked, .renew, .purchaseRequired),
+        (.revoked, .verifyExistingEntitlement, .activationPending),
 
         (.offline, .retry, .activationPending),
         (.offline, .reenterKey, .keyReady),
+        (.offline, .verifyExistingEntitlement, .activationPending),
 
         (.serviceError, .retry, .activationPending),
         (.serviceError, .reenterKey, .keyReady),
+        (.serviceError, .verifyExistingEntitlement, .activationPending),
 
         (.publicFreeSkip, .choosePrivatePath, .purchaseRequired)
     ]

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -302,6 +302,13 @@ the same Mac. In that exact case it opens a reconciliation path:
   copying its private key. The key file must be a current-user-owned regular
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
+- its single **Verify existing access** action first proves the exact App and
+  Review Target with `doctor github --repo`, then runs credential-free
+  `license status --refresh true` through the same matched worker and config.
+  The native app never reads, copies, migrates, or prompts for the worker's
+  Activation Key. GitHub-reported repository visibility and an active live API
+  entitlement covering that visibility are both required; unknown, expired,
+  revoked, malformed, or offline proof fails closed;
 - Overview runs one provider-backed repository/PR-scoped dry review first. A
   live review is enabled only for that config revision and the returned
   40-character head SHA, and requires explicit confirmation (see

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -115,6 +115,15 @@ repository-scoped entitlement must still pass before a new dry or live review.
 Local config alone never establishes membership, installation authority, or
 review authorization.
 
+The single **Verify existing access** action first runs `doctor github` for the
+exact selected repository and then runs credential-free
+`license status --refresh true --json` through the same matched worker and
+config—even when the native app has a separate current-launch activation.
+Only a live API-sourced entitlement covering GitHub's reported visibility
+unlocks review work. The app never reads, copies, or prompts for that worker's
+Activation Key; expired, revoked, malformed, offline, or stale results remain
+retryable and fail closed.
+
 An existing worker may already monitor several GitHub App-authorized
 repositories. NeonDiff preserves that allowlist and requires one explicit
 **Review Target** in the native repository table. The Activation Key request


### PR DESCRIPTION
## Customer failure

The signed/notarized beta.30 app can prove the exact existing local worker GitHub App and repository access, but still leaves Overview locked and asks the user to recover/paste an Activation Key that the worker already uses for a live API-backed entitlement. That hidden repair blocks the B0 installed-app golden path.

Related to #699. This does not close the broader issue.

## Acceptance criteria

- one **Verify existing access** action proves the exact App/repository, then runs `license status --refresh true` through the exact matched worker/config
- native code never reads, copies, migrates, or prompts for the worker Activation Key
- the entitlement command receives no stdin and no GitHub credential environment
- useful work unlocks only for an API-returned active entitlement covering GitHub-reported repository visibility
- missing/unknown, public-only-for-private, expired, revoked, malformed, offline, nonzero, or stale-context results fail closed
- a persisted active state from a previous launch is revalidated rather than trusted

## Failing-first proof

Before the implementation, the installed beta.30 UI remained `SETUP CONFIGURED · REVERIFY TO RUN` after exact GitHub access verification, while the same exact worker/config returned an API-backed active private-repository entitlement. The focused tests also failed because no entitlement command ran and the exact worker executable was not reused for `license status`.

## Focused proof

- ExistingLocalBotReconciliationTests: 33/33
- LaunchAgentLocalBotConfigurationTests: 15/15
- ActivationStateMachineTests: 10/10
- OwnerReferenceUXContractTests: 7/7
- ProductionBoundaryContractTests: 18/18
- `git diff --check`

## Non-goals

No billing or checkout change, managed GitHub App/B1 work, worker install/update change, publication, release, broader #517 matrix, or generalized harness. Installed-candidate UI dry/live proof remains after merge.