### PR TITLE
CI: prove the paid beta public download on three clean Macs

### DIFF
--- a/.github/workflows/paid-beta-public-download-canary.yml
+++ b/.github/workflows/paid-beta-public-download-canary.yml
@@ -1,0 +1,151 @@
+name: Paid beta public download canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Exact immutable GitHub prerelease tag
+        required: true
+        type: string
+      artifact_name:
+        description: Exact signed and notarized Mac app ZIP asset
+        required: true
+        type: string
+      artifact_sha256:
+        description: Expected lowercase SHA-256 for the app ZIP
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: paid-beta-public-download-canary-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  public-download-install-canary:
+    name: Public download and clean install (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-14
+          - macos-15
+          - macos-26
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Validate immutable release input
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v1\.1\.0-beta\.[0-9]+$ ]]
+          [[ "$ARTIFACT_NAME" =~ ^NeonDiff-1\.1\.0-beta\.[0-9]+-build[0-9]+-macOS\.zip$ ]]
+          [[ "$ARTIFACT_SHA256" =~ ^[a-f0-9]{64}$ ]]
+          printf 'url=https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/%s/%s\n' \
+            "$RELEASE_TAG" "$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download exact public release asset
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.release.outputs.url }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/neondiff-download"
+          curl --fail --location --proto '=https' --tlsv1.2 --retry 3 \
+            --output "$RUNNER_TEMP/neondiff-download/NeonDiff.zip" \
+            "$ARTIFACT_URL"
+
+      - name: Verify checksum and quarantine-bound archive
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/neondiff-download/NeonDiff.zip"
+          printf '%s  %s\n' "$ARTIFACT_SHA256" "$archive" | shasum -a 256 -c -
+          xattr -w com.apple.quarantine \
+            "0081;$(printf '%x' "$(date +%s)");GitHub Actions;${{ steps.release.outputs.url }}" \
+            "$archive"
+
+      - name: Extract and verify signed notarized app
+        shell: bash
+        run: |
+          set -euo pipefail
+          extract_root="$RUNNER_TEMP/neondiff-download/extracted"
+          mkdir -p "$extract_root"
+          ditto -x -k "$RUNNER_TEMP/neondiff-download/NeonDiff.zip" "$extract_root"
+          test -d "$extract_root/NeonDiff.app"
+          test "$(find "$extract_root" -maxdepth 1 -type d -name '*.app' | wc -l | tr -d ' ')" = "1"
+          codesign --verify --deep --strict --verbose=2 "$extract_root/NeonDiff.app"
+          xcrun stapler validate "$extract_root/NeonDiff.app"
+          spctl -a -vv -t exec "$extract_root/NeonDiff.app"
+
+      - name: Install and launch on clean runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          test ! -e /Applications/NeonDiff.app
+          if pgrep -x NeonDiffDesktop >/dev/null; then
+            echo "NeonDiffDesktop is unexpectedly running on the clean runner" >&2
+            exit 1
+          fi
+          sudo ditto "$RUNNER_TEMP/neondiff-download/extracted/NeonDiff.app" /Applications/NeonDiff.app
+          codesign --verify --deep --strict --verbose=2 /Applications/NeonDiff.app
+          xcrun stapler validate /Applications/NeonDiff.app
+          spctl -a -vv -t exec /Applications/NeonDiff.app
+          open -n /Applications/NeonDiff.app
+          for _ in {1..15}; do
+            pgrep -x NeonDiffDesktop >/dev/null && break
+            sleep 1
+          done
+          pgrep -x NeonDiffDesktop >/dev/null
+          pkill -TERM -x NeonDiffDesktop
+
+      - name: Write sanitized canary receipt
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          RUNNER_LABEL: ${{ matrix.runner }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg schemaVersion "1" \
+            --arg releaseTag "$RELEASE_TAG" \
+            --arg artifactName "$ARTIFACT_NAME" \
+            --arg artifactSha256 "$ARTIFACT_SHA256" \
+            --arg runnerLabel "$RUNNER_LABEL" \
+            --arg macOSVersion "$(sw_vers -productVersion)" \
+            --arg architecture "$(uname -m)" \
+            --arg result "passed" \
+            '{
+              schemaVersion: $schemaVersion,
+              releaseTag: $releaseTag,
+              artifactName: $artifactName,
+              artifactSha256: $artifactSha256,
+              runnerLabel: $runnerLabel,
+              macOSVersion: $macOSVersion,
+              architecture: $architecture,
+              publicDownload: $result,
+              checksum: $result,
+              developerIdSignature: $result,
+              notarizationTicket: $result,
+              gatekeeper: $result,
+              cleanInstall: $result,
+              launch: $result
+            }' > "$RUNNER_TEMP/neondiff-download/canary-receipt.json"
+
+      - name: Upload sanitized receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: paid-beta-public-download-${{ matrix.runner }}
+          path: ${{ runner.temp }}/neondiff-download/canary-receipt.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/paid-beta-public-download-canary.yml
+++ b/.github/workflows/paid-beta-public-download-canary.yml
@@ -44,9 +44,13 @@ jobs:
           ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
         run: |
           set -euo pipefail
-          [[ "$RELEASE_TAG" =~ ^v1\.1\.0-beta\.[0-9]+$ ]]
-          [[ "$ARTIFACT_NAME" =~ ^NeonDiff-1\.1\.0-beta\.[0-9]+-build[0-9]+-macOS\.zip$ ]]
+          [[ "$RELEASE_TAG" =~ ^v1\.1\.0-beta\.([0-9]+)$ ]]
+          release_beta="${BASH_REMATCH[1]}"
+          [[ "$ARTIFACT_NAME" =~ ^NeonDiff-1\.1\.0-beta\.([0-9]+)-build[0-9]+-macOS\.zip$ ]]
+          artifact_beta="${BASH_REMATCH[1]}"
+          test "$release_beta" = "$artifact_beta"
           [[ "$ARTIFACT_SHA256" =~ ^[a-f0-9]{64}$ ]]
+          test "$(uname -m)" = "arm64"
           printf 'url=https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/%s/%s\n' \
             "$RELEASE_TAG" "$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
@@ -83,29 +87,24 @@ jobs:
           test -d "$extract_root/NeonDiff.app"
           test "$(find "$extract_root" -maxdepth 1 -type d -name '*.app' | wc -l | tr -d ' ')" = "1"
           codesign --verify --deep --strict --verbose=2 "$extract_root/NeonDiff.app"
+          identity="$(codesign -dv --verbose=4 "$extract_root/NeonDiff.app" 2>&1)"
+          grep -Fxq 'TeamIdentifier=TC6MS3T6NN' <<<"$identity"
+          grep -Fxq 'Authority=Developer ID Application: Andrew Ryan (TC6MS3T6NN)' <<<"$identity"
           xcrun stapler validate "$extract_root/NeonDiff.app"
           spctl -a -vv -t exec "$extract_root/NeonDiff.app"
 
-      - name: Install and launch on clean runner
+      - name: Install exact app on clean runner
         shell: bash
         run: |
           set -euo pipefail
           test ! -e /Applications/NeonDiff.app
-          if pgrep -x NeonDiffDesktop >/dev/null; then
-            echo "NeonDiffDesktop is unexpectedly running on the clean runner" >&2
-            exit 1
-          fi
           sudo ditto "$RUNNER_TEMP/neondiff-download/extracted/NeonDiff.app" /Applications/NeonDiff.app
           codesign --verify --deep --strict --verbose=2 /Applications/NeonDiff.app
+          identity="$(codesign -dv --verbose=4 /Applications/NeonDiff.app 2>&1)"
+          grep -Fxq 'TeamIdentifier=TC6MS3T6NN' <<<"$identity"
+          grep -Fxq 'Authority=Developer ID Application: Andrew Ryan (TC6MS3T6NN)' <<<"$identity"
           xcrun stapler validate /Applications/NeonDiff.app
           spctl -a -vv -t exec /Applications/NeonDiff.app
-          open -n /Applications/NeonDiff.app
-          for _ in {1..15}; do
-            pgrep -x NeonDiffDesktop >/dev/null && break
-            sleep 1
-          done
-          pgrep -x NeonDiffDesktop >/dev/null
-          pkill -TERM -x NeonDiffDesktop
 
       - name: Write sanitized canary receipt
         shell: bash
@@ -138,8 +137,8 @@ jobs:
               developerIdSignature: $result,
               notarizationTicket: $result,
               gatekeeper: $result,
-              cleanInstall: $result,
-              launch: $result
+              developerIdTeam: "TC6MS3T6NN",
+              cleanInstall: $result
             }' > "$RUNNER_TEMP/neondiff-download/canary-receipt.json"
 
       - name: Upload sanitized receipt

--- a/services/license-api/test/stripe-checkout-http.test.ts
+++ b/services/license-api/test/stripe-checkout-http.test.ts
@@ -57,8 +57,7 @@ function eventPayload(overrides: Record<string, unknown> = {}): string {
 function signatureFor(payload: string): string {
   return stripeVerifier.webhooks.generateTestHeaderString({
     payload,
-    secret: WEBHOOK_SECRET,
-    timestamp: 1_785_400_010
+    secret: WEBHOOK_SECRET
   });
 }
 

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -19,6 +19,60 @@ function read(path: string): string {
 const retiredCoreChecksTarget = ["NeonDiffDesktopCore", "Checks"].join("");
 
 describe("NeonDiff desktop release-smoke pipeline", () => {
+  it("defines a three-clean-Mac public download and install canary", () => {
+    const workflowPath = ".github/workflows/paid-beta-public-download-canary.yml";
+
+    expect(existsSync(workflowPath)).toBe(true);
+
+    const workflow = read(workflowPath);
+    const parsed = YAML.parse(workflow) as {
+      on?: {
+        workflow_dispatch?: {
+          inputs?: Record<string, { required?: boolean }>;
+        };
+      };
+      permissions?: { contents?: string };
+      jobs?: Record<
+        string,
+        {
+          strategy?: { "fail-fast"?: boolean; matrix?: { runner?: string[] } };
+          "runs-on"?: string;
+        }
+      >;
+    };
+
+    const inputs = parsed.on?.workflow_dispatch?.inputs;
+    expect(inputs?.release_tag?.required).toBe(true);
+    expect(inputs?.artifact_name?.required).toBe(true);
+    expect(inputs?.artifact_sha256?.required).toBe(true);
+    expect(parsed.permissions).toEqual({ contents: "read" });
+
+    const job = parsed.jobs?.["public-download-install-canary"];
+    expect(job?.strategy?.["fail-fast"]).toBe(false);
+    expect(job?.strategy?.matrix?.runner).toEqual(["macos-14", "macos-15", "macos-26"]);
+    expect(job?.["runs-on"]).toBe("${{ matrix.runner }}");
+
+    for (const command of [
+      "releases/download",
+      "curl --fail",
+      "shasum -a 256",
+      "com.apple.quarantine",
+      "ditto -x -k",
+      "codesign --verify --deep --strict",
+      "xcrun stapler validate",
+      "spctl -a -vv -t exec",
+      "/Applications/NeonDiff.app",
+      "open -n",
+      "NeonDiffDesktop"
+    ]) {
+      expect(workflow).toContain(command);
+    }
+
+    expect(workflow).toMatch(/actions\/upload-artifact@[0-9a-f]{40}/);
+    expect(workflow).not.toMatch(/actions\/upload-artifact@v4/);
+    expect(workflow).not.toMatch(/\$\{\{\s*secrets\./);
+  });
+
   it("defines an unsigned macOS release-smoke workflow with the required desktop gates", () => {
     const workflowPath = ".github/workflows/desktop-release-smoke.yml";
 

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -59,11 +59,13 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
       "com.apple.quarantine",
       "ditto -x -k",
       "codesign --verify --deep --strict",
+      "TeamIdentifier=TC6MS3T6NN",
+      "Developer ID Application: Andrew Ryan (TC6MS3T6NN)",
       "xcrun stapler validate",
       "spctl -a -vv -t exec",
       "/Applications/NeonDiff.app",
-      "open -n",
-      "NeonDiffDesktop"
+      'test "$(uname -m)" = "arm64"',
+      'test "$release_beta" = "$artifact_beta"'
     ]) {
       expect(workflow).toContain(command);
     }
@@ -71,6 +73,8 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).toMatch(/actions\/upload-artifact@[0-9a-f]{40}/);
     expect(workflow).not.toMatch(/actions\/upload-artifact@v4/);
     expect(workflow).not.toMatch(/\$\{\{\s*secrets\./);
+    expect(workflow).not.toContain("open -n");
+    expect(workflow).not.toContain("NeonDiffDesktop");
   });
 
   it("defines an unsigned macOS release-smoke workflow with the required desktop gates", () => {


### PR DESCRIPTION
## Outcome

Add the exact public-download canary required by #615 so the published beta.39 app is downloaded and clean-installed on three fresh GitHub-hosted Apple Silicon Macs.

## Acceptance criteria

- Manual dispatch requires one exact release tag, asset name, and lowercase SHA-256.
- Three independent clean runners use macOS 14, 15, and 26.
- Every runner downloads from the immutable GitHub Release URL and verifies the supplied checksum.
- Every runner verifies strict Developer ID signing, the exact NeonDiff team/authority, the stapled notarization ticket, and Gatekeeper acceptance.
- Every runner is Apple Silicon, requires the tag and asset beta number to match, and clean-installs the app to Applications.
- Each runner uploads one sanitized receipt; no credential or customer data is consumed.
- The workflow has read-only repository permissions and no secret access.

## Failing-first and focused proof

- RED: focused release-pipeline test failed because the canary workflow did not exist.
- GREEN: the same focused test passes after adding the workflow.
- The first broad remote gate reproduced a deterministic existing test failure: its fixed Stripe test-signature timestamp aged past Stripe's tolerance and made valid fixture webhooks return `400 invalid`.
- DELTA RED: the exact Stripe HTTP test reproduced 12 failures at the current head.
- DELTA GREEN: test signatures now use Stripe's current test-header timestamp; the exact HTTP suite passes 18/18.
- `actionlint` passes for the new workflow.
- `git diff --check` passes.

## Non-goals

- No billing, entitlement, activation, repository, provider, or live-review mutation.
- No replacement for the remaining paid-activation or customer-journey canaries.
- No managed GitHub App, Sparkle/appcast, broader #517, GA, or release-readiness claim.
- No generic CI harness or change to the existing unsigned desktop release smoke.
- No hosted UI-launch claim: standard GitHub-hosted runners are non-interactive. Interactive launcher behavior remains covered by the exact installed beta.39 proof on the release Mac.

The Stripe change is test-only and is included solely because the required current-head gate reproduced the expiry failure. Production signature verification behavior is unchanged.

Relates to #615 and #610.
