### PR TITLE
fix(desktop): resume pending New Bot after manual rollback

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1555,7 +1555,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
                $0.id == savedBotID
                    && ($0.status == .verified || $0.status == .pending)
            }) {
-            selectBotInstallation(savedBotID)
+            let preservesPendingPlan = restoredPendingNewBotPlan(
+                account: initial,
+                savedBotID: savedBotID,
+                requiresCurrentSelection: false
+            ) != nil
+            selectBotInstallation(
+                savedBotID,
+                preservesPendingNewBotPlan: preservesPendingPlan
+            )
         } else {
             dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
             dependencies.preferences.removeValue(
@@ -1592,6 +1600,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func selectBotInstallation(_ botID: String) {
+        selectBotInstallation(botID, preservesPendingNewBotPlan: false)
+    }
+
+    private func selectBotInstallation(
+        _ botID: String,
+        preservesPendingNewBotPlan: Bool
+    ) {
         guard let account = selectedAccountWorkspace,
               let bot = account.bots.first(where: { $0.id == botID }),
               bot.status == .verified || bot.status == .pending
@@ -1604,9 +1619,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         resetWorkspaceBoundRuntimeState()
         accountWorkspaceSelection.selectBot(botID)
         pendingNewBotPlan = nil
-        dependencies.preferences.removeValue(
-            forKey: pendingNewBotPlanPreferenceKey
-        )
+        if !preservesPendingNewBotPlan {
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
+        }
         dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
         if let localConfigPath = bot.localConfigPath {
             configPath = localConfigPath
@@ -1627,6 +1644,32 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func beginNewBot(appSlug: String = "new-neondiff-bot") {
         guard let account = selectedAccountWorkspace else {
             accountWorkspaceStatus = "Choose an account before creating a bot."
+            return
+        }
+        if pendingNewBotPlan == nil,
+           let restoredPlan = restoredPendingNewBotPlan(
+               account: account,
+               savedBotID: nil,
+               requiresCurrentSelection: false
+           ) {
+            resetWorkspaceBoundRuntimeState()
+            pendingNewBotPlan = restoredPlan
+            accountWorkspaceSelection.selectBot(restoredPlan.bot.id)
+            configPath = restoredPlan.bot.localConfigPath ?? configPath
+            dependencies.preferences.set(
+                restoredPlan.bot.id,
+                forKey: accountBotPreferenceKey
+            )
+            dependencies.preferences.set(
+                configPath,
+                forKey: Self.configPathPreferenceKey
+            )
+            persistPendingNewBotPlan(restoredPlan)
+            accountWorkspaceStatus = "Resumed the pending New Bot setup on this Mac."
+            reopenOnboarding(at: .welcome)
+            if dependencies.fileWriter.fileExists(at: URL(filePath: configPath)) {
+                inspectConfig()
+            }
             return
         }
         do {
@@ -1763,14 +1806,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func restoredPendingNewBotPlan(
         account: DesktopAccountWorkspace,
-        savedBotID: String?
+        savedBotID: String?,
+        requiresCurrentSelection: Bool = true
     ) -> DesktopNewBotPlan? {
         guard account.role != nil,
-              let savedBotID,
-              savedBotID.range(
-                of: "^pending-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-                options: .regularExpression
-              ) != nil,
               let serialized = dependencies.preferences.string(
                 forKey: pendingNewBotPlanPreferenceKey
               ),
@@ -1781,15 +1820,25 @@ package final class NeonDiffDesktopModel: ObservableObject {
               ),
               persisted.schemaVersion == 1,
               persisted.accountID == account.id,
-              persisted.botID == savedBotID,
-              dependencies.preferences.string(forKey: Self.configPathPreferenceKey)
-                == persisted.configPath,
+              persisted.botID.range(
+                of: "^pending-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                options: .regularExpression
+              ) != nil,
               persisted.appSlug.range(
                 of: "^[a-z0-9][a-z0-9-]{0,99}$",
                 options: .regularExpression
               ) != nil
         else {
             return nil
+        }
+        if requiresCurrentSelection {
+            guard persisted.botID == savedBotID,
+                  dependencies.preferences.string(
+                      forKey: Self.configPathPreferenceKey
+                  ) == persisted.configPath
+            else {
+                return nil
+            }
         }
 
         let botsDirectory = dependencies.fileWriter.applicationSupportDirectory
@@ -1814,7 +1863,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return DesktopNewBotPlan(
             accountID: account.id,
             bot: DesktopBotInstallation(
-                id: savedBotID,
+                id: persisted.botID,
                 appID: 0,
                 appSlug: persisted.appSlug,
                 mode: .byo,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1867,6 +1867,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
+        let occupiedConfigPaths = Set(
+            account.bots.compactMap(\.localConfigPath).map(normalizedPath)
+        )
+        guard !occupiedConfigPaths.contains(configURL.path) else {
+            return nil
+        }
 
         return DesktopNewBotPlan(
             accountID: account.id,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1600,6 +1600,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func selectBotInstallation(_ botID: String) {
+        if accountWorkspaceSelection.botID == botID,
+           let selectedBot = selectedBotInstallation,
+           selectedBot.status == .verified || selectedBot.status == .pending {
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
+            return
+        }
         selectBotInstallation(botID, preservesPendingNewBotPlan: false)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -500,6 +500,128 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func explicitNewBotResumesPendingPlanAfterOlderBuildSelectionDrift() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let repository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let firstLaunch = ModelDependencyFixture(root: root)
+        firstLaunch.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        firstLaunch.model.beginNewBot()
+        let original = try #require(firstLaunch.model.pendingNewBotPlan)
+        let pendingConfigPath = try #require(original.bot.localConfigPath)
+        let pendingConfigURL = URL(filePath: pendingConfigPath)
+        let pendingConfigData = Data(#"{"pilotRepos":["\#(repository)"]}"#.utf8)
+        try FileManager.default.createDirectory(
+            at: pendingConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try pendingConfigData.write(to: pendingConfigURL)
+        let savedPendingPlan = try #require(
+            firstLaunch.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+        )
+
+        let existingConfigURL = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(electricSheep.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("evaos-code-review-bot", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+        try FileManager.default.createDirectory(
+            at: existingConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"pilotRepos":["electricsheephq/existing-bot"]}"#.utf8)
+            .write(to: existingConfigURL)
+        let existingBot = bot(
+            id: "bot-evaos-code-review-bot",
+            slug: "evaos-code-review-bot",
+            configPath: existingConfigURL.path
+        )
+        let account = workspace(
+            id: electricSheep.id,
+            name: electricSheep.name,
+            bots: [existingBot]
+        )
+        var pendingInspectPayload = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(ModelDependencyFixture.configInspectJSON.utf8)
+            ) as? [String: Any]
+        )
+        var pendingInspectedConfig = try #require(
+            pendingInspectPayload["config"] as? [String: Any]
+        )
+        pendingInspectedConfig["pilotRepos"] = [repository]
+        pendingInspectPayload["config"] = pendingInspectedConfig
+        let pendingInspectJSON = try #require(String(
+            data: JSONSerialization.data(withJSONObject: pendingInspectPayload),
+            encoding: .utf8
+        ))
+        let reinstalled = ModelDependencyFixture(
+            root: root,
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: ModelDependencyFixture.configInspectJSON,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: pendingInspectJSON,
+                    stderr: ""
+                ))
+            ],
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": electricSheep.id,
+                "neondiff.accountBotID": existingBot.id,
+                "neondiff.configPath": existingConfigURL.path,
+                "neondiff.pendingNewBotPlan.v1": savedPendingPlan
+            ]
+        )
+
+        reinstalled.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        await reinstalled.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where reinstalled.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(reinstalled.model.selectedBotInstallation?.id == existingBot.id)
+        #expect(reinstalled.model.pendingNewBotPlan == nil)
+        #expect(reinstalled.model.configPath == existingConfigURL.path)
+        #expect(
+            reinstalled.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+                == savedPendingPlan
+        )
+
+        reinstalled.model.beginNewBot()
+        for _ in 0..<100 where reinstalled.cli.calls.count < 2 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        for _ in 0..<100 where reinstalled.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(reinstalled.model.pendingNewBotPlan == original)
+        #expect(reinstalled.model.accountWorkspaceSelection.botID == original.bot.id)
+        #expect(reinstalled.model.configPath == pendingConfigPath)
+        #expect(
+            reinstalled.preferences.string(forKey: "neondiff.accountBotID")
+                == original.bot.id
+        )
+        #expect(
+            reinstalled.preferences.string(forKey: "neondiff.configPath")
+                == pendingConfigPath
+        )
+        #expect(try Data(contentsOf: pendingConfigURL) == pendingConfigData)
+        #expect(reinstalled.cli.calls.count == 2)
+        if reinstalled.cli.calls.count == 2 {
+            #expect(reinstalled.cli.calls[1].arguments == [
+                "config", "inspect", "--config", pendingConfigPath
+            ])
+        }
+        #expect(reinstalled.model.repos.map(\.name) == [repository])
+    }
+
+    @MainActor
     @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
         let root = fixtureURL("/fixture/model-app-support", directory: true)
         let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -648,6 +648,77 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func pendingNewBotRecoveryRejectsConfigNowOwnedByAuthoritativeBot() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let account = workspace(
+            id: electricSheep.id,
+            name: electricSheep.name,
+            bots: []
+        )
+        let conflictingConfigPath = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(account.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("new-neondiff-bot", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
+        let existingBot = bot(
+            id: "bot-existing",
+            slug: "new-neondiff-bot",
+            configPath: conflictingConfigPath
+        )
+        let authoritativeAccount = workspace(
+            id: account.id,
+            name: account.name,
+            bots: [existingBot]
+        )
+        let stalePendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let persistedPlan = String(
+            data: try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "accountID": account.id,
+                "botID": stalePendingBotID,
+                "appSlug": "new-neondiff-bot",
+                "configPath": conflictingConfigPath
+            ]),
+            encoding: .utf8
+        )!
+        let fixture = ModelDependencyFixture(
+            root: root,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": account.id,
+                "neondiff.accountBotID": existingBot.id,
+                "neondiff.configPath": conflictingConfigPath,
+                "neondiff.pendingNewBotPlan.v1": persistedPlan
+            ]
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([authoritativeAccount]))
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where fixture.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(fixture.model.selectedBotInstallation?.id == existingBot.id)
+        #expect(
+            fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+                == nil
+        )
+
+        fixture.model.beginNewBot()
+
+        let replacement = try #require(fixture.model.pendingNewBotPlan)
+        #expect(replacement.bot.id != stalePendingBotID)
+        #expect(replacement.bot.localConfigPath != conflictingConfigPath)
+        #expect(
+            replacement.bot.localConfigPath?
+                .contains("/Bots/new-neondiff-bot-2/config.local.json") == true
+        )
+    }
+
+    @MainActor
     @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
         let root = fixtureURL("/fixture/model-app-support", directory: true)
         let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -256,6 +256,32 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func explicitlyReselectingRestoredBotAbandonsPreservedPendingPlan() throws {
+        let existingBot = bot(id: "bot-existing", slug: "existing-bot", configPath: nil)
+        let account = workspace(id: "account-existing", name: "Existing Account", bots: [existingBot])
+        let pendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let pendingConfigPath = fixtureURL("/fixture/model-app-support/Accounts/\(account.id)/Bots/new-neondiff-bot/config.local.json").path
+        let persistedPlan = String(data: try JSONSerialization.data(withJSONObject: ["schemaVersion": 1, "accountID": account.id, "botID": pendingBotID, "appSlug": "new-neondiff-bot", "configPath": pendingConfigPath]), encoding: .utf8)!
+        let fixture = ModelDependencyFixture(preferenceStrings: ["neondiff.accountWorkspaceID": account.id, "neondiff.accountBotID": existingBot.id, "neondiff.configPath": "/fixture/existing-bot/config.local.json", "neondiff.pendingNewBotPlan.v1": persistedPlan])
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        #expect(fixture.model.accountWorkspaceSelection.botID == existingBot.id)
+        #expect(fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1") == persistedPlan)
+        fixture.model.repos = [RepoMonitor(name: "account-existing/private", enabled: true)]
+        fixture.model.providers.providerKeyStored = true
+        fixture.model.github.installationCount = 1
+        let selectedConfigPath = fixture.model.configPath
+
+        fixture.model.selectBotInstallation(existingBot.id)
+
+        #expect(fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1") == nil)
+        #expect(fixture.model.accountWorkspaceSelection.botID == existingBot.id)
+        #expect(fixture.model.configPath == selectedConfigPath)
+        #expect(fixture.model.repos == [RepoMonitor(name: "account-existing/private", enabled: true)])
+        #expect(fixture.model.providers.providerKeyStored)
+        #expect(fixture.model.github.installationCount == 1)
+    }
+
+    @MainActor
     @Test func catalogLocalPathLossInvalidatesSelectedBotRuntimeState() {
         let localBot = bot(
             id: "bot-local",


### PR DESCRIPTION
## Customer gate

A signed beta.43 → beta.42 → beta.43 manual rollback preserved the pending New Bot config bytes, but beta.42 changed the saved selection to the existing bot. Reinstalled beta.43 then opened a blank numbered draft when the customer explicitly chose NEW BOT instead of resuming the preserved same-account setup.

Related to #449 and tracker #610. This PR does not close either broader release gate.

## Acceptance criteria

- Keep the legitimate existing bot selected after reinstall; do not auto-switch to a local draft.
- Preserve only a structurally valid, same-account, account-scoped pending-plan record during automatic existing-bot restoration.
- When the customer explicitly chooses NEW BOT, resume that preserved draft, restore its ID/config preferences, reopen onboarding, and inspect the existing config without writing it.
- Preserve explicit existing-bot selection behavior: it still clears pending state.
- Preserve Keychain, activation, repository authority, account isolation, and fail-closed review gates.

## Failing-first proof

On exact base `69ae0cf5635366667abe79b6f793691ec1747d2d`, `swift test --filter AccountWorkspaceSelectionTests.explicitNewBotResumesPendingPlanAfterOlderBuildSelectionDrift` failed with seven expected mismatches: a new pending ID/path, no second config inspection, and no restored repository state while the original config bytes remained intact.

## Focused green proof

- Targeted rollback recovery regression: passed.
- `AccountWorkspaceSelectionTests`: 26/26 passed.
- `AccountLinkModelTests.launchRefreshPreservesPendingNewBotForAccountWithExistingLocalBot`: 1/1 passed.
- `git diff --check 69ae0cf..HEAD`: passed.

## Non-goals

- No billing, activation, GitHub credential, provider, review-posting, signing/notarization, website, publication, or canary change.
- No managed GitHub App, Sparkle, broader #517 matrix, or generalized test harness.
- No release or customer-readiness claim from this source change.

## Required merge gate

One independent current-head semantic review of the account/persistence boundary, current-head required CI, then a new signed/notarized candidate and installed manual rollback/re-update canary. Source/CI alone do not prove installed recovery.