### PR TITLE
fix(mac): preserve omitted ZCode endpoint in provider patch

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -32,6 +32,7 @@ struct ProviderSettingsView: View {
                     }
                     .pickerStyle(.menu)
                     OperatorTextField(title: "Endpoint", text: $model.providers.selectedProviderBaseUrl)
+                        .disabled(!model.providers.selectedProviderEndpointIsEditable)
                     OperatorTextField(title: "Model", text: $model.providers.selectedProviderModel)
                     if let target = model.providers.selectedRegistryTarget {
                         Text("\(target.adapter) · \(target.authMode) · \(target.enabled ? "enabled" : "disabled")")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -180,6 +180,10 @@ public struct ProviderSettings: Equatable {
         }
     }
 
+    public var selectedProviderEndpointIsEditable: Bool {
+        selectedRegistryTarget?.authMode != "zcode-app-config"
+    }
+
     public var selectedProviderModel: String {
         get { selectedRegistryTarget?.model ?? "" }
         set {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -30,7 +30,9 @@ public enum ProviderRegistryPatchBuilder {
         var selectedProviderPatch: [String: Any] = [
             "model": selectedModel
         ]
-        if target.authMode != "zcode-app-config" {
+        if target.authMode != "zcode-app-config"
+            || !target.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
             selectedProviderPatch["baseUrl"] = target.baseUrl
         }
         let patch: [String: Any] = [

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -27,15 +27,18 @@ public enum ProviderRegistryPatchBuilder {
             zcodePatch["model"] = selectedModel
             zcodePatch["providerId"] = target.id
         }
+        var selectedProviderPatch: [String: Any] = [
+            "model": selectedModel
+        ]
+        if target.authMode != "zcode-app-config" {
+            selectedProviderPatch["baseUrl"] = target.baseUrl
+        }
         let patch: [String: Any] = [
             "zcode": zcodePatch,
             "providers": [
                 "defaultProviderId": target.id,
                 "providers": [
-                    target.id: [
-                        "baseUrl": target.baseUrl,
-                        "model": selectedModel
-                    ]
+                    target.id: selectedProviderPatch
                 ]
             ]
         ]

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 15, sortedMessageSHA256: "9ec0489e5dfaef880a825084f664596bd8ff3f47da7cbeaa13114f8a07a6f216"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 17, sortedMessageSHA256: "6b7ca6124aeaeb2d20758b2bc8c240c4d2f9258c985c5638312418485df0f941"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 396)
-        #expect(Set(messages).count == 302)
-        #expect(coreChecksSHA256(messages.sorted()) == "4da08485572c85c5e20cbc675b3f9f18c5fd5df9aa2c916da869a40c9aec3252")
+        #expect(messages.count == 398)
+        #expect(Set(messages).count == 304)
+        #expect(coreChecksSHA256(messages.sorted()) == "9f39d7cf772f27d6055883c72d6e85f39cd43e0c807712ca3f987a7770b8dbab")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 13, sortedMessageSHA256: "6bb85adae3951f123b8f4754bd23e0c0c7fffc33ea55cc8cdff83b71964f6713"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 14, sortedMessageSHA256: "2a0222bc3992bd96f3d347a543a2be50565ca576c4b3c79d8eecc4c93e183002"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 394)
-        #expect(Set(messages).count == 300)
-        #expect(coreChecksSHA256(messages.sorted()) == "9ae56c81aaf49619e16d11a7f94ce462005cdf2a27907713fbc0b60ec077dfbc")
+        #expect(messages.count == 395)
+        #expect(Set(messages).count == 301)
+        #expect(coreChecksSHA256(messages.sorted()) == "96bd6ab39f3e3e8ba629b58b5cecef429af00b30c49ffa22a9bf9d046e3ea04f")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 14, sortedMessageSHA256: "2a0222bc3992bd96f3d347a543a2be50565ca576c4b3c79d8eecc4c93e183002"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 15, sortedMessageSHA256: "9ec0489e5dfaef880a825084f664596bd8ff3f47da7cbeaa13114f8a07a6f216"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 395)
-        #expect(Set(messages).count == 301)
-        #expect(coreChecksSHA256(messages.sorted()) == "96bd6ab39f3e3e8ba629b58b5cecef429af00b30c49ffa22a9bf9d046e3ea04f")
+        #expect(messages.count == 396)
+        #expect(Set(messages).count == 302)
+        #expect(coreChecksSHA256(messages.sorted()) == "4da08485572c85c5e20cbc675b3f9f18c5fd5df9aa2c916da869a40c9aec3252")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -47,10 +47,17 @@ import Darwin
         let providerPatchData = try ProviderRegistryPatchBuilder.data(for: providerSettings)
         let providerPatchObject = try JSONSerialization.jsonObject(with: providerPatchData) as? [String: Any]
         let providerPatchZCode = providerPatchObject?["zcode"] as? [String: Any]
+        let providerPatchRegistry = providerPatchObject?["providers"] as? [String: Any]
+        let providerPatchEntries = providerPatchRegistry?["providers"] as? [String: Any]
+        let selectedProviderPatch = providerPatchEntries?["zcode"] as? [String: Any]
         context.expect(
             providerPatchZCode?["providerId"] as? String == "zcode"
                 && providerPatchZCode?["model"] as? String == "zcode-model",
             "ZCode-managed provider patch binds the exact selected execution provider and model"
+        )
+        context.expect(
+            selectedProviderPatch?["baseUrl"] == nil,
+            "ZCode app-config patch preserves an omitted endpoint instead of writing an invalid empty URL"
         )
     } else {
         context.expect(false, "ZCode-managed registry snapshot remains parseable")

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -44,6 +44,10 @@ import Darwin
         licenseKeyStored: false
     )
     if let providerSettings = zcodeManagedSnapshot?.providers {
+        context.expect(
+            providerSettings.selectedProviderEndpointIsEditable == false,
+            "ZCode app-config endpoints are read-only in the native provider editor"
+        )
         let providerPatchData = try ProviderRegistryPatchBuilder.data(for: providerSettings)
         let providerPatchObject = try JSONSerialization.jsonObject(with: providerPatchData) as? [String: Any]
         let providerPatchZCode = providerPatchObject?["zcode"] as? [String: Any]
@@ -54,6 +58,10 @@ import Darwin
             providerPatchZCode?["providerId"] as? String == "zcode"
                 && providerPatchZCode?["model"] as? String == "zcode-model",
             "ZCode-managed provider patch binds the exact selected execution provider and model"
+        )
+        context.expect(
+            selectedProviderPatch?["model"] as? String == "zcode-model",
+            "ZCode registry patch preserves the selected model"
         )
         context.expect(
             selectedProviderPatch?["baseUrl"] == nil,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -63,6 +63,25 @@ import Darwin
         context.expect(false, "ZCode-managed registry snapshot remains parseable")
     }
 
+    let zcodeManagedEndpointSnapshot = ConfigInspectParser.parse(
+        #"{"ok":true,"command":"config inspect","revision":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","config":{"zcode":{"model":"zcode-model","cliPath":"zcode","appConfigPath":"zcode.json","providerId":"zcode"},"providers":{"defaultProviderId":"zcode","providers":{"zcode":{"enabled":true,"adapter":"zcode","displayName":"ZCode","baseUrl":"https://zcode.example/v1","model":"zcode-model","authMode":"zcode-app-config"}}}}}"#,
+        providerKeyStored: false,
+        licenseKeyStored: false
+    )
+    if let providerSettings = zcodeManagedEndpointSnapshot?.providers {
+        let providerPatchData = try ProviderRegistryPatchBuilder.data(for: providerSettings)
+        let providerPatchObject = try JSONSerialization.jsonObject(with: providerPatchData) as? [String: Any]
+        let providerPatchRegistry = providerPatchObject?["providers"] as? [String: Any]
+        let providerPatchEntries = providerPatchRegistry?["providers"] as? [String: Any]
+        let selectedProviderPatch = providerPatchEntries?["zcode"] as? [String: Any]
+        context.expect(
+            selectedProviderPatch?["baseUrl"] as? String == "https://zcode.example/v1",
+            "ZCode app-config patch preserves an explicit nonempty endpoint"
+        )
+    } else {
+        context.expect(false, "ZCode-managed registry snapshot with an endpoint remains parseable")
+    }
+
     let emptyModelSnapshot = ConfigInspectParser.parse(
         #"{"ok":true,"command":"config inspect","revision":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"zcode":{"model":"fallback-model","cliPath":"zcode","appConfigPath":"zcode.json"},"providers":{"defaultProviderId":"gateway","providers":{"gateway":{"enabled":true,"adapter":"openai-compatible","displayName":"Gateway","baseUrl":"https://saved.example/v1","model":"","authMode":"api-key-env"}}}}}"#,
         providerKeyStored: true,


### PR DESCRIPTION
## Installed failure

Signed/notarized NeonDiff beta.33 (1.1.0 build 11035, exact source `7e0084efd0affa1bf3814f9a60120266be2a1ac5`) restored the existing ElectricSheep bot at 4/4 ready. On the Providers page, **Preview Patch** was available for the legacy missing ZCode binding.

Clicking Preview failed closed with:

`candidate config failed validation: config.providers.providers.zcode-glm.baseUrl must be a valid URL`

The existing `zcode-app-config` provider legitimately omits an endpoint. The native patch builder materialized the parser’s empty fallback as `baseUrl: ""`, turning that omission into an invalid patch value and trapping the user with both Preview and Apply disabled.

## Bounded fix

- omit `baseUrl` from provider patches only when the selected target uses `zcode-app-config`
- keep the selected model and explicit ZCode provider binding unchanged
- preserve `baseUrl` for ordinary provider targets
- add failing-first coverage for the exact omitted-endpoint ZCode path

## Proof

- RED: `ProviderRegistryTests` failed on the new omitted-endpoint assertion
- GREEN: `ProviderRegistryTests` 1/1
- GREEN: `ProviderConfigurationPatchTests` 5/5
- GREEN: `ExistingLocalBotReconciliationTests` 39/39
- GREEN: `git diff --check`

## Acceptance criteria

- current-head remote CI, CodeQL, and Swift PR gate pass
- one bounded independent review finds no current credential, provider-selection, config-write, or authorization bypass
- the exact signed successor candidate can Preview and Apply the legacy binding through the installed UI

## Non-goals

No repository allowlist rewrite, provider auth change, Keychain change, entitlement change, billing, checkout, publication, managed B1 work, broad compatibility matrix, or #517 closure. #699 and #646 remain open through installed dry/live/relaunch proof.

Relates to #699 and #610.
