### PR TITLE
fix: make review runtime authority explicit

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -22,7 +22,11 @@ evaos-review-bot status --config config.local.json
 
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
-  durable queue counts, and recommended actions.
+  durable queue counts, review-runtime authority, and recommended actions. The
+  `review_runtime_authority_valid` gate is derived from configuration only: it
+  identifies whether Codex CLI or legacy ZCode is authoritative and states that
+  automatic cross-runtime fallback is absent. It does not prove installed
+  adoption, provider reachability, review success, posting, or release.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
   budget status, leases, heartbeat, and bot-owned process rows. It can classify

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -97,8 +97,9 @@ provider listing, general doctor, operator status, and review receipts:
 - Per-invocation review suppression disables execution; it does not select a
   different runtime.
 
-An invalid authority report means registry metadata contradicts the executor
-that current worker code would attempt. Correct the metadata or configuration
+An invalid legacy authority report means an explicit `zcode.providerId` pin has
+no matching registry entry, is disabled, or contradicts the ZCode executor that
+current worker code would attempt. Correct the pin or registry metadata
 deliberately; do not change routing merely to make doctor green. Authority
 output proves configuration precedence only, not CLI login, provider reachability,
 installed adoption, review success, posting, release, or customer readiness.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -45,7 +45,8 @@ evidence.
 
 Status definitions:
 
-- `default beta path`: shipped live review route in this beta.
+- `default beta path`: shipped legacy review route when `codexRuntime.enabled`
+  is false.
 - `tested by NeonDiff`: covered by NeonDiff fixture, doctor, smoke, or live-route
   proof named in repo evidence; this still does not claim quality parity.
 - `compatible by interface`: the provider exposes an API shape NeonDiff can
@@ -56,7 +57,7 @@ Status definitions:
 
 | Provider, runtime, or resource | Status | How to verify | Egress posture | Tracking |
 | --- | --- | --- | --- | --- |
-| GLM/Z.AI through ZCode (`zcode-glm`) | `default beta path`; `tested by NeonDiff` as the current live review route | `neondiff providers doctor --config config.local.json --json`, then a dry-run review before live posting | Hosted Z.AI/GLM path through ZCode can receive prompts and diffs | Provider sprint [#238](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/238) |
+| GLM/Z.AI through ZCode (`zcode-glm`) | `default beta path` when Codex is disabled; `tested by NeonDiff` as the legacy review route | Inspect `runtimeAuthority`, then run `neondiff providers doctor --config config.local.json --json` and a dry-run review before live posting | Hosted Z.AI/GLM path through ZCode can receive prompts and diffs when it is authoritative or explicitly used for a self-consistency re-check | Provider sprint [#238](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/238) |
 | Ollama on `http://localhost:11434/v1` | `compatible by interface`; `ollama-format-json-schema` request construction shipped behind explicit config | Enable the local provider and run `neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json`, then a review fixture/dry-run | No-egress only when endpoint is loopback or self-hosted and the model runs locally | OpenAI-compatible adapter [#240](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/240), schema mode [#399](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/399) |
 | LM Studio, vLLM, llama.cpp, SGLang, or local OpenAI-compatible gateway | `compatible by interface`; schema-constrained request construction shipped behind explicit config | Use an explicit provider id and local `/v1` base URL; promote only after fixture and dry-run review proof | No-egress only for local/self-hosted endpoints; hosted gateways are remote egress | OpenAI-compatible adapter [#240](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/240), schema mode [#399](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/399) |
 | Hosted OpenAI-compatible BYOK gateway | `compatible by interface`; remote smoke and live review proof required | Store only `apiKeyEnv`, run a single-provider smoke, then record redacted evidence before live review | Hosted provider receives prompts and diffs | Hosted BYOK coverage [#241](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/241) |
@@ -78,6 +79,30 @@ Check enabled provider metadata:
 neondiff providers doctor --config config.local.json --json
 ```
 
+`runtimeAuthority` is the execution-selection truth shared by config inspect,
+provider listing, general doctor, operator status, and review receipts:
+
+- `codexRuntime.enabled=true` selects Codex CLI for canonical review execution.
+- Otherwise canonical review execution calls ZCode using `zcode` configuration.
+- On the legacy path, `zcode.providerId` pins the ZCode app provider. When it is
+  absent, ZCode selects a matching enabled app provider; the registry default
+  is compared as diagnostic metadata but does not route the request.
+- Provider-registry defaults are diagnostic and setup metadata. They do not
+  replace the canonical executor selected by the rule above.
+- There is no automatic Codex-to-ZCode or ZCode-to-registry fallback. Codex
+  failures are terminal, and ZCode retry attempts stay on ZCode.
+- An explicit self-consistency provider is an auxiliary second draw. It is not
+  a fallback and cannot replace a canonical finding when that second draw
+  fails.
+- Per-invocation review suppression disables execution; it does not select a
+  different runtime.
+
+An invalid authority report means registry metadata contradicts the executor
+that current worker code would attempt. Correct the metadata or configuration
+deliberately; do not change routing merely to make doctor green. Authority
+output proves configuration precedence only, not CLI login, provider reachability,
+installed adoption, review success, posting, release, or customer readiness.
+
 Smoke an OpenAI-compatible `/models` endpoint:
 
 ```bash
@@ -88,7 +113,8 @@ neondiff providers doctor \
   --json
 ```
 
-The native desktop Providers pane uses this saved registry as its authority.
+The native desktop Providers pane uses this saved registry as its authority for
+provider setup and verification, not for canonical review-executor selection.
 It does not treat `desktop.openAICompatibleEndpoint` as a verified target.
 Preview and Apply endpoint/model changes first; the subsequent explicit Verify
 click pins `--provider` and `--expected-config-revision`, reads the key from
@@ -289,7 +315,9 @@ sandbox, strict findings schema, bounded output, hard timeout, and pre/post
 checkout-state comparison. Codex uses its existing
 login internally; NeonDiff does not read or receive OAuth material. Model and
 reasoning effort are explicit configuration, and availability remains subject
-to the authenticated Codex account. Claude Code and OpenCode remain discovery
+to the authenticated Codex account. A failed Codex invocation does not invoke
+ZCode automatically; it returns a terminal review/queue failure. Claude Code
+and OpenCode remain discovery
 only. See [docs/agent-runtime-adapters.md](agent-runtime-adapters.md).
 
 ```json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,7 @@ import {
   resolvePathFollowingExistingSymlinks
 } from "./path-safety.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { classifyReviewRuntimeAuthority } from "./review-runtime-authority.js";
 import { runOnceCliCommand } from "./run-once-cli.js";
 import { redactSecrets, stringifyRedactedJson } from "./secrets.js";
 import { buildSkillPackContextPacket } from "./skill-packs.js";
@@ -302,29 +303,16 @@ async function main(): Promise<void> {
     }
     const config = loadConfig(args.config);
     if (action === "list") {
-      const codexRuntime = config.codexRuntime?.enabled ? config.codexRuntime : undefined;
+      const runtimeAuthority = classifyReviewRuntimeAuthority(config);
       console.log(stringifyProviderOutput({
-        ok: true,
+        ok: runtimeAuthority.ok,
         command: "providers list",
-        proofBoundary: codexRuntime
-          ? "Provider registry visibility plus active Codex CLI runtime selection; this does not prove an installed review or GitHub post."
-          : "Provider registry visibility only; live review execution uses the configured ZCode runtime.",
-        activeRuntime: codexRuntime
-          ? {
-              providerId: "codex-cli-oauth",
-              adapter: "codex-cli",
-              model: codexRuntime.model,
-              auth: "existing-codex-session"
-            }
-          : {
-              providerId: config.zcode.providerId,
-              adapter: "zcode",
-              model: config.zcode.model,
-              auth: "zcode-app-config"
-            },
+        proofBoundary: runtimeAuthority.proofBoundary,
+        activeRuntime: runtimeAuthority.execution,
+        runtimeAuthority,
         ...buildProviderRegistrySummary({
           registry: config.providers!,
-          ...(codexRuntime ? {} : {
+          ...(runtimeAuthority.execution.adapter === "codex-cli" ? {} : {
             currentZCode: {
               providerId: config.zcode.providerId,
               model: config.zcode.model
@@ -332,6 +320,7 @@ async function main(): Promise<void> {
           })
         })
       }));
+      if (!runtimeAuthority.ok) process.exitCode = 1;
       return;
     }
     if (action === "doctor") {
@@ -366,9 +355,11 @@ async function main(): Promise<void> {
         ...(providerId ? { providerId } : {}),
         smoke
       });
+      const runtimeAuthority = classifyReviewRuntimeAuthority(config);
       console.log(stringifyProviderOutput({
         ...result,
-        proofBoundary: "Provider readiness check only; alternate providers are not selected for live review execution by this command."
+        runtimeAuthority,
+        proofBoundary: "Provider registry readiness is reported separately from review execution authority; this command does not select or change a live review runtime."
       }));
       if (!result.ok) process.exitCode = 1;
       return;
@@ -429,11 +420,14 @@ async function main(): Promise<void> {
       if (!result.ok) process.exitCode = 1;
       return;
     }
-    const zcode = resolveZCodeProviderEnv({
-      appConfigPath: config.zcode.appConfigPath,
-      model: config.zcode.model,
-      providerId: config.zcode.providerId
-    });
+    const runtimeAuthority = classifyReviewRuntimeAuthority(config);
+    const zcode = runtimeAuthority.state === "legacy_authoritative"
+      ? resolveZCodeProviderEnv({
+          appConfigPath: config.zcode.appConfigPath,
+          model: config.zcode.model,
+          providerId: config.zcode.providerId
+        })
+      : undefined;
     const github = new GitHubApi(config.github);
     const readChecks = [];
     const monitoredRepos = listReposToScan(config);
@@ -461,7 +455,7 @@ async function main(): Promise<void> {
       canPostAsApp: github.canPostAsApp(),
       issueReadChecks: await collectIssueEnrichmentReadChecks(config, github)
     });
-    const ok = readChecks.every((check) => check.ok) && issueEnrichment.ok;
+    const ok = runtimeAuthority.ok && readChecks.every((check) => check.ok) && issueEnrichment.ok;
     console.log(stringifyRedactedJson({
       ok,
       pilotRepos: config.pilotRepos,
@@ -476,7 +470,8 @@ async function main(): Promise<void> {
       commandsEnabled: config.commands.enabled,
       statePath: config.statePath,
       workRoot: config.workRoot,
-      zcode: zcode.redacted,
+      runtimeAuthority,
+      ...(zcode ? { zcode: zcode.redacted } : {}),
       github: {
         canPostAsApp: github.canPostAsApp(),
         readMode: github.canPostAsApp() ? "app_installation" : "fallback_token",
@@ -689,6 +684,7 @@ async function main(): Promise<void> {
       release,
       coverage,
       agents,
+      runtimeAuthority: classifyReviewRuntimeAuthority(config),
       providerCooldowns,
       durableQueue,
       issueEnrichment: buildIssueEnrichmentStatus({

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -17,6 +17,7 @@ import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { loadConfig, loadConfigFromObject, type BotConfig, type RepoProfileConfig } from "./config.js";
 import { isApiKeyEnvName, isProviderId } from "./providers.js";
+import { classifyReviewRuntimeAuthority, type ReviewRuntimeAuthority } from "./review-runtime-authority.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const SECRET_KEY_PATTERN = /(?:token|secret|password|cookie|license(?:Key|Token|Secret)|api[_-]?key(?!env)|privateKey)/i;
@@ -108,6 +109,7 @@ export interface ConfigInspectResult {
   source: "file" | "defaults";
   revision: string;
   editablePaths: string[];
+  runtimeAuthority?: ReviewRuntimeAuthority;
   config?: unknown;
   error?: string;
 }
@@ -183,6 +185,7 @@ export function inspectConfigForDesktop(configPath?: string, fileOps?: Partial<C
       source: exists ? "file" : "defaults",
       revision: snapshot?.revision ?? "",
       editablePaths: editablePatchPaths(),
+      runtimeAuthority: classifyReviewRuntimeAuthority(config),
       config: redactConfigObject(config)
     };
   } catch (error) {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -185,7 +185,7 @@ export function inspectConfigForDesktop(configPath?: string, fileOps?: Partial<C
       source: exists ? "file" : "defaults",
       revision: snapshot?.revision ?? "",
       editablePaths: editablePatchPaths(),
-      runtimeAuthority: classifyReviewRuntimeAuthority(config),
+      runtimeAuthority: redactConfigObject(classifyReviewRuntimeAuthority(config)) as ReviewRuntimeAuthority,
       config: redactConfigObject(config)
     };
   } catch (error) {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -14,6 +14,7 @@ import type {
 import type { IssueEnrichmentStatus } from "./issue-enrichment.js";
 import type { ReviewBudgetStatus } from "./review-budget.js";
 import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
+import type { ReviewRuntimeAuthority } from "./review-runtime-authority.js";
 import { redactSecrets } from "./secrets.js";
 import {
   parseProviderCooldownError,
@@ -72,6 +73,7 @@ export interface OperatorStatus {
   durableQueue?: OperatorDurableQueueSnapshot;
   issueEnrichment?: IssueEnrichmentStatus;
   issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
+  runtimeAuthority?: ReviewRuntimeAuthority;
 }
 
 export interface RuntimeInventory {
@@ -401,6 +403,7 @@ export function buildOperatorStatus(input: {
   durableQueue?: OperatorDurableQueueSnapshot;
   issueEnrichment?: IssueEnrichmentStatus;
   issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
+  runtimeAuthority?: ReviewRuntimeAuthority;
   checkedAt?: string;
 }): OperatorStatus {
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
@@ -428,9 +431,17 @@ export function buildOperatorStatus(input: {
   const issueEnrichmentRuntimeRetryableDeferred = issueEnrichmentRuntime?.summary.retryableDeferred ?? 0;
   const issueEnrichmentRuntimeRetryableDeferredDetail =
     describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
+  const runtimeAuthority = input.runtimeAuthority;
 
   const gates = [
     ...input.release.gates,
+    ...(runtimeAuthority
+      ? [{
+          name: "review_runtime_authority_valid",
+          ok: runtimeAuthority.ok,
+          detail: `${runtimeAuthority.state}: ${runtimeAuthority.reason}; executor=${runtimeAuthority.execution.adapter}/${runtimeAuthority.execution.model}; automaticFallback=${runtimeAuthority.automaticFallback.reachable}`
+        }]
+      : []),
     {
       name: "queue_no_pending_heads",
       ok: pendingHeads === 0,
@@ -511,7 +522,10 @@ export function buildOperatorStatus(input: {
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
     ...(issueEnrichmentRuntimeFailed > 0 ? ["inspect failed issue-enrichment records before promotion"] : []),
-    ...(issueEnrichmentRuntimeRetryableDeferred > 0 ? ["retry or inspect deferred issue-enrichment records"] : [])
+    ...(issueEnrichmentRuntimeRetryableDeferred > 0 ? ["retry or inspect deferred issue-enrichment records"] : []),
+    ...(runtimeAuthority && !runtimeAuthority.ok
+      ? ["align diagnostic provider metadata with the configured review executor; do not change routing solely to clear status"]
+      : [])
   ]);
 
   return {
@@ -552,7 +566,8 @@ export function buildOperatorStatus(input: {
     providerCooldowns,
     ...(durableQueue ? { durableQueue } : {}),
     ...(issueEnrichment ? { issueEnrichment } : {}),
-    ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {})
+    ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {}),
+    ...(runtimeAuthority ? { runtimeAuthority } : {})
   };
 }
 

--- a/src/review-runtime-authority.ts
+++ b/src/review-runtime-authority.ts
@@ -1,0 +1,146 @@
+import type { BotConfig } from "./config.js";
+import type { ProviderAdapter, ProviderAuthMode } from "./providers.js";
+
+export type ReviewRuntimeAuthorityState =
+  | "codex_authoritative"
+  | "legacy_authoritative"
+  | "invalid_authoritative";
+
+export type ReviewRuntimeAuthorityReason =
+  | "codex_enabled"
+  | "legacy_zcode_enabled"
+  | "legacy_registry_mismatch"
+  | "both_disabled";
+
+export interface ReviewRuntimeAuthority {
+  ok: boolean;
+  state: ReviewRuntimeAuthorityState;
+  reason: ReviewRuntimeAuthorityReason;
+  execution: {
+    providerId: string;
+    adapter: "codex-cli" | "zcode";
+    model: string;
+    auth: "existing-codex-session" | "zcode-app-config";
+    willAttempt: boolean;
+  };
+  legacyProviderMetadata: {
+    registryDefaultProviderId: string;
+    providerId: string;
+    selectionSource: "zcode.providerId" | "providers.defaultProviderId";
+    exists: boolean;
+    enabled: boolean;
+    adapter: ProviderAdapter | null;
+    model: string | null;
+    authMode: ProviderAuthMode | null;
+    reviewCapable: boolean;
+    jsonOutputCapable: boolean;
+    matchesExecution: boolean;
+    authoritative: false;
+    role: "diagnostic_metadata_only";
+  };
+  automaticFallback: {
+    configured: false;
+    reachable: false;
+    target: null;
+    reason: string;
+  };
+  proofBoundary: string;
+}
+
+const DYNAMIC_ZCODE_PROVIDER_ID = "zcode-app-selected";
+
+export function classifyReviewRuntimeAuthority(
+  config: BotConfig,
+  options: { executionRequested?: boolean } = {}
+): ReviewRuntimeAuthority {
+  const executionRequested = options.executionRequested ?? true;
+  const registry = config.providers!;
+  const registryProviderId = config.zcode.providerId ?? registry.defaultProviderId;
+  const registryProvider = registry.providers[registryProviderId];
+  const registryMatchesZCode = Boolean(
+    registryProvider?.enabled
+    && registryProvider.adapter === "zcode"
+    && registryProvider.model === config.zcode.model
+    && registryProvider.authMode === "zcode-app-config"
+    && registryProvider.capabilities.review
+    && registryProvider.capabilities.jsonOutput
+  );
+  const legacyProviderMetadata: ReviewRuntimeAuthority["legacyProviderMetadata"] = {
+    registryDefaultProviderId: registry.defaultProviderId,
+    providerId: registryProviderId,
+    selectionSource: config.zcode.providerId ? "zcode.providerId" : "providers.defaultProviderId",
+    exists: Boolean(registryProvider),
+    enabled: Boolean(registryProvider?.enabled),
+    adapter: registryProvider?.adapter ?? null,
+    model: registryProvider?.model ?? null,
+    authMode: registryProvider?.authMode ?? null,
+    reviewCapable: Boolean(registryProvider?.capabilities.review),
+    jsonOutputCapable: Boolean(registryProvider?.capabilities.jsonOutput),
+    matchesExecution: registryMatchesZCode,
+    authoritative: false,
+    role: "diagnostic_metadata_only"
+  };
+  const automaticFallback = {
+    configured: false as const,
+    reachable: false as const,
+    target: null,
+    reason: "No automatic cross-runtime fallback exists: Codex failures are terminal and ZCode retries stay on ZCode."
+  };
+
+  if (config.codexRuntime?.enabled === true) {
+    return {
+      ok: true,
+      state: "codex_authoritative",
+      reason: "codex_enabled",
+      execution: {
+        providerId: "codex-cli-oauth",
+        adapter: "codex-cli",
+        model: config.codexRuntime.model,
+        auth: "existing-codex-session",
+        willAttempt: executionRequested
+      },
+      legacyProviderMetadata,
+      automaticFallback,
+      proofBoundary: "Configuration authority only; this does not prove Codex CLI login, an installed review, GitHub posting, release, or runtime adoption."
+    };
+  }
+
+  const execution = {
+    providerId: config.zcode.providerId ?? DYNAMIC_ZCODE_PROVIDER_ID,
+    adapter: "zcode" as const,
+    model: config.zcode.model,
+    auth: "zcode-app-config" as const,
+    willAttempt: executionRequested
+  };
+  if (registryProvider && !registryProvider.enabled) {
+    return {
+      ok: false,
+      state: "invalid_authoritative",
+      reason: "both_disabled",
+      execution,
+      legacyProviderMetadata,
+      automaticFallback,
+      proofBoundary: "Configuration authority is invalid: Codex and the selected legacy registry metadata are disabled, although current worker code would still attempt ZCode."
+    };
+  }
+  if (!registryMatchesZCode) {
+    return {
+      ok: false,
+      state: "invalid_authoritative",
+      reason: "legacy_registry_mismatch",
+      execution,
+      legacyProviderMetadata,
+      automaticFallback,
+      proofBoundary: "Configuration authority is invalid: registry metadata does not match the ZCode executor that current worker code would attempt."
+    };
+  }
+  return {
+    ok: true,
+    state: "legacy_authoritative",
+    reason: "legacy_zcode_enabled",
+    execution,
+    legacyProviderMetadata,
+    automaticFallback,
+    proofBoundary: "Configuration authority only; this does not prove ZCode credentials, provider reachability, an installed review, GitHub posting, release, or runtime adoption."
+  };
+}

--- a/src/review-runtime-authority.ts
+++ b/src/review-runtime-authority.ts
@@ -24,9 +24,9 @@ export interface ReviewRuntimeAuthority {
     willAttempt: boolean;
   };
   legacyProviderMetadata: {
-    registryDefaultProviderId: string;
-    providerId: string;
-    selectionSource: "zcode.providerId" | "providers.defaultProviderId";
+    registryDefaultProviderId: string | null;
+    providerId: string | null;
+    selectionSource: "zcode.providerId" | "providers.defaultProviderId" | "none";
     exists: boolean;
     enabled: boolean;
     adapter: ProviderAdapter | null;
@@ -54,9 +54,11 @@ export function classifyReviewRuntimeAuthority(
   options: { executionRequested?: boolean } = {}
 ): ReviewRuntimeAuthority {
   const executionRequested = options.executionRequested ?? true;
-  const registry = config.providers!;
-  const registryProviderId = config.zcode.providerId ?? registry.defaultProviderId;
-  const registryProvider = registry.providers[registryProviderId];
+  const registry = config.providers;
+  const explicitProviderId = config.zcode.providerId;
+  const registryDefaultProviderId = registry?.defaultProviderId ?? null;
+  const registryProviderId = explicitProviderId ?? registryDefaultProviderId;
+  const registryProvider = registryProviderId ? registry?.providers[registryProviderId] : undefined;
   const registryMatchesZCode = Boolean(
     registryProvider?.enabled
     && registryProvider.adapter === "zcode"
@@ -66,9 +68,11 @@ export function classifyReviewRuntimeAuthority(
     && registryProvider.capabilities.jsonOutput
   );
   const legacyProviderMetadata: ReviewRuntimeAuthority["legacyProviderMetadata"] = {
-    registryDefaultProviderId: registry.defaultProviderId,
+    registryDefaultProviderId,
     providerId: registryProviderId,
-    selectionSource: config.zcode.providerId ? "zcode.providerId" : "providers.defaultProviderId",
+    selectionSource: explicitProviderId
+      ? "zcode.providerId"
+      : registryDefaultProviderId ? "providers.defaultProviderId" : "none",
     exists: Boolean(registryProvider),
     enabled: Boolean(registryProvider?.enabled),
     adapter: registryProvider?.adapter ?? null,
@@ -112,7 +116,7 @@ export function classifyReviewRuntimeAuthority(
     auth: "zcode-app-config" as const,
     willAttempt: executionRequested
   };
-  if (registryProvider && !registryProvider.enabled) {
+  if (explicitProviderId && registryProvider && !registryProvider.enabled) {
     return {
       ok: false,
       state: "invalid_authoritative",
@@ -123,7 +127,7 @@ export function classifyReviewRuntimeAuthority(
       proofBoundary: "Configuration authority is invalid: Codex and the selected legacy registry metadata are disabled, although current worker code would still attempt ZCode."
     };
   }
-  if (!registryMatchesZCode) {
+  if (explicitProviderId && !registryMatchesZCode) {
     return {
       ok: false,
       state: "invalid_authoritative",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,6 +66,7 @@ import {
 } from "./review-event-policy.js";
 import { selectReviewMode } from "./review-mode-router.js";
 import type { ReviewModeAnalysisPlan } from "./review-mode-types.js";
+import { classifyReviewRuntimeAuthority } from "./review-runtime-authority.js";
 import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
@@ -157,29 +158,14 @@ function recordConsumedAuthorizationIncident(input: {
 }
 
 export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMetadata {
-  if (config.codexRuntime?.enabled) {
-    return {
-      providerId: "codex-cli-oauth",
-      adapter: "codex-cli",
-      model: config.codexRuntime.model,
-      displayName: "Codex CLI (existing OAuth session)"
-    };
-  }
-  const providerId = resolveReviewRegistryProviderId(config);
-  const provider = config.providers?.providers[providerId];
-  if (!provider) {
-    return {
-      providerId,
-      adapter: "zcode (registry miss)",
-      model: "unknown",
-      displayName: "Unregistered provider id"
-    };
-  }
+  const authority = classifyReviewRuntimeAuthority(config);
   return {
-    providerId,
-    adapter: provider.adapter,
-    model: provider.model,
-    ...(provider.displayName ? { displayName: provider.displayName } : {})
+    providerId: authority.execution.providerId,
+    adapter: authority.execution.adapter,
+    model: authority.execution.model,
+    displayName: authority.execution.adapter === "codex-cli"
+      ? "Codex CLI (existing OAuth session)"
+      : "ZCode (app configuration)"
   };
 }
 
@@ -3922,7 +3908,8 @@ export function resolveSelfConsistencyBackend(
   config: BotConfig,
   selfConsistencyConfig: SelfConsistencyConfig
 ): { useCodex: boolean; providerId?: string } {
-  const useCodex = Boolean(config.codexRuntime?.enabled && selfConsistencyConfig.provider === undefined);
+  const authority = classifyReviewRuntimeAuthority(config);
+  const useCodex = authority.execution.adapter === "codex-cli" && selfConsistencyConfig.provider === undefined;
   return {
     useCodex,
     providerId: useCodex ? "codex-cli-oauth" : (selfConsistencyConfig.provider ?? config.zcode.providerId)
@@ -4226,6 +4213,7 @@ async function runChunkedZCodeReview(input: {
   }
 
   const completedAt = new Date();
+  const authority = classifyReviewRuntimeAuthority(input.config);
   return {
     status: "reviewed",
     result: {
@@ -4235,8 +4223,8 @@ async function runChunkedZCodeReview(input: {
       attempts,
       degradedRecovery,
       runtime: {
-        provider: input.config.codexRuntime?.enabled ? "codex-cli-oauth" : input.config.zcode.providerId,
-        model: input.config.codexRuntime?.enabled ? input.config.codexRuntime.model : input.config.zcode.model,
+        provider: authority.execution.providerId,
+        model: authority.execution.model,
         startedAt: startedAt.toISOString(),
         completedAt: completedAt.toISOString(),
         latencyMs: completedAt.getTime() - startedAt.getTime(),
@@ -4248,7 +4236,7 @@ async function runChunkedZCodeReview(input: {
 }
 
 function disabledZCodeReviewResult(config: BotConfig): ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput } {
-  const codexRuntime = config.codexRuntime?.enabled ? config.codexRuntime : undefined;
+  const authority = classifyReviewRuntimeAuthority(config, { executionRequested: false });
   return {
     findings: [],
     droppedFromSchema: [],
@@ -4256,12 +4244,13 @@ function disabledZCodeReviewResult(config: BotConfig): ZCodeReviewResult & { run
     attempts: 0,
     degradedRecovery: false,
     runtime: {
-      provider: codexRuntime ? "codex-cli-oauth" : config.zcode.providerId,
-      model: codexRuntime?.model ?? config.zcode.model,
+      provider: authority.execution.providerId,
+      model: authority.execution.model,
       providerAttempts: 0,
-      notes: [codexRuntime
-        ? "Configured review execution disabled for this dry-run; provider latency and token usage were not measured."
-        : "ZCode execution disabled for this dry-run; provider latency and token usage were not measured."]
+      notes: [
+        "Configured review execution disabled for this dry-run; provider latency and token usage were not measured.",
+        authority.automaticFallback.reason
+      ]
     }
   };
 }
@@ -4273,33 +4262,36 @@ async function runConfiguredReview(input: {
   evidenceDir: string;
   assertProviderConfigCurrent?: () => void;
 }): Promise<ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput }> {
-  if (!input.config.codexRuntime?.enabled) return runZCodeReviewWithProviderRetry(input);
+  const authority = classifyReviewRuntimeAuthority(input.config);
+  if (authority.execution.adapter === "zcode") return runZCodeReviewWithProviderRetry(input);
+  const codexRuntime = input.config.codexRuntime!;
   input.assertProviderConfigCurrent?.();
   const startedAt = new Date();
   const result = await runCodexReview({
     cwd: input.worktreePath,
     prompt: input.prompt,
-    cliPath: input.config.codexRuntime.cliPath,
-    model: input.config.codexRuntime.model,
-    reasoningEffort: input.config.codexRuntime.reasoningEffort,
+    cliPath: codexRuntime.cliPath,
+    model: codexRuntime.model,
+    reasoningEffort: codexRuntime.reasoningEffort,
     evidenceDir: input.evidenceDir,
-    timeoutMs: input.config.codexRuntime.timeoutMs,
-    maxOutputBytes: input.config.codexRuntime.maxOutputBytes
+    timeoutMs: codexRuntime.timeoutMs,
+    maxOutputBytes: codexRuntime.maxOutputBytes
   });
   const completedAt = new Date();
   return {
     ...result,
     runtime: {
-      provider: "codex-cli-oauth",
-      model: input.config.codexRuntime.model,
+      provider: authority.execution.providerId,
+      model: authority.execution.model,
       startedAt: startedAt.toISOString(),
       completedAt: completedAt.toISOString(),
       latencyMs: completedAt.getTime() - startedAt.getTime(),
       providerAttempts: 1,
       notes: [
-        `Codex CLI reasoning effort: ${input.config.codexRuntime.reasoningEffort}.`,
+        `Codex CLI reasoning effort: ${codexRuntime.reasoningEffort}.`,
         "Codex CLI used its existing authenticated session; NeonDiff did not read or receive OAuth material.",
-        "Codex runtime retries are disabled; a failed invocation returns one terminal queue failure."
+        "Codex runtime retries are disabled; a failed invocation returns one terminal queue failure.",
+        authority.automaticFallback.reason
       ]
     }
   };
@@ -4313,6 +4305,7 @@ async function runZCodeReviewWithProviderRetry(input: {
   assertProviderConfigCurrent?: () => void;
 }): Promise<ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput }> {
   const startedAt = new Date();
+  const authority = classifyReviewRuntimeAuthority(input.config);
   let providerAttempts = 0;
   const result = await runWithProviderRetry({
     config: input.config,
@@ -4337,14 +4330,15 @@ async function runZCodeReviewWithProviderRetry(input: {
   return {
     ...result,
     runtime: {
-      provider: input.config.zcode.providerId,
-      model: input.config.zcode.model,
+      provider: authority.execution.providerId,
+      model: authority.execution.model,
       startedAt: startedAt.toISOString(),
       completedAt: completedAt.toISOString(),
       latencyMs: completedAt.getTime() - startedAt.getTime(),
       notes: [
         `Observed outer provider retry attempts: ${providerAttempts}.`,
         "Internal ZCode retry attempts and token usage are not exposed by the configured provider path; providerAttempts and token metrics remain null.",
+        authority.automaticFallback.reason,
         // Retry-degraded provenance (#304): surfaced only when the strict-JSON retry path produced
         // the accepted parse, so evidence packets and the ledger runtime honestly flag it.
         ...(result.degradedRecovery

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,7 +66,7 @@ import {
 } from "./review-event-policy.js";
 import { selectReviewMode } from "./review-mode-router.js";
 import type { ReviewModeAnalysisPlan } from "./review-mode-types.js";
-import { classifyReviewRuntimeAuthority } from "./review-runtime-authority.js";
+import { classifyReviewRuntimeAuthority, type ReviewRuntimeAuthority } from "./review-runtime-authority.js";
 import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
@@ -167,6 +167,10 @@ export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMe
       ? "Codex CLI (existing OAuth session)"
       : "ZCode (app configuration)"
   };
+}
+
+function reviewRuntimeAuthorityNote(authority: ReviewRuntimeAuthority): string {
+  return `Review runtime authority: state=${authority.state}; reason=${authority.reason}.`;
 }
 
 function resolveReviewContextWindowTokens(config: BotConfig): number | undefined {
@@ -4128,6 +4132,8 @@ async function runChunkedZCodeReview(input: {
   assertProviderConfigCurrent?: () => void;
 }): Promise<ContextBudgetReviewExecution> {
   const startedAt = new Date();
+  const authority = classifyReviewRuntimeAuthority(input.config);
+  const authorityNote = reviewRuntimeAuthorityNote(authority);
   const findings: ZCodeReviewResult["findings"] = [];
   const droppedFromSchema: ZCodeReviewResult["droppedFromSchema"] = [];
   const rawResponses: Array<{ index: number; rawResponse: string }> = [];
@@ -4208,12 +4214,13 @@ async function runChunkedZCodeReview(input: {
       runtimeNotes.push(`chunk ${chunk.index}: dropped ${droppedCrossChunkFindings.length} finding(s) outside this chunk's file set.`);
     }
     if (result.runtime.notes) {
-      runtimeNotes.push(...result.runtime.notes.map((note) => `chunk ${chunk.index}: ${note}`));
+      runtimeNotes.push(...result.runtime.notes
+        .filter((note) => note !== authorityNote)
+        .map((note) => `chunk ${chunk.index}: ${note}`));
     }
   }
 
   const completedAt = new Date();
-  const authority = classifyReviewRuntimeAuthority(input.config);
   return {
     status: "reviewed",
     result: {
@@ -4229,7 +4236,7 @@ async function runChunkedZCodeReview(input: {
         completedAt: completedAt.toISOString(),
         latencyMs: completedAt.getTime() - startedAt.getTime(),
         providerAttempts,
-        notes: runtimeNotes
+        notes: [authorityNote, ...runtimeNotes]
       }
     }
   };
@@ -4249,6 +4256,7 @@ function disabledZCodeReviewResult(config: BotConfig): ZCodeReviewResult & { run
       providerAttempts: 0,
       notes: [
         "Configured review execution disabled for this dry-run; provider latency and token usage were not measured.",
+        reviewRuntimeAuthorityNote(authority),
         authority.automaticFallback.reason
       ]
     }
@@ -4291,6 +4299,7 @@ async function runConfiguredReview(input: {
         `Codex CLI reasoning effort: ${codexRuntime.reasoningEffort}.`,
         "Codex CLI used its existing authenticated session; NeonDiff did not read or receive OAuth material.",
         "Codex runtime retries are disabled; a failed invocation returns one terminal queue failure.",
+        reviewRuntimeAuthorityNote(authority),
         authority.automaticFallback.reason
       ]
     }
@@ -4338,6 +4347,7 @@ async function runZCodeReviewWithProviderRetry(input: {
       notes: [
         `Observed outer provider retry attempts: ${providerAttempts}.`,
         "Internal ZCode retry attempts and token usage are not exposed by the configured provider path; providerAttempts and token metrics remain null.",
+        reviewRuntimeAuthorityNote(authority),
         authority.automaticFallback.reason,
         // Retry-degraded provenance (#304): surfaced only when the strict-JSON retry path produced
         // the accepted parse, so evidence packets and the ledger runtime honestly flag it.

--- a/tests/codex-runtime.test.ts
+++ b/tests/codex-runtime.test.ts
@@ -43,6 +43,27 @@ describe("Codex CLI review runtime", () => {
     });
   });
 
+  it("keeps receipt metadata on the actual ZCode executor when registry metadata disagrees", () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            capabilities: { review: true, jsonOutput: true }
+          }
+        }
+      }
+    });
+
+    expect(buildReviewProviderMetadata(config)).toMatchObject({
+      providerId: "zcode-app-selected",
+      adapter: "zcode",
+      model: "GLM-5.2",
+      displayName: "ZCode (app configuration)"
+    });
+  });
+
   it("constructs a read-only ephemeral invocation without OAuth material", () => {
     const invocation = buildCodexExecInvocation({
       cliPath: "/Users/test/.local/bin/codex",

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
-import { inspectConfigForDesktop, patchConfigForDesktop } from "../src/config-cli.js";
+import { configRevision, inspectConfigForDesktop, patchConfigForDesktop } from "../src/config-cli.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -45,8 +45,22 @@ describe("desktop config CLI", () => {
       ok: true,
       command: "config inspect",
       exists: true,
-      source: "file"
+      source: "file",
+      runtimeAuthority: {
+        ok: true,
+        state: "legacy_authoritative",
+        execution: {
+          adapter: "zcode",
+          model: "GLM-5.2"
+        },
+        automaticFallback: {
+          configured: false,
+          reachable: false,
+          target: null
+        }
+      }
     });
+    expect(output.revision).toBe(configRevision(readFileSync(configPath, "utf8")));
     expect(output.editablePaths).toContain("zcode.model");
     expect(output.editablePaths).toContain("codexRuntime.enabled");
     expect(output.editablePaths).toContain("codexRuntime.reasoningEffort");

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -117,6 +117,24 @@ describe("desktop config CLI", () => {
     });
   });
 
+  it("redacts secret-looking runtime authority values with the effective config", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const secretProviderId = `ghp_${"a".repeat(40)}`;
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"], workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"), evidenceDir: join(root, "evidence"),
+      zcode: { providerId: secretProviderId }
+    });
+
+    const output = await runConfig(["config", "inspect", "--config", configPath]);
+
+    expect(output.runtimeAuthority.execution.providerId).toBe("[redacted-secret]");
+    expect(output.runtimeAuthority.legacyProviderMetadata.providerId).toBe("[redacted-secret]");
+    expect(output.config.zcode.providerId).toBe("[redacted-secret]");
+    expect(JSON.stringify(output)).not.toContain(secretProviderId);
+  });
+
   it("retries inspect when the config changes during its stable read", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -29,7 +29,8 @@ import { buildIssueEnrichmentStatus } from "../src/issue-enrichment.js";
 import type { ReviewBudgetStatus } from "../src/review-budget.js";
 import type { ReleaseStatus } from "../src/release-status.js";
 import type { RepoProviderCooldownRecord } from "../src/state.js";
-import { loadConfig } from "../src/config.js";
+import { loadConfig, loadConfigFromObject } from "../src/config.js";
+import { classifyReviewRuntimeAuthority } from "../src/review-runtime-authority.js";
 
 describe("operator CLI summaries", () => {
   const tempDirs: string[] = [];
@@ -98,6 +99,37 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("gates operator status on the derived review-runtime authority", () => {
+    const validAuthority = classifyReviewRuntimeAuthority(loadConfigFromObject({}));
+    const valid = buildOperatorStatus({
+      release: releaseStatus({}),
+      agents: agentInventory({}),
+      runtimeAuthority: validAuthority
+    });
+    expect(valid.runtimeAuthority).toEqual(validAuthority);
+    expect(valid.gates).toContainEqual(expect.objectContaining({
+      name: "review_runtime_authority_valid",
+      ok: true
+    }));
+
+    const invalidAuthority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      providers: { providers: { "zcode-glm": { enabled: false } } }
+    }));
+    const invalid = buildOperatorStatus({
+      release: releaseStatus({}),
+      agents: agentInventory({}),
+      runtimeAuthority: invalidAuthority
+    });
+    expect(invalid.ok).toBe(false);
+    expect(invalid.failedGates).toContainEqual(expect.objectContaining({
+      name: "review_runtime_authority_valid",
+      ok: false
+    }));
+    expect(invalid.recommendedActions).toContain(
+      "align diagnostic provider metadata with the configured review executor; do not change routing solely to clear status"
+    );
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -115,6 +115,7 @@ describe("operator CLI summaries", () => {
     }));
 
     const invalidAuthority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      zcode: { providerId: "zcode-glm" },
       providers: { providers: { "zcode-glm": { enabled: false } } }
     }));
     const invalid = buildOperatorStatus({

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -814,20 +814,117 @@ exit 1
         timeoutMs: 300_000,
         maxOutputBytes: 20 * 1024 * 1024,
         contextWindowTokens: 128_000
+      },
+      providers: {
+        providers: {
+          "zcode-glm": { enabled: false }
+        }
       }
     }));
 
     const list = JSON.parse((await runCli(["providers", "list", "--config", configPath])).stdout);
     expect(list).toMatchObject({
+      ok: true,
       activeRuntime: {
         providerId: "codex-cli-oauth",
         adapter: "codex-cli",
         model: "gpt-5.6-luna",
-        auth: "existing-codex-session"
+        auth: "existing-codex-session",
+        willAttempt: true
+      },
+      runtimeAuthority: {
+        state: "codex_authoritative",
+        reason: "codex_enabled",
+        legacyProviderMetadata: {
+          providerId: "zcode-glm",
+          enabled: false,
+          authoritative: false
+        },
+        automaticFallback: {
+          configured: false,
+          reachable: false,
+          target: null
+        }
       }
     });
     expect(list.proofBoundary).toMatch(/Codex CLI/i);
     expect(list.proofBoundary).not.toMatch(/remains ZCode-backed/i);
+  });
+
+  it("does not read legacy ZCode app configuration when Codex is authoritative", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-codex-authority-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      pilotRepos: [],
+      codexRuntime: {
+        enabled: true,
+        cliPath: "/Users/test/.local/bin/codex",
+        model: "gpt-5.6-luna",
+        reasoningEffort: "xhigh",
+        timeoutMs: 300_000,
+        maxOutputBytes: 20 * 1024 * 1024,
+        contextWindowTokens: 128_000
+      },
+      zcode: {
+        appConfigPath: join(root, "missing-zcode-config.json")
+      },
+      providers: {
+        providers: {
+          "zcode-glm": { enabled: false }
+        }
+      }
+    }));
+
+    const doctor = JSON.parse((await runCli(["doctor", "--config", configPath])).stdout);
+    expect(doctor).toMatchObject({
+      ok: true,
+      runtimeAuthority: {
+        ok: true,
+        state: "codex_authoritative",
+        execution: {
+          adapter: "codex-cli",
+          model: "gpt-5.6-luna"
+        }
+      }
+    });
+    expect(doctor).not.toHaveProperty("zcode");
+  });
+
+  it("reports both-disabled authority without reading legacy ZCode credentials", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-invalid-authority-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      pilotRepos: [],
+      zcode: {
+        appConfigPath: join(root, "missing-zcode-config.json")
+      },
+      providers: {
+        providers: {
+          "zcode-glm": { enabled: false }
+        }
+      }
+    }));
+
+    const result = await runCli(["doctor", "--config", configPath]).then(
+      () => { throw new Error("doctor unexpectedly accepted invalid runtime authority"); },
+      (error: unknown) => error as { stdout: string }
+    );
+    const doctor = JSON.parse(result.stdout);
+    expect(doctor).toMatchObject({
+      ok: false,
+      runtimeAuthority: {
+        ok: false,
+        state: "invalid_authoritative",
+        reason: "both_disabled",
+        execution: {
+          adapter: "zcode",
+          willAttempt: true
+        }
+      }
+    });
+    expect(doctor).not.toHaveProperty("zcode");
   });
 
   it("blocks providers doctor smoke before contacting a configured endpoint without activation", async () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -898,6 +898,7 @@ exit 1
     writeFileSync(configPath, JSON.stringify({
       pilotRepos: [],
       zcode: {
+        providerId: "zcode-glm",
         appConfigPath: join(root, "missing-zcode-config.json")
       },
       providers: {

--- a/tests/review-runtime-authority.test.ts
+++ b/tests/review-runtime-authority.test.ts
@@ -63,7 +63,7 @@ describe("review runtime authority", () => {
     });
   });
 
-  it("reports an enabled non-ZCode registry default as invalid without changing the executor", () => {
+  it("keeps a dynamic ZCode selection authoritative despite unrelated registry defaults", () => {
     const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({
       providers: {
         defaultProviderId: "openai-compatible",
@@ -77,9 +77,9 @@ describe("review runtime authority", () => {
     }));
 
     expect(authority).toMatchObject({
-      ok: false,
-      state: "invalid_authoritative",
-      reason: "legacy_registry_mismatch",
+      ok: true,
+      state: "legacy_authoritative",
+      reason: "legacy_zcode_enabled",
       execution: {
         adapter: "zcode",
         providerId: "zcode-app-selected",
@@ -90,6 +90,27 @@ describe("review runtime authority", () => {
         adapter: "openai-compatible",
         authoritative: false,
         matchesExecution: false
+      }
+    });
+  });
+
+  it("keeps dynamic ZCode authoritative when the optional provider registry is absent", () => {
+    const config = loadConfigFromObject({});
+    config.providers = undefined;
+
+    const authority = classifyReviewRuntimeAuthority(config);
+
+    expect(authority).toMatchObject({
+      ok: true,
+      state: "legacy_authoritative",
+      reason: "legacy_zcode_enabled",
+      execution: { providerId: "zcode-app-selected", adapter: "zcode" },
+      legacyProviderMetadata: {
+        registryDefaultProviderId: null,
+        providerId: null,
+        selectionSource: "none",
+        exists: false,
+        authoritative: false
       }
     });
   });
@@ -123,6 +144,7 @@ describe("review runtime authority", () => {
 
   it("reports Codex-disabled plus legacy-disabled as invalid while preserving current attempt truth", () => {
     const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      zcode: { providerId: "zcode-glm" },
       providers: {
         providers: {
           "zcode-glm": { enabled: false }
@@ -142,6 +164,25 @@ describe("review runtime authority", () => {
         providerId: "zcode-glm",
         enabled: false,
         authoritative: false
+      }
+    });
+  });
+
+  it("fails closed when an explicit ZCode provider pin has no registry entry", () => {
+    const config = loadConfigFromObject({ zcode: { providerId: "missing-zcode-provider" } });
+    config.providers = undefined;
+
+    expect(classifyReviewRuntimeAuthority(config)).toMatchObject({
+      ok: false,
+      state: "invalid_authoritative",
+      reason: "legacy_registry_mismatch",
+      execution: { providerId: "missing-zcode-provider", adapter: "zcode" },
+      legacyProviderMetadata: {
+        registryDefaultProviderId: null,
+        providerId: "missing-zcode-provider",
+        selectionSource: "zcode.providerId",
+        exists: false,
+        matchesExecution: false
       }
     });
   });

--- a/tests/review-runtime-authority.test.ts
+++ b/tests/review-runtime-authority.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+import { classifyReviewRuntimeAuthority } from "../src/review-runtime-authority.js";
+
+describe("review runtime authority", () => {
+  it("classifies the default matching ZCode route as legacy-authoritative", () => {
+    const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({}));
+
+    expect(authority).toMatchObject({
+      ok: true,
+      state: "legacy_authoritative",
+      reason: "legacy_zcode_enabled",
+      execution: {
+        adapter: "zcode",
+        providerId: "zcode-app-selected",
+        model: "GLM-5.2",
+        auth: "zcode-app-config",
+        willAttempt: true
+      },
+      automaticFallback: {
+        configured: false,
+        reachable: false,
+        target: null
+      }
+    });
+  });
+
+  it("keeps configured legacy metadata visible but non-authoritative under Codex", () => {
+    const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      codexRuntime: {
+        enabled: true,
+        cliPath: "/Users/test/.local/bin/codex",
+        model: "gpt-5.6-luna",
+        reasoningEffort: "xhigh",
+        timeoutMs: 600_000,
+        maxOutputBytes: 20 * 1024 * 1024,
+        contextWindowTokens: 128_000
+      }
+    }));
+
+    expect(authority).toMatchObject({
+      ok: true,
+      state: "codex_authoritative",
+      reason: "codex_enabled",
+      execution: {
+        adapter: "codex-cli",
+        providerId: "codex-cli-oauth",
+        model: "gpt-5.6-luna",
+        auth: "existing-codex-session",
+        willAttempt: true
+      },
+      legacyProviderMetadata: {
+        registryDefaultProviderId: "zcode-glm",
+        providerId: "zcode-glm",
+        selectionSource: "providers.defaultProviderId",
+        authoritative: false
+      },
+      automaticFallback: {
+        configured: false,
+        reachable: false,
+        target: null
+      }
+    });
+  });
+
+  it("reports an enabled non-ZCode registry default as invalid without changing the executor", () => {
+    const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            capabilities: { review: true, jsonOutput: true }
+          }
+        }
+      }
+    }));
+
+    expect(authority).toMatchObject({
+      ok: false,
+      state: "invalid_authoritative",
+      reason: "legacy_registry_mismatch",
+      execution: {
+        adapter: "zcode",
+        providerId: "zcode-app-selected",
+        willAttempt: true
+      },
+      legacyProviderMetadata: {
+        providerId: "openai-compatible",
+        adapter: "openai-compatible",
+        authoritative: false,
+        matchesExecution: false
+      }
+    });
+  });
+
+  it("makes an explicit zcode provider id take precedence over registry default metadata", () => {
+    const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      zcode: { providerId: "zcode-glm" },
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": { enabled: true }
+        }
+      }
+    }));
+
+    expect(authority).toMatchObject({
+      ok: true,
+      state: "legacy_authoritative",
+      execution: {
+        providerId: "zcode-glm",
+        adapter: "zcode"
+      },
+      legacyProviderMetadata: {
+        registryDefaultProviderId: "openai-compatible",
+        providerId: "zcode-glm",
+        selectionSource: "zcode.providerId",
+        matchesExecution: true
+      }
+    });
+  });
+
+  it("reports Codex-disabled plus legacy-disabled as invalid while preserving current attempt truth", () => {
+    const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({
+      providers: {
+        providers: {
+          "zcode-glm": { enabled: false }
+        }
+      }
+    }));
+
+    expect(authority).toMatchObject({
+      ok: false,
+      state: "invalid_authoritative",
+      reason: "both_disabled",
+      execution: {
+        adapter: "zcode",
+        willAttempt: true
+      },
+      legacyProviderMetadata: {
+        providerId: "zcode-glm",
+        enabled: false,
+        authoritative: false
+      }
+    });
+  });
+
+  it("reports per-invocation execution suppression without inventing a fallback", () => {
+    const authority = classifyReviewRuntimeAuthority(loadConfigFromObject({}), {
+      executionRequested: false
+    });
+
+    expect(authority.execution.willAttempt).toBe(false);
+    expect(authority.automaticFallback).toEqual(expect.objectContaining({
+      configured: false,
+      reachable: false,
+      target: null
+    }));
+  });
+});

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -93,7 +93,7 @@ describe("worker review settings preview evidence", () => {
     });
     expect(preview).not.toHaveProperty("reviewEventAuthorization");
     expect(walkthrough).toContain("### Review Settings Preview");
-    expect(walkthrough).toContain("Provider: GLM/Z.ai through ZCode (`zcode-glm`, zcode, model `GLM-5.2`).");
+    expect(walkthrough).toContain("Provider: ZCode (app configuration) (`zcode-glm`, zcode, model `GLM-5.2`).");
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
     expectSettingsPathInstructionCodeSpan(walkthrough, "src/`templates`/**");
     expect(walkthrough).not.toContain(secretLikeToken);
@@ -101,7 +101,10 @@ describe("worker review settings preview evidence", () => {
       provider: "zcode-glm",
       model: "GLM-5.2",
       providerAttempts: 0,
-      notes: ["ZCode execution disabled for this dry-run; provider latency and token usage were not measured."]
+      notes: [
+        "Configured review execution disabled for this dry-run; provider latency and token usage were not measured.",
+        "No automatic cross-runtime fallback exists: Codex failures are terminal and ZCode retries stay on ZCode."
+      ]
     });
     state.close();
   });
@@ -155,7 +158,7 @@ describe("worker review settings preview evidence", () => {
     state.close();
   });
 
-  it("uses the selected registry id for metadata when ZCode has a distinct execution id", () => {
+  it("uses the explicit ZCode execution id for metadata instead of the registry default", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-metadata-"));
     roots.push(root);
     const config = minimalConfig(root);
@@ -180,10 +183,10 @@ describe("worker review settings preview evidence", () => {
     };
 
     expect(buildReviewProviderMetadata(config)).toEqual({
-      providerId: "zcode-glm",
+      providerId: "ghost-provider",
       adapter: "zcode",
       model: "GLM-5.2",
-      displayName: "GLM/Z.ai through ZCode"
+      displayName: "ZCode (app configuration)"
     });
   });
 });

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -103,6 +103,7 @@ describe("worker review settings preview evidence", () => {
       providerAttempts: 0,
       notes: [
         "Configured review execution disabled for this dry-run; provider latency and token usage were not measured.",
+        "Review runtime authority: state=legacy_authoritative; reason=legacy_zcode_enabled.",
         "No automatic cross-runtime fallback exists: Codex failures are terminal and ZCode retries stay on ZCode."
       ]
     });
@@ -184,6 +185,21 @@ describe("worker review settings preview evidence", () => {
 
     expect(buildReviewProviderMetadata(config)).toEqual({
       providerId: "ghost-provider",
+      adapter: "zcode",
+      model: "GLM-5.2",
+      displayName: "ZCode (app configuration)"
+    });
+  });
+
+  it("keeps shared provider receipt metadata truthful without an optional registry", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-metadata-no-registry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.zcode.providerId = undefined;
+    config.providers = undefined;
+
+    expect(buildReviewProviderMetadata(config)).toEqual({
+      providerId: "zcode-app-selected",
       adapter: "zcode",
       model: "GLM-5.2",
       displayName: "ZCode (app configuration)"


### PR DESCRIPTION
Closes #742
Parent tracker: #738

## Outcome

NeonDiff now reports the same deterministic review-runtime authority across config inspect, provider diagnostics, general doctor, operator status, and review receipts. This is a diagnostics and metadata correction only; executor routing, models, retries, timeouts, sandboxing, schemas, ensembles, posting authority, and credentials are unchanged.

## Source identity

- Base: `1a2f08a336d3bbcc1b6d0934db58b933d1980206`
- Head: `481cfdf42b33201c4ea2be9cdeed21bfaf765c5b`

## Current-source call path

- Canonical and ensemble review execution reaches `runConfiguredReview`.
- `codexRuntime.enabled=true` selects Codex CLI; otherwise the same existing selector calls ZCode.
- Codex failures are terminal. No catch invokes ZCode.
- ZCode provider retries remain on ZCode.
- An explicit self-consistency provider is an auxiliary second draw, not fallback.
- Per-invocation execution suppression disables the review call; it does not select another runtime.

## Authority contract

- `codex_authoritative`: Codex CLI is the canonical executor. Legacy registry metadata remains visible but cannot make current-runtime doctor/status red.
- `legacy_authoritative`: the canonical executor is ZCode. `zcode.providerId` pins the ZCode app provider; otherwise the registry default is diagnostic comparison metadata while the app resolves the matching provider.
- `invalid_authoritative`: registry metadata contradicts the ZCode executor current code would still attempt. Diagnostics fail closed without silently changing dispatch.
- `both_disabled`: Codex and selected legacy registry metadata are disabled. Output states truthfully that current worker code would still attempt ZCode.
- `automaticFallback` is always `configured:false`, `reachable:false`, and `target:null` because no automatic cross-runtime fallback exists.

## Focused proof

- Failing-first classifier test initially failed because the shared authority module did not exist.
- Review-driven failing-first checks reproduced dynamic-registry coupling, missing optional registry handling, unredacted authority output, and missing receipt authority notes before the bounded continuation; all now pass.
- `npx vitest run tests/review-runtime-authority.test.ts tests/codex-runtime.test.ts tests/config-cli.test.ts tests/operator-cli.test.ts tests/worker-settings-preview.test.ts` — 93 passed.
- Targeted `tests/public-cli.test.ts` authority cases — 3 passed.
- `npm run build` — passed.
- `git diff --check` — passed.

One optional wide local `public-cli` pass reached 186/189 before the owned assertion fixes; its remaining unrelated failure was the existing native-Keychain test timing out at the repository's five-second local limit. The exact authority CLI cases pass, and canonical GitHub CI remains the broad-suite gate.

Required CI at the prior reviewed head found three stale expectations in `tests/worker-settings-preview.test.ts`: registry display/id instead of the explicit ZCode execution authority, and the old dry-run note without the no-fallback truth. The test-only delta `0e352520e443a933d9979bac65c085643ee76127..8e87206fa5d6bf10d7fcdd7db9ad705b7a0b35a8` aligns those assertions with the already-reviewed implementation. Independent delta-only review passed at 99% confidence with the prior CI failure fixed and no delta-caused or delta-exposed findings. Exact-head required `Build, test, and package` and `Swift desktop gate` checks passed.

The owner-authorized bounded continuation at `481cfdf42b33201c4ea2be9cdeed21bfaf765c5b` makes the optional registry diagnostic-only for dynamic ZCode, retains fail-closed validation for explicit provider pins, redacts derived authority output, and records one authority state/reason note in canonical, disabled, chunked, and ensemble receipt paths. Independent delta review of `8e87206fa5d6bf10d7fcdd7db9ad705b7a0b35a8..481cfdf42b33201c4ea2be9cdeed21bfaf765c5b` passed at 97% confidence with all #748 and current review-thread blockers fixed and no new findings. Exact-head required `Build, test, and package` and `Swift desktop gate` checks passed; CodeQL language analyses, aggregate, Linux daemon smoke, and security checks also passed.

## Late follow-up disposition

#752 is retained as a non-blocking owner follow-up outside milestone #21. This PR identifies the executor truthfully and does not change routing. Choosing dynamic ZCode context capacity would change execution/chunking behavior and therefore hits #742's explicit owner-decision hard stop. The current behavior remains unchanged and the follow-up does not block #742 readiness.

## Boundaries

No live config, ZCode app config, credential, daemon, launchd service, installed runtime, model route, provider request, posting path, release, deployment, or customer surface was mutated. This exact head is ready only for owner merge consideration.
