### PR TITLE
Allow desktop patches for the shadow review ensemble

### DIFF
--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -47,6 +47,8 @@ const EXACT_PATCH_PATHS = new Set([
   "canaryPulls",
   "reviewConcurrency.maxActiveRuns",
   "reviewConcurrency.leaseTtlMs",
+  "reviewEnsemble.enabled",
+  "reviewEnsemble.mode",
   "worktreeCleanup.enabled",
   "worktreeCleanup.retentionMs",
   "worktreeCleanup.intervalMs",

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -486,6 +486,10 @@ describe("desktop config CLI", () => {
         maxActiveRuns: 2,
         leaseTtlMs: 600_000
       },
+      reviewEnsemble: {
+        enabled: true,
+        mode: "shadow"
+      },
       worktreeCleanup: {
         enabled: true,
         retentionMs: 7_200_000,
@@ -528,6 +532,8 @@ describe("desktop config CLI", () => {
         "skipDrafts",
         "reviewConcurrency.maxActiveRuns",
         "reviewConcurrency.leaseTtlMs",
+        "reviewEnsemble.enabled",
+        "reviewEnsemble.mode",
         "worktreeCleanup.enabled",
         "worktreeCleanup.retentionMs",
         "worktreeCleanup.intervalMs",


### PR DESCRIPTION
## Summary

- allow the desktop-safe config patcher to edit `reviewEnsemble.enabled`
- allow the only valid mode, `reviewEnsemble.mode = shadow`
- extend the existing control-center config test

## Why

The beta43 shadow activation validated the new config schema but the supported config editor did not expose these two paths, forcing an exact guarded file edit. This closes that narrow operator-path gap and provides the first organic beta43 shadow-ensemble canary for #735.

## Proof

- `npm test -- --run tests/config-cli.test.ts` (25 passed)
- `npm run build`
- `git diff --check`

## Boundaries

This PR does not change the default-off ensemble state, review concurrency, model routing, scheduler authority, posting policy, release state, or customer readiness.
