### PR TITLE
fix(desktop): reuse installed worker for new bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,13 @@ plan before it presents the initialization action; it never initializes the
 `_unselected` placeholder. A new native config receives bot-isolated runtime,
 state, evidence, and license paths beside that config instead of reusing the
 packaged worker's placeholder `/tmp/neondiff` tree. If one exact
-checksum-managed local worker already exists
-for the selected LaunchAgent label, the app reuses it for these isolated setup
-commands instead of silently invoking an older global `neondiff` command. It
-does not borrow the existing bot's credential environment; GitHub verification
-receives the new bot's Keychain-owned private key only through bounded stdin.
+checksum-managed local worker already exists for the selected LaunchAgent
+label, the app reuses it for these isolated setup commands instead of resolving
+them through a global `neondiff` command. It does not borrow the existing bot's
+credential environment; GitHub verification receives the new bot's
+Keychain-owned private key only through bounded stdin. If zero or multiple
+managed worker contexts are found, this reuse path is not selected; installing
+and proving exactly one managed worker remains a separate distribution gate.
 This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.

--- a/README.md
+++ b/README.md
@@ -174,10 +174,18 @@ is a paid path for every repository and does not claim the managed public-free
 model. On a clean Mac, native first run exposes **Initialize Local Config**
 (non-destructive; never force-overwrites), **Add Repository**, **Apply
 Repository**, and **Verify App Access**, so the customer does not need a
-terminal or an operator edit to reach the repository-verification gate. A new
-native config receives bot-isolated runtime, state, evidence, and license paths
-beside that config instead of reusing the packaged worker's placeholder
-`/tmp/neondiff` tree. This
+terminal or an operator edit to reach the repository-verification gate. When
+the verified account has no bot yet, the app allocates that isolated new-bot
+plan before it presents the initialization action; it never initializes the
+`_unselected` placeholder. A new native config receives bot-isolated runtime,
+state, evidence, and license paths beside that config instead of reusing the
+packaged worker's placeholder `/tmp/neondiff` tree. If one exact
+checksum-managed local worker already exists
+for the selected LaunchAgent label, the app reuses it for these isolated setup
+commands instead of silently invoking an older global `neondiff` command. It
+does not borrow the existing bot's credential environment; GitHub verification
+receives the new bot's Keychain-owned private key only through bounded stdin.
+This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.
 After Checkout displays a one-shot NeonDiff Activation Key, return to the

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -425,11 +425,18 @@ package enum DesktopLocalBotExecutionContextResolver {
         arguments: [String],
         executionContexts: [DesktopLocalBotExecutionContext]
     ) -> String? {
-        matchingContext(
-            executablePath: executablePath,
-            arguments: arguments,
-            executionContexts: executionContexts,
-            commandAccess: .executableReuse
+        (
+            matchingContext(
+                executablePath: executablePath,
+                arguments: arguments,
+                executionContexts: executionContexts,
+                commandAccess: .executableReuse
+            )
+            ?? unboundManagedWorkerContext(
+                executablePath: executablePath,
+                arguments: arguments,
+                executionContexts: executionContexts
+            )
         )?.executablePath
     }
 
@@ -443,6 +450,10 @@ package enum DesktopLocalBotExecutionContextResolver {
             arguments: arguments,
             executionContexts: executionContexts,
             commandAccess: .executableReuse
+        ) ?? unboundManagedWorkerContext(
+            executablePath: executablePath,
+            arguments: arguments,
+            executionContexts: executionContexts
         ) else {
             return arguments
         }
@@ -498,5 +509,154 @@ package enum DesktopLocalBotExecutionContextResolver {
         }
         guard matches.count == 1 else { return nil }
         return matches[0]
+    }
+
+    /// A newly created account bot has an isolated config path, so it cannot
+    /// match the existing LaunchAgent config that proved the local worker.
+    /// Reuse only the exact installer-managed worker executable for the
+    /// bounded first-run commands that do not borrow the existing bot's
+    /// credential environment. The separate `resolve` method intentionally
+    /// remains exact-config-only.
+    private static func unboundManagedWorkerContext(
+        executablePath: String,
+        arguments: [String],
+        executionContexts: [DesktopLocalBotExecutionContext]
+    ) -> DesktopLocalBotExecutionContext? {
+        guard executablePath == "neondiff",
+              isSupportedUnboundCommand(arguments),
+              isIsolatedAccountBotConfig(arguments)
+        else {
+            return nil
+        }
+        let matches = executionContexts.filter(isInstallerManagedWorker)
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
+
+    private static func isSupportedUnboundCommand(_ arguments: [String]) -> Bool {
+        if arguments.count == 3,
+           arguments[0] == "init",
+           arguments[1] == "--config"
+        {
+            return true
+        }
+        if arguments.count == 4,
+           Array(arguments.prefix(2)) == ["config", "inspect"],
+           arguments[2] == "--config"
+        {
+            return true
+        }
+        if Array(arguments.prefix(2)) == ["config", "patch"] {
+            return isSupportedConfigPatch(arguments)
+        }
+        guard arguments.count == 9,
+              Array(arguments.prefix(2)) == ["doctor", "github"],
+              arguments[2] == "--config",
+              arguments[4] == "--github-app-id",
+              !arguments[5].isEmpty,
+              arguments[5].utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+              Int64(arguments[5]).map({ $0 > 0 }) == true,
+              arguments[6] == "--github-app-private-key-stdin",
+              arguments[7] == "true",
+              arguments[8] == "--json"
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static func isSupportedConfigPatch(_ arguments: [String]) -> Bool {
+        guard arguments.count >= 8,
+              arguments.count.isMultiple(of: 2)
+        else {
+            return false
+        }
+
+        var values: [String: String] = [:]
+        var index = 2
+        while index < arguments.count {
+            let flag = arguments[index]
+            let value = arguments[index + 1]
+            guard [
+                "--config",
+                "--input",
+                "--dry-run",
+                "--expected-revision",
+                "--confirm"
+            ].contains(flag),
+            values[flag] == nil,
+            !value.isEmpty
+            else {
+                return false
+            }
+            values[flag] = value
+            index += 2
+        }
+
+        guard values["--config"] != nil,
+              values["--input"].map({ $0.hasPrefix("/") }) == true,
+              let dryRun = values["--dry-run"],
+              dryRun == "true" || dryRun == "false"
+        else {
+            return false
+        }
+        if dryRun == "true" {
+            return values["--confirm"] == nil
+        }
+        return values["--confirm"] == "true"
+    }
+
+    private static func isIsolatedAccountBotConfig(_ arguments: [String]) -> Bool {
+        let configIndexes = arguments.indices.filter {
+            arguments[$0] == "--config"
+        }
+        guard configIndexes.count == 1,
+              let index = configIndexes.first,
+              arguments.index(after: index) < arguments.endIndex
+        else {
+            return false
+        }
+        let rawPath = arguments[arguments.index(after: index)]
+        guard rawPath.hasPrefix("/") else { return false }
+        let components = URL(filePath: rawPath).standardizedFileURL.pathComponents
+        guard components.count >= 8 else { return false }
+        let suffix = Array(components.suffix(8))
+        return suffix[0] == "Library"
+            && suffix[1] == "Application Support"
+            && suffix[2] == "NeonDiffDesktop"
+            && suffix[3] == "Accounts"
+            && !suffix[4].isEmpty
+            && suffix[4] != "_unselected"
+            && suffix[5] == "Bots"
+            && !suffix[6].isEmpty
+            && suffix[7] == "config.local.json"
+    }
+
+    private static func isInstallerManagedWorker(
+        _ context: DesktopLocalBotExecutionContext
+    ) -> Bool {
+        guard let executablePath = context.executablePath,
+              executablePath.hasPrefix("/"),
+              URL(filePath: executablePath).lastPathComponent == "node",
+              context.argumentPrefix.count == 1
+        else {
+            return false
+        }
+        let components = URL(
+            filePath: context.argumentPrefix[0]
+        ).standardizedFileURL.pathComponents
+        guard components.count >= 11 else { return false }
+        let suffix = Array(components.suffix(11))
+        return suffix[0] == "Library"
+            && suffix[1] == "Application Support"
+            && suffix[2] == "NeonDiffDesktop"
+            && suffix[3] == "Workers"
+            && !suffix[4].isEmpty
+            && suffix[5] == "current"
+            && suffix[6] == "node_modules"
+            && suffix[7] == "neondiff"
+            && suffix[8] == "dist"
+            && suffix[9] == "src"
+            && suffix[10] == "cli.js"
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1527,6 +1527,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             selectBotInstallation(savedBotID)
         } else {
             dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+            if initial.bots.isEmpty {
+                beginNewBot()
+            }
         }
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -410,6 +410,26 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func firstCatalogAllocatesAnIsolatedPlanForAnAccountWithoutBots() throws {
+        let account = workspace(
+            id: "account-new",
+            name: "New Account",
+            bots: []
+        )
+        let fixture = ModelDependencyFixture()
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+
+        let plan = try #require(fixture.model.pendingNewBotPlan)
+        #expect(plan.accountID == account.id)
+        #expect(fixture.model.accountWorkspaceSelection.accountID == account.id)
+        #expect(fixture.model.accountWorkspaceSelection.botID == plan.bot.id)
+        #expect(fixture.model.configPath == plan.bot.localConfigPath)
+        #expect(!fixture.model.configPath.contains("/Accounts/_unselected/"))
+        #expect(fixture.model.isOnboardingPresented)
+    }
+
+    @MainActor
     @Test func staleConfigInspectCannotPopulateTheNewWorkspace() async throws {
         let botA = bot(id: "bot-a", slug: "bot-a", configPath: "/fixture/a/config.local.json")
         let botB = bot(id: "bot-b", slug: "bot-b", configPath: "/fixture/b/config.local.json")

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -357,6 +357,165 @@ import Testing
         ) == nil)
     }
 
+    @Test func reusesInstallerManagedWorkerForAnIsolatedNewBotConfig() throws {
+        let label = "com.electricsheephq.evaos-code-review-bot"
+        let existingConfigPath =
+            "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let isolatedConfigPath =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/new-bot/config.local.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let nodePath = "/opt/homebrew/bin/node"
+        let workerRoot = URL(
+            filePath: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers"
+        )
+        .appendingPathComponent(label, isDirectory: true)
+        .standardizedFileURL
+        let workerCLI = workerRoot
+            .appendingPathComponent(
+                "current/node_modules/neondiff/dist/src/cli.js"
+            )
+            .standardizedFileURL
+        let context = try #require(
+            DesktopLaunchAgentExecutionContextParser.parse(
+                data: propertyList(
+                    label: label,
+                    environment: [
+                        "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                        "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                    ],
+                    arguments: [
+                        nodePath,
+                        workerCLI.path,
+                        "daemon",
+                        "--config",
+                        existingConfigPath
+                    ]
+                ),
+                expectedLabel: label,
+                installedWorkerRoot: workerRoot,
+                privateKeyPathIsSafe: { $0.path == privateKeyPath }
+            )
+        )
+        let initialize = ["init", "--config", isolatedConfigPath]
+        let inspect = ["config", "inspect", "--config", isolatedConfigPath]
+        let patch = [
+            "config", "patch",
+            "--config", isolatedConfigPath,
+            "--input", "/tmp/public-safe-patch.json",
+            "--dry-run", "false",
+            "--confirm", "true"
+        ]
+
+        for arguments in [initialize, inspect, patch] {
+            #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                executablePath: "neondiff",
+                arguments: arguments,
+                executionContexts: [context]
+            ) == nodePath)
+            #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+                executablePath: "neondiff",
+                arguments: arguments,
+                executionContexts: [context]
+            ) == [workerCLI.path] + arguments)
+            #expect(DesktopLocalBotExecutionContextResolver.resolve(
+                executablePath: "neondiff",
+                arguments: arguments,
+                executionContexts: [context]
+            ).isEmpty)
+        }
+    }
+
+    @Test func reusesInstallerManagedWorkerForIsolatedBYODoctorOnlyWithStdin() throws {
+        let label = "com.electricsheephq.evaos-code-review-bot"
+        let existingConfigPath =
+            "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"
+        let isolatedConfigPath =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/new-bot/config.local.json"
+        let privateKeyPath = "/Users/test/.config/neondiff/app.pem"
+        let nodePath = "/opt/homebrew/bin/node"
+        let workerRoot = URL(
+            filePath: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers"
+        )
+        .appendingPathComponent(label, isDirectory: true)
+        .standardizedFileURL
+        let workerCLI = workerRoot
+            .appendingPathComponent(
+                "current/node_modules/neondiff/dist/src/cli.js"
+            )
+            .standardizedFileURL
+        let context = try #require(
+            DesktopLaunchAgentExecutionContextParser.parse(
+                data: propertyList(
+                    label: label,
+                    environment: [
+                        "EVAOS_REVIEW_BOT_APP_ID": "4184532",
+                        "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH": privateKeyPath
+                    ],
+                    arguments: [
+                        nodePath,
+                        workerCLI.path,
+                        "daemon",
+                        "--config",
+                        existingConfigPath
+                    ]
+                ),
+                expectedLabel: label,
+                installedWorkerRoot: workerRoot,
+                privateKeyPathIsSafe: { $0.path == privateKeyPath }
+            )
+        )
+        let verifiedArguments = [
+            "doctor", "github",
+            "--config", isolatedConfigPath,
+            "--github-app-id", "4184532",
+            "--github-app-private-key-stdin", "true",
+            "--json"
+        ]
+        let missingStdinContract = [
+            "doctor", "github",
+            "--config", isolatedConfigPath,
+            "--json"
+        ]
+        let widenedDoctorContract = verifiedArguments + ["--repo", "owner/repo"]
+
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: verifiedArguments,
+            executionContexts: [context]
+        ) == nodePath)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: "neondiff",
+            arguments: verifiedArguments,
+            executionContexts: [context]
+        ) == [workerCLI.path] + verifiedArguments)
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: verifiedArguments,
+            executionContexts: [context]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: missingStdinContract,
+            executionContexts: [context]
+        ) == nil)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: widenedDoctorContract,
+            executionContexts: [context]
+        ) == nil)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: [
+                "config", "patch",
+                "--config", isolatedConfigPath,
+                "--input", "/tmp/public-safe-patch.json",
+                "--dry-run", "true",
+                "--confirm", "true"
+            ],
+            executionContexts: [context]
+        ) == nil)
+    }
+
     @Test func preservesTheAcceptedSourceRunnerInvocationForDesktopCommands() throws {
         let workingDirectory = "/Volumes/LEXAR/repos/evaos-code-review-bot"
         let configPath = "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json"

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -279,6 +279,17 @@ For a B0 customer, the native first-run path is:
 5. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
    the exact configured repository through that App installation.
 
+For a verified account with no bot yet, the app allocates the isolated new-bot
+plan before showing **Initialize Local Config**. It never initializes the
+`Accounts/_unselected` placeholder.
+
+When the same Mac already has one exact checksum-managed worker for the selected
+LaunchAgent label, the app reuses that worker for the isolated bot's `init`,
+`config inspect`, `config patch`, and private-key-stdin GitHub doctor commands.
+It does not silently fall back to an older global `neondiff` package, and it
+does not pass the existing bot's App ID or private-key file environment into the
+new bot process.
+
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate
 gates. No invitation is required when the versioned public GitHub prerelease is

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -286,9 +286,11 @@ plan before showing **Initialize Local Config**. It never initializes the
 When the same Mac already has one exact checksum-managed worker for the selected
 LaunchAgent label, the app reuses that worker for the isolated bot's `init`,
 `config inspect`, `config patch`, and private-key-stdin GitHub doctor commands.
-It does not silently fall back to an older global `neondiff` package, and it
-does not pass the existing bot's App ID or private-key file environment into the
-new bot process.
+Within that proven one-worker case, it does not resolve those commands through
+an older global `neondiff` package, and it does not pass the existing bot's App
+ID or private-key file environment into the new bot process. Zero or ambiguous
+managed-worker discovery does not select this reuse path; installing and proving
+exactly one managed worker is a separate distribution gate.
 
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -136,7 +136,14 @@ integration proof under #630.
    Initialization never uses `--force`; the app updates `pilotRepos` through
    `config patch`, and no operator edits the customer's config file. Each new
    bot config receives isolated runtime, state, evidence, and license paths
-   beside that config rather than the packaged worker's placeholder paths.
+   beside that config rather than the packaged worker's placeholder paths. An
+   account with no bot gets this isolated plan before the initialization action
+   appears; the app never initializes the `_unselected` placeholder.
+   If one exact checksum-managed worker already exists for the selected
+   LaunchAgent label, these isolated config commands and the bounded
+   private-key-stdin GitHub doctor reuse that worker instead of an older global
+   `neondiff` command. The new bot never inherits the existing bot's credential
+   environment.
 
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -141,9 +141,11 @@ integration proof under #630.
    appears; the app never initializes the `_unselected` placeholder.
    If one exact checksum-managed worker already exists for the selected
    LaunchAgent label, these isolated config commands and the bounded
-   private-key-stdin GitHub doctor reuse that worker instead of an older global
-   `neondiff` command. The new bot never inherits the existing bot's credential
-   environment.
+   private-key-stdin GitHub doctor reuse that worker instead of resolving
+   through a global `neondiff` command. The new bot never inherits the existing
+   bot's credential environment. Zero or ambiguous managed-worker discovery
+   does not select this reuse path; the exact worker installation remains a
+   separate distribution gate.
 
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native


### PR DESCRIPTION
## Outcome

Fixes the reproduced installed-app onboarding mismatch for a paid BYO account
with no server bot:

- automatically allocates an isolated new-bot plan instead of initializing the
  `_unselected` placeholder;
- reuses one exact installer-managed worker for the bounded isolated setup
  commands when the desktop preference is the normal `neondiff` default;
- keeps existing-bot credential environment exact-config-only;
- rejects widened command shapes outside init, inspect, patch, and
  private-key-stdin GitHub verification.

Related to #699. This does not close the broader installed customer path.

## Acceptance criteria

- [x] A verified account with zero bots receives an isolated account/bot config
      before onboarding starts.
- [x] Initialize, inspect, and repository patch use the exact
      installer-managed worker without a Settings-path repair.
- [x] Existing GitHub App ID/private-key-path environment is not inherited by
      the new bot.
- [x] BYO GitHub doctor reuse requires the exact stdin-only command contract.
- [x] A development app with the default `neondiff` preference initialized the
      new config and applied a repository through the installed beta.41 worker.

## Focused proof

- `LaunchAgentLocalBotConfigurationTests`: 17/17
- `AccountWorkspaceSelectionTests`: 23/23
- `git diff --check`
- Source base: `74a57cd1bdb675d73410ec486964b3715cff155f`
- Reviewed implementation head: `a799c99b2abbed2a3e3f5dbb0e3e10f5ad955120`
- Current docs-only delta head: `81be560e2a8fbafef743e87bfcac071104a96a3a`

## Non-goals / proof boundary

- No private-key verification, activation, provider setup, dry review, live
  review, relaunch/recovery, or entitlement-loss proof.
- No worker-installer UX automation.
- No billing, website, signing, notarization, publication, beta, release, or
  customer-readiness claim.
- No change to managed GitHub App, Sparkle, broad #517, or GA scope.
