### PR TITLE
fix(mac): expose legacy ZCode binding migration

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1942,17 +1942,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && providerLoadedSnapshot?.configPath == configPath
             && providerLoadedRevision != nil
             && providerLoadedSnapshot != nil
-            && (
-                providerLoadedSnapshot != currentProviderConfigurationSnapshot
-                    || selectedZCodeBindingNeedsExplicitWrite
-            )
+            && providerLoadedSnapshot != desiredProviderConfigurationSnapshot
             && !isConfigPatchInProgress
             && !isConfigInspectInProgress
     }
 
     package var canApplyProviderConfig: Bool {
         canEditProviderConfiguration
-            && previewedProviderSnapshot == currentProviderConfigurationSnapshot
+            && previewedProviderSnapshot == desiredProviderConfigurationSnapshot
             && previewedProviderExpectedRevision == providerLoadedRevision
             && !isConfigPatchInProgress
             && !isConfigInspectInProgress
@@ -1966,18 +1963,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         ProviderConfigurationSnapshot(providers: providers, configPath: configPath)
     }
 
-    /// Older local agents may have a complete ZCode app-config provider entry
-    /// without the explicit `zcode.providerId` binding required by scoped
-    /// native reviews. Keep that review boundary fail closed, but expose the
-    /// existing preview/apply migration so the user can write and read back the
-    /// exact selected provider instead of becoming trapped.
-    private var selectedZCodeBindingNeedsExplicitWrite: Bool {
-        guard let target = providers.selectedRegistryTarget,
-              target.authMode == "zcode-app-config"
-        else {
-            return false
-        }
-        return providers.zcodeProviderId != target.id
+    /// Provider patch generation writes the selected ZCode app-config target as
+    /// the explicit execution binding. Model that intended result separately
+    /// from the currently loaded config so legacy workers can preview and apply
+    /// the migration without a dry-run response authorizing useful work.
+    private var desiredProviderConfigurationSnapshot: ProviderConfigurationSnapshot {
+        ProviderConfigurationSnapshot(
+            providers: providers,
+            configPath: configPath,
+            bindSelectedZCodeProvider: true
+        )
     }
 
     private var currentControlCenterSnapshot: DesktopControlCenterSnapshot {
@@ -4660,7 +4655,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         arguments.append(contentsOf: ["--expected-revision", expectedRevision])
         let proof = PendingProviderPatchProof(
             id: UUID(),
-            snapshot: currentProviderConfigurationSnapshot,
+            snapshot: desiredProviderConfigurationSnapshot,
             expectedRevision: expectedRevision,
             mode: dryRun ? .preview : .apply
         )
@@ -5630,7 +5625,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         pendingProviderPatchProof = PendingProviderPatchProof(
             id: UUID(),
-            snapshot: currentProviderConfigurationSnapshot,
+            snapshot: desiredProviderConfigurationSnapshot,
             expectedRevision: expectedRevision,
             mode: mode
         )
@@ -5652,7 +5647,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         pendingProviderPatchProof = PendingProviderPatchProof(
             id: UUID(),
-            snapshot: currentProviderConfigurationSnapshot,
+            snapshot: desiredProviderConfigurationSnapshot,
             expectedRevision: expectedRevision,
             mode: mode
         )
@@ -5771,14 +5766,25 @@ private struct ProviderConfigurationSnapshot: Equatable, Sendable {
     let zcodeModel: String
     let zcodeCliPath: String
     let zcodeAppConfigPath: String
+    let zcodeProviderId: String
     let selectedProviderId: String
     let registryTargets: [ProviderRegistryTarget]
 
-    init(providers: ProviderSettings, configPath: String) {
+    init(
+        providers: ProviderSettings,
+        configPath: String,
+        bindSelectedZCodeProvider: Bool = false
+    ) {
         self.configPath = configPath
         zcodeModel = providers.zcodeModel
         zcodeCliPath = providers.zcodeCliPath
         zcodeAppConfigPath = providers.zcodeAppConfigPath
+        if bindSelectedZCodeProvider,
+           providers.selectedRegistryTarget?.authMode == "zcode-app-config" {
+            zcodeProviderId = providers.selectedProviderId
+        } else {
+            zcodeProviderId = providers.zcodeProviderId
+        }
         selectedProviderId = providers.selectedProviderId
         registryTargets = providers.registryTargets
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1942,7 +1942,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && providerLoadedSnapshot?.configPath == configPath
             && providerLoadedRevision != nil
             && providerLoadedSnapshot != nil
-            && providerLoadedSnapshot != currentProviderConfigurationSnapshot
+            && (
+                providerLoadedSnapshot != currentProviderConfigurationSnapshot
+                    || selectedZCodeBindingNeedsExplicitWrite
+            )
             && !isConfigPatchInProgress
             && !isConfigInspectInProgress
     }
@@ -1961,6 +1964,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private var currentProviderConfigurationSnapshot: ProviderConfigurationSnapshot {
         ProviderConfigurationSnapshot(providers: providers, configPath: configPath)
+    }
+
+    /// Older local agents may have a complete ZCode app-config provider entry
+    /// without the explicit `zcode.providerId` binding required by scoped
+    /// native reviews. Keep that review boundary fail closed, but expose the
+    /// existing preview/apply migration so the user can write and read back the
+    /// exact selected provider instead of becoming trapped.
+    private var selectedZCodeBindingNeedsExplicitWrite: Bool {
+        guard let target = providers.selectedRegistryTarget,
+              target.authMode == "zcode-app-config"
+        else {
+            return false
+        }
+        return providers.zcodeProviderId != target.id
     }
 
     private var currentControlCenterSnapshot: DesktopControlCenterSnapshot {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderConfigurationPatchTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderConfigurationPatchTests.swift
@@ -127,4 +127,16 @@ import NeonDiffDesktopCore
         #expect(arguments.contains("--confirm"))
         #expect(arguments.contains("true"))
     }
+
+    @Test func legacyZCodeConfigCanPreviewItsMissingExplicitProviderBinding() {
+        let fixture = ModelDependencyFixture(productionBoundary: .testVerified)
+        let revision = String(repeating: "a", count: 64)
+        fixture.loadConfig(
+            #"{"ok":true,"command":"config inspect","revision":"\#(revision)","config":{"pilotRepos":[],"zcode":{"model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
+        )
+
+        #expect(fixture.model.providerSetupReady)
+        #expect(!fixture.model.scopedReviewProviderReady)
+        #expect(fixture.model.canPreviewProviderConfig)
+    }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderConfigurationPatchTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderConfigurationPatchTests.swift
@@ -130,13 +130,31 @@ import NeonDiffDesktopCore
 
     @Test func legacyZCodeConfigCanPreviewItsMissingExplicitProviderBinding() {
         let fixture = ModelDependencyFixture(productionBoundary: .testVerified)
-        let revision = String(repeating: "a", count: 64)
+        let revisionBefore = String(repeating: "a", count: 64)
+        let revisionAfter = String(repeating: "b", count: 64)
         fixture.loadConfig(
-            #"{"ok":true,"command":"config inspect","revision":"\#(revision)","config":{"pilotRepos":[],"zcode":{"model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
+            #"{"ok":true,"command":"config inspect","revision":"\#(revisionBefore)","config":{"pilotRepos":[],"zcode":{"model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
         )
 
         #expect(fixture.model.providerSetupReady)
         #expect(!fixture.model.scopedReviewProviderReady)
         #expect(fixture.model.canPreviewProviderConfig)
+
+        let previewJSON = #"{"ok":true,"command":"config patch","dryRun":true,"wrote":false,"revisionBefore":"\#(revisionBefore)","revisionAfter":"\#(revisionBefore)","config":{"pilotRepos":[],"zcode":{"providerId":"zcode-glm","model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
+        fixture.model.applyProviderPatchResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: previewJSON, stderr: ""),
+            mode: .preview
+        )
+        #expect(fixture.model.canApplyProviderConfig)
+        #expect(!fixture.model.providerSetupReady)
+        #expect(!fixture.model.scopedReviewProviderReady)
+
+        let applyJSON = #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"\#(revisionBefore)","revisionAfter":"\#(revisionAfter)","config":{"pilotRepos":[],"zcode":{"providerId":"zcode-glm","model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
+        fixture.model.applyProviderPatchResultForTesting(
+            CLIRunResult(exitCode: 0, stdout: applyJSON, stderr: ""),
+            mode: .apply
+        )
+        #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.scopedReviewProviderReady)
     }
 }


### PR DESCRIPTION
## Acceptance gate

- A real installed BYO beta candidate with a legacy ZCode app-config provider and no explicit `zcode.providerId` can use the existing revision-bound Preview/Apply migration.
- Scoped reviews remain blocked until that exact provider binding is written and read back.
- Failing-first coverage proves the prior trapped state and the restored recovery action.

## What changed

- Treat a selected `zcode-app-config` provider whose explicit ZCode binding differs or is absent as a provider configuration change eligible for Preview.
- Reuse the existing compare-and-swap preview, confirmed apply, and readback path; the scoped-review authorization guard is unchanged.

## Proof

- RED: `ProviderConfigurationPatchTests.legacyZCodeConfigCanPreviewItsMissingExplicitProviderBinding` failed because `canPreviewProviderConfig` was false.
- GREEN: `ProviderConfigurationPatchTests` — 5/5.
- GREEN: `ExistingLocalBotReconciliationTests` — 39/39.
- GREEN: `git diff --check`.
- Real installed beta.32 observation: repository and API-backed entitlement verified; provider showed `APP CONFIG LOADED`; dry review failed closed on missing explicit ZCode binding while Preview/Apply remained disabled.

## Non-goals

- No relaxation of scoped-review, entitlement, repository, GitHub App, provider, or worker authorization.
- No automatic config write.
- No provider-key, GitHub-key, billing, checkout, publication, or customer-canary changes.
- No release claim. The installed candidate must be rebuilt from the eventual merge SHA and re-proven.

Related to #699 and #610.
