### PR TITLE
fix(license): accept header-safe checkout issuance auth

### DIFF
--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -6,7 +6,8 @@ import {
   issueCheckoutLicense,
   malformedIssuanceResult,
   parseIssuanceRequest,
-  validateBearerSecret
+  validateBearerSecret,
+  validateIssuanceAuthorization
 } from "./issuance.js";
 import {
   activate,
@@ -297,7 +298,13 @@ async function handleIssuanceRequest(
   if (!options.issuanceSecret) {
     return writeJson(res, 503, { status: "server", detail: "license issuance is not configured" });
   }
-  if (!validateBearerSecret(req.headers.authorization, options.issuanceSecret)) {
+  if (
+    !validateIssuanceAuthorization(
+      req.headers.authorization,
+      req.headers["x-neondiff-issuance-authorization"],
+      options.issuanceSecret
+    )
+  ) {
     return writeJson(res, 401, { status: "unauthorized", detail: "license issuance authorization failed" });
   }
 

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -299,6 +299,8 @@ async function handleIssuanceRequest(
     return writeJson(res, 503, { status: "server", detail: "license issuance is not configured" });
   }
   if (
+    hasDuplicateRawHeader(req, "authorization") ||
+    hasDuplicateRawHeader(req, "x-neondiff-issuance-authorization") ||
     !validateIssuanceAuthorization(
       req.headers.authorization,
       req.headers["x-neondiff-issuance-authorization"],
@@ -324,6 +326,17 @@ async function handleIssuanceRequest(
       malformedIssuanceResult(error instanceof Error ? error.message : "malformed request body")
     );
   }
+}
+
+function hasDuplicateRawHeader(req: IncomingMessage, name: string): boolean {
+  let matches = 0;
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    if (req.rawHeaders[index]?.toLowerCase() === name) {
+      matches += 1;
+      if (matches > 1) return true;
+    }
+  }
+  return false;
 }
 
 export function startLicenseServer(options: LicenseHttpOptions & { port?: number; host?: string }): Promise<{ server: Server; url: string }> {

--- a/services/license-api/src/issuance.ts
+++ b/services/license-api/src/issuance.ts
@@ -22,6 +22,8 @@ const ISSUANCE_FIELDS = new Set([
   "externalCheckoutId",
   "seats"
 ]);
+const ISSUANCE_AUTHORIZATION_PURPOSE = "neondiff-license-issuance-auth-v1";
+const DERIVED_ISSUANCE_AUTHORIZATION_PATTERN = /^v1\.[A-Za-z0-9_-]{43}$/;
 
 export interface LicenseIssuanceRequest {
   idempotencyKey: string;
@@ -158,6 +160,30 @@ export function validateBearerSecret(header: string | string[] | undefined, expe
   if (!value?.startsWith(prefix)) return false;
   const supplied = value.slice(prefix.length);
   return timingSafeEqualDigest(supplied, expected);
+}
+
+export function deriveIssuanceAuthorization(secret: string): string {
+  const digest = createHmac("sha256", secret)
+    .update(ISSUANCE_AUTHORIZATION_PURPOSE)
+    .digest("base64url");
+  return `v1.${digest}`;
+}
+
+export function validateIssuanceAuthorization(
+  bearerHeader: string | string[] | undefined,
+  derivedHeader: string | string[] | undefined,
+  expectedSecret: string
+): boolean {
+  const hasBearer = bearerHeader !== undefined;
+  const hasDerived = derivedHeader !== undefined;
+  if (hasBearer === hasDerived) return false;
+
+  if (hasBearer) {
+    return !Array.isArray(bearerHeader) && validateBearerSecret(bearerHeader, expectedSecret);
+  }
+  if (Array.isArray(derivedHeader) || !derivedHeader) return false;
+  if (!DERIVED_ISSUANCE_AUTHORIZATION_PATTERN.test(derivedHeader)) return false;
+  return timingSafeEqualDigest(derivedHeader, deriveIssuanceAuthorization(expectedSecret));
 }
 
 function deriveCheckoutLicenseKey(secret: string, idempotencyKey: string): string {

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
-import type { Server } from "node:http";
+import { request as httpRequest, type Server } from "node:http";
 import { LicenseStore } from "../src/store.ts";
 import { startLicenseServer } from "../src/http.ts";
 import {
@@ -37,6 +37,41 @@ async function post(
   });
   const text = await res.text();
   return { status: res.status, json: text ? JSON.parse(text) : {} };
+}
+
+async function postWithHeaders(
+  url: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string | string[]>
+): Promise<{ status: number; json: any }> {
+  const payload = JSON.stringify(body);
+  return await new Promise((resolve, reject) => {
+    const req = httpRequest(
+      `${url}${path}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+          ...headers
+        }
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          resolve({
+            status: res.statusCode ?? 0,
+            json: text ? JSON.parse(text) : {}
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end(payload);
+  });
 }
 
 describe("license http transport", () => {
@@ -241,6 +276,28 @@ describe("license issuance transport", () => {
       validateIssuanceAuthorization(undefined, "v1.invalid", issuanceSecret),
       false
     );
+  });
+
+  it("rejects duplicate raw Authorization fields before Node normalizes them", async () => {
+    const before = store.listLicenses().length;
+    const duplicate = await postWithHeaders(
+      url,
+      "/v1/admin/licenses/issue",
+      checkoutBody({
+        idempotencyKey: "checkout-session-duplicate-bearer",
+        externalSubscriptionId: "sub_duplicate_bearer",
+        externalCheckoutId: "cs_duplicate_bearer"
+      }),
+      {
+        Authorization: [
+          `Bearer ${issuanceSecret}`,
+          `Bearer ${issuanceSecret}`
+        ]
+      }
+    );
+
+    assert.equal(duplicate.status, 401);
+    assert.equal(store.listLicenses().length, before);
   });
 
   it("issues a product-native license key for checkout fulfillment", async () => {

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -3,6 +3,10 @@ import { after, before, describe, it } from "node:test";
 import type { Server } from "node:http";
 import { LicenseStore } from "../src/store.ts";
 import { startLicenseServer } from "../src/http.ts";
+import {
+  deriveIssuanceAuthorization,
+  validateIssuanceAuthorization
+} from "../src/issuance.ts";
 import { RateLimiter } from "../src/service.ts";
 
 const fakeKey = (tag: string): string => ["nd", "live", `${tag}${"x".repeat(24 - tag.length)}`].join("_");
@@ -139,6 +143,9 @@ describe("license issuance transport", () => {
   let url: string;
   const issuanceSecret = ["test", "issuance", "secret", "0123456789"].join("_");
   const auth = { Authorization: `Bearer ${issuanceSecret}` };
+  const derivedAuth = {
+    "X-NeonDiff-Issuance-Authorization": deriveIssuanceAuthorization(issuanceSecret)
+  };
 
   before(async () => {
     store = new LicenseStore(":memory:", {
@@ -166,6 +173,74 @@ describe("license issuance transport", () => {
     });
     assert.equal(res.status, 401);
     assert.equal(store.listLicenses().length, 0);
+  });
+
+  it("accepts the route-scoped derived credential without exposing the raw secret", async () => {
+    const authorization = deriveIssuanceAuthorization(issuanceSecret);
+    assert.match(authorization, /^v1\.[A-Za-z0-9_-]{43}$/);
+    assert.ok(!authorization.includes(issuanceSecret));
+
+    const before = store.listLicenses().length;
+    const issued = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      checkoutBody({
+        idempotencyKey: "checkout-session-derived",
+        externalSubscriptionId: "sub_derived",
+        externalCheckoutId: "cs_derived"
+      }),
+      derivedAuth
+    );
+
+    assert.equal(issued.status, 200);
+    assert.equal(issued.json.replayed, false);
+    assert.equal(store.listLicenses().length, before + 1);
+  });
+
+  it("preserves one idempotent issuance across derived and bearer credentials", async () => {
+    const body = checkoutBody({
+      idempotencyKey: "checkout-session-cross-credential",
+      externalSubscriptionId: "sub_cross_credential",
+      externalCheckoutId: "cs_cross_credential"
+    });
+    const before = store.listLicenses().length;
+    const first = await post(url, "/v1/admin/licenses/issue", body, derivedAuth);
+    const replay = await post(url, "/v1/admin/licenses/issue", body, auth);
+
+    assert.equal(first.status, 200);
+    assert.equal(replay.status, 200);
+    assert.equal(replay.json.replayed, true);
+    assert.equal(replay.json.licenseKey, first.json.licenseKey);
+    assert.equal(store.listLicenses().length, before + 1);
+  });
+
+  it("rejects dual, malformed, and array-valued issuance credentials", async () => {
+    const before = store.listLicenses().length;
+    const dual = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      checkoutBody({
+        idempotencyKey: "checkout-session-dual-auth",
+        externalSubscriptionId: "sub_dual_auth",
+        externalCheckoutId: "cs_dual_auth"
+      }),
+      { ...auth, ...derivedAuth }
+    );
+    assert.equal(dual.status, 401);
+    assert.equal(store.listLicenses().length, before);
+
+    assert.equal(
+      validateIssuanceAuthorization(
+        undefined,
+        ["v1.invalid", deriveIssuanceAuthorization(issuanceSecret)],
+        issuanceSecret
+      ),
+      false
+    );
+    assert.equal(
+      validateIssuanceAuthorization(undefined, "v1.invalid", issuanceSecret),
+      false
+    );
   });
 
   it("issues a product-native license key for checkout fulfillment", async () => {

--- a/tests/helpers/in-process-license-api.ts
+++ b/tests/helpers/in-process-license-api.ts
@@ -21,12 +21,14 @@ export function createInProcessLicenseApi(issuanceSecret: string): InProcessLice
   const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const path = new URL(String(input)).pathname;
     const body = String(init?.body ?? "");
+    const headerEntries = Array.from(new Headers(init?.headers).entries());
     return await new Promise<Response>((resolve, reject) => {
       let requestErrorCallback: ((error: Error) => void) | undefined;
       const req: any = {
         method: init?.method ?? "POST",
         url: path,
-        headers: Object.fromEntries(new Headers(init?.headers).entries()),
+        headers: Object.fromEntries(headerEntries),
+        rawHeaders: headerEntries.flatMap(([name, value]) => [name, value]),
         socket: { remoteAddress: "127.0.0.1" },
         on(event: string, callback: (value?: unknown) => void) {
           if (event === "data" && body) callback(Buffer.from(body));


### PR DESCRIPTION
Related: #562
Related: #610

## Acceptance criteria
- `/v1/admin/licenses/issue` accepts a purpose-bound HMAC-SHA256 credential in `X-NeonDiff-Issuance-Authorization`.
- The existing bearer credential remains valid for a coordinated zero-downtime deploy.
- Missing, malformed, array-valued, and dual credentials fail closed with the existing generic 401.
- Derived and bearer requests share the existing idempotency/store contract and cannot mint duplicates.
- The raw shared secret is never placed in the derived header or logged.

## Non-goals
- No secret rotation.
- No change to lifecycle authorization, license derivation, request bodies, persistence schema, entitlement policy, billing, or retry behavior.
- No release or customer-readiness claim.

## Failing-first and focused proof
- RED: `node --import tsx --test test/http.test.ts --test-name-pattern="license issuance transport"` failed because the derived auth exports did not exist.
- GREEN: same focused command, 22/22.
- `npm run build` in `services/license-api`.
- `git diff --check`.

Agent-authored. Broad validation remains GitHub CI.