### PR TITLE
feat(desktop): add credential-free clean-Mac worker install

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,13 @@ is a paid path for every repository and does not claim the managed public-free
 model. On a clean Mac without an executable local worker, native first run
 blocks **Initialize Local Config**, **Apply Repository**, and **Verify App
 Access** and routes the customer to **Install / Update Local Worker** instead
-of invoking a missing `neondiff` command. The current checksum-bound worker
-installer updates or rolls back one existing LaunchAgent; it does not yet
-bootstrap a worker on a Mac with no LaunchAgent. That exact first-install
-artifact and clean-Mac proof remain a separate distribution gate. Once an
+of invoking a missing `neondiff` command. The checksum-bound bundle's explicit
+`first-install` command installs only its verified CLI in a private current-user
+version directory and writes a credential-free installation marker. It creates
+or loads no LaunchAgent and starts no daemon. Native first run can use that
+exact worker for bounded setup commands; review and daemon readiness remain
+separate gates. The immutable published prerelease and clean-Mac artifact proof
+remain distribution gates. Once an
 executable global or checksum-managed worker is available, native first run
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ the same immutable GitHub prerelease as the app rather than an unpublished npm
 version or an unpinned source checkout. No invitation is required when the
 versioned public GitHub prerelease is published and the neondiff.com
 purchase/download path is live.
+The worker installer requires Node.js 26 or newer resolving through the
+approved stable path `/opt/homebrew/bin/node` or `/usr/local/bin/node`.
 When the app reports **Worker update required**, choose **Install / Update Local
 Worker**. Verify the outer worker bundle ZIP against the prerelease notes, then
 verify the extracted release manifest and inner `.tgz` tarball against the

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -4,16 +4,20 @@ import NeonDiffDesktopCore
 
 struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
     private let localBotConfigurations: [DesktopLocalBotConfiguration]
-    private let localBotExecutionContexts: [DesktopLocalBotExecutionContext]
+    private let localBotExecutionContextProvider:
+        @Sendable () -> [DesktopLocalBotExecutionContext]
     private let defaultWorkingDirectory: URL?
 
     init(
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
+        localBotExecutionContextProvider:
+            (@Sendable () -> [DesktopLocalBotExecutionContext])? = nil,
         defaultWorkingDirectory: URL? = NeonDiffCLIResolver.defaultWorkingDirectory()
     ) {
         self.localBotConfigurations = localBotConfigurations
-        self.localBotExecutionContexts = localBotExecutionContexts
+        self.localBotExecutionContextProvider =
+            localBotExecutionContextProvider ?? { localBotExecutionContexts }
         self.defaultWorkingDirectory = defaultWorkingDirectory
     }
 
@@ -23,6 +27,7 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
         standardInput: Data?,
         timeout: TimeInterval
     ) async throws -> CLIRunResult {
+        let localBotExecutionContexts = localBotExecutionContextProvider()
         let workingDirectory = DesktopLocalBotWorkingDirectoryResolver.resolve(
             arguments: arguments,
             localBotConfigurations: localBotConfigurations,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -25,8 +25,44 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             )
             .appendingPathComponent(label, isDirectory: true)
             .standardizedFileURL
-        guard let data = try? Data(contentsOf: launchAgentURL, options: .mappedIfSafe) else {
+        let launchAgentData = try? Data(
+            contentsOf: launchAgentURL,
+            options: .mappedIfSafe
+        )
+        if launchAgentData == nil, entryExists(launchAgentURL) {
             return Snapshot(configurations: [], executionContexts: [])
+        }
+        guard let data = launchAgentData else {
+            let installationURL = installedWorkerRoot
+                .appendingPathComponent("installation.json")
+            guard isSafeInstallationFile(installationURL),
+                  let installationData = try? Data(
+                    contentsOf: installationURL,
+                    options: .mappedIfSafe
+                  ),
+                  let context =
+                    DesktopInstalledWorkerExecutionContextParser.parse(
+                        data: installationData,
+                        expectedLabel: label,
+                        installedWorkerRoot: installedWorkerRoot,
+                        resolveCLI: {
+                            let resolved = $0.resolvingSymlinksInPath()
+                            return resolved == $0 ? nil : resolved
+                        },
+                        cliIsSafe: {
+                            isSafeInstalledCLI($0, fileManager: fileManager)
+                        },
+                        nodeIsExecutable: {
+                            isExecutableRegularFile($0, fileManager: fileManager)
+                        }
+                    )
+            else {
+                return Snapshot(configurations: [], executionContexts: [])
+            }
+            return Snapshot(
+                configurations: [],
+                executionContexts: [context]
+            )
         }
         let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
             data: data,
@@ -85,5 +121,45 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             return false
         }
         return true
+    }
+
+    private static func isSafeInstallationFile(_ url: URL) -> Bool {
+        var entry = stat()
+        return lstat(url.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && entry.st_uid == getuid()
+            && (entry.st_mode & 0o077) == 0
+            && entry.st_size > 0
+            && entry.st_size <= 1024 * 1024
+    }
+
+    private static func entryExists(_ url: URL) -> Bool {
+        var entry = stat()
+        return lstat(url.path, &entry) == 0
+    }
+
+    private static func isSafeInstalledCLI(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        var entry = stat()
+        return lstat(url.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && entry.st_uid == getuid()
+            && (entry.st_mode & 0o022) == 0
+            && entry.st_size > 0
+            && entry.st_size <= 50 * 1024 * 1024
+            && fileManager.isReadableFile(atPath: url.path)
+    }
+
+    private static func isExecutableRegularFile(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let resolved = url.resolvingSymlinksInPath()
+        var entry = stat()
+        return lstat(resolved.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && fileManager.isExecutableFile(atPath: resolved.path)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -25,6 +25,7 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             )
             .appendingPathComponent(label, isDirectory: true)
             .standardizedFileURL
+            .resolvingSymlinksInPath()
         let launchAgentData = try? Data(
             contentsOf: launchAgentURL,
             options: .mappedIfSafe

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -40,12 +40,19 @@ enum NeonDiffDesktopCompositionRoot {
             LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
         let localBotConfigurations = localBotSnapshot.configurations
         let localBotExecutionContexts = localBotSnapshot.executionContexts
-        return NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
+        let localBotExecutionContextProvider:
+            @Sendable () -> [DesktopLocalBotExecutionContext] = {
+                LaunchAgentLocalBotConfigurationDiscovery
+                    .discoverExecutionContexts()
+            }
+        let model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: AppKitClipboard(),
             urlOpener: AppKitURLOpener(),
             cli: FoundationDesktopCLIExecutor(
                 localBotConfigurations: localBotConfigurations,
                 localBotExecutionContexts: localBotExecutionContexts,
+                localBotExecutionContextProvider:
+                    localBotExecutionContextProvider,
                 defaultWorkingDirectory: cliWorkingDirectory
             ),
             dashboard: FoundationDesktopDashboardLauncher(),
@@ -70,5 +77,8 @@ enum NeonDiffDesktopCompositionRoot {
                 \.configPath
             )
         ))
+        model.localWorkerExecutionContextProvider =
+            localBotExecutionContextProvider
+        return model
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -331,6 +331,91 @@ package enum DesktopLaunchAgentExecutionContextParser {
     }
 }
 
+package enum DesktopInstalledWorkerExecutionContextParser {
+    private struct Installation: Decodable {
+        let schemaVersion: Int
+        let installationKind: String
+        let launchdLabel: String
+        let nodePath: String
+        let candidateHead: String
+        let packageVersion: String
+        let manifestSHA256: String
+    }
+
+    package static func parse(
+        data: Data,
+        expectedLabel: String,
+        installedWorkerRoot: URL,
+        resolveCLI: (URL) -> URL?,
+        cliIsSafe: (URL) -> Bool,
+        nodeIsExecutable: (URL) -> Bool
+    ) -> DesktopLocalBotExecutionContext? {
+        let allowedKeys: Set<String> = [
+            "schemaVersion",
+            "installationKind",
+            "launchdLabel",
+            "nodePath",
+            "candidateHead",
+            "packageVersion",
+            "manifestSHA256"
+        ]
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? [String: Any],
+              Set(dictionary.keys) == allowedKeys,
+              let installation = try? JSONDecoder().decode(
+            Installation.self,
+            from: data
+        ),
+        installation.schemaVersion == 1,
+        installation.installationKind == "credential-free-cli",
+        installation.launchdLabel == expectedLabel,
+        ["/opt/homebrew/bin/node", "/usr/local/bin/node"].contains(
+            installation.nodePath
+        ),
+        isLowercaseHex(installation.candidateHead, count: 40),
+        installation.packageVersion.range(
+            of: #"^1\.1\.0-beta\.[1-9][0-9]{0,3}$"#,
+            options: .regularExpression
+        ) != nil,
+        isLowercaseHex(installation.manifestSHA256, count: 64)
+        else {
+            return nil
+        }
+        let nodeURL = URL(filePath: installation.nodePath).standardizedFileURL
+        guard nodeIsExecutable(nodeURL) else { return nil }
+
+        let candidateCLI = installedWorkerRoot
+            .appendingPathComponent(
+                "current/node_modules/neondiff/dist/src/cli.js"
+            )
+            .standardizedFileURL
+        let versionID = "\(installation.packageVersion)-\(installation.candidateHead.prefix(12))"
+        let expectedResolvedCLI = installedWorkerRoot
+            .appendingPathComponent("versions/\(versionID)", isDirectory: true)
+            .appendingPathComponent("node_modules/neondiff/dist/src/cli.js")
+            .standardizedFileURL
+        guard let resolvedCLI = resolveCLI(candidateCLI),
+              resolvedCLI.standardizedFileURL == expectedResolvedCLI,
+              cliIsSafe(resolvedCLI)
+        else {
+            return nil
+        }
+        return DesktopLocalBotExecutionContext(
+            configPath: "",
+            executablePath: nodeURL.path,
+            argumentPrefix: [candidateCLI.path],
+            environmentOverrides: [:]
+        )
+    }
+
+    private static func isLowercaseHex(_ value: String, count: Int) -> Bool {
+        value.utf8.count == count
+            && value.utf8.allSatisfy {
+                ($0 >= 48 && $0 <= 57) || ($0 >= 97 && $0 <= 102)
+            }
+    }
+}
+
 private func approvedNeonDiffDaemonInvocation(
     _ arguments: [String],
     workingDirectory: URL,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -590,7 +590,9 @@ package enum DesktopLocalBotExecutionContextResolver {
         guard rawConfigPath.hasPrefix("/") else { return nil }
         let configPath = URL(filePath: rawConfigPath).standardizedFileURL.path
         let matches = executionContexts.filter {
-            URL(filePath: $0.configPath).standardizedFileURL.path == configPath
+            !$0.configPath.isEmpty
+                && URL(filePath: $0.configPath).standardizedFileURL.path
+                    == configPath
         }
         guard matches.count == 1 else { return nil }
         return matches[0]

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -163,6 +163,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var scopedDryRunHeadSHA: String?
     @Published package private(set) var scopedReviewStatus = "Verify current access before running a dry review."
     @Published package private(set) var localWorkerReviewCompatibility: DesktopLocalWorkerReviewCompatibility = .unknown
+    @Published package private(set) var currentLocalWorkerExecutionContexts:
+        [DesktopLocalBotExecutionContext] = []
+    package var localWorkerExecutionContextProvider:
+        (@MainActor () -> [DesktopLocalBotExecutionContext])?
     @Published package var logText = "No logs loaded."
     @Published package var lastError: String?
     @Published package var lastCommandLine = ""
@@ -465,7 +469,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             || DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
                 executablePath: cliPath,
                 arguments: ["init", "--config", configPath],
-                executionContexts: dependencies.localBotExecutionContexts
+                executionContexts: currentLocalWorkerExecutionContexts
             ) != nil
             || NeonDiffCLIResolver.resolveExecutablePath(
                 cliPath,
@@ -734,6 +738,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
         self.activationLicenseClientOverride = activationLicenseClient
+        self.currentLocalWorkerExecutionContexts =
+            dependencies.localBotExecutionContexts
         self.configPath = dependencies.preferences.string(forKey: Self.configPathPreferenceKey)
             ?? dependencies.fileWriter.applicationSupportDirectory
                 .appendingPathComponent("config.local.json")
@@ -2413,6 +2419,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func openLocalWorkerUpdateGuide() {
+        if let localWorkerExecutionContextProvider {
+            currentLocalWorkerExecutionContexts =
+                localWorkerExecutionContextProvider()
+            if localWorkerCLIAvailable {
+                lastError = nil
+                return
+            }
+        }
         guard dependencies.urlOpener.open(dependencies.localWorkerUpdateGuideURL) else {
             lastError = "NeonDiff could not open the local worker installer guide."
             return

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -33,6 +33,35 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.urlOpener.urls == [guideURL])
     }
 
+    @Test func installerActionRefreshesNewCredentialFreeWorkerWithoutRelaunch() {
+        let fixture = ModelDependencyFixture(
+            preferenceStrings: [
+                "neondiff.cliPath": "neondiff",
+                "neondiff.configPath":
+                    "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/new-bot/config.local.json"
+            ],
+            productionBoundary: exactB0Boundary
+        )
+        let workerCLI =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/com.electricsheephq.evaos-code-review-bot/current/node_modules/neondiff/dist/src/cli.js"
+        fixture.model.localWorkerExecutionContextProvider = {
+            [
+                DesktopLocalBotExecutionContext(
+                    configPath: "",
+                    executablePath: "/usr/local/bin/node",
+                    argumentPrefix: [workerCLI],
+                    environmentOverrides: [:]
+                )
+            ]
+        }
+
+        #expect(!fixture.model.localWorkerCLIAvailable)
+        fixture.model.openLocalWorkerUpdateGuide()
+
+        #expect(fixture.model.localWorkerCLIAvailable)
+        #expect(fixture.urlOpener.urls.isEmpty)
+    }
+
     @Test func cleanInstallInitializationUsesNonDestructiveCLIInit() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(CLIRunResult(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -38,6 +38,93 @@ import Testing
         ))
     }
 
+    @Test func discoversCredentialFreeInstalledWorkerForBoundedFirstRunCommands() throws {
+        let label = "com.electricsheephq.evaos-code-review-bot"
+        let workerRoot = URL(
+            filePath: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers"
+        )
+        .appendingPathComponent(label, isDirectory: true)
+        let head = String(repeating: "7", count: 40)
+        let version = "1.1.0-beta.27"
+        let versionID = "\(version)-\(head.prefix(12))"
+        let currentCLI = workerRoot.appendingPathComponent(
+            "current/node_modules/neondiff/dist/src/cli.js"
+        )
+        let resolvedCLI = workerRoot.appendingPathComponent(
+            "versions/\(versionID)/node_modules/neondiff/dist/src/cli.js"
+        )
+        let data = try #require(
+            """
+            {"schemaVersion":1,"installationKind":"credential-free-cli","launchdLabel":"\(label)","nodePath":"/opt/homebrew/bin/node","candidateHead":"\(head)","packageVersion":"\(version)","manifestSHA256":"\(String(repeating: "a", count: 64))"}
+            """.data(using: .utf8)
+        )
+
+        let context = try #require(
+            DesktopInstalledWorkerExecutionContextParser.parse(
+                data: data,
+                expectedLabel: label,
+                installedWorkerRoot: workerRoot,
+                resolveCLI: { $0 == currentCLI ? resolvedCLI : nil },
+                cliIsSafe: { $0 == resolvedCLI },
+                nodeIsExecutable: { $0.path == "/opt/homebrew/bin/node" }
+            )
+        )
+        #expect(context.environmentOverrides.isEmpty)
+        #expect(context.configPath.isEmpty)
+
+        let isolatedConfig =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/new-bot/config.local.json"
+        let arguments = ["init", "--config", isolatedConfig]
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ) == "/opt/homebrew/bin/node")
+        #expect(DesktopLocalBotExecutionContextResolver.resolveArguments(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ) == [currentCLI.path] + arguments)
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [context]
+        ).isEmpty)
+
+        let arbitraryNode = Data(
+            String(decoding: data, as: UTF8.self)
+                .replacingOccurrences(
+                    of: "/opt/homebrew/bin/node",
+                    with: "/tmp/node"
+                )
+                .utf8
+        )
+        #expect(DesktopInstalledWorkerExecutionContextParser.parse(
+            data: arbitraryNode,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot,
+            resolveCLI: { _ in resolvedCLI },
+            cliIsSafe: { _ in true },
+            nodeIsExecutable: { _ in true }
+        ) == nil)
+        let unexpectedField = Data(
+            String(decoding: data, as: UTF8.self)
+                .replacingOccurrences(
+                    of: #"{"schemaVersion""#,
+                    with: #"{"unexpected":"value","schemaVersion""#
+                )
+                .utf8
+        )
+        #expect(DesktopInstalledWorkerExecutionContextParser.parse(
+            data: unexpectedField,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot,
+            resolveCLI: { _ in resolvedCLI },
+            cliIsSafe: { _ in true },
+            nodeIsExecutable: { _ in true }
+        ) == nil)
+    }
+
     @Test func rejectsWrongLabelMissingConfigAndConflictingAppIDs() throws {
         let configURL = URL(filePath: "/tmp/existing-neondiff-worker.json")
         let wrongLabel = try propertyList(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/LaunchAgentLocalBotConfigurationTests.swift
@@ -123,6 +123,30 @@ import Testing
             cliIsSafe: { _ in true },
             nodeIsExecutable: { _ in true }
         ) == nil)
+        let mismatchedVersion = Data(
+            String(decoding: data, as: UTF8.self)
+                .replacingOccurrences(
+                    of: version,
+                    with: "1.1.0-beta.28"
+                )
+                .utf8
+        )
+        #expect(DesktopInstalledWorkerExecutionContextParser.parse(
+            data: mismatchedVersion,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot,
+            resolveCLI: { _ in resolvedCLI },
+            cliIsSafe: { _ in true },
+            nodeIsExecutable: { _ in true }
+        ) == nil)
+        #expect(DesktopInstalledWorkerExecutionContextParser.parse(
+            data: data,
+            expectedLabel: label,
+            installedWorkerRoot: workerRoot,
+            resolveCLI: { _ in resolvedCLI },
+            cliIsSafe: { _ in false },
+            nodeIsExecutable: { _ in true }
+        ) == nil)
     }
 
     @Test func rejectsWrongLabelMissingConfigAndConflictingAppIDs() throws {
@@ -247,6 +271,32 @@ import Testing
             localBotConfigurations: [configuration],
             fallback: fallback
         ) == fallback)
+    }
+
+    @Test func emptyInstalledWorkerSentinelCannotMatchProcessWorkingDirectory() {
+        let normalizedWorkingDirectory =
+            URL(filePath: "").standardizedFileURL.path
+        let emptySentinel = DesktopLocalBotExecutionContext(
+            configPath: "",
+            executablePath: "/usr/local/bin/node",
+            argumentPrefix: ["/should/not/run.js"],
+            environmentOverrides: ["SHOULD_NOT_LEAK": "value"]
+        )
+        let arguments = [
+            "doctor", "github",
+            "--config", normalizedWorkingDirectory
+        ]
+
+        #expect(DesktopLocalBotExecutionContextResolver.resolve(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [emptySentinel]
+        ).isEmpty)
+        #expect(DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+            executablePath: "neondiff",
+            arguments: arguments,
+            executionContexts: [emptySentinel]
+        ) == nil)
     }
 
     @Test func normalizesExistingWorkerCredentialCoordinatesForOneExactConfig() throws {

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -268,15 +268,11 @@ For a B0 customer, the native first-run path is:
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
 2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
    PEM, then choose **Store in Keychain**.
-3. On a clean install, choose **Initialize Local Config**. This invokes the
-   non-destructive `neondiff init` path and never supplies `--force`; an existing
-   config is not overwritten. The generated config keeps its runtime, state,
-   evidence, and license files in bot-isolated directories beside the config,
-   outside the packaged worker or source checkout.
-   If NeonDiff reports that the local worker command is unavailable, this and
-   the later CLI-backed setup controls remain disabled. Choose **Install /
-   Update Local Worker** to open the version-matched release guide. From the
-   verified extracted bundle, preview the credential-free install:
+3. On a clean install, if NeonDiff reports that the local worker command is
+   unavailable, choose **Install / Update Local Worker** before **Initialize
+   Local Config**. From the verified extracted bundle, use Node.js 26 or newer
+   through the approved stable path `/opt/homebrew/bin/node` or
+   `/usr/local/bin/node`, then preview the credential-free install:
 
    ```bash
    BUNDLE_DIR="$(pwd -P)"
@@ -294,8 +290,13 @@ For a B0 customer, the native first-run path is:
    credential-free marker. It creates or loads no LaunchAgent, starts no
    daemon, and never reads or writes GitHub, provider, or license credentials.
    It refuses an existing LaunchAgent or worker state; use the existing-worker
-   update flow below for those machines. Return to NeonDiff and retry the
-   initialization action. Review and daemon readiness remain separate gates.
+   update flow below for those machines. Return to NeonDiff and choose
+   **Install / Update Local Worker** once more to refresh discovery; when the
+   worker is available, choose **Initialize Local Config**. Initialization
+   invokes the non-destructive `neondiff init` path without `--force`, never
+   overwrites an existing config, and keeps bot-isolated runtime, state,
+   evidence, and license paths beside the config. Review and daemon readiness
+   remain separate gates.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command; the customer does not edit a config file.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -275,11 +275,27 @@ For a B0 customer, the native first-run path is:
    outside the packaged worker or source checkout.
    If NeonDiff reports that the local worker command is unavailable, this and
    the later CLI-backed setup controls remain disabled. Choose **Install /
-   Update Local Worker** to open the version-matched release guide. Continue
-   only when that exact release provides a checksum-bound worker bundle and a
-   supported first-install path. The current B0 update/rollback installer
-   requires an existing LaunchAgent and does not bootstrap a clean Mac; until a
-   matching first-install artifact exists, this is a release blocker.
+   Update Local Worker** to open the version-matched release guide. From the
+   verified extracted bundle, preview the credential-free install:
+
+   ```bash
+   BUNDLE_DIR="$(pwd -P)"
+   node install-b0-worker-candidate.mjs first-install \
+     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
+     --manifest-sha256 <manifest-sha256-from-release> \
+     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
+     --launchd-label com.electricsheephq.evaos-code-review-bot \
+     --dry-run true
+   ```
+
+   Inspect the public-safe preview, then repeat it with
+   `--dry-run false --confirm true`. It installs only the exact verified CLI
+   into a private versioned current-user directory and writes a 0600
+   credential-free marker. It creates or loads no LaunchAgent, starts no
+   daemon, and never reads or writes GitHub, provider, or license credentials.
+   It refuses an existing LaunchAgent or worker state; use the existing-worker
+   update flow below for those machines. Return to NeonDiff and retry the
+   initialization action. Review and daemon readiness remain separate gates.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command; the customer does not edit a config file.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -130,9 +130,13 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In native NeonDiff first run, store the App ID and private key, and on a clean
-   install choose **Initialize Local Config**. Enter the same `owner/repo`, then
-   choose **Add Repository**, **Apply Repository**, and **Verify App Access**.
+7. In native NeonDiff first run, store the App ID and private key. On a clean
+   Mac, choose **Install / Update Local Worker** and complete the checksum-bound
+   `first-install` with Node.js 26 or newer through `/opt/homebrew/bin/node` or
+   `/usr/local/bin/node`. Return to NeonDiff, choose **Install / Update Local
+   Worker** once more to refresh discovery, then choose **Initialize Local
+   Config**. Enter the same `owner/repo`, then choose **Add Repository**,
+   **Apply Repository**, and **Verify App Access**.
    Initialization never uses `--force`; the app updates `pilotRepos` through
    `config patch`, and no operator edits the customer's config file. Each new
    bot config receives isolated runtime, state, evidence, and license paths

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -144,19 +144,19 @@ integration proof under #630.
    existing local bot on the same account or allocate another numbered config
    directory; the customer can explicitly choose another account or bot to end
    the pending flow.
-   If one exact checksum-managed worker already exists for the selected
-   LaunchAgent label, these isolated config commands and the bounded
-   private-key-stdin GitHub doctor reuse that worker instead of resolving
-   through a global `neondiff` command. The new bot never inherits the existing
-   bot's credential environment. Zero or ambiguous managed-worker discovery
-   does not select this reuse path; the exact worker installation remains a
-   separate distribution gate.
+   If one exact checksum-managed worker exists, these isolated config commands
+   and the bounded private-key-stdin GitHub doctor reuse that worker instead of
+   resolving through a global `neondiff` command. On a clean Mac, the bundle's
+   confirmed `first-install` command creates only a private versioned CLI and
+   credential-free 0600 marker; it creates or loads no LaunchAgent and starts
+   no daemon. The new bot receives no inherited credential environment. Zero
+   or ambiguous managed-worker discovery does not select this reuse path.
    If the configured local worker command is unavailable, the CLI-backed
    controls remain disabled and **Install / Update Local Worker** opens the
-   version-matched release guide. Do not treat that link as clean-Mac bootstrap
-   proof: the current B0 update/rollback installer requires an existing
-   LaunchAgent. A clean Mac remains blocked until the exact release supplies a
-   checksum-bound worker bundle and supported first-install path.
+   version-matched release guide. Continue only with its checksum-bound
+   manifest/tarball and dry-run-default, confirm-required `first-install`
+   command. Source support does not prove that immutable release publication,
+   signing, clean-Mac execution, review, or daemon readiness has passed.
 
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native

--- a/scripts/build-b0-worker-bundle.mjs
+++ b/scripts/build-b0-worker-bundle.mjs
@@ -111,7 +111,27 @@ The installer verifies the inner \`.tgz\` tarball
 \`${tarballFilename}\` against the release manifest before mutation. Compare
 that tarball SHA-256 with the prerelease notes as well.
 
-From this extracted directory, preview the exact migration:
+On a clean Mac with no NeonDiff LaunchAgent or worker state, preview the
+credential-free CLI install:
+
+\`\`\`sh
+BUNDLE_DIR="$(pwd -P)"
+node install-b0-worker-candidate.mjs first-install \\
+  --manifest "$BUNDLE_DIR/${manifestFilename}" \\
+  --manifest-sha256 ${manifestSHA256} \\
+  --tarball "$BUNDLE_DIR/${tarballFilename}" \\
+  --launchd-label com.electricsheephq.evaos-code-review-bot \\
+  --dry-run true
+\`\`\`
+
+After the preview reports the expected label/version, repeat it with
+\`--dry-run false --confirm true\`. First install writes only the verified
+versioned CLI and its private installation marker. It creates or loads no
+LaunchAgent, starts no daemon, and reads no credentials. Return to NeonDiff and
+continue with **Initialize Local Config**; review and daemon readiness remain
+separate gates.
+
+For an existing LaunchAgent, preview the exact migration instead:
 
 \`\`\`sh
 BUNDLE_DIR="$(pwd -P)"

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -25,9 +25,9 @@ import {
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
-  requireMissingWorkerVersion,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
+  selectWorkerVersionAction,
   validateWorkerCandidate
 } from "./lib/b0-worker-installer.mjs";
 
@@ -289,10 +289,26 @@ function verifyInstalledWorker(versionRoot, expectedVersion) {
   }
 }
 
-function installVersion({ versionsRoot, versionID, tarballPath, manifestBytes, manifestSHA256, packageVersion }) {
+function installVersion({
+  versionsRoot,
+  versionID,
+  tarballPath,
+  manifestBytes,
+  manifestSHA256,
+  packageVersion,
+  rejectExisting
+}) {
   const versionRoot = join(versionsRoot, versionID);
   if (!pathIsInside(versionsRoot, versionRoot)) fail("worker version path escaped the version root");
-  requireMissingWorkerVersion(versionRoot);
+  const action = selectWorkerVersionAction(versionRoot, { rejectExisting });
+  if (action === "reuse") {
+    const embeddedManifest = join(versionRoot, ".neondiff-candidate-manifest.json");
+    requireAbsoluteRegularFile(embeddedManifest, MAX_MANIFEST_BYTES, "installed candidate manifest");
+    const embeddedBytes = readFileSync(embeddedManifest);
+    if (Buffer.compare(embeddedBytes, manifestBytes) !== 0) fail("installed candidate manifest mismatch");
+    verifyInstalledWorker(versionRoot, packageVersion);
+    return versionRoot;
+  }
 
   const staging = join(versionsRoot, `.staging-${process.pid}-${randomUUID()}`);
   mkdirSync(staging, { mode: 0o700 });
@@ -557,7 +573,8 @@ function firstInstall(args) {
       tarballPath,
       manifestBytes,
       manifestSHA256,
-      packageVersion: candidate.packageVersion
+      packageVersion: candidate.packageVersion,
+      rejectExisting: true
     });
     writeState(paths.installationPath, plan.nextState);
     try {
@@ -622,7 +639,8 @@ function update(args) {
       tarballPath,
       manifestBytes,
       manifestSHA256,
-      packageVersion: candidate.packageVersion
+      packageVersion: candidate.packageVersion,
+      rejectExisting: false
     });
     const relativeTarget = join("versions", plan.versionID);
     const restarted = mutateLaunchAgent({

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -25,9 +25,9 @@ import {
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
+  requireMissingWorkerVersion,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
-  validateExistingWorkerVersionEvidence,
   validateWorkerCandidate
 } from "./lib/b0-worker-installer.mjs";
 
@@ -268,12 +268,9 @@ function resolveNpmPath() {
   fail("npm was not found beside Node or in an approved install location");
 }
 
-function verifyInstalledWorker(versionRoot, expectedVersion, boundCLIPath = null) {
-  const cliPath = boundCLIPath
-    ?? join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js");
-  if (!boundCLIPath) {
-    requireAbsoluteRegularFile(cliPath, 50 * 1024 * 1024, "installed worker CLI", false);
-  }
+function verifyInstalledWorker(versionRoot, expectedVersion) {
+  const cliPath = join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js");
+  requireAbsoluteRegularFile(cliPath, 50 * 1024 * 1024, "installed worker CLI", false);
   const version = execFileSync(process.execPath, [cliPath, "--version"], {
     ...CHILD_PROCESS_OPTIONS
   }).trim();
@@ -295,17 +292,7 @@ function verifyInstalledWorker(versionRoot, expectedVersion, boundCLIPath = null
 function installVersion({ versionsRoot, versionID, tarballPath, manifestBytes, manifestSHA256, packageVersion }) {
   const versionRoot = join(versionsRoot, versionID);
   if (!pathIsInside(versionsRoot, versionRoot)) fail("worker version path escaped the version root");
-  if (pathEntryExists(versionRoot)) {
-    const evidence = validateExistingWorkerVersionEvidence({
-      versionsRoot,
-      versionRoot,
-      manifestBytes,
-      manifestSHA256,
-      packageVersion
-    });
-    verifyInstalledWorker(evidence.versionRoot, packageVersion, evidence.cliPath);
-    return evidence.versionRoot;
-  }
+  requireMissingWorkerVersion(versionRoot);
 
   const staging = join(versionsRoot, `.staging-${process.pid}-${randomUUID()}`);
   mkdirSync(staging, { mode: 0o700 });

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -24,7 +24,9 @@ import {
   planWorkerFirstInstall,
   planWorkerRollback,
   planWorkerUpdate,
+  recoverFailedFirstInstall,
   recoverPreviouslyLoadedWorker,
+  requireFirstInstallLaunchdUnloaded,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
   selectWorkerVersionAction,
@@ -347,8 +349,29 @@ function currentTarget(currentLink, versionsRoot) {
 
 function switchCurrent(currentLink, relativeTarget) {
   const temporary = `${currentLink}.next-${process.pid}-${randomUUID()}`;
-  symlinkSync(relativeTarget, temporary);
-  renameSync(temporary, currentLink);
+  try {
+    symlinkSync(relativeTarget, temporary);
+    renameSync(temporary, currentLink);
+  } catch (error) {
+    safeUnlink(temporary);
+    throw error;
+  }
+}
+
+function removeFreshWorkerVersion(versionRoot, versionsRoot) {
+  if (!pathIsInside(versionsRoot, versionRoot)) {
+    fail("first-install recovery version escaped the version root");
+  }
+  const entry = lstatSync(versionRoot);
+  if (entry.isSymbolicLink() || !entry.isDirectory()) {
+    fail("first-install recovery version is not the created directory");
+  }
+  const realVersionsRoot = realpathSync(versionsRoot);
+  const realVersionRoot = realpathSync(versionRoot);
+  if (!pathIsInside(realVersionsRoot, realVersionRoot)) {
+    fail("first-install recovery version escaped the real version root");
+  }
+  rmSync(realVersionRoot, { recursive: true });
 }
 
 function launchdState(label) {
@@ -561,13 +584,15 @@ function firstInstall(args) {
     packageVersion: candidate.packageVersion,
     manifestSHA256
   });
+  requireFirstInstallLaunchdUnloaded(launchdState(label));
   if (dryRun) {
     console.log(JSON.stringify({ ok: true, dryRun: true, ...plan.publicSummary }));
     return;
   }
   withWorkerLock(paths, () => {
     assertFirstInstallTargetUnused(paths);
-    installVersion({
+    requireFirstInstallLaunchdUnloaded(launchdState(label));
+    const versionRoot = installVersion({
       versionsRoot: paths.versionsRoot,
       versionID: plan.versionID,
       tarballPath,
@@ -576,11 +601,36 @@ function firstInstall(args) {
       packageVersion: candidate.packageVersion,
       rejectExisting: true
     });
-    writeState(paths.installationPath, plan.nextState);
+    const relativeTarget = join("versions", plan.versionID);
     try {
-      switchCurrent(paths.currentLink, join("versions", plan.versionID));
+      writeState(paths.installationPath, plan.nextState);
+      switchCurrent(paths.currentLink, relativeTarget);
     } catch (error) {
-      safeUnlink(paths.installationPath);
+      try {
+        recoverFailedFirstInstall({
+          expectedCurrentTarget: relativeTarget,
+          observedCurrentTarget: currentTarget(
+            paths.currentLink,
+            paths.versionsRoot
+          ),
+          removeCurrent: () => safeUnlink(paths.currentLink),
+          removeMarker: () => safeUnlink(paths.installationPath),
+          removeVersion: () => removeFreshWorkerVersion(
+            versionRoot,
+            paths.versionsRoot
+          )
+        });
+      } catch (recoveryError) {
+        fail(
+          `first install failed and cleanup was incomplete: ${
+            error instanceof Error ? error.message : String(error)
+          }; ${
+            recoveryError instanceof Error
+              ? recoveryError.message
+              : String(recoveryError)
+          }`
+        );
+      }
       throw error;
     }
   });

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -21,6 +21,7 @@ import {
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
+  planWorkerFirstInstall,
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
@@ -33,6 +34,7 @@ const MAX_MANIFEST_BYTES = 1024 * 1024;
 const MAX_TARBALL_BYTES = 100 * 1024 * 1024;
 const MAX_PLIST_BYTES = 1024 * 1024;
 const STATE_FILENAME = "state.json";
+const INSTALLATION_FILENAME = "installation.json";
 const LOCK_DIRECTORY = ".install-lock";
 const LOCK_OWNER_FILENAME = "owner.json";
 const LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -52,18 +54,26 @@ function usage() {
   console.log(`Install or roll back one checksum-bound NeonDiff B0 worker.
 
 Usage:
+  node install-b0-worker-candidate.mjs first-install \\
+    --manifest /absolute/path/manifest.json \\
+    --manifest-sha256 <64-lowercase-hex> \\
+    --tarball /absolute/path/neondiff-1.1.0-beta.N.tgz \\
+    --launchd-label <label> [--dry-run true]
+
   node install-b0-worker-candidate.mjs update \\
     --manifest /absolute/path/manifest.json \\
     --manifest-sha256 <64-lowercase-hex> \\
     --tarball /absolute/path/neondiff-1.1.0-beta.N.tgz \\
     --launchd-label <label> [--dry-run true]
 
+  node install-b0-worker-candidate.mjs first-install ... --dry-run false --confirm true
   node install-b0-worker-candidate.mjs update ... --dry-run false --confirm true
   node install-b0-worker-candidate.mjs rollback --launchd-label <label> [--dry-run true]
   node install-b0-worker-candidate.mjs rollback --launchd-label <label> --dry-run false --confirm true
 
-The installer uses a user-owned versioned prefix, preserves the existing
-config and LaunchAgent environment, and never reads or copies private-key bytes.
+First install creates only a credential-free CLI worker; it does not create or
+load a LaunchAgent. Updates preserve the existing config and LaunchAgent
+environment. The installer never reads or copies private-key bytes.
 Dry-run is the default. Live mutation requires --dry-run false --confirm true.`);
 }
 
@@ -153,9 +163,33 @@ function standardPaths(label) {
     versionsRoot: join(workerRoot, "versions"),
     currentLink: join(workerRoot, "current"),
     statePath: join(workerRoot, STATE_FILENAME),
+    installationPath: join(workerRoot, INSTALLATION_FILENAME),
     lockPath: join(workerRoot, LOCK_DIRECTORY),
     plistPath: join(home, "Library", "LaunchAgents", `${label}.plist`)
   };
+}
+
+function pathEntryExists(path) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function assertFirstInstallTargetUnused(paths) {
+  if (pathEntryExists(paths.plistPath)) {
+    fail("first install refuses an existing LaunchAgent; use update instead");
+  }
+  if (
+    pathEntryExists(paths.currentLink)
+    || pathEntryExists(paths.statePath)
+    || pathEntryExists(paths.installationPath)
+  ) {
+    fail("first install refuses existing or ambiguous worker state");
+  }
 }
 
 function parsePlist(path) {
@@ -481,6 +515,67 @@ function withWorkerLock(paths, operation) {
   }
 }
 
+function firstInstall(args) {
+  const dryRun = requireLiveConfirmation(args);
+  const manifestPath = requireAbsoluteRegularFile(
+    required(args, "manifest"),
+    MAX_MANIFEST_BYTES,
+    "candidate manifest"
+  );
+  const tarballPath = requireAbsoluteRegularFile(
+    required(args, "tarball"),
+    MAX_TARBALL_BYTES,
+    "candidate tarball"
+  );
+  const manifestSHA256 = required(args, "manifest-sha256");
+  const label = required(args, "launchd-label");
+  const paths = standardPaths(label);
+  assertFirstInstallTargetUnused(paths);
+  const manifestBytes = readFileSync(manifestPath);
+  const candidate = validateWorkerCandidate({
+    manifestBytes,
+    manifestSHA256,
+    tarballBytes: readFileSync(tarballPath),
+    tarballFilename: basename(tarballPath)
+  });
+  const nodePath = selectStableNodeLaunchPath({
+    execPath: process.execPath,
+    stableCandidates: ["/opt/homebrew/bin/node", "/usr/local/bin/node"],
+    resolvePath: realpathSync
+  });
+  const plan = planWorkerFirstInstall({
+    launchdLabel: label,
+    workerRoot: paths.workerRoot,
+    nodePath,
+    candidateHead: candidate.candidateHead,
+    packageVersion: candidate.packageVersion,
+    manifestSHA256
+  });
+  if (dryRun) {
+    console.log(JSON.stringify({ ok: true, dryRun: true, ...plan.publicSummary }));
+    return;
+  }
+  withWorkerLock(paths, () => {
+    assertFirstInstallTargetUnused(paths);
+    installVersion({
+      versionsRoot: paths.versionsRoot,
+      versionID: plan.versionID,
+      tarballPath,
+      manifestBytes,
+      manifestSHA256,
+      packageVersion: candidate.packageVersion
+    });
+    writeState(paths.installationPath, plan.nextState);
+    try {
+      switchCurrent(paths.currentLink, join("versions", plan.versionID));
+    } catch (error) {
+      safeUnlink(paths.installationPath);
+      throw error;
+    }
+  });
+  console.log(JSON.stringify({ ok: true, dryRun: false, ...plan.publicSummary }));
+}
+
 function update(args) {
   const dryRun = requireLiveConfirmation(args);
   const manifestPath = requireAbsoluteRegularFile(
@@ -593,9 +688,10 @@ function main() {
   }
   requireSupportedRuntime();
   const args = parseArgs(values);
-  if (action === "update") update(args);
+  if (action === "first-install") firstInstall(args);
+  else if (action === "update") update(args);
   else if (action === "rollback") rollback(args);
-  else fail("action must be update or rollback");
+  else fail("action must be first-install, update, or rollback");
 }
 
 try {

--- a/scripts/install-b0-worker-candidate.mjs
+++ b/scripts/install-b0-worker-candidate.mjs
@@ -27,6 +27,7 @@ import {
   recoverPreviouslyLoadedWorker,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
+  validateExistingWorkerVersionEvidence,
   validateWorkerCandidate
 } from "./lib/b0-worker-installer.mjs";
 
@@ -267,9 +268,12 @@ function resolveNpmPath() {
   fail("npm was not found beside Node or in an approved install location");
 }
 
-function verifyInstalledWorker(versionRoot, expectedVersion) {
-  const cliPath = join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js");
-  requireAbsoluteRegularFile(cliPath, 50 * 1024 * 1024, "installed worker CLI", false);
+function verifyInstalledWorker(versionRoot, expectedVersion, boundCLIPath = null) {
+  const cliPath = boundCLIPath
+    ?? join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js");
+  if (!boundCLIPath) {
+    requireAbsoluteRegularFile(cliPath, 50 * 1024 * 1024, "installed worker CLI", false);
+  }
   const version = execFileSync(process.execPath, [cliPath, "--version"], {
     ...CHILD_PROCESS_OPTIONS
   }).trim();
@@ -291,13 +295,16 @@ function verifyInstalledWorker(versionRoot, expectedVersion) {
 function installVersion({ versionsRoot, versionID, tarballPath, manifestBytes, manifestSHA256, packageVersion }) {
   const versionRoot = join(versionsRoot, versionID);
   if (!pathIsInside(versionsRoot, versionRoot)) fail("worker version path escaped the version root");
-  if (existsSync(versionRoot)) {
-    const embeddedManifest = join(versionRoot, ".neondiff-candidate-manifest.json");
-    requireAbsoluteRegularFile(embeddedManifest, MAX_MANIFEST_BYTES, "installed candidate manifest");
-    const embeddedBytes = readFileSync(embeddedManifest);
-    if (Buffer.compare(embeddedBytes, manifestBytes) !== 0) fail("installed candidate manifest mismatch");
-    verifyInstalledWorker(versionRoot, packageVersion);
-    return versionRoot;
+  if (pathEntryExists(versionRoot)) {
+    const evidence = validateExistingWorkerVersionEvidence({
+      versionsRoot,
+      versionRoot,
+      manifestBytes,
+      manifestSHA256,
+      packageVersion
+    });
+    verifyInstalledWorker(evidence.versionRoot, packageVersion, evidence.cliPath);
+    return evidence.versionRoot;
   }
 
   const staging = join(versionsRoot, `.staging-${process.pid}-${randomUUID()}`);

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -191,14 +191,23 @@ export function validateWorkerCandidate({
   };
 }
 
-export function requireMissingWorkerVersion(versionRoot) {
+export function selectWorkerVersionAction(
+  versionRoot,
+  { rejectExisting }
+) {
+  if (rejectExisting !== true && rejectExisting !== false) {
+    fail("worker version policy is invalid");
+  }
   try {
     lstatSync(versionRoot);
   } catch (error) {
-    if (error && typeof error === "object" && error.code === "ENOENT") return;
+    if (error && typeof error === "object" && error.code === "ENOENT") return "install";
     throw error;
   }
-  fail("worker version already exists; refusing unverified reuse");
+  if (rejectExisting) {
+    fail("worker version already exists; refusing unverified reuse");
+  }
+  return "reuse";
 }
 
 export function planWorkerFirstInstall({

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -5,6 +5,10 @@ const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const PACKAGE_VERSION_PATTERN = /^1\.1\.0-beta\.[1-9][0-9]{0,3}$/;
 const LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const STABLE_NODE_PATHS = new Set([
+  "/opt/homebrew/bin/node",
+  "/usr/local/bin/node"
+]);
 const REQUIRED_REVIEW_FLAGS = ["--expected-config-revision", "--zcode"];
 const APP_ID_KEYS = ["NEONDIFF_GITHUB_APP_ID", "EVAOS_REVIEW_BOT_APP_ID"];
 const PRIVATE_KEY_KEYS = [
@@ -183,6 +187,48 @@ export function validateWorkerCandidate({
     packageVersion,
     tarballSHA256: manifest.package.sha256,
     reviewFlags: [...REQUIRED_REVIEW_FLAGS]
+  };
+}
+
+export function planWorkerFirstInstall({
+  launchdLabel,
+  workerRoot,
+  nodePath,
+  candidateHead,
+  packageVersion,
+  manifestSHA256
+}) {
+  if (!LABEL_PATTERN.test(launchdLabel)) fail("launchd label is invalid");
+  if (!isAbsolute(workerRoot)) fail("worker path must be absolute");
+  if (!STABLE_NODE_PATHS.has(nodePath)) fail("approved stable Node path is required");
+  if (!FULL_SHA_PATTERN.test(candidateHead)) fail("candidate head is invalid");
+  if (!PACKAGE_VERSION_PATTERN.test(packageVersion)) {
+    fail("candidate package version is invalid");
+  }
+  if (!SHA256_PATTERN.test(manifestSHA256)) {
+    fail("candidate manifest SHA-256 is invalid");
+  }
+  const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
+  return {
+    versionID,
+    nextState: {
+      schemaVersion: 1,
+      installationKind: "credential-free-cli",
+      launchdLabel,
+      nodePath,
+      candidateHead,
+      packageVersion,
+      manifestSHA256
+    },
+    publicSummary: {
+      action: "first-install",
+      launchdLabel,
+      packageVersion,
+      candidateHead,
+      createsLaunchAgent: false,
+      startsDaemon: false,
+      readsCredentials: false
+    }
   };
 }
 

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { basename, isAbsolute, join, relative, sep } from "node:path";
 
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
@@ -32,6 +33,23 @@ function clone(value) {
 function isPathAtOrInside(root, candidate) {
   const rel = relative(root, candidate);
   return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function readConfinedRegularFile(root, candidate, maximumSize, label) {
+  const entry = lstatSync(candidate);
+  if (
+    entry.isSymbolicLink()
+    || !entry.isFile()
+    || entry.size <= 0
+    || entry.size > maximumSize
+    || (typeof process.getuid === "function" && entry.uid !== process.getuid())
+    || (entry.mode & 0o022) !== 0
+  ) {
+    fail(`${label} is not an owner-controlled regular file`);
+  }
+  const resolved = realpathSync(candidate);
+  if (!isPathAtOrInside(root, resolved)) fail(`${label} escaped the worker version`);
+  return { bytes: readFileSync(resolved), path: resolved };
 }
 
 function consistentEnvironmentValue(environment, keys, validator, label) {
@@ -188,6 +206,74 @@ export function validateWorkerCandidate({
     tarballSHA256: manifest.package.sha256,
     reviewFlags: [...REQUIRED_REVIEW_FLAGS]
   };
+}
+
+export function validateExistingWorkerVersionEvidence({
+  versionsRoot,
+  versionRoot,
+  manifestBytes,
+  manifestSHA256,
+  packageVersion
+}) {
+  const versionsEntry = lstatSync(versionsRoot);
+  const versionEntry = lstatSync(versionRoot);
+  if (
+    versionsEntry.isSymbolicLink()
+    || !versionsEntry.isDirectory()
+    || versionEntry.isSymbolicLink()
+    || !versionEntry.isDirectory()
+  ) {
+    fail("existing worker version must be a real directory");
+  }
+  const realVersionsRoot = realpathSync(versionsRoot);
+  const realVersionRoot = realpathSync(versionRoot);
+  if (
+    !isPathAtOrInside(realVersionsRoot, realVersionRoot)
+    || (typeof process.getuid === "function" && versionEntry.uid !== process.getuid())
+    || (versionEntry.mode & 0o077) !== 0
+  ) {
+    fail("existing worker version is outside the private version root");
+  }
+  const embeddedManifest = readConfinedRegularFile(
+    realVersionRoot,
+    join(versionRoot, ".neondiff-candidate-manifest.json"),
+    1024 * 1024,
+    "installed candidate manifest"
+  );
+  if (Buffer.compare(embeddedManifest.bytes, manifestBytes) !== 0) {
+    fail("installed candidate manifest mismatch");
+  }
+  const embeddedDigest = readConfinedRegularFile(
+    realVersionRoot,
+    join(versionRoot, ".neondiff-candidate-manifest.sha256"),
+    1024,
+    "installed candidate manifest digest"
+  );
+  if (embeddedDigest.bytes.toString("utf8") !== `${manifestSHA256}\n`) {
+    fail("installed candidate manifest digest mismatch");
+  }
+  const packageEvidence = readConfinedRegularFile(
+    realVersionRoot,
+    join(versionRoot, "node_modules", "neondiff", "package.json"),
+    1024 * 1024,
+    "installed worker package evidence"
+  );
+  let installedPackage;
+  try {
+    installedPackage = JSON.parse(packageEvidence.bytes.toString("utf8"));
+  } catch {
+    fail("installed worker package evidence is invalid");
+  }
+  if (installedPackage?.name !== "neondiff" || installedPackage?.version !== packageVersion) {
+    fail("installed worker package identity mismatch");
+  }
+  const cli = readConfinedRegularFile(
+    realVersionRoot,
+    join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js"),
+    50 * 1024 * 1024,
+    "installed worker CLI"
+  );
+  return { versionRoot: realVersionRoot, cliPath: cli.path };
 }
 
 export function planWorkerFirstInstall({

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { lstatSync } from "node:fs";
 import { basename, isAbsolute, join, relative, sep } from "node:path";
 
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
@@ -33,23 +33,6 @@ function clone(value) {
 function isPathAtOrInside(root, candidate) {
   const rel = relative(root, candidate);
   return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
-}
-
-function readConfinedRegularFile(root, candidate, maximumSize, label) {
-  const entry = lstatSync(candidate);
-  if (
-    entry.isSymbolicLink()
-    || !entry.isFile()
-    || entry.size <= 0
-    || entry.size > maximumSize
-    || (typeof process.getuid === "function" && entry.uid !== process.getuid())
-    || (entry.mode & 0o022) !== 0
-  ) {
-    fail(`${label} is not an owner-controlled regular file`);
-  }
-  const resolved = realpathSync(candidate);
-  if (!isPathAtOrInside(root, resolved)) fail(`${label} escaped the worker version`);
-  return { bytes: readFileSync(resolved), path: resolved };
 }
 
 function consistentEnvironmentValue(environment, keys, validator, label) {
@@ -208,72 +191,14 @@ export function validateWorkerCandidate({
   };
 }
 
-export function validateExistingWorkerVersionEvidence({
-  versionsRoot,
-  versionRoot,
-  manifestBytes,
-  manifestSHA256,
-  packageVersion
-}) {
-  const versionsEntry = lstatSync(versionsRoot);
-  const versionEntry = lstatSync(versionRoot);
-  if (
-    versionsEntry.isSymbolicLink()
-    || !versionsEntry.isDirectory()
-    || versionEntry.isSymbolicLink()
-    || !versionEntry.isDirectory()
-  ) {
-    fail("existing worker version must be a real directory");
-  }
-  const realVersionsRoot = realpathSync(versionsRoot);
-  const realVersionRoot = realpathSync(versionRoot);
-  if (
-    !isPathAtOrInside(realVersionsRoot, realVersionRoot)
-    || (typeof process.getuid === "function" && versionEntry.uid !== process.getuid())
-    || (versionEntry.mode & 0o077) !== 0
-  ) {
-    fail("existing worker version is outside the private version root");
-  }
-  const embeddedManifest = readConfinedRegularFile(
-    realVersionRoot,
-    join(versionRoot, ".neondiff-candidate-manifest.json"),
-    1024 * 1024,
-    "installed candidate manifest"
-  );
-  if (Buffer.compare(embeddedManifest.bytes, manifestBytes) !== 0) {
-    fail("installed candidate manifest mismatch");
-  }
-  const embeddedDigest = readConfinedRegularFile(
-    realVersionRoot,
-    join(versionRoot, ".neondiff-candidate-manifest.sha256"),
-    1024,
-    "installed candidate manifest digest"
-  );
-  if (embeddedDigest.bytes.toString("utf8") !== `${manifestSHA256}\n`) {
-    fail("installed candidate manifest digest mismatch");
-  }
-  const packageEvidence = readConfinedRegularFile(
-    realVersionRoot,
-    join(versionRoot, "node_modules", "neondiff", "package.json"),
-    1024 * 1024,
-    "installed worker package evidence"
-  );
-  let installedPackage;
+export function requireMissingWorkerVersion(versionRoot) {
   try {
-    installedPackage = JSON.parse(packageEvidence.bytes.toString("utf8"));
-  } catch {
-    fail("installed worker package evidence is invalid");
+    lstatSync(versionRoot);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return;
+    throw error;
   }
-  if (installedPackage?.name !== "neondiff" || installedPackage?.version !== packageVersion) {
-    fail("installed worker package identity mismatch");
-  }
-  const cli = readConfinedRegularFile(
-    realVersionRoot,
-    join(versionRoot, "node_modules", "neondiff", "dist", "src", "cli.js"),
-    50 * 1024 * 1024,
-    "installed worker CLI"
-  );
-  return { versionRoot: realVersionRoot, cliPath: cli.path };
+  fail("worker version already exists; refusing unverified reuse");
 }
 
 export function planWorkerFirstInstall({

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -210,6 +210,31 @@ export function selectWorkerVersionAction(
   return "reuse";
 }
 
+export function requireFirstInstallLaunchdUnloaded(state) {
+  if (state?.loaded !== false) {
+    fail("first install refuses a loaded LaunchAgent");
+  }
+  return false;
+}
+
+export function recoverFailedFirstInstall({
+  expectedCurrentTarget,
+  observedCurrentTarget,
+  removeCurrent,
+  removeMarker,
+  removeVersion
+}) {
+  if (
+    observedCurrentTarget !== null
+    && observedCurrentTarget !== expectedCurrentTarget
+  ) {
+    fail("first-install recovery found an unexpected current worker");
+  }
+  if (observedCurrentTarget === expectedCurrentTarget) removeCurrent();
+  removeMarker();
+  removeVersion();
+}
+
 export function planWorkerFirstInstall({
   launchdLabel,
   workerRoot,
@@ -220,7 +245,11 @@ export function planWorkerFirstInstall({
 }) {
   if (!LABEL_PATTERN.test(launchdLabel)) fail("launchd label is invalid");
   if (!isAbsolute(workerRoot)) fail("worker path must be absolute");
-  if (!STABLE_NODE_PATHS.has(nodePath)) fail("approved stable Node path is required");
+  if (!STABLE_NODE_PATHS.has(nodePath)) {
+    fail(
+      "approved stable Node path is required (/opt/homebrew/bin/node or /usr/local/bin/node)"
+    );
+  }
   if (!FULL_SHA_PATTERN.test(candidateHead)) fail("candidate head is invalid");
   if (!PACKAGE_VERSION_PATTERN.test(packageVersion)) {
     fail("candidate package version is invalid");

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
+  planWorkerFirstInstall,
   planWorkerRollback,
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
@@ -71,6 +72,40 @@ function launchAgent() {
 }
 
 describe("B0 worker installer", () => {
+  it("plans a credential-free clean-Mac worker install without a LaunchAgent", () => {
+    const plan = planWorkerFirstInstall({
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      workerRoot:
+        "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/com.electricsheephq.evaos-code-review-bot",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+
+    expect(plan.versionID).toBe(`1.1.0-beta.27-${candidateHead.slice(0, 12)}`);
+    expect(plan.nextState).toEqual({
+      schemaVersion: 1,
+      installationKind: "credential-free-cli",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      nodePath: "/opt/homebrew/bin/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    });
+    expect(JSON.stringify(plan)).not.toMatch(
+      /EnvironmentVariables|private.?key|github.?app/i
+    );
+    expect(() => planWorkerFirstInstall({
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      workerRoot: "/Users/test/Library/Application Support/NeonDiffDesktop/Workers/test",
+      nodePath: "/tmp/node",
+      candidateHead,
+      packageVersion,
+      manifestSHA256: "a".repeat(64)
+    })).toThrow("approved stable Node path is required");
+  });
+
   it("keeps a stable Node command when it resolves to the running Node binary", () => {
     const resolved = new Map([
       ["/opt/homebrew/Cellar/node/26.5.1/bin/node", "/opt/homebrew/Cellar/node/26.5.1/bin/node"],
@@ -114,6 +149,7 @@ describe("B0 worker installer", () => {
     const help = spawnSync(process.execPath, [scriptPath, "--help"], { encoding: "utf8" });
     expect(help.status).toBe(0);
     expect(help.stdout).toContain("update");
+    expect(help.stdout).toContain("first-install");
     expect(help.stdout).toContain("rollback");
     expect(help.stdout).toContain("--manifest-sha256");
     expect(help.stdout).toContain("--dry-run false --confirm true");

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -4,9 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  realpathSync,
-  symlinkSync,
-  writeFileSync
+  symlinkSync
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -18,8 +16,8 @@ import {
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
   retryTransientLaunchdBootstrap,
+  requireMissingWorkerVersion,
   selectStableNodeLaunchPath,
-  validateExistingWorkerVersionEvidence,
   validateWorkerCandidate
 } from "../scripts/lib/b0-worker-installer.mjs";
 
@@ -83,62 +81,26 @@ function launchAgent() {
 }
 
 describe("B0 worker installer", () => {
-  it("rejects an existing version symlink before returning an executable CLI", () => {
+  it("rejects every existing version entry before CLI execution", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-worker-reuse-"));
     const versionsRoot = join(root, "versions");
     const outsideRoot = join(root, "outside");
     const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
+    const symlinkVersion = join(versionsRoot, versionID);
+    const forgedVersion = join(versionsRoot, `${versionID}-forged`);
     mkdirSync(versionsRoot, { mode: 0o700 });
     mkdirSync(outsideRoot, { mode: 0o700 });
-    symlinkSync(outsideRoot, join(versionsRoot, versionID));
+    symlinkSync(outsideRoot, symlinkVersion);
+    mkdirSync(forgedVersion, { mode: 0o700 });
 
-    expect(() => validateExistingWorkerVersionEvidence({
-      versionsRoot,
-      versionRoot: join(versionsRoot, versionID),
-      manifestBytes: Buffer.from(`${JSON.stringify(candidateManifest())}\n`),
-      manifestSHA256: "a".repeat(64),
-      packageVersion
-    })).toThrow("existing worker version must be a real directory");
-  });
-
-  it("binds valid existing-version reuse to exact installer and package evidence", () => {
-    const root = mkdtempSync(join(tmpdir(), "neondiff-worker-reuse-"));
-    const versionsRoot = join(root, "versions");
-    const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
-    const versionRoot = join(versionsRoot, versionID);
-    const packageRoot = join(versionRoot, "node_modules", "neondiff");
-    const cliPath = join(packageRoot, "dist", "src", "cli.js");
-    const manifestBytes = Buffer.from(`${JSON.stringify(candidateManifest())}\n`);
-    const manifestSHA256 = createHash("sha256").update(manifestBytes).digest("hex");
-    mkdirSync(join(packageRoot, "dist", "src"), { recursive: true, mode: 0o700 });
-    writeFileSync(join(versionRoot, ".neondiff-candidate-manifest.json"), manifestBytes);
-    writeFileSync(
-      join(versionRoot, ".neondiff-candidate-manifest.sha256"),
-      `${manifestSHA256}\n`
-    );
-    writeFileSync(
-      join(packageRoot, "package.json"),
-      `${JSON.stringify({ name: "neondiff", version: packageVersion })}\n`
-    );
-    writeFileSync(cliPath, "#!/usr/bin/env node\n");
-
-    expect(validateExistingWorkerVersionEvidence({
-      versionsRoot,
-      versionRoot,
-      manifestBytes,
-      manifestSHA256,
-      packageVersion
-    })).toEqual({
-      versionRoot: realpathSync(versionRoot),
-      cliPath: realpathSync(cliPath)
-    });
-    expect(() => validateExistingWorkerVersionEvidence({
-      versionsRoot,
-      versionRoot,
-      manifestBytes: Buffer.from("other candidate"),
-      manifestSHA256,
-      packageVersion
-    })).toThrow("installed candidate manifest mismatch");
+    for (const versionRoot of [symlinkVersion, forgedVersion]) {
+      let cliExecutions = 0;
+      expect(() => {
+        requireMissingWorkerVersion(versionRoot);
+        cliExecutions += 1;
+      }).toThrow("worker version already exists; refusing unverified reuse");
+      expect(cliExecutions).toBe(0);
+    }
   });
 
   it("plans a credential-free clean-Mac worker install without a LaunchAgent", () => {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -1,6 +1,16 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  writeFileSync
+} from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   planWorkerFirstInstall,
@@ -9,6 +19,7 @@ import {
   recoverPreviouslyLoadedWorker,
   retryTransientLaunchdBootstrap,
   selectStableNodeLaunchPath,
+  validateExistingWorkerVersionEvidence,
   validateWorkerCandidate
 } from "../scripts/lib/b0-worker-installer.mjs";
 
@@ -72,6 +83,64 @@ function launchAgent() {
 }
 
 describe("B0 worker installer", () => {
+  it("rejects an existing version symlink before returning an executable CLI", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-worker-reuse-"));
+    const versionsRoot = join(root, "versions");
+    const outsideRoot = join(root, "outside");
+    const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
+    mkdirSync(versionsRoot, { mode: 0o700 });
+    mkdirSync(outsideRoot, { mode: 0o700 });
+    symlinkSync(outsideRoot, join(versionsRoot, versionID));
+
+    expect(() => validateExistingWorkerVersionEvidence({
+      versionsRoot,
+      versionRoot: join(versionsRoot, versionID),
+      manifestBytes: Buffer.from(`${JSON.stringify(candidateManifest())}\n`),
+      manifestSHA256: "a".repeat(64),
+      packageVersion
+    })).toThrow("existing worker version must be a real directory");
+  });
+
+  it("binds valid existing-version reuse to exact installer and package evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-worker-reuse-"));
+    const versionsRoot = join(root, "versions");
+    const versionID = `${packageVersion}-${candidateHead.slice(0, 12)}`;
+    const versionRoot = join(versionsRoot, versionID);
+    const packageRoot = join(versionRoot, "node_modules", "neondiff");
+    const cliPath = join(packageRoot, "dist", "src", "cli.js");
+    const manifestBytes = Buffer.from(`${JSON.stringify(candidateManifest())}\n`);
+    const manifestSHA256 = createHash("sha256").update(manifestBytes).digest("hex");
+    mkdirSync(join(packageRoot, "dist", "src"), { recursive: true, mode: 0o700 });
+    writeFileSync(join(versionRoot, ".neondiff-candidate-manifest.json"), manifestBytes);
+    writeFileSync(
+      join(versionRoot, ".neondiff-candidate-manifest.sha256"),
+      `${manifestSHA256}\n`
+    );
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      `${JSON.stringify({ name: "neondiff", version: packageVersion })}\n`
+    );
+    writeFileSync(cliPath, "#!/usr/bin/env node\n");
+
+    expect(validateExistingWorkerVersionEvidence({
+      versionsRoot,
+      versionRoot,
+      manifestBytes,
+      manifestSHA256,
+      packageVersion
+    })).toEqual({
+      versionRoot: realpathSync(versionRoot),
+      cliPath: realpathSync(cliPath)
+    });
+    expect(() => validateExistingWorkerVersionEvidence({
+      versionsRoot,
+      versionRoot,
+      manifestBytes: Buffer.from("other candidate"),
+      manifestSHA256,
+      packageVersion
+    })).toThrow("installed candidate manifest mismatch");
+  });
+
   it("plans a credential-free clean-Mac worker install without a LaunchAgent", () => {
     const plan = planWorkerFirstInstall({
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -16,7 +16,7 @@ import {
   planWorkerUpdate,
   recoverPreviouslyLoadedWorker,
   retryTransientLaunchdBootstrap,
-  requireMissingWorkerVersion,
+  selectWorkerVersionAction,
   selectStableNodeLaunchPath,
   validateWorkerCandidate
 } from "../scripts/lib/b0-worker-installer.mjs";
@@ -96,11 +96,19 @@ describe("B0 worker installer", () => {
     for (const versionRoot of [symlinkVersion, forgedVersion]) {
       let cliExecutions = 0;
       expect(() => {
-        requireMissingWorkerVersion(versionRoot);
+        selectWorkerVersionAction(versionRoot, { rejectExisting: true });
         cliExecutions += 1;
       }).toThrow("worker version already exists; refusing unverified reuse");
       expect(cliExecutions).toBe(0);
+      expect(selectWorkerVersionAction(
+        versionRoot,
+        { rejectExisting: false }
+      )).toBe("reuse");
     }
+    expect(selectWorkerVersionAction(
+      join(versionsRoot, "missing"),
+      { rejectExisting: true }
+    )).toBe("install");
   });
 
   it("plans a credential-free clean-Mac worker install without a LaunchAgent", () => {

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -14,7 +14,9 @@ import {
   planWorkerFirstInstall,
   planWorkerRollback,
   planWorkerUpdate,
+  recoverFailedFirstInstall,
   recoverPreviouslyLoadedWorker,
+  requireFirstInstallLaunchdUnloaded,
   retryTransientLaunchdBootstrap,
   selectWorkerVersionAction,
   selectStableNodeLaunchPath,
@@ -81,7 +83,7 @@ function launchAgent() {
 }
 
 describe("B0 worker installer", () => {
-  it("rejects every existing version entry before CLI execution", () => {
+  it("classifies strict first-install rejection and legacy update reuse", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-worker-reuse-"));
     const versionsRoot = join(root, "versions");
     const outsideRoot = join(root, "outside");
@@ -94,12 +96,10 @@ describe("B0 worker installer", () => {
     mkdirSync(forgedVersion, { mode: 0o700 });
 
     for (const versionRoot of [symlinkVersion, forgedVersion]) {
-      let cliExecutions = 0;
-      expect(() => {
-        selectWorkerVersionAction(versionRoot, { rejectExisting: true });
-        cliExecutions += 1;
-      }).toThrow("worker version already exists; refusing unverified reuse");
-      expect(cliExecutions).toBe(0);
+      expect(() => selectWorkerVersionAction(
+        versionRoot,
+        { rejectExisting: true }
+      )).toThrow("worker version already exists; refusing unverified reuse");
       expect(selectWorkerVersionAction(
         versionRoot,
         { rejectExisting: false }
@@ -109,6 +109,33 @@ describe("B0 worker installer", () => {
       join(versionsRoot, "missing"),
       { rejectExisting: true }
     )).toBe("install");
+  });
+
+  it("requires a definitively unloaded launchd label for first install", () => {
+    expect(() => requireFirstInstallLaunchdUnloaded({ loaded: true }))
+      .toThrow("first install refuses a loaded LaunchAgent");
+    expect(requireFirstInstallLaunchdUnloaded({ loaded: false })).toBe(false);
+  });
+
+  it("recovers only the fresh first-install activation after a later failure", () => {
+    const removals: string[] = [];
+    recoverFailedFirstInstall({
+      expectedCurrentTarget: "versions/exact",
+      observedCurrentTarget: "versions/exact",
+      removeCurrent: () => removals.push("current"),
+      removeMarker: () => removals.push("marker"),
+      removeVersion: () => removals.push("version")
+    });
+    expect(removals).toEqual(["current", "marker", "version"]);
+
+    expect(() => recoverFailedFirstInstall({
+      expectedCurrentTarget: "versions/exact",
+      observedCurrentTarget: "versions/other",
+      removeCurrent: () => removals.push("wrong-current"),
+      removeMarker: () => removals.push("wrong-marker"),
+      removeVersion: () => removals.push("wrong-version")
+    })).toThrow("first-install recovery found an unexpected current worker");
+    expect(removals).toEqual(["current", "marker", "version"]);
   });
 
   it("plans a credential-free clean-Mac worker install without a LaunchAgent", () => {
@@ -142,7 +169,9 @@ describe("B0 worker installer", () => {
       candidateHead,
       packageVersion,
       manifestSHA256: "a".repeat(64)
-    })).toThrow("approved stable Node path is required");
+    })).toThrow(
+      "approved stable Node path is required (/opt/homebrew/bin/node or /usr/local/bin/node)"
+    );
   });
 
   it("keeps a stable Node command when it resolves to the running Node binary", () => {


### PR DESCRIPTION
## Outcome

Adds the bounded #753 clean-Mac first-install slice so the signed app can use the exact checksum-bound worker for isolated setup commands without requiring a global `neondiff` install or creating a credential-bearing daemon.

## Acceptance criteria

- `first-install` verifies the exact manifest and tarball before mutation.
- Mutation is dry-run by default and requires `--dry-run false --confirm true`.
- The worker is installed into a private versioned current-user directory.
- The installer writes an atomic, owner-only, credential-free marker.
- It creates or loads no LaunchAgent, starts no daemon, and reads no credential.
- Native discovery accepts only the exact version-derived CLI under the private worker root and an approved stable Node path.
- The resulting empty-environment context is eligible only through the existing isolated init/config/doctor allowlist.
- First-install rejects any pre-existing candidate version entry before CLI execution.
- Existing update/rollback behavior is not changed by this slice.

## Focused proof

- Failing-first coverage reproduced the missing first-install planner.
- Installer suite: 13/13 passed at exact head `cd4cb7c03dfe9aecd9866996e5df98e5a09520d5`.
- Swift installed-worker discovery suite: 18/18 passed.
- Desktop executable target rebuilt.
- Both edited Node scripts pass `node --check`.
- `git diff --check origin/main..HEAD` passes.

## Security/review disposition

Bounded review found that legacy update reuse needs separate exact artifact binding while preserving same-candidate retry. That is split to P0 #755 and remains a paid-beta/manual-update blocker. This PR keeps strict no-reuse behavior for new first-install only and does not claim the legacy update path secure or release-ready.

## Non-goals

- No LaunchAgent creation or daemon bootstrap.
- No private-key, provider-key, activation-key, config, allowlist, or entitlement migration.
- No managed GitHub App, billing, Sparkle, or broader GA work.
- No signed artifact, installed runtime, public beta, release, or customer-readiness claim from this PR.

Relates to #753. Tracker: #610. Follow-up release blocker: #755.