### PR TITLE
fix(desktop): accept the activation key Checkout issued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ for the semver/GA-line and npm dist-tag policy.
 
 ### Fixed
 
+- Keep the native paid-BYO License pane usable after browser Checkout: customers
+  can paste the issued one-shot Activation Key through the Keychain-only path,
+  while the checkout action opens the public pricing page without trapping the
+  app in a state that hides existing-key entry.
 - Make configured review concurrency real: ZCode execution is asynchronous,
   each daemon cycle settles one bounded parallel PR batch, issue enrichment
   runs independently at its durable single-lane cap, and execution/session

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Repository**, and **Verify App Access**, so the customer does not need a
 terminal or an operator edit to reach the repository-verification gate. This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.
+After Checkout displays a one-shot NeonDiff Activation Key, return to the
+native **License** pane and paste it there. **Buy an Activation Key** opens the
+public pricing page without hiding that secure existing-key field, so returning
+from the browser does not require a second purchase or an operator-only state
+change. The app stores the key through its existing Keychain-only activation
+path and clears the plaintext field after the customer continues.
 When the signed-in account already contains a verified bot and its App identity
 matches a local launchd/config candidate on this Mac, the native app reuses that
 authoritative account/bot intersection instead of asking the user to initialize

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -69,6 +69,15 @@ struct ActivationStateView: View {
                     .accessibilityIdentifier("neondiff.activation.primary")
                 }
 
+                if presentation.state == .purchaseRequired {
+                    Button("Buy an Activation Key") {
+                        model.openActivationCheckout()
+                    }
+                    .buttonStyle(NDSecondaryButtonStyle())
+                    .accessibilityLabel("Open NeonDiff checkout in your browser")
+                    .accessibilityIdentifier("neondiff.activation.checkout")
+                }
+
                 if presentation.showsNotifyOption {
                     Button("Notify me when checkout reopens") {
                         model.requestActivationNotifyWhenCheckoutReopens()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -103,6 +103,9 @@ package enum DesktopReleaseRouting {
     private static let releasesURL = URL(
         string: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases"
     )!
+    package static let activationCheckoutURL = URL(
+        string: "https://www.neondiff.com/#pricing"
+    )!
 
     package static func localWorkerUpdateGuideURL(shortVersion: String?) -> URL {
         guard let shortVersion else { return releasesURL }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3864,10 +3864,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
             || dependencies.preferences.bool(forKey: activationHandoffEnabledKey)
     }
 
-    /// Production checkout stays disabled pending #562 + website #46. Until then
-    /// the private route renders the honest `checkout_paused` state.
+    /// Paid BYO production builds expose the public purchase surface. Other
+    /// boundaries retain the explicit preference gate and honest paused state.
     package var activationCheckoutEnabled: Bool {
-        dependencies.preferences.bool(forKey: activationCheckoutEnabledKey)
+        dependencies.productionBoundary.byoGitHubEnabled
+            || dependencies.preferences.bool(forKey: activationCheckoutEnabledKey)
     }
 
     package var activationPresentation: ActivationStatePresentation {
@@ -3948,6 +3949,21 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func beginActivationCheckout() {
         applyActivationEvent(activationCheckoutEnabled ? .beginCheckout : .checkoutUnavailable)
+    }
+
+    /// Open the public purchase surface without moving away from the existing-key
+    /// entry state. Checkout returns a one-shot key in the browser, so the customer
+    /// must still be able to paste that key here after returning to the app.
+    package func openActivationCheckout() {
+        guard activationCheckoutEnabled else {
+            applyActivationEvent(.checkoutUnavailable)
+            return
+        }
+        guard dependencies.urlOpener.open(DesktopReleaseRouting.activationCheckoutURL) else {
+            lastError = "Could not open NeonDiff checkout. Visit neondiff.com to purchase an Activation Key."
+            return
+        }
+        lastError = nil
     }
 
     package func cancelActivationCheckout() {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -200,15 +200,15 @@ public enum ActivationStateMachine {
             return ActivationStatePresentation(
                 state: state,
                 title: "Private repositories need activation",
-                cause: "Private repository review requires an active \(keyTerm). Get one through checkout, or paste a key you already have.",
+                cause: "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
                 recovery: ActivationRecovery(
-                    label: "Get a \(keyTerm)",
-                    event: .beginCheckout,
-                    accessibilityLabel: "Open checkout to get a \(keyTerm)"
+                    label: "Continue with this key",
+                    event: .provideExistingKey,
+                    accessibilityLabel: "Store the existing \(keyTerm) securely and continue"
                 ),
                 accessibilityLabel: "Private repositories require an active \(keyTerm).",
                 isSuccess: false,
-                requiresKeyEntry: false,
+                requiresKeyEntry: true,
                 showsNotifyOption: false
             )
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -73,12 +73,14 @@ import NeonDiffDesktopCore
         secretStore: RecordingKeychain = RecordingKeychain(),
         cli: RecordingCLIExecutor = RecordingCLIExecutor(),
         clock: TestClock = TestClock(),
+        urlOpener: RecordingURLOpener = RecordingURLOpener(),
+        productionBoundary: DesktopProductionBoundary = .testVerified,
         client: (any ActivationLicenseClienting)? = nil
     ) -> NeonDiffDesktopModel {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let dependencies = DesktopAppDependencies(
             clipboard: RecordingClipboard(),
-            urlOpener: RecordingURLOpener(),
+            urlOpener: urlOpener,
             cli: cli,
             dashboard: RecordingDashboardLauncher(),
             preferences: preferences,
@@ -87,7 +89,7 @@ import NeonDiffDesktopCore
             providerVerifier: RecordingProviderVerifier(),
             secretStore: secretStore,
             githubAuthenticator: StubGitHubAuthenticator(),
-            productionBoundary: .testVerified
+            productionBoundary: productionBoundary
         )
         return NeonDiffDesktopModel(dependencies: dependencies, activationLicenseClient: client)
     }
@@ -142,6 +144,20 @@ import NeonDiffDesktopCore
         model.beginActivationCheckout()
         #expect(model.activationState == .checkoutPaused)
         #expect(model.activationPresentation.showsNotifyOption)
+    }
+
+    @Test func paidBYOCheckoutOpensPublicPricingWithoutTrappingExistingKeyEntry() {
+        let opener = RecordingURLOpener()
+        let model = makeModel(
+            urlOpener: opener,
+            productionBoundary: .testAccountLink
+        )
+
+        model.openActivationCheckout()
+
+        #expect(opener.urls == [URL(string: "https://www.neondiff.com/#pricing")!])
+        #expect(model.activationState == .purchaseRequired)
+        #expect(model.activationPresentation.requiresKeyEntry)
     }
 
     @Test func provideExistingKeyStoresInKeychainOnlyAndAdvances() {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationStateMachineTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationStateMachineTests.swift
@@ -153,6 +153,16 @@ import Testing
                 "checkout_paused must tell users existing keys still activate")
     }
 
+    @Test func purchaseRequiredAcceptsTheKeyCheckoutAlreadyIssued() {
+        let p = ActivationStateMachine.presentation(for: .purchaseRequired)
+
+        #expect(p.requiresKeyEntry, "purchase_required must not hide existing-key entry")
+        #expect(
+            p.recovery?.event == .provideExistingKey,
+            "purchase_required must let a customer continue with the key returned by checkout"
+        )
+    }
+
     @Test func presentationNeverEmbedsRawKeyMaterial() {
         // Redaction invariant: presentation copy is derived only from the state and
         // a caller-supplied REDACTED prefix — a raw secret can never leak into copy.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -283,6 +283,14 @@ gates. No invitation is required when the versioned public GitHub prerelease is
 published and the neondiff.com purchase/download path is live. Until both are
 true, the candidate and its GitHub prerelease assets remain held.
 
+After Checkout displays the one-shot NeonDiff Activation Key, return to the
+native **License** pane, paste the key, and choose **Continue with this key**,
+then **Activate**. **Buy an Activation Key** opens the public pricing page but
+keeps the existing-key field available when the customer returns. The key is
+stored only through the app's Keychain activation path and the plaintext field
+is cleared; do not paste it into Terminal, config, logs, screenshots, or
+evidence.
+
 ### Existing bot on this Mac
 
 After account linking, the native app may find a server-verified bot whose App

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -136,6 +136,13 @@ integration proof under #630.
    Initialization never uses `--force`; the app updates `pilotRepos` through
    `config patch`, and no operator edits the customer's config file.
 
+GitHub setup and paid activation remain separate gates. After Checkout returns
+the one-shot NeonDiff Activation Key, the customer pastes it in the native
+**License** pane. The **Buy an Activation Key** control opens the public pricing
+page without replacing or hiding existing-key entry, and the app clears the
+plaintext field after storing the key through its Keychain-only activation
+path.
+
 If account linking finds a server-verified bot whose exact App identity and
 GitHub account match a local launchd/config candidate on this Mac, NeonDiff
 shows that existing connection instead of presenting clean-install credential


### PR DESCRIPTION
## Outcome

Customers who return from paid Checkout with a one-shot Activation Key can paste it into the native License pane, continue through the existing Keychain-only path, and activate without buying again or requiring an operator state change.

Related to #723. This does not close #610, #646, or #615.

## Acceptance criteria

- `purchase_required` shows secure existing-key entry and `Continue with this key`.
- `Buy an Activation Key` opens `https://www.neondiff.com/#pricing`.
- Opening Checkout leaves the app in `purchase_required`, so key entry remains available on return.
- The existing activation path stores the key through the Keychain abstraction and clears plaintext input.
- Focused model tests and a Swift package build pass.
- Current-head remote CI and one independent activation/secret-path semantic review pass before merge.

## Non-goals

- No second purchase or production billing mutation.
- No entitlement-server, Stripe, Fly, Supabase, GitHub App, provider, or worker behavior change.
- No new activation storage or CLI fallback.
- No signing, notarization, publication, beta, or customer-readiness claim.
- No broader #517 or GA matrix work.

## Failing-first proof

Before the source change, the new handoff test failed to compile because the model had no checkout-opening action; the existing `purchase_required` presentation also set `requiresKeyEntry = false`. The implementation adds that bounded action and makes existing-key entry the primary recovery.

Focused local proof at `c8dfa90`:

- `swift test --filter ActivationStateMachineTests`: 11 passed.
- `swift test --filter ActivationHandoffModelTests`: 22 passed.
- `swift build`: passed.
- `git diff --check`: passed.

Installed activation, remote CI, merge, signed artifact, and customer-path proof remain separate pending gates.
