### PR TITLE
fix: bound launchd worker log retention

### DIFF
--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -38,8 +38,51 @@ Minimum LaunchAgent environment block:
   <string>/absolute/path/to/neondiff.private-key.pem</string>
   <key>NODE_OPTIONS</key>
   <string>--use-system-ca</string>
+  <key>NEONDIFF_LAUNCHD_STDOUT_PATH</key>
+  <string>/Users/your-user/Library/Logs/evaos-code-review-bot/launchd.out.log</string>
+  <key>NEONDIFF_LAUNCHD_STDERR_PATH</key>
+  <string>/Users/your-user/Library/Logs/evaos-code-review-bot/launchd.err.log</string>
+  <key>NEONDIFF_LAUNCHD_LOG_MAX_BYTES</key>
+  <string>10485760</string>
+  <key>NEONDIFF_LAUNCHD_LOG_ARCHIVE_COUNT</key>
+  <string>5</string>
+  <key>NEONDIFF_LAUNCHD_LOG_MAX_AGE_HOURS</key>
+  <string>168</string>
 </dict>
 ```
+
+## Bounded launchd logs
+
+The managed LaunchAgent policy bounds stdout and stderr independently. Each
+live file rotates before the next record would take it past 10 MiB, retains at
+most five archives, and removes archives older than 168 hours. One record may
+be larger than the threshold; otherwise the expected upper bound is about
+120 MiB across two live files and ten archives. The log directory is `0700`;
+live files and archives are `0600` and must be owned by the current user.
+
+Rotation copies the current bytes into a private same-directory archive,
+durably closes that archive, and then truncates the already-open inherited file
+descriptor. The visible live path keeps the same device and inode, so launchd
+does not need to reopen it and the worker continues writing after rotation.
+The runtime fails closed on symlinks, a path/descriptor inode mismatch, broader
+permissions, wrong ownership, or an archive/copy/truncate failure. It never
+renames the live inode and does not use a second daemon, log shipper, or
+privileged `/etc/newsyslog.d` policy.
+
+The worker installer adds the exact policy idempotently, creates missing live
+files without reading or truncating them, and narrows their permissions. It
+preserves existing archives. Rolling back to an earlier managed worker keeps
+the policy; rolling back to the original invocation restores the original
+environment values and leaves the directory, live files, and archives in
+place. Uninstall or rollback must not delete unrelated logs. Archives contain
+only the exact already-local log bytes and remain in the same private directory;
+rotation does not copy credentials or logs to another surface.
+
+Source and packaging tests do not prove installed adoption. A separately
+authorized post-install smoke must verify a fresh heartbeat, continued stdout
+and stderr writes through one rotation, bounded file growth, and the installed
+plist values. Do not truncate the current log or restart launchd merely to
+validate source changes.
 
 Only switch to `--dry-run false` after:
 

--- a/launchd/evaos-code-review-bot.plist.example
+++ b/launchd/evaos-code-review-bot.plist.example
@@ -34,6 +34,16 @@
     <string>REPLACE_WITH_APP_ID</string>
     <key>EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH</key>
     <string>/absolute/path/to/private-key.pem</string>
+    <key>NEONDIFF_LAUNCHD_STDOUT_PATH</key>
+    <string>/Users/lume/Library/Logs/evaos-code-review-bot/launchd.out.log</string>
+    <key>NEONDIFF_LAUNCHD_STDERR_PATH</key>
+    <string>/Users/lume/Library/Logs/evaos-code-review-bot/launchd.err.log</string>
+    <key>NEONDIFF_LAUNCHD_LOG_MAX_BYTES</key>
+    <string>10485760</string>
+    <key>NEONDIFF_LAUNCHD_LOG_ARCHIVE_COUNT</key>
+    <string>5</string>
+    <key>NEONDIFF_LAUNCHD_LOG_MAX_AGE_HOURS</key>
+    <string>168</string>
   </dict>
   <key>RunAtLoad</key>
   <false/>

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -4,12 +4,10 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
-  closeSync,
   copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
-  openSync,
   readFileSync,
   readlinkSync,
   realpathSync,
@@ -25,6 +23,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "nod
 import {
   planWorkerRollback,
   planWorkerUpdate,
+  prepareLaunchdLogFiles,
   recoverPreviouslyLoadedWorker,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
@@ -193,42 +192,6 @@ function writePlistFromTemplate(templatePath, destinationPath, launchAgent) {
     || JSON.stringify(readback.EnvironmentVariables) !== JSON.stringify(launchAgent.EnvironmentVariables)
   ) {
     fail("LaunchAgent staged readback mismatch");
-  }
-}
-
-function prepareLaunchdLogFiles(launchAgent) {
-  const paths = [launchAgent.StandardOutPath, launchAgent.StandardErrorPath];
-  if (!paths.every((path) => typeof path === "string" && isAbsolute(path)) || paths[0] === paths[1]) {
-    fail("LaunchAgent log paths are invalid");
-  }
-  const directory = dirname(paths[0]);
-  if (dirname(paths[1]) !== directory) fail("LaunchAgent log paths must share one directory");
-  if (!existsSync(directory)) mkdirSync(directory, { recursive: true, mode: 0o700 });
-  const directoryEntry = lstatSync(directory);
-  if (directoryEntry.isSymbolicLink() || !directoryEntry.isDirectory()) {
-    fail("LaunchAgent log directory must be a real directory");
-  }
-  if (typeof process.getuid === "function" && directoryEntry.uid !== process.getuid()) {
-    fail("LaunchAgent log directory must be owned by the current user");
-  }
-  if (realpathSync(directory) !== resolve(directory)) {
-    fail("LaunchAgent log directory must not traverse symlinks");
-  }
-  chmodSync(directory, 0o700);
-  for (const path of paths) {
-    if (!existsSync(path)) {
-      const fd = openSync(path, "a", 0o600);
-      closeSync(fd);
-      continue;
-    }
-    const entry = lstatSync(path);
-    if (entry.isSymbolicLink() || !entry.isFile()) {
-      fail("LaunchAgent log path must be a regular non-symlink file");
-    }
-    if (typeof process.getuid === "function" && entry.uid !== process.getuid()) {
-      fail("LaunchAgent log path must be owned by the current user");
-    }
-    chmodSync(path, 0o600);
   }
 }
 

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -4,10 +4,12 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
   readlinkSync,
   realpathSync,
@@ -180,6 +182,9 @@ function writePlistFromTemplate(templatePath, destinationPath, launchAgent) {
   execFileSync("/usr/bin/plutil", [
     "-replace", "WorkingDirectory", "-string", launchAgent.WorkingDirectory, destinationPath
   ], CHILD_PROCESS_OPTIONS);
+  execFileSync("/usr/bin/plutil", [
+    "-replace", "EnvironmentVariables", "-json", JSON.stringify(launchAgent.EnvironmentVariables), destinationPath
+  ], CHILD_PROCESS_OPTIONS);
   const readback = parsePlist(destinationPath);
   if (
     readback.Label !== launchAgent.Label
@@ -188,6 +193,42 @@ function writePlistFromTemplate(templatePath, destinationPath, launchAgent) {
     || JSON.stringify(readback.EnvironmentVariables) !== JSON.stringify(launchAgent.EnvironmentVariables)
   ) {
     fail("LaunchAgent staged readback mismatch");
+  }
+}
+
+function prepareLaunchdLogFiles(launchAgent) {
+  const paths = [launchAgent.StandardOutPath, launchAgent.StandardErrorPath];
+  if (!paths.every((path) => typeof path === "string" && isAbsolute(path)) || paths[0] === paths[1]) {
+    fail("LaunchAgent log paths are invalid");
+  }
+  const directory = dirname(paths[0]);
+  if (dirname(paths[1]) !== directory) fail("LaunchAgent log paths must share one directory");
+  if (!existsSync(directory)) mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryEntry = lstatSync(directory);
+  if (directoryEntry.isSymbolicLink() || !directoryEntry.isDirectory()) {
+    fail("LaunchAgent log directory must be a real directory");
+  }
+  if (typeof process.getuid === "function" && directoryEntry.uid !== process.getuid()) {
+    fail("LaunchAgent log directory must be owned by the current user");
+  }
+  if (realpathSync(directory) !== resolve(directory)) {
+    fail("LaunchAgent log directory must not traverse symlinks");
+  }
+  chmodSync(directory, 0o700);
+  for (const path of paths) {
+    if (!existsSync(path)) {
+      const fd = openSync(path, "a", 0o600);
+      closeSync(fd);
+      continue;
+    }
+    const entry = lstatSync(path);
+    if (entry.isSymbolicLink() || !entry.isFile()) {
+      fail("LaunchAgent log path must be a regular non-symlink file");
+    }
+    if (typeof process.getuid === "function" && entry.uid !== process.getuid()) {
+      fail("LaunchAgent log path must be owned by the current user");
+    }
+    chmodSync(path, 0o600);
   }
 }
 
@@ -527,6 +568,7 @@ function update(args) {
     return;
   }
   const result = withWorkerLock(paths, () => {
+    prepareLaunchdLogFiles(plan.nextLaunchAgent);
     installVersion({
       versionsRoot: paths.versionsRoot,
       versionID: plan.versionID,

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { basename, isAbsolute, join, relative, sep } from "node:path";
+import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
@@ -11,6 +11,19 @@ const PRIVATE_KEY_KEYS = [
   "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
   "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH"
 ];
+export const LAUNCHD_LOG_ROTATION_POLICY = Object.freeze({
+  maxBytes: 10 * 1024 * 1024,
+  archiveCount: 5,
+  maxAgeHours: 168,
+  descriptorMode: "copy_ftruncate_same_inode"
+});
+export const LAUNCHD_LOG_ROTATION_ENV = Object.freeze({
+  stdoutPath: "NEONDIFF_LAUNCHD_STDOUT_PATH",
+  stderrPath: "NEONDIFF_LAUNCHD_STDERR_PATH",
+  maxBytes: "NEONDIFF_LAUNCHD_LOG_MAX_BYTES",
+  archiveCount: "NEONDIFF_LAUNCHD_LOG_ARCHIVE_COUNT",
+  maxAgeHours: "NEONDIFF_LAUNCHD_LOG_MAX_AGE_HOURS"
+});
 const LAUNCHD_BOOTSTRAP_RETRY_DELAYS_MS = [250, 750, 2_000, 5_000, 10_000];
 
 function fail(message) {
@@ -98,6 +111,13 @@ function validateLaunchAgent(launchAgent, expectedLabel) {
     (value) => isAbsolute(value),
     "GitHub App private-key path"
   );
+  const logRotationEnvironment = buildLaunchdLogRotationEnvironment(launchAgent);
+  for (const [name, expectedValue] of Object.entries(logRotationEnvironment)) {
+    const currentValue = environment[name];
+    if (currentValue !== undefined && currentValue !== expectedValue) {
+      fail(`LaunchAgent has conflicting ${name}`);
+    }
+  }
 
   const daemonIndex = daemonIndexFor(launchAgent.ProgramArguments, launchAgent.WorkingDirectory);
   const daemonArguments = launchAgent.ProgramArguments.slice(daemonIndex + 1);
@@ -113,8 +133,54 @@ function validateLaunchAgent(launchAgent, expectedLabel) {
   }
   return {
     daemonArguments,
-    configPath: daemonArguments[configIndexes[0] + 1]
+    configPath: daemonArguments[configIndexes[0] + 1],
+    logRotationEnvironment
   };
+}
+
+function buildLaunchdLogRotationEnvironment(launchAgent) {
+  const stdoutPath = launchAgent.StandardOutPath;
+  const stderrPath = launchAgent.StandardErrorPath;
+  if (!isAbsolute(stdoutPath ?? "") || !isAbsolute(stderrPath ?? "") || stdoutPath === stderrPath) {
+    fail("LaunchAgent must have distinct absolute stdout and stderr log paths");
+  }
+  if (resolve(stdoutPath) !== stdoutPath || resolve(stderrPath) !== stderrPath) {
+    fail("LaunchAgent log paths must be normalized absolute paths");
+  }
+  const stdoutDirectory = stdoutPath.slice(0, stdoutPath.lastIndexOf("/"));
+  const stderrDirectory = stderrPath.slice(0, stderrPath.lastIndexOf("/"));
+  if (
+    stdoutDirectory !== stderrDirectory
+    || !stdoutDirectory.endsWith("/Library/Logs/evaos-code-review-bot")
+  ) {
+    fail("LaunchAgent logs must share the private user Library/Logs/evaos-code-review-bot directory");
+  }
+  return {
+    [LAUNCHD_LOG_ROTATION_ENV.stdoutPath]: stdoutPath,
+    [LAUNCHD_LOG_ROTATION_ENV.stderrPath]: stderrPath,
+    [LAUNCHD_LOG_ROTATION_ENV.maxBytes]: String(LAUNCHD_LOG_ROTATION_POLICY.maxBytes),
+    [LAUNCHD_LOG_ROTATION_ENV.archiveCount]: String(LAUNCHD_LOG_ROTATION_POLICY.archiveCount),
+    [LAUNCHD_LOG_ROTATION_ENV.maxAgeHours]: String(LAUNCHD_LOG_ROTATION_POLICY.maxAgeHours)
+  };
+}
+
+function captureManagedLogEnvironment(environment) {
+  return Object.fromEntries(
+    Object.values(LAUNCHD_LOG_ROTATION_ENV).map((name) => [
+      name,
+      Object.prototype.hasOwnProperty.call(environment, name) ? environment[name] : null
+    ])
+  );
+}
+
+function restoreManagedLogEnvironment(environment, original) {
+  const restored = clone(environment);
+  for (const name of Object.values(LAUNCHD_LOG_ROTATION_ENV)) {
+    const value = original?.[name];
+    if (typeof value === "string") restored[name] = value;
+    else delete restored[name];
+  }
+  return restored;
 }
 
 export function validateWorkerCandidate({
@@ -200,7 +266,7 @@ export function planWorkerUpdate({
   if (!FULL_SHA_PATTERN.test(candidateHead)) fail("candidate head is invalid");
   if (!PACKAGE_VERSION_PATTERN.test(packageVersion)) fail("candidate package version is invalid");
   if (!SHA256_PATTERN.test(manifestSHA256)) fail("candidate manifest SHA-256 is invalid");
-  const { daemonArguments, configPath } = validateLaunchAgent(launchAgent, expectedLabel);
+  const { daemonArguments, configPath, logRotationEnvironment } = validateLaunchAgent(launchAgent, expectedLabel);
   const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
   const currentPackageRoot = join(workerRoot, "current", "node_modules", "neondiff");
   if (previousState && previousState.launchdLabel !== expectedLabel) {
@@ -225,6 +291,10 @@ export function planWorkerUpdate({
     ...daemonArguments
   ];
   nextLaunchAgent.WorkingDirectory = launchAgent.WorkingDirectory;
+  nextLaunchAgent.EnvironmentVariables = {
+    ...nextLaunchAgent.EnvironmentVariables,
+    ...logRotationEnvironment
+  };
 
   const originalProgramArguments = previousState?.originalProgramArguments
     ?? clone(launchAgent.ProgramArguments);
@@ -234,6 +304,8 @@ export function planWorkerUpdate({
   const previousPackageVersion = previousVersionID
     ? previousState?.packageVersion ?? null
     : null;
+  const originalLogRotationEnvironment = previousState?.originalLogRotationEnvironment
+    ?? captureManagedLogEnvironment(launchAgent.EnvironmentVariables);
   const nextState = {
     schemaVersion: 1,
     launchdLabel: expectedLabel,
@@ -242,6 +314,7 @@ export function planWorkerUpdate({
     previousPackageVersion,
     originalProgramArguments,
     originalWorkingDirectory,
+    originalLogRotationEnvironment,
     candidateHead,
     packageVersion,
     manifestSHA256
@@ -259,7 +332,11 @@ export function planWorkerUpdate({
       preservesConfiguration: true,
       preservesCredentials: true,
       preservesProviderState: true,
-      preservesRepositoryAllowlist: true
+      preservesRepositoryAllowlist: true,
+      logRotation: {
+        ...LAUNCHD_LOG_ROTATION_POLICY,
+        private: true
+      }
     }
   };
 }
@@ -321,6 +398,10 @@ export function planWorkerRollback({ state, currentLaunchAgent, expectedLabel })
   const nextLaunchAgent = clone(currentLaunchAgent);
   nextLaunchAgent.ProgramArguments = clone(state.originalProgramArguments);
   nextLaunchAgent.WorkingDirectory = state.originalWorkingDirectory;
+  nextLaunchAgent.EnvironmentVariables = restoreManagedLogEnvironment(
+    nextLaunchAgent.EnvironmentVariables,
+    state.originalLogRotationEnvironment
+  );
   validateLaunchAgent(nextLaunchAgent, expectedLabel);
   return {
     nextLaunchAgent,

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -51,11 +51,16 @@ function lstatIfPresent(path) {
   }
 }
 
-function requireCurrentUserPrivateFile(entry, label) {
+function requireCurrentUserSingleLinkFile(entry, label) {
   if (!entry.isFile()) fail(`${label} must be a regular non-symlink file`);
   if (typeof process.getuid === "function" && entry.uid !== process.getuid()) {
     fail(`${label} must be owned by the current user`);
   }
+  if (entry.nlink !== 1) fail(`${label} must have exactly one link`);
+}
+
+function requireCurrentUserPrivateFile(entry, label) {
+  requireCurrentUserSingleLinkFile(entry, label);
   if ((entry.mode & 0o077) !== 0) fail(`${label} must be private to the current user (0600)`);
 }
 
@@ -89,15 +94,26 @@ export function prepareLaunchdLogFiles(launchAgent) {
       if (typeof process.getuid === "function" && existing.uid !== process.getuid()) {
         fail("LaunchAgent log path must be owned by the current user");
       }
+      requireCurrentUserSingleLinkFile(existing, "LaunchAgent log path");
       let fd;
       try {
         fd = openSync(path, constants.O_WRONLY | constants.O_NOFOLLOW);
-        fchmodSync(fd, 0o600);
         const descriptorEntry = fstatSync(fd);
         const pathEntry = lstatSync(path);
-        requireCurrentUserPrivateFile(descriptorEntry, "LaunchAgent log descriptor");
-        requireCurrentUserPrivateFile(pathEntry, "LaunchAgent log path");
+        requireCurrentUserSingleLinkFile(descriptorEntry, "LaunchAgent log descriptor");
+        requireCurrentUserSingleLinkFile(pathEntry, "LaunchAgent log path");
         if (descriptorEntry.dev !== pathEntry.dev || descriptorEntry.ino !== pathEntry.ino) {
+          fail("LaunchAgent log path changed while permissions were prepared");
+        }
+        fchmodSync(fd, 0o600);
+        const preparedDescriptorEntry = fstatSync(fd);
+        const preparedPathEntry = lstatSync(path);
+        requireCurrentUserPrivateFile(preparedDescriptorEntry, "LaunchAgent log descriptor");
+        requireCurrentUserPrivateFile(preparedPathEntry, "LaunchAgent log path");
+        if (
+          preparedDescriptorEntry.dev !== preparedPathEntry.dev
+          || preparedDescriptorEntry.ino !== preparedPathEntry.ino
+        ) {
           fail("LaunchAgent log path changed while permissions were prepared");
         }
       } catch (error) {
@@ -118,12 +134,22 @@ export function prepareLaunchdLogFiles(launchAgent) {
         constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
         0o600
       );
-      fchmodSync(fd, 0o600);
       const descriptorEntry = fstatSync(fd);
       const pathEntry = lstatSync(path);
-      requireCurrentUserPrivateFile(descriptorEntry, "LaunchAgent log descriptor");
-      requireCurrentUserPrivateFile(pathEntry, "LaunchAgent log path");
+      requireCurrentUserSingleLinkFile(descriptorEntry, "LaunchAgent log descriptor");
+      requireCurrentUserSingleLinkFile(pathEntry, "LaunchAgent log path");
       if (descriptorEntry.dev !== pathEntry.dev || descriptorEntry.ino !== pathEntry.ino) {
+        fail("LaunchAgent log path changed while it was created");
+      }
+      fchmodSync(fd, 0o600);
+      const preparedDescriptorEntry = fstatSync(fd);
+      const preparedPathEntry = lstatSync(path);
+      requireCurrentUserPrivateFile(preparedDescriptorEntry, "LaunchAgent log descriptor");
+      requireCurrentUserPrivateFile(preparedPathEntry, "LaunchAgent log path");
+      if (
+        preparedDescriptorEntry.dev !== preparedPathEntry.dev
+        || preparedDescriptorEntry.ino !== preparedPathEntry.ino
+      ) {
         fail("LaunchAgent log path changed while it was created");
       }
     } catch (error) {

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -10,6 +10,7 @@ import {
   openSync,
   realpathSync
 } from "node:fs";
+import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
@@ -88,7 +89,25 @@ export function prepareLaunchdLogFiles(launchAgent) {
       if (typeof process.getuid === "function" && existing.uid !== process.getuid()) {
         fail("LaunchAgent log path must be owned by the current user");
       }
-      chmodSync(path, 0o600);
+      let fd;
+      try {
+        fd = openSync(path, constants.O_WRONLY | constants.O_NOFOLLOW);
+        fchmodSync(fd, 0o600);
+        const descriptorEntry = fstatSync(fd);
+        const pathEntry = lstatSync(path);
+        requireCurrentUserPrivateFile(descriptorEntry, "LaunchAgent log descriptor");
+        requireCurrentUserPrivateFile(pathEntry, "LaunchAgent log path");
+        if (descriptorEntry.dev !== pathEntry.dev || descriptorEntry.ino !== pathEntry.ino) {
+          fail("LaunchAgent log path changed while permissions were prepared");
+        }
+      } catch (error) {
+        if (error?.code === "ELOOP") {
+          fail("LaunchAgent log path must be a regular non-symlink file");
+        }
+        throw error;
+      } finally {
+        if (fd !== undefined) closeSync(fd);
+      }
       continue;
     }
 
@@ -235,11 +254,12 @@ function buildLaunchdLogRotationEnvironment(launchAgent) {
   if (resolve(stdoutPath) !== stdoutPath || resolve(stderrPath) !== stderrPath) {
     fail("LaunchAgent log paths must be normalized absolute paths");
   }
-  const stdoutDirectory = stdoutPath.slice(0, stdoutPath.lastIndexOf("/"));
-  const stderrDirectory = stderrPath.slice(0, stderrPath.lastIndexOf("/"));
+  const stdoutDirectory = dirname(stdoutPath);
+  const stderrDirectory = dirname(stderrPath);
+  const expectedDirectory = join(homedir(), "Library", "Logs", "evaos-code-review-bot");
   if (
     stdoutDirectory !== stderrDirectory
-    || !stdoutDirectory.endsWith("/Library/Logs/evaos-code-review-bot")
+    || stdoutDirectory !== expectedDirectory
   ) {
     fail("LaunchAgent logs must share the private user Library/Logs/evaos-code-review-bot directory");
   }

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -1,5 +1,16 @@
 import { createHash } from "node:crypto";
-import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  realpathSync
+} from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
@@ -28,6 +39,83 @@ const LAUNCHD_BOOTSTRAP_RETRY_DELAYS_MS = [250, 750, 2_000, 5_000, 10_000];
 
 function fail(message) {
   throw new Error(message);
+}
+
+function lstatIfPresent(path) {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function requireCurrentUserPrivateFile(entry, label) {
+  if (!entry.isFile()) fail(`${label} must be a regular non-symlink file`);
+  if (typeof process.getuid === "function" && entry.uid !== process.getuid()) {
+    fail(`${label} must be owned by the current user`);
+  }
+  if ((entry.mode & 0o077) !== 0) fail(`${label} must be private to the current user (0600)`);
+}
+
+export function prepareLaunchdLogFiles(launchAgent) {
+  const paths = [launchAgent.StandardOutPath, launchAgent.StandardErrorPath];
+  if (!paths.every((path) => typeof path === "string" && isAbsolute(path)) || paths[0] === paths[1]) {
+    fail("LaunchAgent log paths are invalid");
+  }
+  const directory = dirname(paths[0]);
+  if (dirname(paths[1]) !== directory) fail("LaunchAgent log paths must share one directory");
+  if (lstatIfPresent(directory) === null) mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryEntry = lstatSync(directory);
+  if (directoryEntry.isSymbolicLink() || !directoryEntry.isDirectory()) {
+    fail("LaunchAgent log directory must be a real directory");
+  }
+  if (typeof process.getuid === "function" && directoryEntry.uid !== process.getuid()) {
+    fail("LaunchAgent log directory must be owned by the current user");
+  }
+  if (realpathSync(directory) !== resolve(directory)) {
+    fail("LaunchAgent log directory must not traverse symlinks");
+  }
+  chmodSync(directory, 0o700);
+
+  for (const path of paths) {
+    const existing = lstatIfPresent(path);
+    if (existing !== null) {
+      if (existing.isSymbolicLink()) {
+        fail("LaunchAgent log path must be a regular non-symlink file");
+      }
+      if (!existing.isFile()) fail("LaunchAgent log path must be a regular non-symlink file");
+      if (typeof process.getuid === "function" && existing.uid !== process.getuid()) {
+        fail("LaunchAgent log path must be owned by the current user");
+      }
+      chmodSync(path, 0o600);
+      continue;
+    }
+
+    let fd;
+    try {
+      fd = openSync(
+        path,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+        0o600
+      );
+      fchmodSync(fd, 0o600);
+      const descriptorEntry = fstatSync(fd);
+      const pathEntry = lstatSync(path);
+      requireCurrentUserPrivateFile(descriptorEntry, "LaunchAgent log descriptor");
+      requireCurrentUserPrivateFile(pathEntry, "LaunchAgent log path");
+      if (descriptorEntry.dev !== pathEntry.dev || descriptorEntry.ino !== pathEntry.ino) {
+        fail("LaunchAgent log path changed while it was created");
+      }
+    } catch (error) {
+      if (error?.code === "EEXIST" || error?.code === "ELOOP") {
+        fail("LaunchAgent log path must be a regular non-symlink file");
+      }
+      throw error;
+    } finally {
+      if (fd !== undefined) closeSync(fd);
+    }
+  }
 }
 
 function sha256(value) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { loadConfig, validateLicenseConfigOverride, type BotConfig } from "./con
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { collectProviderThrottleReport } from "./provider-throttle-report.js";
 import { runDaemonCycle, shouldExitDaemonAfterFailedCycle } from "./daemon.js";
+import { createLaunchdDaemonLogWriters, installLaunchdDaemonConsole } from "./daemon-log.js";
 import {
   runLaunchdControlCommand,
   type LaunchctlResult
@@ -2355,6 +2356,8 @@ async function main(): Promise<void> {
     }
     const config = loadConfig(args.config);
     const monitoredRepos = listReposToScan(config);
+    const launchdLogWriters = createLaunchdDaemonLogWriters();
+    if (launchdLogWriters) installLaunchdDaemonConsole(launchdLogWriters);
     let cycle = 0;
     const runOnce = args.once === "true";
     for (;;) {
@@ -2371,7 +2374,8 @@ async function main(): Promise<void> {
         reviewSchedulerEnabled: config.reviewScheduler?.enabled === true,
         issueEnrichmentEnabled: config.issueEnrichment?.enabled === true,
         worktreeCleanupDue: config.worktreeCleanup!.enabled && (cycle === 1 || (cycle - 1) % cleanupIntervalCycles === 0),
-        configPath: args.config
+        configPath: args.config,
+        ...(launchdLogWriters ? launchdLogWriters : {})
       });
       if (shouldExitDaemonAfterFailedCycle(cycleResult, runOnce)) {
         process.exitCode = 1;

--- a/src/daemon-log.ts
+++ b/src/daemon-log.ts
@@ -4,12 +4,12 @@ import {
   fstatSync,
   fsyncSync,
   ftruncateSync,
+  linkSync,
   lstatSync,
   openSync,
-  readFileSync,
   readdirSync,
+  readSync,
   realpathSync,
-  renameSync,
   rmSync,
   writeSync
 } from "node:fs";
@@ -152,17 +152,18 @@ function archiveLaunchdLog(input: {
   const archiveName = launchdArchiveName(input.path, input.now, input.archiveSequence);
   const archivePath = resolve(directory, archiveName);
   const temporaryPath = `${archivePath}.tmp`;
-  const bytes = readInheritedLogSnapshot(input.path, input.fd);
   let temporaryFd: number | undefined;
   let temporaryCreated = false;
   try {
     temporaryFd = openSync(temporaryPath, "wx", 0o600);
     temporaryCreated = true;
-    writeAll(temporaryFd, bytes);
+    copyInheritedLogSnapshot(input.path, input.fd, temporaryFd);
     fsyncSync(temporaryFd);
     closeSync(temporaryFd);
     temporaryFd = undefined;
-    renameSync(temporaryPath, archivePath);
+    linkSync(temporaryPath, archivePath);
+    rmSync(temporaryPath);
+    temporaryCreated = false;
     fsyncDirectory(directory);
     assertPrivateArchive(archivePath);
     pruneLaunchdLogArchives(input.path, input.archiveCount, input.maxAgeMs, input.now, archivePath);
@@ -182,7 +183,7 @@ function archiveLaunchdLog(input: {
   }
 }
 
-function readInheritedLogSnapshot(path: string, inheritedFd: number): Buffer {
+function copyInheritedLogSnapshot(path: string, inheritedFd: number, archiveFd: number): void {
   const sourceFd = openSync(resolve(path), constants.O_RDONLY | constants.O_NOFOLLOW);
   try {
     const source = fstatSync(sourceFd) as Stats;
@@ -190,7 +191,26 @@ function readInheritedLogSnapshot(path: string, inheritedFd: number): Buffer {
     if (!source.isFile() || source.dev !== inherited.dev || source.ino !== inherited.ino) {
       throw new Error("launchd log snapshot must use the inherited descriptor inode");
     }
-    return readFileSync(sourceFd);
+    if (source.nlink !== 1 || inherited.nlink !== 1) {
+      throw new Error("launchd log path must have exactly one link");
+    }
+    const snapshotLength = source.size;
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let snapshotOffset = 0;
+    while (snapshotOffset < snapshotLength) {
+      const bytesRead = readSync(
+        sourceFd,
+        buffer,
+        0,
+        Math.min(buffer.byteLength, snapshotLength - snapshotOffset),
+        snapshotOffset
+      );
+      if (bytesRead === 0) {
+        throw new Error("launchd log snapshot changed before it could be archived");
+      }
+      writeAll(archiveFd, buffer, bytesRead);
+      snapshotOffset += bytesRead;
+    }
   } finally {
     closeSync(sourceFd);
   }
@@ -246,6 +266,9 @@ function assertPrivateLaunchdLog(path: string, fd: number): Stats {
   if (!fdEntry.isFile() || fdEntry.dev !== pathEntry.dev || fdEntry.ino !== pathEntry.ino) {
     throw new Error("launchd log path and inherited descriptor must identify the same regular file");
   }
+  if (pathEntry.nlink !== 1 || fdEntry.nlink !== 1) {
+    throw new Error("launchd log path must have exactly one link");
+  }
   return fdEntry;
 }
 
@@ -276,9 +299,9 @@ function launchdArchivePattern(path: string): RegExp {
   return new RegExp(`^${escaped}\\.neondiff-\\d{8}T\\d{9}Z-\\d+-\\d+\\.archive$`);
 }
 
-function writeAll(fd: number, bytes: Buffer): void {
+function writeAll(fd: number, bytes: Buffer, byteLength = bytes.byteLength): void {
   let offset = 0;
-  while (offset < bytes.byteLength) offset += writeSync(fd, bytes, offset, bytes.byteLength - offset);
+  while (offset < byteLength) offset += writeSync(fd, bytes, offset, byteLength - offset);
 }
 
 function fsyncDirectory(path: string): void {

--- a/src/daemon-log.ts
+++ b/src/daemon-log.ts
@@ -154,8 +154,10 @@ function archiveLaunchdLog(input: {
   const temporaryPath = `${archivePath}.tmp`;
   const bytes = readInheritedLogSnapshot(input.path, input.fd);
   let temporaryFd: number | undefined;
+  let temporaryCreated = false;
   try {
     temporaryFd = openSync(temporaryPath, "wx", 0o600);
+    temporaryCreated = true;
     writeAll(temporaryFd, bytes);
     fsyncSync(temporaryFd);
     closeSync(temporaryFd);
@@ -169,10 +171,12 @@ function archiveLaunchdLog(input: {
     assertPrivateLaunchdLog(input.path, input.fd);
   } catch (error) {
     if (temporaryFd !== undefined) closeSync(temporaryFd);
-    try {
-      rmSync(temporaryPath, { force: true });
-    } catch {
-      // Preserve the original rotation failure; the private temp path is bounded and exact.
+    if (temporaryCreated) {
+      try {
+        rmSync(temporaryPath, { force: true });
+      } catch {
+        // Preserve the original rotation failure; only this call's private temp path is eligible.
+      }
     }
     throw error;
   }

--- a/src/daemon-log.ts
+++ b/src/daemon-log.ts
@@ -1,4 +1,51 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  fsyncSync,
+  ftruncateSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeSync
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { format } from "node:util";
 import { redactSecrets } from "./secrets.js";
+
+export const LAUNCHD_LOG_POLICY = {
+  maxBytes: 10 * 1024 * 1024,
+  archiveCount: 5,
+  maxAgeHours: 168,
+  descriptorMode: "copy_ftruncate_same_inode" as const
+};
+
+export const LAUNCHD_LOG_ENV = {
+  stdoutPath: "NEONDIFF_LAUNCHD_STDOUT_PATH",
+  stderrPath: "NEONDIFF_LAUNCHD_STDERR_PATH",
+  maxBytes: "NEONDIFF_LAUNCHD_LOG_MAX_BYTES",
+  archiveCount: "NEONDIFF_LAUNCHD_LOG_ARCHIVE_COUNT",
+  maxAgeHours: "NEONDIFF_LAUNCHD_LOG_MAX_AGE_HOURS"
+} as const;
+
+export interface LaunchdLogWriterOptions {
+  path: string;
+  fd: number;
+  maxBytes?: number;
+  archiveCount?: number;
+  maxAgeMs?: number;
+  now?: () => Date;
+}
+
+export interface LaunchdDaemonLogWriters {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+}
 
 export interface DaemonLogEvent {
   event: string;
@@ -13,6 +60,241 @@ export function formatDaemonLog(input: DaemonLogEvent, now = new Date()): string
     level,
     ...redactRecord(rest)
   });
+}
+
+export function createLaunchdDaemonLogWriters(
+  env: NodeJS.ProcessEnv = process.env
+): LaunchdDaemonLogWriters | undefined {
+  const values = Object.values(LAUNCHD_LOG_ENV).map((name) => env[name]);
+  if (values.every((value) => value === undefined)) return undefined;
+  if (values.some((value) => value === undefined)) {
+    throw new Error("launchd log rotation environment is incomplete");
+  }
+  const stdoutPath = env[LAUNCHD_LOG_ENV.stdoutPath]!;
+  const stderrPath = env[LAUNCHD_LOG_ENV.stderrPath]!;
+  if (resolve(stdoutPath) === resolve(stderrPath)) {
+    throw new Error("launchd stdout and stderr paths must be distinct");
+  }
+  const maxBytes = parsePositivePolicyInteger(env[LAUNCHD_LOG_ENV.maxBytes]!, LAUNCHD_LOG_ENV.maxBytes);
+  const archiveCount = parsePositivePolicyInteger(
+    env[LAUNCHD_LOG_ENV.archiveCount]!,
+    LAUNCHD_LOG_ENV.archiveCount
+  );
+  const maxAgeHours = parsePositivePolicyInteger(
+    env[LAUNCHD_LOG_ENV.maxAgeHours]!,
+    LAUNCHD_LOG_ENV.maxAgeHours
+  );
+  return {
+    stdout: createLaunchdLogWriter({
+      path: stdoutPath,
+      fd: process.stdout.fd,
+      maxBytes,
+      archiveCount,
+      maxAgeMs: maxAgeHours * 60 * 60 * 1_000
+    }),
+    stderr: createLaunchdLogWriter({
+      path: stderrPath,
+      fd: process.stderr.fd,
+      maxBytes,
+      archiveCount,
+      maxAgeMs: maxAgeHours * 60 * 60 * 1_000
+    })
+  };
+}
+
+export function installLaunchdDaemonConsole(writers: LaunchdDaemonLogWriters): void {
+  console.log = (...values: unknown[]) => writers.stdout(redactSecrets(format(...values)));
+  console.info = (...values: unknown[]) => writers.stdout(redactSecrets(format(...values)));
+  console.warn = (...values: unknown[]) => writers.stderr(redactSecrets(format(...values)));
+  console.error = (...values: unknown[]) => writers.stderr(redactSecrets(format(...values)));
+}
+
+export function createLaunchdLogWriter(options: LaunchdLogWriterOptions): (line: string) => void {
+  const maxBytes = options.maxBytes ?? LAUNCHD_LOG_POLICY.maxBytes;
+  const archiveCount = options.archiveCount ?? LAUNCHD_LOG_POLICY.archiveCount;
+  const maxAgeMs = options.maxAgeMs ?? LAUNCHD_LOG_POLICY.maxAgeHours * 60 * 60 * 1_000;
+  const now = options.now ?? (() => new Date());
+  validatePolicyInteger(maxBytes, "maxBytes");
+  validatePolicyInteger(archiveCount, "archiveCount");
+  validatePolicyInteger(maxAgeMs, "maxAgeMs");
+  assertPrivateLaunchdLog(options.path, options.fd);
+  pruneLaunchdLogArchives(options.path, archiveCount, maxAgeMs, now());
+  let archiveSequence = 0;
+  return (line: string): void => {
+    const record = Buffer.from(`${line}\n`, "utf8");
+    pruneLaunchdLogArchives(options.path, archiveCount, maxAgeMs, now());
+    const live = assertPrivateLaunchdLog(options.path, options.fd);
+    if (live.size + record.byteLength > maxBytes && live.size > 0) {
+      archiveSequence += 1;
+      archiveLaunchdLog({
+        path: options.path,
+        fd: options.fd,
+        archiveCount,
+        maxAgeMs,
+        now: now(),
+        archiveSequence
+      });
+    }
+    writeAll(options.fd, record);
+  };
+}
+
+function archiveLaunchdLog(input: {
+  path: string;
+  fd: number;
+  archiveCount: number;
+  maxAgeMs: number;
+  now: Date;
+  archiveSequence: number;
+}): void {
+  assertPrivateLaunchdLog(input.path, input.fd);
+  const directory = dirname(resolve(input.path));
+  const archiveName = launchdArchiveName(input.path, input.now, input.archiveSequence);
+  const archivePath = resolve(directory, archiveName);
+  const temporaryPath = `${archivePath}.tmp`;
+  const bytes = readInheritedLogSnapshot(input.path, input.fd);
+  let temporaryFd: number | undefined;
+  try {
+    temporaryFd = openSync(temporaryPath, "wx", 0o600);
+    writeAll(temporaryFd, bytes);
+    fsyncSync(temporaryFd);
+    closeSync(temporaryFd);
+    temporaryFd = undefined;
+    renameSync(temporaryPath, archivePath);
+    fsyncDirectory(directory);
+    assertPrivateArchive(archivePath);
+    pruneLaunchdLogArchives(input.path, input.archiveCount, input.maxAgeMs, input.now, archivePath);
+    assertPrivateLaunchdLog(input.path, input.fd);
+    ftruncateSync(input.fd, 0);
+    assertPrivateLaunchdLog(input.path, input.fd);
+  } catch (error) {
+    if (temporaryFd !== undefined) closeSync(temporaryFd);
+    try {
+      rmSync(temporaryPath, { force: true });
+    } catch {
+      // Preserve the original rotation failure; the private temp path is bounded and exact.
+    }
+    throw error;
+  }
+}
+
+function readInheritedLogSnapshot(path: string, inheritedFd: number): Buffer {
+  const sourceFd = openSync(resolve(path), constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const source = fstatSync(sourceFd) as Stats;
+    const inherited = fstatSync(inheritedFd) as Stats;
+    if (!source.isFile() || source.dev !== inherited.dev || source.ino !== inherited.ino) {
+      throw new Error("launchd log snapshot must use the inherited descriptor inode");
+    }
+    return readFileSync(sourceFd);
+  } finally {
+    closeSync(sourceFd);
+  }
+}
+
+function pruneLaunchdLogArchives(
+  path: string,
+  archiveCount: number,
+  maxAgeMs: number,
+  now: Date,
+  protectedArchivePath?: string
+): void {
+  const directory = dirname(resolve(path));
+  const archivePattern = launchdArchivePattern(path);
+  const archives = readdirSync(directory)
+    .filter((name) => archivePattern.test(name))
+    .map((name) => {
+      const archivePath = resolve(directory, name);
+      const metadata = assertPrivateArchive(archivePath);
+      return { path: archivePath, mtimeMs: metadata.mtimeMs };
+    })
+    .sort((left, right) => {
+      if (left.path === right.path) return 0;
+      if (left.path === protectedArchivePath) return -1;
+      if (right.path === protectedArchivePath) return 1;
+      return right.mtimeMs - left.mtimeMs || right.path.localeCompare(left.path);
+    });
+  for (const [index, archive] of archives.entries()) {
+    if (
+      archive.path !== protectedArchivePath
+      && (index >= archiveCount || now.getTime() - archive.mtimeMs > maxAgeMs)
+    ) {
+      rmSync(archive.path);
+    }
+  }
+}
+
+function assertPrivateLaunchdLog(path: string, fd: number): Stats {
+  const resolvedPath = resolve(path);
+  const directory = dirname(resolvedPath);
+  if (realpathSync(directory) !== directory) throw new Error("launchd log directory must not traverse symlinks");
+  const directoryEntry = lstatSync(directory) as Stats;
+  if (!directoryEntry.isDirectory() || directoryEntry.isSymbolicLink()) {
+    throw new Error("launchd log directory must be a real directory");
+  }
+  assertCurrentUserPrivate(directoryEntry, "launchd log directory");
+  const pathEntry = lstatSync(resolvedPath) as Stats;
+  if (!pathEntry.isFile() || pathEntry.isSymbolicLink()) {
+    throw new Error("launchd log path must be a regular non-symlink file");
+  }
+  assertCurrentUserPrivate(pathEntry, "launchd log path");
+  const fdEntry = fstatSync(fd) as Stats;
+  if (!fdEntry.isFile() || fdEntry.dev !== pathEntry.dev || fdEntry.ino !== pathEntry.ino) {
+    throw new Error("launchd log path and inherited descriptor must identify the same regular file");
+  }
+  return fdEntry;
+}
+
+function assertPrivateArchive(path: string): Stats {
+  const entry = lstatSync(path) as Stats;
+  if (!entry.isFile() || entry.isSymbolicLink()) {
+    throw new Error("launchd log archive must be a regular non-symlink file");
+  }
+  assertCurrentUserPrivate(entry, "launchd log archive");
+  return entry;
+}
+
+function assertCurrentUserPrivate(entry: Stats, label: string): void {
+  const getuid = process.getuid;
+  if (typeof getuid !== "function" || entry.uid !== getuid()) {
+    throw new Error(`${label} must be owned by the current user`);
+  }
+  if ((entry.mode & 0o077) !== 0) throw new Error(`${label} must not be group or world accessible`);
+}
+
+function launchdArchiveName(path: string, now: Date, sequence: number): string {
+  const timestamp = now.toISOString().replace(/[-:.]/g, "");
+  return `${basename(path)}.neondiff-${timestamp}-${process.pid}-${sequence}.archive`;
+}
+
+function launchdArchivePattern(path: string): RegExp {
+  const escaped = basename(path).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped}\\.neondiff-\\d{8}T\\d{9}Z-\\d+-\\d+\\.archive$`);
+}
+
+function writeAll(fd: number, bytes: Buffer): void {
+  let offset = 0;
+  while (offset < bytes.byteLength) offset += writeSync(fd, bytes, offset, bytes.byteLength - offset);
+}
+
+function fsyncDirectory(path: string): void {
+  const fd = openSync(path, "r");
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function parsePositivePolicyInteger(value: string, label: string): number {
+  if (!/^[1-9][0-9]*$/.test(value)) throw new Error(`${label} must be a positive integer`);
+  const parsed = Number(value);
+  validatePolicyInteger(parsed, label);
+  return parsed;
+}
+
+function validatePolicyInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${label} must be a positive safe integer`);
 }
 
 function redactRecord(value: Record<string, unknown>): Record<string, unknown> {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -7,10 +8,12 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
-  symlinkSync
+  statSync,
+  symlinkSync,
+  writeFileSync
 } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -81,8 +84,8 @@ function launchAgent() {
       "true"
     ],
     WorkingDirectory: "/Users/test/neondiff",
-    StandardOutPath: "/Users/test/Library/Logs/evaos-code-review-bot/launchd.out.log",
-    StandardErrorPath: "/Users/test/Library/Logs/evaos-code-review-bot/launchd.err.log",
+    StandardOutPath: join(homedir(), "Library", "Logs", "evaos-code-review-bot", "launchd.out.log"),
+    StandardErrorPath: join(homedir(), "Library", "Logs", "evaos-code-review-bot", "launchd.err.log"),
     EnvironmentVariables: {
       NEONDIFF_GITHUB_APP_ID: "123456",
       NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: "/Users/test/.config/neondiff/app.pem"
@@ -120,6 +123,43 @@ describe("B0 worker installer", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("narrows existing managed log permissions without truncating contents", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-existing-")));
+    try {
+      const stdoutPath = join(root, "launchd.out.log");
+      const stderrPath = join(root, "launchd.err.log");
+      writeFileSync(stdoutPath, "keep stdout", { mode: 0o600 });
+      writeFileSync(stderrPath, "keep stderr", { mode: 0o600 });
+      chmodSync(stdoutPath, 0o644);
+      chmodSync(stderrPath, 0o644);
+
+      prepareLaunchdLogFiles({ StandardOutPath: stdoutPath, StandardErrorPath: stderrPath });
+
+      expect(readFileSync(stdoutPath, "utf8")).toBe("keep stdout");
+      expect(readFileSync(stderrPath, "utf8")).toBe("keep stderr");
+      expect(statSync(stdoutPath).mode & 0o777).toBe(0o600);
+      expect(statSync(stderrPath).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects normalized launchd log paths outside the current user's Library", () => {
+    const outsideHome = launchAgent();
+    outsideHome.StandardOutPath = "/tmp/Library/Logs/evaos-code-review-bot/launchd.out.log";
+    outsideHome.StandardErrorPath = "/tmp/Library/Logs/evaos-code-review-bot/launchd.err.log";
+
+    expect(() => planWorkerUpdate({
+      launchAgent: outsideHome,
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    })).toThrow("private user Library/Logs/evaos-code-review-bot directory");
   });
 
   it("keeps a stable Node command when it resolves to the running Node binary", () => {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -144,6 +145,24 @@ describe("B0 worker installer", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("rejects a hardlinked managed log before changing the shared inode", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-hardlink-install-")));
+    try {
+      const directory = join(root, "logs");
+      const stdoutPath = join(directory, "launchd.out.log");
+      const stderrPath = join(directory, "launchd.err.log");
+      const operatorPath = join(root, "operator-owned.log");
+      mkdirSync(directory, { mode: 0o700 });
+      writeFileSync(operatorPath, "preserve", { mode: 0o644 });
+      linkSync(operatorPath, stdoutPath);
+      expect(() => prepareLaunchdLogFiles({ StandardOutPath: stdoutPath, StandardErrorPath: stderrPath })).toThrow("must have exactly one link");
+      expect(readFileSync(operatorPath, "utf8")).toBe("preserve");
+      expect(statSync(operatorPath).mode & 0o777).toBe(0o644);
+      expect(statSync(operatorPath).nlink).toBe(2);
+      expect(existsSync(stderrPath)).toBe(false);
+    } finally { rmSync(root, { recursive: true, force: true }); }
   });
 
   it("rejects normalized launchd log paths outside the current user's Library", () => {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -1,6 +1,17 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync
+} from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   LAUNCHD_LOG_ENV as RUNTIME_LOG_ENV,
@@ -11,6 +22,7 @@ import {
   LAUNCHD_LOG_ROTATION_POLICY,
   planWorkerRollback,
   planWorkerUpdate,
+  prepareLaunchdLogFiles,
   recoverPreviouslyLoadedWorker,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
@@ -87,6 +99,27 @@ describe("B0 worker installer", () => {
     expect(plist).toContain(`<string>${LAUNCHD_LOG_ROTATION_POLICY.maxBytes}</string>`);
     expect(plist).toContain(`<string>${LAUNCHD_LOG_ROTATION_POLICY.archiveCount}</string>`);
     expect(plist).toContain(`<string>${LAUNCHD_LOG_ROTATION_POLICY.maxAgeHours}</string>`);
+  });
+
+  it("rejects a dangling managed log symlink without creating its target", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-install-")));
+    try {
+      const directory = join(root, "Library", "Logs", "evaos-code-review-bot");
+      const stdoutPath = join(directory, "launchd.out.log");
+      const stderrPath = join(directory, "launchd.err.log");
+      const redirectedTarget = join(root, "redirected.out.log");
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      symlinkSync(redirectedTarget, stdoutPath);
+
+      expect(() => prepareLaunchdLogFiles({
+        StandardOutPath: stdoutPath,
+        StandardErrorPath: stderrPath
+      })).toThrow("regular non-symlink file");
+      expect(lstatSync(stdoutPath).isSymbolicLink()).toBe(true);
+      expect(existsSync(redirectedTarget)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps a stable Node command when it resolves to the running Node binary", () => {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -3,6 +3,12 @@ import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
+  LAUNCHD_LOG_ENV as RUNTIME_LOG_ENV,
+  LAUNCHD_LOG_POLICY as RUNTIME_LOG_POLICY
+} from "../src/daemon-log.js";
+import {
+  LAUNCHD_LOG_ROTATION_ENV,
+  LAUNCHD_LOG_ROTATION_POLICY,
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
@@ -63,6 +69,8 @@ function launchAgent() {
       "true"
     ],
     WorkingDirectory: "/Users/test/neondiff",
+    StandardOutPath: "/Users/test/Library/Logs/evaos-code-review-bot/launchd.out.log",
+    StandardErrorPath: "/Users/test/Library/Logs/evaos-code-review-bot/launchd.err.log",
     EnvironmentVariables: {
       NEONDIFF_GITHUB_APP_ID: "123456",
       NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: "/Users/test/.config/neondiff/app.pem"
@@ -71,6 +79,16 @@ function launchAgent() {
 }
 
 describe("B0 worker installer", () => {
+  it("keeps the runtime, installer, and example plist on one bounded log policy", () => {
+    expect(LAUNCHD_LOG_ROTATION_POLICY).toEqual(RUNTIME_LOG_POLICY);
+    expect(LAUNCHD_LOG_ROTATION_ENV).toEqual(RUNTIME_LOG_ENV);
+    const plist = readFileSync("launchd/evaos-code-review-bot.plist.example", "utf8");
+    for (const name of Object.values(LAUNCHD_LOG_ROTATION_ENV)) expect(plist).toContain(`<key>${name}</key>`);
+    expect(plist).toContain(`<string>${LAUNCHD_LOG_ROTATION_POLICY.maxBytes}</string>`);
+    expect(plist).toContain(`<string>${LAUNCHD_LOG_ROTATION_POLICY.archiveCount}</string>`);
+    expect(plist).toContain(`<string>${LAUNCHD_LOG_ROTATION_POLICY.maxAgeHours}</string>`);
+  });
+
   it("keeps a stable Node command when it resolves to the running Node binary", () => {
     const resolved = new Map([
       ["/opt/homebrew/Cellar/node/26.5.1/bin/node", "/opt/homebrew/Cellar/node/26.5.1/bin/node"],
@@ -212,7 +230,14 @@ describe("B0 worker installer", () => {
     expect(plan.versionID).toBe(`1.1.0-beta.27-${candidateHead.slice(0, 12)}`);
     expect(plan.configPath).toBe("/Users/test/.config/neondiff/config.local.json");
     expect(plan.nextLaunchAgent.Label).toBe("com.electricsheephq.neondiff");
-    expect(plan.nextLaunchAgent.EnvironmentVariables).toEqual(launchAgent().EnvironmentVariables);
+    expect(plan.nextLaunchAgent.EnvironmentVariables).toMatchObject({
+      ...launchAgent().EnvironmentVariables,
+      [LAUNCHD_LOG_ROTATION_ENV.stdoutPath]: launchAgent().StandardOutPath,
+      [LAUNCHD_LOG_ROTATION_ENV.stderrPath]: launchAgent().StandardErrorPath,
+      [LAUNCHD_LOG_ROTATION_ENV.maxBytes]: String(LAUNCHD_LOG_ROTATION_POLICY.maxBytes),
+      [LAUNCHD_LOG_ROTATION_ENV.archiveCount]: String(LAUNCHD_LOG_ROTATION_POLICY.archiveCount),
+      [LAUNCHD_LOG_ROTATION_ENV.maxAgeHours]: String(LAUNCHD_LOG_ROTATION_POLICY.maxAgeHours)
+    });
     expect(plan.nextLaunchAgent.ProgramArguments).toEqual([
       "/opt/homebrew/bin/node",
       "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/current/node_modules/neondiff/dist/src/cli.js",
@@ -223,6 +248,10 @@ describe("B0 worker installer", () => {
       "true"
     ]);
     expect(plan.nextLaunchAgent.WorkingDirectory).toBe(launchAgent().WorkingDirectory);
+    expect(plan.publicSummary.logRotation).toEqual({
+      ...LAUNCHD_LOG_ROTATION_POLICY,
+      private: true
+    });
     expect(JSON.stringify(plan.publicSummary)).not.toContain("app.pem");
     expect(JSON.stringify(plan.publicSummary)).not.toContain("config.local.json");
   });
@@ -256,7 +285,44 @@ describe("B0 worker installer", () => {
     });
     expect(rollback.nextLaunchAgent.ProgramArguments).toEqual(launchAgent().ProgramArguments);
     expect(rollback.nextLaunchAgent.WorkingDirectory).toBe(launchAgent().WorkingDirectory);
+    expect(rollback.nextLaunchAgent.EnvironmentVariables).toEqual(launchAgent().EnvironmentVariables);
     expect(rollback.publicSummary).toMatchObject({ action: "rollback", target: "original-worker" });
+  });
+
+  it("plans launchd log rotation idempotently and rejects conflicting managed policy", () => {
+    const first = planWorkerUpdate({
+      launchAgent: launchAgent(),
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+    const repeated = planWorkerUpdate({
+      launchAgent: first.nextLaunchAgent,
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64),
+      previousState: first.nextState
+    });
+    expect(repeated.nextLaunchAgent.EnvironmentVariables).toEqual(first.nextLaunchAgent.EnvironmentVariables);
+    expect(repeated.nextState.originalLogRotationEnvironment).toEqual(first.nextState.originalLogRotationEnvironment);
+
+    const conflicting = launchAgent();
+    conflicting.EnvironmentVariables[LAUNCHD_LOG_ROTATION_ENV.maxBytes] = "999";
+    expect(() => planWorkerUpdate({
+      launchAgent: conflicting,
+      expectedLabel: "com.electricsheephq.neondiff",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    })).toThrow(`conflicting ${LAUNCHD_LOG_ROTATION_ENV.maxBytes}`);
   });
 
   it("fails closed when managed worker state is missing or belongs to another label", () => {

--- a/tests/daemon-log.test.ts
+++ b/tests/daemon-log.test.ts
@@ -2,6 +2,7 @@ import {
   closeSync,
   chmodSync,
   fstatSync,
+  linkSync,
   mkdtempSync,
   openSync,
   readFileSync,
@@ -129,6 +130,62 @@ describe("daemon heartbeat logs", () => {
     } finally {
       closeSync(fd);
     }
+  });
+
+  it("rejects a hardlinked live log before archive or truncation", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-hardlink-")));
+    roots.push(root);
+    const livePath = join(root, "launchd.out.log");
+    const linkedPath = join(root, "operator-owned.log");
+    writeFileSync(livePath, "preserve", { mode: 0o600 });
+    linkSync(livePath, linkedPath);
+    const fd = openSync(livePath, "a");
+    try {
+      expect(() => createLaunchdLogWriter({ path: livePath, fd, maxBytes: 1 })).toThrow(
+        "must have exactly one link"
+      );
+      expect(readFileSync(livePath, "utf8")).toBe("preserve");
+      expect(readFileSync(linkedPath, "utf8")).toBe("preserve");
+      expect(statSync(linkedPath).nlink).toBe(2);
+    } finally { closeSync(fd); }
+  });
+
+  it("copies a fixed initial snapshot through a bounded buffer", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-bounded-")));
+    roots.push(root);
+    const livePath = join(root, "launchd.out.log");
+    const initial = Buffer.alloc(192 * 1024 + 17, "x");
+    writeFileSync(livePath, initial, { mode: 0o600 });
+    const fd = openSync(livePath, "a");
+    try {
+      const writer = createLaunchdLogWriter({ path: livePath, fd, maxBytes: initial.byteLength, archiveCount: 2, maxAgeMs: 7 * 24 * 60 * 60 * 1_000, now: () => new Date("2026-08-10T00:00:00.000Z") });
+      writer("new");
+      const archive = readdirSync(root).find((name) => name.endsWith(".archive"));
+      expect(archive).toBeDefined();
+      expect(readFileSync(join(root, archive!))).toEqual(initial);
+      expect(readFileSync(livePath, "utf8")).toBe("new\n");
+    } finally { closeSync(fd); }
+    const implementation = readFileSync(new URL("../src/daemon-log.ts", import.meta.url), "utf8");
+    expect(implementation).toContain("readSync(");
+    expect(implementation).toContain("snapshotLength = source.size");
+    expect(implementation).not.toContain("readFileSync(sourceFd)");
+  });
+
+  it("preserves an existing exact archive destination and the live log", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-final-collision-")));
+    roots.push(root);
+    const livePath = join(root, "launchd.out.log");
+    const finalPath = join(root, `${basename(livePath)}.neondiff-20260810T000000000Z-${process.pid}-1.archive`);
+    writeFileSync(livePath, "preserve", { mode: 0o600 });
+    writeFileSync(finalPath, "existing archive", { mode: 0o600 });
+    const fd = openSync(livePath, "a");
+    try {
+      const writer = createLaunchdLogWriter({ path: livePath, fd, maxBytes: 1, archiveCount: 5, maxAgeMs: 7 * 24 * 60 * 60 * 1_000, now: () => new Date("2026-08-10T00:00:00.000Z") });
+      expect(() => writer("x")).toThrow();
+      expect(readFileSync(finalPath, "utf8")).toBe("existing archive");
+      expect(readFileSync(livePath, "utf8")).toBe("preserve");
+      expect(readdirSync(root)).not.toContain(`${basename(finalPath)}.tmp`);
+    } finally { closeSync(fd); }
   });
 
   it("bounds archive count and age without touching unrelated files", () => {

--- a/tests/daemon-log.test.ts
+++ b/tests/daemon-log.test.ts
@@ -1,7 +1,35 @@
-import { describe, expect, it } from "vitest";
-import { formatDaemonLog } from "../src/daemon-log.js";
+import {
+  closeSync,
+  chmodSync,
+  fstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+  writeSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLaunchdLogWriter,
+  formatDaemonLog,
+  installLaunchdDaemonConsole
+} from "../src/daemon-log.js";
 
 describe("daemon heartbeat logs", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
   it("emits structured JSON with cycle and result counters", () => {
     const log = JSON.parse(formatDaemonLog({
       event: "daemon_cycle_complete",
@@ -40,5 +68,162 @@ describe("daemon heartbeat logs", () => {
 
     expect(log).toContain("[redacted-secret]");
     expect(log).not.toContain("ghp_fake_token");
+  });
+
+  it("routes owned daemon console output through bounded redacted streams", () => {
+    const original = {
+      log: console.log,
+      info: console.info,
+      warn: console.warn,
+      error: console.error
+    };
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    try {
+      installLaunchdDaemonConsole({
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line)
+      });
+      console.log("cycle", { ok: true });
+      console.warn("failed with ghp_fake_token");
+    } finally {
+      console.log = original.log;
+      console.info = original.info;
+      console.warn = original.warn;
+      console.error = original.error;
+    }
+    expect(stdout).toEqual(["cycle { ok: true }"]);
+    expect(stderr).toEqual(["failed with [redacted-secret]"]);
+  });
+
+  it("rotates launchd output by copying then truncating the inherited inode", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-log-")));
+    roots.push(root);
+    const livePath = join(root, "launchd.out.log");
+    const fd = openSync(livePath, "a", 0o600);
+    try {
+      writeSync(fd, "12345678");
+      const before = fstatSync(fd);
+      const writer = createLaunchdLogWriter({
+        path: livePath,
+        fd,
+        maxBytes: 10,
+        archiveCount: 2,
+        maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
+        now: () => new Date("2026-08-10T00:00:00.000Z")
+      });
+
+      writer("new");
+
+      const afterFd = fstatSync(fd);
+      const afterPath = statSync(livePath);
+      expect({ dev: afterFd.dev, ino: afterFd.ino }).toEqual({ dev: before.dev, ino: before.ino });
+      expect({ dev: afterPath.dev, ino: afterPath.ino }).toEqual({ dev: before.dev, ino: before.ino });
+      expect(readFileSync(livePath, "utf8")).toBe("new\n");
+      const archives = readdirSync(root).filter((name) => name !== basename(livePath));
+      expect(archives).toHaveLength(1);
+      expect(readFileSync(join(root, archives[0]!), "utf8")).toBe("12345678");
+      expect(statSync(root).mode & 0o777).toBe(0o700);
+      expect(statSync(livePath).mode & 0o777).toBe(0o600);
+      expect(statSync(join(root, archives[0]!)).mode & 0o777).toBe(0o600);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("bounds archive count and age without touching unrelated files", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-retention-")));
+    roots.push(root);
+    const livePath = join(root, "launchd.out.log");
+    const unrelatedPath = join(root, "operator-notes.log");
+    const fd = openSync(livePath, "a", 0o600);
+    const times = [
+      "2026-08-10T00:00:00.000Z",
+      "2026-08-10T01:00:00.000Z",
+      "2026-08-10T02:00:00.000Z"
+    ];
+    let index = 0;
+    try {
+      writeSync(fd, "12345678");
+      writeFileSync(unrelatedPath, "keep", { mode: 0o600 });
+      const writer = createLaunchdLogWriter({
+        path: livePath,
+        fd,
+        maxBytes: 10,
+        archiveCount: 2,
+        maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
+        now: () => new Date(times[Math.min(index++, times.length - 1)]!)
+      });
+      writer("a");
+      writer("12345678");
+      writer("b");
+      writer("12345678");
+      writer("c");
+      const archives = readdirSync(root).filter((name) => name.includes(".neondiff-") && name.endsWith(".archive"));
+      expect(archives).toHaveLength(2);
+      expect(readFileSync(unrelatedPath, "utf8")).toBe("keep");
+
+      const oldestArchive = join(root, archives[0]!);
+      utimesSync(oldestArchive, new Date("2026-08-01T00:00:00.000Z"), new Date("2026-08-01T00:00:00.000Z"));
+      createLaunchdLogWriter({
+        path: livePath,
+        fd,
+        maxBytes: 10,
+        archiveCount: 2,
+        maxAgeMs: 24 * 60 * 60 * 1_000,
+        now: () => new Date("2026-08-10T03:00:00.000Z")
+      });
+      expect(readdirSync(root)).not.toContain(basename(oldestArchive));
+      expect(readFileSync(unrelatedPath, "utf8")).toBe("keep");
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("fails closed before truncation for permissive, symlinked, or mismatched logs", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-launchd-log-guard-")));
+    roots.push(root);
+    const livePath = join(root, "launchd.out.log");
+    const otherPath = join(root, "other.log");
+    const symlinkPath = join(root, "symlink.log");
+    const fd = openSync(livePath, "a", 0o600);
+    const otherFd = openSync(otherPath, "a", 0o600);
+    try {
+      writeSync(fd, "preserve");
+      chmodSync(livePath, 0o644);
+      expect(() => createLaunchdLogWriter({ path: livePath, fd, maxBytes: 1 })).toThrow(
+        "must not be group or world accessible"
+      );
+      expect(readFileSync(livePath, "utf8")).toBe("preserve");
+      chmodSync(livePath, 0o600);
+
+      symlinkSync(livePath, symlinkPath);
+      expect(() => createLaunchdLogWriter({ path: symlinkPath, fd, maxBytes: 1 })).toThrow(
+        "regular non-symlink file"
+      );
+      expect(readFileSync(livePath, "utf8")).toBe("preserve");
+
+      expect(() => createLaunchdLogWriter({ path: livePath, fd: otherFd, maxBytes: 1 })).toThrow(
+        "same regular file"
+      );
+      expect(readFileSync(livePath, "utf8")).toBe("preserve");
+
+      const collision = join(
+        root,
+        `${basename(livePath)}.neondiff-20260810T000000000Z-${process.pid}-1.archive.tmp`
+      );
+      writeFileSync(collision, "private collision", { mode: 0o600 });
+      const writer = createLaunchdLogWriter({
+        path: livePath,
+        fd,
+        maxBytes: 1,
+        now: () => new Date("2026-08-10T00:00:00.000Z")
+      });
+      expect(() => writer("x")).toThrow();
+      expect(readFileSync(livePath, "utf8")).toBe("preserve");
+    } finally {
+      closeSync(otherFd);
+      closeSync(fd);
+    }
   });
 });

--- a/tests/daemon-log.test.ts
+++ b/tests/daemon-log.test.ts
@@ -221,6 +221,7 @@ describe("daemon heartbeat logs", () => {
       });
       expect(() => writer("x")).toThrow();
       expect(readFileSync(livePath, "utf8")).toBe("preserve");
+      expect(readFileSync(collision, "utf8")).toBe("private collision");
     } finally {
       closeSync(otherFd);
       closeSync(fd);


### PR DESCRIPTION
Closes #740
Parent tracker: #738

## Outcome

The managed launchd worker now has a bounded, private stdout/stderr retention policy that preserves launchd's inherited file descriptors. This is source and packaging proof only; the installed daemon and current logs were not touched.

## Source identity

- Base: `1a2f08a336d3bbcc1b6d0934db58b933d1980206`
- Head: `96d66e087a56173615d97810a9a3723ddfd1fa61`

## Policy

- 10 MiB threshold per live stream
- five archives per stream
- 168-hour maximum archive age
- `0700` directory and `0600` live/archive files, current-user ownership only
- approximately 120 MiB expected bound across two live files and ten archives, apart from one oversized record

## Descriptor and secret boundary

The daemon copies the current live bytes from an `O_NOFOLLOW` descriptor verified against launchd's inherited device/inode, fsyncs and atomically names a private same-directory archive, then truncates the inherited descriptor. The live path keeps the same device/inode, so subsequent writes remain visible without a restart or reopen. Symlinks, broader permissions, wrong ownership, descriptor mismatch, archive collision, copy failure, or truncate failure stop before unsafe continuation. Owned daemon console output is routed through the same bounded writers with secret redaction.

Installer planning adds the exact policy idempotently while preserving unrelated environment and credentials. Confirmed installation rejects existing symlinks, creates truly missing files with exclusive no-follow flags, verifies the opened descriptor against the private path, and does not read or truncate log contents. Previous-managed rollback retains the policy; original-worker rollback restores only the managed environment values and leaves all logs and archives in place.

## Focused proof

- Failing-first test initially failed because `createLaunchdLogWriter` did not exist.
- Review-driven failing-first test proved a dangling managed log symlink redirected creation before the fix; it now remains a symlink and its target is not created.
- Review-driven failing-first checks reproduced hardlink mutation, whole-file buffering, and archive-destination clobbering before the bounded continuation; all now pass.
- `npx vitest run tests/daemon-log.test.ts tests/daemon-loop.test.ts tests/b0-worker-installer.test.ts` — 42 passed.
- `npm run build` — passed.
- `plutil -lint launchd/evaos-code-review-bot.plist.example` — passed.
- `git diff --check` — passed.

## Review disposition

- Initial independent semantic review at `77928e2607190fbf3587ec9024bd57ce0f1e8f39`: one P2, fixed in `46b66d38cd7d9800ddc8b23c7c498bdc459f8ffd`.
- CodeQL's production annotation was the same installer race and is fixed by the same delta. Its five other annotations are confined to cleanup inside fresh test-owned temporary directories and are not shipped or installed paths.
- Delta-only independent review of `77928e2607190fbf3587ec9024bd57ce0f1e8f39..46b66d38cd7d9800ddc8b23c7c498bdc459f8ffd` passed at 99% confidence with no new P0-P2 findings.
- Late review received one bounded final fix batch under the delivery-governor checkpoint. Head `ef41dfee46111b1b68519c84b62ce33bc96c595d` now preserves pre-existing archive-temp collisions, narrows existing live-log permissions through a no-follow descriptor without truncation, and requires the exact current-user log directory. A final targeted delta review of `46b66d38cd7d9800ddc8b23c7c498bdc459f8ffd..ef41dfee46111b1b68519c84b62ce33bc96c595d` passed at 98% confidence with all three findings fixed and no new P0-P2 findings.
- The owner-authorized bounded continuation at `96d66e087a56173615d97810a9a3723ddfd1fa61` rejects hardlinked live files before permission mutation or truncation, copies a fixed initial snapshot through a 64 KiB buffer, and finalizes archives with no-clobber semantics. Independent delta review of `ef41dfee46111b1b68519c84b62ce33bc96c595d..96d66e087a56173615d97810a9a3723ddfd1fa61` passed at 98% confidence with all three #747 blockers fixed and no new P0-P2 findings.
- Every other late review item has one terminal disposition in the PR: not applicable, accepted tradeoff, or won't-fix within the issue-owned gate.
- A post-ready automated pass on the unchanged head raised repeated arbitrary records larger than 10 MiB, rollback to a pre-feature managed binary, and pre-existing ACL grants. These received accepted-tradeoff or not-applicable dispositions: none is a reproduced current supported path, and truncation/splitting, rollback capability enforcement, or an ACL subsystem would exceed #740's approved normal-operation source/packaging gate. All three threads are resolved without a head change.
- Canonical remote CI for exact head `96d66e087a56173615d97810a9a3723ddfd1fa61`: required `Build, test, and package` and `Swift desktop gate` checks passed. All three CodeQL language analyses passed. The optional CodeQL aggregate remains red only for test-owned temporary-directory race annotations; each thread has an explicit not-applicable disposition and is resolved.

## Late follow-up disposition

#751 is retained as a non-blocking follow-up outside milestone #21. Repairing an owner-owned `0400` file is an accepted tradeoff because the supported installer-managed path creates and maintains `0600` files. Crash-left temporary archive cleanup is concrete crash-recovery hardening, but it is outside this issue's normal-operation source/packaging gate. Neither concern changes this reviewed head or blocks #740 readiness.

## Boundaries

No current log was read, copied, truncated, rotated, or deleted. No launchd command, service restart, installed config update, sudo action, credential mutation, release, deployment, or customer action occurred. Installed-runtime adoption and a rotation canary require separate authority and must not be inferred from this PR. This exact head is ready only for owner merge consideration.
