### PR TITLE
feat: route Stripe subscription lifecycle directly to Fly

### DIFF
--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -302,6 +302,13 @@ export interface CheckoutSubscriptionBindingRecord extends CheckoutSubscriptionB
   createdAt: string;
 }
 
+export interface CheckoutSubscriptionBindingLookup {
+  readonly provider: "stripe";
+  readonly providerAccountId: string;
+  readonly providerMode: "test" | "live";
+  readonly externalSubscriptionId: string;
+}
+
 export interface IssueBoundCheckoutLicenseInput {
   idempotencyKey: string;
   checkoutLookupKey: CheckoutLookupKey;
@@ -1185,6 +1192,40 @@ export class LicenseStore {
     }
   }
 
+  /**
+   * Resolve the immutable checkout issuance authority from the exact provider
+   * subscription tuple. This intentionally returns only the internal issuance
+   * key, never a raw license key or customer-facing credential.
+   */
+  resolveCheckoutIssuanceIdempotencyKey(
+    input: CheckoutSubscriptionBindingLookup
+  ): string | undefined {
+    if (
+      input.provider !== "stripe" ||
+      (input.providerMode !== "test" && input.providerMode !== "live") ||
+      !isBoundedLookupValue(input.providerAccountId, 160) ||
+      !isBoundedLookupValue(input.externalSubscriptionId, 160)
+    ) {
+      return undefined;
+    }
+    const row = this.db
+      .prepare(
+        `select issuance_idempotency_key
+         from checkout_subscription_bindings
+         where provider = ?
+           and provider_account_id = ?
+           and provider_mode = ?
+           and external_subscription_id = ?`
+      )
+      .get(
+        input.provider,
+        input.providerAccountId,
+        input.providerMode,
+        input.externalSubscriptionId
+      ) as Pick<CheckoutSubscriptionBindingRow, "issuance_idempotency_key"> | undefined;
+    return row?.issuance_idempotency_key;
+  }
+
   private insertLicense(rawKey: string, input: IssueLicenseInput): { rawKey: string; record: LicenseRecord } {
     const licenseKeyHash = hashLicenseKey(rawKey);
     const seats = input.seats ?? 1;
@@ -1325,6 +1366,15 @@ export class LicenseStore {
       .run(licenseKeyHash, machineId);
     return Number(info.changes) > 0;
   }
+}
+
+function isBoundedLookupValue(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maxLength &&
+    value === value.trim()
+  );
 }
 
 function mapLicense(row: LicenseRow): LicenseRecord {

--- a/services/license-api/src/stripe-checkout.ts
+++ b/services/license-api/src/stripe-checkout.ts
@@ -6,6 +6,10 @@ import {
 } from "./checkout-policy.js";
 import { deriveCheckoutLicenseKey } from "./issuance.js";
 import {
+  LifecycleRequestError,
+  parseSubscriptionLifecycleRequest
+} from "./subscription-lifecycle.js";
+import {
   CheckoutIssuanceConflictError,
   CheckoutIssuancePolicyError,
   CheckoutIssuanceTransientError,
@@ -14,14 +18,27 @@ import {
   CheckoutRedemptionInvalidError,
   CheckoutRedemptionNotFoundError,
   CheckoutRedemptionTransientError,
+  SubscriptionLifecycleConflictError,
+  SubscriptionLifecycleNotFoundError,
+  SubscriptionLifecyclePolicyError,
+  SubscriptionLifecycleTerminalError,
+  SubscriptionLifecycleTransientError,
+  SubscriptionLifecycleUnsupportedCommandError,
   type LicenseRecord,
   type LicenseStore
 } from "./store.js";
 
 const DEFAULT_REDEMPTION_TTL_MS = 30 * 60 * 1_000;
 const MAX_REDEMPTION_TTL_MS = 24 * 60 * 60 * 1_000;
-const STRIPE_ID_PATTERN = /^(?:acct|cs_(?:live|test)|cus|evt|price|prod|sub)_[A-Za-z0-9_]+$/;
+const STRIPE_ID_PATTERN = /^(?:acct|cs_(?:live|test)|cus|evt|in|price|prod|sub)_[A-Za-z0-9_]+$/;
 const TOKEN_HASH_PATTERN = /^[a-f0-9]{64}$/;
+const STRIPE_LIFECYCLE_EVENT_TYPES = new Set([
+  "invoice.paid",
+  "invoice.payment_succeeded",
+  "invoice.payment_failed",
+  "customer.subscription.updated",
+  "customer.subscription.deleted"
+]);
 
 export interface AllowedStripePrice {
   priceId: string;
@@ -50,6 +67,20 @@ export interface StripeCheckoutFulfillmentResult {
   status: "fulfilled";
   replayed: boolean;
 }
+
+export interface StripeCheckoutLifecycleResult {
+  status:
+    | "updated"
+    | "replayed"
+    | "ignored_stale"
+    | "payment_attention"
+    | "terminally_revoked";
+  replayed: boolean;
+}
+
+export type StripeCheckoutWebhookResult =
+  | StripeCheckoutFulfillmentResult
+  | StripeCheckoutLifecycleResult;
 
 export interface StripeCheckoutRedemptionResult {
   status: "redeemed";
@@ -99,7 +130,7 @@ export async function fulfillStripeCheckoutWebhook(options: {
   rawBody: string;
   signature: string;
   now: Date;
-}): Promise<StripeCheckoutFulfillmentResult> {
+}): Promise<StripeCheckoutWebhookResult> {
   const { store, runtime, rawBody, signature, now } = options;
   if (!Number.isFinite(now.getTime())) {
     throw new StripeCheckoutUnavailableError("checkout clock is unavailable");
@@ -113,10 +144,8 @@ export async function fulfillStripeCheckoutWebhook(options: {
   }
 
   const eventId = stripeId(verifiedEvent.id, "evt", "event id");
-  if (verifiedEvent.type !== "checkout.session.completed") {
-    throw new StripeCheckoutInvalidError("Stripe event type is unsupported");
-  }
-  positiveInteger(verifiedEvent.created, "event created");
+  const eventType = requiredString(verifiedEvent.type, "event type", 80);
+  const eventCreatedAt = positiveInteger(verifiedEvent.created, "event created");
   const eventLiveMode = boolean(verifiedEvent.livemode, "event livemode");
   const expectedLiveMode = config.mode === "live";
   if (eventLiveMode !== expectedLiveMode) {
@@ -127,7 +156,22 @@ export async function fulfillStripeCheckoutWebhook(options: {
     throw new StripeCheckoutInvalidError("Stripe event account is invalid");
   }
   const eventData = record(verifiedEvent.data);
-  const eventSession = record(eventData.object);
+  const eventObject = record(eventData.object);
+  if (eventType !== "checkout.session.completed") {
+    if (!STRIPE_LIFECYCLE_EVENT_TYPES.has(eventType)) {
+      throw new StripeCheckoutInvalidError("Stripe event type is unsupported");
+    }
+    return fulfillStripeSubscriptionLifecycle({
+      store,
+      runtime: config,
+      eventId,
+      eventType,
+      eventCreatedAt,
+      eventObject,
+      now
+    });
+  }
+  const eventSession = eventObject;
   const eventSessionId = stripeId(eventSession.id, "cs_", "checkout session id");
   const eventHash = createHash("sha256").update(rawBody).digest("hex");
   const existing = store.getStripeCheckoutFulfillmentForEvent(eventId);
@@ -202,6 +246,399 @@ export async function fulfillStripeCheckoutWebhook(options: {
     }
     throw new StripeCheckoutUnavailableError("Stripe checkout fulfillment failed");
   }
+}
+
+async function fulfillStripeSubscriptionLifecycle(options: {
+  store: LicenseStore;
+  runtime: ReturnType<typeof validateRuntime>;
+  eventId: string;
+  eventType: string;
+  eventCreatedAt: number;
+  eventObject: Record<string, unknown>;
+  now: Date;
+}): Promise<StripeCheckoutLifecycleResult> {
+  const { store, runtime, eventId, eventType, eventCreatedAt, eventObject, now } = options;
+  let account: Record<string, unknown>;
+  try {
+    account = record(await runtime.gateway.retrieveAccount(runtime.expectedAccountId));
+  } catch (error) {
+    if (error instanceof StripeCheckoutInvalidError) throw error;
+    throw new StripeCheckoutUnavailableError("Stripe lifecycle verification is unavailable");
+  }
+  const accountId = stripeId(account.id, "acct_", "account id");
+  if (accountId !== runtime.expectedAccountId) {
+    throw new StripeCheckoutInvalidError("Stripe API account is invalid");
+  }
+
+  const externalSubscriptionId = lifecycleSubscriptionId(eventType, eventObject);
+  const issuanceIdempotencyKey = store.resolveCheckoutIssuanceIdempotencyKey({
+    provider: "stripe",
+    providerAccountId: accountId,
+    providerMode: runtime.mode,
+    externalSubscriptionId
+  });
+  if (!issuanceIdempotencyKey) {
+    // Stripe event delivery order is not guaranteed. A retryable response lets
+    // checkout.session.completed establish the immutable binding first.
+    throw new StripeCheckoutUnavailableError("Stripe lifecycle binding is unavailable");
+  }
+
+  let lifecycleBody: Record<string, unknown>;
+  try {
+    lifecycleBody = await normalizeStripeLifecycleEvent({
+      runtime,
+      eventId,
+      eventType,
+      eventCreatedAt,
+      eventObject,
+      issuanceIdempotencyKey,
+      externalSubscriptionId,
+      accountId
+    });
+  } catch (error) {
+    if (
+      error instanceof StripeCheckoutInvalidError ||
+      error instanceof StripeCheckoutUnavailableError
+    ) {
+      throw error;
+    }
+    throw new StripeCheckoutUnavailableError("Stripe lifecycle verification is unavailable");
+  }
+
+  let request;
+  try {
+    request = parseSubscriptionLifecycleRequest(JSON.stringify(lifecycleBody), now);
+  } catch (error) {
+    if (error instanceof LifecycleRequestError) {
+      throw new StripeCheckoutInvalidError("Stripe lifecycle event is invalid");
+    }
+    throw new StripeCheckoutUnavailableError("Stripe lifecycle normalization failed");
+  }
+
+  try {
+    const applied = store.applyCheckoutSubscriptionLifecycle(request);
+    return { status: applied.status, replayed: applied.replayed };
+  } catch (error) {
+    if (error instanceof SubscriptionLifecycleConflictError) {
+      throw new StripeCheckoutConflictError("Stripe lifecycle event conflicts");
+    }
+    if (error instanceof SubscriptionLifecycleNotFoundError) {
+      throw new StripeCheckoutUnavailableError("Stripe lifecycle binding is unavailable");
+    }
+    if (
+      error instanceof SubscriptionLifecyclePolicyError ||
+      error instanceof SubscriptionLifecycleTerminalError ||
+      error instanceof SubscriptionLifecycleUnsupportedCommandError
+    ) {
+      throw new StripeCheckoutInvalidError("Stripe lifecycle event is invalid");
+    }
+    if (error instanceof SubscriptionLifecycleTransientError) {
+      throw new StripeCheckoutUnavailableError("Stripe lifecycle storage is unavailable");
+    }
+    throw new StripeCheckoutUnavailableError("Stripe lifecycle application failed");
+  }
+}
+
+async function normalizeStripeLifecycleEvent(options: {
+  runtime: ReturnType<typeof validateRuntime>;
+  eventId: string;
+  eventType: string;
+  eventCreatedAt: number;
+  eventObject: Record<string, unknown>;
+  issuanceIdempotencyKey: string;
+  externalSubscriptionId: string;
+  accountId: string;
+}): Promise<Record<string, unknown>> {
+  const {
+    runtime,
+    eventId,
+    eventType,
+    eventCreatedAt,
+    eventObject,
+    issuanceIdempotencyKey,
+    externalSubscriptionId,
+    accountId
+  } = options;
+  if (
+    boolean(eventObject.livemode, "lifecycle object livemode") !==
+    (runtime.mode === "live")
+  ) {
+    throw new StripeCheckoutInvalidError("Stripe lifecycle object mode is invalid");
+  }
+  const common = {
+    schemaVersion: 1,
+    issuanceIdempotencyKey,
+    eventId,
+    eventCreatedAt,
+    provider: "stripe",
+    providerAccountId: accountId,
+    providerMode: runtime.mode,
+    externalSubscriptionId
+  };
+
+  if (
+    eventType === "invoice.paid" ||
+    eventType === "invoice.payment_succeeded" ||
+    eventType === "invoice.payment_failed"
+  ) {
+    const subscription = await retrieveLifecycleSubscription(
+      runtime,
+      externalSubscriptionId
+    );
+    if (eventType === "invoice.payment_failed") {
+      if (
+        !["active", "past_due", "incomplete", "paused"].includes(
+          subscription.status
+        )
+      ) {
+        throw new StripeCheckoutInvalidError(
+          "Stripe failed-payment subscription state is invalid"
+        );
+      }
+      return {
+        ...common,
+        providerEventType: eventType,
+        command: "payment_attention",
+        subscriptionStatus: subscription.status,
+        cancelAtPeriodEnd: subscription.cancelAtPeriodEnd
+      };
+    }
+    if (subscription.status !== "active") {
+      throw new StripeCheckoutInvalidError(
+        "Stripe paid invoice subscription is not active"
+      );
+    }
+    return {
+      ...common,
+      providerEventType: eventType,
+      command: "renew_paid",
+      paymentReference: stripeId(eventObject.id, "in_", "invoice id"),
+      amountPaidMinor: positiveInteger(eventObject.amount_paid, "invoice amount paid"),
+      currency: exactString(eventObject.currency, "usd", "invoice currency"),
+      paidOutOfBand: invoicePaidOutOfBand(eventObject),
+      billingReason: exactString(
+        eventObject.billing_reason,
+        "subscription_cycle",
+        "invoice billing reason"
+      ),
+      subscriptionStatus: "active",
+      currentPeriodEnd: new Date(
+        invoiceSubscriptionPeriodEnd(eventObject, externalSubscriptionId) * 1_000
+      ).toISOString(),
+      cancelAtPeriodEnd: false
+    };
+  }
+
+  const subscription = normalizeSubscriptionSnapshot(
+    eventObject,
+    runtime.mode,
+    externalSubscriptionId
+  );
+  if (eventType === "customer.subscription.deleted") {
+    if (!["canceled", "unpaid", "incomplete_expired"].includes(subscription.status)) {
+      throw new StripeCheckoutInvalidError("Stripe deleted subscription state is invalid");
+    }
+    return {
+      ...common,
+      providerEventType: eventType,
+      command: "revoke",
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: false
+    };
+  }
+
+  if (subscription.status === "canceled" ||
+      subscription.status === "unpaid" ||
+      subscription.status === "incomplete_expired") {
+    return {
+      ...common,
+      providerEventType: eventType,
+      command: "revoke",
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: false
+    };
+  }
+  if (
+    (subscription.status === "active" || subscription.status === "trialing") &&
+    subscription.cancelAtPeriodEnd
+  ) {
+    return {
+      ...common,
+      providerEventType: eventType,
+      command: "cancel_at_period_end",
+      subscriptionStatus: subscription.status,
+      currentPeriodEnd: new Date(
+        requiredSubscriptionPeriodEnd(eventObject) * 1_000
+      ).toISOString(),
+      cancelAtPeriodEnd: true
+    };
+  }
+  if (subscription.status === "active" || subscription.status === "trialing") {
+    return {
+      ...common,
+      providerEventType: eventType,
+      command: "reconcile",
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: false
+    };
+  }
+  if (["past_due", "incomplete", "paused"].includes(subscription.status)) {
+    return {
+      ...common,
+      providerEventType: eventType,
+      command: "payment_attention",
+      subscriptionStatus: subscription.status,
+      cancelAtPeriodEnd: subscription.cancelAtPeriodEnd
+    };
+  }
+  throw new StripeCheckoutInvalidError("Stripe subscription state is unsupported");
+}
+
+async function retrieveLifecycleSubscription(
+  runtime: ReturnType<typeof validateRuntime>,
+  expectedSubscriptionId: string
+): Promise<{ status: string; cancelAtPeriodEnd: boolean }> {
+  let raw: Record<string, unknown>;
+  try {
+    raw = record(
+      await runtime.gateway.retrieveSubscription(expectedSubscriptionId)
+    );
+  } catch (error) {
+    if (error instanceof StripeCheckoutInvalidError) throw error;
+    throw new StripeCheckoutUnavailableError(
+      "Stripe subscription verification is unavailable"
+    );
+  }
+  const normalized = normalizeSubscriptionSnapshot(
+    raw,
+    runtime.mode,
+    expectedSubscriptionId
+  );
+  return {
+    status: normalized.status,
+    cancelAtPeriodEnd: normalized.cancelAtPeriodEnd
+  };
+}
+
+function normalizeSubscriptionSnapshot(
+  value: Record<string, unknown>,
+  mode: "test" | "live",
+  expectedSubscriptionId: string
+): { status: string; cancelAtPeriodEnd: boolean } {
+  const subscriptionId = stripeId(value.id, "sub_", "subscription id");
+  if (subscriptionId !== expectedSubscriptionId) {
+    throw new StripeCheckoutInvalidError("Stripe subscription changed");
+  }
+  if (
+    boolean(value.livemode, "subscription livemode") !==
+    (mode === "live")
+  ) {
+    throw new StripeCheckoutInvalidError("Stripe subscription mode is invalid");
+  }
+  return {
+    status: requiredString(value.status, "subscription status", 40),
+    cancelAtPeriodEnd: boolean(
+      value.cancel_at_period_end,
+      "subscription cancel at period end"
+    )
+  };
+}
+
+function lifecycleSubscriptionId(
+  eventType: string,
+  eventObject: Record<string, unknown>
+): string {
+  if (eventType.startsWith("customer.subscription.")) {
+    return stripeId(eventObject.id, "sub_", "subscription id");
+  }
+  const direct = stripeReference(eventObject.subscription);
+  if (direct) return stripeId(direct, "sub_", "subscription id");
+  const parent = record(eventObject.parent);
+  if (parent.type !== "subscription_details") {
+    throw new StripeCheckoutInvalidError("Stripe invoice subscription is invalid");
+  }
+  const details = record(parent.subscription_details);
+  return stripeId(
+    stripeReference(details.subscription),
+    "sub_",
+    "subscription id"
+  );
+}
+
+function invoiceSubscriptionPeriodEnd(
+  invoice: Record<string, unknown>,
+  externalSubscriptionId: string
+): number {
+  const lines = record(invoice.lines);
+  const data = Array.isArray(lines.data) ? lines.data : [];
+  const periodEnds = data.flatMap((entry) => {
+    const line = record(entry);
+    const subscription = stripeReference(line.subscription);
+    if (subscription !== externalSubscriptionId) return [];
+    const parent = record(line.parent);
+    if (parent.type !== "subscription_item_details") return [];
+    return [positiveInteger(record(line.period).end, "invoice service period end")];
+  });
+  if (periodEnds.length === 0 || new Set(periodEnds).size !== 1) {
+    throw new StripeCheckoutInvalidError(
+      "Stripe invoice service period is ambiguous"
+    );
+  }
+  return periodEnds[0]!;
+}
+
+function requiredSubscriptionPeriodEnd(subscription: Record<string, unknown>): number {
+  if (subscription.current_period_end !== undefined) {
+    return positiveInteger(
+      subscription.current_period_end,
+      "subscription period end"
+    );
+  }
+  const items = record(subscription.items);
+  const data = Array.isArray(items.data) ? items.data : [];
+  if (data.length !== 1) {
+    throw new StripeCheckoutInvalidError(
+      "Stripe subscription must contain exactly one item"
+    );
+  }
+  return positiveInteger(
+    record(data[0]).current_period_end,
+    "subscription period end"
+  );
+}
+
+function invoicePaidOutOfBand(invoice: Record<string, unknown>): false {
+  if (invoice.amount_paid_off_stripe !== undefined) {
+    const paidOffStripe = nonNegativeInteger(
+      invoice.amount_paid_off_stripe,
+      "invoice amount paid off Stripe"
+    );
+    if (paidOffStripe !== 0) {
+      throw new StripeCheckoutInvalidError(
+        "Stripe invoice paid out of band is invalid"
+      );
+    }
+    if (invoice.paid_out_of_band === true) {
+      throw new StripeCheckoutInvalidError(
+        "Stripe invoice paid out of band is invalid"
+      );
+    }
+    return false;
+  }
+  if (invoice.paid_out_of_band !== false) {
+    throw new StripeCheckoutInvalidError(
+      "Stripe invoice paid out of band is invalid"
+    );
+  }
+  return false;
+}
+
+function stripeReference(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return optionalString((value as Record<string, unknown>).id);
+  }
+  return undefined;
 }
 
 export function redeemStripeCheckout(options: {
@@ -471,6 +908,20 @@ function positiveInteger(value: unknown, field: string): number {
     throw new StripeCheckoutInvalidError(`${field} is invalid`);
   }
   return Number(value);
+}
+
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new StripeCheckoutInvalidError(`${field} is invalid`);
+  }
+  return Number(value);
+}
+
+function exactString(value: unknown, expected: string, field: string): string {
+  if (value !== expected) {
+    throw new StripeCheckoutInvalidError(`${field} is invalid`);
+  }
+  return expected;
 }
 
 function boolean(value: unknown, field: string): boolean {

--- a/services/license-api/src/stripe-checkout.ts
+++ b/services/license-api/src/stripe-checkout.ts
@@ -573,10 +573,21 @@ function invoiceSubscriptionPeriodEnd(
   const data = Array.isArray(lines.data) ? lines.data : [];
   const periodEnds = data.flatMap((entry) => {
     const line = record(entry);
-    const subscription = stripeReference(line.subscription);
-    if (subscription !== externalSubscriptionId) return [];
     const parent = record(line.parent);
     if (parent.type !== "subscription_item_details") return [];
+    const details = record(parent.subscription_item_details);
+    const subscription = stripeReference(details.subscription);
+    const legacySubscription = stripeReference(line.subscription);
+    if (
+      legacySubscription &&
+      subscription &&
+      legacySubscription !== subscription
+    ) {
+      throw new StripeCheckoutInvalidError(
+        "Stripe invoice subscription correlation conflicts"
+      );
+    }
+    if (subscription !== externalSubscriptionId) return [];
     return [positiveInteger(record(line.period).end, "invoice service period end")];
   });
   if (periodEnds.length === 0 || new Set(periodEnds).size !== 1) {

--- a/services/license-api/test/stripe-checkout-http.test.ts
+++ b/services/license-api/test/stripe-checkout-http.test.ts
@@ -19,6 +19,9 @@ const SUBSCRIPTION_ID = "sub_neondiff_checkout_1";
 const CUSTOMER_ID = "cus_neondiff_checkout_1";
 const TOKEN = "A".repeat(48);
 const TOKEN_HASH = createHash("sha256").update(TOKEN).digest("hex");
+const RENEWAL_PERIOD_END = Math.floor(
+  Date.parse("2026-08-30T00:00:00.000Z") / 1_000
+);
 const stripeVerifier = new Stripe("sk_test_not_used_for_network", {
   apiVersion: "2026-06-24.dahlia"
 });
@@ -59,11 +62,28 @@ function signatureFor(payload: string): string {
   });
 }
 
+function lifecycleEventPayload(
+  type: string,
+  object: Record<string, unknown>,
+  id: string
+): string {
+  return JSON.stringify({
+    id,
+    object: "event",
+    api_version: "2026-06-24.dahlia",
+    created: 1_785_384_000,
+    livemode: true,
+    type,
+    data: { object }
+  });
+}
+
 function snapshots(overrides: {
   accountId?: string;
   priceId?: string;
   productId?: string;
   subscriptionStatus?: string;
+  cancelAtPeriodEnd?: boolean;
 } = {}) {
   const accountId = overrides.accountId ?? "acct_neondiff_live";
   const priceId = overrides.priceId ?? "price_neondiff_monthly";
@@ -102,6 +122,7 @@ function snapshots(overrides: {
       customer: CUSTOMER_ID,
       livemode: true,
       status: overrides.subscriptionStatus ?? "trialing",
+      cancel_at_period_end: overrides.cancelAtPeriodEnd ?? false,
       metadata: {
         priceLookupKey: "neondiff_monthly",
         fulfillmentTokenHash: TOKEN_HASH
@@ -110,6 +131,7 @@ function snapshots(overrides: {
         data: [
           {
             quantity: 1,
+            current_period_end: RENEWAL_PERIOD_END,
             price: {
               id: priceId,
               lookup_key: "neondiff_monthly",
@@ -216,6 +238,11 @@ async function postWebhook(url: string, payload = eventPayload()) {
     "Content-Type": "application/json",
     "Stripe-Signature": signatureFor(payload)
   });
+}
+
+async function seedCheckout(url: string): Promise<void> {
+  const response = await postWebhook(url);
+  assert.equal(response.status, 200, JSON.stringify(response.json));
 }
 
 describe("direct Stripe checkout fulfillment", () => {
@@ -463,6 +490,200 @@ describe("direct Stripe checkout validation boundaries", () => {
         );
         assert.equal(expired.status, 410);
         assert.deepEqual(expired.json, { status: "expired" });
+      }
+    );
+  });
+});
+
+describe("direct Stripe subscription lifecycle", () => {
+  it("extends the bound entitlement from a paid renewal without returning identifiers", async () => {
+    await withCheckoutServer(
+      { gateway: gatewayFor({ subscriptionStatus: "active" }) },
+      async ({ store, url }) => {
+        await seedCheckout(url);
+        const payload = lifecycleEventPayload(
+          "invoice.paid",
+          {
+            id: "in_neondiff_renewal_1",
+            object: "invoice",
+            livemode: true,
+            subscription: SUBSCRIPTION_ID,
+            amount_paid: 100,
+            currency: "usd",
+            paid_out_of_band: false,
+            billing_reason: "subscription_cycle",
+            lines: {
+              data: [
+                {
+                  subscription: SUBSCRIPTION_ID,
+                  parent: { type: "subscription_item_details" },
+                  period: { end: RENEWAL_PERIOD_END }
+                }
+              ]
+            }
+          },
+          "evt_neondiff_renewal_1"
+        );
+
+        const response = await postWebhook(url, payload);
+        assert.equal(response.status, 200, JSON.stringify(response.json));
+        assert.deepEqual(response.json, { status: "updated", replayed: false });
+        assert.equal(store.listLicenses()[0]?.expiresAt, "2026-08-30T00:00:00.000Z");
+        const serialized = JSON.stringify(response.json);
+        assert.ok(!serialized.includes("nd_live_"));
+        assert.ok(!serialized.includes("in_neondiff"));
+        assert.ok(!serialized.includes(SUBSCRIPTION_ID));
+        assert.ok(!serialized.includes(CUSTOMER_ID));
+
+        const replay = await postWebhook(url, payload);
+        assert.equal(replay.status, 200, JSON.stringify(replay.json));
+        assert.deepEqual(replay.json, { status: "replayed", replayed: true });
+        assert.equal(store.listLicenses().length, 1);
+
+        const changed = lifecycleEventPayload(
+          "invoice.paid",
+          {
+            id: "in_neondiff_renewal_1",
+            object: "invoice",
+            livemode: true,
+            subscription: SUBSCRIPTION_ID,
+            amount_paid: 200,
+            currency: "usd",
+            paid_out_of_band: false,
+            billing_reason: "subscription_cycle",
+            lines: {
+              data: [
+                {
+                  subscription: SUBSCRIPTION_ID,
+                  parent: { type: "subscription_item_details" },
+                  period: { end: RENEWAL_PERIOD_END }
+                }
+              ]
+            }
+          },
+          "evt_neondiff_renewal_1"
+        );
+        const conflict = await postWebhook(url, changed);
+        assert.equal(conflict.status, 409);
+        assert.deepEqual(conflict.json, { status: "conflict" });
+      }
+    );
+  });
+
+  it("records a failed payment without revoking or shortening the entitlement", async () => {
+    await withCheckoutServer(
+      { gateway: gatewayFor({ subscriptionStatus: "active" }) },
+      async ({ store, url }) => {
+        await seedCheckout(url);
+        const before = store.listLicenses()[0];
+        const payload = lifecycleEventPayload(
+          "invoice.payment_failed",
+          {
+            id: "in_neondiff_failed_1",
+            object: "invoice",
+            livemode: true,
+            subscription: SUBSCRIPTION_ID
+          },
+          "evt_neondiff_failed_1"
+        );
+
+        const response = await postWebhook(url, payload);
+        assert.equal(response.status, 200, JSON.stringify(response.json));
+        assert.deepEqual(response.json, {
+          status: "payment_attention",
+          replayed: false
+        });
+        const after = store.listLicenses()[0];
+        assert.equal(after?.status, "active");
+        assert.equal(after?.expiresAt, before?.expiresAt);
+      }
+    );
+  });
+
+  it("terminally revokes the bound entitlement from a deleted subscription", async () => {
+    await withCheckoutServer({}, async ({ store, url }) => {
+      await seedCheckout(url);
+      const payload = lifecycleEventPayload(
+        "customer.subscription.deleted",
+        {
+          id: SUBSCRIPTION_ID,
+          object: "subscription",
+          livemode: true,
+          status: "canceled",
+          cancel_at_period_end: false,
+          items: {
+            data: [{ current_period_end: RENEWAL_PERIOD_END }]
+          }
+        },
+        "evt_neondiff_deleted_1"
+      );
+
+      const response = await postWebhook(url, payload);
+      assert.equal(response.status, 200, JSON.stringify(response.json));
+      assert.deepEqual(response.json, {
+        status: "terminally_revoked",
+        replayed: false
+      });
+      assert.equal(store.listLicenses()[0]?.status, "revoked");
+      assert.equal(
+        store.listLicenses()[0]?.revocationReason,
+        "subscription_canceled"
+      );
+    });
+  });
+
+  it("records scheduled cancellation without shortening the paid entitlement", async () => {
+    await withCheckoutServer({}, async ({ store, url }) => {
+      await seedCheckout(url);
+      const before = store.listLicenses()[0];
+      const payload = lifecycleEventPayload(
+        "customer.subscription.updated",
+        {
+          id: SUBSCRIPTION_ID,
+          object: "subscription",
+          livemode: true,
+          status: "active",
+          cancel_at_period_end: true,
+          items: {
+            data: [{ current_period_end: RENEWAL_PERIOD_END }]
+          }
+        },
+        "evt_neondiff_cancel_scheduled_1"
+      );
+
+      const response = await postWebhook(url, payload);
+      assert.equal(response.status, 200, JSON.stringify(response.json));
+      assert.deepEqual(response.json, { status: "updated", replayed: false });
+      const after = store.listLicenses()[0];
+      assert.equal(after?.status, "active");
+      assert.equal(after?.expiresAt, before?.expiresAt);
+    });
+  });
+
+  it("does not mutate a license for an unbound subscription", async () => {
+    await withCheckoutServer(
+      { gateway: gatewayFor({ subscriptionStatus: "active" }) },
+      async ({ store, url }) => {
+        await seedCheckout(url);
+        const before = store.listLicenses()[0];
+        const payload = lifecycleEventPayload(
+          "customer.subscription.updated",
+          {
+            id: "sub_neondiff_unbound",
+            object: "subscription",
+            livemode: true,
+            status: "active",
+            cancel_at_period_end: false,
+            items: {
+              data: [{ current_period_end: RENEWAL_PERIOD_END }]
+            }
+          },
+          "evt_neondiff_unbound_1"
+        );
+
+        const response = await postWebhook(url, payload);
+        assert.notEqual(response.status, 200);
+        assert.deepEqual(store.listLicenses()[0], before);
       }
     );
   });

--- a/services/license-api/test/stripe-checkout-http.test.ts
+++ b/services/license-api/test/stripe-checkout-http.test.ts
@@ -515,8 +515,12 @@ describe("direct Stripe subscription lifecycle", () => {
             lines: {
               data: [
                 {
-                  subscription: SUBSCRIPTION_ID,
-                  parent: { type: "subscription_item_details" },
+                  parent: {
+                    type: "subscription_item_details",
+                    subscription_item_details: {
+                      subscription: SUBSCRIPTION_ID
+                    }
+                  },
                   period: { end: RENEWAL_PERIOD_END }
                 }
               ]
@@ -554,8 +558,12 @@ describe("direct Stripe subscription lifecycle", () => {
             lines: {
               data: [
                 {
-                  subscription: SUBSCRIPTION_ID,
-                  parent: { type: "subscription_item_details" },
+                  parent: {
+                    type: "subscription_item_details",
+                    subscription_item_details: {
+                      subscription: SUBSCRIPTION_ID
+                    }
+                  },
                   period: { end: RENEWAL_PERIOD_END }
                 }
               ]

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -241,6 +241,44 @@ describe("checkout subscription lifecycle binding", () => {
       store.close();
     }
   });
+
+  it("resolves only the internal issuance key for the exact subscription tuple", () => {
+    const store = new LicenseStore(":memory:", { now: () => NOW });
+    try {
+      const issued = issueBound(store);
+      const lookup = {
+        provider: "stripe" as const,
+        providerAccountId: issued.request.providerAccountId,
+        providerMode: issued.request.providerMode,
+        externalSubscriptionId: issued.request.externalSubscriptionId
+      };
+      assert.equal(
+        store.resolveCheckoutIssuanceIdempotencyKey(lookup),
+        issued.request.idempotencyKey
+      );
+      for (const override of [
+        { provider: "other-provider" },
+        { providerAccountId: "acct_other" },
+        { providerMode: "test" },
+        { externalSubscriptionId: "sub_other" }
+      ]) {
+        assert.equal(
+          store.resolveCheckoutIssuanceIdempotencyKey({
+            ...lookup,
+            ...override
+          } as typeof lookup),
+          undefined
+        );
+      }
+      assert.ok(
+        !store
+          .resolveCheckoutIssuanceIdempotencyKey(lookup)!
+          .includes(issued.rawKey)
+      );
+    } finally {
+      store.close();
+    }
+  });
 });
 
 describe("checkout subscription lifecycle replay", () => {


### PR DESCRIPTION
Related: #718

## Customer gate

After direct Checkout issuance, Stripe renewal, scheduled cancellation, payment-loss, and terminal subscription events must update the same Fly-owned entitlement without relying on Lovable or Supabase as license authority.

## Acceptance criteria

- Verify the raw Stripe signature, expected account, mode, event identity, and supported event type.
- Resolve only the immutable checkout binding tuple for the subscription.
- Normalize paid renewal, payment attention, scheduled cancellation, reconciliation, and terminal revoke into the existing schema-v1 lifecycle contract.
- Apply through the existing transactional lifecycle store with exact replay and conflict behavior.
- Return only bounded status and replay state; never return license keys, redemption tokens, customer IDs, invoice IDs, or subscription IDs.
- Unknown or not-yet-bound subscriptions make no entitlement mutation and remain retryable for out-of-order Stripe delivery.

## Non-goals

- No database migration or new secret.
- No Lovable or Supabase replacement.
- No website publication, Fly deployment, Stripe endpoint mutation, checkout enablement, signing, release, or customer-readiness claim.
- No change to pricing, entitlement policy, or existing lifecycle store semantics.

## Failing-first and focused proof

- RED: the direct webhook returned bounded invalid responses for invoice renewal, payment failure, and subscription deletion while the unbound-subscription safety case already made no mutation.
- GREEN: node --import tsx --test services/license-api/test/stripe-checkout-http.test.ts services/license-api/test/subscription-lifecycle-http.test.ts services/license-api/test/subscription-lifecycle-store.test.ts (64/64)
- GREEN: npm --prefix services/license-api run build
- GREEN: git diff --check

Agent-authored change. Broad repository validation remains the current-head GitHub CI gate.