### PR TITLE
fix(desktop): preserve pending New Bot setup across relaunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ Repository**, and **Verify App Access**, so the customer does not need a
 terminal or an operator edit to reach the repository-verification gate. When
 the verified account has no bot yet, the app allocates that isolated new-bot
 plan before it presents the initialization action; it never initializes the
-`_unselected` placeholder. A new native config receives bot-isolated runtime,
+`_unselected` placeholder. If the customer quits during that setup, the next
+launch restores the same pending bot and config path—even when the account also
+has an existing local bot—and reopens onboarding instead of allocating another
+config directory. A new native config receives bot-isolated runtime,
 state, evidence, and license paths beside that config instead of reusing the
 packaged worker's placeholder `/tmp/neondiff` tree. If one exact
 checksum-managed local worker already exists for the selected LaunchAgent

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -698,6 +698,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var workspaceContextGeneration: UInt64 = 0
     private let accountWorkspacePreferenceKey = "neondiff.accountWorkspaceID"
     private let accountBotPreferenceKey = "neondiff.accountBotID"
+    private let pendingNewBotPlanPreferenceKey = "neondiff.pendingNewBotPlan.v1"
+
+    private struct PersistedPendingNewBotPlan: Codable {
+        let schemaVersion: Int
+        let accountID: String
+        let botID: String
+        let appSlug: String
+        let configPath: String
+    }
 
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
@@ -1485,6 +1494,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     accountWorkspaceSelection.selectBot(nil)
                     pendingNewBotPlan = nil
                     dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+                    dependencies.preferences.removeValue(
+                        forKey: pendingNewBotPlanPreferenceKey
+                    )
                     accountWorkspaceStatus = "The selected bot is no longer authorized. Choose another bot or create a new one."
                     return
                 }
@@ -1519,7 +1531,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let initial = catalog.accounts.first(where: { $0.id == saved }) ?? catalog.accounts[0]
         let savedBotID = dependencies.preferences.string(forKey: accountBotPreferenceKey)
         selectAccountWorkspace(initial.id, clearSavedBot: false)
-        if let savedBotID,
+        if let restoredPlan = restoredPendingNewBotPlan(
+            account: initial,
+            savedBotID: savedBotID
+        ) {
+            pendingNewBotPlan = restoredPlan
+            accountWorkspaceSelection.selectBot(restoredPlan.bot.id)
+            configPath = restoredPlan.bot.localConfigPath ?? configPath
+            accountWorkspaceStatus = "Restored the pending New Bot setup on this Mac."
+            if dependencies.fileWriter.fileExists(at: URL(filePath: configPath)) {
+                inspectConfig(allowDuringAccountRestore: true)
+            } else {
+                reopenOnboarding(at: .welcome)
+            }
+        } else if let savedBotID,
            initial.bots.contains(where: {
                $0.id == savedBotID
                    && ($0.status == .verified || $0.status == .pending)
@@ -1527,6 +1552,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             selectBotInstallation(savedBotID)
         } else {
             dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
             if initial.bots.isEmpty {
                 beginNewBot()
             }
@@ -1550,6 +1578,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.preferences.set(accountID, forKey: accountWorkspacePreferenceKey)
         if clearSavedBot {
             dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
         }
         accountWorkspaceStatus = "Account selected. Choose an existing bot or create a new one."
     }
@@ -1567,6 +1598,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         resetWorkspaceBoundRuntimeState()
         accountWorkspaceSelection.selectBot(botID)
         pendingNewBotPlan = nil
+        dependencies.preferences.removeValue(
+            forKey: pendingNewBotPlanPreferenceKey
+        )
         dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
         if let localConfigPath = bot.localConfigPath {
             configPath = localConfigPath
@@ -1606,6 +1640,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             accountWorkspaceSelection.selectBot(plan.bot.id)
             configPath = plan.bot.localConfigPath ?? configPath
             dependencies.preferences.set(plan.bot.id, forKey: accountBotPreferenceKey)
+            dependencies.preferences.set(configPath, forKey: "neondiff.configPath")
+            persistPendingNewBotPlan(plan)
             accountWorkspaceStatus = "New bot setup is isolated from existing bot configs."
             reopenOnboarding(at: .welcome)
         } catch {
@@ -1717,6 +1753,106 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .appendingPathComponent(appSlug, isDirectory: true)
             .appendingPathComponent("config.local.json")
             .standardizedFileURL.path
+    }
+
+    private func restoredPendingNewBotPlan(
+        account: DesktopAccountWorkspace,
+        savedBotID: String?
+    ) -> DesktopNewBotPlan? {
+        guard account.role != nil,
+              let savedBotID,
+              savedBotID.range(
+                of: "^pending-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                options: .regularExpression
+              ) != nil,
+              let serialized = dependencies.preferences.string(
+                forKey: pendingNewBotPlanPreferenceKey
+              ),
+              let data = serialized.data(using: .utf8),
+              let persisted = try? JSONDecoder().decode(
+                PersistedPendingNewBotPlan.self,
+                from: data
+              ),
+              persisted.schemaVersion == 1,
+              persisted.accountID == account.id,
+              persisted.botID == savedBotID,
+              dependencies.preferences.string(forKey: "neondiff.configPath")
+                == persisted.configPath,
+              persisted.appSlug.range(
+                of: "^[a-z0-9][a-z0-9-]{0,99}$",
+                options: .regularExpression
+              ) != nil
+        else {
+            return nil
+        }
+
+        let botsDirectory = dependencies.fileWriter.applicationSupportDirectory
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(account.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .standardizedFileURL
+        let configURL = URL(filePath: persisted.configPath).standardizedFileURL
+        let botDirectory = configURL.deletingLastPathComponent()
+        let directoryName = botDirectory.lastPathComponent
+        guard configURL.lastPathComponent == "config.local.json",
+              botDirectory.deletingLastPathComponent() == botsDirectory,
+              directoryName == persisted.appSlug
+                || isNumberedNewBotDirectory(
+                    directoryName,
+                    appSlug: persisted.appSlug
+                )
+        else {
+            return nil
+        }
+
+        return DesktopNewBotPlan(
+            accountID: account.id,
+            bot: DesktopBotInstallation(
+                id: savedBotID,
+                appID: 0,
+                appSlug: persisted.appSlug,
+                mode: .byo,
+                githubInstallationID: nil,
+                githubAccountLogin: nil,
+                status: .pending,
+                localConfigPath: configURL.path
+            )
+        )
+    }
+
+    private func persistPendingNewBotPlan(_ plan: DesktopNewBotPlan) {
+        guard let configPath = plan.bot.localConfigPath,
+              let data = try? JSONEncoder().encode(PersistedPendingNewBotPlan(
+                schemaVersion: 1,
+                accountID: plan.accountID,
+                botID: plan.bot.id,
+                appSlug: plan.bot.appSlug,
+                configPath: configPath
+              )),
+              let serialized = String(data: data, encoding: .utf8)
+        else {
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
+            return
+        }
+        dependencies.preferences.set(
+            serialized,
+            forKey: pendingNewBotPlanPreferenceKey
+        )
+    }
+
+    private func isNumberedNewBotDirectory(
+        _ directoryName: String,
+        appSlug: String
+    ) -> Bool {
+        let prefix = appSlug + "-"
+        guard directoryName.hasPrefix(prefix),
+              let suffix = Int(directoryName.dropFirst(prefix.count))
+        else {
+            return false
+        }
+        return suffix >= 2 && directoryName == "\(prefix)\(suffix)"
     }
 
     #if DEBUG

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -699,6 +699,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private let accountWorkspacePreferenceKey = "neondiff.accountWorkspaceID"
     private let accountBotPreferenceKey = "neondiff.accountBotID"
     private let pendingNewBotPlanPreferenceKey = "neondiff.pendingNewBotPlan.v1"
+    private static let configPathPreferenceKey = "neondiff.configPath"
 
     private struct PersistedPendingNewBotPlan: Codable {
         let schemaVersion: Int
@@ -711,7 +712,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
         self.activationLicenseClientOverride = activationLicenseClient
-        self.configPath = dependencies.preferences.string(forKey: "neondiff.configPath")
+        self.configPath = dependencies.preferences.string(forKey: Self.configPathPreferenceKey)
             ?? dependencies.fileWriter.applicationSupportDirectory
                 .appendingPathComponent("config.local.json")
                 .standardizedFileURL.path
@@ -1280,7 +1281,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         applyAccountWorkspaceCatalog(.loaded(accounts))
 
-        if selectedBotInstallation == nil,
+        if pendingNewBotPlan == nil,
+           selectedBotInstallation == nil,
            let localBot = selectedAccountWorkspace?.bots.first(where: {
                $0.status == .verified && $0.localConfigPath != nil
            }) {
@@ -1297,6 +1299,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     ) {
         guard isAutomaticAccountWorkspaceRefreshInProgress else { return }
         isAutomaticAccountWorkspaceRefreshInProgress = false
+        if pendingNewBotPlan != nil {
+            isOnboardingPresented = true
+            return
+        }
         guard !dependencies.preferences.bool(forKey: onboardingCompletedKey) else {
             isOnboardingPresented = false
             return
@@ -1640,7 +1646,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             accountWorkspaceSelection.selectBot(plan.bot.id)
             configPath = plan.bot.localConfigPath ?? configPath
             dependencies.preferences.set(plan.bot.id, forKey: accountBotPreferenceKey)
-            dependencies.preferences.set(configPath, forKey: "neondiff.configPath")
+            dependencies.preferences.set(configPath, forKey: Self.configPathPreferenceKey)
             persistPendingNewBotPlan(plan)
             accountWorkspaceStatus = "New bot setup is isolated from existing bot configs."
             reopenOnboarding(at: .welcome)
@@ -1776,7 +1782,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
               persisted.schemaVersion == 1,
               persisted.accountID == account.id,
               persisted.botID == savedBotID,
-              dependencies.preferences.string(forKey: "neondiff.configPath")
+              dependencies.preferences.string(forKey: Self.configPathPreferenceKey)
                 == persisted.configPath,
               persisted.appSlug.range(
                 of: "^[a-z0-9][a-z0-9-]{0,99}$",
@@ -2138,7 +2144,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = providerVerificationSafetyLatchMessage
             return
         }
-        dependencies.preferences.set(configPath, forKey: "neondiff.configPath")
+        dependencies.preferences.set(configPath, forKey: Self.configPathPreferenceKey)
         dependencies.preferences.set(cliPath, forKey: "neondiff.cliPath")
         dependencies.preferences.set(launchdLabel, forKey: "neondiff.launchdLabel")
         if controlCenterLoadedSnapshot?.configPath != configPath {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountLinkModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountLinkModelTests.swift
@@ -145,6 +145,70 @@ import NeonDiffDesktopCore
         #expect(model.customerSurfaceStatus == "SETUP INCOMPLETE")
     }
 
+    @Test func launchRefreshPreservesPendingNewBotForAccountWithExistingLocalBot() async throws {
+        let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
+            .appendingPathComponent("neondiff-account-pending-bot-\(UUID().uuidString)", isDirectory: true)
+        let fileWriter = TemporaryFileWriter(root: root)
+        let existingConfigURL = root.appendingPathComponent("existing-worker.json")
+        try fileWriter.write(Data("{}".utf8), to: existingConfigURL)
+        let pendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let pendingConfigURL = root
+            .appendingPathComponent("Accounts/account-electric-sheep/Bots/new-neondiff-bot/config.local.json")
+        try fileWriter.write(Data("{}".utf8), to: pendingConfigURL)
+        let preferences = MemoryPreferences()
+        preferences.set("account-electric-sheep", forKey: "neondiff.accountWorkspaceID")
+        preferences.set(pendingBotID, forKey: "neondiff.accountBotID")
+        preferences.set(pendingConfigURL.path, forKey: "neondiff.configPath")
+        preferences.set(true, forKey: "neondiff.hasCompletedActivationOnboarding.v2")
+        preferences.set(
+            """
+            {"schemaVersion":1,"accountID":"account-electric-sheep","botID":"\(pendingBotID)","appSlug":"new-neondiff-bot","configPath":"\(pendingConfigURL.path)"}
+            """,
+            forKey: "neondiff.pendingNewBotPlan.v1"
+        )
+        let secrets = AccountLinkMemorySecretStore()
+        _ = try GitHubBrokerDeviceIdentityStore(secretStore: secrets).loadOrCreate()
+        let model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
+            clipboard: RecordingClipboard(),
+            urlOpener: RecordingURLOpener(),
+            cli: RecordingCLIExecutor(result: CLIRunResult(
+                exitCode: 0,
+                stdout: ModelDependencyFixture.configInspectJSON,
+                stderr: ""
+            )),
+            dashboard: RecordingDashboardLauncher(),
+            preferences: preferences,
+            clock: TestClock(),
+            fileWriter: fileWriter,
+            providerVerifier: RecordingProviderVerifier(),
+            secretStore: secrets,
+            githubAuthenticator: StubGitHubAuthenticator(),
+            accountLink: ScriptedAccountLink(workspaceResults: [
+                .success(AccountLinkFixtures.electricSheep)
+            ]),
+            productionBoundary: .testAccountLink,
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4242,
+                    configPath: existingConfigURL.path
+                )
+            ]
+        ))
+
+        #expect(!model.isOnboardingPresented)
+
+        model.refreshAccountWorkspacesOnLaunch()
+        await model.waitForAccountLinkOperation()
+        for _ in 0..<50 where model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+
+        #expect(model.pendingNewBotPlan?.bot.id == pendingBotID)
+        #expect(model.accountWorkspaceSelection.botID == pendingBotID)
+        #expect(model.configPath == pendingConfigURL.path)
+        #expect(model.isOnboardingPresented)
+    }
+
     @Test func launchRefreshFailureStaysInRetryStateInsteadOfClaimingFirstRun() async throws {
         let root = URL(filePath: NSTemporaryDirectory(), directoryHint: .isDirectory)
             .appendingPathComponent("neondiff-account-launch-failure-\(UUID().uuidString)", isDirectory: true)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -430,6 +430,115 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func pendingNewBotPlanAndConfigPathSurviveRelaunch() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let repository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let firstLaunch = ModelDependencyFixture(root: root)
+        firstLaunch.model.applyAccountWorkspaceCatalog(.loaded([personal]))
+        let original = try #require(firstLaunch.model.pendingNewBotPlan)
+        let originalConfigPath = try #require(original.bot.localConfigPath)
+        let originalConfigURL = URL(filePath: originalConfigPath)
+        try FileManager.default.createDirectory(
+            at: originalConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"pilotRepos":["\#(repository)"]}"#.utf8)
+            .write(to: originalConfigURL)
+
+        let savedConfigPath = try #require(
+            firstLaunch.preferences.string(forKey: "neondiff.configPath")
+        )
+        let savedBotID = try #require(
+            firstLaunch.preferences.string(forKey: "neondiff.accountBotID")
+        )
+        let savedPendingPlan = try #require(
+            firstLaunch.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+        )
+        var inspectPayload = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(ModelDependencyFixture.configInspectJSON.utf8)
+            ) as? [String: Any]
+        )
+        var inspectedConfig = try #require(inspectPayload["config"] as? [String: Any])
+        inspectedConfig["pilotRepos"] = [repository]
+        inspectPayload["config"] = inspectedConfig
+        let inspectJSON = try #require(String(
+            data: JSONSerialization.data(withJSONObject: inspectPayload),
+            encoding: .utf8
+        ))
+        let relaunched = ModelDependencyFixture(
+            root: root,
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: inspectJSON,
+                stderr: ""
+            ))],
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": personal.id,
+                "neondiff.accountBotID": savedBotID,
+                "neondiff.configPath": savedConfigPath,
+                "neondiff.pendingNewBotPlan.v1": savedPendingPlan
+            ]
+        )
+
+        relaunched.model.applyAccountWorkspaceCatalog(.loaded([personal]))
+        await relaunched.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where relaunched.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(relaunched.model.pendingNewBotPlan == original)
+        #expect(relaunched.model.accountWorkspaceSelection.botID == original.bot.id)
+        #expect(relaunched.model.configPath == originalConfigPath)
+        #expect(relaunched.cli.calls[0].arguments == [
+            "config", "inspect", "--config", originalConfigPath
+        ])
+        #expect(relaunched.model.lastError == nil)
+        #expect(relaunched.model.repos.map(\.name) == [repository])
+    }
+
+    @MainActor
+    @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
+        let root = fixtureURL("/fixture/model-app-support", directory: true)
+        let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let injectedPath = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent("another-account", isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("new-neondiff-bot", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .path
+        let serialized = String(
+            data: try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "accountID": personal.id,
+                "botID": savedBotID,
+                "appSlug": "new-neondiff-bot",
+                "configPath": injectedPath
+            ]),
+            encoding: .utf8
+        )!
+        let fixture = ModelDependencyFixture(
+            root: root,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": personal.id,
+                "neondiff.accountBotID": savedBotID,
+                "neondiff.configPath": injectedPath,
+                "neondiff.pendingNewBotPlan.v1": serialized
+            ]
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([personal]))
+
+        let replacement = try #require(fixture.model.pendingNewBotPlan)
+        #expect(replacement.bot.id != savedBotID)
+        #expect(replacement.bot.localConfigPath != injectedPath)
+        #expect(replacement.bot.localConfigPath?.contains("/Accounts/\(personal.id)/Bots/") == true)
+    }
+
+    @MainActor
     @Test func staleConfigInspectCannotPopulateTheNewWorkspace() async throws {
         let botA = bot(id: "bot-a", slug: "bot-a", configPath: "/fixture/a/config.local.json")
         let botB = bot(id: "bot-b", slug: "bot-b", configPath: "/fixture/b/config.local.json")

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -283,6 +283,13 @@ For a verified account with no bot yet, the app allocates the isolated new-bot
 plan before showing **Initialize Local Config**. It never initializes the
 `Accounts/_unselected` placeholder.
 
+If the customer quits before setup is complete, relaunch NeonDiff and continue
+the same pending bot. The app restores the exact account-scoped config path and
+reopens onboarding rather than creating a second `new-neondiff-bot-*`
+directory. This recovery also takes precedence over automatic selection of an
+older local bot under the same account. Choosing another account or an existing
+bot explicitly still ends the pending setup.
+
 When the same Mac already has one exact checksum-managed worker for the selected
 LaunchAgent label, the app reuses that worker for the isolated bot's `init`,
 `config inspect`, `config patch`, and private-key-stdin GitHub doctor commands.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -139,6 +139,11 @@ integration proof under #630.
    beside that config rather than the packaged worker's placeholder paths. An
    account with no bot gets this isolated plan before the initialization action
    appears; the app never initializes the `_unselected` placeholder.
+   If NeonDiff is quit mid-setup, relaunch restores that exact pending bot and
+   config path and reopens onboarding. It does not silently fall back to an
+   existing local bot on the same account or allocate another numbered config
+   directory; the customer can explicitly choose another account or bot to end
+   the pending flow.
    If one exact checksum-managed worker already exists for the selected
    LaunchAgent label, these isolated config commands and the bounded
    private-key-stdin GitHub doctor reuse that worker instead of resolving


### PR DESCRIPTION
Related to #646 and tracked by #610.

## Customer failure

The exact downloaded beta.42 app lost the active pending New Bot workspace after quit/rollback/reinstall. Each launch allocated another `new-neondiff-bot-N` config path, then `config inspect` returned defaults for that nonexistent path while the customer’s previously applied repository remained in an older isolated config.

## Acceptance criteria

- Persist the pending bot ID, app slug, and exact isolated config path as one schema-v1 preference record when New Bot begins.
- Restore that same pending plan after relaunch only when the saved bot ID, saved config path, selected authoritative account, and persisted record agree.
- Require the restored path to remain exactly under the selected account’s `Bots/<slug-or-numbered-slug>/config.local.json` directory.
- Re-inspect an existing restored config automatically so its repository state returns without hidden operator repair.
- Reject a cross-account or malformed persisted path and allocate a fresh isolated plan.
- During automatic account refresh, keep the restored pending plan ahead of the existing-local-bot fallback and reopen onboarding even when the account previously completed onboarding.
- Keep README, setup, GitHub App setup, and the unpublished website onboarding copy aligned with that relaunch behavior.

## Non-goals

- No automatic choice among ambiguous pre-fix orphaned New Bot configs.
- No GitHub credential write, provider setup, activation, review execution, billing, signing, notarization, release, managed GitHub App, Sparkle, or broader #517 work.
- No claim that beta.42 rollback is customer-safe; a later candidate must use this fix and prove candidate-to-beta.42 rollback.

## Proof

- RED before implementation: `pendingNewBotPlanAndConfigPathSurviveRelaunch` failed because `neondiff.configPath` was not persisted.
- RED review delta: `launchRefreshPreservesPendingNewBotForAccountWithExistingLocalBot` failed by replacing the pending bot/config with the existing local bot and hiding onboarding.
- GREEN after implementation: `AccountWorkspaceSelectionTests` — 25/25 passed; `AccountLinkModelTests` — 14/14 passed.
- Installed development proof at the initial head restored the exact repository and `new-neondiff-bot-5` config after quit/relaunch without allocating `new-neondiff-bot-6`. This local signed build was not notarized or published.
- Matching unpublished website copy: https://github.com/electricsheephq/neon-diff-agent-website/pull/92
- `git diff --check` passed.
