### PR TITLE
Add a default-off Luna review ensemble

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,11 @@
     "maxActiveRuns": 5,
     "leaseTtlMs": 900000
   },
+  "_reviewEnsembleComment": "Experimental default-off shadow team. One canonical full-diff anchor plus state, boundary, and failure specialists run concurrently. Only the anchor may post or write canonical processed-head state; specialist output is evidence-only.",
+  "reviewEnsemble": {
+    "enabled": false,
+    "mode": "shadow"
+  },
   "_worktreeCleanupComment": "Periodic daemon cleanup is limited to stale, clean, Git-registered NeonDiff review worktrees. retentionMs cannot be shorter than two hours or the active review lease TTL. Set enabled:false to disable deletion.",
   "worktreeCleanup": {
     "enabled": true,

--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -296,17 +296,44 @@ PR's changed surface instead of a flat FIFO priority (#301, `src/scheduler.ts`).
 - **`elevatedPriority` must be `<= docsOnlyPriority` whenever `enabled` is `true`.** Config validation fails closed if this invariant is violated, since a higher numeric value leases *later* and an inverted ordering would mean docs-only PRs jump ahead of elevated-risk ones.
 - **Never de-prioritizes a self-repo below its existing elevation**, and elevation is derived solely from the already-shipped changed-surface validation report — this feature introduces no new path-classification logic.
 
+### `reviewEnsemble`
+
+`config.reviewEnsemble` controls the experimental four-lane Luna review team. It is absent/default-off
+unless explicitly enabled. The ordinary full-diff review remains the canonical anchor; state,
+boundary, and failure specialists add isolated shadow evidence.
+
+| Key | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `enabled` | `boolean` | `false` | Runs the three specialist leaves alongside the ordinary anchor. When false, provider execution and evidence paths are unchanged. |
+| `mode` | `"shadow"` | `"shadow"` | The only accepted mode. Specialist findings are reduced into a non-posting packet. |
+
+**Safety invariants:**
+
+- The parent keeps one queue job, lease, exact-head claim, and canonical processed-review row. Leaves
+  are never represented as queue jobs and never call `reviewPull` recursively.
+- The anchor keeps its original prompt and alone controls the GitHub review. Slow or failed specialists
+  cannot delay the canonical post, change its findings/event, or write canonical state.
+- Every leaf reviews the same immutable repo, pull, base SHA, and head SHA using the same strict schema,
+  worktree, read-only Codex runtime, timeout, and output cap. Chunked reviews retain the lane focus in
+  every chunk.
+- Specialist receipts, runtime data, failures, and the globally deduplicated shadow packet are written
+  below `review-ensemble/`. The packet always records `postingEligible: false`.
+- Enabling the team multiplies provider executions per active parent (four full-subject lanes, with
+  additional calls when context chunking applies). Size `reviewConcurrency` and provider capacity for
+  that explicit cost before activation.
+
 ### `reviewLenses`
 
 `config.reviewLenses` controls default-off advisory review lenses (`src/review-lenses.ts`).
 Lenses are small built-in text packets for first-principles, architecture, decision, and lean
-review. They are rendered like other bounded context packets, not as native ZCode skills.
+review plus the state, boundary, and failure specialist prompts used by the shadow ensemble. They are
+rendered like other bounded context packets, not as native ZCode skills.
 
 | Key | Type | Default | What it does |
 | --- | --- | --- | --- |
 | `enabled` | `boolean` | `false` | Master switch. When `false`, no lens packet is built and the review prompt is unchanged. |
 | `packetVersion` | `string` | `review-lens-packet-v0.1` | Packet schema/version marker written into evidence. |
-| `active` | `Array<{id,surface,mode}>` | `[]` | Explicit lens activations. Allowed ids: `first_principles`, `architecture`, `decision`, `lean`. Allowed surfaces: `issue_enrichment`, `pr_shadow`, `walkthrough`. Allowed modes: `dry_run`, `summary`, `shadow`. |
+| `active` | `Array<{id,surface,mode}>` | `[]` | Explicit lens activations. Allowed ids: `first_principles`, `architecture`, `decision`, `lean`, `state`, `boundary`, `failure`. Allowed surfaces: `issue_enrichment`, `pr_shadow`, `walkthrough`. Allowed modes: `dry_run`, `summary`, `shadow`. |
 | `maxLensBytes` | `integer` (`>= 1`) | `4000` | Per-lens byte cap before a lens is omitted from the packet. |
 | `maxPacketBytes` | `integer` (`>= 500`) | `12000` | Total rendered packet cap. Lenses over budget are omitted and recorded in packet evidence. |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,10 @@ import { isApiKeyEnvName, isProviderId, isProviderStructuredOutputMode, PROVIDER
 import { REGRESSION_CATEGORIES, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type { ReviewMode, ReviewModeDefinition, ReviewModesConfig } from "./review-mode-types.js";
 import { validateRelativePacketPath, type RepoWikiContextConfig } from "./repo-wiki-context.js";
+import {
+  validateReviewEnsembleConfig,
+  type ReviewEnsembleConfig
+} from "./review-ensemble.js";
 import { DEFAULT_REVIEW_LENS_CONFIG, validateReviewLensConfig, type ReviewLensConfig } from "./review-lenses.js";
 import type { ReviewEventPolicyConfig } from "./review-event-policy.js";
 import { containsSecretLikeText } from "./secrets.js";
@@ -62,6 +66,7 @@ export interface BotConfig {
     headCountLimit: number;
   };
   reviewScheduler?: ReviewSchedulerConfig;
+  reviewEnsemble?: ReviewEnsembleConfig;
   riskWeightedQueue?: RiskWeightedQueueConfig;
   /** Review mode router (#266, default off / absent). Absent ⇒ byte-identical + zero evidence. */
   reviewModes?: ReviewModesConfig;
@@ -344,6 +349,10 @@ const DEFAULT_CONFIG: BotConfig = {
     maxQueuedPerRepo: 10,
     manualCommandReserve: 1,
     backgroundPriority: 50
+  },
+  reviewEnsemble: {
+    enabled: false,
+    mode: "shadow"
   },
   riskWeightedQueue: {
     enabled: false
@@ -671,6 +680,9 @@ function validateConfig(config: BotConfig): void {
   const reviewScheduler = config.reviewScheduler ?? DEFAULT_CONFIG.reviewScheduler!;
   config.reviewScheduler = reviewScheduler;
   validateReviewSchedulerConfig(reviewScheduler, "config.reviewScheduler");
+  const reviewEnsemble = config.reviewEnsemble ?? DEFAULT_CONFIG.reviewEnsemble!;
+  config.reviewEnsemble = reviewEnsemble;
+  validateReviewEnsembleConfig(reviewEnsemble, "config.reviewEnsemble");
   const riskWeightedQueue = config.riskWeightedQueue ?? DEFAULT_CONFIG.riskWeightedQueue!;
   config.riskWeightedQueue = riskWeightedQueue;
   validateRiskWeightedQueueConfig(riskWeightedQueue, "config.riskWeightedQueue", reviewScheduler.backgroundPriority);

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -180,27 +180,26 @@ export const SAME_RUN_DEDUP_MIN_PREFIX_LENGTH = 12;
  * kept and later members are dropped, so callers should pass findings pre-sorted by rank.
  */
 export function suppressSameRunNearDuplicates(findings: Finding[]): { kept: Finding[]; dropped: Finding[] } {
-  const kept: Array<{ finding: Finding; category: string; normalizedTitle: string }> = [];
+  const kept: Finding[] = [];
   const dropped: Finding[] = [];
 
   for (const finding of findings) {
-    const category = normalizeFindingCategory(finding);
-    const normalizedTitle = normalizeTitleForDedup(finding.title);
-    const isDuplicate = kept.some(
-      (entry) =>
-        entry.finding.path === finding.path &&
-        entry.category === category &&
-        Math.abs(entry.finding.line - finding.line) <= SAME_RUN_DEDUP_MAX_LINE_DELTA &&
-        titlesAreNearDuplicate(entry.normalizedTitle, normalizedTitle)
-    );
+    const isDuplicate = kept.some((entry) => sameRunFindingsAreNearDuplicates(entry, finding));
     if (isDuplicate) {
       dropped.push(finding);
       continue;
     }
-    kept.push({ finding, category, normalizedTitle });
+    kept.push(finding);
   }
 
-  return { kept: kept.map((entry) => entry.finding), dropped };
+  return { kept, dropped };
+}
+
+export function sameRunFindingsAreNearDuplicates(left: Finding, right: Finding): boolean {
+  return left.path === right.path &&
+    normalizeFindingCategory(left) === normalizeFindingCategory(right) &&
+    Math.abs(left.line - right.line) <= SAME_RUN_DEDUP_MAX_LINE_DELTA &&
+    titlesAreNearDuplicate(normalizeTitleForDedup(left.title), normalizeTitleForDedup(right.title));
 }
 
 export function normalizeTitleForDedup(title: string): string {

--- a/src/review-ensemble.ts
+++ b/src/review-ensemble.ts
@@ -1,0 +1,275 @@
+import { createHash } from "node:crypto";
+import { buildFindingFingerprint } from "./findings.js";
+import { applyDeterministicReviewGate, type DeterministicReviewGateResult } from "./review-gate.js";
+import { getBuiltInReviewLensDefinition } from "./review-lenses.js";
+import { redactSecrets } from "./secrets.js";
+import type { DroppedFinding, Finding, PullFilePatch } from "./types.js";
+
+export const REVIEW_ENSEMBLE_PLAN_VERSION = "review-ensemble-plan-v0.1";
+export const REVIEW_ENSEMBLE_PACKET_VERSION = "review-ensemble-packet-v0.1";
+
+export type ReviewEnsembleMode = "shadow";
+export type ReviewEnsembleLeafId = "anchor" | "state" | "boundary" | "failure";
+
+export interface ReviewEnsembleConfig {
+  enabled: boolean;
+  mode: ReviewEnsembleMode;
+}
+
+export interface ReviewEnsembleSubject {
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  headSha: string;
+}
+
+export interface ReviewEnsembleLeafPlan {
+  id: ReviewEnsembleLeafId;
+  required: boolean;
+}
+
+export interface ReviewEnsemblePlan {
+  version: typeof REVIEW_ENSEMBLE_PLAN_VERSION;
+  mode: ReviewEnsembleMode;
+  leaves: ReviewEnsembleLeafPlan[];
+}
+
+export interface ReviewEnsembleLeafOutput {
+  findings: Finding[];
+  dropped: DroppedFinding[];
+  runtime?: object;
+}
+
+export interface ReviewEnsembleLeafReceipt extends ReviewEnsembleLeafOutput {
+  leafId: ReviewEnsembleLeafId;
+  required: boolean;
+  status: "completed" | "failed";
+  subject: ReviewEnsembleSubject;
+  error?: string;
+}
+
+export interface ReviewEnsembleManifestLeaf {
+  id: ReviewEnsembleLeafId;
+  required: boolean;
+  status: "completed" | "failed";
+  error?: string;
+}
+
+export interface ReviewEnsembleManifest {
+  version: typeof REVIEW_ENSEMBLE_PLAN_VERSION;
+  mode: ReviewEnsembleMode;
+  subject: ReviewEnsembleSubject;
+  startedAt: string;
+  completedAt: string;
+  complete: boolean;
+  leaves: ReviewEnsembleManifestLeaf[];
+  proofBoundary: string;
+}
+
+export interface ReviewEnsembleRun {
+  manifest: ReviewEnsembleManifest;
+  receipts: ReviewEnsembleLeafReceipt[];
+}
+
+export interface ReviewEnsemblePacket {
+  packetVersion: typeof REVIEW_ENSEMBLE_PACKET_VERSION;
+  generatedAt: string;
+  subject: ReviewEnsembleSubject;
+  complete: boolean;
+  postingEligible: false;
+  leaves: ReviewEnsembleManifestLeaf[];
+  gate: DeterministicReviewGateResult;
+  provenance: Record<string, ReviewEnsembleLeafId[]>;
+  proofBoundary: string;
+  sha256: string;
+}
+
+const CANONICAL_LEAVES: ReviewEnsembleLeafPlan[] = [
+  { id: "anchor", required: true },
+  { id: "state", required: true },
+  { id: "boundary", required: true },
+  { id: "failure", required: true }
+];
+
+const LEAF_ORDER = new Map(CANONICAL_LEAVES.map((leaf, index) => [leaf.id, index]));
+
+export function buildReviewEnsemblePlan(config: ReviewEnsembleConfig): ReviewEnsemblePlan | undefined {
+  validateReviewEnsembleConfig(config, "reviewEnsemble");
+  if (!config.enabled) return undefined;
+  return {
+    version: REVIEW_ENSEMBLE_PLAN_VERSION,
+    mode: config.mode,
+    leaves: CANONICAL_LEAVES.map((leaf) => ({ ...leaf }))
+  };
+}
+
+export function validateReviewEnsembleConfig(config: ReviewEnsembleConfig, label: string): void {
+  if (!isRecord(config)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(config)) {
+    if (!new Set(["enabled", "mode"]).has(key)) {
+      throw new Error(`${label} has unknown key "${key}"; expected only enabled or mode`);
+    }
+  }
+  if (typeof config.enabled !== "boolean") throw new Error(`${label}.enabled must be a boolean`);
+  if (config.mode !== "shadow") throw new Error(`${label}.mode must be shadow`);
+}
+
+export function buildReviewEnsembleLeafPrompt(basePrompt: string, leafId: ReviewEnsembleLeafId): string {
+  if (leafId === "anchor") return basePrompt;
+  const guidance = getBuiltInReviewLensDefinition(leafId);
+  return [
+    basePrompt.trimEnd(),
+    "",
+    "## Additional isolated review focus",
+    guidance.title,
+    guidance.body,
+    "Do not use tools, agents, web, MCP, shell, memory, or writes. Use only the supplied immutable review context.",
+    "For each reproduced finding, include the smallest safe fix direction, a focused acceptance check, and relevant non-goals in the finding body.",
+    "Return the same strict findings schema. This leaf cannot post, approve, edit, or change review policy.",
+    ""
+  ].join("\n");
+}
+
+export async function executeReviewEnsemble(input: {
+  plan: ReviewEnsemblePlan;
+  subject: ReviewEnsembleSubject;
+  runLeaf: (leaf: ReviewEnsembleLeafPlan) => Promise<ReviewEnsembleLeafOutput>;
+  startedAt?: string;
+  completedAt?: () => string;
+}): Promise<ReviewEnsembleRun> {
+  const startedAt = input.startedAt ?? new Date().toISOString();
+  requireIsoTimestamp(startedAt, "review ensemble startedAt");
+  const settled = await Promise.allSettled(input.plan.leaves.map((leaf) => input.runLeaf(leaf)));
+  const receipts = input.plan.leaves.map((leaf, index): ReviewEnsembleLeafReceipt => {
+    const result = settled[index]!;
+    if (result.status === "fulfilled") {
+      return {
+        leafId: leaf.id,
+        required: leaf.required,
+        status: "completed",
+        subject: { ...input.subject },
+        findings: result.value.findings,
+        dropped: result.value.dropped,
+        ...(result.value.runtime ? { runtime: result.value.runtime } : {})
+      };
+    }
+    return {
+      leafId: leaf.id,
+      required: leaf.required,
+      status: "failed",
+      subject: { ...input.subject },
+      findings: [],
+      dropped: [],
+      error: redactSecrets(result.reason instanceof Error ? result.reason.message : String(result.reason))
+    };
+  });
+  const completedAt = input.completedAt?.() ?? new Date().toISOString();
+  requireIsoTimestamp(completedAt, "review ensemble completedAt");
+  const leaves = receipts.map(toManifestLeaf);
+  return {
+    manifest: {
+      version: input.plan.version,
+      mode: input.plan.mode,
+      subject: { ...input.subject },
+      startedAt,
+      completedAt,
+      complete: leaves.every((leaf) => !leaf.required || leaf.status === "completed"),
+      leaves,
+      proofBoundary: "Shadow ensemble evidence is advisory only. It cannot post, approve, edit code, write processed-head state, or change the canonical parent review result."
+    },
+    receipts
+  };
+}
+
+export function reduceReviewEnsemble(input: {
+  subject: ReviewEnsembleSubject;
+  files: PullFilePatch[];
+  receipts: ReviewEnsembleLeafReceipt[];
+  generatedAt?: string;
+  gatePolicy?: Omit<Parameters<typeof applyDeterministicReviewGate>[0], "findings" | "files" | "droppedFromSchema">;
+}): ReviewEnsemblePacket {
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  requireIsoTimestamp(generatedAt, "review ensemble generatedAt");
+  const receipts = normalizeReceipts(input.subject, input.receipts);
+  const complete = CANONICAL_LEAVES.every((expected) => {
+    const receipt = receipts.find((candidate) => candidate.leafId === expected.id);
+    return !expected.required || receipt?.status === "completed";
+  });
+  const completed = receipts.filter((receipt) => receipt.status === "completed");
+  const findings = completed.flatMap((receipt) => receipt.findings);
+  const dropped = completed.flatMap((receipt) => receipt.dropped);
+  const gate = applyDeterministicReviewGate({
+    findings,
+    files: input.files,
+    droppedFromSchema: dropped,
+    ...input.gatePolicy
+  });
+  const provenance: Record<string, ReviewEnsembleLeafId[]> = {};
+  for (const receipt of completed) {
+    for (const item of receipt.findings) {
+      const fingerprint = buildFindingFingerprint(item);
+      const ids = provenance[fingerprint] ?? [];
+      if (!ids.includes(receipt.leafId)) ids.push(receipt.leafId);
+      provenance[fingerprint] = ids.sort(compareLeafId);
+    }
+  }
+  const leaves = receipts.map(toManifestLeaf);
+  const proofBoundary = "This packet is a non-posting shadow reduction. Only the canonical parent review may own GitHub posting, processed-head state, readiness, or review-event authority.";
+  const payload: Omit<ReviewEnsemblePacket, "sha256"> = {
+    packetVersion: REVIEW_ENSEMBLE_PACKET_VERSION,
+    generatedAt,
+    subject: input.subject,
+    complete,
+    postingEligible: false as const,
+    leaves,
+    gate,
+    provenance,
+    proofBoundary
+  };
+  return {
+    ...payload,
+    sha256: createHash("sha256").update(stableStringify(payload)).digest("hex")
+  };
+}
+
+function normalizeReceipts(subject: ReviewEnsembleSubject, receipts: ReviewEnsembleLeafReceipt[]): ReviewEnsembleLeafReceipt[] {
+  const seen = new Set<ReviewEnsembleLeafId>();
+  for (const receipt of receipts) {
+    if (seen.has(receipt.leafId)) throw new Error(`duplicate review ensemble leaf receipt: ${receipt.leafId}`);
+    seen.add(receipt.leafId);
+    if (receipt.subject.repo !== subject.repo) throw new Error(`review ensemble repo mismatch for ${receipt.leafId}`);
+    if (receipt.subject.pullNumber !== subject.pullNumber) throw new Error(`review ensemble pull number mismatch for ${receipt.leafId}`);
+    if (receipt.subject.baseSha !== subject.baseSha) throw new Error(`review ensemble base SHA mismatch for ${receipt.leafId}`);
+    if (receipt.subject.headSha !== subject.headSha) throw new Error(`review ensemble head SHA mismatch for ${receipt.leafId}`);
+  }
+  return [...receipts].sort((left, right) => compareLeafId(left.leafId, right.leafId));
+}
+
+function toManifestLeaf(receipt: ReviewEnsembleLeafReceipt): ReviewEnsembleManifestLeaf {
+  return {
+    id: receipt.leafId,
+    required: receipt.required,
+    status: receipt.status,
+    ...(receipt.error ? { error: redactSecrets(receipt.error) } : {})
+  };
+}
+
+function compareLeafId(left: ReviewEnsembleLeafId, right: ReviewEnsembleLeafId): number {
+  return (LEAF_ORDER.get(left) ?? Number.MAX_SAFE_INTEGER) - (LEAF_ORDER.get(right) ?? Number.MAX_SAFE_INTEGER);
+}
+
+function requireIsoTimestamp(value: string, label: string): void {
+  if (!Number.isFinite(Date.parse(value))) throw new Error(`${label} must be an ISO timestamp`);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(",")}}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/review-ensemble.ts
+++ b/src/review-ensemble.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { buildFindingFingerprint } from "./findings.js";
+import { buildFindingFingerprint, sameRunFindingsAreNearDuplicates } from "./findings.js";
 import { applyDeterministicReviewGate, type DeterministicReviewGateResult } from "./review-gate.js";
 import { getBuiltInReviewLensDefinition } from "./review-lenses.js";
 import { redactSecrets } from "./secrets.js";
@@ -205,12 +205,17 @@ export function reduceReviewEnsemble(input: {
     ...input.gatePolicy
   });
   const provenance: Record<string, ReviewEnsembleLeafId[]> = {};
+  const gatedRepresentatives = gate.comments.flatMap((comment) => {
+    const representative = findings.find((item) => buildFindingFingerprint(item) === comment.fingerprint);
+    return representative ? [{ fingerprint: comment.fingerprint, representative }] : [];
+  });
   for (const receipt of completed) {
     for (const item of receipt.findings) {
-      const fingerprint = buildFindingFingerprint(item);
-      const ids = provenance[fingerprint] ?? [];
+      const cluster = gatedRepresentatives.find(({ representative }) => sameRunFindingsAreNearDuplicates(representative, item));
+      if (!cluster) continue;
+      const ids = provenance[cluster.fingerprint] ?? [];
       if (!ids.includes(receipt.leafId)) ids.push(receipt.leafId);
-      provenance[fingerprint] = ids.sort(compareLeafId);
+      provenance[cluster.fingerprint] = ids.sort(compareLeafId);
     }
   }
   const leaves = receipts.map(toManifestLeaf);

--- a/src/review-lenses.ts
+++ b/src/review-lenses.ts
@@ -6,7 +6,14 @@ export const REVIEW_LENS_PACKET_VERSION = "review-lens-packet-v0.1";
 export const REVIEW_LENS_ADVISORY =
   "Review lenses are advisory context only. Current PR diff, checkout files, schema validation, current-head checks, redaction, and posting policy remain authoritative.";
 
-export type ReviewLensId = "first_principles" | "architecture" | "decision" | "lean";
+export type ReviewLensId =
+  | "first_principles"
+  | "architecture"
+  | "decision"
+  | "lean"
+  | "state"
+  | "boundary"
+  | "failure";
 export type ReviewLensSurface = "issue_enrichment" | "pr_shadow" | "walkthrough";
 export type ReviewLensMode = "dry_run" | "summary" | "shadow";
 
@@ -132,8 +139,41 @@ export const BUILT_IN_REVIEW_LENSES: ReviewLensDefinition[] = [
       "Never request changes from this lens alone.",
       "Never suggest removing validation, auth, security, accessibility, observability, migrations, data-loss handling, concurrency protection, or tests for changed behavior."
     ].join("\n")
+  },
+  {
+    id: "state",
+    title: "State and lifecycle review",
+    body: [
+      "Trace creation, resume, retry, cancellation, teardown, and idempotent re-entry.",
+      "Check that state ownership and persisted/in-memory transitions remain consistent across every changed path.",
+      "Report only a concrete supported-path failure; do not propose speculative hardening."
+    ].join("\n")
+  },
+  {
+    id: "boundary",
+    title: "Authority and integration-boundary review",
+    body: [
+      "Trace identities, authorization, API/data-shape contracts, caller/callee assumptions, and default-branch compatibility.",
+      "Check that the changed boundary preserves its documented authority and supported consumers.",
+      "Report only a concrete supported-path failure; do not propose speculative hardening."
+    ].join("\n")
+  },
+  {
+    id: "failure",
+    title: "Failure, concurrency, and operator-truth review",
+    body: [
+      "Trace partial failure, retry, timeout, concurrent execution, rollback, and degraded-mode behavior.",
+      "Check that reported status and durable evidence match what actually happened.",
+      "Report only a concrete supported-path failure; do not propose speculative hardening."
+    ].join("\n")
   }
 ];
+
+export function getBuiltInReviewLensDefinition(id: ReviewLensId): ReviewLensDefinition {
+  const definition = BUILT_IN_REVIEW_LENSES.find((candidate) => candidate.id === id);
+  if (!definition) throw new Error(`No built-in review lens definition exists for ${id}`);
+  return definition;
+}
 
 export function validateReviewLensConfig(config: ReviewLensConfig, label: string): void {
   if (!isRecord(config)) throw new Error(`${label} must be an object`);
@@ -393,7 +433,7 @@ function validateReviewLensActivation(value: unknown, label: string): void {
   for (const key of Object.keys(value)) {
     if (!["id", "surface", "mode"].includes(key)) throw new Error(`${label} has unknown key "${key}"; expected only id, surface, or mode`);
   }
-  if (!isLensId(value.id)) throw new Error(`${label}.id must be one of: first_principles, architecture, decision, lean`);
+  if (!isLensId(value.id)) throw new Error(`${label}.id must be one of: first_principles, architecture, decision, lean, state, boundary, failure`);
   if (!isSurface(value.surface)) throw new Error(`${label}.surface must be one of: issue_enrichment, pr_shadow, walkthrough`);
   if (!isMode(value.mode)) throw new Error(`${label}.mode must be one of: dry_run, summary, shadow`);
 }
@@ -403,7 +443,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isLensId(value: unknown): value is ReviewLensId {
-  return value === "first_principles" || value === "architecture" || value === "decision" || value === "lean";
+  return value === "first_principles" || value === "architecture" || value === "decision" || value === "lean" ||
+    value === "state" || value === "boundary" || value === "failure";
 }
 
 function isSurface(value: unknown): value is ReviewLensSurface {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1762,6 +1762,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   let headClaim: ReviewHeadClaim | undefined;
   let budgetStarted = false;
   let ensembleEvidencePromise: Promise<void> | undefined;
+  let startShadowLeaves: (() => void) | undefined;
   const releaseReviewCapacity = (): void => {
     // Crash-safe release-on-failure (#295): if we hold the per-head claim and the finally runs
     // before recordProcessed retired it (error/early return), release it so the head is re-claimable.
@@ -1935,52 +1936,10 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       contextBudget,
       promptForFiles,
       useZCode: input.useZCode,
-      evidenceDir
+      evidenceDir,
+      assertProviderConfigCurrent: assertApprovedProviderConfigCurrent
     });
-    assertApprovedProviderConfigCurrent();
-    if (zcodeExecution.status === "skipped_stale_head") return "skipped_stale_head";
-    if (zcodeExecution.status === "skipped_context_budget") return "skipped_context_budget";
-    const zcodeResult = zcodeExecution.result;
-    if (zcodeExecution.ensemblePromise) {
-      ensembleEvidencePromise = zcodeExecution.ensemblePromise
-        .then(() => undefined)
-        .catch((error) => {
-          writeRedactedJsonBestEffort(join(evidenceDir, "review-ensemble", "evidence-error.json"), {
-            error: redactSecrets(error instanceof Error ? error.message : String(error)),
-            recordedAt: new Date().toISOString()
-          });
-        });
-    }
-
-    assertGitClean(worktree.path);
-
-    const liveBeforePlan = await github.getPull(repo, pull.number);
-    const staleBeforePlan = detectStalePullHead({ expected: pull, live: liveBeforePlan, phase: "before_plan" });
-    if (staleBeforePlan) {
-      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforePlan, evidenceDir });
-      return "skipped_stale_head";
-    }
-
-    const gatedFindings = applyRetryDegradedConfidencePenalty(
-      zcodeResult.findings,
-      zcodeResult.degradedRecovery,
-      config.reviewGate?.retryDegradedConfidencePenalty
-    );
-    const gate = applyDeterministicReviewGate({
-      findings: gatedFindings,
-      files: reviewFiles,
-      droppedFromSchema: zcodeResult.droppedFromSchema,
-      maxInlineComments: config.reviewGate?.maxInlineComments ?? 25,
-      repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints,
-      repoMemoryFalsePositives: repoMemory.falsePositives,
-      publicConfidencePolicy: config.confidenceCalibration?.publicDisplay,
-      ...(config.reviewGate?.requestChangesConfidenceFloors
-        ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
-        : {}),
-      ...(config.reviewGate?.categoryPrecisionFloors
-        ? { categoryPrecisionFloors: config.reviewGate.categoryPrecisionFloors }
-        : {})
-    });
+    startShadowLeaves = zcodeExecution.startShadowLeaves;
     if (zcodeExecution.ensemblePromise) {
       ensembleEvidencePromise = zcodeExecution.ensemblePromise
         .then((ensemble) => {
@@ -2015,16 +1974,56 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           });
         });
     }
+    assertApprovedProviderConfigCurrent();
+    if (zcodeExecution.status === "skipped_stale_head") return "skipped_stale_head";
+    if (zcodeExecution.status === "skipped_context_budget") return "skipped_context_budget";
+    const zcodeResult = zcodeExecution.result;
+
+    assertGitClean(worktree.path);
+
+    const liveBeforePlan = await github.getPull(repo, pull.number);
+    const staleBeforePlan = detectStalePullHead({ expected: pull, live: liveBeforePlan, phase: "before_plan" });
+    if (staleBeforePlan) {
+      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforePlan, evidenceDir });
+      return "skipped_stale_head";
+    }
+
+    const gatedFindings = applyRetryDegradedConfidencePenalty(
+      zcodeResult.findings,
+      zcodeResult.degradedRecovery,
+      config.reviewGate?.retryDegradedConfidencePenalty
+    );
+    const gate = applyDeterministicReviewGate({
+      findings: gatedFindings,
+      files: reviewFiles,
+      droppedFromSchema: zcodeResult.droppedFromSchema,
+      maxInlineComments: config.reviewGate?.maxInlineComments ?? 25,
+      repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints,
+      repoMemoryFalsePositives: repoMemory.falsePositives,
+      publicConfidencePolicy: config.confidenceCalibration?.publicDisplay,
+      ...(config.reviewGate?.requestChangesConfidenceFloors
+        ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
+        : {}),
+      ...(config.reviewGate?.categoryPrecisionFloors
+        ? { categoryPrecisionFloors: config.reviewGate.categoryPrecisionFloors }
+        : {})
+    });
     // Opt-in P0/P1 self-consistency re-check (#303): post-dedup, pre-event-decision. Quieter-only —
     // disagreement can lower confidence and strip REQUEST_CHANGES eligibility, never raise/add. When
     // disabled (default) this is a no-op returning the gate's own comments/event, byte-identical.
-    const selfConsistency = await applySelfConsistencyRecheck({
-      config,
-      gate,
-      files: reviewFiles,
-      worktreePath: worktree.path,
-      evidenceDir
-    });
+    let selfConsistency: Awaited<ReturnType<typeof applySelfConsistencyRecheck>>;
+    try {
+      selfConsistency = await applySelfConsistencyRecheck({
+        config,
+        gate,
+        files: reviewFiles,
+        worktreePath: worktree.path,
+        evidenceDir
+      });
+    } finally {
+      startShadowLeaves?.();
+      startShadowLeaves = undefined;
+    }
     assertApprovedProviderConfigCurrent();
     if (selfConsistency.runtimeNote && Array.isArray(zcodeResult.runtime.notes)) {
       zcodeResult.runtime.notes.push(selfConsistency.runtimeNote);
@@ -2498,6 +2497,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     }
     return manualReviewRequested ? "reviewed_command" : "reviewed";
   } finally {
+    startShadowLeaves?.();
     if (ensembleEvidencePromise) await ensembleEvidencePromise;
     releaseReviewCapacity();
   }
@@ -3945,14 +3945,17 @@ function parseSelfConsistencyVerdict(rawResponse: string): SelfConsistencySecond
   return { verified, confidence };
 }
 
-type ContextBudgetReviewExecution =
+type ContextBudgetReviewExecution = (
   | {
       status: "reviewed";
       result: ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput };
-      ensemblePromise?: Promise<ReviewEnsembleRun>;
     }
   | { status: "skipped_context_budget" }
-  | { status: "skipped_stale_head" };
+  | { status: "skipped_stale_head" }
+) & {
+  ensemblePromise?: Promise<ReviewEnsembleRun>;
+  startShadowLeaves?: () => void;
+};
 
 async function runReviewWithContextBudget(input: {
   config: BotConfig;
@@ -3967,6 +3970,7 @@ async function runReviewWithContextBudget(input: {
   promptForFiles: (files: PullFilePatch[]) => string;
   useZCode: boolean;
   evidenceDir: string;
+  assertProviderConfigCurrent?: () => void;
 }): Promise<ContextBudgetReviewExecution> {
   const plan = buildReviewEnsemblePlan(input.config.reviewEnsemble ?? { enabled: false, mode: "shadow" });
   if (!plan) return runSingleReviewWithContextBudget(input);
@@ -3978,6 +3982,18 @@ async function runReviewWithContextBudget(input: {
     headSha: input.pull.head.sha
   };
   const executions = new Map<string, ContextBudgetReviewExecution>();
+  const delayShadowLeaves = Boolean(input.config.reviewGate?.selfConsistency?.enabled);
+  let releaseShadowLeaves: (() => void) | undefined;
+  const shadowStart = delayShadowLeaves
+    ? new Promise<void>((resolve) => {
+        let released = false;
+        releaseShadowLeaves = () => {
+          if (released) return;
+          released = true;
+          resolve();
+        };
+      })
+    : Promise.resolve();
   const anchorPromise = runSingleReviewWithContextBudget({
     ...input,
     authority: "canonical"
@@ -3986,6 +4002,7 @@ async function runReviewWithContextBudget(input: {
     plan,
     subject,
     runLeaf: async (leaf) => {
+      if (leaf.id !== "anchor") await shadowStart;
       const execution = leaf.id === "anchor"
         ? await anchorPromise
         : await (async () => {
@@ -4042,11 +4059,16 @@ async function runReviewWithContextBudget(input: {
   try {
     const anchor = await anchorPromise;
     if (anchor.status !== "reviewed") {
-      await ensemblePromise.catch(() => undefined);
-      return anchor;
+      releaseShadowLeaves?.();
+      return { ...anchor, ensemblePromise };
     }
-    return { ...anchor, ensemblePromise };
+    return {
+      ...anchor,
+      ensemblePromise,
+      ...(releaseShadowLeaves ? { startShadowLeaves: releaseShadowLeaves } : {})
+    };
   } catch (error) {
+    releaseShadowLeaves?.();
     await ensemblePromise.catch(() => undefined);
     throw error;
   }
@@ -4066,6 +4088,7 @@ async function runSingleReviewWithContextBudget(input: {
   useZCode: boolean;
   evidenceDir: string;
   authority?: "canonical" | "shadow";
+  assertProviderConfigCurrent?: () => void;
 }): Promise<ContextBudgetReviewExecution> {
   if (input.contextBudget.mode === "chunk") {
     return runChunkedZCodeReview({
@@ -4079,7 +4102,8 @@ async function runSingleReviewWithContextBudget(input: {
         config: input.config,
         worktreePath: input.worktreePath,
         prompt: input.prompt,
-        evidenceDir: input.evidenceDir
+        evidenceDir: input.evidenceDir,
+        assertProviderConfigCurrent: input.assertProviderConfigCurrent
       })
     : disabledZCodeReviewResult(input.config);
   return { status: "reviewed", result };
@@ -4097,6 +4121,7 @@ async function runChunkedZCodeReview(input: {
   useZCode: boolean;
   evidenceDir: string;
   authority?: "canonical" | "shadow";
+  assertProviderConfigCurrent?: () => void;
 }): Promise<ContextBudgetReviewExecution> {
   const startedAt = new Date();
   const findings: ZCodeReviewResult["findings"] = [];
@@ -4131,7 +4156,8 @@ async function runChunkedZCodeReview(input: {
             config: input.config,
             worktreePath: input.worktreePath,
             prompt,
-            evidenceDir: chunkDir
+            evidenceDir: chunkDir,
+            assertProviderConfigCurrent: input.assertProviderConfigCurrent
           })
         : disabledZCodeReviewResult(input.config);
     } catch (error) {
@@ -4223,8 +4249,10 @@ async function runConfiguredReview(input: {
   worktreePath: string;
   prompt: string;
   evidenceDir: string;
+  assertProviderConfigCurrent?: () => void;
 }): Promise<ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput }> {
   if (!input.config.codexRuntime?.enabled) return runZCodeReviewWithProviderRetry(input);
+  input.assertProviderConfigCurrent?.();
   const startedAt = new Date();
   const result = await runCodexReview({
     cwd: input.worktreePath,
@@ -4260,6 +4288,7 @@ async function runZCodeReviewWithProviderRetry(input: {
   worktreePath: string;
   prompt: string;
   evidenceDir: string;
+  assertProviderConfigCurrent?: () => void;
 }): Promise<ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput }> {
   const startedAt = new Date();
   let providerAttempts = 0;
@@ -4267,6 +4296,7 @@ async function runZCodeReviewWithProviderRetry(input: {
     config: input.config,
     evidenceDir: input.evidenceDir,
     operation: () => {
+      input.assertProviderConfigCurrent?.();
       providerAttempts += 1;
       return runZCodeReview({
         cwd: input.worktreePath,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,6 +51,14 @@ import {
 } from "./repo-policy.js";
 import { applyDeterministicReviewGate, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
 import {
+  buildReviewEnsembleLeafPrompt,
+  buildReviewEnsemblePlan,
+  executeReviewEnsemble,
+  reduceReviewEnsemble,
+  type ReviewEnsembleRun,
+  type ReviewEnsembleSubject
+} from "./review-ensemble.js";
+import {
   decideReviewEventPolicy,
   type ReviewEventAuthorizationAttempt,
   type ReviewEventDecision,
@@ -1753,6 +1761,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   let lease: ReviewRunLease | undefined;
   let headClaim: ReviewHeadClaim | undefined;
   let budgetStarted = false;
+  let ensembleEvidencePromise: Promise<void> | undefined;
   const releaseReviewCapacity = (): void => {
     // Crash-safe release-on-failure (#295): if we hold the per-head claim and the finally runs
     // before recordProcessed retired it (error/early return), release it so the head is re-claimable.
@@ -1922,6 +1931,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       pull,
       worktreePath: worktree.path,
       prompt,
+      files: reviewFiles,
       contextBudget,
       promptForFiles,
       useZCode: input.useZCode,
@@ -1931,6 +1941,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (zcodeExecution.status === "skipped_stale_head") return "skipped_stale_head";
     if (zcodeExecution.status === "skipped_context_budget") return "skipped_context_budget";
     const zcodeResult = zcodeExecution.result;
+    if (zcodeExecution.ensemblePromise) {
+      ensembleEvidencePromise = zcodeExecution.ensemblePromise
+        .then(() => undefined)
+        .catch((error) => {
+          writeRedactedJsonBestEffort(join(evidenceDir, "review-ensemble", "evidence-error.json"), {
+            error: redactSecrets(error instanceof Error ? error.message : String(error)),
+            recordedAt: new Date().toISOString()
+          });
+        });
+    }
 
     assertGitClean(worktree.path);
 
@@ -1961,6 +1981,40 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         ? { categoryPrecisionFloors: config.reviewGate.categoryPrecisionFloors }
         : {})
     });
+    if (zcodeExecution.ensemblePromise) {
+      ensembleEvidencePromise = zcodeExecution.ensemblePromise
+        .then((ensemble) => {
+          const shadowPacket = reduceReviewEnsemble({
+            subject: {
+              repo,
+              pullNumber: pull.number,
+              baseSha: pull.base.sha,
+              headSha: pull.head.sha
+            },
+            files: reviewFiles,
+            receipts: ensemble.receipts,
+            gatePolicy: {
+              maxInlineComments: config.reviewGate?.maxInlineComments ?? 25,
+              repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints,
+              repoMemoryFalsePositives: repoMemory.falsePositives,
+              publicConfidencePolicy: config.confidenceCalibration?.publicDisplay,
+              ...(config.reviewGate?.requestChangesConfidenceFloors
+                ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
+                : {}),
+              ...(config.reviewGate?.categoryPrecisionFloors
+                ? { categoryPrecisionFloors: config.reviewGate.categoryPrecisionFloors }
+                : {})
+            }
+          });
+          writeRedactedJson(join(evidenceDir, "review-ensemble", "shadow-packet.json"), shadowPacket);
+        })
+        .catch((error) => {
+          writeRedactedJsonBestEffort(join(evidenceDir, "review-ensemble", "evidence-error.json"), {
+            error: redactSecrets(error instanceof Error ? error.message : String(error)),
+            recordedAt: new Date().toISOString()
+          });
+        });
+    }
     // Opt-in P0/P1 self-consistency re-check (#303): post-dedup, pre-event-decision. Quieter-only —
     // disagreement can lower confidence and strip REQUEST_CHANGES eligibility, never raise/add. When
     // disabled (default) this is a no-op returning the gate's own comments/event, byte-identical.
@@ -2430,7 +2484,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         });
       }
     }
-    releaseReviewCapacity();
     if (headChangedDuringPost) return "posted_stale_head";
     if (postReviewHeadLookupFailed) return "posted_head_unverified";
     if (!headChangedDuringPost && !postReviewHeadLookupFailed && input.processedHeadPolicy !== "retry_failed_head") {
@@ -2445,6 +2498,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     }
     return manualReviewRequested ? "reviewed_command" : "reviewed";
   } finally {
+    if (ensembleEvidencePromise) await ensembleEvidencePromise;
     releaseReviewCapacity();
   }
 }
@@ -3892,7 +3946,11 @@ function parseSelfConsistencyVerdict(rawResponse: string): SelfConsistencySecond
 }
 
 type ContextBudgetReviewExecution =
-  | { status: "reviewed"; result: ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput } }
+  | {
+      status: "reviewed";
+      result: ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput };
+      ensemblePromise?: Promise<ReviewEnsembleRun>;
+    }
   | { status: "skipped_context_budget" }
   | { status: "skipped_stale_head" };
 
@@ -3904,10 +3962,110 @@ async function runReviewWithContextBudget(input: {
   pull: PullRequestSummary;
   worktreePath: string;
   prompt: string;
+  files: PullFilePatch[];
   contextBudget: ContextBudgetPlan;
   promptForFiles: (files: PullFilePatch[]) => string;
   useZCode: boolean;
   evidenceDir: string;
+}): Promise<ContextBudgetReviewExecution> {
+  const plan = buildReviewEnsemblePlan(input.config.reviewEnsemble ?? { enabled: false, mode: "shadow" });
+  if (!plan) return runSingleReviewWithContextBudget(input);
+
+  const subject: ReviewEnsembleSubject = {
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    baseSha: input.pull.base.sha,
+    headSha: input.pull.head.sha
+  };
+  const executions = new Map<string, ContextBudgetReviewExecution>();
+  const anchorPromise = runSingleReviewWithContextBudget({
+    ...input,
+    authority: "canonical"
+  });
+  const ensemblePromise = executeReviewEnsemble({
+    plan,
+    subject,
+    runLeaf: async (leaf) => {
+      const execution = leaf.id === "anchor"
+        ? await anchorPromise
+        : await (async () => {
+            const prompt = buildReviewEnsembleLeafPrompt(input.prompt, leaf.id);
+            const promptForFiles = (files: PullFilePatch[]) => buildReviewEnsembleLeafPrompt(input.promptForFiles(files), leaf.id);
+            const evidenceDir = join(input.evidenceDir, "review-ensemble", "leaves", leaf.id, "provider");
+            const contextBudget = planContextBudget({
+              prompt,
+              files: input.files,
+              contextWindowTokens: resolveReviewContextWindowTokens(input.config),
+              config: input.config.contextBudget,
+              buildPrompt: promptForFiles
+            });
+            mkdirSync(evidenceDir, { recursive: true });
+            writeRedactedJson(join(evidenceDir, "context-budget.json"), contextBudgetEvidence(contextBudget));
+            if (contextBudget.mode === "skip") {
+              return { status: "skipped_context_budget" } as ContextBudgetReviewExecution;
+            }
+            return runSingleReviewWithContextBudget({
+              ...input,
+              prompt,
+              contextBudget,
+              promptForFiles,
+              evidenceDir,
+              authority: "shadow"
+            });
+          })();
+      executions.set(leaf.id, execution);
+      if (execution.status !== "reviewed") {
+        throw new Error(`review ensemble ${leaf.id} ended with ${execution.status}`);
+      }
+      return {
+        findings: applyRetryDegradedConfidencePenalty(
+          execution.result.findings,
+          execution.result.degradedRecovery,
+          input.config.reviewGate?.retryDegradedConfidencePenalty
+        ),
+        dropped: execution.result.droppedFromSchema,
+        runtime: execution.result.runtime
+      };
+    }
+  }).then((ensemble) => {
+    const ensembleDir = join(input.evidenceDir, "review-ensemble");
+    mkdirSync(ensembleDir, { recursive: true });
+    writeRedactedJson(join(ensembleDir, "manifest.json"), ensemble.manifest);
+    for (const receipt of ensemble.receipts) {
+      const leafDir = join(ensembleDir, "leaves", receipt.leafId);
+      mkdirSync(leafDir, { recursive: true });
+      writeRedactedJson(join(leafDir, "receipt.json"), receipt);
+    }
+    return ensemble;
+  });
+
+  try {
+    const anchor = await anchorPromise;
+    if (anchor.status !== "reviewed") {
+      await ensemblePromise.catch(() => undefined);
+      return anchor;
+    }
+    return { ...anchor, ensemblePromise };
+  } catch (error) {
+    await ensemblePromise.catch(() => undefined);
+    throw error;
+  }
+}
+
+async function runSingleReviewWithContextBudget(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  worktreePath: string;
+  prompt: string;
+  files: PullFilePatch[];
+  contextBudget: ContextBudgetPlan;
+  promptForFiles: (files: PullFilePatch[]) => string;
+  useZCode: boolean;
+  evidenceDir: string;
+  authority?: "canonical" | "shadow";
 }): Promise<ContextBudgetReviewExecution> {
   if (input.contextBudget.mode === "chunk") {
     return runChunkedZCodeReview({
@@ -3938,6 +4096,7 @@ async function runChunkedZCodeReview(input: {
   promptForFiles: (files: PullFilePatch[]) => string;
   useZCode: boolean;
   evidenceDir: string;
+  authority?: "canonical" | "shadow";
 }): Promise<ContextBudgetReviewExecution> {
   const startedAt = new Date();
   const findings: ZCodeReviewResult["findings"] = [];
@@ -3952,7 +4111,12 @@ async function runChunkedZCodeReview(input: {
     const livePull = await input.github.getPull(input.repo, input.pull.number);
     const stale = detectStalePullHead({ expected: input.pull, live: livePull, phase: "before_chunk" });
     if (stale) {
-      recordStaleHeadSkip({ state: input.state, repo: input.repo, pull: input.pull, stale, evidenceDir: input.evidenceDir });
+      if (input.authority !== "shadow") {
+        recordStaleHeadSkip({ state: input.state, repo: input.repo, pull: input.pull, stale, evidenceDir: input.evidenceDir });
+      } else {
+        mkdirSync(input.evidenceDir, { recursive: true });
+        writeRedactedJson(join(input.evidenceDir, "stale-head.json"), stale);
+      }
       return { status: "skipped_stale_head" };
     }
     const chunkDir = join(input.evidenceDir, "context-chunks", `chunk-${String(chunk.index).padStart(3, "0")}`);
@@ -3981,14 +4145,16 @@ async function runChunkedZCodeReview(input: {
         error: failure.message,
         recordedAt: new Date().toISOString()
       });
-      recordFailedReview({
-        config: input.config,
-        state: input.state,
-        repo: input.repo,
-        pull: input.pull,
-        error: failure,
-        writeErrorEvidence: false
-      });
+      if (input.authority !== "shadow") {
+        recordFailedReview({
+          config: input.config,
+          state: input.state,
+          repo: input.repo,
+          pull: input.pull,
+          error: failure,
+          writeErrorEvidence: false
+        });
+      }
       return { status: "skipped_context_budget" };
     }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1976,7 +1976,20 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     }
     assertApprovedProviderConfigCurrent();
     if (zcodeExecution.status === "skipped_stale_head") return "skipped_stale_head";
-    if (zcodeExecution.status === "skipped_context_budget") return "skipped_context_budget";
+    if (zcodeExecution.status === "skipped_context_budget") {
+      if (zcodeExecution.deferredFailure) {
+        await ensembleEvidencePromise;
+        recordFailedReview({
+          config,
+          state,
+          repo,
+          pull,
+          error: zcodeExecution.deferredFailure,
+          writeErrorEvidence: false
+        });
+      }
+      return "skipped_context_budget";
+    }
     const zcodeResult = zcodeExecution.result;
 
     assertGitClean(worktree.path);
@@ -2483,6 +2496,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         });
       }
     }
+    if (!ensembleEvidencePromise) releaseReviewCapacity();
     if (headChangedDuringPost) return "posted_stale_head";
     if (postReviewHeadLookupFailed) return "posted_head_unverified";
     if (!headChangedDuringPost && !postReviewHeadLookupFailed && input.processedHeadPolicy !== "retry_failed_head") {
@@ -3950,7 +3964,7 @@ type ContextBudgetReviewExecution = (
       status: "reviewed";
       result: ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput };
     }
-  | { status: "skipped_context_budget" }
+  | { status: "skipped_context_budget"; deferredFailure?: Error }
   | { status: "skipped_stale_head" }
 ) & {
   ensemblePromise?: Promise<ReviewEnsembleRun>;
@@ -3996,7 +4010,8 @@ async function runReviewWithContextBudget(input: {
     : Promise.resolve();
   const anchorPromise = runSingleReviewWithContextBudget({
     ...input,
-    authority: "canonical"
+    authority: "canonical",
+    deferCanonicalFailureRecord: true
   });
   const ensemblePromise = executeReviewEnsemble({
     plan,
@@ -4088,6 +4103,7 @@ async function runSingleReviewWithContextBudget(input: {
   useZCode: boolean;
   evidenceDir: string;
   authority?: "canonical" | "shadow";
+  deferCanonicalFailureRecord?: boolean;
   assertProviderConfigCurrent?: () => void;
 }): Promise<ContextBudgetReviewExecution> {
   if (input.contextBudget.mode === "chunk") {
@@ -4121,6 +4137,7 @@ async function runChunkedZCodeReview(input: {
   useZCode: boolean;
   evidenceDir: string;
   authority?: "canonical" | "shadow";
+  deferCanonicalFailureRecord?: boolean;
   assertProviderConfigCurrent?: () => void;
 }): Promise<ContextBudgetReviewExecution> {
   const startedAt = new Date();
@@ -4171,7 +4188,7 @@ async function runChunkedZCodeReview(input: {
         error: failure.message,
         recordedAt: new Date().toISOString()
       });
-      if (input.authority !== "shadow") {
+      if (input.authority !== "shadow" && !input.deferCanonicalFailureRecord) {
         recordFailedReview({
           config: input.config,
           state: input.state,
@@ -4181,7 +4198,12 @@ async function runChunkedZCodeReview(input: {
           writeErrorEvidence: false
         });
       }
-      return { status: "skipped_context_budget" };
+      return {
+        status: "skipped_context_budget",
+        ...(input.authority !== "shadow" && input.deferCanonicalFailureRecord
+          ? { deferredFailure: failure }
+          : {})
+      };
     }
 
     const allowedFilenames = new Set(chunk.filenames);

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -354,47 +354,75 @@ function buildStrictJsonRetryPrompt(originalPrompt: string): string {
   ].join("\n");
 }
 
+interface ActiveZCodeReviewPolicy {
+  users: number;
+  configDir: string;
+  configPath: string;
+  hadConfigDir: boolean;
+  originalConfig: { contents: string; mode: number } | null;
+}
+
+const activeZCodeReviewPolicies = new Map<string, ActiveZCodeReviewPolicy>();
+
 export function withTemporaryZCodeReviewPolicy<T>(cwd: string, evidenceDir: string | undefined, run: () => T): T {
   const configDir = join(cwd, ".zcode");
   const configPath = join(configDir, "config.json");
-  const hadConfigDir = existsSync(configDir);
-  const originalConfig = existsSync(configPath)
-    ? { contents: readFileSync(configPath, "utf8"), mode: statSync(configPath).mode }
-    : null;
   const policy = buildZCodeReviewPolicy();
-
-  mkdirSync(configDir, { recursive: true });
-  writeFileAtomic(configPath, `${JSON.stringify(policy, null, 2)}\n`, 0o600);
-  if (evidenceDir) {
-    mkdirSync(evidenceDir, { recursive: true });
-    writeFileAtomic(join(evidenceDir, "zcode-review-policy.json"), `${JSON.stringify(policy, null, 2)}\n`, 0o600);
+  let activePolicy = activeZCodeReviewPolicies.get(configPath);
+  if (activePolicy) {
+    activePolicy.users += 1;
+  } else {
+    activePolicy = {
+      users: 1,
+      configDir,
+      configPath,
+      hadConfigDir: existsSync(configDir),
+      originalConfig: existsSync(configPath)
+        ? { contents: readFileSync(configPath, "utf8"), mode: statSync(configPath).mode }
+        : null
+    };
+    mkdirSync(configDir, { recursive: true });
+    writeFileAtomic(configPath, `${JSON.stringify(policy, null, 2)}\n`, 0o600);
+    activeZCodeReviewPolicies.set(configPath, activePolicy);
   }
 
-  const restore = () => {
-    if (originalConfig) {
-      mkdirSync(configDir, { recursive: true });
-      writeFileAtomic(configPath, originalConfig.contents, originalConfig.mode);
-    } else {
-      rmSync(configPath, { force: true });
-      if (!hadConfigDir) {
-        try {
-          rmdirSync(configDir);
-        } catch {
-          // Leave a non-empty directory in place; the clean-worktree guard will catch it.
+  const release = () => {
+    const current = activeZCodeReviewPolicies.get(configPath);
+    if (!current) return;
+    current.users -= 1;
+    if (current.users > 0) return;
+    try {
+      if (current.originalConfig) {
+        mkdirSync(current.configDir, { recursive: true });
+        writeFileAtomic(current.configPath, current.originalConfig.contents, current.originalConfig.mode);
+      } else {
+        rmSync(current.configPath, { force: true });
+        if (!current.hadConfigDir) {
+          try {
+            rmdirSync(current.configDir);
+          } catch {
+            // Leave a non-empty directory in place; the clean-worktree guard will catch it.
+          }
         }
       }
+    } finally {
+      activeZCodeReviewPolicies.delete(configPath);
     }
   };
 
   try {
+    if (evidenceDir) {
+      mkdirSync(evidenceDir, { recursive: true });
+      writeFileAtomic(join(evidenceDir, "zcode-review-policy.json"), `${JSON.stringify(policy, null, 2)}\n`, 0o600);
+    }
     const result = run();
     if (isPromiseLike(result)) {
-      return result.finally(restore) as T;
+      return result.finally(release) as T;
     }
-    restore();
+    release();
     return result;
   } catch (error) {
-    restore();
+    release();
     throw error;
   }
 }

--- a/tests/review-ensemble.test.ts
+++ b/tests/review-ensemble.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import type { Finding, PullFilePatch } from "../src/types.js";
+import {
+  buildReviewEnsembleLeafPrompt,
+  buildReviewEnsemblePlan,
+  executeReviewEnsemble,
+  reduceReviewEnsemble,
+  type ReviewEnsembleLeafReceipt,
+  type ReviewEnsembleSubject
+} from "../src/review-ensemble.js";
+
+const subject: ReviewEnsembleSubject = {
+  repo: "owner/repo",
+  pullNumber: 42,
+  baseSha: "b".repeat(40),
+  headSha: "a".repeat(40)
+};
+
+const files: PullFilePatch[] = [
+  {
+    filename: "src/session.ts",
+    patch: "@@ -1 +1 @@\n-export const value = 1;\n+export const value = 2;"
+  }
+];
+
+const finding: Finding = {
+  severity: "P2",
+  path: "src/session.ts",
+  line: 1,
+  title: "Resume loses the active session",
+  body: "The resumed path resets state before the caller can reuse it.",
+  confidence: 0.96,
+  category: "runtime_correctness",
+  why_this_matters: "A supported resume request returns an unusable session."
+};
+
+describe("review ensemble planning", () => {
+  it("is absent by default and plans one canonical ordered team when enabled", () => {
+    expect(buildReviewEnsemblePlan({ enabled: false, mode: "shadow" })).toBeUndefined();
+
+    expect(buildReviewEnsemblePlan({ enabled: true, mode: "shadow" })).toEqual({
+      version: "review-ensemble-plan-v0.1",
+      mode: "shadow",
+      leaves: [
+        { id: "anchor", required: true },
+        { id: "state", required: true },
+        { id: "boundary", required: true },
+        { id: "failure", required: true }
+      ]
+    });
+  });
+
+  it("keeps the anchor prompt unchanged and makes specialist prompts advisory", () => {
+    const prompt = "Review this immutable diff.";
+    expect(buildReviewEnsembleLeafPrompt(prompt, "anchor")).toBe(prompt);
+
+    const statePrompt = buildReviewEnsembleLeafPrompt(prompt, "state");
+    expect(statePrompt).toContain("State and lifecycle review");
+    expect(statePrompt).toContain("Do not use tools");
+    expect(statePrompt).toContain("smallest safe fix direction");
+    expect(statePrompt).toContain(prompt);
+  });
+});
+
+describe("review ensemble execution", () => {
+  it("executes every required leaf concurrently and records one complete manifest", async () => {
+    const plan = buildReviewEnsemblePlan({ enabled: true, mode: "shadow" });
+    if (!plan) throw new Error("expected plan");
+    let active = 0;
+    let maxActive = 0;
+
+    const run = await executeReviewEnsemble({
+      plan,
+      subject,
+      startedAt: "2026-08-09T12:00:00.000Z",
+      completedAt: () => "2026-08-09T12:00:01.000Z",
+      runLeaf: async (leaf) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return { findings: [{ ...finding, title: `${finding.title} (${leaf.id})` }], dropped: [] };
+      }
+    });
+
+    expect(maxActive).toBe(4);
+    expect(run.manifest.complete).toBe(true);
+    expect(run.manifest.leaves.map((leaf) => [leaf.id, leaf.status])).toEqual([
+      ["anchor", "completed"],
+      ["state", "completed"],
+      ["boundary", "completed"],
+      ["failure", "completed"]
+    ]);
+  });
+
+  it("fails closed on required coverage while retaining successful leaf evidence", async () => {
+    const plan = buildReviewEnsemblePlan({ enabled: true, mode: "shadow" });
+    if (!plan) throw new Error("expected plan");
+
+    const run = await executeReviewEnsemble({
+      plan,
+      subject,
+      runLeaf: async (leaf) => {
+        if (leaf.id === "failure") throw new Error("provider failed for token ghp" + "_secret_value");
+        return { findings: [finding], dropped: [] };
+      }
+    });
+
+    expect(run.manifest.complete).toBe(false);
+    expect(run.manifest.leaves.find((leaf) => leaf.id === "failure")).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("[redacted-secret]")
+    });
+    expect(run.receipts).toHaveLength(4);
+    expect(run.receipts.filter((receipt) => receipt.status === "completed")).toHaveLength(3);
+  });
+});
+
+describe("review ensemble reduction", () => {
+  it("deduplicates across all lanes once and records fingerprint provenance", () => {
+    const receipts = ["failure", "anchor", "boundary", "state"].map((id) => completedReceipt(id as ReviewEnsembleLeafReceipt["leafId"], [finding]));
+
+    const packet = reduceReviewEnsemble({
+      subject,
+      files,
+      receipts,
+      generatedAt: "2026-08-09T12:00:02.000Z"
+    });
+
+    expect(packet.complete).toBe(true);
+    expect(packet.gate.comments).toHaveLength(1);
+    expect(packet.gate.dropped.filter((entry) => entry.reason === "same_run_near_duplicate")).toHaveLength(3);
+    expect(Object.values(packet.provenance)).toEqual([["anchor", "state", "boundary", "failure"]]);
+    expect(packet.postingEligible).toBe(false);
+    expect(packet.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("rejects mixed immutable subjects before reduction", () => {
+    const receipt = completedReceipt("anchor", [finding]);
+    receipt.subject = { ...subject, headSha: "c".repeat(40) };
+
+    expect(() => reduceReviewEnsemble({ subject, files, receipts: [receipt] })).toThrow(/head SHA mismatch/);
+  });
+
+  it("keeps partial results visible but incomplete when a required lens failed", () => {
+    const packet = reduceReviewEnsemble({
+      subject,
+      files,
+      receipts: [
+        completedReceipt("anchor", [finding]),
+        completedReceipt("state", []),
+        completedReceipt("boundary", []),
+        {
+          leafId: "failure",
+          required: true,
+          status: "failed",
+          subject,
+          findings: [],
+          dropped: [],
+          error: "timeout"
+        }
+      ]
+    });
+
+    expect(packet.complete).toBe(false);
+    expect(packet.gate.comments).toHaveLength(1);
+    expect(packet.postingEligible).toBe(false);
+  });
+});
+
+function completedReceipt(
+  leafId: ReviewEnsembleLeafReceipt["leafId"],
+  findings: Finding[]
+): ReviewEnsembleLeafReceipt {
+  return {
+    leafId,
+    required: true,
+    status: "completed",
+    subject,
+    findings,
+    dropped: []
+  };
+}

--- a/tests/review-ensemble.test.ts
+++ b/tests/review-ensemble.test.ts
@@ -135,6 +135,27 @@ describe("review ensemble reduction", () => {
     expect(packet.sha256).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("attributes near-duplicate lane findings to the retained gate fingerprint", () => {
+    const receipts = [
+      completedReceipt("anchor", [finding]),
+      completedReceipt("state", [{
+        ...finding,
+        line: 3,
+        title: `${finding.title} after reconnect`,
+        body: "The lifecycle lens observed the same reset through a different path."
+      }]),
+      completedReceipt("boundary", []),
+      completedReceipt("failure", [])
+    ];
+
+    const packet = reduceReviewEnsemble({ subject, files, receipts });
+
+    expect(packet.gate.comments).toHaveLength(1);
+    const retainedFingerprint = packet.gate.comments[0]!.fingerprint;
+    expect(Object.keys(packet.provenance)).toEqual([retainedFingerprint]);
+    expect(packet.provenance[retainedFingerprint]).toEqual(["anchor", "state"]);
+  });
+
   it("rejects mixed immutable subjects before reduction", () => {
     const receipt = completedReceipt("anchor", [finding]);
     receipt.subject = { ...subject, headSha: "c".repeat(40) };

--- a/tests/review-lenses.test.ts
+++ b/tests/review-lenses.test.ts
@@ -77,6 +77,29 @@ describe("review lenses config and packet safety", () => {
     expect(result.redactionReport.ok).toBe(true);
   });
 
+  it("provides bounded state, boundary, and failure specialist lenses", () => {
+    const result = buildReviewLensPacket({
+      config: reviewLensConfig({
+        active: [
+          { id: "failure", surface: "pr_shadow", mode: "shadow" },
+          { id: "state", surface: "pr_shadow", mode: "shadow" },
+          { id: "boundary", surface: "pr_shadow", mode: "shadow" }
+        ]
+      }),
+      surface: "pr_shadow",
+      generatedAt: "2026-08-09T00:00:00.000Z"
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected specialist lens packet");
+    expect(result.packet.lenses.map((lens) => lens.id)).toEqual(["boundary", "failure", "state"]);
+    expect(result.packet.markdown).toContain("State and lifecycle review");
+    expect(result.packet.markdown).toContain("Authority and integration-boundary review");
+    expect(result.packet.markdown).toContain("Failure, concurrency, and operator-truth review");
+    expect(result.packet.markdown).toContain("speculative hardening");
+    expect(result.packet.byteEstimate).toBeLessThanOrEqual(12_000);
+  });
+
   it("omits disallowed or oversized built-in lens text and redacts secret-looking text", () => {
     const result = buildReviewLensPacket({
       config: reviewLensConfig({

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -27,6 +27,26 @@ describe("review scheduler config", () => {
       overloadBackoffMaxDurationMs: 10 * 60_000,
       overloadBackoffJitterMs: 30_000
     });
+    expect(config.reviewEnsemble).toEqual({
+      enabled: false,
+      mode: "shadow"
+    });
+  });
+
+  it("loads and validates the disabled-by-default shadow ensemble", () => {
+    expect(loadConfig(writeConfig({
+      reviewEnsemble: {
+        enabled: true,
+        mode: "shadow"
+      }
+    })).reviewEnsemble).toEqual({ enabled: true, mode: "shadow" });
+
+    expect(() => loadConfig(writeConfig({ reviewEnsemble: { enabled: true, mode: "posting" } }))).toThrow(
+      /config\.reviewEnsemble\.mode must be shadow/
+    );
+    expect(() => loadConfig(writeConfig({ reviewEnsemble: { enabled: true, concurrency: 4 } }))).toThrow(
+      /config\.reviewEnsemble has unknown key/
+    );
   });
 
   it("rejects scheduler settings that cannot preserve manual reserve capacity", () => {

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -566,6 +566,46 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("releases ordinary review capacity before direct-review status reconciliation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-capacity-before-reconcile-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewStatusComment = { enabled: true };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(425, "4".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Canonical finding")]);
+    let reconciliationLease: ReturnType<ReviewStateStore["tryAcquireReviewRunLease"]>;
+    const github = {
+      getPull: async () => pull,
+      listPullFiles: async () => files,
+      canPostAsApp: () => true,
+      createReview: async (input: typeof createdReviews[number]) => {
+        createdReviews.push(input);
+        return { html_url: `https://github.test/review/${createdReviews.length}`, id: createdReviews.length };
+      },
+      upsertIssueComment: async () => {
+        reconciliationLease = state.tryAcquireReviewRunLease(1, 60_000);
+        return { action: "created" as const, html_url: "https://github.test/comment/1", id: 1 };
+      }
+    } as unknown as GitHubApi;
+
+    const result = await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    expect(reconciliationLease).toBeDefined();
+    if (reconciliationLease) state.releaseReviewRunLease(reconciliationLease.leaseId);
+    state.close();
+  });
+
   it("finishes canonical self-consistency before starting advisory leaves", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-self-consistency-priority-"));
     roots.push(root);
@@ -675,6 +715,65 @@ describe("worker context budget preflight", () => {
     expect(JSON.parse(readFileSync(join(ensembleDir, "shadow-packet.json"), "utf8"))).toMatchObject({
       complete: false,
       postingEligible: false
+    });
+    state.close();
+  });
+
+  it("defers retry admission until chunk-failure shadow evidence settles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-anchor-claim-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    config.reviewGate = { maxInlineComments: 25, selfConsistency: { enabled: true } };
+    config.contextBudget = {
+      enabled: true,
+      overflow: "chunk",
+      reservedOutputTokens: 50,
+      charsPerToken: 1,
+      providerFudgeFactor: 1,
+      maxChunks: 5
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(429, "1".repeat(40));
+    const files = [pullFile("src/a.ts", 5_000), pullFile("src/b.ts", 5_000)];
+    const largestSinglePromptLength = Math.max(...files.map((entry) => reviewPromptLength(config, pull, [entry])));
+    config.providers!.providers["zcode-glm"]!.contextWindowTokens = largestSinglePromptLength + config.contextBudget.reservedOutputTokens + 2_000;
+    zcodeFirstFailuresByPath.set("src/a.ts", { message: "anchor provider failure" });
+    let releaseSpecialist: (() => void) | undefined;
+    zcodeBarriersByPath.set("State and lifecycle review", new Promise<void>((resolve) => {
+      releaseSpecialist = resolve;
+    }));
+
+    const review = reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+    await vi.waitFor(() => {
+      expect(zcodePrompts.some((prompt) => prompt.includes("State and lifecycle review"))).toBe(true);
+    });
+
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toBeUndefined();
+    expect(await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      processedHeadPolicy: "retry_failed_head"
+    })).toBe("skipped_processed");
+
+    releaseSpecialist?.();
+    expect(await review).toBe("skipped_context_budget");
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("context_budget_chunk_provider_failure")
     });
     state.close();
   });

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -9,8 +9,10 @@ import type { Finding, PullRequestSummary } from "../src/types.js";
 import { testLicenseAdmission } from "./helpers/license-admission.js";
 
 const zcodePrompts = vi.hoisted((): string[] => []);
+const zcodeCompletedPrompts = vi.hoisted((): string[] => []);
 const zcodeFindingsByPath = vi.hoisted(() => new Map<string, Finding[]>());
 const zcodeFailuresByPath = vi.hoisted(() => new Map<string, string>());
+const zcodeDelaysByPath = vi.hoisted(() => new Map<string, number>());
 const createdReviews = vi.hoisted((): Array<{
   repo: string;
   pullNumber: number;
@@ -44,13 +46,16 @@ vi.mock("../src/zcode.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/zcode.js")>();
   return {
     ...actual,
-    runZCodeReview: vi.fn((input: { prompt: string }) => {
+    runZCodeReview: vi.fn(async (input: { prompt: string }) => {
       zcodePrompts.push(input.prompt);
+      const delay = [...zcodeDelaysByPath.entries()].find(([path]) => input.prompt.includes(path));
+      if (delay) await new Promise((resolve) => setTimeout(resolve, delay[1]));
       const failure = [...zcodeFailuresByPath.entries()].find(([path]) => input.prompt.includes(path));
       if (failure) throw new Error(failure[1]);
       const findings = [...zcodeFindingsByPath.entries()]
         .filter(([path]) => input.prompt.includes(path))
         .flatMap(([, entries]) => entries);
+      zcodeCompletedPrompts.push(input.prompt);
       return {
         findings,
         droppedFromSchema: [],
@@ -143,8 +148,10 @@ describe("worker context budget preflight", () => {
 
   afterEach(() => {
     zcodePrompts.length = 0;
+    zcodeCompletedPrompts.length = 0;
     zcodeFindingsByPath.clear();
     zcodeFailuresByPath.clear();
+    zcodeDelaysByPath.clear();
     createdReviews.length = 0;
     walkthroughBuildEvents.length = 0;
     delete reviewPostControl.error;
@@ -411,6 +418,175 @@ describe("worker context budget preflight", () => {
       status: "posted",
       reviewUrl: `https://github.com/electricsheephq/WorldOS/pull/${pull.number}#pullrequestreview-1`
     });
+    state.close();
+  });
+
+  it("runs the enabled shadow ensemble without changing the canonical posted review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-shadow-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(421, "9".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Anchor finding")]);
+    zcodeFindingsByPath.set("State and lifecycle review", [finding("src/a.ts", "State-only finding")]);
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    expect(zcodePrompts).toHaveLength(4);
+    expect(zcodePrompts.filter((prompt) => prompt.includes("State and lifecycle review"))).toHaveLength(1);
+    expect(zcodePrompts.filter((prompt) => prompt.includes("Authority and integration-boundary review"))).toHaveLength(1);
+    expect(zcodePrompts.filter((prompt) => prompt.includes("Failure, concurrency, and operator-truth review"))).toHaveLength(1);
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]?.comments.map((comment) => comment.title)).toEqual(["Anchor finding"]);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({ status: "posted" });
+
+    const ensembleDir = join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha,
+      "review-ensemble"
+    );
+    expect(JSON.parse(readFileSync(join(ensembleDir, "manifest.json"), "utf8"))).toMatchObject({
+      complete: true,
+      subject: { repo: "electricsheephq/WorldOS", pullNumber: pull.number, headSha: pull.head.sha }
+    });
+    expect(JSON.parse(readFileSync(join(ensembleDir, "shadow-packet.json"), "utf8"))).toMatchObject({
+      complete: true,
+      postingEligible: false,
+      gate: { comments: expect.arrayContaining([expect.objectContaining({ title: "State-only finding" })]) }
+    });
+    state.close();
+  });
+
+  it("keeps a specialist failure out of canonical processed state", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-partial-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(423, "6".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Canonical finding")]);
+    zcodeFailuresByPath.set("Failure, concurrency, and operator-truth review", "specialist provider failed");
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]?.comments.map((comment) => comment.title)).toEqual(["Canonical finding"]);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({ status: "posted" });
+    const ensembleDir = join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha,
+      "review-ensemble"
+    );
+    expect(JSON.parse(readFileSync(join(ensembleDir, "manifest.json"), "utf8"))).toMatchObject({
+      complete: false,
+      leaves: expect.arrayContaining([
+        expect.objectContaining({ id: "failure", status: "failed", error: "specialist provider failed" })
+      ])
+    });
+    expect(JSON.parse(readFileSync(join(ensembleDir, "shadow-packet.json"), "utf8"))).toMatchObject({
+      complete: false,
+      postingEligible: false
+    });
+    state.close();
+  });
+
+  it("posts the canonical anchor before a slow specialist settles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-slow-shadow-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(424, "5".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Canonical before shadow")]);
+    zcodeDelaysByPath.set("State and lifecycle review", 100);
+    reviewPostControl.afterCreate = () => {
+      expect(zcodeCompletedPrompts.some((prompt) => prompt.includes("State and lifecycle review"))).toBe(false);
+    };
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    expect(createdReviews).toHaveLength(1);
+    expect(zcodeCompletedPrompts.some((prompt) => prompt.includes("State and lifecycle review"))).toBe(true);
+    state.close();
+  });
+
+  it("applies every ensemble lens to every context chunk while retaining one canonical post", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-chunk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    config.contextBudget = {
+      enabled: true,
+      overflow: "chunk",
+      reservedOutputTokens: 50,
+      charsPerToken: 1,
+      providerFudgeFactor: 1,
+      maxChunks: 5
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(422, "7".repeat(40));
+    const files = [pullFile("src/a.ts", 5_000), pullFile("src/b.ts", 5_000)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Chunk anchor finding")]);
+    const largestSinglePromptLength = Math.max(...files.map((entry) => reviewPromptLength(config, pull, [entry])));
+    config.providers!.providers["zcode-glm"]!.contextWindowTokens = largestSinglePromptLength + config.contextBudget.reservedOutputTokens + 2_000;
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    expect(zcodePrompts).toHaveLength(8);
+    expect(zcodePrompts.filter((prompt) => prompt.includes("State and lifecycle review"))).toHaveLength(2);
+    expect(zcodePrompts.filter((prompt) => prompt.includes("Authority and integration-boundary review"))).toHaveLength(2);
+    expect(zcodePrompts.filter((prompt) => prompt.includes("Failure, concurrency, and operator-truth review"))).toHaveLength(2);
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]?.comments.map((comment) => comment.title)).toEqual(["Chunk anchor finding"]);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({ status: "posted" });
     state.close();
   });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +13,8 @@ const zcodeCompletedPrompts = vi.hoisted((): string[] => []);
 const zcodeFindingsByPath = vi.hoisted(() => new Map<string, Finding[]>());
 const zcodeFailuresByPath = vi.hoisted(() => new Map<string, string>());
 const zcodeDelaysByPath = vi.hoisted(() => new Map<string, number>());
+const zcodeBarriersByPath = vi.hoisted(() => new Map<string, Promise<void>>());
+const zcodeFirstFailuresByPath = vi.hoisted(() => new Map<string, { message: string; beforeThrow?: () => void }>());
 const createdReviews = vi.hoisted((): Array<{
   repo: string;
   pullNumber: number;
@@ -50,6 +52,14 @@ vi.mock("../src/zcode.js", async (importOriginal) => {
       zcodePrompts.push(input.prompt);
       const delay = [...zcodeDelaysByPath.entries()].find(([path]) => input.prompt.includes(path));
       if (delay) await new Promise((resolve) => setTimeout(resolve, delay[1]));
+      const barrier = [...zcodeBarriersByPath.entries()].find(([path]) => input.prompt.includes(path));
+      if (barrier) await barrier[1];
+      const firstFailure = [...zcodeFirstFailuresByPath.entries()].find(([path]) => input.prompt.includes(path));
+      if (firstFailure) {
+        zcodeFirstFailuresByPath.delete(firstFailure[0]);
+        firstFailure[1].beforeThrow?.();
+        throw new Error(firstFailure[1].message);
+      }
       const failure = [...zcodeFailuresByPath.entries()].find(([path]) => input.prompt.includes(path));
       if (failure) throw new Error(failure[1]);
       const findings = [...zcodeFindingsByPath.entries()]
@@ -127,6 +137,7 @@ vi.mock("../src/walkthrough.js", async (importOriginal) => {
 
 const {
   localDateFolder,
+  buildReviewApprovalRevision,
   prepareFailedHeadRetry,
   recoverPostedReviewReceipt,
   recoverPostedReviewReceiptForCurrentHead,
@@ -152,6 +163,8 @@ describe("worker context budget preflight", () => {
     zcodeFindingsByPath.clear();
     zcodeFailuresByPath.clear();
     zcodeDelaysByPath.clear();
+    zcodeBarriersByPath.clear();
+    zcodeFirstFailuresByPath.clear();
     createdReviews.length = 0;
     walkthroughBuildEvents.length = 0;
     delete reviewPostControl.error;
@@ -528,9 +541,13 @@ describe("worker context budget preflight", () => {
     const pull = pullSummary(424, "5".repeat(40));
     const files = [pullFile("src/a.ts", 200)];
     zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Canonical before shadow")]);
-    zcodeDelaysByPath.set("State and lifecycle review", 100);
+    let releaseSpecialist: (() => void) | undefined;
+    zcodeBarriersByPath.set("State and lifecycle review", new Promise<void>((resolve) => {
+      releaseSpecialist = resolve;
+    }));
     reviewPostControl.afterCreate = () => {
       expect(zcodeCompletedPrompts.some((prompt) => prompt.includes("State and lifecycle review"))).toBe(false);
+      releaseSpecialist?.();
     };
 
     const result = await reviewPull({
@@ -546,6 +563,119 @@ describe("worker context budget preflight", () => {
     expect(result).toBe("reviewed");
     expect(createdReviews).toHaveLength(1);
     expect(zcodeCompletedPrompts.some((prompt) => prompt.includes("State and lifecycle review"))).toBe(true);
+    state.close();
+  });
+
+  it("finishes canonical self-consistency before starting advisory leaves", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-self-consistency-priority-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    config.reviewGate = { maxInlineComments: 25, selfConsistency: { enabled: true } };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(426, "4".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFindingsByPath.set("src/a.ts", [p1Finding("src/a.ts", "Canonical blocking finding")]);
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    const selfConsistencyIndex = zcodePrompts.findIndex((prompt) => prompt.includes("re-checking a SINGLE prior"));
+    const firstShadowIndex = zcodePrompts.findIndex((prompt) => prompt.includes("State and lifecycle review"));
+    expect(selfConsistencyIndex).toBeGreaterThan(0);
+    expect(firstShadowIndex).toBeGreaterThan(selfConsistencyIndex);
+    state.close();
+  });
+
+  it("rechecks the approved provider revision before an ensemble retry", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-provider-revision-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    const appConfigPath = join(root, "zcode-app.json");
+    writeFileSync(appConfigPath, "{\"provider\":\"one\"}\n");
+    config.zcode.appConfigPath = appConfigPath;
+    const sourceConfigRevision = "f".repeat(64);
+    const approvedRevision = buildReviewApprovalRevision({
+      configRevision: sourceConfigRevision,
+      useZCode: true,
+      zcodeAppConfigPath: appConfigPath
+    })!;
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(427, "3".repeat(40));
+    const files = [pullFile("src/a.ts", 200)];
+    zcodeFirstFailuresByPath.set("src/a.ts", {
+      message: "provider temporarily overloaded",
+      beforeThrow: () => writeFileSync(appConfigPath, "{\"provider\":\"two\"}\n")
+    });
+
+    await expect(reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      configRevision: approvedRevision,
+      sourceConfigRevision
+    })).rejects.toThrow("review-pr provider configuration changed; run a new dry review before posting");
+    expect(createdReviews).toHaveLength(0);
+    state.close();
+  });
+
+  it("writes a shadow packet when a chunked anchor aborts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-anchor-abort-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.reviewEnsemble = { enabled: true, mode: "shadow" };
+    config.contextBudget = {
+      enabled: true,
+      overflow: "chunk",
+      reservedOutputTokens: 50,
+      charsPerToken: 1,
+      providerFudgeFactor: 1,
+      maxChunks: 5
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(428, "2".repeat(40));
+    const files = [pullFile("src/a.ts", 5_000), pullFile("src/b.ts", 5_000)];
+    const largestSinglePromptLength = Math.max(...files.map((entry) => reviewPromptLength(config, pull, [entry])));
+    config.providers!.providers["zcode-glm"]!.contextWindowTokens = largestSinglePromptLength + config.contextBudget.reservedOutputTokens + 2_000;
+    zcodeFailuresByPath.set("src/a.ts", "anchor provider failure");
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true
+    });
+
+    expect(result).toBe("skipped_context_budget");
+    const ensembleDir = join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      `pr-${pull.number}`,
+      pull.head.sha,
+      "review-ensemble"
+    );
+    expect(JSON.parse(readFileSync(join(ensembleDir, "shadow-packet.json"), "utf8"))).toMatchObject({
+      complete: false,
+      postingEligible: false
+    });
     state.close();
   });
 

--- a/tests/zcode-policy.test.ts
+++ b/tests/zcode-policy.test.ts
@@ -82,4 +82,30 @@ describe("temporary ZCode review policy", () => {
 
     expect(readFileSync(configPath, "utf8")).toBe("{\"features\":{\"subagent\":true}}\n");
   });
+
+  it("keeps one shared policy installed until concurrent runs have all settled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "zcode-policy-concurrent-"));
+    roots.push(root);
+    const configDir = join(root, ".zcode");
+    const configPath = join(configDir, "config.json");
+    mkdirSync(configDir);
+    writeFileSync(configPath, "{\"features\":{\"subagent\":true}}\n");
+
+    let releaseFirst: (() => void) | undefined;
+    const first = withTemporaryZCodeReviewPolicy(root, undefined, async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      expect(readFileSync(configPath, "utf8")).toContain("\"Bash\"");
+    });
+    const second = withTemporaryZCodeReviewPolicy(root, undefined, async () => {
+      expect(readFileSync(configPath, "utf8")).toContain("\"Bash\"");
+    });
+
+    await second;
+    expect(readFileSync(configPath, "utf8")).toContain("\"Bash\"");
+    releaseFirst?.();
+    await first;
+    expect(readFileSync(configPath, "utf8")).toBe("{\"features\":{\"subagent\":true}}\n");
+  });
 });


### PR DESCRIPTION
Closes #735

## What changed

- adds a default-off `reviewEnsemble` shadow mode with one unchanged canonical anchor plus state, boundary, and failure specialists
- runs the four full-subject lanes concurrently while preserving one parent queue job, lease, exact-head claim, processed-review row, and GitHub posting authority
- retains lens focus across context-budget chunks and plans each specialist against its own prompt size
- writes isolated leaf receipts, a manifest, runtime evidence, global deduplication/provenance, and a `postingEligible: false` shadow packet
- keeps slow or failed specialists off the canonical posting critical path while holding parent capacity until evidence settles
- documents activation cost and safety boundaries

## Why

The controlled retrospective found that Luna XHigh generic plus focused state/boundary/failure passes recovered 10/11 verified bug clusters at materially lower supplied-rate cost than Sol High. This change adds the smallest default-off production-shaped shadow path needed to validate that route on fresh PRs without changing live review output.

## Validation

- `npm run build`
- 90 focused tests passed across worker context budgets, ensemble reduction, config, and lens behavior
- full repository suite: 2,457 passed; 3 environment/pre-existing failures
  - Keychain CLI test exceeded its 5-second timeout and passed alone with a 15-second timeout
  - desktop manifest test binary was not built locally
  - service-local TypeScript dependency was not installed
- independent semantic review plus one delta-only pass: initial canonical-delay finding fixed; final delta clean at 99% reviewer confidence
- `git diff --check`
- `config.example.json` loads with `reviewEnsemble.enabled=false`

## Proof boundary

This PR is source-only and default-off. It does not change the installed config, launchd worker, live database, GitHub review behavior, release, billing, or customer readiness.

The fresh five-PR Wave A canary attempted to start from isolated state/evidence but stopped before PR fetch/provider execution because the production license API returned HTTP 402 `expired`. No GitHub post or provider spend occurred. Live activation remains blocked on a valid license and a successful isolated canary.
