### PR TITLE
docs: align B0 onboarding with public paid BYO beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,18 @@ package. To preview without changing your machine:
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
-Invite-only B0 Mac candidates use a separate checksum-bound private worker
-bundle rather than an unpublished npm version or an unpinned source checkout.
+The public paid B0 Mac beta uses a separate checksum-bound worker bundle from
+the same immutable GitHub prerelease as the app rather than an unpublished npm
+version or an unpinned source checkout. No invitation is required once the
+#610 public release gate opens.
 When the app reports **Worker update required**, choose **Install / Update Local
-Worker** and follow the exact invite checksums plus the dry-run-first update and
-rollback commands in [docs/SETUP.md](docs/SETUP.md#update-an-existing-local-worker).
+Worker** and compare the exact SHA-256 values in the prerelease notes and
+release manifest before following the dry-run-first update and rollback commands
+in [docs/SETUP.md](docs/SETUP.md#update-an-existing-local-worker).
 This preserves the existing config, LaunchAgent identity/environment, provider
 state, repository allowlist, and credential stores. It is not a public npm,
-GitHub Release, Sparkle, or automatic worker-update claim.
+Sparkle, or automatic worker-update claim before that immutable prerelease is
+published.
 
 Source checkout fallback:
 
@@ -158,14 +162,14 @@ when a release bundle carries the exact `paid-mac-beta-v1` Info.plist contract,
 fixed production broker origin, and explicit broker-enable marker. Those public
 build values are absent by default, so ordinary/debug bundles stay quarantined;
 the server kill switch and every broker/entitlement decision still fail closed.
-The invite-only B0 technical-beta build uses a separate exact
+The public paid B0 BYO beta build uses a separate exact
 `paid-mac-beta-byo-v1` release contract with `NeonDiffBYOGitHubEnabled=true` and
 no managed-broker fields. That contract enables the existing local direct/BYO
 path and API-backed native activation without a hidden defaults mutation. It
 is a paid path for every repository and does not claim the managed public-free
 model. On a clean Mac, native first run exposes **Initialize Local Config**
 (non-destructive; never force-overwrites), **Add Repository**, **Apply
-Repository**, and **Verify App Access**, so the invited customer does not need a
+Repository**, and **Verify App Access**, so the customer does not need a
 terminal or an operator edit to reach the repository-verification gate. This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.

--- a/README.md
+++ b/README.md
@@ -105,17 +105,18 @@ curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 The public paid B0 Mac beta uses a separate checksum-bound worker bundle from
 the same immutable GitHub prerelease as the app rather than an unpublished npm
 version or an unpinned source checkout. No invitation is required once the
-#610 public release gate opens.
+versioned public GitHub prerelease is published and linked from neondiff.com.
 When the app reports **Worker update required**, choose **Install / Update Local
-Worker** and compare the exact SHA-256 values in the prerelease notes and
-release manifest before following the dry-run-first update and rollback commands
-in [docs/SETUP.md](docs/SETUP.md#update-an-existing-local-worker).
+Worker**. Verify the outer worker bundle ZIP against the prerelease notes, then
+verify the extracted release manifest and inner `.tgz` tarball against the
+published SHA-256 values before following the dry-run-first update and rollback
+commands in [docs/SETUP.md](docs/SETUP.md#update-an-existing-local-worker).
 This preserves the existing config, LaunchAgent identity/environment, provider
 state, repository allowlist, and credential stores. It is not a public npm,
 Sparkle, or automatic worker-update claim before that immutable prerelease is
 published.
 
-Source checkout fallback:
+Operator/contributor source checkout fallback:
 
 ```bash
 git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git neondiff
@@ -125,7 +126,9 @@ npm run build
 ```
 
 If you intentionally use the source checkout without the global package,
-substitute `./dist/src/cli.js` anywhere this guide calls `neondiff`.
+substitute `./dist/src/cli.js` anywhere this guide calls `neondiff`. A source
+checkout is not a supported B0 worker update and cannot replace the
+checksum-bound prerelease bundle.
 
 ## Set Up
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 
 The public paid B0 Mac beta uses a separate checksum-bound worker bundle from
 the same immutable GitHub prerelease as the app rather than an unpublished npm
-version or an unpinned source checkout. No invitation is required once the
-versioned public GitHub prerelease is published and linked from neondiff.com.
+version or an unpinned source checkout. No invitation is required when the
+versioned public GitHub prerelease is published and the neondiff.com
+purchase/download path is live.
 When the app reports **Worker update required**, choose **Install / Update Local
 Worker**. Verify the outer worker bundle ZIP against the prerelease notes, then
 verify the extracted release manifest and inner `.tgz` tarball against the

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -58,6 +58,11 @@ enum NeonDiffDesktopCompositionRoot {
             githubBroker: githubBroker,
             accountLink: accountLink,
             productionBoundary: productionBoundary,
+            localWorkerUpdateGuideURL: DesktopReleaseRouting.localWorkerUpdateGuideURL(
+                shortVersion: Bundle.main.object(
+                    forInfoDictionaryKey: "CFBundleShortVersionString"
+                ) as? String
+            ),
             cliWorkingDirectory: cliWorkingDirectory,
             localBotConfigurations: localBotConfigurations,
             localBotExecutionConfigPaths: localBotExecutionContexts.map(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -221,7 +221,7 @@ struct OnboardingWizardView: View {
                 )
             }
 
-            Text("This invite-only technical beta uses a GitHub App owned by you. Paste the App ID and its unencrypted private-key PEM. The private key is stored only in this Mac's Keychain and plaintext input is cleared after every attempt.")
+            Text("This public paid BYO beta uses a GitHub App owned by you. Paste the App ID and its unencrypted private-key PEM. The private key is stored only in this Mac's Keychain and plaintext input is cleared after every attempt.")
                 .operatorBodyText()
                 .fixedSize(horizontal: false, vertical: true)
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -432,7 +432,7 @@ struct ReposView: View {
                     )
                 }
 
-                Text("B0 uses a GitHub App owned and installed by the invited customer. Enter its numeric App ID and paste the full unencrypted PEM private key. NeonDiff stores the key in this Mac's Keychain; it is not written to config or command arguments.")
+                Text("The public paid B0 BYO beta uses a GitHub App owned and installed by the customer. Enter its numeric App ID and paste the full unencrypted PEM private key. NeonDiff stores the key in this Mac's Keychain; it is not written to config or command arguments.")
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -99,6 +99,24 @@ private let approvedAccountConnectURL = URL(
     string: "https://www.neondiff.com/desktop/connect"
 )!
 
+package enum DesktopReleaseRouting {
+    private static let releasesURL = URL(
+        string: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases"
+    )!
+
+    package static func localWorkerUpdateGuideURL(shortVersion: String?) -> URL {
+        guard let shortVersion else { return releasesURL }
+        let version = shortVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        let semverPattern = #"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$"#
+        guard version.range(of: semverPattern, options: .regularExpression) != nil else {
+            return releasesURL
+        }
+        return releasesURL
+            .appendingPathComponent("tag", isDirectory: false)
+            .appendingPathComponent("v\(version)", isDirectory: false)
+    }
+}
+
 package struct DesktopAppDependencies {
     package let clipboard: any DesktopClipboard
     package let urlOpener: any DesktopURLOpener
@@ -113,6 +131,7 @@ package struct DesktopAppDependencies {
     package let githubBroker: (any GitHubBrokerConnecting)?
     package let accountLink: (any NeonDiffAccountLinkConnecting)?
     package let productionBoundary: DesktopProductionBoundary
+    package let localWorkerUpdateGuideURL: URL
     package let cliWorkingDirectory: URL?
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
     package let localBotExecutionConfigPaths: [String]
@@ -131,6 +150,9 @@ package struct DesktopAppDependencies {
         githubBroker: (any GitHubBrokerConnecting)? = nil,
         accountLink: (any NeonDiffAccountLinkConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
+        localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
+            shortVersion: nil
+        ),
         cliWorkingDirectory: URL? = nil,
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         localBotExecutionConfigPaths: [String] = []
@@ -148,6 +170,7 @@ package struct DesktopAppDependencies {
         self.githubBroker = githubBroker
         self.accountLink = accountLink
         self.productionBoundary = productionBoundary
+        self.localWorkerUpdateGuideURL = localWorkerUpdateGuideURL
         self.cliWorkingDirectory = cliWorkingDirectory
         self.localBotConfigurations = localBotConfigurations
         self.localBotExecutionConfigPaths = localBotExecutionConfigPaths

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2165,10 +2165,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func openLocalWorkerUpdateGuide() {
-        let url = URL(
-            string: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/blob/main/docs/SETUP.md#update-an-existing-local-worker"
-        )!
-        guard dependencies.urlOpener.open(url) else {
+        guard dependencies.urlOpener.open(dependencies.localWorkerUpdateGuideURL) else {
             lastError = "NeonDiff could not open the local worker installer guide."
             return
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -651,9 +651,10 @@ import NeonDiffDesktopCore
         #expect(fixture.model.scopedReviewStatus.contains("update required"))
 
         fixture.model.openLocalWorkerUpdateGuide()
-        #expect(fixture.urlOpener.urls.last?.absoluteString.contains(
-            "docs/SETUP.md#update-an-existing-local-worker"
-        ) == true)
+        #expect(
+            fixture.urlOpener.urls.last?.absoluteString
+                == "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.1.0-beta.37"
+        )
 
         fixture.cli.enqueue(.success(CLIRunResult(
             exitCode: 0,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -253,7 +253,10 @@ struct ModelDependencyFixture {
         preferenceStrings: [String: String] = [:],
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         localBotExecutionConfigPaths: [String] = [],
-        productionBoundary: DesktopProductionBoundary = .testVerified
+        productionBoundary: DesktopProductionBoundary = .testVerified,
+        localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
+            shortVersion: "1.1.0-beta.37"
+        )
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
         urlOpener = RecordingURLOpener(result: urlResult)
@@ -288,6 +291,7 @@ struct ModelDependencyFixture {
             githubAuthenticator: githubAuthenticator,
             githubBroker: githubBroker,
             productionBoundary: productionBoundary,
+            localWorkerUpdateGuideURL: localWorkerUpdateGuideURL,
             localBotConfigurations: localBotConfigurations,
             localBotExecutionConfigPaths: localBotExecutionConfigPaths
         ), activationLicenseClient: activationLicenseClient)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -80,10 +80,12 @@ npm run build
 If you intentionally use the source checkout without the global package,
 substitute `./dist/src/cli.js` for `neondiff`.
 
-## 2. Create Or Install A GitHub App
+## 2. Create And Install A Customer-Owned GitHub App
 
-Use the public NeonDiff GitHub App install URL for the beta you are testing, or
-create an equivalent App while the public registration is being finalized. See
+For the public paid B0 BYO beta, create a customer-owned GitHub App in your
+GitHub account or organization and use that App's install URL. The public
+organization-owned NeonDiff App belongs to the later managed B1 path and does
+not replace the B0 private key flow. See
 [docs/github-app-setup.md](github-app-setup.md) for the selected-repo install
 path, uninstall path, evidence packet, and troubleshooting details.
 
@@ -333,10 +335,12 @@ If Overview shows **Worker update required**:
 
 1. Do not run or retry a live review from another terminal. The dry-to-live
    approval contract is not proven for that worker.
-2. Choose **Install / Update Local Worker**. Use only the worker ZIP named in
-   the same immutable GitHub prerelease and release manifest as the installed
-   app. Compare both its ZIP SHA-256 and the manifest SHA-256 with the published
-   prerelease values before extracting it. Do not use an unpinned `main`
+2. Choose **Install / Update Local Worker**. Use only the outer worker bundle
+   ZIP named in the same immutable GitHub prerelease and release manifest as the
+   installed app. Before extracting it, compare the bundle ZIP SHA-256 with the
+   prerelease notes. After extraction, compare the release manifest SHA-256 with
+   the prerelease notes, then compare the inner `.tgz` tarball SHA-256 with both
+   the release manifest and the prerelease notes. Do not use an unpinned `main`
    checkout or trust the ambiguous `1.0.4` version string.
 3. Confirm `node --version` reports Node.js 26 or newer. From the extracted
    directory, preview the checksum-bound migration using the exact LaunchAgent

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -279,8 +279,9 @@ For a B0 customer, the native first-run path is:
 
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate
-gates. No invitation is required once the #610 public purchase/download gate
-opens; until then, the candidate and its GitHub prerelease assets remain held.
+gates. No invitation is required when the versioned public GitHub prerelease is
+published and the neondiff.com purchase/download path is live. Until both are
+true, the candidate and its GitHub prerelease assets remain held.
 
 ### Existing bot on this Mac
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -246,7 +246,7 @@ public configuration values, not secrets, and do not override the server-side
 kill switch. Generic CLI status/deactivate and daemon-admission validation still
 require exact-candidate integration proof under #630.
 
-The invite-only B0 technical beta has a separate, mutually exclusive release
+The public paid B0 BYO beta has a separate, mutually exclusive release
 bundle contract:
 
 - `NeonDiffPaidBetaContract = paid-mac-beta-byo-v1`
@@ -260,7 +260,7 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
-For an invited B0 customer, the native first-run path is:
+For a B0 customer, the native first-run path is:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
@@ -277,7 +277,8 @@ For an invited B0 customer, the native first-run path is:
 
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate
-gates.
+gates. No invitation is required once the #610 public purchase/download gate
+opens; until then, the candidate and its GitHub prerelease assets remain held.
 
 ### Existing bot on this Mac
 
@@ -332,11 +333,11 @@ If Overview shows **Worker update required**:
 
 1. Do not run or retry a live review from another terminal. The dry-to-live
    approval contract is not proven for that worker.
-2. Choose **Install / Update Local Worker**. For the invite-only B0 beta, use
-   only the private worker ZIP named in the invite. Compare both its ZIP
-   SHA-256 and the manifest SHA-256 with the values supplied separately in the
-   invite before extracting it. Do not use an unpinned `main` checkout or trust
-   the ambiguous `1.0.4` version string.
+2. Choose **Install / Update Local Worker**. Use only the worker ZIP named in
+   the same immutable GitHub prerelease and release manifest as the installed
+   app. Compare both its ZIP SHA-256 and the manifest SHA-256 with the published
+   prerelease values before extracting it. Do not use an unpinned `main`
+   checkout or trust the ambiguous `1.0.4` version string.
 3. Confirm `node --version` reports Node.js 26 or newer. From the extracted
    directory, preview the checksum-bound migration using the exact LaunchAgent
    label shown in NeonDiff Settings. The installer requires absolute artifact
@@ -346,7 +347,7 @@ If Overview shows **Worker update required**:
    BUNDLE_DIR="$(pwd -P)"
    node install-b0-worker-candidate.mjs update \
      --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-     --manifest-sha256 <manifest-sha256-from-invite> \
+     --manifest-sha256 <manifest-sha256-from-release> \
      --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
      --launchd-label <existing-label> \
      --dry-run true
@@ -378,8 +379,9 @@ Rollback also requires `--dry-run false --confirm true`. It restores the
 previous versioned worker, or the original LaunchAgent invocation on the first
 migration, without deleting either candidate or touching customer secrets.
 
-Until an invite or immutable release names a compatible worker artifact, this
-state is a release blocker rather than a prompt to repair source files manually.
+Until an immutable GitHub prerelease and release manifest name a compatible
+worker artifact, this state is a release blocker rather than a prompt to repair
+source files manually.
 The app's own Sparkle update does not update an external local worker.
 
 ## 4. Check Readiness
@@ -392,7 +394,7 @@ printing secrets:
 neondiff doctor github --config config.local.json --json
 ```
 
-The invite-only B0 desktop keeps the customer-owned App private key in the
+The public paid B0 BYO desktop keeps the customer-owned App private key in the
 macOS Keychain. Its explicit **Verify App Access** action sends that key only to
 the local CLI's bounded stdin for this check. The native app's clean-install
 config lives in its user-writable Application Support directory; the equivalent

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -6,21 +6,22 @@ comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
 On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
-The invite-only B0 build accepts the invited customer's own App ID and private
-key, one selected repository, and runs the explicit installation check from the
-wizard. The managed B1 path uses the official NeonDiff App and broker under
-#613; it is separate from B0. This document remains the operator/CLI reference
-for both paths' App identity, permission set, and install boundary. Matching
-public website onboarding copy lives in the website repo under
+The public paid B0 BYO build accepts the customer's own App ID and private key,
+one selected repository, and runs the explicit installation check from the
+wizard. No invitation is required once the #610 public purchase/download gate
+opens. The managed B1 path uses the official NeonDiff App and broker under #613;
+it is separate from B0. This document remains the operator/CLI reference for
+both paths' App identity, permission set, and install boundary. Matching public
+website onboarding copy lives in the website repo under
 neon-diff-agent-website#52.
 
 ## Install URL
 
-For B0, create a customer-owned GitHub App in the invited customer's GitHub
-account or organization, then use that App's install link. Record its numeric
-App ID, generate one private key, and keep the downloaded PEM outside git. The
-public, organization-owned NeonDiff App is the separate managed B1 path; do not
-use it to describe or prove B0.
+For B0, create a customer-owned GitHub App in the customer's GitHub account or
+organization, then use that App's install link. Record its numeric App ID,
+generate one private key, and keep the downloaded PEM outside git. The public,
+organization-owned NeonDiff App is the separate managed B1 path; do not use it
+to describe or prove B0.
 
 Install only on selected repositories. NeonDiff does not need organization-wide
 discovery for the v1.0 MVP, and the worker only reviews repos present in your
@@ -138,12 +139,14 @@ to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
 If this matched local worker reports **Worker update required**, choose
-**Install / Update Local Worker** and use only the checksum-bound private B0
-bundle named in the invite. Follow the Node.js 26+, absolute-path, dry-run, and
-confirmed-mutation steps in [SETUP.md](./SETUP.md#update-an-existing-local-worker).
-The label-isolated installer preserves the existing App environment, config,
-provider state, repository allowlist, and private-key file coordinate. Preview
-rollback before confirmed rollback; neither path reads or copies key bytes.
+**Install / Update Local Worker** and use only the checksum-bound B0 bundle
+named in the same immutable GitHub prerelease and release manifest as the app.
+Verify the published ZIP and manifest SHA-256 values, then follow the Node.js
+26+, absolute-path, dry-run, and confirmed-mutation steps in
+[SETUP.md](./SETUP.md#update-an-existing-local-worker). The label-isolated
+installer preserves the existing App environment, config, provider state,
+repository allowlist, and private-key file coordinate. Preview rollback before
+confirmed rollback; neither path reads or copies key bytes.
 
 Keep the private key and local config out of git. A typical shell setup is:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -8,12 +8,12 @@ configuration, state database, and evidence files.
 On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
 The public paid B0 BYO build accepts the customer's own App ID and private key,
 one selected repository, and runs the explicit installation check from the
-wizard. No invitation is required once the #610 public purchase/download gate
-opens. The managed B1 path uses the official NeonDiff App and broker under #613;
-it is separate from B0. This document remains the operator/CLI reference for
-both paths' App identity, permission set, and install boundary. Matching public
-website onboarding copy lives in the website repo under
-neon-diff-agent-website#52.
+wizard. No invitation is required when the versioned public GitHub prerelease
+and neondiff.com purchase/download path are live. The managed B1 path uses the
+official NeonDiff App and broker under #613; it is separate from B0. This
+document remains the operator/CLI reference for both paths' App identity,
+permission set, and install boundary. Matching public website onboarding copy
+lives in the website repo under neon-diff-agent-website#52.
 
 ## Install URL
 
@@ -141,8 +141,11 @@ Daemon-wide start stays blocked for a multi-repository worker.
 If this matched local worker reports **Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle
 named in the same immutable GitHub prerelease and release manifest as the app.
-Verify the published ZIP and manifest SHA-256 values, then follow the Node.js
-26+, absolute-path, dry-run, and confirmed-mutation steps in
+Verify the outer bundle ZIP against the prerelease notes before extraction.
+Then verify the release manifest against its SHA-256 in the prerelease notes,
+and verify the inner `.tgz` tarball against the SHA-256 in both the release
+manifest and prerelease notes before following the Node.js 26+, absolute-path,
+dry-run, and confirmed-mutation steps in
 [SETUP.md](./SETUP.md#update-an-existing-local-worker). The label-isolated
 installer preserves the existing App environment, config, provider state,
 repository allowlist, and private-key file coordinate. Preview rollback before

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -8,12 +8,12 @@ configuration, state database, and evidence files.
 On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
 The public paid B0 BYO build accepts the customer's own App ID and private key,
 one selected repository, and runs the explicit installation check from the
-wizard. No invitation is required when the versioned public GitHub prerelease
-and neondiff.com purchase/download path are live. The managed B1 path uses the
-official NeonDiff App and broker under #613; it is separate from B0. This
-document remains the operator/CLI reference for both paths' App identity,
-permission set, and install boundary. Matching public website onboarding copy
-lives in the website repo under neon-diff-agent-website#52.
+wizard. No invitation is required when the versioned public GitHub prerelease is
+published and the neondiff.com purchase/download path is live. The managed B1
+path uses the official NeonDiff App and broker under #613; it is separate from
+B0. This document remains the operator/CLI reference for both paths' App
+identity, permission set, and install boundary. Matching public website
+onboarding copy lives in the website repo under neon-diff-agent-website#52.
 
 ## Install URL
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -23,6 +23,37 @@ generate one private key, and keep the downloaded PEM outside git. The public,
 organization-owned NeonDiff App is the separate managed B1 path; do not use it
 to describe or prove B0.
 
+### Register the direct B0 App
+
+Open GitHub's [New GitHub App](https://github.com/settings/apps/new) page while
+signed in to the account that should own the App. For an organization-owned App,
+open that organization's **Settings → Developer settings → GitHub Apps → New
+GitHub App** page instead. GitHub's canonical field reference is
+[Registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+
+Use these direct local-worker values:
+
+1. **GitHub App name:** choose a unique customer-owned name.
+2. **Homepage URL:** use `https://www.neondiff.com` or the customer's own
+   project homepage.
+3. **Request user authorization (OAuth) during installation: off.** B0 does not
+   request or store a GitHub user token.
+4. **Callback URL:** blank.
+5. **Setup URL:** blank, with **Redirect on update** off.
+6. **Webhook:** disabled—deselect **Active** and leave the webhook URL blank.
+   The local worker polls; B0 has no webhook receiver.
+7. **Device Flow:** off. It is not used by the direct B0 App path.
+8. Set the repository permissions in the next section and leave all
+   organization and account permissions at **No access**.
+9. Under **Where can this GitHub App be installed?**, choose **Only on this
+   account**.
+10. Create the App, generate one private key, record the numeric App ID, and use
+    the App's public-page install link to install it on selected repositories.
+
+Do not copy the managed-B1 OAuth/callback settings from
+`docs/security/github-app-staging-registration.md`; that registration belongs to
+the broker path and is incompatible with the B0 private-key flow.
+
 Install only on selected repositories. NeonDiff does not need organization-wide
 discovery for the v1.0 MVP, and the worker only reviews repos present in your
 local config allowlist.

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -56,9 +56,10 @@ Use the JSON-first CLI instead of choosing `bootstrap` or `kickstart` from
 plist existence alone. The executable stop/start sequence and confirmation
 requirements live in [the operator CLI guide](operator-cli.md#common-operator-flows).
 
-For an invited B0 Mac worker update, do not edit `ProgramArguments`,
+For a public paid B0 BYO Mac worker update, do not edit `ProgramArguments`,
 `WorkingDirectory`, or credential environment entries by hand. Use the
-checksum-bound private bundle described in
+checksum-bound worker bundle from the same immutable GitHub prerelease as the
+app, as described in
 [SETUP.md](SETUP.md#update-an-existing-local-worker). Its installer validates
 the existing NeonDiff invocation, preserves the label and environment, stages a
 versioned user-owned worker, and changes the plist atomically only after

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -189,14 +189,14 @@ A stored license key is not treated as active entitlement. Repo selection still
 writes only the local allowlist; the worker's pre-checkout license and GitHub App
 gates remain authoritative for review execution.
 
-In the invite-only B0 build, first-run onboarding and the Repos pane accept a
-customer-owned numeric App ID and unencrypted RSA private key. The key is stored
-only in the fixed macOS Keychain account. On a clean install, first run exposes
-the non-destructive **Initialize Local Config** action before the customer adds
-one `owner/repo`, applies it through the typed local config patch, and chooses
-**Verify App Access**. Initialization never force-overwrites an existing config,
-and the customer does not need an operator edit. Verification reads the key only
-on that explicit action, supplies it to
+In the public paid B0 BYO build, first-run onboarding and the Repos pane accept
+a customer-owned numeric App ID and unencrypted RSA private key. The key is
+stored only in the fixed macOS Keychain account. On a clean install, first run
+exposes the non-destructive **Initialize Local Config** action before the
+customer adds one `owner/repo`, applies it through the typed local config patch,
+and chooses **Verify App Access**. Initialization never force-overwrites an
+existing config, and the customer does not need an operator edit. Verification
+reads the key only on that explicit action, supplies it to
 `doctor github` through bounded stdin, and accepts only typed App-installation
 proof for the exact configured repository. Changing the App credentials,
 CLI/config path, or allowlist invalidates that proof. This step does not run a

--- a/scripts/build-b0-worker-bundle.mjs
+++ b/scripts/build-b0-worker-bundle.mjs
@@ -98,12 +98,18 @@ function assertOutputDirectory(repoRoot, requested) {
 function installGuide(candidate, manifestFilename, tarballFilename, manifestSHA256) {
   return `# Install the NeonDiff ${candidate.packageVersion} B0 worker
 
-This private bundle is for the invited B0 technical beta. It is not a public
-npm package, GitHub Release, or automatic update.
+This outer bundle ZIP is for the public paid BYO Mac beta. It is distributed
+only through the immutable GitHub prerelease named in the release manifest; it
+is not a public npm package or an automatic update.
 
-Before continuing, compare this manifest SHA-256 with the value in your invite:
+Before extracting the outer ZIP, compare its SHA-256 with the prerelease notes.
+Then compare this release manifest SHA-256 with the prerelease notes:
 
 \`${manifestSHA256}\`
+
+The installer verifies the inner \`.tgz\` tarball
+\`${tarballFilename}\` against the release manifest before mutation. Compare
+that tarball SHA-256 with the prerelease notes as well.
 
 From this extracted directory, preview the exact migration:
 
@@ -113,7 +119,7 @@ node install-b0-worker-candidate.mjs update \\
   --manifest "$BUNDLE_DIR/${manifestFilename}" \\
   --manifest-sha256 ${manifestSHA256} \\
   --tarball "$BUNDLE_DIR/${tarballFilename}" \\
-  --launchd-label YOUR_INVITED_LAUNCHD_LABEL \\
+  --launchd-label YOUR_NEONDIFF_LAUNCHD_LABEL \\
   --dry-run true
 \`\`\`
 
@@ -128,7 +134,7 @@ Rollback preview:
 
 \`\`\`sh
 node install-b0-worker-candidate.mjs rollback \\
-  --launchd-label YOUR_INVITED_LAUNCHD_LABEL \\
+  --launchd-label YOUR_NEONDIFF_LAUNCHD_LABEL \\
   --dry-run true
 \`\`\`
 
@@ -207,7 +213,7 @@ function main() {
         "lib/b0-worker-installer.mjs",
         "INSTALL.md"
       ],
-      proofBoundary: "Private customer bundle assembly only; no upload, publication, install, rollback, review, beta, release, or customer-readiness claim."
+      proofBoundary: "Worker bundle assembly only; no upload, publication, install, rollback, review, beta, release, or customer-readiness claim."
     };
     writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
     console.log(JSON.stringify({

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -86,6 +86,9 @@ describe("NeonDiff public community funnel", () => {
 
     for (const text of [surfaces.readme, surfaces.setup, surfaces.githubApp]) {
       expect(text).toMatch(/no invitation (?:is )?required/i);
+      expect(text.replace(/\s+/g, " ")).toMatch(
+        /No invitation is required when the versioned public GitHub prerelease is published and the neondiff\.com purchase\/download path is live\./i
+      );
       expect(text).toMatch(/GitHub prerelease|release manifest/i);
       expect(text).toMatch(/SHA-256|checksum/i);
     }

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -101,9 +101,9 @@ describe("NeonDiff public community funnel", () => {
     expect(surfaces.setup).not.toMatch(
       /Use the public NeonDiff GitHub App install URL for the beta/i
     );
+    expect(surfaces.githubApp).toContain("https://github.com/settings/apps/new");
     const registrationGuide = surfaces.githubApp.replace(/\s+/g, " ");
     for (const required of [
-      /github\.com\/settings\/apps\/new/i,
       /Homepage URL/i,
       /Request user authorization.*(?:off|disabled|do not enable)/is,
       /Setup URL.*blank/is,

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -70,7 +70,9 @@ describe("NeonDiff public community funnel", () => {
       nativeRepositories: read(
         "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift"
       ),
-      workerBundle: read("scripts/build-b0-worker-bundle.mjs")
+      workerBundle: read("scripts/build-b0-worker-bundle.mjs"),
+      launchdGuide: read("docs/launchd.md"),
+      desktopGuide: read("docs/neondiff-desktop.md")
     };
 
     for (const [name, text] of Object.entries(surfaces)) {
@@ -99,6 +101,18 @@ describe("NeonDiff public community funnel", () => {
     expect(surfaces.setup).not.toMatch(
       /Use the public NeonDiff GitHub App install URL for the beta/i
     );
+    const registrationGuide = surfaces.githubApp.replace(/\s+/g, " ");
+    for (const required of [
+      /github\.com\/settings\/apps\/new/i,
+      /Homepage URL/i,
+      /Request user authorization.*(?:off|disabled|do not enable)/is,
+      /Setup URL.*blank/is,
+      /webhook.*(?:off|disabled|deselect|uncheck)/is,
+      /Device Flow.*(?:off|disabled|do not enable)/is,
+      /Only on this account/i
+    ]) {
+      expect(registrationGuide).toMatch(required);
+    }
     for (const text of [surfaces.setup, surfaces.githubApp, surfaces.workerBundle]) {
       expect(text).toMatch(/outer.*ZIP|bundle ZIP/i);
       expect(text).toMatch(/inner.*\.tgz|tarball.*\.tgz|\.tgz.*tarball/i);

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -66,12 +66,20 @@ describe("NeonDiff public community funnel", () => {
       githubApp: read("docs/github-app-setup.md"),
       nativeOnboarding: read(
         "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift"
-      )
+      ),
+      nativeRepositories: read(
+        "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift"
+      ),
+      workerBundle: read("scripts/build-b0-worker-bundle.mjs")
     };
 
     for (const [name, text] of Object.entries(surfaces)) {
-      expect(text, name).not.toMatch(
-        /invite-only|\binvited\b|named in the invite|invite checksums|from-invite/i
+      const withoutAllowedNoInvitation = text.replace(
+        /no invitation (?:is )?required/gi,
+        ""
+      );
+      expect(withoutAllowedNoInvitation, name).not.toMatch(
+        /invite-only|\binvited\b|named in the invite|invite checksums|from-invite|by invitation|requires an invitation|an invitation is required/i
       );
       expect(text, name).toMatch(/public paid|public BYO|public.*customer-owned/i);
     }
@@ -80,6 +88,19 @@ describe("NeonDiff public community funnel", () => {
       expect(text).toMatch(/no invitation (?:is )?required/i);
       expect(text).toMatch(/GitHub prerelease|release manifest/i);
       expect(text).toMatch(/SHA-256|checksum/i);
+    }
+
+    expect(surfaces.readme).not.toMatch(/#610 public release gate/i);
+    expect(surfaces.readme).toMatch(/operator|contributor/i);
+    expect(surfaces.setup).toMatch(/create a customer-owned GitHub App/i);
+    expect(surfaces.setup).not.toMatch(
+      /Use the public NeonDiff GitHub App install URL for the beta/i
+    );
+    for (const text of [surfaces.setup, surfaces.githubApp, surfaces.workerBundle]) {
+      expect(text).toMatch(/outer.*ZIP|bundle ZIP/i);
+      expect(text).toMatch(/inner.*\.tgz|tarball.*\.tgz|\.tgz.*tarball/i);
+      expect(text).toMatch(/release notes|prerelease notes/i);
+      expect(text).toMatch(/release manifest/i);
     }
   });
 

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -59,6 +59,30 @@ describe("NeonDiff public community funnel", () => {
     }
   });
 
+  it("public BYO onboarding does not retain the retired invite-only contract", () => {
+    const surfaces = {
+      readme: read("README.md"),
+      setup: read("docs/SETUP.md"),
+      githubApp: read("docs/github-app-setup.md"),
+      nativeOnboarding: read(
+        "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift"
+      )
+    };
+
+    for (const [name, text] of Object.entries(surfaces)) {
+      expect(text, name).not.toMatch(
+        /invite-only|\binvited\b|named in the invite|invite checksums|from-invite/i
+      );
+      expect(text, name).toMatch(/public paid|public BYO|public.*customer-owned/i);
+    }
+
+    for (const text of [surfaces.readme, surfaces.setup, surfaces.githubApp]) {
+      expect(text).toMatch(/no invitation (?:is )?required/i);
+      expect(text).toMatch(/GitHub prerelease|release manifest/i);
+      expect(text).toMatch(/SHA-256|checksum/i);
+    }
+  });
+
   it("license boundary surfaces are canonical and avoid open-source claims", () => {
     const license = read("LICENSE.md");
     const boundary = read("docs/license-boundary.md");


### PR DESCRIPTION
Related: #686
Parent: #646
Tracker: #610

## Customer gate

The installed BYO path has already passed on beta.37, but the native onboarding sheet and required setup docs still described B0 as invite-only. The active roadmap and website now define B0 as a public, paid, self-service BYO beta.

## Acceptance criteria

- Native onboarding describes the customer-owned GitHub App path as the public paid BYO beta.
- README, setup, and GitHub App onboarding say no invitation is required once #610 opens the public purchase/download gate.
- Worker-update instructions bind the app and worker to the same immutable GitHub prerelease/release manifest and published SHA-256 values.
- A cross-surface regression rejects the retired invite-only wording.
- Existing Keychain, entitlement, repository, provider, dry/live review, and managed-App boundaries remain unchanged.

## Failing-first proof

Before the copy changes:

`npm test -- tests/public-community-funnel.test.ts`

failed in the new regression because README still contained `Invite-only B0 Mac candidates`.

After the copy changes:

- `npm test -- tests/public-community-funnel.test.ts` — 10/10 passed
- `node scripts/check-public-claims.mjs` — passed
- `git diff --check` — passed

The focused test used the existing dependency tree from the canonical checkout; no dependency or lockfile changed.

## Non-goals

- No billing, entitlement, activation, repository/provider, worker, review, or authorization logic change
- No managed official GitHub App or Device Flow work
- No signing, notarization, packaging, website publish, checkout, tag, GitHub Release, or customer-canary action
- No release, beta, GA, or customer-readiness claim

## Validation boundary

This is source-copy and regression proof only. A future signed candidate must contain the merged copy before public distribution. The broader purchase, activation, clean-install, canary, and immutable prerelease gates remain open.
