### PR TITLE
fix(desktop): block clean-Mac setup without local worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,20 @@ The public paid B0 BYO beta build uses a separate exact
 no managed-broker fields. That contract enables the existing local direct/BYO
 path and API-backed native activation without a hidden defaults mutation. It
 is a paid path for every repository and does not claim the managed public-free
-model. On a clean Mac, native first run exposes **Initialize Local Config**
-(non-destructive; never force-overwrites), **Add Repository**, **Apply
-Repository**, and **Verify App Access**, so the customer does not need a
-terminal or an operator edit to reach the repository-verification gate. When
-the verified account has no bot yet, the app allocates that isolated new-bot
-plan before it presents the initialization action; it never initializes the
-`_unselected` placeholder. If the customer quits during that setup, the next
+model. On a clean Mac without an executable local worker, native first run
+blocks **Initialize Local Config**, **Apply Repository**, and **Verify App
+Access** and routes the customer to **Install / Update Local Worker** instead
+of invoking a missing `neondiff` command. The current checksum-bound worker
+installer updates or rolls back one existing LaunchAgent; it does not yet
+bootstrap a worker on a Mac with no LaunchAgent. That exact first-install
+artifact and clean-Mac proof remain a separate distribution gate. Once an
+executable global or checksum-managed worker is available, native first run
+exposes **Initialize Local Config** (non-destructive; never force-overwrites),
+**Add Repository**, **Apply Repository**, and **Verify App Access** without a
+terminal or operator config edit. When the verified account has no bot yet,
+the app allocates that isolated new-bot plan before it presents the
+initialization action; it never initializes the `_unselected` placeholder. If
+the customer quits during that setup, the next
 launch restores the same pending bot and config path when its saved selection
 is still current. If an older build or manual rollback selected a verified
 existing bot under the same account, the app keeps that authoritative bot

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -65,6 +65,7 @@ enum NeonDiffDesktopCompositionRoot {
             ),
             cliWorkingDirectory: cliWorkingDirectory,
             localBotConfigurations: localBotConfigurations,
+            localBotExecutionContexts: localBotExecutionContexts,
             localBotExecutionConfigPaths: localBotExecutionContexts.map(
                 \.configPath
             )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -286,6 +286,20 @@ struct OnboardingWizardView: View {
                 .operatorBodyText()
                 .fixedSize(horizontal: false, vertical: true)
 
+            if !model.localWorkerCLIAvailable {
+                Text(model.localWorkerCLIStatus)
+                    .font(.caption)
+                    .foregroundStyle(NeonDiffTheme.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button {
+                    model.openLocalWorkerUpdateGuide()
+                } label: {
+                    Label("Install / Update Local Worker", systemImage: "arrow.down.circle")
+                }
+                .accessibilityIdentifier("neondiff-onboarding-worker-update-guide")
+            }
+
             Button { model.initializeConfigForOnboarding() } label: {
                 Label(
                     model.isConfigInitializationInProgress ? "Initializing…" : "Initialize Local Config",
@@ -293,7 +307,8 @@ struct OnboardingWizardView: View {
                 )
             }
             .disabled(
-                !model.canEditProviderConfiguration
+                !model.localWorkerCLIAvailable
+                    || !model.canEditProviderConfiguration
                     || model.isConfigInitializationInProgress
                     || model.isConfigPatchInProgress
                     || model.isConfigInspectInProgress
@@ -355,6 +370,7 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     model.repos.filter(\.enabled).count != 1
+                        || !model.localWorkerCLIAvailable
                         || !model.canEditProviderConfiguration
                         || model.isConfigInitializationInProgress
                         || model.isConfigPatchInProgress
@@ -370,6 +386,7 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     !model.byoGitHubCredentialsStored
+                        || !model.localWorkerCLIAvailable
                         || model.repos.filter(\.enabled).count != 1
                         || !model.canEditProviderConfiguration
                         || model.isConfigInitializationInProgress

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -431,6 +431,20 @@ struct OnboardingWizardView: View {
                 }
             }
 
+            if !model.localWorkerCLIAvailable {
+                Text(model.localWorkerCLIStatus)
+                    .font(.caption)
+                    .foregroundStyle(NeonDiffTheme.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button {
+                    model.openLocalWorkerUpdateGuide()
+                } label: {
+                    Label("Install / Update Local Worker", systemImage: "arrow.down.circle")
+                }
+                .accessibilityIdentifier("neondiff-onboarding-worker-update-guide")
+            }
+
             if let recovery = model.managedGitHubRecovery {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(recovery.message)
@@ -529,6 +543,7 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     model.selectedManagedGitHubRepository == nil
+                        || !model.localWorkerCLIAvailable
                         || model.isConfigPatchInProgress
                         || model.isConfigInspectInProgress
                 )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -137,6 +137,7 @@ package struct DesktopAppDependencies {
     package let localWorkerUpdateGuideURL: URL
     package let cliWorkingDirectory: URL?
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
+    package let localBotExecutionContexts: [DesktopLocalBotExecutionContext]
     package let localBotExecutionConfigPaths: [String]
 
     package init(
@@ -158,6 +159,7 @@ package struct DesktopAppDependencies {
         ),
         cliWorkingDirectory: URL? = nil,
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
+        localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         localBotExecutionConfigPaths: [String] = []
     ) {
         self.clipboard = clipboard
@@ -176,6 +178,7 @@ package struct DesktopAppDependencies {
         self.localWorkerUpdateGuideURL = localWorkerUpdateGuideURL
         self.cliWorkingDirectory = cliWorkingDirectory
         self.localBotConfigurations = localBotConfigurations
+        self.localBotExecutionContexts = localBotExecutionContexts
         self.localBotExecutionConfigPaths = localBotExecutionConfigPaths
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -462,6 +462,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// execution context is already discovery-proven and remains eligible.
     package var localWorkerCLIAvailable: Bool {
         existingLocalAgentAccessAvailable
+            || DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                executablePath: cliPath,
+                arguments: ["init", "--config", configPath],
+                executionContexts: dependencies.localBotExecutionContexts
+            ) != nil
             || NeonDiffCLIResolver.resolveExecutablePath(
                 cliPath,
                 workingDirectory: dependencies.cliWorkingDirectory

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -457,6 +457,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && !isScopedReviewInProgress
     }
 
+    /// Resolve only the configured executable through the same fixed desktop
+    /// resolver used by the production CLI client. An exact existing-agent
+    /// execution context is already discovery-proven and remains eligible.
+    package var localWorkerCLIAvailable: Bool {
+        existingLocalAgentAccessAvailable
+            || NeonDiffCLIResolver.resolveExecutablePath(
+                cliPath,
+                workingDirectory: dependencies.cliWorkingDirectory
+            ) != nil
+    }
+
+    package var localWorkerCLIStatus: String {
+        localWorkerCLIAvailable
+            ? "Local worker command is available."
+            : "Local worker command \(cliPath) is unavailable. Install the version-matched worker before continuing."
+    }
+
     /// Stopping an already-running daemon is a safety remediation, not useful
     /// review work. Keep it available for a verified production build even if
     /// the current repository binding or entitlement proof has been revoked.
@@ -2583,6 +2600,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = "Local config initialization is available only in the customer-owned GitHub App beta path."
             return
         }
+        guard requireLocalWorkerCLI() else { return }
         guard canEditProviderConfiguration else {
             lastError = providerVerificationSafetyLatchMessage ?? "Wait for provider verification cleanup before changing config."
             return
@@ -3420,6 +3438,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard !isSetupMutationBlocked else {
             lastError = "Retry account verification before verifying GitHub App setup."
             byoGitHubCredentialStatus = lastError ?? "Account check required"
+            return
+        }
+        guard requireLocalWorkerCLI() else {
+            byoGitHubCredentialStatus = lastError ?? "Local worker unavailable"
             return
         }
         guard byoGitHubCredentialOnboardingAvailable else {
@@ -4955,6 +4977,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     private func runRepoSelectionPatch(dryRun: Bool) {
+        guard requireLocalWorkerCLI() else { return }
         guard canEditProviderConfiguration else {
             lastError = "Wait for provider verification cleanup before changing config."
             return
@@ -5007,6 +5030,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
             displayCommand: dryRun ? repoSelectionPatchPreviewCommand : repoSelectionPatchApplyCommand,
             repoPatchProof: proof
         )
+    }
+
+    @discardableResult
+    private func requireLocalWorkerCLI() -> Bool {
+        guard localWorkerCLIAvailable else {
+            let message =
+                "Local worker command \(cliPath) is unavailable. Choose Install / Update Local Worker before continuing."
+            lastError = message
+            logText = message
+            configInitializationStatus = message
+            return false
+        }
+        return true
     }
 
     private func gitHubAccessTokenForAPI(workspaceGeneration: UInt64) async throws -> String {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/AccountWorkspaceSelectionTests.swift
@@ -1051,7 +1051,8 @@ import NeonDiffDesktopCore
                 .success(CLIRunResult(exitCode: 0, stdout: resultA, stderr: "")),
                 .success(CLIRunResult(exitCode: 0, stdout: resultB, stderr: ""))
             ],
-            suspendCLIRuns: true
+            suspendCLIRuns: true,
+            preferenceStrings: ["neondiff.cliPath": "/usr/bin/true"]
         )
         fixture.model.applyAccountWorkspaceCatalog(.loaded([accountA, accountB]))
         fixture.model.selectBotInstallation(botA.id)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -6,6 +6,33 @@ import NeonDiffDesktopCore
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
 struct BYOGitHubAppCredentialOnboardingTests {
+    @Test func missingConfiguredCLIBlocksStepOneAndRoutesToWorkerInstaller() {
+        let guideURL = URL(
+            string: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.1.0-beta.37"
+        )!
+        let fixture = ModelDependencyFixture(
+            preferenceStrings: [
+                "neondiff.cliPath": "/fixture/missing/neondiff"
+            ],
+            productionBoundary: exactB0Boundary,
+            localWorkerUpdateGuideURL: guideURL
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+
+        #expect(!fixture.model.localWorkerCLIAvailable)
+        #expect(fixture.model.localWorkerCLIStatus.contains("/fixture/missing/neondiff"))
+
+        fixture.model.initializeConfigForOnboarding()
+        fixture.model.applyRepoAllowlistPatch()
+        fixture.model.verifyBYOGitHubAppCredentials()
+
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.model.lastError?.contains("Install / Update Local Worker") == true)
+
+        fixture.model.openLocalWorkerUpdateGuide()
+        #expect(fixture.urlOpener.urls == [guideURL])
+    }
+
     @Test func cleanInstallInitializationUsesNonDestructiveCLIInit() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(CLIRunResult(
@@ -13,9 +40,13 @@ struct BYOGitHubAppCredentialOnboardingTests {
                 stdout: #"{"ok":true,"command":"init","created":true}"#,
                 stderr: ""
             ))],
+            preferenceStrings: [
+                "neondiff.cliPath": "/usr/bin/true"
+            ],
             productionBoundary: exactB0Boundary
         )
 
+        #expect(fixture.model.localWorkerCLIAvailable)
         fixture.model.initializeConfigForOnboarding()
         await fixture.cli.waitUntilCallCount(1)
 
@@ -23,6 +54,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
             .appendingPathComponent("config.local.json")
             .standardizedFileURL.path
         #expect(fixture.model.configPath == expectedConfigPath)
+        #expect(fixture.cli.calls[0].executablePath == "/usr/bin/true")
         #expect(fixture.cli.calls[0].arguments == ["init", "--config", expectedConfigPath])
         #expect(!fixture.cli.calls[0].arguments.contains("--force"))
         #expect(fixture.model.configInitializeCommand.commandLine.contains(" init --config "))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -61,6 +61,31 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.configInitializeCommand.commandLine.contains("--force"))
     }
 
+    @Test func isolatedNewBotCanReuseOneInstallerManagedWorker() {
+        let configPath =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account-a/Bots/new-neondiff-bot/config.local.json"
+        let workerCLI =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/v1.1.0-beta.44/current/node_modules/neondiff/dist/src/cli.js"
+        let fixture = ModelDependencyFixture(
+            preferenceStrings: [
+                "neondiff.cliPath": "neondiff",
+                "neondiff.configPath": configPath
+            ],
+            localBotExecutionContexts: [
+                DesktopLocalBotExecutionContext(
+                    configPath: "/Users/test/existing/config.local.json",
+                    executablePath: "/usr/local/bin/node",
+                    argumentPrefix: [workerCLI],
+                    environmentOverrides: [:]
+                )
+            ],
+            productionBoundary: exactB0Boundary
+        )
+
+        #expect(fixture.model.configPath == configPath)
+        #expect(fixture.model.localWorkerCLIAvailable)
+    }
+
     @Test func repositoryRemovalIsBlockedDuringProviderVerificationCleanup() {
         let fixture = ModelDependencyFixture(productionBoundary: exactB0Boundary)
         let repository = RepoMonitor(name: "acme/demo", enabled: true)
@@ -173,6 +198,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
         )
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(doctorResult)],
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
@@ -224,6 +250,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
             cliOutcomes: [.success(doctorResult(
                 readChecks: doctorReadCheck(repo: "acme/demo")
             ))],
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
@@ -262,6 +289,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
                 ))
             ],
             activationLicenseClient: ActiveBYOActivationClient(),
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
@@ -350,6 +378,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
         for scenario in scenarios {
             let fixture = ModelDependencyFixture(
                 cliOutcomes: [.success(doctorResult(readChecks: scenario.readChecks))],
+                preferenceStrings: availableCLIPreference,
                 productionBoundary: exactB0Boundary
             )
             fixture.model.repos = scenario.configuredRepositories
@@ -376,6 +405,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
     @Test func enabledRepositoryMutationRevokesUsefulWorkUntilReverified() async throws {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
@@ -401,6 +431,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
             suspendCLIRuns: true,
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
@@ -428,6 +459,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.failure(NSError(domain: "fixture-old-workspace", code: 1))],
             suspendCLIRuns: true,
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         let accountA = fixtureWorkspace(id: "account-a")
@@ -453,6 +485,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo")))],
             suspendCLIRuns: true,
+            preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
         fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
@@ -489,6 +522,10 @@ private func fixtureWorkspace(id: String) -> DesktopAccountWorkspace {
         bots: []
     )
 }
+
+private let availableCLIPreference = [
+    "neondiff.cliPath": "/usr/bin/true"
+]
 
 @MainActor
 private func waitForBYOVerification(_ fixture: ModelDependencyFixture) async {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1569,6 +1569,7 @@ import NeonDiffDesktopCore
                 ))
             ],
             githubBroker: broker,
+            preferenceStrings: ["neondiff.cliPath": "/usr/bin/true"],
             productionBoundary: .testManaged
         )
         let bot = DesktopBotInstallation(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/GitHubAuthorizationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/GitHubAuthorizationTests.swift
@@ -176,6 +176,7 @@ import NeonDiffDesktopCore
                 stdout: #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["electric/public"]}}"#,
                 stderr: ""
             ))],
+            preferenceStrings: ["neondiff.cliPath": "/usr/bin/true"],
             productionBoundary: .testVerified
         )
         fixture.model.repos = [RepoMonitor(name: "electric/public", enabled: true)]
@@ -207,6 +208,7 @@ import NeonDiffDesktopCore
                 stdout: #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["electric/public"]}}"#,
                 stderr: ""
             ))],
+            preferenceStrings: ["neondiff.cliPath": "/usr/bin/true"],
             productionBoundary: .testVerified
         )
         fixture.model.repos = [RepoMonitor(name: "electric/public", enabled: true)]
@@ -228,6 +230,7 @@ import NeonDiffDesktopCore
                 stderr: ""
             ))],
             suspendCLIRuns: true,
+            preferenceStrings: ["neondiff.cliPath": "/usr/bin/true"],
             productionBoundary: .testVerified
         )
         fixture.model.repos = [RepoMonitor(name: "electric/public", enabled: true)]

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -633,6 +633,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
             activationLicenseClient: ActiveManagedActivationClient(),
+            preferenceStrings: availableManagedCLIPreference,
             productionBoundary: .testManaged
         )
         fixture.model.startManagedGitHubConnection()
@@ -668,6 +669,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
             activationLicenseClient: ActiveManagedActivationClient(),
+            preferenceStrings: availableManagedCLIPreference,
             productionBoundary: .testManaged
         )
         fixture.model.startManagedGitHubConnection()
@@ -728,6 +730,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let broker = ScriptedGitHubBroker()
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
+            preferenceStrings: availableManagedCLIPreference,
             productionBoundary: .testManaged
         )
         fixture.model.startManagedGitHubConnection()
@@ -761,6 +764,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let broker = ScriptedGitHubBroker()
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
+            preferenceStrings: availableManagedCLIPreference,
             productionBoundary: .testManaged
         )
         fixture.model.startManagedGitHubConnection()
@@ -793,6 +797,7 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let broker = ScriptedGitHubBroker()
         let fixture = ModelDependencyFixture(
             githubBroker: broker,
+            preferenceStrings: availableManagedCLIPreference,
             productionBoundary: .testManaged
         )
         fixture.model.startManagedGitHubConnection()
@@ -814,6 +819,10 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.lastError == nil)
     }
 }
+
+private let availableManagedCLIPreference = [
+    "neondiff.cliPath": "/usr/bin/true"
+]
 
 private func managedRepoPatchJSON(repository: String, wrote: Bool = true) -> String {
     let revisionAfter = wrote

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -252,6 +252,7 @@ struct ModelDependencyFixture {
         preferenceBools: [String: Bool] = [:],
         preferenceStrings: [String: String] = [:],
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
+        localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         localBotExecutionConfigPaths: [String] = [],
         productionBoundary: DesktopProductionBoundary = .testVerified,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
@@ -293,6 +294,7 @@ struct ModelDependencyFixture {
             productionBoundary: productionBoundary,
             localWorkerUpdateGuideURL: localWorkerUpdateGuideURL,
             localBotConfigurations: localBotConfigurations,
+            localBotExecutionContexts: localBotExecutionContexts,
             localBotExecutionConfigPaths: localBotExecutionConfigPaths
         ), activationLicenseClient: activationLicenseClient)
     }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -273,6 +273,13 @@ For a B0 customer, the native first-run path is:
    config is not overwritten. The generated config keeps its runtime, state,
    evidence, and license files in bot-isolated directories beside the config,
    outside the packaged worker or source checkout.
+   If NeonDiff reports that the local worker command is unavailable, this and
+   the later CLI-backed setup controls remain disabled. Choose **Install /
+   Update Local Worker** to open the version-matched release guide. Continue
+   only when that exact release provides a checksum-bound worker bundle and a
+   supported first-install path. The current B0 update/rollback installer
+   requires an existing LaunchAgent and does not bootstrap a clean Mac; until a
+   matching first-install artifact exists, this is a release blocker.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command; the customer does not edit a config file.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -151,6 +151,12 @@ integration proof under #630.
    bot's credential environment. Zero or ambiguous managed-worker discovery
    does not select this reuse path; the exact worker installation remains a
    separate distribution gate.
+   If the configured local worker command is unavailable, the CLI-backed
+   controls remain disabled and **Install / Update Local Worker** opens the
+   version-matched release guide. Do not treat that link as clean-Mac bootstrap
+   proof: the current B0 update/rollback installer requires an existing
+   LaunchAgent. A clean Mac remains blocked until the exact release supplies a
+   checksum-bound worker bundle and supported first-install path.
 
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native


### PR DESCRIPTION
## Outcome

Fail closed on a clean Mac before onboarding invokes a missing `neondiff` CLI, and expose the existing version-matched worker guide as the supported next action.

Related to #753, #686, and #610. This PR does not close the broader installed-path issues.

## Acceptance criteria

- A missing exact configured CLI is represented as an explicit prerequisite.
- Initialize Config, repository patching, and BYO GitHub verification never invoke `/usr/bin/env neondiff` while the CLI is unavailable.
- Onboarding offers one **Install / Update Local Worker** action through the existing release-routing URL.
- Existing CLI and discovery-proven existing-agent paths remain eligible.
- One exact checksum-managed worker remains eligible for an isolated new-bot config.
- Documentation says the current update/rollback installer needs an existing LaunchAgent and is not clean-Mac bootstrap proof.

## Non-goals

- No worker auto-download or first-install implementation.
- No updater framework, new dependency, launchd mutation, or credential handling change.
- No GitHub App key generation, billing, signing, notarization, publication, or release claim.
- No managed App, Sparkle, broad #517, or GA work.

## Reproduction

Installed beta.44 build 11048 successfully linked the production account and loaded ElectricSheep plus its verified bot. On this clean Mac, no standard worker LaunchAgent or worker directory exists. Selecting that bot and choosing **Initialize Local Config** returned:

`env: neondiff: No such file or directory`

## Validation

- `git diff --check origin/main..HEAD` passed.
- Failing-first `isolatedNewBotCanReuseOneInstallerManagedWorker` reproduced false availability on the prior head.
- `swift test --skip-update --filter BYOGitHubAppCredentialOnboardingTests` passed 17/17 on the source head.
- Remote run `31709239295` exposed five managed test fixtures that still depended on an implicit global CLI; the AppCore step hit its 8-minute bound while one test waited for a blocked scripted call.
- `swift test --skip-update --filter ManagedGitHubOnboardingTests` passes 21/21.
- The next current-head run reached the end of AppCore in 0.528s and identified the remaining two deterministic legacy-patch fixtures; `swift test --skip-update --filter GitHubAuthorizationTests` now passes 12/12.
- Exact head is `4367f19b6d135f6a53214d35461bf94f60379816`.
- Independent semantic review passed at 97% on the production delta; the final test-only delta passed targeted review at 99%.
- Current-head remote CI remains the merge gate.

## Proof boundary

This is source/build proof only. It does not install a worker, create a clean-Mac first-install artifact, prove CI or installed behavior, or make NeonDiff ready for release or customers.
