### PR TITLE
Fix BYO repository policy setup in desktop onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Every meaningful PR should name the proof it ran:
 - focused validation command
 - `npm test` and `npm run build`, or why CI is the right place for heavier validation
 - dry-run review evidence when the change affects review behavior
-- evidence path such as `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/YYYY-MM-DD/issue-<number>/`
+- evidence path such as `/Users/m1/Codex/evidence/neondiff/YYYY-MM-DD/issue-<number>/`
 
 Evidence should contain public-safe summaries, counts, refs, hashes, setup
 status, blocker codes, and command names. It must not contain secrets, raw PR

--- a/README.md
+++ b/README.md
@@ -193,7 +193,10 @@ remain distribution gates. Once an
 executable global or checksum-managed worker is available, native first run
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
-terminal or operator config edit. When the verified account has no bot yet,
+terminal or operator config edit. **Apply Repository** writes both the selected
+`pilotRepos` allowlist and an enabled policy profile for each selected
+repository, preserving any existing per-repository policy fields. When the
+verified account has no bot yet,
 the app allocates that isolated new-bot plan before it presents the
 initialization action; it never initializes the `_unselected` placeholder. If
 the customer quits during that setup, the next

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3702,11 +3702,41 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case .existingLocalAgent:
             expectedCredentialSource = "configured"
         }
+        let report = result.stdout.data(using: .utf8).flatMap {
+            try? JSONDecoder().decode(BYOGitHubDoctorReport.self, from: $0)
+        }
+        let expectedRepositories = normalizedExactRepoNames(
+            expectedContext.repositories
+        )
+        let reportedRepositories = report.flatMap {
+            normalizedExactRepoNames($0.github.readChecks.map(\.repo))
+        }
+        if result.exitCode == 0,
+           let report,
+           let expectedRepositories,
+           !expectedRepositories.isEmpty,
+           reportedRepositories == expectedRepositories
+        {
+            let missingProfiles = report.github.readChecks
+                .filter { $0.skippedByPolicy == "repo_profile_missing" }
+                .map(\.repo)
+                .sorted {
+                    $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+                }
+            if !missingProfiles.isEmpty {
+                byoGitHubCredentialsVerified = false
+                lastError =
+                    "NeonDiff repository policy is missing an enabled profile for \(missingProfiles.joined(separator: ", ")). Apply Repository again, then retry App verification."
+                byoGitHubCredentialStatus = lastError ?? "Repository policy missing"
+                logText =
+                    "GitHub credentials and installation access were not accepted because the selected repository is missing an enabled local policy profile."
+                return
+            }
+        }
         guard result.exitCode == 0,
-              let data = result.stdout.data(using: .utf8),
-              let report = try? JSONDecoder().decode(BYOGitHubDoctorReport.self, from: data),
-              let expectedRepositories = normalizedExactRepoNames(expectedContext.repositories),
-              let reportedRepositories = normalizedExactRepoNames(report.github.readChecks.map(\.repo)),
+              let report,
+              let expectedRepositories,
+              let reportedRepositories,
               !expectedRepositories.isEmpty,
               reportedRepositories == expectedRepositories,
               report.ok,
@@ -5518,8 +5548,22 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .filter(\.enabled)
             .map(\.name)
         let uniqueRepos = uniqueSortedRepoNames(selectedRepos)
+        let configuredRepos = uniqueSortedRepoNames(repos.map(\.name))
+        let repoProfiles = Dictionary(
+            uniqueKeysWithValues: configuredRepos.map { repository in
+                let enabled = repos.contains {
+                    $0.enabled
+                        && $0.name.caseInsensitiveCompare(repository)
+                            == .orderedSame
+                }
+                return (repository, ["enabled": enabled])
+            }
+        )
         let patch: [String: Any] = [
-            "pilotRepos": uniqueRepos
+            "pilotRepos": uniqueRepos,
+            "repoProfiles": [
+                "repos": repoProfiles
+            ]
         ]
         let data = try JSONSerialization.data(withJSONObject: patch, options: [.prettyPrinted, .sortedKeys])
         try dependencies.fileWriter.write(data, to: repoSelectionPatchPath)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -83,6 +83,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var configPath: String {
         didSet {
             guard configPath != oldValue else { return }
+            pendingRemovedRepoProfileNames.removeAll()
             selectedBYOReviewRepository = nil
             invalidateRepoApplicationProof()
             invalidateProviderConfigAuthorization()
@@ -721,6 +722,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var previewedProviderExpectedRevision: String?
     private var pendingProviderPatchProof: PendingProviderPatchProof?
     private var pendingRepoPatchProof: PendingRepoPatchProof?
+    private var pendingRemovedRepoProfileNames = Set<String>()
     private var workspaceContextGeneration: UInt64 = 0
     private let accountWorkspacePreferenceKey = "neondiff.accountWorkspaceID"
     private let accountBotPreferenceKey = "neondiff.accountBotID"
@@ -2796,6 +2798,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         if let index = repos.firstIndex(where: { $0.name.caseInsensitiveCompare(repoName) == .orderedSame }) {
             repos[index].enabled = true
+        } else if let removedName = pendingRemovedRepoProfileNames.first(where: {
+            $0.caseInsensitiveCompare(repoName) == .orderedSame
+        }) {
+            pendingRemovedRepoProfileNames.remove(removedName)
+            repos.append(RepoMonitor(name: removedName, enabled: true, profile: "selected"))
+            repos.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         } else {
             repos.append(RepoMonitor(name: repoName, enabled: true, profile: "selected"))
             repos.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
@@ -2919,6 +2927,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         repos.removeAll { $0.id == repo.id }
+        pendingRemovedRepoProfileNames.insert(repo.name)
         lastError = nil
         logText = "Repo removed locally. Preview or apply the config patch to persist it."
     }
@@ -3711,11 +3720,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let reportedRepositories = report.flatMap {
             normalizedExactRepoNames($0.github.readChecks.map(\.repo))
         }
-        if result.exitCode == 0,
-           let report,
+        if let report,
            let expectedRepositories,
            !expectedRepositories.isEmpty,
-           reportedRepositories == expectedRepositories
+           reportedRepositories == expectedRepositories,
+           report.command == "doctor github",
+           report.appCredentials.source == expectedCredentialSource
         {
             let unavailableProfiles = report.github.readChecks
                 .filter {
@@ -5068,6 +5078,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 repositories: uniqueSortedRepoNames(
                     repos.filter(\.enabled).map(\.name)
                 ),
+                removedProfileNames: pendingRemovedRepoProfileNames,
                 managedRepository: managedGitHubAvailable
                     ? selectedManagedGitHubRepository
                     : nil,
@@ -5551,7 +5562,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .filter(\.enabled)
             .map(\.name)
         let uniqueRepos = uniqueSortedRepoNames(selectedRepos)
-        let configuredRepos = uniqueSortedRepoNames(repos.map(\.name))
+        let configuredRepos = uniqueSortedRepoNames(
+            repos.map(\.name) + Array(pendingRemovedRepoProfileNames)
+        )
         let repoProfiles = Dictionary(
             uniqueKeysWithValues: configuredRepos.map { repository in
                 let enabled = repos.contains {
@@ -5776,6 +5789,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 }
                 github = parsedGitHub
                 if commandName == "config inspect" {
+                    pendingRemovedRepoProfileNames.removeAll()
                     let inspectedRepositories = uniqueSortedRepoNames(
                         snapshot.repos
                             .filter(\.enabled)
@@ -5851,6 +5865,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 clearPendingProviderPatchProof(ifOwnedBy: providerPatchProof)
             }
             if commandName == "config patch", let repoPatchProof {
+                pendingRemovedRepoProfileNames.subtract(
+                    repoPatchProof.removedProfileNames
+                )
                 appliedRepoSelection = AppliedRepoSelection(
                     repositories: repoPatchProof.repositories,
                     configPath: repoPatchProof.configPath
@@ -6132,6 +6149,7 @@ private struct PendingProviderPatchProof: Sendable {
 private struct PendingRepoPatchProof: Sendable {
     let id: UUID
     let repositories: [String]
+    let removedProfileNames: Set<String>
     let managedRepository: String?
     let configPath: String
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3717,16 +3717,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
            !expectedRepositories.isEmpty,
            reportedRepositories == expectedRepositories
         {
-            let missingProfiles = report.github.readChecks
-                .filter { $0.skippedByPolicy == "repo_profile_missing" }
+            let unavailableProfiles = report.github.readChecks
+                .filter {
+                    $0.skippedByPolicy == "repo_profile_missing"
+                        || $0.skippedByPolicy == "repo_profile_disabled"
+                }
                 .map(\.repo)
                 .sorted {
                     $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
                 }
-            if !missingProfiles.isEmpty {
+            if !unavailableProfiles.isEmpty {
                 byoGitHubCredentialsVerified = false
                 lastError =
-                    "NeonDiff repository policy is missing an enabled profile for \(missingProfiles.joined(separator: ", ")). Apply Repository again, then retry App verification."
+                    "NeonDiff repository policy is missing an enabled profile for \(unavailableProfiles.joined(separator: ", ")). Apply Repository again, then retry App verification."
                 byoGitHubCredentialStatus = lastError ?? "Repository policy missing"
                 logText =
                     "GitHub credentials and installation access were not accepted because the selected repository is missing an enabled local policy profile."

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -76,11 +76,21 @@ public enum ConfigInspectParser {
             }.sorted()
             : pilotRepos
         let repos = reposToShow.map { repo in
-            let profile = repoProfiles[repo] as? [String: Any]
+            let profileKey = repoProfiles.keys
+                .sorted()
+                .first {
+                    $0.caseInsensitiveCompare(repo) == .orderedSame
+                }
+            let canonicalRepo = profileKey ?? repo
+            let profile = repoProfiles[canonicalRepo] as? [String: Any]
             let enabled = profile?["enabled"] as? Bool ?? true
             let displayName = profile?["displayName"] as? String
             let reviewProfile = profile?["reviewProfile"] as? String
-            return RepoMonitor(name: repo, enabled: enabled, profile: displayName ?? reviewProfile ?? "default")
+            return RepoMonitor(
+                name: canonicalRepo,
+                enabled: enabled,
+                profile: displayName ?? reviewProfile ?? "default"
+            )
         }
 
         let zcode = config["zcode"] as? [String: Any]

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -305,6 +305,62 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
+    @Test func byoRepositoryApplyKeepsPolicyProfilesAlignedWithRepositorySelection() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: byoRepoPatchJSON(repository: "acme/demo"),
+                stderr: ""
+            ))],
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [
+            RepoMonitor(name: "acme/demo", enabled: true),
+            RepoMonitor(name: "acme/disabled", enabled: false)
+        ]
+
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
+        let write = try #require(fixture.fileWriter.writes.last)
+        let patch = try #require(
+            JSONSerialization.jsonObject(with: write.data) as? [String: Any]
+        )
+        #expect(patch["pilotRepos"] as? [String] == ["acme/demo"])
+        let repoProfiles = try #require(patch["repoProfiles"] as? [String: Any])
+        let repositories = try #require(repoProfiles["repos"] as? [String: Any])
+        let selectedProfile = try #require(repositories["acme/demo"] as? [String: Any])
+        let disabledProfile = try #require(repositories["acme/disabled"] as? [String: Any])
+        #expect(selectedProfile["enabled"] as? Bool == true)
+        #expect(disabledProfile["enabled"] as? Bool == false)
+    }
+
+    @Test func missingRepositoryProfileReportsPolicyRecoveryInsteadOfInstallationFailure() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult(
+                readChecks: doctorReadCheck(
+                    repo: "acme/demo",
+                    skippedByPolicy: "repo_profile_missing"
+                )
+            ))],
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.lastError?.contains("repository policy") == true)
+        #expect(fixture.model.lastError?.contains("Apply Repository") == true)
+        #expect(fixture.model.lastError?.contains("App installation") == false)
+    }
+
     @Test func cleanInstallBYOUnlocksAfterExactSetupAndActivation() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
@@ -581,7 +637,9 @@ private func doctorReadCheck(
     skippedByPolicy: String? = nil,
     ok: Bool = true
 ) -> String {
-    let skippedField = skippedByPolicy.map { #",\"skippedByPolicy\":\"\#($0)\""# } ?? ""
+    let skippedField = skippedByPolicy.map {
+        #","skippedByPolicy":"\#($0)""#
+    } ?? ""
     return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -336,13 +336,54 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(disabledProfile["enabled"] as? Bool == false)
     }
 
+    @Test func removingFinalRepositoryDisablesItsPersistedPolicyProfile() async throws {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":[],"repoProfiles":{"repos":{"acme/demo":{"enabled":false}}}}}"#,
+                stderr: ""
+            ))],
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        let repository = RepoMonitor(name: "acme/demo", enabled: true)
+        fixture.model.repos = [repository]
+
+        fixture.model.removeRepoFromAllowlist(repository)
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
+        let write = try #require(fixture.fileWriter.writes.last)
+        let patch = try #require(
+            JSONSerialization.jsonObject(with: write.data) as? [String: Any]
+        )
+        #expect(patch["pilotRepos"] as? [String] == [])
+        let repoProfiles = try #require(patch["repoProfiles"] as? [String: Any])
+        let repositories = try #require(repoProfiles["repos"] as? [String: Any])
+        let removedProfile = try #require(repositories["acme/demo"] as? [String: Any])
+        #expect(removedProfile["enabled"] as? Bool == false)
+    }
+
+    @Test func configInspectReusesExistingPolicyProfileCasing() throws {
+        let snapshot = try #require(ConfigInspectParser.parse(
+            #"{"ok":true,"command":"config inspect","config":{"pilotRepos":["acme/demo"],"repoProfiles":{"repos":{"Acme/Demo":{"enabled":false,"reviewProfile":"strict"}}}}}"#,
+            providerKeyStored: false,
+            licenseKeyStored: false
+        ))
+
+        #expect(snapshot.repos.map(\.name) == ["Acme/Demo"])
+        #expect(snapshot.repos.map(\.profile) == ["strict"])
+    }
+
     @Test func missingRepositoryProfileReportsPolicyRecoveryInsteadOfInstallationFailure() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(doctorResult(
                 readChecks: doctorReadCheck(
                     repo: "acme/demo",
                     skippedByPolicy: "repo_profile_missing"
-                )
+                ),
+                exitCode: 1,
+                ok: false
             ))],
             preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
@@ -367,7 +408,9 @@ struct BYOGitHubAppCredentialOnboardingTests {
                 readChecks: doctorReadCheck(
                     repo: "acme/demo",
                     skippedByPolicy: "repo_profile_disabled"
-                )
+                ),
+                exitCode: 1,
+                ok: false
             ))],
             preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
@@ -649,10 +692,14 @@ private func byoRepoPatchJSON(repository: String) -> String {
     #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":["\#(repository)"]}}"#
 }
 
-private func doctorResult(readChecks: String) -> CLIRunResult {
+private func doctorResult(
+    readChecks: String,
+    exitCode: Int32 = 0,
+    ok: Bool = true
+) -> CLIRunResult {
     CLIRunResult(
-        exitCode: 0,
-        stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
+        exitCode: exitCode,
+        stdout: #"{"ok":\#(ok),"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
         stderr: ""
     )
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -361,6 +361,31 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.lastError?.contains("App installation") == false)
     }
 
+    @Test func disabledRepositoryProfileReportsPolicyRecoveryInsteadOfInstallationFailure() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult(
+                readChecks: doctorReadCheck(
+                    repo: "acme/demo",
+                    skippedByPolicy: "repo_profile_disabled"
+                )
+            ))],
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.lastError?.contains("repository policy") == true)
+        #expect(fixture.model.lastError?.contains("Apply Repository") == true)
+        #expect(fixture.model.lastError?.contains("App installation") == false)
+    }
+
     @Test func cleanInstallBYOUnlocksAfterExactSetupAndActivation() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -303,10 +303,12 @@ For a B0 customer, the native first-run path is:
    policy profile; the customer does not edit a config file. Existing
    per-repository policy fields are preserved.
 5. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
-   the exact configured repository through that App installation.
+   the exact configured repository through that App installation. If the local
+   profile is missing or disabled, apply the repository again before retrying
+   verification.
 
-If verification reports a missing repository policy, choose **Apply
-Repository** again before retrying **Verify App Access**. This is a local
+If verification reports a missing or disabled repository policy profile,
+choose **Apply Repository** again before retrying **Verify App Access**. This is a local
 configuration recovery step, not evidence that the GitHub App installation is
 missing.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -299,9 +299,16 @@ For a B0 customer, the native first-run path is:
    remain separate gates.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
-   patch` command; the customer does not edit a config file.
+   patch` command and ensures every selected repository has an enabled local
+   policy profile; the customer does not edit a config file. Existing
+   per-repository policy fields are preserved.
 5. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
    the exact configured repository through that App installation.
+
+If verification reports a missing repository policy, choose **Apply
+Repository** again before retrying **Verify App Access**. This is a local
+configuration recovery step, not evidence that the GitHub App installation is
+missing.
 
 For a verified account with no bot yet, the app allocates the isolated new-bot
 plan before showing **Initialize Local Config**. It never initializes the

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -137,8 +137,12 @@ integration proof under #630.
    Worker** once more to refresh discovery, then choose **Initialize Local
    Config**. Enter the same `owner/repo`, then choose **Add Repository**,
    **Apply Repository**, and **Verify App Access**.
-   Initialization never uses `--force`; the app updates `pilotRepos` through
-   `config patch`, and no operator edits the customer's config file. Each new
+   Initialization never uses `--force`; the app updates `pilotRepos` and the
+   selected repository's enabled policy profile through `config patch`, and no
+   operator edits the customer's config file. Existing policy fields for that
+   repository are preserved. If verification reports a missing repository
+   policy, apply the repository again before retrying verification; that
+   message does not mean the App installation is missing. Each new
    bot config receives isolated runtime, state, evidence, and license paths
    beside that config rather than the packaged worker's placeholder paths. An
    account with no bot gets this isolated plan before the initialization action

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -140,8 +140,9 @@ integration proof under #630.
    Initialization never uses `--force`; the app updates `pilotRepos` and the
    selected repository's enabled policy profile through `config patch`, and no
    operator edits the customer's config file. Existing policy fields for that
-   repository are preserved. If verification reports a missing repository
-   policy, apply the repository again before retrying verification; that
+   repository are preserved. If verification reports a missing or disabled
+   repository policy profile, apply the repository again before retrying
+   verification; that
    message does not mean the App installation is missing. Each new
    bot config receives isolated runtime, state, evidence, and license paths
    beside that config rather than the packaged worker's placeholder paths. An


### PR DESCRIPTION
## Outcome

The native paid-BYO onboarding path now applies repository selection as both:

- the exact `pilotRepos` allowlist; and
- an explicit enabled/disabled `repoProfiles.repos` policy leaf for every repository shown in the native selection.

This keeps worker policy aligned when organization fallbacks are disabled and prevents a deselected profile from becoming active when `pilotRepos` becomes empty. Existing per-repository policy fields are preserved by the typed leaf patch.

When `doctor github` reports `repo_profile_missing` for the exact selected repository set, the app now explains the local recovery step (`Apply Repository` again) instead of falsely blaming the GitHub App installation.

Related: #646
Related: #686

## Root cause

The native action wrote only `pilotRepos`. The worker correctly requires an enabled explicit profile when `repoProfiles.enableOrgFallbacks` is false, so valid GitHub App credentials and installation access were skipped as `repo_profile_missing`.

## Acceptance criteria

- [x] Failing-first coverage reproduces a selected repository without a policy profile.
- [x] Native Apply writes enabled profiles for selected repositories and disabled profiles for deselected repositories.
- [x] Existing policy fields remain outside the patch and are preserved by typed leaf merge.
- [x] Exact `repo_profile_missing` evidence produces a truthful local recovery message.
- [x] Keychain-only private-key custody and fail-closed verification remain unchanged.
- [x] The real installed beta.45 config accepted the one-leaf patch and its normal Keychain-backed Verify action then passed for `electricsheephq/evaos-code-review-bot-neondiff`.

## Non-goals

- No provider, activation, billing, daemon, dry/live review, updater, managed GitHub App, release, publication, or GA change.
- No GitHub App permission expansion.
- No secret read, export, log, or config-file credential storage.
- This PR does not claim a new signed candidate, release, or customer readiness.

## Validation

Failing first:

- `swift test --skip-update --filter BYOGitHubAppCredentialOnboardingTests.byoRepositoryApplyWritesAnEnabledPolicyProfileForEverySelectedRepository`
- `swift test --skip-update --filter BYOGitHubAppCredentialOnboardingTests.missingRepositoryProfileReportsPolicyRecoveryInsteadOfInstallationFailure`
- follow-up deselection regression failed until disabled profiles were emitted.

Focused green:

- `swift test --skip-update --filter BYOGitHubAppCredentialOnboardingTests` — 20/20 passed.
- `git diff --check` — passed.

Installed-path proof boundary:

- beta.45 worker config patch dry-run and confirmed apply changed only `repoProfiles.repos.electricsheephq/evaos-code-review-bot-neondiff.enabled`;
- the installed beta.45 app then displayed `Verified App installation access for electricsheephq/evaos-code-review-bot-neondiff`;
- no provider, activation, review, release, or customer-use claim follows from this proof.

## Documentation

README, setup, and GitHub App setup now explain the policy leaf and recovery step. The current evidence-root example uses `/Users/m1/Codex`; historical release/evidence records were not rewritten.
