### PR TITLE
fix: preserve active health recovery ordering

### DIFF
--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1858,14 +1858,25 @@ function zcodeTimeoutRecommendedActions(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
 ): string[] {
-  const retainedFailedQueueJobs = release.database.failedReviewQueueJobCount;
-  const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount;
+  const retainedTimeoutJobs = release.database.zcodeTimeoutFailedReviewQueueJobCount;
+  const activeTimeoutJobs = release.database.activeZCodeTimeoutFailedReviewQueueJobCount;
   if (
-    retainedFailedQueueJobs !== undefined &&
-    activeFailedQueueJobs !== undefined &&
-    activeFailedQueueJobs < retainedFailedQueueJobs
+    retainedTimeoutJobs !== undefined &&
+    activeTimeoutJobs !== undefined &&
+    activeTimeoutJobs < retainedTimeoutJobs
   ) {
     return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+  }
+  if (retainedTimeoutJobs === undefined || activeTimeoutJobs === undefined) {
+    const retainedFailedQueueJobs = release.database.failedReviewQueueJobCount;
+    const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount;
+    if (
+      retainedFailedQueueJobs !== undefined &&
+      activeFailedQueueJobs !== undefined &&
+      activeFailedQueueJobs < retainedFailedQueueJobs
+    ) {
+      return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+    }
   }
   const retryCommands = buildZCodeTimeoutRetryCommandsForJobs({
     configPath: release.releaseUnit.configPath,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2641,9 +2641,9 @@ function readReviewQueueCounts(
                   and p.pull_number = q.pull_number
                   and p.status = 'posted'
                   and (p.error is null or p.error = '')
-                  and datetime(p.created_at) is not null
-                  and datetime(q.updated_at) is not null
-                  and datetime(p.created_at) > datetime(q.updated_at)
+                  and julianday(p.created_at) is not null
+                  and julianday(q.updated_at) is not null
+                  and julianday(p.created_at) > julianday(q.updated_at)
               ) as recovered
        from review_queue_jobs q
        where q.state = 'failed'`

--- a/src/state.ts
+++ b/src/state.ts
@@ -916,13 +916,14 @@ export class ReviewStateStore {
   }
 
   recordProcessed(record: ProcessedReviewRecord): void {
+    const completedAt = new Date().toISOString();
     this.db.exec("begin immediate");
     try {
       this.db
         .prepare(
           `insert or replace into processed_reviews
             (repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at)
-           values (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+           values (?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           record.repo,
@@ -932,7 +933,8 @@ export class ReviewStateStore {
           record.configRevision ?? null,
           record.event ?? null,
           record.reviewUrl ?? null,
-          record.error ?? null
+          record.error ?? null,
+          completedAt
         );
       // Completion and claim retirement are one transaction. A later ordinary claimant must see
       // either the live claim or the durable processed row, never a gap between the two.
@@ -1879,11 +1881,11 @@ export class ReviewStateStore {
       if (!preserveExistingBlocking) {
         this.db
           .prepare(
-            `insert or replace into processed_reviews
+          `insert or replace into processed_reviews
               (repo, pull_number, head_sha, status, event, review_url, error, created_at)
-             values (?, ?, ?, 'posted', ?, ?, null, datetime('now'))`
+             values (?, ?, ?, 'posted', ?, ?, null, ?)`
           )
-          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl);
+          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl, postedAt);
       }
       const readinessEvent = preserveExistingBlocking ? "REQUEST_CHANGES" : input.event;
       const readinessUrl = preserveExistingBlocking ? existingProcessed?.reviewUrl : input.reviewUrl;

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1638,6 +1638,46 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions.join("\n")).not.toContain("retry-failed");
   });
 
+  it("keeps retry guidance for an active timeout when recovered history is non-timeout", () => {
+    const activeTimeout = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 216,
+      headSha: "active-timeout",
+      state: "failed",
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000"
+    });
+    const recoveredOrdinaryFailure = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 215,
+      headSha: "recovered-ordinary",
+      state: "failed",
+      lastError: "provider failed before posting"
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        database: {
+          errorCount: 1,
+          failedReviewQueueJobCount: 2,
+          activeFailedReviewQueueJobCount: 1,
+          zcodeTimeoutFailedReviewQueueJobCount: 1,
+          activeZCodeTimeoutFailedReviewQueueJobCount: 1,
+          activeRetryableZCodeTimeoutFailedReviewQueueJobCount: 1,
+          activeExhaustedZCodeTimeoutFailedReviewQueueJobCount: 0
+        }
+      }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({
+        summary: { ...cleanDurableQueueSummary(), total: 2, failed: 2 },
+        jobs: [activeTimeout, recoveredOrdinaryFailure]
+      })
+    });
+
+    expect(status.recommendedActions).toContain(
+      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 216 --head-sha active-timeout --dry-run false --zcode true"
+    );
+  });
+
   it("keeps blocked-on-proof readiness above processed coverage for the same head", () => {
     const dashboard = buildOperatorDashboard({
       coverage: coverageReport({ ok: true, processed: [processedEntry(8, "head-proof", "posted")] }),

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6277,6 +6277,128 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     expect(detailedStatus.budget?.delayed.length).toBeLessThanOrEqual(1);
   });
 
+  it("preserves sub-second queue recovery ordering in both directions", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-subsecond-recovery-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null,
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "failed-subsecond",
+        "automatic:owner/repo#17@failed-head",
+        "owner/repo",
+        "owner",
+        17,
+        "failed-head",
+        "provider failed",
+        "2026-07-01T00:00:00.100Z",
+        "2026-07-01T00:00:00.100Z"
+      );
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "failed-after-post",
+        "automatic:owner/repo#18@failed-head",
+        "owner/repo",
+        "owner",
+        18,
+        "failed-head",
+        "provider failed",
+        "2026-07-01T00:00:00.900Z",
+        "2026-07-01T00:00:00.900Z"
+      );
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+         values (?, ?, ?, 'posted', 'COMMENT', ?, null, ?)`
+      ).run(
+        "owner/repo",
+        17,
+        "later-clean-head",
+        "https://github.test/owner/repo/pull/17#pullrequestreview-1",
+        "2026-07-01T00:00:00.900Z"
+      );
+      db.prepare(
+        `insert into processed_reviews
+          (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+         values (?, ?, ?, 'posted', 'COMMENT', ?, null, ?)`
+      ).run(
+        "owner/repo",
+        18,
+        "earlier-clean-head",
+        "https://github.test/owner/repo/pull/18#pullrequestreview-1",
+        "2026-07-01T00:00:00.100Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({
+      failedReviewQueueJobCount: 2,
+      activeFailedReviewQueueJobCount: 1,
+      recentActiveFailedReviewQueueJobCount: 1
+    });
+    expect(status.gates.find((gate) => gate.name === "queue_no_failed_jobs")).toMatchObject({
+      name: "queue_no_failed_jobs",
+      ok: false,
+      detail: expect.stringContaining("1 active failed durable queue job(s); 2 retained history")
+    });
+  });
+
   it("does not fail the provider-deferred gate when retryable jobs are waiting on capacity", () => {
     const status = buildReleaseStatus({
       repo: {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -31,6 +31,24 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("records processed review completion with millisecond ordering precision", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-precision-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1206,
+      headSha: "precision-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+
+    expect(store.getProcessedReview("electricsheephq/WorldOS", 1206, "precision-head")?.createdAt)
+      .toMatch(/\.\d{3}Z$/);
+    store.close();
+  });
+
   it("stores normalized issue enrichment body hashes and rejects invalid hashes", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-"));
     roots.push(root);


### PR DESCRIPTION
Closes #749
Parent tracker: #738
Blocked PR: #744

## Outcome

This isolated delta keeps current-vs-historical doctor health truthful at sub-second recovery boundaries and preserves retry guidance for an active ZCode timeout when retained history is unrelated.

## Source identity

- Base branch/head: `fix/741-doctor-health` / `c192f5f063b8e9e634052bad4ec5064186c5d7fa`
- Head: `51e9d022ff982098095be3e2ac3d31289ceaebd0`

## Changes

- New processed-review completion rows use millisecond ISO timestamps; the authorized-post seam reuses its exact posted timestamp.
- Queue recovery compares valid timestamps with fractional precision and remains fail-closed for malformed, equal, or earlier evidence.
- Timeout retry suppression compares retained and active timeout counts. It falls back to the broader legacy counts only when timeout-specific active fields are unavailable.
- Recovered timeout history still suppresses ambiguous per-job retry commands; recovered non-timeout history no longer hides the retry action for a live timeout.

## Focused proof

- Failing-first: 3 failures / 237 passes reproduced both defects and the missing millisecond write precision.
- `npx vitest run tests/state.test.ts tests/release-status.test.ts tests/operator-cli.test.ts` — 240 passed.
- `npm run build` — passed.
- `git diff --check` — passed.

## Boundaries

No queue schema migration, historical record deletion, retry execution, provider/model/routing change, daemon/service action, live-config or credential access, merge, release, deployment, or customer action occurred. This is source/CI/review proof only.
