### PR TITLE
fix(mac): keep provider binding complete through Preview

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -28,6 +28,10 @@ public enum ProviderRegistryPatchBuilder {
             zcodePatch["providerId"] = target.id
         }
         var selectedProviderPatch: [String: Any] = [
+            "enabled": target.enabled,
+            "adapter": target.adapter,
+            "displayName": target.displayName,
+            "authMode": target.authMode,
             "model": selectedModel
         ]
         if target.authMode != "zcode-app-config"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -24,7 +24,14 @@ import Darwin
         let providerPatchRegistry = providerPatchObject?["providers"] as? [String: Any]
         let providerPatchEntries = providerPatchRegistry?["providers"] as? [String: Any]
         let selectedProviderPatch = providerPatchEntries?["gateway"] as? [String: Any]
-        context.expect(selectedProviderPatch?["baseUrl"] as? String == "https://saved.example/v1", "provider patch uses the selected saved registry target")
+        context.expect(
+            selectedProviderPatch?["baseUrl"] as? String == "https://saved.example/v1"
+                && selectedProviderPatch?["enabled"] as? Bool == true
+                && selectedProviderPatch?["adapter"] as? String == "openai-compatible"
+                && selectedProviderPatch?["displayName"] as? String == "Gateway"
+                && selectedProviderPatch?["authMode"] as? String == "api-key-env",
+            "provider patch uses the selected saved registry target"
+        )
         context.expect(providerPatchZCode?["providerId"] == nil, "direct provider patch preserves the existing ZCode execution provider")
         context.expect(providerPatchZCode?["model"] as? String == "zcode-model", "direct provider patch preserves the existing ZCode execution model")
         context.expect(!providerPatchText.contains("https://legacy.example/v1"), "legacy desktop endpoint cannot enter the provider registry patch")
@@ -33,7 +40,9 @@ import Darwin
                 && Set(providerPatchZCode?.keys.map { $0 } ?? []) == Set(["cliPath", "appConfigPath", "model"])
                 && Set(providerPatchRegistry?.keys.map { $0 } ?? []) == Set(["defaultProviderId", "providers"])
                 && Set(providerPatchEntries?.keys.map { $0 } ?? []) == Set(["gateway"])
-                && Set(selectedProviderPatch?.keys.map { $0 } ?? []) == Set(["baseUrl", "model"]),
+                && Set(selectedProviderPatch?.keys.map { $0 } ?? []) == Set([
+                    "enabled", "adapter", "displayName", "authMode", "baseUrl", "model"
+                ]),
             "provider registry patch contains only the explicit non-secret schema"
         )
     }
@@ -60,7 +69,11 @@ import Darwin
             "ZCode-managed provider patch binds the exact selected execution provider and model"
         )
         context.expect(
-            selectedProviderPatch?["model"] as? String == "zcode-model",
+            selectedProviderPatch?["model"] as? String == "zcode-model"
+                && selectedProviderPatch?["enabled"] as? Bool == true
+                && selectedProviderPatch?["adapter"] as? String == "zcode"
+                && selectedProviderPatch?["displayName"] as? String == "ZCode"
+                && selectedProviderPatch?["authMode"] as? String == "zcode-app-config",
             "ZCode registry patch preserves the selected model"
         )
         context.expect(


### PR DESCRIPTION
Related: #699
Parent: #610 and #646

## Bounded acceptance criteria

- The installed B0 existing-bot provider Preview emits a complete non-secret selected provider binding.
- Config-patch readback remains parseable instead of clearing the provider/model UI.
- ZCode app-config keeps its endpoint omitted when blank and preserves an explicit nonempty endpoint.
- The legacy config remains unchanged until the separately confirmed Apply action.

## Observed failure

Signed/notarized beta34 (1.1.0 build 11036) restored the exact existing bot at 4/4. Clicking Preview Patch produced a partial provider entry containing only model, so readback discarded it and dropped the app to 3/4 with a blank provider/model.

## Change

Persist the selected provider's existing enabled, adapter, display name, and auth mode alongside model and the already-bounded endpoint. These are non-secret registry metadata already loaded by the app.

## Failing-first and focused proof

- RED: `swift test --package-path apps/neondiff-desktop --filter ProviderRegistryTests` failed on the missing complete provider binding/schema.
- GREEN: the same focused test passed.
- GREEN: `swift test --package-path apps/neondiff-desktop --filter ProviderConfigurationPatchTests` (5/5).
- GREEN: `swift test --package-path apps/neondiff-desktop --filter NeonDiffDesktopCoreTests` (59/59, ledger included).
- GREEN: `git diff --check`.

## Non-goals

No billing, checkout, publication, live config write, launchd mutation, managed GitHub App/B1 work, broader #517 matrix, generalized harness, or release claim. #699 remains open until the new installed candidate passes the whole usability gate.