### PR TITLE
fix(mac): keep the scoped dry-review recovery actionable

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -438,6 +438,11 @@ struct OverviewView: View {
         }
     }
 
+    private var isScopedDryReviewButtonDisabled: Bool {
+        model.isScopedReviewInProgress
+            || model.positivePendingReviewPullNumber == nil
+    }
+
     @ViewBuilder
     private var scopedReviewControls: some View {
         TextField("PR number", text: $model.pendingReviewPullNumber)
@@ -455,12 +460,7 @@ struct OverviewView: View {
             )
         }
         .buttonStyle(ReferenceOutlineButtonStyle())
-        .disabled(
-            !model.scopedReviewExecutionAvailable
-                || !model.providerSetupReady
-                || model.isScopedReviewInProgress
-                || model.positivePendingReviewPullNumber == nil
-        )
+        .disabled(isScopedDryReviewButtonDisabled)
         .accessibilityIdentifier("neondiff-scoped-review-dry")
 
         Button {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1194,6 +1194,37 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func multiRepoExistingAgentWithoutStoredAppKeyUnlocksScopedReviewAfterReverify() async {
+        let targetRepository =
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            ),
+            repositories: [
+                "electricsheephq/WorldOS",
+                targetRepository
+            ]
+        )
+
+        #expect(!fixture.model.byoGitHubAppIdStored)
+        #expect(!fixture.model.byoGitHubPrivateKeyStored)
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 4))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        fixture.model.pendingReviewPullNumber = "708"
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.scopedReviewExecutionAvailable)
+        #expect(fixture.model.positivePendingReviewPullNumber == 708)
+    }
+
+    @MainActor
     @Test func staleExactWorkerStatusClearsOwnedProgressState() async throws {
         let fixture = await preparedExistingAgentVerificationFixture(
             visibility: "private",
@@ -1709,17 +1740,19 @@ import NeonDiffDesktopCore
     private func preparedExistingAgentVerificationFixture(
         visibility: String,
         licenseResult: CLIRunResult,
-        activationLicenseClient: (any ActivationLicenseClienting)? = nil
+        activationLicenseClient: (any ActivationLicenseClienting)? = nil,
+        repositories: [String]? = nil
     ) async -> ModelDependencyFixture {
         let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"
+        let configuredRepositories = repositories ?? [targetRepository]
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
                 .success(CLIRunResult(
                     exitCode: 0,
                     stdout: existingBotConfig(
                         authMode: "zcode-app-config",
-                        repositories: [targetRepository]
+                        repositories: configuredRepositories
                     ),
                     stderr: ""
                 )),

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/OwnerReferenceUXContractTests.swift
@@ -310,6 +310,14 @@ import Testing
         #expect(overview.contains("Retry Worker Check"))
         #expect(overview.contains("neondiff-worker-update-guide"))
         #expect(overview.contains("neondiff-worker-retry-check"))
+        #expect(overview.contains("private var isScopedDryReviewButtonDisabled: Bool"))
+        #expect(overview.contains(".disabled(isScopedDryReviewButtonDisabled)"))
+        #expect(
+            !overview.contains(
+                "!model.scopedReviewExecutionAvailable\n"
+                    + "                || !model.providerSetupReady"
+            )
+        )
         #expect(overview.contains("Existing bot configured"))
         #expect(overview.contains("Restoring this Mac"))
         #expect(overview.contains("CHECKING LOCAL SETUP"))


### PR DESCRIPTION
Related to #699 and tracker #610.

## Observed installed-app failure

The signed/notarized 1.1.0 build 11033 candidate at source `4deb2a26937d78d93748c17087a0784761fef309` restored the ElectricSheep account, exact local bot, provider, repository target, GitHub App access, and API-backed entitlement. After entering disposable PR #708, the native `Run Dry Review` action nevertheless remained disabled while the customer surface reported 4 of 4 setup gates ready.

## Bounded acceptance

- A positive PR number keeps the dry-review action actionable unless a review is already running.
- Clicking still calls the existing fail-closed model authorization gate before any CLI command.
- Existing GitHub, repository, entitlement, provider, exact-config, and worker compatibility checks are unchanged.
- The existing multi-repository local-agent shape without copied App Keychain material remains authorized only after exact App/repository and API-backed entitlement verification.
- The next signed installed candidate can continue dry/live proof on PR #708 without hidden operator repair.

## Non-goals

- No entitlement, repository-binding, provider, Keychain, CLI, daemon, billing, checkout, release, or publication behavior changes.
- No broad #517 matrix work.
- No claim that beta.31, B0, or a customer release is published or accepted.

## Failing-first and focused proof

- RED: `OwnerReferenceUXContractTests.shellAndHomeExposeTheOwnerReferenceHierarchy` failed on the installed-gate contract before the view change.
- GREEN: `OwnerReferenceUXContractTests` 7/7.
- GREEN: `ExistingLocalBotReconciliationTests` 39/39, including the new multi-repo/no-stored-App-key verified-agent case.
- GREEN: `git diff --check`.

Exact head: `dc63139`.