### PR TITLE
fix(desktop): isolate clean bot state paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ for the semver/GA-line and npm dist-tag policy.
 
 ### Fixed
 
+- Make clean native bot setup immediately patchable: `neondiff init` now gives
+  configs outside protected source/package roots isolated runtime, state,
+  evidence, and license paths beside the config instead of retaining the
+  packaged worker's `/tmp/neondiff` placeholders.
 - Keep the native paid-BYO License pane usable after browser Checkout: customers
   can paste the issued one-shot Activation Key through the Keychain-only path,
   while the checkout action opens the public pricing page without trapping the

--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ is a paid path for every repository and does not claim the managed public-free
 model. On a clean Mac, native first run exposes **Initialize Local Config**
 (non-destructive; never force-overwrites), **Add Repository**, **Apply
 Repository**, and **Verify App Access**, so the customer does not need a
-terminal or an operator edit to reach the repository-verification gate. This
+terminal or an operator edit to reach the repository-verification gate. A new
+native config receives bot-isolated runtime, state, evidence, and license paths
+beside that config instead of reusing the packaged worker's placeholder
+`/tmp/neondiff` tree. This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.
 After Checkout displays a one-shot NeonDiff Activation Key, return to the

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -270,7 +270,9 @@ For a B0 customer, the native first-run path is:
    PEM, then choose **Store in Keychain**.
 3. On a clean install, choose **Initialize Local Config**. This invokes the
    non-destructive `neondiff init` path and never supplies `--force`; an existing
-   config is not overwritten.
+   config is not overwritten. The generated config keeps its runtime, state,
+   evidence, and license files in bot-isolated directories beside the config,
+   outside the packaged worker or source checkout.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command; the customer does not edit a config file.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -134,7 +134,9 @@ integration proof under #630.
    install choose **Initialize Local Config**. Enter the same `owner/repo`, then
    choose **Add Repository**, **Apply Repository**, and **Verify App Access**.
    Initialization never uses `--force`; the app updates `pilotRepos` through
-   `config patch`, and no operator edits the customer's config file.
+   `config patch`, and no operator edits the customer's config file. Each new
+   bot config receives isolated runtime, state, evidence, and license paths
+   beside that config rather than the packaged worker's placeholder paths.
 
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,6 +108,11 @@ import { runProvidersVerifyCommand } from "./providers-verify-command.js";
 import { collectReleaseStatus, collectReleaseStatusWithConfig, type ReleaseStatus } from "./release-status.js";
 import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
+import {
+  assertPathOutsideProtectedRoot,
+  getProtectedCheckoutRoots,
+  resolvePathFollowingExistingSymlinks
+} from "./path-safety.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { runOnceCliCommand } from "./run-once-cli.js";
 import { redactSecrets, stringifyRedactedJson } from "./secrets.js";
@@ -2431,10 +2436,11 @@ function runInitCommand(args: ParsedArgs): {
   const backupPath = force && existsSync(configPath) ? backupInitForceTarget(configPath) : undefined;
   mkdirSync(dirname(configPath), { recursive: true });
   const exampleConfig = readFileSync(examplePath, "utf8");
+  const initializedConfig = buildInitializedConfig(exampleConfig, configPath);
   if (force) {
-    writeFileAtomic(configPath, exampleConfig);
+    writeFileAtomic(configPath, initializedConfig);
   } else {
-    writeNewFile(configPath, exampleConfig);
+    writeNewFile(configPath, initializedConfig);
   }
   return {
     ok: true,
@@ -2449,6 +2455,47 @@ function runInitCommand(args: ParsedArgs): {
       `neondiff status --config ${configPath} --json`
     ],
   };
+}
+
+function buildInitializedConfig(exampleConfig: string, configPath: string): string {
+  const configDirectory = resolvePathFollowingExistingSymlinks(dirname(configPath));
+  try {
+    assertPathOutsideProtectedRoot({
+      path: configDirectory,
+      protectedRoot: undefined,
+      protectedRoots: getProtectedCheckoutRoots(),
+      pathLabel: "init config directory",
+      protectedRootLabel: "protected checkout root"
+    });
+  } catch (error) {
+    if (
+      !(error instanceof Error)
+      || !error.message.startsWith("init config directory must be outside protected checkout root; got ")
+    ) {
+      throw error;
+    }
+    return exampleConfig;
+  }
+
+  const initialized = JSON.parse(exampleConfig) as Record<string, unknown>;
+  const stateDirectory = join(configDirectory, "state");
+  initialized.workRoot = join(configDirectory, "runtime");
+  initialized.statePath = join(stateDirectory, "reviews.sqlite");
+  initialized.evidenceDir = join(configDirectory, "evidence");
+
+  const existingLicense = initialized.license;
+  const license = existingLicense !== null
+      && typeof existingLicense === "object"
+      && !Array.isArray(existingLicense)
+    ? { ...(existingLicense as Record<string, unknown>) }
+    : {};
+  license.cachePath = join(stateDirectory, "license", "entitlement-cache.json");
+  if (license.storageBackend === "file") {
+    license.keyPath = join(stateDirectory, "license", "license-key.txt");
+  }
+  initialized.license = license;
+
+  return `${JSON.stringify(initialized, null, 2)}\n`;
 }
 
 function resolvePackageRoot(): string {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -176,6 +176,81 @@ describe("public NeonDiff CLI surface", () => {
     });
   });
 
+  it("initializes isolated desktop state outside the packaged worker root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-desktop-packaged-worker-"));
+    roots.push(root);
+    const botRoot = join(root, "accounts", "paid-canary", "bots", "private-review");
+    const configPath = join(botRoot, "config.local.json");
+    const cliSourcePath = join(repoRoot, "src/cli.ts");
+    const env = {
+      ...process.env,
+      NODE_OPTIONS: "--experimental-sqlite",
+      NEONDIFF_PROTECTED_CHECKOUT_ROOT: "/tmp/neondiff"
+    };
+
+    const initialized = await execFileAsync(process.execPath, [
+      tsxCliPath,
+      cliSourcePath,
+      "init",
+      "--config",
+      configPath
+    ], {
+      cwd: "/",
+      env
+    });
+    expect(JSON.parse(initialized.stdout)).toMatchObject({
+      ok: true,
+      command: "init",
+      created: true,
+      configPath
+    });
+
+    const initializedConfig = JSON.parse(readFileSync(configPath, "utf8"));
+    const resolvedBotRoot = realpathSync(botRoot);
+    expect(initializedConfig.workRoot).toBe(join(resolvedBotRoot, "runtime"));
+    expect(initializedConfig.statePath).toBe(join(resolvedBotRoot, "state", "reviews.sqlite"));
+    expect(initializedConfig.evidenceDir).toBe(join(resolvedBotRoot, "evidence"));
+
+    const inspected = await execFileAsync(process.execPath, [
+      tsxCliPath,
+      cliSourcePath,
+      "config",
+      "inspect",
+      "--config",
+      configPath
+    ], {
+      cwd: "/",
+      env
+    });
+    expect(JSON.parse(inspected.stdout)).toMatchObject({
+      ok: true,
+      command: "config inspect"
+    });
+  });
+
+  it("keeps packaged example paths when init targets a protected checkout", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-init-protected-checkout-"));
+    roots.push(root);
+    const checkoutRoot = join(root, "checkout");
+    const configPath = join(checkoutRoot, "config.local.json");
+    mkdirSync(join(checkoutRoot, ".git"), { recursive: true });
+
+    const { stdout } = await runCli(["init", "--config", configPath], {
+      cwd: "/",
+      env: { NEONDIFF_PROTECTED_CHECKOUT_ROOT: checkoutRoot }
+    });
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      ok: true,
+      command: "init",
+      created: true,
+      configPath
+    });
+    expect(readFileSync(configPath, "utf8")).toBe(
+      readFileSync(join(repoRoot, "config.example.json"), "utf8")
+    );
+  });
+
   it("still rejects license state inside a non-package Git checkout", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-non-package-checkout-"));
     roots.push(root);
@@ -1907,7 +1982,18 @@ exit 1
     expect(realpathSync(output.configPath)).toBe(realpathSync(configPath));
     expect(existsSync(configPath)).toBe(true);
     const config = readFileSync(configPath, "utf8");
-    expect(config).toBe(example);
+    const parsedConfig = JSON.parse(config);
+    const resolvedRoot = realpathSync(root);
+    expect(parsedConfig).toMatchObject({
+      workRoot: join(resolvedRoot, "runtime"),
+      statePath: join(resolvedRoot, "state", "reviews.sqlite"),
+      evidenceDir: join(resolvedRoot, "evidence"),
+      license: {
+        cachePath: join(resolvedRoot, "state", "license", "entitlement-cache.json"),
+        keyPath: join(resolvedRoot, "state", "license", "license-key.txt")
+      }
+    });
+    expect(config).toContain("\"pilotRepos\"");
     expect(example).toContain("\"pilotRepos\"");
     const fixtureLeakPattern = new RegExp(
       String.raw`ghp_|BEGIN ${"PRIVATE KEY"}|api[_-]?key["']?\s*[:=]\s*["'][A-Za-z0-9._~+/=-]{16,}`,


### PR DESCRIPTION
Related to #699.

## Acceptance criteria
- Clean native New Bot initialization creates bot-isolated runtime, state, evidence, and license paths beside its config.
- The initialized config remains valid when the packaged worker root is `/tmp/neondiff`.
- Checkout-local CLI initialization keeps the packaged example paths rather than placing mutable state inside a protected checkout.
- Existing configs are never overwritten without the existing explicit force contract.

## Installed failure reproduced
The exact downloaded/notarized beta.40 New Bot path reached `Initialize Local Config` but `Apply Repository` failed because the generated license cache remained under the packaged worker placeholder root. This PR fixes only that current supported-path failure.

## Failing-first and local proof
- RED: packaged-worker-root init test received `/tmp/neondiff/runtime` instead of the isolated bot runtime path.
- GREEN: 6 focused init/non-overwrite tests passed.
- `npx tsc -p tsconfig.build.json --noEmit` passed.
- `git diff --check` passed.

## Non-goals
- No GitHub App credential creation, rotation, storage-boundary change, or permission expansion.
- No billing, activation API, daemon, provider, signing, notarization, release, or publication change.
- No claim that the broader #699 installed path, private review, canaries, or paid beta gate is complete.