### PR TITLE
fix(billing): make exact checkout redemption safely replayable

### DIFF
--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -193,7 +193,7 @@ Environment:
   deterministic checkout key derivation. It is not an HTTP authorization
   credential and is never shared with Lovable or browser code.
 - `NEONDIFF_STRIPE_REDEMPTION_ORIGIN` — exact HTTPS website origin allowed to
-  redeem once.
+  redeem and safely replay the exact request until the fulfillment TTL expires.
 - `NEONDIFF_STRIPE_MONTHLY_PRICE_ID`,
   `NEONDIFF_STRIPE_MONTHLY_PRODUCT_ID`,
   `NEONDIFF_STRIPE_YEARLY_PRICE_ID`,

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -6,7 +6,7 @@ It implements the exact HTTP contract the shipped client (`src/license.ts`)
 already calls — activate / validate / deactivate — backed by SQLite, with an
 admin CLI that mints keys. Guarded server-to-server routes issue checkout
 licenses and apply provider subscription lifecycle events. The direct Stripe
-webhook and one-use browser redemption contract are owned here; Lovable and
+webhook and short-lived, idempotent browser redemption contract are owned here; Lovable and
 Supabase remain the website, account, and subscription-projection surfaces but
 are not the license-issuance authority.
 
@@ -24,7 +24,7 @@ Eight `POST` endpoints, JSON in / JSON out (`Content-Type: application/json`):
 | `/v1/license/deactivate` | `{ licenseKey, repo?, machineId }` | `{ status:"active", … }` (idempotent) | 404 invalid |
 | `/v1/admin/licenses/issue` | `{ idempotencyKey, checkoutLookupKey, ... }` + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | `{ status:"issued", licenseKey:"nd_live_...", entitlement, replayed }` | 401 unauthorized · 400 malformed/unsupported lookup or policy · 409 idempotency conflict |
 | `/v1/webhooks/stripe` | raw Stripe event + `Stripe-Signature` | redacted `{ status:"fulfilled", replayed }` | 400 invalid · 409 conflict · 503 unavailable |
-| `/v1/checkout/redeem` | `{ sessionId, fulfillmentToken }` from the exact configured website origin | one-time `{ status:"redeemed", licenseKey, entitlement }` | 403 wrong origin · 404 invalid/not found · 410 expired/consumed · 503 unavailable |
+| `/v1/checkout/redeem` | `{ sessionId, fulfillmentToken }` from the exact configured website origin | `{ status:"redeemed", licenseKey, entitlement }`; an exact retry returns the same deterministic key until the fulfillment TTL expires | 403 wrong origin · 404 invalid/not found · 410 expired · 503 unavailable |
 | `/v1/admin/licenses/issue-lifecycle` | exact release identity + GitHub Actions OIDC bearer | short-lived lifecycle license + all-scope entitlement | 401 invalid workflow token · 403 candidate SHA mismatch · 409 workflow-run conflict · 503 unconfigured |
 | `/v1/admin/licenses/lifecycle` | strict subscription command + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | redacted `{ status, replayed, entitlement }` | 400 invalid · 401 unauthorized · 404 not_found · 409 conflict/terminally_revoked · 429 rate_limited · 503 unavailable |
 

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -72,9 +72,11 @@ license key or redemption token.
 
 `POST /v1/checkout/redeem` accepts only the exact configured HTTPS website
 origin. A valid Checkout Session ID plus the fragment-held fulfillment token
-returns the raw license key once. Wrong tokens do not consume fulfillment;
-expired and previously redeemed tokens return `410`. Responses use exact-origin
-CORS, `Cache-Control: no-store`, and `Referrer-Policy: no-referrer`.
+returns the raw license key. An exact retry within the fulfillment TTL returns
+that same deterministic key without another issuance. Wrong tokens do not
+consume fulfillment, and expired tokens return `410`. Responses use
+exact-origin CORS, `Cache-Control: no-store`, and
+`Referrer-Policy: no-referrer`.
 
 This source contract is not deployment, live billing, activation, publication,
 or customer proof. Issue

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -822,9 +822,6 @@ export class LicenseStore {
       transactionStarted = true;
       const row = this.getStripeCheckoutFulfillmentByCheckoutId(externalCheckoutId);
       if (!row) throw new CheckoutRedemptionNotFoundError("checkout fulfillment was not found");
-      if (row.redeemed_at) {
-        throw new CheckoutRedemptionConsumedError("checkout fulfillment was already consumed");
-      }
       const expiresAt = Date.parse(row.fulfillment_expires_at);
       if (!Number.isFinite(expiresAt) || expiresAt <= now.getTime()) {
         throw new CheckoutRedemptionExpiredError("checkout fulfillment has expired");
@@ -842,6 +839,14 @@ export class LicenseStore {
       }
       if (record.expiresAt && Date.parse(record.expiresAt) <= now.getTime()) {
         throw new CheckoutRedemptionExpiredError("checkout entitlement has expired");
+      }
+      if (row.redeemed_at) {
+        this.db.exec("commit");
+        return {
+          rawKey,
+          record,
+          fulfillment: stripeCheckoutFulfillmentFromRow(row)
+        };
       }
       const redeemedAt = now.toISOString();
       const updated = this.db

--- a/services/license-api/test/stripe-checkout-http.test.ts
+++ b/services/license-api/test/stripe-checkout-http.test.ts
@@ -311,7 +311,7 @@ describe("direct Stripe checkout fulfillment", () => {
     assert.equal(store.listLicenses().length, beforeCount);
   });
 
-  it("returns the raw license only for one exact redemption", async () => {
+  it("replays the same deterministic license for an exact redemption retry", async () => {
     const first = await postRaw(
       url,
       "/v1/checkout/redeem",
@@ -336,9 +336,26 @@ describe("direct Stripe checkout fulfillment", () => {
         Origin: ALLOWED_ORIGIN
       }
     );
-    assert.equal(replay.status, 410);
-    assert.deepEqual(replay.json, { status: "consumed" });
-    assert.ok(!JSON.stringify(replay.json).includes(first.json.licenseKey));
+    assert.equal(replay.status, 200);
+    assert.equal(replay.json.status, "redeemed");
+    assert.equal(replay.json.licenseKey, first.json.licenseKey);
+    assert.equal(replay.headers.get("cache-control"), "no-store");
+
+    const wrongToken = await postRaw(
+      url,
+      "/v1/checkout/redeem",
+      JSON.stringify({
+        sessionId: SESSION_ID,
+        fulfillmentToken: "B".repeat(48)
+      }),
+      {
+        "Content-Type": "application/json",
+        Origin: ALLOWED_ORIGIN
+      }
+    );
+    assert.equal(wrongToken.status, 404);
+    assert.deepEqual(wrongToken.json, { status: "not_found" });
+    assert.ok(!JSON.stringify(wrongToken.json).includes(first.json.licenseKey));
   });
 
   it("maps malformed redemption JSON to a bounded not-found response", async () => {


### PR DESCRIPTION
Relates to #646 and #610. Follow-up to the direct Stripe-to-Fly paid checkout slice.

Acceptance criteria:
- an exact retry of the same session and fulfillment token within the existing short TTL returns the same deterministic license key
- a wrong token still fails closed without exposing the key
- expiry, entitlement state, origin, signature, account, mode, price, and idempotent issuance boundaries remain unchanged
- no duplicate license or fulfillment record is created

Non-goals:
- no new billing provider, Supabase replacement, website redesign, managed GitHub App work, signing, publication, or GA claim
- no longer-lived credential storage and no reusable raw key at rest

Failing-first proof:
- focused HTTP test reproduced the second exact request returning 410 after the first response could have been lost
- focused license API HTTP suite: 18/18
- TypeScript build: green

This is source/CI proof only until merged and deployed; it is not a live checkout, activation, beta, or release claim.