### PR TITLE
fix(mac): preserve ZCode execution provider binding

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -835,7 +835,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var scopedReviewProviderReady: Bool {
         providerSetupReady
             && providers.selectedRegistryTarget?.authMode == "zcode-app-config"
-            && providers.zcodeProviderId == providers.selectedProviderId
+            && !providers.zcodeProviderId
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty
     }
 
     /// Account entitlement is server authority for the selected existing bot's
@@ -1963,16 +1965,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         ProviderConfigurationSnapshot(providers: providers, configPath: configPath)
     }
 
-    /// Provider patch generation writes the selected ZCode app-config target as
-    /// the explicit execution binding. Model that intended result separately
-    /// from the currently loaded config so legacy workers can preview and apply
-    /// the migration without a dry-run response authorizing useful work.
+    /// The provider registry and ZCode app config use distinct identifier
+    /// namespaces. Preserve the execution binding loaded from ZCode instead of
+    /// inventing one from the selected NeonDiff registry entry.
     private var desiredProviderConfigurationSnapshot: ProviderConfigurationSnapshot {
-        ProviderConfigurationSnapshot(
-            providers: providers,
-            configPath: configPath,
-            bindSelectedZCodeProvider: true
-        )
+        ProviderConfigurationSnapshot(providers: providers, configPath: configPath)
     }
 
     private var currentControlCenterSnapshot: DesktopControlCenterSnapshot {
@@ -5772,19 +5769,13 @@ private struct ProviderConfigurationSnapshot: Equatable, Sendable {
 
     init(
         providers: ProviderSettings,
-        configPath: String,
-        bindSelectedZCodeProvider: Bool = false
+        configPath: String
     ) {
         self.configPath = configPath
         zcodeModel = providers.zcodeModel
         zcodeCliPath = providers.zcodeCliPath
         zcodeAppConfigPath = providers.zcodeAppConfigPath
-        if bindSelectedZCodeProvider,
-           providers.selectedRegistryTarget?.authMode == "zcode-app-config" {
-            zcodeProviderId = providers.selectedProviderId
-        } else {
-            zcodeProviderId = providers.zcodeProviderId
-        }
+        zcodeProviderId = providers.zcodeProviderId
         selectedProviderId = providers.selectedProviderId
         registryTargets = providers.registryTargets
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ProviderRegistryPatchBuilder.swift
@@ -25,7 +25,11 @@ public enum ProviderRegistryPatchBuilder {
         ]
         if target.authMode == "zcode-app-config" {
             zcodePatch["model"] = selectedModel
-            zcodePatch["providerId"] = target.id
+            let existingProviderId = providers.zcodeProviderId
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !existingProviderId.isEmpty {
+                zcodePatch["providerId"] = existingProviderId
+            }
         }
         var providerPatches: [String: [String: Any]] = [:]
         for registryTarget in providers.registryTargets {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -540,7 +540,7 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
-    @Test func scopedReviewRejectsAProviderDifferentFromTheOneZCodeWillExecute() {
+    @Test func scopedReviewAcceptsAnExplicitProviderFromZCodesOwnNamespace() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
             productionBoundary: .testAccountLink
@@ -553,7 +553,7 @@ import NeonDiffDesktopCore
         )
 
         #expect(fixture.model.providerSetupReady)
-        #expect(!fixture.model.scopedReviewProviderReady)
+        #expect(fixture.model.scopedReviewProviderReady)
     }
 
     @MainActor

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderConfigurationPatchTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProviderConfigurationPatchTests.swift
@@ -128,33 +128,16 @@ import NeonDiffDesktopCore
         #expect(arguments.contains("true"))
     }
 
-    @Test func legacyZCodeConfigCanPreviewItsMissingExplicitProviderBinding() {
+    @Test func legacyZCodeConfigDoesNotInventBindingOrOfferNoOpApply() {
         let fixture = ModelDependencyFixture(productionBoundary: .testVerified)
         let revisionBefore = String(repeating: "a", count: 64)
-        let revisionAfter = String(repeating: "b", count: 64)
         fixture.loadConfig(
             #"{"ok":true,"command":"config inspect","revision":"\#(revisionBefore)","config":{"pilotRepos":[],"zcode":{"model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
         )
 
         #expect(fixture.model.providerSetupReady)
         #expect(!fixture.model.scopedReviewProviderReady)
-        #expect(fixture.model.canPreviewProviderConfig)
-
-        let previewJSON = #"{"ok":true,"command":"config patch","dryRun":true,"wrote":false,"revisionBefore":"\#(revisionBefore)","revisionAfter":"\#(revisionBefore)","config":{"pilotRepos":[],"zcode":{"providerId":"zcode-glm","model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
-        fixture.model.applyProviderPatchResultForTesting(
-            CLIRunResult(exitCode: 0, stdout: previewJSON, stderr: ""),
-            mode: .preview
-        )
-        #expect(fixture.model.canApplyProviderConfig)
-        #expect(!fixture.model.providerSetupReady)
-        #expect(!fixture.model.scopedReviewProviderReady)
-
-        let applyJSON = #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"\#(revisionBefore)","revisionAfter":"\#(revisionAfter)","config":{"pilotRepos":[],"zcode":{"providerId":"zcode-glm","model":"GLM-5.2","cliPath":"/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs","appConfigPath":"/Volumes/LEXAR/zcode/.zcode/v2/config.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"openai-compatible","displayName":"GLM/Z.ai through ZCode","baseUrl":"","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#
-        fixture.model.applyProviderPatchResultForTesting(
-            CLIRunResult(exitCode: 0, stdout: applyJSON, stderr: ""),
-            mode: .apply
-        )
-        #expect(fixture.model.providerSetupReady)
-        #expect(fixture.model.scopedReviewProviderReady)
+        #expect(!fixture.model.canPreviewProviderConfig)
+        #expect(!fixture.model.canApplyProviderConfig)
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -31,7 +31,7 @@ let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChec
     .detachedCommandLaunchContracts: .init(assertionCount: 4, sortedMessageSHA256: "d2256a821d4f0eecfba2db5484b48e617ae10a09a007626268a76e82dbb70ddb"),
     .githubRecoveryRepositoryAndRateLimitContracts: .init(assertionCount: 29, sortedMessageSHA256: "bc27311a9264ba1b20622afabc316a78e48f1ea8539bff071564faaebf8a4092"),
     .configInspectAndPatchContracts: .init(assertionCount: 27, sortedMessageSHA256: "c963178d0c437cf22ab1e5cec966440761ac87c1730a9c5cd2ddc3107932393c"),
-    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 17, sortedMessageSHA256: "6c7cc922267b166cf4350429f0d03ccd6d9ac27c2b8ca3c837665ccbbfe63418"),
+    .providerRegistryParsingAndPatchContracts: .init(assertionCount: 18, sortedMessageSHA256: "23855ce5b6245a4c51ce0780e361aba8b2802a648a522b35829b7717dccdf440"),
     .providerVerificationTransportAndStrictEnvelopeContracts: .init(assertionCount: 37, sortedMessageSHA256: "27b74eecdf695f4be3fca3d9bf1090c8c41a2d27b1ca20e0e3ad47e6da28199e"),
     .canonicalRedactorCorpusContracts: .init(assertionCount: 195, sortedMessageSHA256: "b1af4e9101e9255b709cf93af983827cb367a7f37d1993940f004b0da2591c41"),
     .providerVerificationEscapingAndBudgetContracts: .init(assertionCount: 20, sortedMessageSHA256: "aabd8511ab77476e062c96210aee2ccafabaae2489d31fb44a7545313af56f1a")
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 398)
-        #expect(Set(messages).count == 304)
-        #expect(coreChecksSHA256(messages.sorted()) == "2062e67ae91800abd9aebb4d0ec3cc9679a28963d4281e057e9fe340f1ef0676")
+        #expect(messages.count == 399)
+        #expect(Set(messages).count == 305)
+        #expect(coreChecksSHA256(messages.sorted()) == "f2083dd698110687a5ca34d02c211c29fda4d25e4d0e007a03a5cef0d6de5ba0")
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/ProviderRegistryScenarios.swift
@@ -74,9 +74,9 @@ import Darwin
         let providerPatchEntries = providerPatchRegistry?["providers"] as? [String: Any]
         let selectedProviderPatch = providerPatchEntries?["zcode"] as? [String: Any]
         context.expect(
-            providerPatchZCode?["providerId"] as? String == "zcode"
+            providerPatchZCode?["providerId"] as? String == "prior-zcode"
                 && providerPatchZCode?["model"] as? String == "zcode-model",
-            "ZCode-managed provider patch binds the exact selected execution provider and model"
+            "ZCode-managed provider patch preserves the exact existing execution provider and selected model"
         )
         context.expect(
             selectedProviderPatch?["model"] as? String == "zcode-model"
@@ -92,6 +92,23 @@ import Darwin
         )
     } else {
         context.expect(false, "ZCode-managed registry snapshot remains parseable")
+    }
+
+    let unboundZCodeSnapshot = ConfigInspectParser.parse(
+        #"{"ok":true,"command":"config inspect","revision":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","config":{"zcode":{"model":"GLM-5.2","cliPath":"zcode","appConfigPath":"zcode.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"zcode","displayName":"GLM/Z.ai through ZCode","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#,
+        providerKeyStored: false,
+        licenseKeyStored: false
+    )
+    if let providerSettings = unboundZCodeSnapshot?.providers {
+        let providerPatchData = try ProviderRegistryPatchBuilder.data(for: providerSettings)
+        let providerPatchObject = try JSONSerialization.jsonObject(with: providerPatchData) as? [String: Any]
+        let providerPatchZCode = providerPatchObject?["zcode"] as? [String: Any]
+        context.expect(
+            providerPatchZCode?["providerId"] == nil,
+            "an unbound ZCode execution provider stays unbound instead of inheriting the NeonDiff registry id"
+        )
+    } else {
+        context.expect(false, "unbound ZCode registry snapshot remains parseable")
     }
 
     let zcodeManagedEndpointSnapshot = ConfigInspectParser.parse(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -148,7 +148,7 @@ function recordConsumedAuthorizationIncident(input: {
 }
 
 export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMetadata {
-  const providerId = config.zcode.providerId ?? config.providers?.defaultProviderId ?? "zcode-glm";
+  const providerId = resolveReviewRegistryProviderId(config);
   const provider = config.providers?.providers[providerId];
   if (!provider) {
     return {
@@ -167,8 +167,12 @@ export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMe
 }
 
 function resolveReviewContextWindowTokens(config: BotConfig): number | undefined {
-  const providerId = config.zcode.providerId ?? config.providers?.defaultProviderId ?? "zcode-glm";
+  const providerId = resolveReviewRegistryProviderId(config);
   return config.providers?.providers[providerId]?.contextWindowTokens;
+}
+
+function resolveReviewRegistryProviderId(config: BotConfig): string {
+  return config.providers?.defaultProviderId ?? config.zcode.providerId ?? "zcode-glm";
 }
 
 function contextBudgetEvidence(plan: ContextBudgetPlan): Record<string, unknown> {

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -200,6 +200,7 @@ describe("worker context budget preflight", () => {
       providerFudgeFactor: 1,
       maxChunks: 4
     };
+    config.zcode.providerId = "builtin:zai-coding-plan";
     config.providers!.providers["zcode-glm"]!.contextWindowTokens = 500;
     const state = new ReviewStateStore(config.statePath);
     const pull = pullSummary(401, "c".repeat(40));

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -155,7 +155,7 @@ describe("worker review settings preview evidence", () => {
     state.close();
   });
 
-  it("marks stale zcode provider ids as registry misses instead of silently claiming a configured provider", () => {
+  it("uses the selected registry id for metadata when ZCode has a distinct execution id", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-metadata-"));
     roots.push(root);
     const config = minimalConfig(root);
@@ -180,10 +180,10 @@ describe("worker review settings preview evidence", () => {
     };
 
     expect(buildReviewProviderMetadata(config)).toEqual({
-      providerId: "ghost-provider",
-      adapter: "zcode (registry miss)",
-      model: "unknown",
-      displayName: "Unregistered provider id"
+      providerId: "zcode-glm",
+      adapter: "zcode",
+      model: "GLM-5.2",
+      displayName: "GLM/Z.ai through ZCode"
     });
   });
 });


### PR DESCRIPTION
Related to #699.

## Acceptance criteria
- Provider Apply preserves an existing ZCode execution-provider ID instead of replacing it with the NeonDiff registry entry ID.
- A legacy/unbound ZCode configuration remains unbound; the desktop does not invent an execution provider.
- Provider selection, model, and the non-secret registry patch remain unchanged.
- Focused failing-first desktop-core and app-model tests pass.

## Observed failure
The installed beta.36 Provider Apply flow wrote `zcode-glm` as the ZCode execution provider. The live worker then failed closed because that ID is not an enabled provider in the ZCode app config.

## Proof
- RED: `ProviderRegistryTests/providerRegistryParsingAndPatchContracts` failed on both preserved-bound and unbound cases before the source change.
- GREEN: the same focused test passes after the change.
- GREEN: `ProviderConfigurationPatchTests` passes (5 tests).
- GREEN: `git diff --check`.

## Non-goals
- No billing, activation, release, or publication change.
- No provider catalog redesign or credential migration.
- No broad #517 closure or generalized harness expansion.
- This PR does not itself prove a signed customer artifact or successful live review.