### PR TITLE
fix(desktop): recover pending New Bot without config alias collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,11 @@ terminal or an operator edit to reach the repository-verification gate. When
 the verified account has no bot yet, the app allocates that isolated new-bot
 plan before it presents the initialization action; it never initializes the
 `_unselected` placeholder. If the customer quits during that setup, the next
-launch restores the same pending bot and config path—even when the account also
-has an existing local bot—and reopens onboarding instead of allocating another
-config directory. A new native config receives bot-isolated runtime,
+launch restores the same pending bot and config path when its saved selection
+is still current. If an older build or manual rollback selected a verified
+existing bot under the same account, the app keeps that authoritative bot
+selected and resumes the validated pending setup only after the customer
+explicitly chooses **NEW BOT**. A new native config receives bot-isolated runtime,
 state, evidence, and license paths beside that config instead of reusing the
 packaged worker's placeholder `/tmp/neondiff` tree. If one exact
 checksum-managed local worker already exists for the selected LaunchAgent

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/ApplicationSupportFileWriter.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/ApplicationSupportFileWriter.swift
@@ -20,6 +20,28 @@ final class ApplicationSupportFileWriter: DesktopFileWriting, @unchecked Sendabl
         fileManager.fileExists(atPath: url.standardizedFileURL.path)
     }
 
+    func pathsReferToSameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        let lhsURL = lhs.standardizedFileURL.resolvingSymlinksInPath()
+        let rhsURL = rhs.standardizedFileURL.resolvingSymlinksInPath()
+        if lhsURL.path.caseInsensitiveCompare(rhsURL.path) == .orderedSame {
+            return true
+        }
+        guard let lhsAttributes = try? fileManager.attributesOfItem(
+            atPath: lhsURL.path
+        ),
+        let rhsAttributes = try? fileManager.attributesOfItem(
+            atPath: rhsURL.path
+        ),
+        let lhsSystem = lhsAttributes[.systemNumber] as? NSNumber,
+        let rhsSystem = rhsAttributes[.systemNumber] as? NSNumber,
+        let lhsFile = lhsAttributes[.systemFileNumber] as? NSNumber,
+        let rhsFile = rhsAttributes[.systemFileNumber] as? NSNumber
+        else {
+            return false
+        }
+        return lhsSystem == rhsSystem && lhsFile == rhsFile
+    }
+
     func write(_ data: Data, to url: URL) throws {
         let destination = url.standardizedFileURL
         let rootPath = applicationSupportDirectory.path

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Dependencies/DesktopFileWriting.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Dependencies/DesktopFileWriting.swift
@@ -3,5 +3,20 @@ import Foundation
 package protocol DesktopFileWriting: Sendable {
     var applicationSupportDirectory: URL { get }
     func fileExists(at url: URL) -> Bool
+    func pathsReferToSameFile(_ lhs: URL, _ rhs: URL) -> Bool
     func write(_ data: Data, to url: URL) throws
+}
+
+package extension DesktopFileWriting {
+    func pathsReferToSameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        let lhsPath = lhs
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        let rhsPath = rhs
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        return lhsPath.caseInsensitiveCompare(rhsPath) == .orderedSame
+    }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1555,7 +1555,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
                $0.id == savedBotID
                    && ($0.status == .verified || $0.status == .pending)
            }) {
-            selectBotInstallation(savedBotID)
+            let preservesPendingPlan = restoredPendingNewBotPlan(
+                account: initial,
+                savedBotID: savedBotID,
+                requiresCurrentSelection: false
+            ) != nil
+            selectBotInstallation(
+                savedBotID,
+                preservesPendingNewBotPlan: preservesPendingPlan
+            )
         } else {
             dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
             dependencies.preferences.removeValue(
@@ -1592,6 +1600,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func selectBotInstallation(_ botID: String) {
+        selectBotInstallation(botID, preservesPendingNewBotPlan: false)
+    }
+
+    private func selectBotInstallation(
+        _ botID: String,
+        preservesPendingNewBotPlan: Bool
+    ) {
         guard let account = selectedAccountWorkspace,
               let bot = account.bots.first(where: { $0.id == botID }),
               bot.status == .verified || bot.status == .pending
@@ -1604,9 +1619,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         resetWorkspaceBoundRuntimeState()
         accountWorkspaceSelection.selectBot(botID)
         pendingNewBotPlan = nil
-        dependencies.preferences.removeValue(
-            forKey: pendingNewBotPlanPreferenceKey
-        )
+        if !preservesPendingNewBotPlan {
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
+        }
         dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
         if let localConfigPath = bot.localConfigPath {
             configPath = localConfigPath
@@ -1627,6 +1644,32 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func beginNewBot(appSlug: String = "new-neondiff-bot") {
         guard let account = selectedAccountWorkspace else {
             accountWorkspaceStatus = "Choose an account before creating a bot."
+            return
+        }
+        if pendingNewBotPlan == nil,
+           let restoredPlan = restoredPendingNewBotPlan(
+               account: account,
+               savedBotID: nil,
+               requiresCurrentSelection: false
+           ) {
+            resetWorkspaceBoundRuntimeState()
+            pendingNewBotPlan = restoredPlan
+            accountWorkspaceSelection.selectBot(restoredPlan.bot.id)
+            configPath = restoredPlan.bot.localConfigPath ?? configPath
+            dependencies.preferences.set(
+                restoredPlan.bot.id,
+                forKey: accountBotPreferenceKey
+            )
+            dependencies.preferences.set(
+                configPath,
+                forKey: Self.configPathPreferenceKey
+            )
+            persistPendingNewBotPlan(restoredPlan)
+            accountWorkspaceStatus = "Resumed the pending New Bot setup on this Mac."
+            reopenOnboarding(at: .welcome)
+            if dependencies.fileWriter.fileExists(at: URL(filePath: configPath)) {
+                inspectConfig()
+            }
             return
         }
         do {
@@ -1763,14 +1806,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func restoredPendingNewBotPlan(
         account: DesktopAccountWorkspace,
-        savedBotID: String?
+        savedBotID: String?,
+        requiresCurrentSelection: Bool = true
     ) -> DesktopNewBotPlan? {
         guard account.role != nil,
-              let savedBotID,
-              savedBotID.range(
-                of: "^pending-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-                options: .regularExpression
-              ) != nil,
               let serialized = dependencies.preferences.string(
                 forKey: pendingNewBotPlanPreferenceKey
               ),
@@ -1781,15 +1820,25 @@ package final class NeonDiffDesktopModel: ObservableObject {
               ),
               persisted.schemaVersion == 1,
               persisted.accountID == account.id,
-              persisted.botID == savedBotID,
-              dependencies.preferences.string(forKey: Self.configPathPreferenceKey)
-                == persisted.configPath,
+              persisted.botID.range(
+                of: "^pending-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                options: .regularExpression
+              ) != nil,
               persisted.appSlug.range(
                 of: "^[a-z0-9][a-z0-9-]{0,99}$",
                 options: .regularExpression
               ) != nil
         else {
             return nil
+        }
+        if requiresCurrentSelection {
+            guard persisted.botID == savedBotID,
+                  dependencies.preferences.string(
+                      forKey: Self.configPathPreferenceKey
+                  ) == persisted.configPath
+            else {
+                return nil
+            }
         }
 
         let botsDirectory = dependencies.fileWriter.applicationSupportDirectory
@@ -1814,7 +1863,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return DesktopNewBotPlan(
             accountID: account.id,
             bot: DesktopBotInstallation(
-                id: savedBotID,
+                id: persisted.botID,
                 appID: 0,
                 appSlug: persisted.appSlug,
                 mode: .byo,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1857,8 +1857,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let configURL = URL(filePath: persisted.configPath).standardizedFileURL
         let botDirectory = configURL.deletingLastPathComponent()
         let directoryName = botDirectory.lastPathComponent
+        let resolvedBotsDirectory = botsDirectory.resolvingSymlinksInPath()
+        let resolvedBotParent = botDirectory
+            .resolvingSymlinksInPath()
+            .deletingLastPathComponent()
         guard configURL.lastPathComponent == "config.local.json",
               botDirectory.deletingLastPathComponent() == botsDirectory,
+              resolvedBotParent.path.caseInsensitiveCompare(
+                  resolvedBotsDirectory.path
+              ) == .orderedSame,
               directoryName == persisted.appSlug
                 || isNumberedNewBotDirectory(
                     directoryName,
@@ -1867,10 +1874,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
-        let configPathIsOwned = account.bots
+        let configPathIsOwned = accountWorkspaceCatalog.accounts
+            .flatMap(\.bots)
             .compactMap(\.localConfigPath)
             .contains(where: {
-                pathsReferToSameConfigFile($0, configURL.path)
+                dependencies.fileWriter.pathsReferToSameFile(
+                    URL(filePath: $0),
+                    configURL
+                )
             })
         guard !configPathIsOwned else {
             return nil
@@ -1924,35 +1935,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         return suffix >= 2 && directoryName == "\(prefix)\(suffix)"
-    }
-
-    private func pathsReferToSameConfigFile(
-        _ lhs: String,
-        _ rhs: String
-    ) -> Bool {
-        let lhsURL = URL(filePath: lhs)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-        let rhsURL = URL(filePath: rhs)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-        if lhsURL.path.caseInsensitiveCompare(rhsURL.path) == .orderedSame {
-            return true
-        }
-        guard let lhsAttributes = try? FileManager.default.attributesOfItem(
-            atPath: lhsURL.path
-        ),
-        let rhsAttributes = try? FileManager.default.attributesOfItem(
-            atPath: rhsURL.path
-        ),
-        let lhsSystem = lhsAttributes[.systemNumber] as? NSNumber,
-        let rhsSystem = rhsAttributes[.systemNumber] as? NSNumber,
-        let lhsFile = lhsAttributes[.systemFileNumber] as? NSNumber,
-        let rhsFile = rhsAttributes[.systemFileNumber] as? NSNumber
-        else {
-            return false
-        }
-        return lhsSystem == rhsSystem && lhsFile == rhsFile
     }
 
     #if DEBUG

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1867,6 +1867,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
+        let occupiedConfigPaths = Set(
+            account.bots.compactMap(\.localConfigPath).map(normalizedPath)
+        )
+        guard !occupiedConfigPaths.contains(configURL.path) else {
+            return nil
+        }
 
         return DesktopNewBotPlan(
             accountID: account.id,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1600,6 +1600,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func selectBotInstallation(_ botID: String) {
+        if accountWorkspaceSelection.botID == botID,
+           let selectedBot = selectedBotInstallation,
+           selectedBot.status == .verified || selectedBot.status == .pending {
+            dependencies.preferences.removeValue(
+                forKey: pendingNewBotPlanPreferenceKey
+            )
+            return
+        }
         selectBotInstallation(botID, preservesPendingNewBotPlan: false)
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1867,10 +1867,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
-        let occupiedConfigPaths = Set(
-            account.bots.compactMap(\.localConfigPath).map(normalizedPath)
-        )
-        guard !occupiedConfigPaths.contains(configURL.path) else {
+        let configPathIsOwned = account.bots
+            .compactMap(\.localConfigPath)
+            .contains(where: {
+                pathsReferToSameConfigFile($0, configURL.path)
+            })
+        guard !configPathIsOwned else {
             return nil
         }
 
@@ -1922,6 +1924,35 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         return suffix >= 2 && directoryName == "\(prefix)\(suffix)"
+    }
+
+    private func pathsReferToSameConfigFile(
+        _ lhs: String,
+        _ rhs: String
+    ) -> Bool {
+        let lhsURL = URL(filePath: lhs)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let rhsURL = URL(filePath: rhs)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        if lhsURL.path.caseInsensitiveCompare(rhsURL.path) == .orderedSame {
+            return true
+        }
+        guard let lhsAttributes = try? FileManager.default.attributesOfItem(
+            atPath: lhsURL.path
+        ),
+        let rhsAttributes = try? FileManager.default.attributesOfItem(
+            atPath: rhsURL.path
+        ),
+        let lhsSystem = lhsAttributes[.systemNumber] as? NSNumber,
+        let rhsSystem = rhsAttributes[.systemNumber] as? NSNumber,
+        let lhsFile = lhsAttributes[.systemFileNumber] as? NSNumber,
+        let rhsFile = rhsAttributes[.systemFileNumber] as? NSNumber
+        else {
+            return false
+        }
+        return lhsSystem == rhsSystem && lhsFile == rhsFile
     }
 
     #if DEBUG

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -500,6 +500,128 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func explicitNewBotResumesPendingPlanAfterOlderBuildSelectionDrift() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let repository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let firstLaunch = ModelDependencyFixture(root: root)
+        firstLaunch.model.applyAccountWorkspaceCatalog(.loaded([electricSheep]))
+        firstLaunch.model.beginNewBot()
+        let original = try #require(firstLaunch.model.pendingNewBotPlan)
+        let pendingConfigPath = try #require(original.bot.localConfigPath)
+        let pendingConfigURL = URL(filePath: pendingConfigPath)
+        let pendingConfigData = Data(#"{"pilotRepos":["\#(repository)"]}"#.utf8)
+        try FileManager.default.createDirectory(
+            at: pendingConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try pendingConfigData.write(to: pendingConfigURL)
+        let savedPendingPlan = try #require(
+            firstLaunch.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+        )
+
+        let existingConfigURL = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(electricSheep.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("evaos-code-review-bot", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+        try FileManager.default.createDirectory(
+            at: existingConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"pilotRepos":["electricsheephq/existing-bot"]}"#.utf8)
+            .write(to: existingConfigURL)
+        let existingBot = bot(
+            id: "bot-evaos-code-review-bot",
+            slug: "evaos-code-review-bot",
+            configPath: existingConfigURL.path
+        )
+        let account = workspace(
+            id: electricSheep.id,
+            name: electricSheep.name,
+            bots: [existingBot]
+        )
+        var pendingInspectPayload = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(ModelDependencyFixture.configInspectJSON.utf8)
+            ) as? [String: Any]
+        )
+        var pendingInspectedConfig = try #require(
+            pendingInspectPayload["config"] as? [String: Any]
+        )
+        pendingInspectedConfig["pilotRepos"] = [repository]
+        pendingInspectPayload["config"] = pendingInspectedConfig
+        let pendingInspectJSON = try #require(String(
+            data: JSONSerialization.data(withJSONObject: pendingInspectPayload),
+            encoding: .utf8
+        ))
+        let reinstalled = ModelDependencyFixture(
+            root: root,
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: ModelDependencyFixture.configInspectJSON,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: pendingInspectJSON,
+                    stderr: ""
+                ))
+            ],
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": electricSheep.id,
+                "neondiff.accountBotID": existingBot.id,
+                "neondiff.configPath": existingConfigURL.path,
+                "neondiff.pendingNewBotPlan.v1": savedPendingPlan
+            ]
+        )
+
+        reinstalled.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        await reinstalled.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where reinstalled.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(reinstalled.model.selectedBotInstallation?.id == existingBot.id)
+        #expect(reinstalled.model.pendingNewBotPlan == nil)
+        #expect(reinstalled.model.configPath == existingConfigURL.path)
+        #expect(
+            reinstalled.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+                == savedPendingPlan
+        )
+
+        reinstalled.model.beginNewBot()
+        for _ in 0..<100 where reinstalled.cli.calls.count < 2 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        for _ in 0..<100 where reinstalled.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(reinstalled.model.pendingNewBotPlan == original)
+        #expect(reinstalled.model.accountWorkspaceSelection.botID == original.bot.id)
+        #expect(reinstalled.model.configPath == pendingConfigPath)
+        #expect(
+            reinstalled.preferences.string(forKey: "neondiff.accountBotID")
+                == original.bot.id
+        )
+        #expect(
+            reinstalled.preferences.string(forKey: "neondiff.configPath")
+                == pendingConfigPath
+        )
+        #expect(try Data(contentsOf: pendingConfigURL) == pendingConfigData)
+        #expect(reinstalled.cli.calls.count == 2)
+        if reinstalled.cli.calls.count == 2 {
+            #expect(reinstalled.cli.calls[1].arguments == [
+                "config", "inspect", "--config", pendingConfigPath
+            ])
+        }
+        #expect(reinstalled.model.repos.map(\.name) == [repository])
+    }
+
+    @MainActor
     @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
         let root = fixtureURL("/fixture/model-app-support", directory: true)
         let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -648,6 +648,77 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func pendingNewBotRecoveryRejectsConfigNowOwnedByAuthoritativeBot() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let account = workspace(
+            id: electricSheep.id,
+            name: electricSheep.name,
+            bots: []
+        )
+        let conflictingConfigPath = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(account.id, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("new-neondiff-bot", isDirectory: true)
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
+        let existingBot = bot(
+            id: "bot-existing",
+            slug: "new-neondiff-bot",
+            configPath: conflictingConfigPath
+        )
+        let authoritativeAccount = workspace(
+            id: account.id,
+            name: account.name,
+            bots: [existingBot]
+        )
+        let stalePendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let persistedPlan = String(
+            data: try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "accountID": account.id,
+                "botID": stalePendingBotID,
+                "appSlug": "new-neondiff-bot",
+                "configPath": conflictingConfigPath
+            ]),
+            encoding: .utf8
+        )!
+        let fixture = ModelDependencyFixture(
+            root: root,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": account.id,
+                "neondiff.accountBotID": existingBot.id,
+                "neondiff.configPath": conflictingConfigPath,
+                "neondiff.pendingNewBotPlan.v1": persistedPlan
+            ]
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([authoritativeAccount]))
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where fixture.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(fixture.model.selectedBotInstallation?.id == existingBot.id)
+        #expect(
+            fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+                == nil
+        )
+
+        fixture.model.beginNewBot()
+
+        let replacement = try #require(fixture.model.pendingNewBotPlan)
+        #expect(replacement.bot.id != stalePendingBotID)
+        #expect(replacement.bot.localConfigPath != conflictingConfigPath)
+        #expect(
+            replacement.bot.localConfigPath?
+                .contains("/Bots/new-neondiff-bot-2/config.local.json") == true
+        )
+    }
+
+    @MainActor
     @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
         let root = fixtureURL("/fixture/model-app-support", directory: true)
         let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -256,6 +256,32 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func explicitlyReselectingRestoredBotAbandonsPreservedPendingPlan() throws {
+        let existingBot = bot(id: "bot-existing", slug: "existing-bot", configPath: nil)
+        let account = workspace(id: "account-existing", name: "Existing Account", bots: [existingBot])
+        let pendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let pendingConfigPath = fixtureURL("/fixture/model-app-support/Accounts/\(account.id)/Bots/new-neondiff-bot/config.local.json").path
+        let persistedPlan = String(data: try JSONSerialization.data(withJSONObject: ["schemaVersion": 1, "accountID": account.id, "botID": pendingBotID, "appSlug": "new-neondiff-bot", "configPath": pendingConfigPath]), encoding: .utf8)!
+        let fixture = ModelDependencyFixture(preferenceStrings: ["neondiff.accountWorkspaceID": account.id, "neondiff.accountBotID": existingBot.id, "neondiff.configPath": "/fixture/existing-bot/config.local.json", "neondiff.pendingNewBotPlan.v1": persistedPlan])
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([account]))
+        #expect(fixture.model.accountWorkspaceSelection.botID == existingBot.id)
+        #expect(fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1") == persistedPlan)
+        fixture.model.repos = [RepoMonitor(name: "account-existing/private", enabled: true)]
+        fixture.model.providers.providerKeyStored = true
+        fixture.model.github.installationCount = 1
+        let selectedConfigPath = fixture.model.configPath
+
+        fixture.model.selectBotInstallation(existingBot.id)
+
+        #expect(fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1") == nil)
+        #expect(fixture.model.accountWorkspaceSelection.botID == existingBot.id)
+        #expect(fixture.model.configPath == selectedConfigPath)
+        #expect(fixture.model.repos == [RepoMonitor(name: "account-existing/private", enabled: true)])
+        #expect(fixture.model.providers.providerKeyStored)
+        #expect(fixture.model.github.installationCount == 1)
+    }
+
+    @MainActor
     @Test func catalogLocalPathLossInvalidatesSelectedBotRuntimeState() {
         let localBot = bot(
             id: "bot-local",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -719,6 +719,98 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func pendingNewBotRecoveryRejectsFilesystemAliasOwnedByAuthoritativeBot() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let aliasRoot = root
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(root.lastPathComponent)-alias", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: aliasRoot)
+            try? FileManager.default.removeItem(at: root)
+        }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(
+            at: aliasRoot,
+            withDestinationURL: root
+        )
+        let account = workspace(
+            id: electricSheep.id,
+            name: electricSheep.name,
+            bots: []
+        )
+        let relativeConfigPath = "Accounts/\(account.id)/Bots/new-neondiff-bot/config.local.json"
+        let pendingConfigURL = root.appendingPathComponent(relativeConfigPath)
+        try FileManager.default.createDirectory(
+            at: pendingConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"pilotRepos":[]}"#.utf8).write(to: pendingConfigURL)
+        let authoritativeConfigPath = aliasRoot
+            .appendingPathComponent(
+                relativeConfigPath.replacingOccurrences(
+                    of: "/Bots/",
+                    with: "/bots/"
+                )
+            )
+            .standardizedFileURL.path
+        let existingBot = bot(
+            id: "bot-existing",
+            slug: "new-neondiff-bot",
+            configPath: authoritativeConfigPath
+        )
+        let authoritativeAccount = workspace(
+            id: account.id,
+            name: account.name,
+            bots: [existingBot]
+        )
+        let stalePendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let persistedPlan = String(
+            data: try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "accountID": account.id,
+                "botID": stalePendingBotID,
+                "appSlug": "new-neondiff-bot",
+                "configPath": pendingConfigURL.standardizedFileURL.path
+            ]),
+            encoding: .utf8
+        )!
+        let fixture = ModelDependencyFixture(
+            root: root,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": account.id,
+                "neondiff.accountBotID": existingBot.id,
+                "neondiff.configPath": authoritativeConfigPath,
+                "neondiff.pendingNewBotPlan.v1": persistedPlan
+            ]
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([authoritativeAccount]))
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where fixture.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(fixture.model.selectedBotInstallation?.id == existingBot.id)
+        #expect(
+            fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+                == nil
+        )
+
+        fixture.model.beginNewBot()
+
+        let replacement = try #require(fixture.model.pendingNewBotPlan)
+        #expect(replacement.bot.id != stalePendingBotID)
+        #expect(
+            replacement.bot.localConfigPath
+                != pendingConfigURL.standardizedFileURL.path
+        )
+    }
+
+    @MainActor
     @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
         let root = fixtureURL("/fixture/model-app-support", directory: true)
         let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -811,6 +811,107 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func pendingNewBotRecoveryRejectsCrossAccountDirectoryAlias() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let accountAID = "account-a"
+        let accountBID = "account-b"
+        let accountABotsDirectory = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(accountAID, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+        let victimBotDirectory = root
+            .appendingPathComponent("Accounts", isDirectory: true)
+            .appendingPathComponent(accountBID, isDirectory: true)
+            .appendingPathComponent("Bots", isDirectory: true)
+            .appendingPathComponent("victim-bot", isDirectory: true)
+        let victimConfigURL = victimBotDirectory
+            .appendingPathComponent("config.local.json")
+        let victimConfigData = Data(#"{"pilotRepos":["account-b/private"]}"#.utf8)
+        try FileManager.default.createDirectory(
+            at: accountABotsDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: victimBotDirectory,
+            withIntermediateDirectories: true
+        )
+        try victimConfigData.write(to: victimConfigURL)
+        let aliasedPendingDirectory = accountABotsDirectory
+            .appendingPathComponent("new-neondiff-bot", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: aliasedPendingDirectory,
+            withDestinationURL: victimBotDirectory
+        )
+        let accountAExistingBot = bot(
+            id: "bot-account-a",
+            slug: "account-a-bot",
+            configPath: accountABotsDirectory
+                .appendingPathComponent("account-a-bot", isDirectory: true)
+                .appendingPathComponent("config.local.json")
+                .path
+        )
+        let accountBVictimBot = bot(
+            id: "bot-account-b",
+            slug: "victim-bot",
+            configPath: victimConfigURL.path
+        )
+        let accountA = workspace(
+            id: accountAID,
+            name: "Account A",
+            bots: [accountAExistingBot]
+        )
+        let accountB = workspace(
+            id: accountBID,
+            name: "Account B",
+            bots: [accountBVictimBot]
+        )
+        let stalePendingBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"
+        let aliasedPendingConfigPath = aliasedPendingDirectory
+            .appendingPathComponent("config.local.json")
+            .standardizedFileURL.path
+        let persistedPlan = String(
+            data: try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "accountID": accountA.id,
+                "botID": stalePendingBotID,
+                "appSlug": "new-neondiff-bot",
+                "configPath": aliasedPendingConfigPath
+            ]),
+            encoding: .utf8
+        )!
+        let fixture = ModelDependencyFixture(
+            root: root,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": accountA.id,
+                "neondiff.accountBotID": accountAExistingBot.id,
+                "neondiff.configPath": accountAExistingBot.localConfigPath!,
+                "neondiff.pendingNewBotPlan.v1": persistedPlan
+            ]
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
+        await fixture.cli.waitUntilCallCount(1)
+        for _ in 0..<100 where fixture.model.isConfigInspectInProgress {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(fixture.model.selectedBotInstallation?.id == accountAExistingBot.id)
+        #expect(
+            fixture.preferences.string(forKey: "neondiff.pendingNewBotPlan.v1")
+                == nil
+        )
+
+        fixture.model.beginNewBot()
+
+        let replacement = try #require(fixture.model.pendingNewBotPlan)
+        #expect(replacement.bot.id != stalePendingBotID)
+        #expect(replacement.bot.localConfigPath != aliasedPendingConfigPath)
+        #expect(try Data(contentsOf: victimConfigURL) == victimConfigData)
+    }
+
+    @MainActor
     @Test func pendingNewBotRelaunchRejectsAConfigOutsideTheSelectedAccount() throws {
         let root = fixtureURL("/fixture/model-app-support", directory: true)
         let savedBotID = "pending-75f906e6-08f9-4ca0-bf6a-e83b964543e2"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
@@ -250,6 +250,28 @@ final class TemporaryFileWriter: DesktopFileWriting, @unchecked Sendable {
         } || FileManager.default.fileExists(atPath: destination.path)
     }
 
+    func pathsReferToSameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        let lhsURL = lhs.standardizedFileURL.resolvingSymlinksInPath()
+        let rhsURL = rhs.standardizedFileURL.resolvingSymlinksInPath()
+        if lhsURL.path.caseInsensitiveCompare(rhsURL.path) == .orderedSame {
+            return true
+        }
+        guard let lhsAttributes = try? FileManager.default.attributesOfItem(
+            atPath: lhsURL.path
+        ),
+        let rhsAttributes = try? FileManager.default.attributesOfItem(
+            atPath: rhsURL.path
+        ),
+        let lhsSystem = lhsAttributes[.systemNumber] as? NSNumber,
+        let rhsSystem = rhsAttributes[.systemNumber] as? NSNumber,
+        let lhsFile = lhsAttributes[.systemFileNumber] as? NSNumber,
+        let rhsFile = rhsAttributes[.systemFileNumber] as? NSNumber
+        else {
+            return false
+        }
+        return lhsSystem == rhsSystem && lhsFile == rhsFile
+    }
+
     func write(_ data: Data, to url: URL) throws {
         let destination = url.standardizedFileURL
         let rootPath = applicationSupportDirectory.path

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -286,9 +286,13 @@ plan before showing **Initialize Local Config**. It never initializes the
 If the customer quits before setup is complete, relaunch NeonDiff and continue
 the same pending bot. The app restores the exact account-scoped config path and
 reopens onboarding rather than creating a second `new-neondiff-bot-*`
-directory. This recovery also takes precedence over automatic selection of an
-older local bot under the same account. Choosing another account or an existing
-bot explicitly still ends the pending setup.
+directory. If an older build or manual rollback changed the saved selection to
+a verified existing bot under the same account, relaunch keeps that
+authoritative bot selected and preserves only a structurally valid,
+account-scoped pending plan. Choose **NEW BOT** to resume that preserved setup;
+the app rejects it if any authorized bot now owns the same config identity.
+Choosing another account or explicitly choosing an existing bot ends the
+pending setup.
 
 When the same Mac already has one exact checksum-managed worker for the selected
 LaunchAgent label, the app reuses that worker for the isolated bot's `init`,


### PR DESCRIPTION
## Customer gate

A signed beta.43 → beta.42 → beta.43 rollback preserved a pending New Bot config, but the older build changed the saved selection to an existing bot. Recovery must keep that existing bot selected until the customer explicitly chooses NEW BOT, then resume only an isolated draft. This replacement also rejects a persisted draft when the authoritative account catalog already owns the same config through an exact path, case alias, symlink, or same-filesystem identity.

Supersedes #728 because its review budget was exhausted by a reproduced current-head filesystem-alias blocker. Related to #699, #449, and tracker #610. This PR does not close those broader release gates.

## Acceptance criteria

- Keep the legitimate existing bot selected after reinstall; never auto-switch to a local draft.
- Preserve only a structurally valid, same-account, account-scoped pending plan during automatic restoration.
- On explicit NEW BOT, resume that draft only when no authoritative bot owns the same config filesystem identity.
- Reject exact, case-insensitive, symlink, and same-volume file-identity aliases; allocate a fresh isolated path instead.
- Explicitly selecting the current existing bot abandons the preserved draft without resetting verified runtime state.
- Preserve config bytes, Keychain, activation, repository authority, account isolation, and fail-closed review gates.

## Failing-first proof

- On base 69ae0cf, explicitNewBotResumesPendingPlanAfterOlderBuildSelectionDrift failed with a new blank pending ID/path and no restored repository state.
- On 1750b163, explicitlyReselectingRestoredBotAbandonsPreservedPendingPlan failed because the persisted draft remained.
- On 2940990, pendingNewBotRecoveryRejectsConfigNowOwnedByAuthoritativeBot failed because the stale UUID/path were reused.
- On bff0b7b, pendingNewBotRecoveryRejectsFilesystemAliasOwnedByAuthoritativeBot failed because a symlink/case alias was accepted. A direct host check also returned lexicallyEqual=false and sameFileNumber=true.

## Focused green proof

- Filesystem-alias regression: passed.
- AccountWorkspaceSelectionTests: 29/29 passed.
- AccountLinkModelTests.launchRefreshPreservesPendingNewBotForAccountWithExistingLocalBot: 1/1 passed.
- git diff --check: passed.

## Non-goals

- No billing, activation, GitHub credential, provider, review-posting, signing/notarization, website, publication, or canary change.
- No managed GitHub App, Sparkle, broader #517 matrix, generalized harness, or additional recovery hardening.
- No release or customer-readiness claim from source or CI.

## Required merge gate

One stable-head independent semantic review of account, persistence, and filesystem-identity isolation; one current-head remote gate; explicit inspection of review threads, top-level feedback, and annotations. After merge, build one new signed/notarized candidate and run the installed manual rollback/re-update canary. No additional hardening lane unless current execution fails.