### PR TITLE
Fix worktree cleanup scheduling by elapsed time

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2369,7 +2369,8 @@ async function main(): Promise<void> {
         enabled: config.worktreeCleanup!.enabled,
         intervalMs: config.worktreeCleanup!.intervalMs,
         nextCleanupAtMs: nextWorktreeCleanupAtMs,
-        nowMs: performance.now()
+        nowMs: performance.now(),
+        runOnce
       });
       nextWorktreeCleanupAtMs = worktreeCleanupSchedule.nextCleanupAtMs;
       const cycleResult = await runDaemonCycle({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,11 @@ import { fileURLToPath } from "node:url";
 import { loadConfig, validateLicenseConfigOverride, type BotConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { collectProviderThrottleReport } from "./provider-throttle-report.js";
-import { runDaemonCycle, shouldExitDaemonAfterFailedCycle } from "./daemon.js";
+import {
+  advanceWorktreeCleanupDeadline,
+  runDaemonCycle,
+  shouldExitDaemonAfterFailedCycle
+} from "./daemon.js";
 import {
   runLaunchdControlCommand,
   type LaunchctlResult
@@ -2356,11 +2360,18 @@ async function main(): Promise<void> {
     const config = loadConfig(args.config);
     const monitoredRepos = listReposToScan(config);
     let cycle = 0;
+    let nextWorktreeCleanupAtMs = performance.now() + config.worktreeCleanup!.intervalMs;
     const runOnce = args.once === "true";
     for (;;) {
       cycle += 1;
       const dryRun = args["dry-run"] !== "false";
-      const cleanupIntervalCycles = Math.max(1, Math.ceil(config.worktreeCleanup!.intervalMs / config.pollIntervalMs));
+      const worktreeCleanupSchedule = advanceWorktreeCleanupDeadline({
+        enabled: config.worktreeCleanup!.enabled,
+        intervalMs: config.worktreeCleanup!.intervalMs,
+        nextCleanupAtMs: nextWorktreeCleanupAtMs,
+        nowMs: performance.now()
+      });
+      nextWorktreeCleanupAtMs = worktreeCleanupSchedule.nextCleanupAtMs;
       const cycleResult = await runDaemonCycle({
         cycle,
         dryRun,
@@ -2370,7 +2381,7 @@ async function main(): Promise<void> {
         commandsEnabled: config.commands.enabled,
         reviewSchedulerEnabled: config.reviewScheduler?.enabled === true,
         issueEnrichmentEnabled: config.issueEnrichment?.enabled === true,
-        worktreeCleanupDue: config.worktreeCleanup!.enabled && (cycle === 1 || (cycle - 1) % cleanupIntervalCycles === 0),
+        worktreeCleanupDue: worktreeCleanupSchedule.due,
         configPath: args.config
       });
       if (shouldExitDaemonAfterFailedCycle(cycleResult, runOnce)) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -33,8 +33,12 @@ export function advanceWorktreeCleanupDeadline(input: {
   intervalMs: number;
   nextCleanupAtMs: number;
   nowMs: number;
+  runOnce?: boolean;
 }): { due: boolean; nextCleanupAtMs: number } {
-  if (!input.enabled || input.nowMs < input.nextCleanupAtMs) {
+  if (!input.enabled) {
+    return { due: false, nextCleanupAtMs: input.nextCleanupAtMs };
+  }
+  if (!input.runOnce && input.nowMs < input.nextCleanupAtMs) {
     return { due: false, nextCleanupAtMs: input.nextCleanupAtMs };
   }
   return {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -28,6 +28,21 @@ export function shouldExitDaemonAfterFailedCycle(result: DaemonCycleResult, runO
   return !result.ok && (runOnce || result.failureKind === "admission_denied");
 }
 
+export function advanceWorktreeCleanupDeadline(input: {
+  enabled: boolean;
+  intervalMs: number;
+  nextCleanupAtMs: number;
+  nowMs: number;
+}): { due: boolean; nextCleanupAtMs: number } {
+  if (!input.enabled || input.nowMs < input.nextCleanupAtMs) {
+    return { due: false, nextCleanupAtMs: input.nextCleanupAtMs };
+  }
+  return {
+    due: true,
+    nextCleanupAtMs: input.nowMs + input.intervalMs
+  };
+}
+
 export interface RunDaemonCycleOptions {
   cycle: number;
   dryRun: boolean;

--- a/tests/worktree-cleanup-schedule.test.ts
+++ b/tests/worktree-cleanup-schedule.test.ts
@@ -68,4 +68,14 @@ describe("worktree cleanup elapsed-time scheduling", () => {
       nowMs: 2 * INTERVAL_MS
     })).toEqual({ due: false, nextCleanupAtMs: INTERVAL_MS });
   });
+
+  it("preserves cleanup for the documented one-shot daemon path", () => {
+    expect(advanceWorktreeCleanupDeadline({
+      enabled: true,
+      intervalMs: INTERVAL_MS,
+      nextCleanupAtMs: INTERVAL_MS,
+      nowMs: 0,
+      runOnce: true
+    })).toEqual({ due: true, nextCleanupAtMs: INTERVAL_MS });
+  });
 });

--- a/tests/worktree-cleanup-schedule.test.ts
+++ b/tests/worktree-cleanup-schedule.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { advanceWorktreeCleanupDeadline } from "../src/daemon.js";
+
+const INTERVAL_MS = 30 * 60_000;
+
+describe("worktree cleanup elapsed-time scheduling", () => {
+  it("uses the configured elapsed deadline across fast and slow daemon cycles", () => {
+    let nextCleanupAtMs = INTERVAL_MS;
+
+    for (const nowMs of [0, 10_000, 60_000, INTERVAL_MS - 1]) {
+      const result = advanceWorktreeCleanupDeadline({
+        enabled: true,
+        intervalMs: INTERVAL_MS,
+        nextCleanupAtMs,
+        nowMs
+      });
+      expect(result.due).toBe(false);
+      nextCleanupAtMs = result.nextCleanupAtMs;
+    }
+
+    const boundary = advanceWorktreeCleanupDeadline({
+      enabled: true,
+      intervalMs: INTERVAL_MS,
+      nextCleanupAtMs,
+      nowMs: INTERVAL_MS
+    });
+    expect(boundary).toEqual({ due: true, nextCleanupAtMs: 2 * INTERVAL_MS });
+
+    const slowCycle = advanceWorktreeCleanupDeadline({
+      enabled: true,
+      intervalMs: INTERVAL_MS,
+      nextCleanupAtMs: INTERVAL_MS,
+      nowMs: 2 * INTERVAL_MS + 5 * 60_000
+    });
+    expect(slowCycle).toEqual({
+      due: true,
+      nextCleanupAtMs: 3 * INTERVAL_MS + 5 * 60_000
+    });
+  });
+
+  it("initializes restart timing without an immediate cleanup storm or indefinite postponement", () => {
+    const restartedAtMs = 50_000;
+    const nextCleanupAtMs = restartedAtMs + INTERVAL_MS;
+
+    expect(advanceWorktreeCleanupDeadline({
+      enabled: true,
+      intervalMs: INTERVAL_MS,
+      nextCleanupAtMs,
+      nowMs: restartedAtMs
+    }).due).toBe(false);
+
+    expect(advanceWorktreeCleanupDeadline({
+      enabled: true,
+      intervalMs: INTERVAL_MS,
+      nextCleanupAtMs,
+      nowMs: nextCleanupAtMs
+    })).toEqual({
+      due: true,
+      nextCleanupAtMs: nextCleanupAtMs + INTERVAL_MS
+    });
+  });
+
+  it("stays disabled without consuming or moving the stored deadline", () => {
+    expect(advanceWorktreeCleanupDeadline({
+      enabled: false,
+      intervalMs: INTERVAL_MS,
+      nextCleanupAtMs: INTERVAL_MS,
+      nowMs: 2 * INTERVAL_MS
+    })).toEqual({ due: false, nextCleanupAtMs: INTERVAL_MS });
+  });
+});


### PR DESCRIPTION
Closes #739
Related: #738

## What changed

- Replace daemon-cycle-derived worktree cleanup timing with one monotonic elapsed-time deadline.
- Initialize the deadline one configured interval after daemon start, avoiding restart cleanup storms while guaranteeing the next eligible cycle runs cleanup after the interval.
- Reschedule from the actual due cycle so long cycles do not trigger catch-up cleanup bursts.
- Add focused fast-cycle, slow-cycle, exact-boundary, restart, and disabled-state tests.

## Root cause

The daemon divided `worktreeCleanup.intervalMs` by `pollIntervalMs` and treated that as a cycle count. A cycle includes scanning all monitored repositories, so real cycle duration can be much longer than the poll delay and a 30-minute interval can stretch into hours.

## Validation

- Failing first: `npx vitest run tests/worktree-cleanup-schedule.test.ts` — 3/3 failed before implementation because elapsed-deadline scheduling did not exist.
- `npx vitest run tests/worktree-cleanup-schedule.test.ts tests/daemon-loop.test.ts tests/worktree-cleanup.test.ts` — 37 passed.
- `npm run build` — passed.
- `git diff --check` — passed.

Exact base: `1a2f08a336d3bbcc1b6d0934db58b933d1980206`

Initial head: `10c8389`

## Safety and proof boundary

The existing retention floor, active-review suppression, active-head/open-handle checks, clean-state checks, exact-head/path integrity, symlink handling, and fail-closed deletion behavior are unchanged and covered by the focused cleanup suite.

This is an agent-authored source change. It does not merge or release code, restart launchd, modify installed config, delete logs or worktrees, prove installed-runtime adoption, or establish customer readiness.
