### PR TITLE
fix: separate current operator health from history

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -27,9 +27,11 @@ evaos-review-bot status --config config.local.json
   recent unrecovered review failure is actionable, `amber` when current gates
   pass but retained failure history exists, and `green` when current gates pass
   without recorded review or queue failure history. The recent-failure window
-  is 24 hours. All-time counts and last-failure timestamps remain visible;
-  later clean posted outcomes recover an older failure without deleting or
-  rewriting its audit row. Malformed timestamps fail closed as recent.
+  is 24 hours. Retained historical counts and last-failure timestamps remain
+  visible; a later clean posted outcome for the same PR can classify an older
+  retained row as recovered. The existing same-head retry replacement behavior
+  is unchanged, so these fields are not an append-only attempt ledger.
+  Malformed timestamps fail closed as recent.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
   budget status, leases, heartbeat, and bot-owned process rows. It can classify

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -22,7 +22,14 @@ evaos-review-bot status --config config.local.json
 
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
-  durable queue counts, and recommended actions.
+  durable queue counts, and recommended actions. JSON is the default; use
+  `--human` for a compact explanation. Health is `red` when a current gate or a
+  recent unrecovered review failure is actionable, `amber` when current gates
+  pass but retained failure history exists, and `green` when current gates pass
+  without recorded review or queue failure history. The recent-failure window
+  is 24 hours. All-time counts and last-failure timestamps remain visible;
+  later clean posted outcomes recover an older failure without deleting or
+  rewriting its audit row. Malformed timestamps fail closed as recent.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
   budget status, leases, heartbeat, and bot-owned process rows. It can classify

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2199,7 +2199,7 @@ async function main(): Promise<void> {
         now: checkedAt
       });
       const retainedFailedQueueJobs = durableQueue.summary.failed;
-      const failedQueueJobs = resolveActiveFailedQueueJobCount(release, retainedFailedQueueJobs);
+      const failedQueueJobs = resolveActiveFailedQueueJobCount(release, retainedFailedQueueJobs, args.repo);
       const retryableProviderDeferred = durableQueue.summary.retryableProviderDeferred;
       const readyToRetry = budget.providerDeferred.readyToRetry;
       const activeProviderCooldownCount = activeProviderCooldowns.length;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2192,7 +2192,14 @@ async function main(): Promise<void> {
         includeDetails: false,
         inputJobLimit: durableQueue.jobs.length + activeProviderCooldowns.length
       });
-      const failedQueueJobs = durableQueue.summary.failed;
+      const release = collectReleaseStatus({
+        cwd: process.cwd(),
+        configPath: args.config,
+        statePath,
+        now: checkedAt
+      });
+      const retainedFailedQueueJobs = durableQueue.summary.failed;
+      const failedQueueJobs = resolveActiveFailedQueueJobCount(release, retainedFailedQueueJobs);
       const retryableProviderDeferred = durableQueue.summary.retryableProviderDeferred;
       const readyToRetry = budget.providerDeferred.readyToRetry;
       const activeProviderCooldownCount = activeProviderCooldowns.length;
@@ -2205,7 +2212,9 @@ async function main(): Promise<void> {
         {
           name: "provider_cooldowns_no_failed_queue_jobs",
           ok: failedQueueJobs === 0,
-          detail: `${failedQueueJobs} failed durable queue job(s)`
+          detail: failedQueueJobs === retainedFailedQueueJobs
+            ? `${failedQueueJobs} failed durable queue job(s)`
+            : `${failedQueueJobs} active failed durable queue job(s); ${retainedFailedQueueJobs} retained history`
         },
         {
           name: "provider_cooldowns_no_retryable_provider_deferred_jobs",
@@ -2231,6 +2240,7 @@ async function main(): Promise<void> {
           total: rows.length,
           expired: expiredCount,
           failedQueueJobs,
+          retainedFailedQueueJobs,
           providerDeferredJobs: durableQueue.summary.providerDeferred,
           retryableProviderDeferredJobs: retryableProviderDeferred,
           readyToRetryProviderDeferredJobs: readyToRetry,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,6 +97,7 @@ import {
   collectOperatorReviewQueue,
   explainPullStatus,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorDurableQueueSnapshot,
@@ -698,7 +699,7 @@ async function main(): Promise<void> {
       }),
       issueEnrichmentRuntime
     });
-    console.log(stringifyRedactedJson(status));
+    console.log(args.human === "true" ? formatOperatorStatusHuman(status) : stringifyRedactedJson(status));
     if (!status.ok) process.exitCode = 1;
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,7 @@ import {
   formatOperatorDashboardHuman,
   formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
+  resolveActiveFailedQueueJobCount,
   summarizeAgentInventory,
   type OperatorDurableQueueSnapshot,
   type OperatorQueueSnapshot
@@ -574,7 +575,7 @@ async function main(): Promise<void> {
       budgetJobLimit
     });
     const readyToRetry = status.budget?.providerDeferred.readyToRetry ?? 0;
-    const failed = status.database.failedReviewQueueJobCount ?? 0;
+    const failed = resolveActiveFailedQueueJobCount(status);
     const ok = status.budget?.enabled === true &&
       status.budget.details.inputJobsTruncated !== true &&
       readyToRetry === 0 &&

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1889,8 +1889,13 @@ function zcodeTimeoutRecommendedActions(
 
 export function resolveActiveFailedQueueJobCount(
   release: ReleaseStatus,
-  fallback = 0
+  fallback = 0,
+  repo?: string
 ): number {
+  if (repo) {
+    const repoQueue = release.database.reviewQueueJobsByRepo?.find((entry) => entry.repo === repo);
+    return repoQueue?.activeFailed ?? repoQueue?.failed ?? fallback;
+  }
   return release.database.activeFailedReviewQueueJobCount ??
     release.database.failedReviewQueueJobCount ??
     fallback;

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1858,14 +1858,25 @@ function zcodeTimeoutRecommendedActions(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
 ): string[] {
-  const retainedFailedQueueJobs = release.database.failedReviewQueueJobCount;
-  const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount;
+  const retainedTimeoutJobs = release.database.zcodeTimeoutFailedReviewQueueJobCount;
+  const activeTimeoutJobs = release.database.activeZCodeTimeoutFailedReviewQueueJobCount;
   if (
-    retainedFailedQueueJobs !== undefined &&
-    activeFailedQueueJobs !== undefined &&
-    activeFailedQueueJobs < retainedFailedQueueJobs
+    retainedTimeoutJobs !== undefined &&
+    activeTimeoutJobs !== undefined &&
+    activeTimeoutJobs < retainedTimeoutJobs
   ) {
     return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+  }
+  if (retainedTimeoutJobs === undefined || activeTimeoutJobs === undefined) {
+    const retainedFailedQueueJobs = release.database.failedReviewQueueJobCount;
+    const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount;
+    if (
+      retainedFailedQueueJobs !== undefined &&
+      activeFailedQueueJobs !== undefined &&
+      activeFailedQueueJobs < retainedFailedQueueJobs
+    ) {
+      return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+    }
   }
   const retryCommands = buildZCodeTimeoutRetryCommandsForJobs({
     configPath: release.releaseUnit.configPath,

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -47,6 +47,7 @@ export interface OperatorStatus {
     heartbeatStatus: ReleaseHeartbeatStatus["status"];
     activeLeases: number;
     staleLeases: number;
+    staleReviewLeases: number;
     pendingHeads: number;
     providerDeferredHeads: number;
     skippedHeads: number;
@@ -97,6 +98,7 @@ export interface RuntimeInventory {
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    activeFailedQueueJobs: number;
     zcodeTimeoutFailedQueueJobs: number;
     retryableZCodeTimeoutFailedQueueJobs: number;
     exhaustedZCodeTimeoutFailedQueueJobs: number;
@@ -426,6 +428,8 @@ export function buildOperatorStatus(input: {
     input.release.database.recentUnrecoveredErrorCount ?? failedRows;
   const activeFailedQueueJobs =
     input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
+  const staleActiveReviewQueueJobs = input.release.database.staleActiveReviewQueueJobCount ?? 0;
+  const staleReviewLeases = input.agents.summary.staleLeases + staleActiveReviewQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
@@ -460,17 +464,19 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "agents_no_stale_leases",
-      ok: input.agents.summary.staleLeases === 0,
-      detail: input.agents.summary.staleLeases === 0
+      ok: staleReviewLeases === 0,
+      detail: staleReviewLeases === 0
         ? "0 stale lease(s)"
-        : `${input.agents.summary.staleLeases} stale lease(s)`
+        : staleActiveReviewQueueJobs === 0
+          ? `${staleReviewLeases} stale lease(s)`
+          : `${staleReviewLeases} stale review lease/job(s)`
     },
     {
       name: "durable_queue_no_failed_jobs",
       ok: activeFailedQueueJobs === 0,
       detail: activeFailedQueueJobs === failedQueueJobs
         ? `${failedQueueJobs} failed durable queue job(s)`
-        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} all-time`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
@@ -518,6 +524,7 @@ export function buildOperatorStatus(input: {
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
+    ...(staleActiveReviewQueueJobs > 0 ? ["inspect stale active review queue jobs before restarting or retiring work"] : []),
     ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
       ? zcodeTimeoutRetryActions
@@ -537,13 +544,14 @@ export function buildOperatorStatus(input: {
       failedGateNames: gates.filter((gate) => !gate.ok).map((gate) => gate.name),
       release: input.release,
       activeFailedQueueJobs,
-      staleReviewLeases: input.agents.summary.staleLeases
+      staleReviewLeases
     }),
     summary: {
       launchdState: input.release.launchd.state,
       heartbeatStatus: input.release.heartbeat.status,
       activeLeases: input.agents.summary.activeLeases,
       staleLeases: input.agents.summary.staleLeases,
+      staleReviewLeases,
       pendingHeads,
       providerDeferredHeads,
       skippedHeads: queue?.summary.skipped ?? 0,
@@ -586,7 +594,7 @@ export function formatOperatorStatusHuman(status: OperatorStatus): string {
   return [
     `status: ${health?.state ?? (status.ok ? "green" : "red")} - ${health?.reason ?? (status.ok ? "current gates pass" : "current gates failed")}`,
     `current: activeFailedQueueJobs=${status.summary.activeFailedQueueJobs}` +
-      ` staleReviewLeases=${status.summary.staleLeases}` +
+      ` staleReviewLeases=${status.summary.staleReviewLeases}` +
       ` recentUnrecoveredReviewErrors=${status.summary.recentUnrecoveredFailedRows}`,
     `history: reviewErrors=${status.summary.failedRows} failedQueueJobs=${status.summary.failedQueueJobs}` +
       (health?.lastFailureAt ? ` lastFailureAt=${health.lastFailureAt}` : ""),
@@ -678,6 +686,8 @@ export function buildRuntimeInventory(input: {
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs =
+    input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
@@ -706,8 +716,10 @@ export function buildRuntimeInventory(input: {
     },
     {
       name: "runtime_no_failed_queue_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "runtime_no_zcode_timeout_failed_queue_jobs",
@@ -803,7 +815,7 @@ export function buildRuntimeInventory(input: {
     ...(uncoveredPendingHeads.length > 0 ? ["wait for daemon cycle or run scoped run-once for uncovered pending heads"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
       ? zcodeTimeoutRetryActions
       : []),
@@ -829,6 +841,7 @@ export function buildRuntimeInventory(input: {
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs,
       failedQueueJobs,
+      activeFailedQueueJobs,
       zcodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.total,
       retryableZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.retryable,
       exhaustedZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.exhausted,

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -13,7 +13,12 @@ import type {
 } from "./coverage-audit.js";
 import type { IssueEnrichmentStatus } from "./issue-enrichment.js";
 import type { ReviewBudgetStatus } from "./review-budget.js";
-import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
+import type {
+  ReleaseHealthStatus,
+  ReleaseHeartbeatStatus,
+  ReleaseLaunchdStatus,
+  ReleaseStatus
+} from "./release-status.js";
 import { redactSecrets } from "./secrets.js";
 import {
   parseProviderCooldownError,
@@ -36,6 +41,7 @@ import {
 export interface OperatorStatus {
   ok: boolean;
   checkedAt: string;
+  health?: ReleaseHealthStatus;
   summary: {
     launchdState: ReleaseLaunchdStatus["state"];
     heartbeatStatus: ReleaseHeartbeatStatus["status"];
@@ -47,12 +53,14 @@ export interface OperatorStatus {
     staleHeads: number;
     readFailures: number;
     failedRows: number;
+    recentUnrecoveredFailedRows: number;
     expiredProviderCooldowns: number;
     activeProviderCooldowns: number;
     queuedJobs: number;
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    activeFailedQueueJobs: number;
     zcodeTimeoutFailedQueueJobs: number;
     retryableZCodeTimeoutFailedQueueJobs: number;
     exhaustedZCodeTimeoutFailedQueueJobs: number;
@@ -414,6 +422,10 @@ export function buildOperatorStatus(input: {
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const recentUnrecoveredFailedRows =
+    input.release.database.recentUnrecoveredErrorCount ?? failedRows;
+  const activeFailedQueueJobs =
+    input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
@@ -455,8 +467,10 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "durable_queue_no_failed_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} all-time`
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
@@ -504,7 +518,7 @@ export function buildOperatorStatus(input: {
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
       ? zcodeTimeoutRetryActions
       : []),
@@ -514,9 +528,17 @@ export function buildOperatorStatus(input: {
     ...(issueEnrichmentRuntimeRetryableDeferred > 0 ? ["retry or inspect deferred issue-enrichment records"] : [])
   ]);
 
+  const ok = gates.every((gate) => gate.ok);
   return {
-    ok: gates.every((gate) => gate.ok),
+    ok,
     checkedAt: input.checkedAt ?? input.release.checkedAt,
+    health: buildOperatorHealth({
+      ok,
+      failedGateNames: gates.filter((gate) => !gate.ok).map((gate) => gate.name),
+      release: input.release,
+      activeFailedQueueJobs,
+      staleReviewLeases: input.agents.summary.staleLeases
+    }),
     summary: {
       launchdState: input.release.launchd.state,
       heartbeatStatus: input.release.heartbeat.status,
@@ -528,12 +550,14 @@ export function buildOperatorStatus(input: {
       staleHeads,
       readFailures,
       failedRows,
+      recentUnrecoveredFailedRows,
       expiredProviderCooldowns,
       activeProviderCooldowns,
       queuedJobs: durableQueue?.summary.queued ?? 0,
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
       failedQueueJobs,
+      activeFailedQueueJobs,
       zcodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.total,
       retryableZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.retryable,
       exhaustedZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.exhausted,
@@ -553,6 +577,65 @@ export function buildOperatorStatus(input: {
     ...(durableQueue ? { durableQueue } : {}),
     ...(issueEnrichment ? { issueEnrichment } : {}),
     ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {})
+  };
+}
+
+export function formatOperatorStatusHuman(status: OperatorStatus): string {
+  const health = status.health;
+  const failedGates = status.gates.filter((gate) => !gate.ok);
+  return [
+    `status: ${health?.state ?? (status.ok ? "green" : "red")} - ${health?.reason ?? (status.ok ? "current gates pass" : "current gates failed")}`,
+    `current: activeFailedQueueJobs=${status.summary.activeFailedQueueJobs}` +
+      ` staleReviewLeases=${status.summary.staleLeases}` +
+      ` recentUnrecoveredReviewErrors=${status.summary.recentUnrecoveredFailedRows}`,
+    `history: reviewErrors=${status.summary.failedRows} failedQueueJobs=${status.summary.failedQueueJobs}` +
+      (health?.lastFailureAt ? ` lastFailureAt=${health.lastFailureAt}` : ""),
+    ...(failedGates.length > 0
+      ? failedGates.map((gate) => `actionable: ${gate.name} - ${gate.detail}`)
+      : ["actionable: none"]),
+    ...status.recommendedActions.map((action) => `next: ${action}`)
+  ].join("\n");
+}
+
+function buildOperatorHealth(input: {
+  ok: boolean;
+  failedGateNames: string[];
+  release: ReleaseStatus;
+  activeFailedQueueJobs: number;
+  staleReviewLeases: number;
+}): ReleaseHealthStatus {
+  const historyReviewErrors = input.release.database.errorCount;
+  const historyFailedQueueJobs = input.release.database.failedReviewQueueJobCount ?? 0;
+  const state: ReleaseHealthStatus["state"] = !input.ok
+    ? "red"
+    : historyReviewErrors > 0 || historyFailedQueueJobs > 0
+      ? "amber"
+      : "green";
+  const reason = state === "red"
+    ? `current or recent actionable gate(s) failed: ${input.failedGateNames.join(", ")}`
+    : state === "amber"
+      ? `current gates pass; retained history has ${historyReviewErrors} review error(s) and ` +
+        `${historyFailedQueueJobs} failed queue job(s)`
+      : "current gates pass with no recorded review or queue failure history";
+  return {
+    state,
+    reason,
+    failureWindowHours: input.release.database.failureWindowHours ?? 24,
+    active: {
+      failedQueueJobs: input.activeFailedQueueJobs,
+      staleReviewLeases: input.staleReviewLeases
+    },
+    recent: {
+      unrecoveredReviewErrors:
+        input.release.database.recentUnrecoveredErrorCount ?? historyReviewErrors
+    },
+    history: {
+      reviewErrors: historyReviewErrors,
+      failedQueueJobs: historyFailedQueueJobs
+    },
+    ...(input.release.health?.lastFailureAt
+      ? { lastFailureAt: input.release.health.lastFailureAt }
+      : {})
   };
 }
 
@@ -1739,6 +1822,13 @@ function zcodeTimeoutQueueCounts(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
 ): { total: number; retryable: number; exhausted: number } {
+  if (release.database.activeZCodeTimeoutFailedReviewQueueJobCount !== undefined) {
+    return {
+      total: release.database.activeZCodeTimeoutFailedReviewQueueJobCount,
+      retryable: release.database.activeRetryableZCodeTimeoutFailedReviewQueueJobCount ?? 0,
+      exhausted: release.database.activeExhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0
+    };
+  }
   if (release.database.zcodeTimeoutFailedReviewQueueJobCount !== undefined) {
     return {
       total: release.database.zcodeTimeoutFailedReviewQueueJobCount,

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -426,8 +426,7 @@ export function buildOperatorStatus(input: {
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const recentUnrecoveredFailedRows =
     input.release.database.recentUnrecoveredErrorCount ?? failedRows;
-  const activeFailedQueueJobs =
-    input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
+  const activeFailedQueueJobs = resolveActiveFailedQueueJobCount(input.release, failedQueueJobs);
   const staleActiveReviewQueueJobs = input.release.database.staleActiveReviewQueueJobCount ?? 0;
   const staleReviewLeases = input.agents.summary.staleLeases + staleActiveReviewQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
@@ -686,8 +685,7 @@ export function buildRuntimeInventory(input: {
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
-  const activeFailedQueueJobs =
-    input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
+  const activeFailedQueueJobs = resolveActiveFailedQueueJobCount(input.release, failedQueueJobs);
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
@@ -1860,6 +1858,15 @@ function zcodeTimeoutRecommendedActions(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
 ): string[] {
+  const retainedFailedQueueJobs = release.database.failedReviewQueueJobCount;
+  const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount;
+  if (
+    retainedFailedQueueJobs !== undefined &&
+    activeFailedQueueJobs !== undefined &&
+    activeFailedQueueJobs < retainedFailedQueueJobs
+  ) {
+    return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+  }
   const retryCommands = buildZCodeTimeoutRetryCommandsForJobs({
     configPath: release.releaseUnit.configPath,
     jobs: durableQueue?.jobs ?? []
@@ -1867,6 +1874,15 @@ function zcodeTimeoutRecommendedActions(
   return retryCommands.length > 0
     ? retryCommands
     : [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+}
+
+export function resolveActiveFailedQueueJobCount(
+  release: ReleaseStatus,
+  fallback = 0
+): number {
+  return release.database.activeFailedReviewQueueJobCount ??
+    release.database.failedReviewQueueJobCount ??
+    fallback;
 }
 
 function emptyDurableQueue(now: Date): OperatorDurableQueueSnapshot {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2641,9 +2641,9 @@ function readReviewQueueCounts(
                   and p.pull_number = q.pull_number
                   and p.status = 'posted'
                   and (p.error is null or p.error = '')
-                  and datetime(p.created_at) is not null
-                  and datetime(q.updated_at) is not null
-                  and datetime(p.created_at) > datetime(q.updated_at)
+                  and julianday(p.created_at) is not null
+                  and julianday(q.updated_at) is not null
+                  and julianday(p.created_at) > julianday(q.updated_at)
               ) as recovered
        from review_queue_jobs q
        where q.state = 'failed'`

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -366,7 +366,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
         (input.database.recentUnrecoveredErrorCount === undefined
           ? `${input.database.errorCount} blocking error row(s)`
           : `${recentUnrecoveredErrorCount} recent unrecovered blocking error row(s) in ${failureWindowHours}h; ` +
-            `${input.database.errorCount} all-time; last failure ${input.database.lastErrorAt ?? "unknown"}`) +
+            `${input.database.errorCount} retained history; last failure ${input.database.lastErrorAt ?? "unknown"}`) +
         describeProviderCooldownCounts(input.database)
     },
     {
@@ -382,7 +382,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       detail: activeFailedQueueJobCount === allTimeFailedQueueJobCount
         ? `${allTimeFailedQueueJobCount} failed durable queue job(s)`
         : `${activeFailedQueueJobCount} active failed durable queue job(s); ` +
-          `${allTimeFailedQueueJobCount} all-time; last failure ${input.database.lastFailedReviewQueueJobAt ?? "unknown"}`
+          `${allTimeFailedQueueJobCount} retained history; last failure ${input.database.lastFailedReviewQueueJobAt ?? "unknown"}`
     },
     {
       name: "queue_no_zcode_timeout_failed_jobs",
@@ -391,7 +391,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
         ? `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
           `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
         : `${activeZCodeTimeoutFailedQueueJobCount} active ZCode timeout failed durable queue job(s); ` +
-          `all-time=${zcodeTimeoutFailedQueueJobCount} ` +
+          `retained=${zcodeTimeoutFailedQueueJobCount} ` +
           `retryable=${input.database.activeRetryableZCodeTimeoutFailedReviewQueueJobCount ?? retryableZCodeTimeoutFailedQueueJobCount} ` +
           `exhausted=${input.database.activeExhaustedZCodeTimeoutFailedReviewQueueJobCount ?? exhaustedZCodeTimeoutFailedQueueJobCount}`
     },

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2416,9 +2416,9 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
                       and recovered.pull_number = processed_reviews.pull_number
                       and recovered.status = 'posted'
                       and (recovered.error is null or recovered.error = '')
-                      and datetime(recovered.created_at) is not null
-                      and datetime(processed_reviews.created_at) is not null
-                      and datetime(recovered.created_at) > datetime(processed_reviews.created_at)
+                      and julianday(recovered.created_at) is not null
+                      and julianday(processed_reviews.created_at) is not null
+                      and julianday(recovered.created_at) > julianday(processed_reviews.created_at)
                   )
                   then 1 else 0
                 end) as unrecoveredErrorCount,
@@ -2433,11 +2433,11 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
                       and recovered.pull_number = processed_reviews.pull_number
                       and recovered.status = 'posted'
                       and (recovered.error is null or recovered.error = '')
-                      and datetime(recovered.created_at) is not null
-                      and datetime(processed_reviews.created_at) is not null
-                      and datetime(recovered.created_at) > datetime(processed_reviews.created_at)
+                      and julianday(recovered.created_at) is not null
+                      and julianday(processed_reviews.created_at) is not null
+                      and julianday(recovered.created_at) > julianday(processed_reviews.created_at)
                   )
-                    and (datetime(created_at) is null or datetime(created_at) >= datetime(?))
+                    and (julianday(created_at) is null or julianday(created_at) >= julianday(?))
                   then 1 else 0
                 end) as recentUnrecoveredErrorCount
            from processed_reviews`

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -105,6 +105,7 @@ export interface ReviewQueueRepoStatus {
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  activeFailed: number;
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -2633,7 +2634,7 @@ function readReviewQueueCounts(
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
   const failedRows = db
     .prepare(
-      `select q.last_error, q.updated_at,
+      `select q.repo, q.last_error, q.updated_at,
               exists (
                 select 1
                 from processed_reviews p
@@ -2648,7 +2649,12 @@ function readReviewQueueCounts(
        from review_queue_jobs q
        where q.state = 'failed'`
     )
-    .all() as unknown as Array<{ last_error: string | null; updated_at: string; recovered: number }>;
+    .all() as unknown as Array<{
+      repo: string;
+      last_error: string | null;
+      updated_at: string;
+      recovered: number;
+    }>;
   const activeFailedRows = failedRows.filter((failedRow) => failedRow.recovered !== 1);
   const failureWindowStartMs = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
   const recentActiveFailedRows = activeFailedRows.filter((failedRow) => {
@@ -2685,7 +2691,8 @@ function readReviewQueueCounts(
       running: repoRow.running ?? 0,
       providerDeferred: repoRow.providerDeferred ?? 0,
       retryableProviderDeferred: repoRow.retryableProviderDeferred ?? 0,
-      failed: repoRow.failed ?? 0
+      failed: repoRow.failed ?? 0,
+      activeFailed: activeFailedRows.filter((failedRow) => failedRow.repo === repoRow.repo).length
     }))
   };
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -30,6 +30,10 @@ export interface ReleaseLaunchdStatus {
 export interface ReleaseDatabaseStatus {
   rowCount: number;
   errorCount: number;
+  failureWindowHours?: number;
+  unrecoveredErrorCount?: number;
+  recentUnrecoveredErrorCount?: number;
+  lastErrorAt?: string;
   skippedCount?: number;
   reviewerSessionCount?: number;
   activeReviewerSessionCount?: number;
@@ -51,13 +55,37 @@ export interface ReleaseDatabaseStatus {
   providerDeferredReviewQueueJobCount?: number;
   retryableProviderDeferredReviewQueueJobCount?: number;
   failedReviewQueueJobCount?: number;
+  activeFailedReviewQueueJobCount?: number;
+  recentActiveFailedReviewQueueJobCount?: number;
+  lastFailedReviewQueueJobAt?: string;
   zcodeTimeoutFailedReviewQueueJobCount?: number;
+  activeZCodeTimeoutFailedReviewQueueJobCount?: number;
   retryableZCodeTimeoutFailedReviewQueueJobCount?: number;
+  activeRetryableZCodeTimeoutFailedReviewQueueJobCount?: number;
   exhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
+  activeExhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
   reviewRunLeaseCount?: number;
   staleReviewRunLeaseCount?: number;
   staleActiveReviewQueueJobCount?: number;
   reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
+}
+
+export interface ReleaseHealthStatus {
+  state: "green" | "amber" | "red";
+  reason: string;
+  failureWindowHours: number;
+  active: {
+    failedQueueJobs: number;
+    staleReviewLeases: number;
+  };
+  recent: {
+    unrecoveredReviewErrors: number;
+  };
+  history: {
+    reviewErrors: number;
+    failedQueueJobs: number;
+  };
+  lastFailureAt?: string;
 }
 
 export interface ReviewerSessionRepoStatus {
@@ -164,9 +192,14 @@ export interface PublicReleaseChannelStatus {
 export interface ReleaseStatus {
   ok: boolean;
   checkedAt: string;
+  health?: ReleaseHealthStatus;
   summary: {
     blockingErrorRows: number;
+    unrecoveredErrorRows?: number;
+    recentUnrecoveredErrorRows?: number;
     failedQueueJobs: number;
+    activeFailedQueueJobs?: number;
+    recentActiveFailedQueueJobs?: number;
     staleReviewLeases: number;
     providerDeferredQueueJobs: number;
     retryableProviderDeferredQueueJobs: number;
@@ -204,6 +237,8 @@ const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
 const LICENSE_PROOF_MAX_AGE_DAYS = 30;
 const LICENSE_PROOF_MAX_AGE_MS = LICENSE_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
 const LICENSE_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
+const FAILURE_HEALTH_WINDOW_HOURS = 24;
+const FAILURE_HEALTH_WINDOW_MS = FAILURE_HEALTH_WINDOW_HOURS * 60 * 60 * 1_000;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const CHECKOUT_ISSUANCE_READY_STATE = "ready";
 const CHECKOUT_ISSUANCE_DEFERRED_STATES = new Set(["deferred", "pending_secret_and_website_publish"]);
@@ -252,7 +287,11 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdRunningOk = input.launchd.state === "running";
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const launchdSystemCaOk = input.launchd.usesSystemCa === true;
-  const dbOk = input.database.errorCount === 0;
+  const failureWindowHours = input.database.failureWindowHours ?? FAILURE_HEALTH_WINDOW_HOURS;
+  const recentUnrecoveredErrorCount =
+    input.database.recentUnrecoveredErrorCount ?? input.database.errorCount;
+  const unrecoveredErrorCount = input.database.unrecoveredErrorCount ?? input.database.errorCount;
+  const dbOk = recentUnrecoveredErrorCount === 0;
   const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
   const retryableExpiredProviderCooldownCount =
     input.database.retryableExpiredProviderCooldownCount ??
@@ -261,11 +300,18 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       (input.database.expiredProviderCooldownCount ?? 0) - (input.database.coveredExpiredProviderCooldownCount ?? 0)
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
-  const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const allTimeFailedQueueJobCount = input.database.failedReviewQueueJobCount ?? 0;
+  const activeFailedQueueJobCount =
+    input.database.activeFailedReviewQueueJobCount ?? allTimeFailedQueueJobCount;
+  const recentActiveFailedQueueJobCount =
+    input.database.recentActiveFailedReviewQueueJobCount ?? activeFailedQueueJobCount;
+  const failedQueueJobsOk = activeFailedQueueJobCount === 0;
   const zcodeTimeoutFailedQueueJobCount = input.database.zcodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const activeZCodeTimeoutFailedQueueJobCount =
+    input.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? zcodeTimeoutFailedQueueJobCount;
   const retryableZCodeTimeoutFailedQueueJobCount = input.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0;
   const exhaustedZCodeTimeoutFailedQueueJobCount = input.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0;
-  const zcodeTimeoutFailedQueueJobsOk = zcodeTimeoutFailedQueueJobCount === 0;
+  const zcodeTimeoutFailedQueueJobsOk = activeZCodeTimeoutFailedQueueJobCount === 0;
   const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
     (input.database.staleActiveReviewQueueJobCount ?? 0);
   const staleReviewLeasesOk = staleReviewLeaseCount === 0;
@@ -317,7 +363,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "live_db_no_errors",
       ok: dbOk,
       detail:
-        `${input.database.errorCount} blocking error row(s)` +
+        (input.database.recentUnrecoveredErrorCount === undefined
+          ? `${input.database.errorCount} blocking error row(s)`
+          : `${recentUnrecoveredErrorCount} recent unrecovered blocking error row(s) in ${failureWindowHours}h; ` +
+            `${input.database.errorCount} all-time; last failure ${input.database.lastErrorAt ?? "unknown"}`) +
         describeProviderCooldownCounts(input.database)
     },
     {
@@ -330,14 +379,21 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "queue_no_failed_jobs",
       ok: failedQueueJobsOk,
-      detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
+      detail: activeFailedQueueJobCount === allTimeFailedQueueJobCount
+        ? `${allTimeFailedQueueJobCount} failed durable queue job(s)`
+        : `${activeFailedQueueJobCount} active failed durable queue job(s); ` +
+          `${allTimeFailedQueueJobCount} all-time; last failure ${input.database.lastFailedReviewQueueJobAt ?? "unknown"}`
     },
     {
       name: "queue_no_zcode_timeout_failed_jobs",
       ok: zcodeTimeoutFailedQueueJobsOk,
-      detail:
-        `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+      detail: activeZCodeTimeoutFailedQueueJobCount === zcodeTimeoutFailedQueueJobCount
+        ? `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+        : `${activeZCodeTimeoutFailedQueueJobCount} active ZCode timeout failed durable queue job(s); ` +
+          `all-time=${zcodeTimeoutFailedQueueJobCount} ` +
+          `retryable=${input.database.activeRetryableZCodeTimeoutFailedReviewQueueJobCount ?? retryableZCodeTimeoutFailedQueueJobCount} ` +
+          `exhausted=${input.database.activeExhaustedZCodeTimeoutFailedReviewQueueJobCount ?? exhaustedZCodeTimeoutFailedQueueJobCount}`
     },
     {
       name: "queue_no_stale_review_leases",
@@ -385,13 +441,26 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     ...runtimeGates,
     ...publicReleaseGates
   ];
+  const health = classifyReleaseHealth({
+    gates,
+    database: input.database,
+    failureWindowHours,
+    recentUnrecoveredErrorCount,
+    activeFailedQueueJobCount,
+    staleReviewLeaseCount
+  });
 
   return {
     ok: gates.every((gate) => gate.ok),
     checkedAt: (input.now ?? new Date()).toISOString(),
+    health,
     summary: {
       blockingErrorRows: input.database.errorCount,
-      failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0,
+      unrecoveredErrorRows: unrecoveredErrorCount,
+      recentUnrecoveredErrorRows: recentUnrecoveredErrorCount,
+      failedQueueJobs: allTimeFailedQueueJobCount,
+      activeFailedQueueJobs: activeFailedQueueJobCount,
+      recentActiveFailedQueueJobs: recentActiveFailedQueueJobCount,
       staleReviewLeases: staleReviewLeaseCount,
       providerDeferredQueueJobs: input.database.providerDeferredReviewQueueJobCount ?? 0,
       retryableProviderDeferredQueueJobs: input.database.retryableProviderDeferredReviewQueueJobCount ?? 0,
@@ -440,6 +509,82 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       unloadCommand: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${input.launchd.label}.plist`
     }
   };
+}
+
+function classifyReleaseHealth(input: {
+  gates: Array<{ name: string; ok: boolean }>;
+  database: ReleaseDatabaseStatus;
+  failureWindowHours: number;
+  recentUnrecoveredErrorCount: number;
+  activeFailedQueueJobCount: number;
+  staleReviewLeaseCount: number;
+}): ReleaseHealthStatus {
+  const failedGateNames = input.gates.filter((gate) => !gate.ok).map((gate) => gate.name);
+  const historyReviewErrors = input.database.errorCount;
+  const historyFailedQueueJobs = input.database.failedReviewQueueJobCount ?? 0;
+  const state: ReleaseHealthStatus["state"] = failedGateNames.length > 0
+    ? "red"
+    : historyReviewErrors > 0 || historyFailedQueueJobs > 0
+      ? "amber"
+      : "green";
+  const reason = state === "red"
+    ? `current or recent actionable gate(s) failed: ${failedGateNames.join(", ")}`
+    : state === "amber"
+      ? `current gates pass; retained history has ${historyReviewErrors} review error(s) and ` +
+        `${historyFailedQueueJobs} failed queue job(s)`
+      : "current gates pass with no recorded review or queue failure history";
+  const lastFailureAt = latestFailureTimestamp(
+    input.database.lastErrorAt,
+    input.database.lastFailedReviewQueueJobAt
+  );
+  return {
+    state,
+    reason,
+    failureWindowHours: input.failureWindowHours,
+    active: {
+      failedQueueJobs: input.activeFailedQueueJobCount,
+      staleReviewLeases: input.staleReviewLeaseCount
+    },
+    recent: {
+      unrecoveredReviewErrors: input.recentUnrecoveredErrorCount
+    },
+    history: {
+      reviewErrors: historyReviewErrors,
+      failedQueueJobs: historyFailedQueueJobs
+    },
+    ...(lastFailureAt ? { lastFailureAt } : {})
+  };
+}
+
+function latestFailureTimestamp(left?: string, right?: string): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (Number.isFinite(leftMs) && Number.isFinite(rightMs)) return leftMs >= rightMs ? left : right;
+  if (Number.isFinite(leftMs)) return left;
+  if (Number.isFinite(rightMs)) return right;
+  return right;
+}
+
+function normalizeDiagnosticTimestamp(value?: string): string | undefined {
+  if (!value) return undefined;
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? new Date(timestampMs).toISOString() : value;
+}
+
+function latestDiagnosticTimestamp(values: string[]): string | undefined {
+  let latest: { value: string; timestampMs: number } | undefined;
+  let malformed: string | undefined;
+  for (const value of values) {
+    const timestampMs = Date.parse(value);
+    if (!Number.isFinite(timestampMs)) {
+      malformed = value;
+      continue;
+    }
+    if (!latest || timestampMs > latest.timestampMs) latest = { value, timestampMs };
+  }
+  return latest ? new Date(latest.timestampMs).toISOString() : malformed;
 }
 
 export function collectReleaseStatus(input: {
@@ -2245,6 +2390,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
   if (!existsSync(statePath)) return { rowCount: 0, errorCount: 0 };
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
+    const failureWindowStart = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
     const row = db
       .prepare(
         `select count(*) as rowCount,
@@ -2258,15 +2404,63 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
                   when status = 'skipped' and error like 'provider_rate_limit_cooldown_until=%' then 0
                   when status != 'skipped' and error is not null and error != '' then 1
                   else 0
-                end) as errorCount
+                end) as errorCount,
+                sum(case
+                  when (
+                    status = 'failed'
+                    or (status != 'skipped' and error is not null and error != '')
+                  ) and not exists (
+                    select 1
+                    from processed_reviews recovered
+                    where recovered.repo = processed_reviews.repo
+                      and recovered.pull_number = processed_reviews.pull_number
+                      and recovered.status = 'posted'
+                      and (recovered.error is null or recovered.error = '')
+                      and datetime(recovered.created_at) is not null
+                      and datetime(processed_reviews.created_at) is not null
+                      and datetime(recovered.created_at) > datetime(processed_reviews.created_at)
+                  )
+                  then 1 else 0
+                end) as unrecoveredErrorCount,
+                sum(case
+                  when (
+                    status = 'failed'
+                    or (status != 'skipped' and error is not null and error != '')
+                  ) and not exists (
+                    select 1
+                    from processed_reviews recovered
+                    where recovered.repo = processed_reviews.repo
+                      and recovered.pull_number = processed_reviews.pull_number
+                      and recovered.status = 'posted'
+                      and (recovered.error is null or recovered.error = '')
+                      and datetime(recovered.created_at) is not null
+                      and datetime(processed_reviews.created_at) is not null
+                      and datetime(recovered.created_at) > datetime(processed_reviews.created_at)
+                  )
+                    and (datetime(created_at) is null or datetime(created_at) >= datetime(?))
+                  then 1 else 0
+                end) as recentUnrecoveredErrorCount
            from processed_reviews`
       )
-      .get() as {
+      .get(failureWindowStart) as {
         rowCount?: number;
         skippedCount?: number | null;
         providerCooldownCount?: number | null;
         errorCount?: number | null;
+        unrecoveredErrorCount?: number | null;
+        recentUnrecoveredErrorCount?: number | null;
       };
+    const lastErrorRow = db
+      .prepare(
+        `select created_at
+         from processed_reviews
+         where status = 'failed'
+            or (status != 'skipped' and error is not null and error != '')
+         order by (datetime(created_at) is not null) desc, datetime(created_at) desc, rowid desc
+         limit 1`
+      )
+      .get() as { created_at?: string } | undefined;
+    const lastErrorAt = normalizeDiagnosticTimestamp(lastErrorRow?.created_at);
     const providerCooldownRows = db
       .prepare(
         `select repo, pull_number, head_sha, error
@@ -2338,14 +2532,24 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
       retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
       failedReviewQueueJobCount: reviewQueue.failed,
+      activeFailedReviewQueueJobCount: reviewQueue.activeFailed,
+      recentActiveFailedReviewQueueJobCount: reviewQueue.recentActiveFailed,
+      ...(reviewQueue.lastFailedAt ? { lastFailedReviewQueueJobAt: reviewQueue.lastFailedAt } : {}),
       zcodeTimeoutFailedReviewQueueJobCount: reviewQueue.zcodeTimeoutFailed,
+      activeZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.activeZcodeTimeoutFailed,
       retryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.retryableZCodeTimeoutFailed,
+      activeRetryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.activeRetryableZCodeTimeoutFailed,
       exhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.exhaustedZCodeTimeoutFailed,
+      activeExhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.activeExhaustedZCodeTimeoutFailed,
       reviewRunLeaseCount: reviewRunLeases.total,
       staleReviewRunLeaseCount: reviewRunLeases.stale,
       staleActiveReviewQueueJobCount,
       reviewQueueJobsByRepo: reviewQueue.byRepo,
-      errorCount: row.errorCount ?? 0
+      errorCount: row.errorCount ?? 0,
+      failureWindowHours: FAILURE_HEALTH_WINDOW_HOURS,
+      unrecoveredErrorCount: row.unrecoveredErrorCount ?? 0,
+      recentUnrecoveredErrorCount: row.recentUnrecoveredErrorCount ?? 0,
+      ...(lastErrorAt ? { lastErrorAt } : {})
     };
   } finally {
     db.close();
@@ -2363,9 +2567,15 @@ function readReviewQueueCounts(
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  activeFailed: number;
+  recentActiveFailed: number;
+  lastFailedAt?: string;
   zcodeTimeoutFailed: number;
+  activeZcodeTimeoutFailed: number;
   retryableZCodeTimeoutFailed: number;
+  activeRetryableZCodeTimeoutFailed: number;
   exhaustedZCodeTimeoutFailed: number;
+  activeExhaustedZCodeTimeoutFailed: number;
   byRepo: ReviewQueueRepoStatus[];
 } {
   const hasTable = db
@@ -2380,9 +2590,14 @@ function readReviewQueueCounts(
       providerDeferred: 0,
       retryableProviderDeferred: 0,
       failed: 0,
+      activeFailed: 0,
+      recentActiveFailed: 0,
       zcodeTimeoutFailed: 0,
+      activeZcodeTimeoutFailed: 0,
       retryableZCodeTimeoutFailed: 0,
+      activeRetryableZCodeTimeoutFailed: 0,
       exhaustedZCodeTimeoutFailed: 0,
+      activeExhaustedZCodeTimeoutFailed: 0,
       byRepo: []
     };
   }
@@ -2416,14 +2631,35 @@ function readReviewQueueCounts(
        order by repo`
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
-  const timeoutRows = db
+  const failedRows = db
     .prepare(
-      `select last_error
-       from review_queue_jobs
-       where state = 'failed' and last_error like ?`
+      `select q.last_error, q.updated_at,
+              exists (
+                select 1
+                from processed_reviews p
+                where p.repo = q.repo
+                  and p.pull_number = q.pull_number
+                  and p.status = 'posted'
+                  and (p.error is null or p.error = '')
+                  and datetime(p.created_at) is not null
+                  and datetime(q.updated_at) is not null
+                  and datetime(p.created_at) > datetime(q.updated_at)
+              ) as recovered
+       from review_queue_jobs q
+       where q.state = 'failed'`
     )
-    .all(`${ZCODE_TIMEOUT_ERROR_PREFIX}%`) as unknown as Array<{ last_error: string | null }>;
-  const timeoutCounts = summarizeZCodeTimeoutErrors(timeoutRows.map((timeoutRow) => timeoutRow.last_error));
+    .all() as unknown as Array<{ last_error: string | null; updated_at: string; recovered: number }>;
+  const activeFailedRows = failedRows.filter((failedRow) => failedRow.recovered !== 1);
+  const failureWindowStartMs = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
+  const recentActiveFailedRows = activeFailedRows.filter((failedRow) => {
+    const updatedAtMs = Date.parse(failedRow.updated_at);
+    return !Number.isFinite(updatedAtMs) || updatedAtMs >= failureWindowStartMs;
+  });
+  const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((failedRow) => failedRow.last_error));
+  const activeTimeoutCounts = summarizeZCodeTimeoutErrors(
+    activeFailedRows.map((failedRow) => failedRow.last_error)
+  );
+  const lastFailedAt = latestDiagnosticTimestamp(failedRows.map((failedRow) => failedRow.updated_at));
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -2432,9 +2668,15 @@ function readReviewQueueCounts(
     providerDeferred: row.providerDeferred ?? 0,
     retryableProviderDeferred: row.retryableProviderDeferred ?? 0,
     failed: row.failed ?? 0,
+    activeFailed: activeFailedRows.length,
+    recentActiveFailed: recentActiveFailedRows.length,
+    ...(lastFailedAt ? { lastFailedAt } : {}),
     zcodeTimeoutFailed: timeoutCounts.total,
+    activeZcodeTimeoutFailed: activeTimeoutCounts.total,
     retryableZCodeTimeoutFailed: timeoutCounts.retryable,
+    activeRetryableZCodeTimeoutFailed: activeTimeoutCounts.retryable,
     exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,
+    activeExhaustedZCodeTimeoutFailed: activeTimeoutCounts.exhausted,
     byRepo: byRepoRows.map((repoRow) => ({
       repo: repoRow.repo,
       total: repoRow.total ?? 0,

--- a/src/state.ts
+++ b/src/state.ts
@@ -916,13 +916,14 @@ export class ReviewStateStore {
   }
 
   recordProcessed(record: ProcessedReviewRecord): void {
+    const completedAt = new Date().toISOString();
     this.db.exec("begin immediate");
     try {
       this.db
         .prepare(
           `insert or replace into processed_reviews
             (repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at)
-           values (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+           values (?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           record.repo,
@@ -932,7 +933,8 @@ export class ReviewStateStore {
           record.configRevision ?? null,
           record.event ?? null,
           record.reviewUrl ?? null,
-          record.error ?? null
+          record.error ?? null,
+          completedAt
         );
       // Completion and claim retirement are one transaction. A later ordinary claimant must see
       // either the live claim or the durable processed row, never a gap between the two.
@@ -1879,11 +1881,11 @@ export class ReviewStateStore {
       if (!preserveExistingBlocking) {
         this.db
           .prepare(
-            `insert or replace into processed_reviews
+          `insert or replace into processed_reviews
               (repo, pull_number, head_sha, status, event, review_url, error, created_at)
-             values (?, ?, ?, 'posted', ?, ?, null, datetime('now'))`
+             values (?, ?, ?, 'posted', ?, ?, null, ?)`
           )
-          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl);
+          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl, postedAt);
       }
       const readinessEvent = preserveExistingBlocking ? "REQUEST_CHANGES" : input.event;
       const readinessUrl = preserveExistingBlocking ? existingProcessed?.reviewUrl : input.reviewUrl;

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1638,6 +1638,46 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions.join("\n")).not.toContain("retry-failed");
   });
 
+  it("keeps retry guidance for an active timeout when recovered history is non-timeout", () => {
+    const activeTimeout = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 216,
+      headSha: "active-timeout",
+      state: "failed",
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000"
+    });
+    const recoveredOrdinaryFailure = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 215,
+      headSha: "recovered-ordinary",
+      state: "failed",
+      lastError: "provider failed before posting"
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        database: {
+          errorCount: 1,
+          failedReviewQueueJobCount: 2,
+          activeFailedReviewQueueJobCount: 1,
+          zcodeTimeoutFailedReviewQueueJobCount: 1,
+          activeZCodeTimeoutFailedReviewQueueJobCount: 1,
+          activeRetryableZCodeTimeoutFailedReviewQueueJobCount: 1,
+          activeExhaustedZCodeTimeoutFailedReviewQueueJobCount: 0
+        }
+      }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({
+        summary: { ...cleanDurableQueueSummary(), total: 2, failed: 2 },
+        jobs: [activeTimeout, recoveredOrdinaryFailure]
+      })
+    });
+
+    expect(status.recommendedActions).toContain(
+      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 216 --head-sha active-timeout --dry-run false --zcode true"
+    );
+  });
+
   it("keeps blocked-on-proof readiness above processed coverage for the same head", () => {
     const dashboard = buildOperatorDashboard({
       coverage: coverageReport({ ok: true, processed: [processedEntry(8, "head-proof", "posted")] }),

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -21,6 +21,7 @@ import {
   formatOperatorDashboardHuman,
   formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
+  resolveActiveFailedQueueJobCount,
   summarizeAgentInventory,
   type OperatorAgentInventory,
   type OperatorDurableQueueSnapshot
@@ -211,6 +212,22 @@ describe("operator CLI summaries", () => {
       detail: "0 active failed durable queue job(s); 1 retained history"
     });
     expect(inventory.recommendedActions).not.toContain("inspect operator queue failed jobs before promotion");
+  });
+
+  it("resolves active failed queue counts for budget and other operator gates", () => {
+    expect(resolveActiveFailedQueueJobCount(releaseStatus({
+      ok: true,
+      database: {
+        failedReviewQueueJobCount: 7,
+        activeFailedReviewQueueJobCount: 0
+      }
+    }))).toBe(0);
+    expect(resolveActiveFailedQueueJobCount(releaseStatus({
+      ok: false,
+      database: {
+        failedReviewQueueJobCount: 7
+      }
+    }))).toBe(7);
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {
@@ -1578,6 +1595,47 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain(
       "npx tsx src/cli.ts queue --config /config/live.json --state failed"
     );
+  });
+
+  it("does not emit retry commands for recovered timeout rows mixed with active failures", () => {
+    const activeTimeout = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 216,
+      headSha: "active-timeout",
+      state: "failed",
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000"
+    });
+    const recoveredTimeout = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 215,
+      headSha: "recovered-timeout",
+      state: "failed",
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000"
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        database: {
+          errorCount: 1,
+          failedReviewQueueJobCount: 2,
+          activeFailedReviewQueueJobCount: 1,
+          zcodeTimeoutFailedReviewQueueJobCount: 2,
+          activeZCodeTimeoutFailedReviewQueueJobCount: 1,
+          activeRetryableZCodeTimeoutFailedReviewQueueJobCount: 1,
+          activeExhaustedZCodeTimeoutFailedReviewQueueJobCount: 0
+        }
+      }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({
+        summary: { ...cleanDurableQueueSummary(), total: 2, failed: 2 },
+        jobs: [activeTimeout, recoveredTimeout]
+      })
+    });
+
+    expect(status.recommendedActions).toContain(
+      "npx tsx src/cli.ts queue --config /config/live.json --state failed"
+    );
+    expect(status.recommendedActions.join("\n")).not.toContain("retry-failed");
   });
 
   it("keeps blocked-on-proof readiness above processed coverage for the same head", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -19,6 +19,7 @@ import {
   explainPullStatus,
   filterBotProcessRows,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorAgentInventory,
@@ -98,6 +99,55 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("reports recovered history as amber while keeping current operator gates actionable", () => {
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: true,
+        database: {
+          errorCount: 51,
+          unrecoveredErrorCount: 0,
+          recentUnrecoveredErrorCount: 0,
+          failedReviewQueueJobCount: 52,
+          activeFailedReviewQueueJobCount: 0,
+          lastErrorAt: "2026-08-09T14:08:22.000Z",
+          failureWindowHours: 24
+        }
+      }),
+      coverage: coverageReport({}),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue: durableQueueSnapshot({
+        ok: false,
+        summary: { ...cleanDurableQueueSummary(), total: 52, failed: 52 }
+      })
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.health).toMatchObject({
+      state: "amber",
+      active: { failedQueueJobs: 0, staleReviewLeases: 0 },
+      recent: { unrecoveredReviewErrors: 0 },
+      history: { reviewErrors: 51, failedQueueJobs: 52 }
+    });
+    expect(status.summary).toMatchObject({
+      failedRows: 51,
+      recentUnrecoveredFailedRows: 0,
+      failedQueueJobs: 52,
+      activeFailedQueueJobs: 0
+    });
+    expect(status.gates).toContainEqual({
+      name: "durable_queue_no_failed_jobs",
+      ok: true,
+      detail: "0 active failed durable queue job(s); 52 all-time"
+    });
+    expect(formatOperatorStatusHuman(status)).toContain("status: amber - current gates pass");
+    expect(formatOperatorStatusHuman(status)).toContain(
+      "current: activeFailedQueueJobs=0 staleReviewLeases=0 recentUnrecoveredReviewErrors=0"
+    );
+    expect(formatOperatorStatusHuman(status)).toContain("history: reviewErrors=51 failedQueueJobs=52");
+    expect(formatOperatorStatusHuman(status)).toContain("actionable: none");
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -140,7 +140,7 @@ describe("operator CLI summaries", () => {
     expect(status.gates).toContainEqual({
       name: "durable_queue_no_failed_jobs",
       ok: true,
-      detail: "0 active failed durable queue job(s); 52 all-time"
+      detail: "0 active failed durable queue job(s); 52 retained history"
     });
     expect(formatOperatorStatusHuman(status)).toContain("status: amber - current gates pass");
     expect(formatOperatorStatusHuman(status)).toContain(
@@ -148,6 +148,69 @@ describe("operator CLI summaries", () => {
     );
     expect(formatOperatorStatusHuman(status)).toContain("history: reviewErrors=51 failedQueueJobs=52");
     expect(formatOperatorStatusHuman(status)).toContain("actionable: none");
+  });
+
+  it("includes stale active queue jobs in current operator health and human output", () => {
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        database: {
+          staleActiveReviewQueueJobCount: 1
+        }
+      }),
+      coverage: coverageReport({}),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue: durableQueueSnapshot({
+        ok: true,
+        summary: cleanDurableQueueSummary()
+      })
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.health).toMatchObject({
+      state: "red",
+      active: { staleReviewLeases: 1 }
+    });
+    expect(status.summary).toMatchObject({
+      staleLeases: 0,
+      staleReviewLeases: 1
+    });
+    expect(status.gates).toContainEqual({
+      name: "agents_no_stale_leases",
+      ok: false,
+      detail: "1 stale review lease/job(s)"
+    });
+    expect(formatOperatorStatusHuman(status)).toContain("staleReviewLeases=1");
+  });
+
+  it("keeps runtime inventory healthy when retained failed queue history is recovered", () => {
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({
+        ok: true,
+        database: {
+          failedReviewQueueJobCount: 1,
+          activeFailedReviewQueueJobCount: 0
+        }
+      }),
+      agents: agentInventory({ ok: true }),
+      durableQueue: durableQueueSnapshot({
+        ok: false,
+        summary: { ...cleanDurableQueueSummary(), total: 1, failed: 1 }
+      })
+    });
+
+    expect(inventory.ok).toBe(true);
+    expect(inventory.summary).toMatchObject({
+      failedQueueJobs: 1,
+      activeFailedQueueJobs: 0
+    });
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_no_failed_queue_jobs",
+      ok: true,
+      detail: "0 active failed durable queue job(s); 1 retained history"
+    });
+    expect(inventory.recommendedActions).not.toContain("inspect operator queue failed jobs before promotion");
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -3587,6 +3587,22 @@ exit 1
         "2026-07-03T00:00:00.100Z"
       );
       db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "failed-other-repo",
+        "automatic:owner/other#128@failed-head",
+        "owner/other",
+        "owner",
+        128,
+        "failed-head",
+        "provider failed",
+        "2026-07-03T00:00:00.100Z",
+        "2026-07-03T00:00:00.100Z"
+      );
+      db.prepare(
         `insert into processed_reviews
           (repo, pull_number, head_sha, status, event, review_url, error, created_at)
          values (?, ?, ?, 'posted', 'COMMENT', ?, null, ?)`

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -3556,6 +3556,72 @@ exit 1
     }
   });
 
+  it("does not block provider-cooldowns on recovered failed queue history", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cooldown-recovered-history-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "failed-recovered-history",
+        "automatic:owner/repo#127@failed-head",
+        "owner/repo",
+        "owner",
+        127,
+        "failed-head",
+        "provider failed",
+        "2026-07-03T00:00:00.100Z",
+        "2026-07-03T00:00:00.100Z"
+      );
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+         values (?, ?, ?, 'posted', 'COMMENT', ?, null, ?)`
+      ).run(
+        "owner/repo",
+        127,
+        "posted-head",
+        "https://github.test/owner/repo/pull/127#pullrequestreview-1",
+        "2026-07-03T00:00:00.900Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const { stdout } = await runCli([
+      "provider-cooldowns",
+      "--config",
+      configPath,
+      "--expired-only",
+      "true",
+      "--repo",
+      "owner/repo"
+    ]);
+    const output = JSON.parse(stdout);
+    expect(output).toMatchObject({
+      ok: true,
+      runtimeOk: true,
+      summary: {
+        failedQueueJobs: 0,
+        retainedFailedQueueJobs: 1
+      }
+    });
+    expect(output.failedGates).toEqual([]);
+  });
+
   it("reports provider-cooldowns backpressured when retryable work waits on active provider capacity", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cooldown-backpressure-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -4916,7 +4916,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     expect(status.gates).toContainEqual({
       name: "live_db_no_errors",
       ok: true,
-      detail: expect.stringContaining("1 all-time")
+      detail: expect.stringContaining("1 retained history")
     });
     const databaseHealth = buildReleaseStatus({
       repo: {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -4889,12 +4889,12 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         `insert into processed_reviews
           (repo, pull_number, head_sha, status, error, created_at)
          values (?, 42, ?, ?, ?, ?)`
-      ).run("electricsheephq/WorldOS", "failed-head", "failed", "provider timeout", "2026-08-10T00:00:00.000Z");
+      ).run("electricsheephq/WorldOS", "failed-head", "failed", "provider timeout", "2026-08-10T00:00:00.100Z");
       db.prepare(
         `insert into processed_reviews
           (repo, pull_number, head_sha, status, error, created_at)
          values (?, 42, ?, ?, null, ?)`
-      ).run("electricsheephq/WorldOS", "posted-head", "posted", "2026-08-10T01:00:00.000Z");
+      ).run("electricsheephq/WorldOS", "posted-head", "posted", "2026-08-10T00:00:00.900Z");
     } finally {
       db.close();
     }
@@ -4911,7 +4911,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
       errorCount: 1,
       unrecoveredErrorCount: 0,
       recentUnrecoveredErrorCount: 0,
-      lastErrorAt: "2026-08-10T00:00:00.000Z"
+      lastErrorAt: "2026-08-10T00:00:00.100Z"
     });
     expect(status.gates).toContainEqual({
       name: "live_db_no_errors",

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6221,7 +6221,8 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         running: 0,
         providerDeferred: 0,
         retryableProviderDeferred: 0,
-        failed: 1
+        failed: 1,
+        activeFailed: 1
       },
       {
         repo: "100yenadmin/evaOS-GUI",
@@ -6231,7 +6232,8 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         running: 0,
         providerDeferred: 2,
         retryableProviderDeferred: 1,
-        failed: 0
+        failed: 0,
+        activeFailed: 0
       },
       {
         repo: "electricsheephq/WorldOS",
@@ -6241,7 +6243,8 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         running: 1,
         providerDeferred: 0,
         retryableProviderDeferred: 0,
-        failed: 0
+        failed: 0,
+        activeFailed: 0
       }
     ]);
     expect(status.gates).toContainEqual({

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6277,6 +6277,128 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     expect(detailedStatus.budget?.delayed.length).toBeLessThanOrEqual(1);
   });
 
+  it("preserves sub-second queue recovery ordering in both directions", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-subsecond-recovery-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null,
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "failed-subsecond",
+        "automatic:owner/repo#17@failed-head",
+        "owner/repo",
+        "owner",
+        17,
+        "failed-head",
+        "provider failed",
+        "2026-07-01T00:00:00.100Z",
+        "2026-07-01T00:00:00.100Z"
+      );
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "failed-after-post",
+        "automatic:owner/repo#18@failed-head",
+        "owner/repo",
+        "owner",
+        18,
+        "failed-head",
+        "provider failed",
+        "2026-07-01T00:00:00.900Z",
+        "2026-07-01T00:00:00.900Z"
+      );
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+         values (?, ?, ?, 'posted', 'COMMENT', ?, null, ?)`
+      ).run(
+        "owner/repo",
+        17,
+        "later-clean-head",
+        "https://github.test/owner/repo/pull/17#pullrequestreview-1",
+        "2026-07-01T00:00:00.900Z"
+      );
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+         values (?, ?, ?, 'posted', 'COMMENT', ?, null, ?)`
+      ).run(
+        "owner/repo",
+        18,
+        "earlier-clean-head",
+        "https://github.test/owner/repo/pull/18#pullrequestreview-1",
+        "2026-07-01T00:00:00.100Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({
+      failedReviewQueueJobCount: 2,
+      activeFailedReviewQueueJobCount: 1,
+      recentActiveFailedReviewQueueJobCount: 1
+    });
+    expect(status.gates.find((gate) => gate.name === "queue_no_failed_jobs")).toMatchObject({
+      name: "queue_no_failed_jobs",
+      ok: false,
+      detail: expect.stringContaining("1 active failed durable queue job(s); 2 retained history")
+    });
+  });
+
   it("does not fail the provider-deferred gate when retryable jobs are waiting on capacity", () => {
     const status = buildReleaseStatus({
       repo: {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -4857,7 +4857,156 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
       ok: true,
       detail: "fresh; age 1000ms; max 120000ms; event daemon_cycle_complete; cycle 5"
     });
+    expect(status.health).toMatchObject({
+      state: "green",
+      active: { failedQueueJobs: 0, staleReviewLeases: 0 },
+      recent: { unrecoveredReviewErrors: 0 },
+      history: { reviewErrors: 0, failedQueueJobs: 0 }
+    });
     expect(status.database.skippedCount).toBe(16);
+  });
+
+  it("keeps recovered historical review failures visible without blocking current database health", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-recovered-history-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null,
+          primary key (repo, pull_number, head_sha)
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, error, created_at)
+         values (?, 42, ?, ?, ?, ?)`
+      ).run("electricsheephq/WorldOS", "failed-head", "failed", "provider timeout", "2026-08-10T00:00:00.000Z");
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, error, created_at)
+         values (?, 42, ?, ?, null, ?)`
+      ).run("electricsheephq/WorldOS", "posted-head", "posted", "2026-08-10T01:00:00.000Z");
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-08-10T02:00:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({
+      errorCount: 1,
+      unrecoveredErrorCount: 0,
+      recentUnrecoveredErrorCount: 0,
+      lastErrorAt: "2026-08-10T00:00:00.000Z"
+    });
+    expect(status.gates).toContainEqual({
+      name: "live_db_no_errors",
+      ok: true,
+      detail: expect.stringContaining("1 all-time")
+    });
+    const databaseHealth = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/config/live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/config/live.json",
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
+      },
+      database: status.database,
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-08-10T02:00:00.000Z")
+    });
+    expect(databaseHealth.health).toMatchObject({
+      state: "amber",
+      recent: { unrecoveredReviewErrors: 0 },
+      history: { reviewErrors: 1 }
+    });
+  });
+
+  it("keeps a recent unrecovered review failure red inside the health window", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-recent-failure-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null,
+          primary key (repo, pull_number, head_sha)
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, error, created_at)
+         values (?, 43, ?, 'failed', ?, ?)`
+      ).run("electricsheephq/WorldOS", "failed-head", "posting failed", "2026-08-10T01:30:00.000Z");
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, error, created_at)
+         values (?, 43, ?, 'skipped', ?, ?)`
+      ).run(
+        "electricsheephq/WorldOS",
+        "skipped-head",
+        "provider_rate_limit_cooldown_until=2026-08-10T03:00:00.000Z;reason=provider_request_rate_limit",
+        "2026-08-10T01:45:00.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-08-10T02:00:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({
+      errorCount: 1,
+      unrecoveredErrorCount: 1,
+      recentUnrecoveredErrorCount: 1,
+      lastErrorAt: "2026-08-10T01:30:00.000Z"
+    });
+    expect(status.gates).toContainEqual({
+      name: "live_db_no_errors",
+      ok: false,
+      detail: expect.stringContaining("1 recent unrecovered blocking error row(s) in 24h")
+    });
+    expect(status.health).toMatchObject({
+      state: "red",
+      recent: { unrecoveredReviewErrors: 1 },
+      history: { reviewErrors: 1 }
+    });
   });
 
   it("reports active provider cooldown skips without treating them as blocking DB errors", () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -31,6 +31,24 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("records processed review completion with millisecond ordering precision", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-precision-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1206,
+      headSha: "precision-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+
+    expect(store.getProcessedReview("electricsheephq/WorldOS", 1206, "precision-head")?.createdAt)
+      .toMatch(/\.\d{3}Z$/);
+    store.close();
+  });
+
   it("stores normalized issue enrichment body hashes and rejects invalid hashes", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-"));
     roots.push(root);


### PR DESCRIPTION
Closes #741
Closes #749
Parent tracker: #738

## Outcome

Operator `status` now separates current/recent actionable failure state from retained historical failure counts. Retained rows remain visible; a later clean posted outcome for the same repo/PR can classify an older retained row as recovered. The existing same-head retry replacement behavior is unchanged, so this is not an append-only attempt ledger.

The existing `doctor` command remains the GitHub/config readiness surface and was already independent of historical SQLite failure counts. This PR changes the aggregation seam that reproduced the false-red runtime status.

## Source identity

- Base: `1a2f08a336d3bbcc1b6d0934db58b933d1980206`
- Head: `4c784579b2697ee2897542f0e961eefa9ad0622d`

## Change

- Add additive `health` output with `green`, `amber`, or `red` state, an exact reason, a documented 24-hour recent-failure window, active/current counts, historical counts, and last-failure time.
- Keep legacy retained-history JSON counts while adding current/recent fields; existing callers without the new fields retain fail-closed behavior.
- Treat a failure as recovered only after a later clean `posted` outcome for the same repo/PR. Later skips do not mask posting failures, and malformed timestamps fail closed as recent.
- Gate failed queue and ZCode timeout counts on unrecovered active jobs while retaining historical terminal counts.
- Add `status --human` output that names current blockers separately from history, including stale active queue jobs even when no agent lease row is stale.
- Make runtime inventory use active failed queue counts for its gate and actions while preserving retained failed counts as history.
- Make `budget-status` use the same active failed queue count, with retained history as a compatibility fallback when the additive classifier is unavailable.
- When a queue snapshot mixes active failures with recovered retained timeout rows, recommend read-only failed-queue inspection instead of emitting retry commands that could target recovered history.
- Preserve millisecond completion timestamps and fractional recovery ordering, so a clean post later in the same second recovers history while malformed, equal, or earlier evidence stays active.
- Suppress timeout retry actions only when retained timeout history exceeds active timeout history; unrelated recovered failures no longer hide the retry for a live timeout.

## Focused proof

- Failing-first historical fixture initially failed because `recentUnrecoveredErrorCount` was absent and `live_db_no_errors` remained false.
- `npx vitest run tests/release-status.test.ts tests/operator-cli.test.ts` — 168 passed.
- Targeted processed-review and repo-scoped provider-cooldown regressions — 4 passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- An optional wider `public-cli` run passed 102/103 public CLI tests and both changed-path suites, but the unrelated native-Keychain no-local-state test timed out at its 5-second ceiling and again in an isolated 10-second rerun. No credential or Keychain code is changed here; canonical remote CI is the required broad gate.

Late current-head review found two issue-owned truth mismatches: stale active queue jobs were missing from operator health/human output, and runtime inventory still gated on retained failed queue totals. Both regressions failed first and are fixed in `ef5d17f210b8488ef6a36eb77cbca46129d4507f`; `2e91ebc7c9f69beb535b5a9835b9f0d937dc8211` bounds the documentation to retained history. A later exact-head pass found budget health still used retained failed totals and mixed timeout rows could emit retry commands for recovered history. Both failed first and are fixed in the final targeted delta `c192f5f063b8e9e634052bad4ec5064186c5d7fa`. The aged-terminal-row and append-only-attempt suggestions received terminal dispositions under the issue's explicit 24-hour window and no-state-redesign ceiling; the live DB gate report was already fixed, and the alleged old-head recovery path is blocked by the existing final server-head read and post-head-change error rewrite. Independent review passed on the initial head at 97%, the first delta at 98%, and the final targeted delta at 98%, with no remaining P0-P2 finding in the changed supported path. Exact-head required `Build, test, and package` and `Swift desktop gate` checks passed.

Two post-ready findings were split into isolated review PR #750 and integrated as exact commit `51e9d022ff982098095be3e2ac3d31289ceaebd0`: processed completions now preserve millisecond ordering and timeout retry suppression uses timeout-specific retained/active counts. Failing-first reproduced three failures; `tests/state.test.ts`, `tests/release-status.test.ts`, and `tests/operator-cli.test.ts` then passed 240/240, build and diff hygiene passed, exact-head required CI passed on the isolated delta, and independent delta review passed at 98% with no new P0-P3 findings. PR #750 is only the durable split-review surface; the commit now lives directly on this PR branch.

The final readiness audit found that processed-review recovery still used second-resolution SQLite comparisons and that `provider-cooldowns` still gated on retained failed queue history. Both failed first and are fixed in `7ebf9fbcc04680da82667ea8b162c73bd78be671`. Independent delta review then found repo-scoped cooldown health consumed the global active-failure count; the final targeted fix `4c784579b2697ee2897542f0e961eefa9ad0622d` adds the active count to the existing per-repo classifier and preserves retained-count fallback. The final targeted delta review passed at 99% confidence with no new P0-P2 findings: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/744#issuecomment-5239590090. Exact-head required [Build, test, and package](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/31384152789/job/93440716584) and [Swift desktop gate](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/31384153069/job/93440828367) checks passed.

## Boundaries

This PR does not clear or rewrite historical records. No queue/retry/posting policy, provider authority, installed config, daemon/service state, credential, release, deployment, or customer surface was changed. This PR may establish source/CI review readiness only; it is not merge, installed-runtime, release, deployment, or customer proof.
