### PR TITLE
feat(desktop): run BYO worker from Keychain

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -26,6 +26,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js 26
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Install sealed-worker build dependencies
+        working-directory: .
+        run: npm ci --ignore-scripts
+
       - name: Run desktop Core tests with nonzero discovery
         run: scripts/run-required-swift-test-suite.sh NeonDiffDesktopCoreTests
 
@@ -55,7 +65,7 @@ jobs:
 
       - name: Enforce release-only fixture boundary
         working-directory: .
-        run: npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiffDesktop.app
+        run: npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiff.app
 
       - name: Package unsigned app bundle and metadata
         env:

--- a/README.md
+++ b/README.md
@@ -180,24 +180,24 @@ The public paid B0 BYO beta build uses a separate exact
 no managed-broker fields. That contract enables the existing local direct/BYO
 path and API-backed native activation without a hidden defaults mutation. It
 is a paid path for every repository and does not claim the managed public-free
-model. On a clean Mac without an executable local worker, native first run
-blocks **Initialize Local Config**, **Apply Repository**, and **Verify App
-Access** and routes the customer to **Install / Update Local Worker** instead
-of invoking a missing `neondiff` command. The checksum-bound bundle's explicit
-`first-install` command installs only its verified CLI in a private current-user
-version directory and writes a credential-free installation marker. It creates
-or loads no LaunchAgent and starts no daemon. After repository, provider,
-activation, and App-access verification, the signed app can install a separate
-secret-free LaunchAgent whose executable is the signed NeonDiff app. The
-headless app validates the exact account-scoped config and checksum-managed
-worker, reads the customer-owned App key and API-backed activation credential
-from its own Keychain without exporting either value, and pipes one bounded JSON
-envelope to the worker's stdin. The plist contains only the
+model. The signed release app contains a sealed NeonDiff worker built from the
+exact reviewed source and a pinned, SHA-256-verified official Node runtime. A
+clean Mac therefore does not need a global CLI or separate worker install for
+the native setup and review path. The separate checksum-bound bundle remains
+available for the customer-owned local-agent path; its explicit `first-install`
+command installs only its verified CLI in a private current-user version
+directory, writes a credential-free installation marker, and creates or loads
+no LaunchAgent. After repository, provider, activation, and App-access
+verification, the signed app can install a secret-free LaunchAgent whose
+executable is the signed NeonDiff app. Before releasing either Keychain secret,
+the app validates its exact Developer ID signature and the running sealed
+worker process, then pipes one bounded JSON envelope to that process's stdin.
+The plist contains only the
 public App ID, config path, launchd label, and signed app path—never a key value
 or key-file path. Review and daemon readiness remain separate gates. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
-gates. Once an
-executable global or checksum-managed worker is available, native first run
+gates. Unsigned development builds still require an executable global or
+checksum-managed worker before native first run
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected
@@ -215,12 +215,11 @@ explicitly chooses **NEW BOT**. A new native config receives bot-isolated runtim
 state, evidence, and license paths beside that config instead of reusing the
 packaged worker's placeholder `/tmp/neondiff` tree. If one exact
 checksum-managed local worker already exists for the selected LaunchAgent
-label, the app reuses it for these isolated setup commands instead of resolving
-them through a global `neondiff` command. It does not borrow the existing bot's
-credential environment; GitHub verification receives the new bot's
-Keychain-owned private key only through bounded stdin. If zero or multiple
-managed worker contexts are found, this reuse path is not selected; installing
-and proving exactly one managed worker remains a separate distribution gate.
+label, the app may reuse it for non-secret legacy commands. Credential-bearing
+commands always use the sealed worker; the app never sends Keychain material to
+a global, customer-writable, or checksum-marker-only executable. A verified
+legacy LaunchAgent remains supported without migrating or exporting its
+existing credential environment.
 This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.

--- a/README.md
+++ b/README.md
@@ -186,10 +186,17 @@ Access** and routes the customer to **Install / Update Local Worker** instead
 of invoking a missing `neondiff` command. The checksum-bound bundle's explicit
 `first-install` command installs only its verified CLI in a private current-user
 version directory and writes a credential-free installation marker. It creates
-or loads no LaunchAgent and starts no daemon. Native first run can use that
-exact worker for bounded setup commands; review and daemon readiness remain
-separate gates. The immutable published prerelease and clean-Mac artifact proof
-remain distribution gates. Once an
+or loads no LaunchAgent and starts no daemon. After repository, provider,
+activation, and App-access verification, the signed app can install a separate
+secret-free LaunchAgent whose executable is the signed NeonDiff app. The
+headless app validates the exact account-scoped config and checksum-managed
+worker, reads the customer-owned App key and API-backed activation credential
+from its own Keychain without exporting either value, and pipes one bounded JSON
+envelope to the worker's stdin. The plist contains only the
+public App ID, config path, launchd label, and signed app path—never a key value
+or key-file path. Review and daemon readiness remain separate gates. The
+immutable published prerelease and clean-Mac artifact proof remain distribution
+gates. Once an
 executable global or checksum-managed worker is available, native first run
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -7,18 +7,29 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
     private let localBotExecutionContextProvider:
         @Sendable () -> [DesktopLocalBotExecutionContext]
     private let defaultWorkingDirectory: URL?
+    private let trustedBundledWorker:
+        DesktopLocalBotExecutionContext?
+    private let trustedProcessValidator:
+        @Sendable (Int32) -> Bool
 
     init(
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         localBotExecutionContextProvider:
             (@Sendable () -> [DesktopLocalBotExecutionContext])? = nil,
-        defaultWorkingDirectory: URL? = NeonDiffCLIResolver.defaultWorkingDirectory()
+        defaultWorkingDirectory: URL? =
+            NeonDiffCLIResolver.defaultWorkingDirectory(),
+        trustedBundledWorker:
+            DesktopLocalBotExecutionContext? = nil,
+        trustedProcessValidator:
+            @escaping @Sendable (Int32) -> Bool = { _ in false }
     ) {
         self.localBotConfigurations = localBotConfigurations
         self.localBotExecutionContextProvider =
             localBotExecutionContextProvider ?? { localBotExecutionContexts }
         self.defaultWorkingDirectory = defaultWorkingDirectory
+        self.trustedBundledWorker = trustedBundledWorker
+        self.trustedProcessValidator = trustedProcessValidator
     }
 
     func run(
@@ -33,26 +44,65 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
             localBotConfigurations: localBotConfigurations,
             fallback: defaultWorkingDirectory
         )
-        let environmentOverrides = DesktopLocalBotExecutionContextResolver.resolve(
-            executablePath: executablePath,
-            arguments: arguments,
-            executionContexts: localBotExecutionContexts
-        )
-        let resolvedExecutablePath =
-            DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+        let requiresTrustedWorker =
+            DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+                arguments: arguments,
+                hasStandardInput: standardInput != nil
+            )
+        if requiresTrustedWorker, executablePath != "neondiff" {
+            throw NeonDiffCLIError.launchFailed(
+                "Credential input is accepted only by the signed bundled NeonDiff worker"
+            )
+        }
+        let trustedContext: DesktopLocalBotExecutionContext?
+        if requiresTrustedWorker {
+            guard let trustedBundledWorker else {
+                throw NeonDiffCLIError.launchFailed(
+                    "The signed bundled NeonDiff worker is unavailable"
+                )
+            }
+            trustedContext = trustedBundledWorker
+        } else {
+            trustedContext = nil
+        }
+        let environmentOverrides =
+            trustedContext?.environmentOverrides
+            ?? DesktopLocalBotExecutionContextResolver.resolve(
                 executablePath: executablePath,
                 arguments: arguments,
                 executionContexts: localBotExecutionContexts
-            ) ?? executablePath
-        let resolvedArguments = DesktopLocalBotExecutionContextResolver.resolveArguments(
-            executablePath: executablePath,
-            arguments: arguments,
-            executionContexts: localBotExecutionContexts
-        )
+            )
+        let resolvedExecutablePath =
+            trustedContext?.executablePath
+            ?? DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                executablePath: executablePath,
+                arguments: arguments,
+                executionContexts: localBotExecutionContexts
+            )
+            ?? executablePath
+        let resolvedArguments: [String]
+        if let trustedContext {
+            resolvedArguments =
+                trustedContext.argumentPrefix + arguments
+        } else {
+            resolvedArguments =
+                DesktopLocalBotExecutionContextResolver.resolveArguments(
+                    executablePath: executablePath,
+                    arguments: arguments,
+                    executionContexts: localBotExecutionContexts
+                )
+        }
+        let processValidator: @Sendable (Int32) -> Bool
+        if requiresTrustedWorker {
+            processValidator = trustedProcessValidator
+        } else {
+            processValidator = { _ in true }
+        }
         let client = NeonDiffCLIClient(
             executablePath: resolvedExecutablePath,
             workingDirectory: workingDirectory,
-            environmentOverrides: environmentOverrides
+            environmentOverrides: environmentOverrides,
+            processStartedValidator: processValidator
         )
         return try await client.runCancellable(
             arguments: resolvedArguments,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -44,16 +44,11 @@ enum FoundationKeychainWorkerDaemonRunner {
                 homeDirectory: homeDirectory
               ),
               let context =
-                LaunchAgentLocalBotConfigurationDiscovery
-                    .discoverInstalledWorkerExecutionContext(
-                        label: request.launchdLabel
-                    ),
+                FoundationTrustedBundledWorker.executionContext(),
               context.environmentOverrides.isEmpty,
               context.configPath.isEmpty,
-              let nodePath = context.executablePath,
-              ["/opt/homebrew/bin/node", "/usr/local/bin/node"]
-                .contains(nodePath),
-              context.argumentPrefix.count == 1
+              let workerPath = context.executablePath,
+              context.argumentPrefix.isEmpty
         else {
             throw WorkerDaemonRunnerError.invalidInvocation
         }
@@ -79,9 +74,9 @@ enum FoundationKeychainWorkerDaemonRunner {
         }
 
         let process = Process()
-        process.executableURL = URL(filePath: nodePath)
+        process.executableURL = URL(filePath: workerPath)
         process.arguments =
-            context.argumentPrefix + [
+            [
                 "daemon",
                 "--config", request.configPath,
                 "--runtime-credentials-stdin", "true"
@@ -94,6 +89,13 @@ enum FoundationKeychainWorkerDaemonRunner {
         let inputPipe = Pipe()
         process.standardInput = inputPipe
         try process.run()
+        guard FoundationTrustedBundledWorker.runningProcessIsTrusted(
+            process.processIdentifier
+        ) else {
+            process.terminate()
+            process.waitUntilExit()
+            throw WorkerDaemonRunnerError.untrustedWorker
+        }
         do {
             try inputPipe.fileHandleForWriting.write(
                 contentsOf: standardInput
@@ -151,4 +153,5 @@ private enum WorkerDaemonRunnerError: Error {
     case invalidInvocation
     case keychainUnavailable
     case stdinFailed
+    case untrustedWorker
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -1,0 +1,154 @@
+import Darwin
+import Foundation
+import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+enum FoundationKeychainWorkerDaemonRunner {
+    private static let appIDPreferenceKey = "neondiff.byoGitHubAppId"
+
+    static func runAndExitIfRequested(
+        arguments: [String] = Array(CommandLine.arguments.dropFirst()),
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) {
+        guard arguments.first
+            == DesktopKeychainWorkerLaunchAgentContract.headlessFlag
+        else {
+            return
+        }
+        let status: Int32
+        do {
+            status = try run(
+                arguments: arguments,
+                homeDirectory: homeDirectory
+            )
+        } catch {
+            status = 78
+        }
+        exit(status)
+    }
+
+    private static func run(
+        arguments: [String],
+        homeDirectory: URL
+    ) throws -> Int32 {
+        guard let request =
+            DesktopKeychainWorkerLaunchAgentContract
+                .parseHeadlessArguments(
+                    arguments,
+                    homeDirectory: homeDirectory
+                ),
+              UserDefaults.standard.string(forKey: appIDPreferenceKey)
+                == request.appID,
+              isSafeConfig(
+                URL(filePath: request.configPath),
+                homeDirectory: homeDirectory
+              ),
+              let context =
+                LaunchAgentLocalBotConfigurationDiscovery
+                    .discoverInstalledWorkerExecutionContext(
+                        label: request.launchdLabel
+                    ),
+              context.environmentOverrides.isEmpty,
+              context.configPath.isEmpty,
+              let nodePath = context.executablePath,
+              ["/opt/homebrew/bin/node", "/usr/local/bin/node"]
+                .contains(nodePath),
+              context.argumentPrefix.count == 1
+        else {
+            throw WorkerDaemonRunnerError.invalidInvocation
+        }
+
+        let secretStore = KeychainSecretStore()
+        guard let stored = try secretStore.readSecret(
+            account: BYOGitHubAppKeychainAccount.privateKey,
+            allowUserInteraction: false
+        ),
+        let licenseKey = try secretStore.readSecret(
+            account: "license/default",
+            allowUserInteraction: false
+        ) else {
+            throw WorkerDaemonRunnerError.keychainUnavailable
+        }
+        var standardInput = try DesktopRuntimeCredentialEnvelope(
+            appID: request.appID,
+            privateKey: stored,
+            licenseKey: licenseKey
+        ).encodedData()
+        defer {
+            standardInput.resetBytes(in: 0..<standardInput.count)
+        }
+
+        let process = Process()
+        process.executableURL = URL(filePath: nodePath)
+        process.arguments =
+            context.argumentPrefix + [
+                "daemon",
+                "--config", request.configPath,
+                "--runtime-credentials-stdin", "true"
+            ]
+        process.environment = boundedEnvironment(homeDirectory: homeDirectory)
+        process.currentDirectoryURL =
+            URL(filePath: request.configPath).deletingLastPathComponent()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let inputPipe = Pipe()
+        process.standardInput = inputPipe
+        try process.run()
+        do {
+            try inputPipe.fileHandleForWriting.write(
+                contentsOf: standardInput
+            )
+            try inputPipe.fileHandleForWriting.close()
+        } catch {
+            process.terminate()
+            throw WorkerDaemonRunnerError.stdinFailed
+        }
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    private static func boundedEnvironment(
+        homeDirectory: URL
+    ) -> [String: String] {
+        let username = NSUserName()
+        return [
+            "HOME": homeDirectory.path,
+            "USER": username,
+            "LOGNAME": username,
+            "PATH":
+                "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+            "NODE_OPTIONS": "--use-system-ca",
+            "TMPDIR": NSTemporaryDirectory()
+        ]
+    }
+
+    private static func isSafeConfig(
+        _ configURL: URL,
+        homeDirectory: URL
+    ) -> Bool {
+        let standardized = configURL.standardizedFileURL
+        guard (try? DesktopKeychainWorkerLaunchAgentRequest(
+            appID: "1",
+            configPath: standardized.path,
+            launchdLabel: "com.example.neondiff",
+            homeDirectory: homeDirectory
+        )) != nil,
+        standardized.resolvingSymlinksInPath().path == standardized.path
+        else {
+            return false
+        }
+        var entry = stat()
+        return lstat(standardized.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && entry.st_uid == getuid()
+            && (entry.st_mode & 0o022) == 0
+            && entry.st_size > 0
+            && entry.st_size <= 10 * 1024 * 1024
+    }
+}
+
+private enum WorkerDaemonRunnerError: Error {
+    case invalidInvocation
+    case keychainUnavailable
+    case stdinFailed
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -101,6 +101,7 @@ enum FoundationKeychainWorkerDaemonRunner {
                 contentsOf: standardInput
             )
             try inputPipe.fileHandleForWriting.close()
+            standardInput.resetBytes(in: 0..<standardInput.count)
         } catch {
             process.terminate()
             throw WorkerDaemonRunnerError.stdinFailed

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -1,0 +1,295 @@
+import Darwin
+import Foundation
+import NeonDiffDesktopAppCore
+
+struct FoundationKeychainWorkerLaunchAgentManager:
+    DesktopKeychainWorkerLaunchAgentManaging,
+    @unchecked Sendable
+{
+    private let appExecutableURL: URL
+    private let homeDirectory: URL
+    private let executionContextProvider:
+        @Sendable (String) -> [DesktopLocalBotExecutionContext]
+
+    init(
+        appExecutableURL: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        executionContextProvider:
+            @escaping @Sendable (String) -> [DesktopLocalBotExecutionContext]
+    ) {
+        self.appExecutableURL = appExecutableURL.standardizedFileURL
+        self.homeDirectory = homeDirectory.standardizedFileURL
+        self.executionContextProvider = executionContextProvider
+    }
+
+    func preview(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) async throws -> String {
+        try validate(request)
+        return "Ready to install a secret-free LaunchAgent for the selected account bot and start the checksum-managed worker."
+    }
+
+    func installAndStart(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) async throws -> String {
+        try await Task.detached {
+            try validate(request)
+            let data =
+                try DesktopKeychainWorkerLaunchAgentContract.propertyListData(
+                    request: request,
+                    appExecutableURL: appExecutableURL
+                )
+            let launchAgentsDirectory = homeDirectory.appending(
+                path: "Library/LaunchAgents",
+                directoryHint: .isDirectory
+            )
+            let plistURL = launchAgentsDirectory.appending(
+                path: "\(request.launchdLabel).plist",
+                directoryHint: .notDirectory
+            )
+            let fileManager = FileManager.default
+            try fileManager.createDirectory(
+                at: launchAgentsDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+
+            let previousData: Data?
+            if entryExists(plistURL) {
+                let existing = try Data(
+                    contentsOf: plistURL,
+                    options: .mappedIfSafe
+                )
+                guard DesktopKeychainWorkerLaunchAgentContract
+                    .parsePropertyList(
+                        existing,
+                        expectedLabel: request.launchdLabel,
+                        homeDirectory: homeDirectory,
+                        appExecutableIsSafe: { $0 == appExecutableURL },
+                        configExists: {
+                            $0.standardizedFileURL.path
+                                == request.configPath
+                        }
+                    ) == request
+                else {
+                    throw WorkerLaunchAgentRuntimeError
+                        .conflictingLaunchAgent
+                }
+                previousData = existing
+            } else {
+                previousData = nil
+            }
+
+            try writeAtomically(data, to: plistURL)
+            do {
+            try restartLaunchAgent(
+                    label: request.launchdLabel,
+                    plistURL: plistURL
+                )
+            } catch {
+                if let previousData {
+                    try? writeAtomically(previousData, to: plistURL)
+                    try? restartLaunchAgent(
+                        label: request.launchdLabel,
+                        plistURL: plistURL
+                    )
+                } else {
+                    try? bootoutLaunchAgent(label: request.launchdLabel)
+                    try? fileManager.removeItem(at: plistURL)
+                }
+                throw error
+            }
+            return "Installed and started the Keychain-backed local review worker without placing its private key in the LaunchAgent."
+        }.value
+    }
+
+    private func validate(
+        _ request: DesktopKeychainWorkerLaunchAgentRequest
+    ) throws {
+        guard isSafeAppExecutable(appExecutableURL),
+              isSafeConfig(URL(filePath: request.configPath)),
+              hasExactInstalledWorker(for: request)
+        else {
+            throw WorkerLaunchAgentRuntimeError.invalidCoordinates
+        }
+    }
+
+    private func hasExactInstalledWorker(
+        for request: DesktopKeychainWorkerLaunchAgentRequest
+    ) -> Bool {
+        let expectedRoot = homeDirectory.appending(
+            path:
+                "Library/Application Support/NeonDiffDesktop/Workers/\(request.launchdLabel)",
+            directoryHint: .isDirectory
+        ).standardizedFileURL
+        let expectedCLI = expectedRoot.appending(
+            path: "current/node_modules/neondiff/dist/src/cli.js",
+            directoryHint: .notDirectory
+        ).standardizedFileURL.path
+        let matches = executionContextProvider(request.launchdLabel).filter {
+            context in
+            guard context.environmentOverrides.isEmpty,
+                  context.configPath.isEmpty
+                    || URL(filePath: context.configPath)
+                        .standardizedFileURL.path == request.configPath,
+                  let executable = context.executablePath,
+                  ["/opt/homebrew/bin/node", "/usr/local/bin/node"]
+                    .contains(executable),
+                  context.argumentPrefix == [expectedCLI]
+            else {
+                return false
+            }
+            return true
+        }
+        return matches.count == 1
+    }
+
+    private func isSafeAppExecutable(_ url: URL) -> Bool {
+        guard url.path
+            == "/Applications/NeonDiff.app/Contents/MacOS/NeonDiff"
+        else {
+            return false
+        }
+        var entry = stat()
+        guard lstat(url.path, &entry) == 0,
+              (entry.st_mode & S_IFMT) == S_IFREG,
+              entry.st_uid == 0 || entry.st_uid == getuid(),
+              (entry.st_mode & 0o022) == 0
+        else {
+            return false
+        }
+        return FileManager.default.isExecutableFile(atPath: url.path)
+    }
+
+    private func isSafeConfig(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        guard standardized.resolvingSymlinksInPath().path
+            == standardized.path
+        else {
+            return false
+        }
+        var entry = stat()
+        return lstat(standardized.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && entry.st_uid == getuid()
+            && (entry.st_mode & 0o022) == 0
+            && entry.st_size > 0
+            && entry.st_size <= 10 * 1024 * 1024
+    }
+}
+
+private enum WorkerLaunchAgentRuntimeError: Error, LocalizedError {
+    case conflictingLaunchAgent
+    case invalidCoordinates
+    case launchctlFailed
+    case launchctlTimedOut
+    case writeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .conflictingLaunchAgent:
+            "The existing LaunchAgent does not match the selected Keychain-only NeonDiff worker."
+        case .invalidCoordinates:
+            "The signed app, account config, or checksum-managed worker could not be validated."
+        case .launchctlFailed:
+            "launchd did not accept the secret-free NeonDiff worker service."
+        case .launchctlTimedOut:
+            "launchd did not finish the worker operation in time."
+        case .writeFailed:
+            "The secret-free NeonDiff LaunchAgent could not be written safely."
+        }
+    }
+}
+
+private func entryExists(_ url: URL) -> Bool {
+    var entry = stat()
+    return lstat(url.path, &entry) == 0
+}
+
+private func writeAtomically(_ data: Data, to destination: URL) throws {
+    let temporary = destination.deletingLastPathComponent().appending(
+        path: ".\(destination.lastPathComponent).\(UUID().uuidString).tmp",
+        directoryHint: .notDirectory
+    )
+    let descriptor = open(
+        temporary.path,
+        O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
+        S_IRUSR | S_IWUSR
+    )
+    guard descriptor >= 0 else {
+        throw WorkerLaunchAgentRuntimeError.writeFailed
+    }
+    var writeError: Error?
+    data.withUnsafeBytes { rawBuffer in
+        guard let baseAddress = rawBuffer.baseAddress else { return }
+        var offset = 0
+        while offset < rawBuffer.count {
+            let result = Darwin.write(
+                descriptor,
+                baseAddress.advanced(by: offset),
+                rawBuffer.count - offset
+            )
+            if result <= 0 {
+                writeError = WorkerLaunchAgentRuntimeError.writeFailed
+                break
+            }
+            offset += result
+        }
+    }
+    if fsync(descriptor) != 0 {
+        writeError = WorkerLaunchAgentRuntimeError.writeFailed
+    }
+    close(descriptor)
+    if let writeError {
+        unlink(temporary.path)
+        throw writeError
+    }
+    guard rename(temporary.path, destination.path) == 0 else {
+        unlink(temporary.path)
+        throw WorkerLaunchAgentRuntimeError.writeFailed
+    }
+}
+
+private func restartLaunchAgent(label: String, plistURL: URL) throws {
+    let domain = "gui/\(getuid())"
+    let target = "\(domain)/\(label)"
+    let status = try runLaunchctl(["print", target], acceptsFailure: true)
+    if status == 0 {
+        _ = try runLaunchctl(["bootout", target])
+    }
+    _ = try runLaunchctl(["bootstrap", domain, plistURL.path])
+    _ = try runLaunchctl(["kickstart", "-k", target])
+}
+
+private func bootoutLaunchAgent(label: String) throws {
+    let target = "gui/\(getuid())/\(label)"
+    _ = try runLaunchctl(["bootout", target])
+}
+
+@discardableResult
+private func runLaunchctl(
+    _ arguments: [String],
+    acceptsFailure: Bool = false
+) throws -> Int32 {
+    let process = Process()
+    process.executableURL = URL(filePath: "/bin/launchctl")
+    process.arguments = arguments
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+    } catch {
+        if acceptsFailure { return 1 }
+        throw WorkerLaunchAgentRuntimeError.launchctlFailed
+    }
+    let semaphore = DispatchSemaphore(value: 0)
+    process.terminationHandler = { _ in semaphore.signal() }
+    guard semaphore.wait(timeout: .now() + 15) == .success else {
+        process.terminate()
+        throw WorkerLaunchAgentRuntimeError.launchctlTimedOut
+    }
+    if !acceptsFailure, process.terminationStatus != 0 {
+        throw WorkerLaunchAgentRuntimeError.launchctlFailed
+    }
+    return process.terminationStatus
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -8,25 +8,24 @@ struct FoundationKeychainWorkerLaunchAgentManager:
 {
     private let appExecutableURL: URL
     private let homeDirectory: URL
-    private let executionContextProvider:
-        @Sendable (String) -> [DesktopLocalBotExecutionContext]
+    private let trustedBundledWorker:
+        DesktopLocalBotExecutionContext
 
     init(
         appExecutableURL: URL,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        executionContextProvider:
-            @escaping @Sendable (String) -> [DesktopLocalBotExecutionContext]
+        trustedBundledWorker: DesktopLocalBotExecutionContext
     ) {
         self.appExecutableURL = appExecutableURL.standardizedFileURL
         self.homeDirectory = homeDirectory.standardizedFileURL
-        self.executionContextProvider = executionContextProvider
+        self.trustedBundledWorker = trustedBundledWorker
     }
 
     func preview(
         request: DesktopKeychainWorkerLaunchAgentRequest
     ) async throws -> String {
         try validate(request)
-        return "Ready to install a secret-free LaunchAgent for the selected account bot and start the checksum-managed worker."
+        return "Ready to install a secret-free LaunchAgent for the selected account bot and start the worker sealed inside the signed NeonDiff app."
     }
 
     func installAndStart(
@@ -66,11 +65,8 @@ struct FoundationKeychainWorkerLaunchAgentManager:
                         expectedLabel: request.launchdLabel,
                         homeDirectory: homeDirectory,
                         appExecutableIsSafe: { $0 == appExecutableURL },
-                        configExists: {
-                            $0.standardizedFileURL.path
-                                == request.configPath
-                        }
-                    ) == request
+                        configExists: isSafeConfig
+                    ) != nil
                 else {
                     throw WorkerLaunchAgentRuntimeError
                         .conflictingLaunchAgent
@@ -108,45 +104,18 @@ struct FoundationKeychainWorkerLaunchAgentManager:
     ) throws {
         guard isSafeAppExecutable(appExecutableURL),
               isSafeConfig(URL(filePath: request.configPath)),
-              hasExactInstalledWorker(for: request)
+              trustedBundledWorker.executablePath
+                == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+              trustedBundledWorker.argumentPrefix.isEmpty,
+              trustedBundledWorker.environmentOverrides.isEmpty
         else {
             throw WorkerLaunchAgentRuntimeError.invalidCoordinates
         }
     }
 
-    private func hasExactInstalledWorker(
-        for request: DesktopKeychainWorkerLaunchAgentRequest
-    ) -> Bool {
-        let expectedRoot = homeDirectory.appending(
-            path:
-                "Library/Application Support/NeonDiffDesktop/Workers/\(request.launchdLabel)",
-            directoryHint: .isDirectory
-        ).standardizedFileURL
-        let expectedCLI = expectedRoot.appending(
-            path: "current/node_modules/neondiff/dist/src/cli.js",
-            directoryHint: .notDirectory
-        ).standardizedFileURL.path
-        let matches = executionContextProvider(request.launchdLabel).filter {
-            context in
-            guard context.environmentOverrides.isEmpty,
-                  context.configPath.isEmpty
-                    || URL(filePath: context.configPath)
-                        .standardizedFileURL.path == request.configPath,
-                  let executable = context.executablePath,
-                  ["/opt/homebrew/bin/node", "/usr/local/bin/node"]
-                    .contains(executable),
-                  context.argumentPrefix == [expectedCLI]
-            else {
-                return false
-            }
-            return true
-        }
-        return matches.count == 1
-    }
-
     private func isSafeAppExecutable(_ url: URL) -> Bool {
         guard url.path
-            == "/Applications/NeonDiff.app/Contents/MacOS/NeonDiff"
+            == "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop"
         else {
             return false
         }
@@ -183,6 +152,7 @@ private enum WorkerLaunchAgentRuntimeError: Error, LocalizedError {
     case invalidCoordinates
     case launchctlFailed
     case launchctlTimedOut
+    case launchctlNotReady
     case writeFailed
 
     var errorDescription: String? {
@@ -190,11 +160,13 @@ private enum WorkerLaunchAgentRuntimeError: Error, LocalizedError {
         case .conflictingLaunchAgent:
             "The existing LaunchAgent does not match the selected Keychain-only NeonDiff worker."
         case .invalidCoordinates:
-            "The signed app, account config, or checksum-managed worker could not be validated."
+            "The signed app, account config, or sealed worker could not be validated."
         case .launchctlFailed:
             "launchd did not accept the secret-free NeonDiff worker service."
         case .launchctlTimedOut:
             "launchd did not finish the worker operation in time."
+        case .launchctlNotReady:
+            "The Keychain-backed local worker did not remain running."
         case .writeFailed:
             "The secret-free NeonDiff LaunchAgent could not be written safely."
         }
@@ -259,6 +231,28 @@ private func restartLaunchAgent(label: String, plistURL: URL) throws {
     }
     _ = try runLaunchctl(["bootstrap", domain, plistURL.path])
     _ = try runLaunchctl(["kickstart", "-k", target])
+    var previousPID: Int32?
+    for _ in 0..<12 {
+        usleep(250_000)
+        let sample = try runLaunchctlCapture(
+            ["print", target],
+            acceptsFailure: true
+        )
+        guard sample.status == 0,
+              let pid =
+                DesktopKeychainWorkerLaunchAgentContract.runningPID(
+                    launchctlPrint: sample.output
+                )
+        else {
+            previousPID = nil
+            continue
+        }
+        if previousPID == pid {
+            return
+        }
+        previousPID = pid
+    }
+    throw WorkerLaunchAgentRuntimeError.launchctlNotReady
 }
 
 private func bootoutLaunchAgent(label: String) throws {
@@ -271,15 +265,26 @@ private func runLaunchctl(
     _ arguments: [String],
     acceptsFailure: Bool = false
 ) throws -> Int32 {
+    try runLaunchctlCapture(
+        arguments,
+        acceptsFailure: acceptsFailure
+    ).status
+}
+
+private func runLaunchctlCapture(
+    _ arguments: [String],
+    acceptsFailure: Bool = false
+) throws -> (status: Int32, output: String) {
     let process = Process()
     process.executableURL = URL(filePath: "/bin/launchctl")
     process.arguments = arguments
-    process.standardOutput = FileHandle.nullDevice
+    let output = Pipe()
+    process.standardOutput = output
     process.standardError = FileHandle.nullDevice
     do {
         try process.run()
     } catch {
-        if acceptsFailure { return 1 }
+        if acceptsFailure { return (1, "") }
         throw WorkerLaunchAgentRuntimeError.launchctlFailed
     }
     let semaphore = DispatchSemaphore(value: 0)
@@ -291,5 +296,9 @@ private func runLaunchctl(
     if !acceptsFailure, process.terminationStatus != 0 {
         throw WorkerLaunchAgentRuntimeError.launchctlFailed
     }
-    return process.terminationStatus
+    let data = output.fileHandleForReading.readDataToEndOfFile()
+    return (
+        process.terminationStatus,
+        String(decoding: data, as: UTF8.self)
+    )
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
@@ -1,0 +1,116 @@
+import Darwin
+import Foundation
+import NeonDiffDesktopAppCore
+import Security
+
+enum FoundationTrustedBundledWorker {
+    private static let appRequirementText =
+        #"anchor apple generic and identifier "com.electricsheephq.NeonDiffDesktop" and certificate leaf[subject.OU] = "TC6MS3T6NN""#
+    private static let workerRequirementText =
+        #"anchor apple generic and certificate leaf[subject.OU] = "TC6MS3T6NN""#
+
+    static func executionContext(
+        bundle: Bundle = .main
+    ) -> DesktopLocalBotExecutionContext? {
+        DesktopTrustedBundledWorkerContract.executionContext(
+            appBundleURL: bundle.bundleURL,
+            appSignatureIsValid: validateAppSignature,
+            sealedFileIsValid: isSafeSealedWorker
+        )
+    }
+
+    static func runningProcessIsTrusted(
+        _ processIdentifier: Int32,
+        bundle: Bundle = .main
+    ) -> Bool {
+        guard validateAppSignature(bundle.bundleURL),
+              processIdentifier > 0,
+              let requirement = requirement(workerRequirementText)
+        else {
+            return false
+        }
+        let attributes = [
+            kSecGuestAttributePid as String:
+                NSNumber(value: processIdentifier)
+        ] as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(
+            nil,
+            attributes,
+            SecCSFlags(),
+            &code
+        ) == errSecSuccess,
+        let code
+        else {
+            return false
+        }
+        return SecCodeCheckValidity(
+            code,
+            SecCSFlags(rawValue: kSecCSStrictValidate),
+            requirement
+        ) == errSecSuccess
+    }
+
+    private static func validateAppSignature(_ bundleURL: URL) -> Bool {
+        guard bundleURL.standardizedFileURL.path
+            == DesktopTrustedBundledWorkerContract.expectedBundlePath,
+              let requirement = requirement(appRequirementText)
+        else {
+            return false
+        }
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(
+            bundleURL as CFURL,
+            SecCSFlags(),
+            &staticCode
+        ) == errSecSuccess,
+        let staticCode
+        else {
+            return false
+        }
+        let flags = SecCSFlags(
+            rawValue:
+                kSecCSCheckAllArchitectures
+                | kSecCSStrictValidate
+                | kSecCSCheckNestedCode
+        )
+        return SecStaticCodeCheckValidity(
+            staticCode,
+            flags,
+            requirement
+        ) == errSecSuccess
+    }
+
+    private static func requirement(
+        _ text: String
+    ) -> SecRequirement? {
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(
+            text as CFString,
+            SecCSFlags(),
+            &requirement
+        ) == errSecSuccess
+        else {
+            return nil
+        }
+        return requirement
+    }
+
+    private static func isSafeSealedWorker(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        guard standardized.resolvingSymlinksInPath().path
+            == standardized.path
+        else {
+            return false
+        }
+        var entry = stat()
+        return lstat(standardized.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && (entry.st_mode & 0o022) == 0
+            && entry.st_size > 1024 * 1024
+            && entry.st_size <= 250 * 1024 * 1024
+            && FileManager.default.isExecutableFile(
+                atPath: standardized.path
+            )
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -57,12 +57,10 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
                 configExists: {
                     isSafeConfigFile($0, fileManager: fileManager)
                 }
-            ),
+           ),
            let appID = Int64(request.appID),
-           let installedContext = discoverInstalledWorkerExecutionContext(
-                label: label,
-                fileManager: fileManager
-           ) {
+           let sealedContext =
+                FoundationTrustedBundledWorker.executionContext() {
             return Snapshot(
                 configurations: [
                     DesktopLocalBotConfiguration(
@@ -77,9 +75,9 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
                     DesktopLocalBotExecutionContext(
                         configPath: request.configPath,
                         executablePath:
-                            installedContext.executablePath,
+                            sealedContext.executablePath,
                         argumentPrefix:
-                            installedContext.argumentPrefix,
+                            sealedContext.argumentPrefix,
                         environmentOverrides: [:]
                     )
                 ]
@@ -198,7 +196,7 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
         fileManager: FileManager
     ) -> Bool {
         guard url.path
-            == "/Applications/NeonDiff.app/Contents/MacOS/NeonDiff"
+            == "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop"
         else {
             return false
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -34,35 +34,55 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             return Snapshot(configurations: [], executionContexts: [])
         }
         guard let data = launchAgentData else {
-            let installationURL = installedWorkerRoot
-                .appendingPathComponent("installation.json")
-            guard isSafeInstallationFile(installationURL),
-                  let installationData = try? Data(
-                    contentsOf: installationURL,
-                    options: .mappedIfSafe
-                  ),
-                  let context =
-                    DesktopInstalledWorkerExecutionContextParser.parse(
-                        data: installationData,
-                        expectedLabel: label,
-                        installedWorkerRoot: installedWorkerRoot,
-                        resolveCLI: {
-                            let resolved = $0.resolvingSymlinksInPath()
-                            return resolved == $0 ? nil : resolved
-                        },
-                        cliIsSafe: {
-                            isSafeInstalledCLI($0, fileManager: fileManager)
-                        },
-                        nodeIsExecutable: {
-                            isExecutableRegularFile($0, fileManager: fileManager)
-                        }
-                    )
+            guard let context = discoverInstalledWorkerExecutionContext(
+                label: label,
+                fileManager: fileManager
+            )
             else {
                 return Snapshot(configurations: [], executionContexts: [])
             }
             return Snapshot(
                 configurations: [],
                 executionContexts: [context]
+            )
+        }
+        if let request =
+            DesktopKeychainWorkerLaunchAgentContract.parsePropertyList(
+                data,
+                expectedLabel: label,
+                homeDirectory: fileManager.homeDirectoryForCurrentUser,
+                appExecutableIsSafe: {
+                    isSafeAppExecutable($0, fileManager: fileManager)
+                },
+                configExists: {
+                    isSafeConfigFile($0, fileManager: fileManager)
+                }
+            ),
+           let appID = Int64(request.appID),
+           let installedContext = discoverInstalledWorkerExecutionContext(
+                label: label,
+                fileManager: fileManager
+           ) {
+            return Snapshot(
+                configurations: [
+                    DesktopLocalBotConfiguration(
+                        appID: appID,
+                        configPath: request.configPath,
+                        workingDirectory: URL(
+                            filePath: request.configPath
+                        ).deletingLastPathComponent().path
+                    )
+                ],
+                executionContexts: [
+                    DesktopLocalBotExecutionContext(
+                        configPath: request.configPath,
+                        executablePath:
+                            installedContext.executablePath,
+                        argumentPrefix:
+                            installedContext.argumentPrefix,
+                        environmentOverrides: [:]
+                    )
+                ]
             )
         }
         let configuration = DesktopLaunchAgentBotConfigurationParser.parse(
@@ -106,6 +126,45 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
         discoverSnapshot(label: label, fileManager: fileManager).executionContexts
     }
 
+    static func discoverInstalledWorkerExecutionContext(
+        label: String = defaultLabel,
+        fileManager: FileManager = .default
+    ) -> DesktopLocalBotExecutionContext? {
+        let installedWorkerRoot = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(
+                "Library/Application Support/NeonDiffDesktop/Workers",
+                isDirectory: true
+            )
+            .appendingPathComponent(label, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let installationURL = installedWorkerRoot
+            .appendingPathComponent("installation.json")
+        guard isSafeInstallationFile(installationURL),
+              let installationData = try? Data(
+                contentsOf: installationURL,
+                options: .mappedIfSafe
+              )
+        else {
+            return nil
+        }
+        return DesktopInstalledWorkerExecutionContextParser.parse(
+            data: installationData,
+            expectedLabel: label,
+            installedWorkerRoot: installedWorkerRoot,
+            resolveCLI: {
+                let resolved = $0.resolvingSymlinksInPath()
+                return resolved == $0 ? nil : resolved
+            },
+            cliIsSafe: {
+                isSafeInstalledCLI($0, fileManager: fileManager)
+            },
+            nodeIsExecutable: {
+                isExecutableRegularFile($0, fileManager: fileManager)
+            }
+        )
+    }
+
     private static func isSafePrivateKeyFile(
         _ url: URL,
         fileManager: FileManager
@@ -132,6 +191,43 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
             && (entry.st_mode & 0o077) == 0
             && entry.st_size > 0
             && entry.st_size <= 1024 * 1024
+    }
+
+    private static func isSafeAppExecutable(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        guard url.path
+            == "/Applications/NeonDiff.app/Contents/MacOS/NeonDiff"
+        else {
+            return false
+        }
+        var entry = stat()
+        return lstat(url.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && (entry.st_uid == 0 || entry.st_uid == getuid())
+            && (entry.st_mode & 0o022) == 0
+            && fileManager.isExecutableFile(atPath: url.path)
+    }
+
+    private static func isSafeConfigFile(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let standardized = url.standardizedFileURL
+        guard standardized.resolvingSymlinksInPath().path
+            == standardized.path
+        else {
+            return false
+        }
+        var entry = stat()
+        return lstat(standardized.path, &entry) == 0
+            && (entry.st_mode & S_IFMT) == S_IFREG
+            && entry.st_uid == getuid()
+            && (entry.st_mode & 0o022) == 0
+            && entry.st_size > 0
+            && entry.st_size <= 10 * 1024 * 1024
+            && fileManager.isReadableFile(atPath: url.path)
     }
 
     private static func entryExists(_ url: URL) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -20,6 +20,7 @@ struct NeonDiffDesktopApp: App {
 #endif
 
     init() {
+        FoundationKeychainWorkerDaemonRunner.runAndExitIfRequested()
 #if DEBUG
         let context: DesktopResolvedEvaluationLaunchContext?
         do {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -45,6 +45,32 @@ enum NeonDiffDesktopCompositionRoot {
                 LaunchAgentLocalBotConfigurationDiscovery
                     .discoverExecutionContexts()
             }
+        let localBotDiscoveryProvider:
+            @Sendable (String) -> DesktopLocalBotDiscoverySnapshot = {
+                label in
+                let snapshot =
+                    LaunchAgentLocalBotConfigurationDiscovery
+                        .discoverSnapshot(label: label)
+                return DesktopLocalBotDiscoverySnapshot(
+                    configurations: snapshot.configurations,
+                    executionContexts: snapshot.executionContexts
+                )
+            }
+        let keychainWorkerLaunchAgentManager:
+            any DesktopKeychainWorkerLaunchAgentManaging
+        if let appExecutableURL = Bundle.main.executableURL {
+            keychainWorkerLaunchAgentManager =
+                FoundationKeychainWorkerLaunchAgentManager(
+                    appExecutableURL: appExecutableURL,
+                    executionContextProvider: { label in
+                        LaunchAgentLocalBotConfigurationDiscovery
+                            .discoverExecutionContexts(label: label)
+                    }
+                )
+        } else {
+            keychainWorkerLaunchAgentManager =
+                UnavailableDesktopKeychainWorkerLaunchAgentManager()
+        }
         let model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
             clipboard: AppKitClipboard(),
             urlOpener: AppKitURLOpener(),
@@ -75,7 +101,10 @@ enum NeonDiffDesktopCompositionRoot {
             localBotExecutionContexts: localBotExecutionContexts,
             localBotExecutionConfigPaths: localBotExecutionContexts.map(
                 \.configPath
-            )
+            ),
+            localBotDiscoveryProvider: localBotDiscoveryProvider,
+            keychainWorkerLaunchAgentManager:
+                keychainWorkerLaunchAgentManager
         ))
         model.localWorkerExecutionContextProvider =
             localBotExecutionContextProvider

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -38,12 +38,22 @@ enum NeonDiffDesktopCompositionRoot {
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
         let localBotSnapshot =
             LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
+        let trustedBundledWorker =
+            FoundationTrustedBundledWorker.executionContext()
         let localBotConfigurations = localBotSnapshot.configurations
-        let localBotExecutionContexts = localBotSnapshot.executionContexts
+        let localBotExecutionContexts =
+            localBotSnapshot.executionContexts
+            + (trustedBundledWorker.map { [$0] } ?? [])
         let localBotExecutionContextProvider:
             @Sendable () -> [DesktopLocalBotExecutionContext] = {
                 LaunchAgentLocalBotConfigurationDiscovery
                     .discoverExecutionContexts()
+                    + (
+                        FoundationTrustedBundledWorker
+                            .executionContext()
+                            .map { [$0] }
+                        ?? []
+                    )
             }
         let localBotDiscoveryProvider:
             @Sendable (String) -> DesktopLocalBotDiscoverySnapshot = {
@@ -53,19 +63,24 @@ enum NeonDiffDesktopCompositionRoot {
                         .discoverSnapshot(label: label)
                 return DesktopLocalBotDiscoverySnapshot(
                     configurations: snapshot.configurations,
-                    executionContexts: snapshot.executionContexts
+                    executionContexts:
+                        snapshot.executionContexts
+                        + (
+                            FoundationTrustedBundledWorker
+                                .executionContext()
+                                .map { [$0] }
+                            ?? []
+                        )
                 )
             }
         let keychainWorkerLaunchAgentManager:
             any DesktopKeychainWorkerLaunchAgentManaging
-        if let appExecutableURL = Bundle.main.executableURL {
+        if let appExecutableURL = Bundle.main.executableURL,
+           let trustedBundledWorker {
             keychainWorkerLaunchAgentManager =
                 FoundationKeychainWorkerLaunchAgentManager(
                     appExecutableURL: appExecutableURL,
-                    executionContextProvider: { label in
-                        LaunchAgentLocalBotConfigurationDiscovery
-                            .discoverExecutionContexts(label: label)
-                    }
+                    trustedBundledWorker: trustedBundledWorker
                 )
         } else {
             keychainWorkerLaunchAgentManager =
@@ -79,7 +94,12 @@ enum NeonDiffDesktopCompositionRoot {
                 localBotExecutionContexts: localBotExecutionContexts,
                 localBotExecutionContextProvider:
                     localBotExecutionContextProvider,
-                defaultWorkingDirectory: cliWorkingDirectory
+                defaultWorkingDirectory: cliWorkingDirectory,
+                trustedBundledWorker: trustedBundledWorker,
+                trustedProcessValidator: {
+                    FoundationTrustedBundledWorker
+                        .runningProcessIsTrusted($0)
+                }
             ),
             dashboard: FoundationDesktopDashboardLauncher(),
             preferences: UserDefaultsDesktopPreferences(.standard),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -646,7 +646,10 @@ struct OnboardingWizardView: View {
                                 Label("Check Status", systemImage: "arrow.clockwise")
                             }
                             Button { model.startDaemon() } label: {
-                                Label("Start/Restart", systemImage: "play.circle")
+                                Label(
+                                    model.daemonStartActionTitle,
+                                    systemImage: "play.circle"
+                                )
                             }
                             .disabled(!model.productionDaemonStartAvailable)
                             Button { model.stopDaemon() } label: {
@@ -665,6 +668,10 @@ struct OnboardingWizardView: View {
                             }
                         }
                     }
+
+                    Text(model.keychainWorkerLaunchAgentStatus)
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
 
                     OperatorBadge(
                         text: model.onboardingFlow.daemonBootstrapChecked ? "Checked" : "Check Required",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -139,6 +139,10 @@ package struct DesktopAppDependencies {
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
     package let localBotExecutionContexts: [DesktopLocalBotExecutionContext]
     package let localBotExecutionConfigPaths: [String]
+    package let localBotDiscoveryProvider:
+        (@Sendable (String) -> DesktopLocalBotDiscoverySnapshot)?
+    package let keychainWorkerLaunchAgentManager:
+        any DesktopKeychainWorkerLaunchAgentManaging
 
     package init(
         clipboard: any DesktopClipboard,
@@ -160,7 +164,12 @@ package struct DesktopAppDependencies {
         cliWorkingDirectory: URL? = nil,
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
-        localBotExecutionConfigPaths: [String] = []
+        localBotExecutionConfigPaths: [String] = [],
+        localBotDiscoveryProvider:
+            (@Sendable (String) -> DesktopLocalBotDiscoverySnapshot)? = nil,
+        keychainWorkerLaunchAgentManager:
+            any DesktopKeychainWorkerLaunchAgentManaging =
+                UnavailableDesktopKeychainWorkerLaunchAgentManager()
     ) {
         self.clipboard = clipboard
         self.urlOpener = urlOpener
@@ -180,5 +189,8 @@ package struct DesktopAppDependencies {
         self.localBotConfigurations = localBotConfigurations
         self.localBotExecutionContexts = localBotExecutionContexts
         self.localBotExecutionConfigPaths = localBotExecutionConfigPaths
+        self.localBotDiscoveryProvider = localBotDiscoveryProvider
+        self.keychainWorkerLaunchAgentManager =
+            keychainWorkerLaunchAgentManager
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -1,0 +1,304 @@
+import Foundation
+import NeonDiffDesktopCore
+
+package struct DesktopKeychainWorkerLaunchAgentRequest:
+    Equatable,
+    Sendable
+{
+    package let appID: String
+    package let configPath: String
+    package let launchdLabel: String
+
+    package init(
+        appID: String,
+        configPath: String,
+        launchdLabel: String,
+        homeDirectory: URL
+    ) throws {
+        guard appID.range(
+            of: #"^[1-9][0-9]{0,19}$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidAppID
+        }
+        guard launchdLabel.range(
+            of: #"^[A-Za-z0-9][A-Za-z0-9.-]{2,127}$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidLaunchdLabel
+        }
+        let normalizedConfig = URL(filePath: configPath).standardizedFileURL
+        guard Self.isAccountBotConfig(
+            normalizedConfig,
+            homeDirectory: homeDirectory
+        ) else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidConfigPath
+        }
+        self.appID = appID
+        self.configPath = normalizedConfig.path
+        self.launchdLabel = launchdLabel
+    }
+
+    private static func isAccountBotConfig(
+        _ configURL: URL,
+        homeDirectory: URL
+    ) -> Bool {
+        let expectedRoot = homeDirectory
+            .appending(
+                path: "Library/Application Support/NeonDiffDesktop/Accounts",
+                directoryHint: .isDirectory
+            )
+            .standardizedFileURL
+        let components = configURL.pathComponents
+        let rootComponents = expectedRoot.pathComponents
+        guard components.count == rootComponents.count + 4,
+              Array(components.prefix(rootComponents.count)) == rootComponents
+        else {
+            return false
+        }
+        let suffix = Array(components.suffix(4))
+        return !suffix[0].isEmpty
+            && suffix[0] != "_unselected"
+            && suffix[1] == "Bots"
+            && suffix[2].range(
+                of: #"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"#,
+                options: .regularExpression
+            ) != nil
+            && suffix[3] == "config.local.json"
+    }
+}
+
+package enum DesktopKeychainWorkerLaunchAgentError:
+    Error,
+    LocalizedError
+{
+    case invalidAppID
+    case invalidConfigPath
+    case invalidLaunchdLabel
+    case invalidAppExecutable
+    case serializationFailed
+
+    package var errorDescription: String? {
+        switch self {
+        case .invalidAppID:
+            "The customer-owned GitHub App ID is invalid."
+        case .invalidConfigPath:
+            "The local worker config must be the selected account bot config."
+        case .invalidLaunchdLabel:
+            "The local worker LaunchAgent label is invalid."
+        case .invalidAppExecutable:
+            "The signed NeonDiff app executable path is invalid."
+        case .serializationFailed:
+            "The secret-free worker LaunchAgent could not be serialized."
+        }
+    }
+}
+
+package enum DesktopKeychainWorkerLaunchAgentContract {
+    package static let headlessFlag = "--neondiff-worker-daemon"
+
+    package static func headlessArguments(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) -> [String] {
+        [
+            headlessFlag,
+            "--config", request.configPath,
+            "--launchd-label", request.launchdLabel,
+            "--github-app-id", request.appID
+        ]
+    }
+
+    package static func propertyListData(
+        request: DesktopKeychainWorkerLaunchAgentRequest,
+        appExecutableURL: URL
+    ) throws -> Data {
+        let executable = appExecutableURL.standardizedFileURL
+        guard executable.path.hasPrefix("/"),
+              executable.lastPathComponent == "NeonDiff"
+        else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidAppExecutable
+        }
+        let propertyList: [String: Any] = [
+            "Label": request.launchdLabel,
+            "ProgramArguments":
+                [executable.path] + headlessArguments(request: request),
+            "RunAtLoad": true,
+            "KeepAlive": true,
+            "ProcessType": "Background",
+            "LimitLoadToSessionType": "Aqua",
+            "ThrottleInterval": 10,
+            "StandardOutPath": "/dev/null",
+            "StandardErrorPath": "/dev/null"
+        ]
+        do {
+            return try PropertyListSerialization.data(
+                fromPropertyList: propertyList,
+                format: .xml,
+                options: 0
+            )
+        } catch {
+            throw DesktopKeychainWorkerLaunchAgentError.serializationFailed
+        }
+    }
+
+    package static func parsePropertyList(
+        _ data: Data,
+        expectedLabel: String,
+        homeDirectory: URL,
+        appExecutableIsSafe: (URL) -> Bool,
+        configExists: (URL) -> Bool
+    ) -> DesktopKeychainWorkerLaunchAgentRequest? {
+        guard let object = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ),
+        let root = object as? [String: Any],
+        Set(root.keys) == [
+            "Label",
+            "ProgramArguments",
+            "RunAtLoad",
+            "KeepAlive",
+            "ProcessType",
+            "LimitLoadToSessionType",
+            "ThrottleInterval",
+            "StandardOutPath",
+            "StandardErrorPath"
+        ],
+        root["Label"] as? String == expectedLabel,
+        root["RunAtLoad"] as? Bool == true,
+        root["KeepAlive"] as? Bool == true,
+        root["ProcessType"] as? String == "Background",
+        root["LimitLoadToSessionType"] as? String == "Aqua",
+        root["ThrottleInterval"] as? Int == 10,
+        root["StandardOutPath"] as? String == "/dev/null",
+        root["StandardErrorPath"] as? String == "/dev/null",
+        let programArguments = root["ProgramArguments"] as? [String],
+        programArguments.count == 8,
+        let executablePath = programArguments.first,
+        executablePath.hasPrefix("/")
+        else {
+            return nil
+        }
+        let executable = URL(filePath: executablePath).standardizedFileURL
+        guard appExecutableIsSafe(executable),
+              let request = parseHeadlessArguments(
+                Array(programArguments.dropFirst()),
+                homeDirectory: homeDirectory
+              ),
+              request.launchdLabel == expectedLabel,
+              configExists(URL(filePath: request.configPath))
+        else {
+            return nil
+        }
+        return request
+    }
+
+    package static func parseHeadlessArguments(
+        _ arguments: [String],
+        homeDirectory: URL
+    ) -> DesktopKeychainWorkerLaunchAgentRequest? {
+        guard arguments.count == 7,
+              arguments[0] == headlessFlag,
+              arguments[1] == "--config",
+              arguments[3] == "--launchd-label",
+              arguments[5] == "--github-app-id"
+        else {
+            return nil
+        }
+        return try? DesktopKeychainWorkerLaunchAgentRequest(
+            appID: arguments[6],
+            configPath: arguments[2],
+            launchdLabel: arguments[4],
+            homeDirectory: homeDirectory
+        )
+    }
+}
+
+package protocol DesktopKeychainWorkerLaunchAgentManaging: Sendable {
+    func preview(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) async throws -> String
+
+    func installAndStart(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) async throws -> String
+}
+
+package struct UnavailableDesktopKeychainWorkerLaunchAgentManager:
+    DesktopKeychainWorkerLaunchAgentManaging
+{
+    package init() {}
+
+    package func preview(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) async throws -> String {
+        throw DesktopKeychainWorkerLaunchAgentError.invalidAppExecutable
+    }
+
+    package func installAndStart(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) async throws -> String {
+        throw DesktopKeychainWorkerLaunchAgentError.invalidAppExecutable
+    }
+}
+
+package struct DesktopLocalBotDiscoverySnapshot: Sendable {
+    package let configurations: [DesktopLocalBotConfiguration]
+    package let executionContexts: [DesktopLocalBotExecutionContext]
+
+    package init(
+        configurations: [DesktopLocalBotConfiguration],
+        executionContexts: [DesktopLocalBotExecutionContext]
+    ) {
+        self.configurations = configurations
+        self.executionContexts = executionContexts
+    }
+}
+
+package struct DesktopRuntimeCredentialEnvelope: Sendable {
+    private let appID: String
+    private let privateKey: String
+    private let licenseKey: String
+
+    package init(
+        appID: String,
+        privateKey: String,
+        licenseKey: String
+    ) throws {
+        self.appID = try BYOGitHubAppCredentialValidator
+            .normalizedAppId(appID)
+        self.privateKey = try BYOGitHubAppCredentialValidator
+            .normalizedPrivateKey(privateKey)
+        guard licenseKey.range(
+            of: #"^nd_live_[A-Za-z0-9_-]{8,}$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopRuntimeCredentialEnvelopeError.invalidLicenseKey
+        }
+        self.licenseKey = licenseKey
+    }
+
+    package func encodedData() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "schemaVersion": 1,
+                "githubAppId": appID,
+                "githubPrivateKey": privateKey,
+                "licenseKey": licenseKey
+            ],
+            options: []
+        )
+    }
+}
+
+package enum DesktopRuntimeCredentialEnvelopeError:
+    Error,
+    LocalizedError
+{
+    case invalidLicenseKey
+
+    package var errorDescription: String? {
+        "The API-backed NeonDiff activation credential is invalid."
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -114,7 +114,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
     ) throws -> Data {
         let executable = appExecutableURL.standardizedFileURL
         guard executable.path.hasPrefix("/"),
-              executable.lastPathComponent == "NeonDiff"
+              executable.lastPathComponent == "NeonDiffDesktop"
         else {
             throw DesktopKeychainWorkerLaunchAgentError.invalidAppExecutable
         }
@@ -213,6 +213,73 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             homeDirectory: homeDirectory
         )
     }
+
+    package static func runningPID(
+        launchctlPrint: String
+    ) -> Int32? {
+        let lines = launchctlPrint.split(
+            whereSeparator: \.isNewline
+        ).map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+        guard lines.contains("state = running") else { return nil }
+        let pidLines = lines.filter { $0.hasPrefix("pid = ") }
+        guard pidLines.count == 1,
+              let rawPID = pidLines.first?.dropFirst("pid = ".count),
+              let pid = Int32(rawPID),
+              pid > 0
+        else {
+            return nil
+        }
+        return pid
+    }
+}
+
+package enum DesktopTrustedBundledWorkerContract {
+    package static let expectedBundlePath = "/Applications/NeonDiff.app"
+    package static let workerRelativePath =
+        "Contents/Helpers/NeonDiffWorker"
+
+    package static func requiresTrustedWorker(
+        arguments: [String],
+        hasStandardInput: Bool
+    ) -> Bool {
+        guard hasStandardInput else { return false }
+        return [
+            "--runtime-credentials-stdin",
+            "--github-app-private-key-stdin",
+            "--license-key-stdin"
+        ].contains { arguments.contains($0) }
+    }
+
+    package static func executionContext(
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> DesktopLocalBotExecutionContext? {
+        let bundle = appBundleURL.standardizedFileURL
+        guard bundle.path == expectedBundlePath,
+              bundle.resolvingSymlinksInPath().path == bundle.path,
+              appSignatureIsValid(bundle)
+        else {
+            return nil
+        }
+        let worker = bundle.appending(
+            path: workerRelativePath,
+            directoryHint: .notDirectory
+        ).standardizedFileURL
+        guard sealedFileIsValid(worker)
+        else {
+            return nil
+        }
+        return DesktopLocalBotExecutionContext(
+            configPath: "",
+            executablePath: worker.path,
+            argumentPrefix: [],
+            environmentOverrides: [:]
+        )
+    }
+
 }
 
 package protocol DesktopKeychainWorkerLaunchAgentManaging: Sendable {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -621,9 +621,14 @@ package enum DesktopLocalBotExecutionContextResolver {
         else {
             return nil
         }
-        let matches = executionContexts.filter(isInstallerManagedWorker)
-        guard matches.count == 1 else { return nil }
-        return matches[0]
+        let trusted = executionContexts.filter(isTrustedBundledWorker)
+        if trusted.count == 1 {
+            return trusted[0]
+        }
+        guard trusted.isEmpty else { return nil }
+        let installed = executionContexts.filter(isInstallerManagedWorker)
+        guard installed.count == 1 else { return nil }
+        return installed[0]
     }
 
     private static func isSupportedUnboundCommand(_ arguments: [String]) -> Bool {
@@ -723,6 +728,20 @@ package enum DesktopLocalBotExecutionContextResolver {
             && suffix[5] == "Bots"
             && !suffix[6].isEmpty
             && suffix[7] == "config.local.json"
+    }
+
+    private static func isTrustedBundledWorker(
+        _ context: DesktopLocalBotExecutionContext
+    ) -> Bool {
+        guard let executablePath = context.executablePath,
+              executablePath
+                == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+              context.argumentPrefix.isEmpty,
+              context.environmentOverrides.isEmpty
+        else {
+            return false
+        }
+        return true
     }
 
     private static func isInstallerManagedWorker(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -564,6 +564,12 @@ package enum DesktopLocalBotExecutionContextResolver {
                     || reviewHelpCommand
                     || Array(arguments.prefix(2)) == ["config", "inspect"]
                     || Array(arguments.prefix(2)) == ["license", "status"]
+                    || (
+                        arguments.count >= 2
+                            && arguments[0] == "daemon"
+                            && ["start", "stop", "status"]
+                                .contains(arguments[1])
+                    )
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2503,7 +2503,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let manager = dependencies.keychainWorkerLaunchAgentManager
         isKeychainWorkerLaunchAgentOperationInProgress = true
         keychainWorkerLaunchAgentStatus =
-            "Validating the signed app, selected config, and installed worker…"
+            "Validating the signed app, selected config, and sealed worker…"
         Task { [weak self] in
             do {
                 let status = try await manager.preview(request: request)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2598,17 +2598,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .filter { !$0.isEmpty }
     }
 
-    private func runtimeCredentialsForReview() -> Data?
-    {
-        guard dependencies.productionBoundary.byoGitHubEnabled,
-              byoGitHubCredentialsStored,
+    private var runtimeCredentialsForReviewRequired: Bool {
+        dependencies.productionBoundary.byoGitHubEnabled
+            && byoGitHubCredentialsStored
+            && (
+                !existingLocalAgentAccessAvailable
+                    || keychainWorkerLaunchAgentActive
+            )
+    }
+
+    private func runtimeCredentialsForReview() -> Data? {
+        guard runtimeCredentialsForReviewRequired,
               byoGitHubCredentialsVerified,
               let appID = storedBYOGitHubAppId
         else {
-            return nil
-        }
-        if existingLocalAgentAccessAvailable,
-           !keychainWorkerLaunchAgentActive {
             return nil
         }
         do {
@@ -2661,8 +2664,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 localWorkerReviewCompatibilityGeneration
         )
         let runtimeCredentials = runtimeCredentialsForReview()
-        if dependencies.productionBoundary.byoGitHubEnabled,
-           byoGitHubCredentialsStored,
+        if runtimeCredentialsForReviewRequired,
            runtimeCredentials == nil {
             return
         }
@@ -2744,8 +2746,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
 
         let runtimeCredentials = runtimeCredentialsForReview()
-        if dependencies.productionBoundary.byoGitHubEnabled,
-           byoGitHubCredentialsStored,
+        if runtimeCredentialsForReviewRequired,
            runtimeCredentials == nil {
             return
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -166,6 +166,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set) var localWorkerReviewCompatibility: DesktopLocalWorkerReviewCompatibility = .unknown
     @Published package private(set) var currentLocalWorkerExecutionContexts:
         [DesktopLocalBotExecutionContext] = []
+    @Published package private(set) var currentLocalBotConfigurations:
+        [DesktopLocalBotConfiguration] = []
+    @Published package private(set) var currentLocalBotExecutionConfigPaths:
+        [String] = []
+    @Published package private(set)
+        var isKeychainWorkerLaunchAgentOperationInProgress = false
+    @Published package private(set) var keychainWorkerLaunchAgentStatus =
+        "Install and start the local review worker when setup is ready."
     package var localWorkerExecutionContextProvider:
         (@MainActor () -> [DesktopLocalBotExecutionContext])?
     @Published package var logText = "No logs loaded."
@@ -425,6 +433,34 @@ package final class NeonDiffDesktopModel: ObservableObject {
         productionUsefulWorkAvailable
             && reviewTargetRuntimeReady
             && scopedReviewProviderReady
+            && (
+                !dependencies.productionBoundary.byoGitHubEnabled
+                    || existingLocalAgentAccessAvailable
+                    || keychainWorkerLaunchAgentInstallAvailable
+            )
+    }
+
+    package var keychainWorkerLaunchAgentInstallAvailable: Bool {
+        dependencies.productionBoundary.byoGitHubEnabled
+            && byoGitHubCredentialsStored
+            && byoGitHubCredentialsVerified
+            && storedBYOGitHubAppId != nil
+            && localWorkerCLIAvailable
+            && !isKeychainWorkerLaunchAgentOperationInProgress
+    }
+
+    package var daemonStartActionTitle: String {
+        existingLocalAgentAccessAvailable
+            ? "Start/Restart"
+            : "Install & Start"
+    }
+
+    private var keychainWorkerLaunchAgentActive: Bool {
+        guard matchingLocalBotConfigurationAvailable else { return false }
+        return currentLocalWorkerExecutionContexts.contains { context in
+            normalizedPath(context.configPath) == normalizedPath(configPath)
+                && context.environmentOverrides.isEmpty
+        }
     }
 
     package var scopedLiveReviewConfirmationAvailable: Bool {
@@ -582,14 +618,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return false
         }
-        return dependencies.localBotExecutionConfigPaths.contains { path in
+        return currentLocalBotExecutionConfigPaths.contains { path in
             normalizedPath(path) == normalizedPath(configPath)
         }
     }
 
     private var matchingLocalBotConfigurationAvailable: Bool {
         guard let bot = selectedBotInstallation else { return false }
-        return dependencies.localBotConfigurations.contains { configuration in
+        return currentLocalBotConfigurations.contains { configuration in
             configuration.appID == bot.appID
                 && normalizedPath(configuration.configPath)
                     == normalizedPath(configPath)
@@ -742,6 +778,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
         self.activationLicenseClientOverride = activationLicenseClient
         self.currentLocalWorkerExecutionContexts =
             dependencies.localBotExecutionContexts
+        self.currentLocalBotConfigurations =
+            dependencies.localBotConfigurations
+        self.currentLocalBotExecutionConfigPaths =
+            dependencies.localBotExecutionConfigPaths
         self.configPath = dependencies.preferences.string(forKey: Self.configPathPreferenceKey)
             ?? dependencies.fileWriter.applicationSupportDirectory
                 .appendingPathComponent("config.local.json")
@@ -1382,7 +1422,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
 
         var candidates: [DesktopLocalBotCandidate] = []
-        for configuration in dependencies.localBotConfigurations {
+        for configuration in currentLocalBotConfigurations {
             let configurationURL = URL(filePath: configuration.configPath)
                 .standardizedFileURL
             guard dependencies.fileWriter.fileExists(at: configurationURL) else {
@@ -2326,6 +2366,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func previewStartDaemon() {
         guard requireProductionDaemonStartAuthorization() else { return }
+        if keychainWorkerLaunchAgentActive
+            || (!existingLocalAgentAccessAvailable
+                && keychainWorkerLaunchAgentInstallAvailable)
+        {
+            previewKeychainWorkerLaunchAgent()
+            return
+        }
         runCLI(arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: startDaemonDryRunCommand)
     }
 
@@ -2336,6 +2383,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func startDaemon() {
         guard requireProductionDaemonStartAuthorization() else { return }
+        if keychainWorkerLaunchAgentActive
+            || (!existingLocalAgentAccessAvailable
+                && keychainWorkerLaunchAgentInstallAvailable)
+        {
+            installAndStartKeychainWorkerLaunchAgent()
+            return
+        }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
@@ -2421,7 +2475,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func openLocalWorkerUpdateGuide() {
-        if let localWorkerExecutionContextProvider {
+        if dependencies.localBotDiscoveryProvider != nil {
+            refreshLocalBotDiscovery()
+            if localWorkerCLIAvailable {
+                lastError = nil
+                return
+            }
+        } else if let localWorkerExecutionContextProvider {
             currentLocalWorkerExecutionContexts =
                 localWorkerExecutionContextProvider()
             if localWorkerCLIAvailable {
@@ -2434,6 +2494,146 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         lastError = nil
+    }
+
+    private func previewKeychainWorkerLaunchAgent() {
+        guard let request = keychainWorkerLaunchAgentRequest() else {
+            return
+        }
+        let manager = dependencies.keychainWorkerLaunchAgentManager
+        isKeychainWorkerLaunchAgentOperationInProgress = true
+        keychainWorkerLaunchAgentStatus =
+            "Validating the signed app, selected config, and installed worker…"
+        Task { [weak self] in
+            do {
+                let status = try await manager.preview(request: request)
+                guard let self else { return }
+                self.isKeychainWorkerLaunchAgentOperationInProgress = false
+                self.keychainWorkerLaunchAgentStatus = status
+                self.lastError = nil
+            } catch {
+                guard let self else { return }
+                self.isKeychainWorkerLaunchAgentOperationInProgress = false
+                self.lastError = NeonDiffRedactor.redact(
+                    error.localizedDescription
+                )
+                self.keychainWorkerLaunchAgentStatus =
+                    self.lastError ?? "Worker LaunchAgent preview failed."
+            }
+        }
+    }
+
+    private func installAndStartKeychainWorkerLaunchAgent() {
+        guard let request = keychainWorkerLaunchAgentRequest() else {
+            return
+        }
+        let manager = dependencies.keychainWorkerLaunchAgentManager
+        isKeychainWorkerLaunchAgentOperationInProgress = true
+        keychainWorkerLaunchAgentStatus =
+            "Installing and starting the secret-free local review worker…"
+        Task { [weak self] in
+            do {
+                let status = try await manager.installAndStart(
+                    request: request
+                )
+                guard let self else { return }
+                self.refreshLocalBotDiscovery()
+                self.isKeychainWorkerLaunchAgentOperationInProgress = false
+                self.keychainWorkerLaunchAgentStatus = status
+                self.lastError = nil
+                self.onboardingFlow.daemonBootstrapChecked = true
+                self.checkLocalWorkerReviewCompatibility()
+            } catch {
+                guard let self else { return }
+                self.isKeychainWorkerLaunchAgentOperationInProgress = false
+                self.lastError = NeonDiffRedactor.redact(
+                    error.localizedDescription
+                )
+                self.keychainWorkerLaunchAgentStatus =
+                    self.lastError ?? "Worker LaunchAgent install failed."
+                self.onboardingFlow.daemonBootstrapChecked = false
+            }
+        }
+    }
+
+    private func keychainWorkerLaunchAgentRequest()
+        -> DesktopKeychainWorkerLaunchAgentRequest?
+    {
+        guard let appID = storedBYOGitHubAppId else {
+            lastError =
+                "Store and verify the customer-owned GitHub App before installing the worker service."
+            keychainWorkerLaunchAgentStatus =
+                lastError ?? "GitHub App setup required."
+            return nil
+        }
+        let homeDirectory = dependencies.fileWriter
+            .applicationSupportDirectory
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        do {
+            return try DesktopKeychainWorkerLaunchAgentRequest(
+                appID: appID,
+                configPath: configPath,
+                launchdLabel: launchdLabel,
+                homeDirectory: homeDirectory
+            )
+        } catch {
+            lastError = NeonDiffRedactor.redact(error.localizedDescription)
+            keychainWorkerLaunchAgentStatus =
+                lastError ?? "The worker coordinates are invalid."
+            return nil
+        }
+    }
+
+    private func refreshLocalBotDiscovery() {
+        guard let provider = dependencies.localBotDiscoveryProvider else {
+            return
+        }
+        let snapshot = provider(launchdLabel)
+        currentLocalBotConfigurations = snapshot.configurations
+        currentLocalWorkerExecutionContexts = snapshot.executionContexts
+        currentLocalBotExecutionConfigPaths = snapshot.executionContexts
+            .map(\.configPath)
+            .filter { !$0.isEmpty }
+    }
+
+    private func runtimeCredentialsForReview() -> Data?
+    {
+        guard dependencies.productionBoundary.byoGitHubEnabled,
+              byoGitHubCredentialsStored,
+              byoGitHubCredentialsVerified,
+              let appID = storedBYOGitHubAppId
+        else {
+            return nil
+        }
+        if existingLocalAgentAccessAvailable,
+           !keychainWorkerLaunchAgentActive {
+            return nil
+        }
+        do {
+            guard let privateKey = try dependencies.secretStore.readSecret(
+                account: BYOGitHubAppKeychainAccount.privateKey,
+                allowUserInteraction: false
+            ),
+            let licenseKey = try dependencies.secretStore.readSecret(
+                account: activationKeyAccount,
+                allowUserInteraction: false
+            ) else {
+                throw BYOGitHubAppCredentialError.invalidPrivateKey
+            }
+            return try DesktopRuntimeCredentialEnvelope(
+                appID: appID,
+                privateKey: privateKey,
+                licenseKey: licenseKey
+            ).encodedData()
+        } catch {
+            lastError =
+                "The GitHub App or API-backed activation credential could not be read safely from Keychain."
+            scopedReviewStatus =
+                "Review blocked before worker execution because Keychain access failed."
+            return nil
+        }
     }
 
     package func runScopedDryReview() {
@@ -2460,7 +2660,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
             workerCompatibilityGeneration:
                 localWorkerReviewCompatibilityGeneration
         )
-        let arguments = [
+        let runtimeCredentials = runtimeCredentialsForReview()
+        if dependencies.productionBoundary.byoGitHubEnabled,
+           byoGitHubCredentialsStored,
+           runtimeCredentials == nil {
+            return
+        }
+        var arguments = [
             "review-pr",
             "--config", configPath,
             "--repo", repository,
@@ -2469,6 +2675,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "--dry-run", "true",
             "--zcode", "true"
         ]
+        if runtimeCredentials != nil {
+            arguments += [
+                "--runtime-credentials-stdin", "true"
+            ]
+        }
+        var standardInput = runtimeCredentials
         let executablePath = cliPath
         let cli = dependencies.cli
         invalidateScopedReviewApproval()
@@ -2486,11 +2698,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         ].joined(separator: " ")
 
         scopedReviewTask = Task.detached {
+            defer {
+                if let count = standardInput?.count {
+                    standardInput?.resetBytes(in: 0..<count)
+                }
+            }
             do {
                 let result = try await cli.run(
                     executablePath: executablePath,
                     arguments: arguments,
-                    standardInput: nil,
+                    standardInput: standardInput,
                     timeout: 600
                 )
                 await MainActor.run {
@@ -2526,7 +2743,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
-        let arguments = [
+        let runtimeCredentials = runtimeCredentialsForReview()
+        if dependencies.productionBoundary.byoGitHubEnabled,
+           byoGitHubCredentialsStored,
+           runtimeCredentials == nil {
+            return
+        }
+        var arguments = [
             "review-pr",
             "--config", approval.configPath,
             "--repo", approval.repo,
@@ -2537,6 +2760,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
             "--confirm", "true",
             "--zcode", "true"
         ]
+        if runtimeCredentials != nil {
+            arguments += [
+                "--runtime-credentials-stdin", "true"
+            ]
+        }
+        var standardInput = runtimeCredentials
         let executablePath = cliPath
         let cli = dependencies.cli
         isScopedReviewInProgress = true
@@ -2554,11 +2783,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         ].joined(separator: " ")
 
         scopedReviewTask = Task.detached {
+            defer {
+                if let count = standardInput?.count {
+                    standardInput?.resetBytes(in: 0..<count)
+                }
+            }
             do {
                 let result = try await cli.run(
                     executablePath: executablePath,
                     arguments: arguments,
-                    standardInput: nil,
+                    standardInput: standardInput,
                     timeout: 600
                 )
                 await MainActor.run {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -433,6 +433,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         productionUsefulWorkAvailable
             && reviewTargetRuntimeReady
             && scopedReviewProviderReady
+            && !isKeychainWorkerLaunchAgentOperationInProgress
             && (
                 !dependencies.productionBoundary.byoGitHubEnabled
                     || existingLocalAgentAccessAvailable

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -83,11 +83,14 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
     private let standardInputWriter: (Int32, UnsafeRawPointer?, Int) -> Int
     private let beforeProcessLaunch: () -> Void
     private let afterProcessLaunch: () -> Void
+    private let processStartedValidator: @Sendable (Int32) -> Bool
 
     public init(
         executablePath: String,
         workingDirectory: URL? = nil,
-        environmentOverrides: [String: String] = [:]
+        environmentOverrides: [String: String] = [:],
+        processStartedValidator:
+            @escaping @Sendable (Int32) -> Bool = { _ in true }
     ) {
         self.executablePath = executablePath
         self.workingDirectory = workingDirectory
@@ -99,6 +102,7 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
         }
         self.beforeProcessLaunch = {}
         self.afterProcessLaunch = {}
+        self.processStartedValidator = processStartedValidator
     }
 
     @_spi(Testing) public init(
@@ -111,7 +115,9 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
             Darwin.write(descriptor, buffer, count)
         },
         beforeProcessLaunch: @escaping () -> Void = {},
-        afterProcessLaunch: @escaping () -> Void = {}
+        afterProcessLaunch: @escaping () -> Void = {},
+        processStartedValidator:
+            @escaping @Sendable (Int32) -> Bool = { _ in true }
     ) {
         self.executablePath = executablePath
         self.workingDirectory = workingDirectory
@@ -121,6 +127,7 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
         self.standardInputWriter = standardInputWriter
         self.beforeProcessLaunch = beforeProcessLaunch
         self.afterProcessLaunch = afterProcessLaunch
+        self.processStartedValidator = processStartedValidator
     }
 
     public func run(
@@ -247,6 +254,18 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting, @unchecked Sendable 
             throw NeonDiffCLIError.launchFailed("Failed to launch NeonDiff CLI at \(executablePath): \(error.localizedDescription)")
         }
         afterProcessLaunch()
+        guard processStartedValidator(process.processIdentifier) else {
+            try? stdinWriteHandle?.close()
+            try? stdout.fileHandleForReading.close()
+            try? stderr.fileHandleForReading.close()
+            try terminateAndReap(
+                process,
+                terminationObserved: terminationObserved
+            )
+            throw NeonDiffCLIError.launchFailed(
+                "The credential-bearing NeonDiff worker failed signed-process validation"
+            )
+        }
 
         var inputOffset = 0
         var inputClosed = standardInput == nil

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import NeonDiffDesktopAppCore
+
+@Suite struct DesktopKeychainWorkerLaunchAgentTests {
+    private let home = URL(filePath: "/Users/test")
+    private let appExecutable = URL(
+        filePath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiff"
+    )
+    private let label = "com.electricsheephq.evaos-code-review-bot"
+    private let appID = "4184532"
+
+    @Test func plistContainsOnlyPublicExactCoordinates() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let request = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            configPath: config.path,
+            launchdLabel: label,
+            homeDirectory: home
+        )
+        let data = try DesktopKeychainWorkerLaunchAgentContract.propertyListData(
+            request: request,
+            appExecutableURL: appExecutable
+        )
+        let text = String(decoding: data, as: UTF8.self)
+
+        #expect(!text.localizedCaseInsensitiveContains("private key"))
+        #expect(!text.contains("github/byo-app/private-key"))
+        #expect(!text.contains("NEONDIFF_GITHUB_APP_PRIVATE_KEY"))
+
+        let parsed = try #require(
+            DesktopKeychainWorkerLaunchAgentContract.parsePropertyList(
+                data,
+                expectedLabel: label,
+                homeDirectory: home,
+                appExecutableIsSafe: { $0 == self.appExecutable },
+                configExists: { $0 == config }
+            )
+        )
+        #expect(parsed == request)
+    }
+
+    @Test func headlessArgumentsFailClosedOutsideAccountConfigOrExactAppIdentity() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let arguments = [
+            "--neondiff-worker-daemon",
+            "--config", config.path,
+            "--launchd-label", label,
+            "--github-app-id", appID
+        ]
+
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseHeadlessArguments(
+            arguments,
+            homeDirectory: home
+        ) != nil)
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseHeadlessArguments(
+            [
+                "--neondiff-worker-daemon",
+                "--config", "/tmp/config.local.json",
+                "--launchd-label", label,
+                "--github-app-id", appID
+            ],
+            homeDirectory: home
+        ) == nil)
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseHeadlessArguments(
+            arguments + ["--private-key", "forbidden"],
+            homeDirectory: home
+        ) == nil)
+    }
+
+    @Test func runtimeEnvelopeContainsBothKeychainSecretsOnlyInBoundedInput() throws {
+        let privateKeyLabel = "PRIVATE" + " KEY"
+        let privateKey = """
+        -----BEGIN \(privateKeyLabel)-----
+        ZmFrZS1maXh0dXJlLXByaXZhdGUta2V5
+        -----END \(privateKeyLabel)-----
+        """
+        let data = try DesktopRuntimeCredentialEnvelope(
+            appID: appID,
+            privateKey: privateKey,
+            licenseKey: "nd_live_runtime_fixture_1234"
+        ).encodedData()
+        let object = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(object["schemaVersion"] as? Int == 1)
+        #expect(object["githubAppId"] as? String == appID)
+        #expect(object["githubPrivateKey"] as? String == privateKey)
+        #expect(
+            object["licenseKey"] as? String
+                == "nd_live_runtime_fixture_1234"
+        )
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite struct DesktopKeychainWorkerLaunchAgentTests {
     private let home = URL(filePath: "/Users/test")
     private let appExecutable = URL(
-        filePath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiff"
+        filePath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop"
     )
     private let label = "com.electricsheephq.evaos-code-review-bot"
     private let appID = "4184532"
@@ -93,6 +93,129 @@ import Testing
         #expect(
             object["licenseKey"] as? String
                 == "nd_live_runtime_fixture_1234"
+        )
+    }
+
+    @Test func credentialBearingCommandsRequireTheSignedBundledWorker() {
+        #expect(DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "review-pr",
+                "--config", "/fixture/config.local.json",
+                "--runtime-credentials-stdin", "true"
+            ],
+            hasStandardInput: true
+        ))
+        #expect(DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "doctor", "github",
+                "--config", "/fixture/config.local.json",
+                "--github-app-private-key-stdin", "true"
+            ],
+            hasStandardInput: true
+        ))
+        #expect(DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "license", "activate",
+                "--license-key-stdin", "true"
+            ],
+            hasStandardInput: true
+        ))
+        #expect(!DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "review-pr",
+                "--config", "/fixture/config.local.json"
+            ],
+            hasStandardInput: false
+        ))
+    }
+
+    @Test func trustedBundledWorkerUsesOnlySealedAppCoordinates() throws {
+        let app = URL(filePath: "/Applications/NeonDiff.app")
+        let context = try #require(
+            DesktopTrustedBundledWorkerContract.executionContext(
+                appBundleURL: app,
+                appSignatureIsValid: { $0 == app },
+                sealedFileIsValid: {
+                    [
+                        "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
+                    ].contains($0.path)
+                }
+            )
+        )
+        #expect(
+            context.executablePath
+                == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
+        )
+        #expect(context.argumentPrefix.isEmpty)
+        #expect(context.environmentOverrides.isEmpty)
+        #expect(DesktopTrustedBundledWorkerContract.executionContext(
+            appBundleURL: app,
+            appSignatureIsValid: { _ in false },
+            sealedFileIsValid: { _ in true }
+        ) == nil)
+    }
+
+    @Test func launchctlReadinessRequiresAStableRunningPID() {
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.runningPID(
+                launchctlPrint: """
+                state = running
+                pid = 41845
+                """
+            ) == 41845
+        )
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.runningPID(
+                launchctlPrint: """
+                state = waiting
+                last exit code = 78
+                """
+            ) == nil
+        )
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.runningPID(
+                launchctlPrint: """
+                state = running
+                pid = 0
+                """
+            ) == nil
+        )
+    }
+
+    @Test func sealedWorkerWinsCleanSetupResolutionOverMutableInstalledWorker() {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        ).path
+        let sealed = DesktopLocalBotExecutionContext(
+            configPath: "",
+            executablePath:
+                "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+            argumentPrefix: [],
+            environmentOverrides: [:]
+        )
+        let mutable = DesktopLocalBotExecutionContext(
+            configPath: "",
+            executablePath: "/opt/homebrew/bin/node",
+            argumentPrefix: [
+                "\(home.path)/Library/Application Support/NeonDiffDesktop/Workers/\(label)/current/node_modules/neondiff/dist/src/cli.js"
+            ],
+            environmentOverrides: [:]
+        )
+        let arguments = ["init", "--config", config]
+
+        #expect(
+            DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                executablePath: "neondiff",
+                arguments: arguments,
+                executionContexts: [mutable, sealed]
+            ) == sealed.executablePath
+        )
+        #expect(
+            DesktopLocalBotExecutionContextResolver.resolveArguments(
+                executablePath: "neondiff",
+                arguments: arguments,
+                executionContexts: [mutable, sealed]
+            ) == arguments
         )
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -766,6 +766,7 @@ import NeonDiffDesktopCore
         ]
         let readChecks =
             #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+        let reviewHeadSHA = String(repeating: "a", count: 40)
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
                 .success(CLIRunResult(
@@ -795,6 +796,11 @@ import NeonDiffDesktopCore
                      "privateRepoAllowed":true,"updateEntitlement":true,
                      "plan":"internal-owner-recovery","seats":1}}
                     """,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","dryRun":true,"useZCode":true,"scope":{"repo":"\#(targetRepository)","pullNumber":760,"headSha":"\#(reviewHeadSHA)","url":"https://github.com/\#(targetRepository)/pull/760"},"result":{"reposScanned":1,"pullsSeen":1,"reviewed":1,"failed":0,"skippedProcessed":0}}"#,
                     stderr: ""
                 ))
             ],
@@ -871,6 +877,25 @@ import NeonDiffDesktopCore
             fixture.model.existingLocalBotBYOGitHubVerificationStatus
                 .contains("entitlement")
         )
+
+        fixture.model.pendingReviewPullNumber = "760"
+        fixture.model.runScopedDryReview()
+        #expect(await reachesCallCount(fixture, 5))
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+        let reviewCall = try #require(fixture.cli.calls.last)
+        #expect(reviewCall.arguments == [
+            "review-pr",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--pr", "760",
+            "--expected-config-revision",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--dry-run", "true",
+            "--zcode", "true"
+        ])
+        #expect(reviewCall.standardInput == nil)
 
         fixture.model.applyAccountWorkspaceCatalog(.loaded([
             workspace(entitlement: .none)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CommandBuilderScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CommandBuilderScenarios.swift
@@ -67,6 +67,36 @@ import Darwin
     context.expect(standardInputResult.stdout.contains("\"receivedBytes\":22"), "CLI standard-input transport returns only redacted metadata")
     context.expect(!standardInputResult.stdout.contains("fixture-provider-value"), "CLI output never echoes standard input")
 
+    var rejectedWorkerWriteCalls = 0
+    let rejectedWorkerClient = NeonDiffCLIClient(
+        executablePath: localCLI.path,
+        workingDirectory: tempRoot,
+        standardInputWriter: { _, _, _ in
+            rejectedWorkerWriteCalls += 1
+            return 0
+        },
+        processStartedValidator: { _ in false }
+    )
+    var rejectedWorkerFailedClosed = false
+    do {
+        _ = try rejectedWorkerClient.run(
+            arguments: ["stdin-check"],
+            standardInput: Data("fixture-provider-value".utf8),
+            timeout: 5
+        )
+    } catch NeonDiffCLIError.launchFailed(let message) {
+        rejectedWorkerFailedClosed =
+            message.contains("signed-process validation")
+    }
+    context.expect(
+        rejectedWorkerFailedClosed,
+        "a rejected worker process fails closed before credential delivery"
+    )
+    context.expect(
+        rejectedWorkerWriteCalls == 0,
+        "a rejected worker process receives zero credential bytes"
+    )
+
     let environmentClient = NeonDiffCLIClient(
         executablePath: localCLI.path,
         workingDirectory: tempRoot,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -23,7 +23,7 @@ struct LegacyCoreChecksScenarioInventory: Sendable {
 
 let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChecksScenarioInventory] = [
     .onboardingFlowContracts: .init(assertionCount: 10, sortedMessageSHA256: "fa52ef66cfc15da0fc622891de083cb4f8c6989b75cda294aa0dce7965ffed11"),
-    .cliResolutionAndStandardInputContracts: .init(assertionCount: 6, sortedMessageSHA256: "562eaee1dd13c170588d3482b5a822bf6e1fe6d363d2221c908f47e857cf8889"),
+    .cliResolutionAndStandardInputContracts: .init(assertionCount: 8, sortedMessageSHA256: "5ebac651f7c224b7c6da0cfd1432bc89eba7b9dccca8f02d8c01ede48e0b48a9"),
     .cliCancellationContracts: .init(assertionCount: 10, sortedMessageSHA256: "4d93d68b30b32e326aad8d2f93dacf515d346cc3fb373a1a9061f829f3c0c0ad"),
     .cliStandardInputTimeoutContracts: .init(assertionCount: 14, sortedMessageSHA256: "a979b18020324519db8eb863c445a7bd2ca9d3a61f7f8e6a447a3742527864d4"),
     .cliCleanupDeadlineAndOutputContracts: .init(assertionCount: 15, sortedMessageSHA256: "8c562230f44b6c485ddbb0a3f414bb193a05f53a22207445c9da3590b39b2989"),
@@ -63,9 +63,9 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
             #expect(values.count == expected?.assertionCount, Comment("scenario \(scenario.rawValue) assertion count"))
             #expect(coreChecksSHA256(values.sorted()) == expected?.sortedMessageSHA256, Comment("scenario \(scenario.rawValue) message inventory"))
         }
-        #expect(messages.count == 399)
-        #expect(Set(messages).count == 305)
-        #expect(coreChecksSHA256(messages.sorted()) == "f2083dd698110687a5ca34d02c211c29fda4d25e4d0e007a03a5cef0d6de5ba0")
+        #expect(messages.count == 401)
+        #expect(Set(messages).count == 307)
+        #expect(coreChecksSHA256(messages.sorted()) == "64e75c14a9906ebf8df47ac2b7556d58b14c8408becabc07652e172e220431fc")
     }
 }
 

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -77,7 +77,7 @@ Minimum local visible-smoke checklist:
 
 1. Run `script/build_and_run.sh run` from `apps/neondiff-desktop/`.
 2. Record the source SHA and built app path, including the exact
-   `dist/NeonDiffDesktop.app` path passed to Computer Use.
+   `dist/NeonDiff.app` path passed to Computer Use.
 3. Record `Welcome visible`: the Welcome screen is present in the launched app.
 4. Navigate to the changed step.
 5. Record `changed button/action clicked`: click the changed button/action.
@@ -122,7 +122,7 @@ Before building, run the read-only credential doctor:
 ```sh
 apps/neondiff-desktop/script/preflight-credentials.sh
 apps/neondiff-desktop/script/preflight-credentials.sh --json \
-  > /Volumes/LEXAR/Codex/evidence/neondiff-desktop/<date>/<version>/credential-preflight.json
+  > /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/credential-preflight.json
 ```
 
 The doctor reports presence only. It does not sign, notarize, upload, fetch
@@ -145,7 +145,7 @@ Required owner/Codex inputs for a real signing run:
 - Sparkle public key as `NEONDIFF_SPARKLE_PUBLIC_ED_KEY`.
 - Sparkle feed URL as `NEONDIFF_SPARKLE_FEED_URL`.
 - Appcast hosting destination and rollback destination.
-- Evidence packet directory under `/Volumes/LEXAR/Codex/evidence/`.
+- Evidence packet directory under `/Users/m1/Codex/evidence/`.
 
 ## Build The Release App
 
@@ -167,16 +167,16 @@ script/build_and_run.sh release-bundle-check
 Expected output artifact:
 
 ```text
-apps/neondiff-desktop/dist/NeonDiffDesktop.app
+apps/neondiff-desktop/dist/NeonDiff.app
 ```
 
 Record the bundle metadata and checksum:
 
 ```sh
-/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" dist/NeonDiffDesktop.app/Contents/Info.plist
-/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" dist/NeonDiffDesktop.app/Contents/Info.plist
-/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" dist/NeonDiffDesktop.app/Contents/Info.plist
-shasum -a 256 dist/NeonDiffDesktop.app/Contents/MacOS/NeonDiffDesktop
+/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" dist/NeonDiff.app/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" dist/NeonDiff.app/Contents/Info.plist
+/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" dist/NeonDiff.app/Contents/Info.plist
+shasum -a 256 dist/NeonDiff.app/Contents/MacOS/NeonDiffDesktop
 ```
 
 Do not ship a dev/ad-hoc artifact from this step. The build is only a candidate
@@ -185,21 +185,29 @@ all pass.
 
 ## Codesign
 
-Sign the embedded framework first when `Sparkle.framework` exists, then sign the
-outer app with hardened runtime and timestamp enabled.
+Sign the sealed worker with its minimal Node JIT entitlements, then the embedded
+framework when it exists, and finally the outer app. Do not use `--deep` to
+replace the already-reviewed nested signatures.
 
 ```sh
 cd apps/neondiff-desktop
 IDENTITY="Developer ID Application: <Team Name> (<TEAMID>)"
-APP="dist/NeonDiffDesktop.app"
+APP="dist/NeonDiff.app"
 SPARKLE_FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework"
+SEALED_WORKER="$APP/Contents/Helpers/NeonDiffWorker"
+WORKER_ENTITLEMENTS="script/worker-runtime.entitlements.plist"
+
+codesign --force --options runtime --timestamp \
+  --entitlements "$WORKER_ENTITLEMENTS" \
+  --sign "$IDENTITY" "$SEALED_WORKER"
 
 if [ -d "$SPARKLE_FRAMEWORK" ]; then
   codesign --force --options runtime --timestamp --sign "$IDENTITY" "$SPARKLE_FRAMEWORK"
 fi
 
-codesign --force --deep --options runtime --timestamp --sign "$IDENTITY" "$APP"
+codesign --force --options runtime --timestamp --sign "$IDENTITY" "$APP"
 codesign --verify --deep --strict --verbose=2 "$APP"
+codesign -d --entitlements :- "$SEALED_WORKER"
 spctl -a -vv --type execute "$APP"
 ```
 
@@ -221,8 +229,8 @@ the notarization paths documented in #324.
 
 ```sh
 cd apps/neondiff-desktop
-APP="dist/NeonDiffDesktop.app"
-ZIP="/Volumes/LEXAR/Codex/evidence/neondiff-desktop/<date>/<version>/NeonDiffDesktop.zip"
+APP="dist/NeonDiff.app"
+ZIP="/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/NeonDiff.zip"
 
 ditto -c -k --keepParent "$APP" "$ZIP"
 shasum -a 256 "$ZIP"
@@ -275,7 +283,7 @@ fabricate a real Sparkle signature.
 ```sh
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture apps/neondiff-desktop/fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/<date>/<version>/neondiff-beta-appcast.xml \
+  --output /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/neondiff-beta-appcast.xml \
   --dry-run
 ```
 
@@ -315,7 +323,7 @@ License boundary:
 Create a public-safe packet under:
 
 ```text
-/Volumes/LEXAR/Codex/evidence/neondiff-desktop/<date>/<version>/
+/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/
 ```
 
 Minimum files:

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 MODE="${1:-run}"
 APP_NAME="NeonDiff"
 PRODUCT_NAME="NeonDiffDesktop"
-BUNDLE_NAME="NeonDiffDesktop"
+BUNDLE_NAME="NeonDiff"
 BUNDLE_ID="com.electricsheephq.NeonDiffDesktop"
 MIN_SYSTEM_VERSION="14.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$ROOT_DIR/../.." && pwd)"
 BUILD_CONFIGURATION="${NEONDIFF_DESKTOP_BUILD_CONFIGURATION:-debug}"
 case "$MODE" in
   release-build|release-bundle-check)
@@ -202,6 +203,10 @@ fi
 cp "$ROOT_DIR/Sources/NeonDiffDesktop/Resources/NeonDiff.icns" "$APP_RESOURCES/NeonDiff.icns"
 cp "$ROOT_DIR/Sources/NeonDiffDesktop/Resources/NeonDiff-Light.icns" "$APP_RESOURCES/NeonDiff-Light.icns"
 cp "$ROOT_DIR/Sources/NeonDiffDesktop/Resources/NeonDiff-Dark.icns" "$APP_RESOURCES/NeonDiff-Dark.icns"
+if [ "$BUILD_CONFIGURATION" = "release" ]; then
+  node "$REPO_ROOT/scripts/build-desktop-sealed-worker.mjs" \
+    --output "$APP_HELPERS/NeonDiffWorker"
+fi
 
 SPARKLE_FRAMEWORK="$(find "$BUILD_DIR" "$ROOT_DIR/.build" -path "*/Sparkle.framework" -type d -print -quit 2>/dev/null || true)"
 if otool -L "$APP_BINARY" | grep -q "Sparkle.framework"; then
@@ -303,6 +308,8 @@ case "$MODE" in
     test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleDisplayName' "$INFO_PLIST")" = "$APP_NAME"
     if [ "$BUILD_CONFIGURATION" = "release" ]; then
       "$SCRIPT_DIR/release-rpaths.sh" assert "$APP_BINARY"
+      test -x "$APP_HELPERS/NeonDiffWorker"
+      test "$("$APP_HELPERS/NeonDiffWorker" --version)" = "1.0.4"
     fi
     INVALID_BUNDLE_ROOT_ENTRIES="$(find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents -print)"
     if [ -n "$INVALID_BUNDLE_ROOT_ENTRIES" ]; then

--- a/apps/neondiff-desktop/script/release-proof.sh
+++ b/apps/neondiff-desktop/script/release-proof.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 APP_NAME="NeonDiff"
 EXECUTABLE_NAME="NeonDiffDesktop"
-BUNDLE_NAME="NeonDiffDesktop"
+BUNDLE_NAME="NeonDiff"
 ARTIFACT_NAME="NeonDiff.app.zip"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/apps/neondiff-desktop/script/worker-runtime.entitlements.plist
+++ b/apps/neondiff-desktop/script/worker-runtime.entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -346,14 +346,14 @@ After App access, provider, repository, and activation are verified, the native
 daemon step offers **Preview Start** followed by **Install & Start** when no
 supported LaunchAgent exists. Preview validates the exact signed
 `/Applications/NeonDiff.app`, account-scoped config, customer-owned App ID, and
-checksum-managed worker. Confirmed install writes one 0600 secret-free plist in
+the worker sealed inside the signed app. Confirmed install writes one 0600 secret-free plist in
 `~/Library/LaunchAgents` and starts it through the current user's launchd
 domain. The plist invokes the signed app's bounded headless mode and contains no
 private-key value or file path. That mode revalidates the same public
 coordinates, reads the App key from NeonDiff's own Keychain without user
 interaction, reads the API-backed activation credential from the same app-owned
-Keychain service, and pipes both values once in a bounded JSON envelope to the
-worker's stdin. A conflicting
+Keychain service, validates the running sealed worker process, and only then
+pipes both values once in a bounded JSON envelope to its stdin. A conflicting
 plist, unsafe app/config/worker path, unavailable Keychain item, or launchd
 failure fails closed. Do not replace this with a `security -w` wrapper, export
 the key to disk, or weaken its Keychain access control.
@@ -519,8 +519,11 @@ passing doctor proves only current installation/repository read access for the
 configured allowlist; it does not execute or post a review.
 
 The signed Mac app uses the same bounded stdin credential contract for
-`review-pr` and the raw long-running daemon. `daemon start|stop|status` control
-subcommands never accept secret stdin. Runtime-only private-key material is
+`review-pr` and the raw long-running daemon. It routes every credential-bearing
+CLI operation to the single executable worker sealed inside the Developer
+ID-signed app and validates the live process before writing stdin.
+`daemon start|stop|status` control subcommands never accept secret stdin.
+Runtime-only private-key material is
 non-enumerable in the in-memory config object, overrides file/token credentials
 for that operation, and is never accepted from JSON config. Runtime-only
 activation material remains outside the config object and is available only to

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -342,6 +342,22 @@ gates. No invitation is required when the versioned public GitHub prerelease is
 published and the neondiff.com purchase/download path is live. Until both are
 true, the candidate and its GitHub prerelease assets remain held.
 
+After App access, provider, repository, and activation are verified, the native
+daemon step offers **Preview Start** followed by **Install & Start** when no
+supported LaunchAgent exists. Preview validates the exact signed
+`/Applications/NeonDiff.app`, account-scoped config, customer-owned App ID, and
+checksum-managed worker. Confirmed install writes one 0600 secret-free plist in
+`~/Library/LaunchAgents` and starts it through the current user's launchd
+domain. The plist invokes the signed app's bounded headless mode and contains no
+private-key value or file path. That mode revalidates the same public
+coordinates, reads the App key from NeonDiff's own Keychain without user
+interaction, reads the API-backed activation credential from the same app-owned
+Keychain service, and pipes both values once in a bounded JSON envelope to the
+worker's stdin. A conflicting
+plist, unsafe app/config/worker path, unavailable Keychain item, or launchd
+failure fails closed. Do not replace this with a `security -w` wrapper, export
+the key to disk, or weaken its Keychain access control.
+
 After Checkout displays the one-shot NeonDiff Activation Key, return to the
 native **License** pane, paste the key, and choose **Continue with this key**,
 then **Activate**. **Buy an Activation Key** opens the public pricing page but
@@ -501,6 +517,14 @@ config, logs, or evidence. The reconciled-existing-worker path may supply only
 the already-configured private-key file path to the exact child process. A
 passing doctor proves only current installation/repository read access for the
 configured allowlist; it does not execute or post a review.
+
+The signed Mac app uses the same bounded stdin credential contract for
+`review-pr` and the raw long-running daemon. `daemon start|stop|status` control
+subcommands never accept secret stdin. Runtime-only private-key material is
+non-enumerable in the in-memory config object, overrides file/token credentials
+for that operation, and is never accepted from JSON config. Runtime-only
+activation material remains outside the config object and is available only to
+the current async review or daemon operation.
 
 Check:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -167,6 +167,18 @@ integration proof under #630.
    command. Source support does not prove that immutable release publication,
    signing, clean-Mac execution, review, or daemon readiness has passed.
 
+8. After App access, provider, repository, and activation are verified, use the
+   native daemon step's **Preview Start** and **Install & Start** actions. The
+   signed app writes a secret-free LaunchAgent that points back to
+   `/Applications/NeonDiff.app` with only the public App ID, exact selected
+   config, and launchd label. Its headless mode validates the checksum-managed
+   worker, reads the private key and API-backed activation credential from the
+   app-owned Keychain, and hands them to the local worker only through one
+   bounded JSON stdin envelope. It never exports either secret, writes a PEM or
+   license file, places a secret in the plist or environment, or uses a generic
+   `security -w` wrapper. Any coordinate mismatch or unavailable Keychain item
+   fails closed before the worker starts.
+
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native
 **License** pane. The **Buy an Activation Key** control opens the public pricing

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^24.0.15",
         "@types/validate-npm-package-license": "^3.0.3",
         "ajv": "^8.20.0",
+        "esbuild": "0.28.1",
         "jose": "^6.2.3",
         "sigstore": "^5.0.0",
         "stripe": "^22.3.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "scripts": {
     "build": "node scripts/prepare-build-output.mjs && tsc -p tsconfig.build.json",
+    "build:desktop-worker": "node scripts/build-desktop-sealed-worker.mjs",
     "postbuild": "chmod +x dist/src/cli.js && node scripts/generate-secret-rules.mjs --check-node",
     "cli": "tsx src/cli.ts",
     "test": "vitest run",
@@ -66,6 +67,7 @@
     "@types/node": "^24.0.15",
     "@types/validate-npm-package-license": "^3.0.3",
     "ajv": "^8.20.0",
+    "esbuild": "0.28.1",
     "jose": "^6.2.3",
     "sigstore": "^5.0.0",
     "stripe": "^22.3.0",

--- a/scripts/build-desktop-sealed-worker.mjs
+++ b/scripts/build-desktop-sealed-worker.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const NODE_VERSION = "26.7.0";
+const NODE_ARCHIVES = {
+  arm64: {
+    filename: `node-v${NODE_VERSION}-darwin-arm64.tar.gz`,
+    sha256: "7ee659a7768e641bbfd5360940660b8e8fd0052f77488f365562bac522fc15d4"
+  },
+  x64: {
+    filename: `node-v${NODE_VERSION}-darwin-x64.tar.gz`,
+    sha256: "f279d1ed28ce57f7788bf23435d2ad7fdd7438904ad5c4d8a1081a7cde3d4b96"
+  }
+};
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseOutputArgument(values) {
+  if (values.length !== 2 || values[0] !== "--output" || !values[1]?.startsWith("/")) {
+    fail("usage: build-desktop-sealed-worker.mjs --output /absolute/path");
+  }
+  return resolve(values[1]);
+}
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function main() {
+  if (process.platform !== "darwin") {
+    fail("the sealed desktop worker can be built only on macOS");
+  }
+  const archive = NODE_ARCHIVES[process.arch];
+  if (!archive) {
+    fail(`unsupported sealed worker architecture: ${process.arch}`);
+  }
+  const output = parseOutputArgument(process.argv.slice(2));
+  if (existsSync(output)) {
+    fail("sealed worker output must not already exist");
+  }
+
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const staging = mkdtempSync(join(tmpdir(), "neondiff-sealed-worker-"));
+  const cacheDirectory = join(
+    homedir(),
+    "Library",
+    "Caches",
+    "NeonDiff",
+    "node-runtime"
+  );
+  const archivePath = process.env.NEONDIFF_NODE_RUNTIME_ARCHIVE
+    ? resolve(process.env.NEONDIFF_NODE_RUNTIME_ARCHIVE)
+    : join(cacheDirectory, archive.filename);
+  try {
+    mkdirSync(cacheDirectory, { recursive: true, mode: 0o700 });
+    if (!existsSync(archivePath)) {
+      execFileSync("/usr/bin/curl", [
+        "--fail",
+        "--location",
+        "--silent",
+        "--show-error",
+        "--output",
+        archivePath,
+        `https://nodejs.org/dist/v${NODE_VERSION}/${archive.filename}`
+      ], { stdio: ["ignore", "ignore", "pipe"] });
+    }
+    if (sha256(archivePath) !== archive.sha256) {
+      fail("the pinned Node runtime archive failed SHA-256 verification");
+    }
+
+    const bundlePath = join(staging, "neondiff-worker.mjs");
+    execFileSync(process.execPath, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    build({
+      entryPoints: [join(repoRoot, "src", "cli.ts")],
+      outfile: bundlePath,
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      target: "node26",
+      sourcemap: false,
+      logLevel: "silent"
+    });
+
+    execFileSync("/usr/bin/tar", [
+      "-xzf",
+      archivePath,
+      "-C",
+      staging
+    ], { stdio: ["ignore", "ignore", "pipe"] });
+    const extractedRoot = join(
+      staging,
+      archive.filename.replace(/\.tar\.gz$/, "")
+    );
+    const nodePath = realpathSync(join(extractedRoot, "bin", "node"));
+    const seaConfigPath = join(staging, "sea-config.json");
+    writeFileSync(
+      seaConfigPath,
+      `${JSON.stringify({
+        main: bundlePath,
+        mainFormat: "module",
+        output,
+        disableExperimentalSEAWarning: true
+      }, null, 2)}\n`,
+      { mode: 0o600 }
+    );
+    mkdirSync(dirname(output), { recursive: true, mode: 0o755 });
+    execFileSync(nodePath, ["--build-sea", seaConfigPath], {
+      cwd: staging,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    chmodSync(output, 0o755);
+    execFileSync("/usr/bin/codesign", [
+      "--force",
+      "--options",
+      "runtime",
+      "--entitlements",
+      join(
+        repoRoot,
+        "apps",
+        "neondiff-desktop",
+        "script",
+        "worker-runtime.entitlements.plist"
+      ),
+      "--sign",
+      "-",
+      output
+    ], { stdio: ["ignore", "ignore", "pipe"] });
+    const reportedVersion = execFileSync(output, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    }).trim();
+    if (reportedVersion !== "1.0.4") {
+      fail(`sealed worker reports unexpected version ${reportedVersion}`);
+    }
+    const dependencies = execFileSync("/usr/bin/otool", ["-L", output], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    }).split("\n").slice(1).map((line) => line.trim()).filter(Boolean);
+    if (dependencies.some(
+      (line) => !line.startsWith("/System/Library/")
+        && !line.startsWith("/usr/lib/")
+    )) {
+      fail("sealed worker has a non-system dynamic library dependency");
+    }
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,7 @@ import { parsePositiveInteger } from "./cli-args.js";
 import { readSecretFromStdin } from "./secret-stdin.js";
 import { classifyCommandLicensePolicy, type CommandLicensePolicy } from "./command-license-policy.js";
 import {
+  applyRuntimeGitHubCredentials,
   resolveRuntimeGitHubCredentials,
   resolveRuntimeCredentialEnvelope,
   withRuntimeGitHubCredentials,
@@ -1137,10 +1138,12 @@ async function main(): Promise<void> {
     const generatedAt = args["generated-at"] ?? new Date().toISOString();
     parseCanonicalIsoTimestamp(generatedAt, "--generated-at");
     const relatedConfig = config.githubRelatedContext!;
-    const github = new GitHubApi({
+    const githubConfig = {
       ...config.github,
       requestTimeoutMs: relatedConfig.requestTimeoutMs
-    });
+    };
+    applyRuntimeGitHubCredentials(githubConfig);
+    const github = new GitHubApi(githubConfig);
     const pull = await github.getPull(repo, pullNumber);
     const result = await buildGitHubRelatedContextPacket({
       repo,
@@ -2352,6 +2355,13 @@ async function main(): Promise<void> {
   if (command === "daemon") {
     const daemonAction = args._[1];
     if (daemonAction === "start" || daemonAction === "stop" || daemonAction === "status") {
+      if (args["runtime-credentials-stdin"] !== undefined
+        || args["github-app-private-key-stdin"] !== undefined
+        || args["github-app-id"] !== undefined) {
+        throw new Error(
+          "credential stdin is supported only for the raw daemon process, not daemon start, stop, or status"
+        );
+      }
       if (daemonAction === "start"
         && args["dry-run"] === "false"
         && args.confirm === "true") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,6 +135,12 @@ import { resolveZCodeProviderEnv } from "./zcode-env.js";
 import { parsePositiveInteger } from "./cli-args.js";
 import { readSecretFromStdin } from "./secret-stdin.js";
 import { classifyCommandLicensePolicy, type CommandLicensePolicy } from "./command-license-policy.js";
+import {
+  resolveRuntimeGitHubCredentials,
+  resolveRuntimeCredentialEnvelope,
+  withRuntimeGitHubCredentials,
+  type RuntimeGitHubCredentials
+} from "./runtime-github-credentials.js";
 
 const LAUNCHCTL_TIMEOUT_MS = 15_000;
 const PLUTIL_TIMEOUT_MS = 5_000;
@@ -2116,29 +2122,35 @@ async function main(): Promise<void> {
       process.exitCode = 1;
       return;
     }
-    const result = await runOnceCliCommand({
-      options: {
-        configPath: args.config,
-        dryRun,
-        repo,
-        pullNumber,
-        useZCode,
-        expectedHeadSha: reviewPrExpectedHeadSha,
-        expectedConfigRevision,
-        processedHeadPolicy:
-          command === "review-pr" && !dryRun && reviewPrExpectedHeadSha
-            ? "approved_dry_run"
-            : command === "review-pr" && dryRun
-              ? "refresh_dry_run"
-              : "normal"
-      },
-      commandName: command,
-      admitImpl: async () => {
-        const admission = await requireClassifiedCommandAdmission(commandLicensePolicy, args.config);
-        if (!admission) throw new Error("review commands require production license admission");
-        return admission;
-      }
-    });
+    const runtimeGitHubCredentials = command === "review-pr"
+      ? await resolveCLIReviewRuntimeCredentials(args)
+      : undefined;
+    const result = await withRuntimeGitHubCredentials(
+      runtimeGitHubCredentials,
+      () => runOnceCliCommand({
+        options: {
+          configPath: args.config,
+          dryRun,
+          repo,
+          pullNumber,
+          useZCode,
+          expectedHeadSha: reviewPrExpectedHeadSha,
+          expectedConfigRevision,
+          processedHeadPolicy:
+            command === "review-pr" && !dryRun && reviewPrExpectedHeadSha
+              ? "approved_dry_run"
+              : command === "review-pr" && dryRun
+                ? "refresh_dry_run"
+                : "normal"
+        },
+        commandName: command,
+        admitImpl: async () => {
+          const admission = await requireClassifiedCommandAdmission(commandLicensePolicy, args.config);
+          if (!admission) throw new Error("review commands require production license admission");
+          return admission;
+        }
+      })
+    );
     console.log(result.output);
     if (result.exitCode !== 0) process.exitCode = result.exitCode;
     return;
@@ -2353,38 +2365,89 @@ async function main(): Promise<void> {
     if (daemonAction) {
       throw new Error("daemon subcommand must be one of: start, stop, status");
     }
-    const config = loadConfig(args.config);
-    const monitoredRepos = listReposToScan(config);
-    let cycle = 0;
-    const runOnce = args.once === "true";
-    for (;;) {
-      cycle += 1;
-      const dryRun = args["dry-run"] !== "false";
-      const cleanupIntervalCycles = Math.max(1, Math.ceil(config.worktreeCleanup!.intervalMs / config.pollIntervalMs));
-      const cycleResult = await runDaemonCycle({
-        cycle,
-        dryRun,
-        pilotRepos: config.pilotRepos,
-        monitoredRepos,
-        canaryPulls: config.canaryPulls ?? [],
-        commandsEnabled: config.commands.enabled,
-        reviewSchedulerEnabled: config.reviewScheduler?.enabled === true,
-        issueEnrichmentEnabled: config.issueEnrichment?.enabled === true,
-        worktreeCleanupDue: config.worktreeCleanup!.enabled && (cycle === 1 || (cycle - 1) % cleanupIntervalCycles === 0),
-        configPath: args.config
-      });
-      if (shouldExitDaemonAfterFailedCycle(cycleResult, runOnce)) {
-        process.exitCode = 1;
-        return;
-      }
-      if (runOnce) {
-        return;
-      }
-      await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
-    }
+    const runtimeGitHubCredentials =
+      await resolveCLIDaemonRuntimeCredentials(args);
+    await withRuntimeGitHubCredentials(
+      runtimeGitHubCredentials,
+      () => runRawDaemon(args)
+    );
+    return;
   }
 
   throw new Error(`Unknown command: ${command ?? "(missing)"}`);
+}
+
+async function runRawDaemon(args: ParsedArgs): Promise<void> {
+  const config = loadConfig(args.config);
+  const monitoredRepos = listReposToScan(config);
+  let cycle = 0;
+  const runOnce = args.once === "true";
+  for (;;) {
+    cycle += 1;
+    const dryRun = args["dry-run"] !== "false";
+    const cleanupIntervalCycles = Math.max(
+      1,
+      Math.ceil(config.worktreeCleanup!.intervalMs / config.pollIntervalMs)
+    );
+    const cycleResult = await runDaemonCycle({
+      cycle,
+      dryRun,
+      pilotRepos: config.pilotRepos,
+      monitoredRepos,
+      canaryPulls: config.canaryPulls ?? [],
+      commandsEnabled: config.commands.enabled,
+      reviewSchedulerEnabled: config.reviewScheduler?.enabled === true,
+      issueEnrichmentEnabled: config.issueEnrichment?.enabled === true,
+      worktreeCleanupDue:
+        config.worktreeCleanup!.enabled
+        && (cycle === 1 || (cycle - 1) % cleanupIntervalCycles === 0),
+      configPath: args.config
+    });
+    if (shouldExitDaemonAfterFailedCycle(cycleResult, runOnce)) {
+      process.exitCode = 1;
+      return;
+    }
+    if (runOnce) return;
+    await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+  }
+}
+
+async function resolveCLIReviewRuntimeCredentials(
+  args: ParsedArgs
+): Promise<RuntimeGitHubCredentials | undefined> {
+  const envelope = await resolveRuntimeCredentialEnvelope({
+    command: "review-pr",
+    subcommand: undefined,
+    runtimeCredentialsStdin: args["runtime-credentials-stdin"],
+    stdin: process.stdin
+  });
+  if (envelope) return envelope;
+  return resolveRuntimeGitHubCredentials({
+    command: "review-pr",
+    subcommand: undefined,
+    appId: args["github-app-id"],
+    privateKeyStdin: args["github-app-private-key-stdin"],
+    stdin: process.stdin
+  });
+}
+
+async function resolveCLIDaemonRuntimeCredentials(
+  args: ParsedArgs
+): Promise<RuntimeGitHubCredentials | undefined> {
+  const envelope = await resolveRuntimeCredentialEnvelope({
+    command: "daemon",
+    subcommand: undefined,
+    runtimeCredentialsStdin: args["runtime-credentials-stdin"],
+    stdin: process.stdin
+  });
+  if (envelope) return envelope;
+  return resolveRuntimeGitHubCredentials({
+    command: "daemon",
+    subcommand: undefined,
+    appId: args["github-app-id"],
+    privateKeyStdin: args["github-app-private-key-stdin"],
+    stdin: process.stdin
+  });
 }
 
 async function collectCoverageReport(args: ParsedArgs, config = loadConfig(args.config), forceScoped = false) {
@@ -3474,7 +3537,10 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--dry-run", description: "true (default) or false; false requires --confirm true." },
       { name: "--confirm", description: "Must be true to allow --dry-run false." },
       { name: "--expected-config-revision", description: "Required lowercase SHA-256 config revision from provider verification for dry and live execution." },
-      { name: "--zcode", description: "Must be true so dry and live reviews execute the same provider path." }
+      { name: "--zcode", description: "Must be true so dry and live reviews execute the same provider path." },
+      { name: "--github-app-id", description: "Numeric customer-owned App ID used only with bounded private-key stdin." },
+      { name: "--github-app-private-key-stdin", description: "true to read one bounded runtime-only App key; never accepted from config." },
+      { name: "--runtime-credentials-stdin", description: "true for the signed app to supply one bounded App-key/license-key JSON envelope." }
     ]
   },
   "run-once": {
@@ -3510,7 +3576,10 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--config", description: "Path to the config file." },
       { name: "--launchd-label", description: "launchd label for start/stop/status subcommands." },
       { name: "--dry-run", description: "true (default) or false for the direct poll loop." },
-      { name: "--once", description: "true to run a single cycle instead of looping (direct poll loop only)." }
+      { name: "--once", description: "true to run a single cycle instead of looping (direct poll loop only)." },
+      { name: "--github-app-id", description: "Numeric customer-owned App ID for the raw poll loop only." },
+      { name: "--github-app-private-key-stdin", description: "true to read one bounded runtime-only App key for the raw poll loop; rejected by start/stop/status." },
+      { name: "--runtime-credentials-stdin", description: "true for the signed app to supply one bounded App-key/license-key JSON envelope to the raw poll loop." }
     ]
   },
   providers: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -615,6 +615,7 @@ export function loadConfigFromObject(fromFile: unknown): BotConfig {
     throw new Error("config files must not contain github.privateKey; use the bounded runtime stdin channel");
   }
   const merged = deepMerge(DEFAULT_CONFIG, fromFile) as BotConfig;
+  merged.github = { ...merged.github };
   merged.worktreeCleanup = { ...merged.worktreeCleanup! };
   const configuredCleanup = isRecord(fromFile) && isRecord(fromFile.worktreeCleanup)
     ? fromFile.worktreeCleanup

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ import { DEFAULT_REVIEW_LENS_CONFIG, validateReviewLensConfig, type ReviewLensCo
 import type { ReviewEventPolicyConfig } from "./review-event-policy.js";
 import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
+import { applyRuntimeGitHubCredentials } from "./runtime-github-credentials.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
 
@@ -129,6 +130,7 @@ export interface BotConfig {
   github: {
     appId?: string;
     clientId?: string;
+    privateKey?: string;
     privateKeyPath?: string;
     token?: string;
     apiBaseUrl?: string;
@@ -607,6 +609,11 @@ export function loadConfig(configPath?: string): BotConfig {
 }
 
 export function loadConfigFromObject(fromFile: unknown): BotConfig {
+  if (isRecord(fromFile)
+    && isRecord(fromFile.github)
+    && Object.prototype.hasOwnProperty.call(fromFile.github, "privateKey")) {
+    throw new Error("config files must not contain github.privateKey; use the bounded runtime stdin channel");
+  }
   const merged = deepMerge(DEFAULT_CONFIG, fromFile) as BotConfig;
   merged.worktreeCleanup = { ...merged.worktreeCleanup! };
   const configuredCleanup = isRecord(fromFile) && isRecord(fromFile.worktreeCleanup)
@@ -632,6 +639,7 @@ export function loadConfigFromObject(fromFile: unknown): BotConfig {
   }) ?? merged.github.privateKeyPath;
   merged.github.token = process.env.GITHUB_TOKEN ?? merged.github.token;
   validateConfig(merged);
+  applyRuntimeGitHubCredentials(merged.github);
 
   return merged;
 }

--- a/src/license-secret-store.ts
+++ b/src/license-secret-store.ts
@@ -1,5 +1,6 @@
 import { constants, closeSync, fstatSync, openSync, readSync } from "node:fs";
 import type { LicenseConfig } from "./license.js";
+import { readRuntimeLicenseKey } from "./runtime-github-credentials.js";
 
 const MAXIMUM_LICENSE_SECRET_BYTES = 512;
 const productionKeyPattern = /^nd_live_[A-Za-z0-9_-]{8,}$/;
@@ -10,6 +11,8 @@ export interface LicenseSecretReader {
 
 export const productionLicenseSecretReader: LicenseSecretReader = {
   read(config) {
+    const runtimeKey = readRuntimeLicenseKey();
+    if (runtimeKey) return runtimeKey;
     if (config.storageBackend !== "file") {
       throw new Error("license secret storage is not supported for production admission; use the approved file backend");
     }

--- a/src/runtime-github-credentials.ts
+++ b/src/runtime-github-credentials.ts
@@ -1,0 +1,169 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createPrivateKey } from "node:crypto";
+import { readSecretFromStdin } from "./secret-stdin.js";
+
+export interface RuntimeGitHubCredentials {
+  appId: string;
+  privateKey: string;
+  licenseKey?: string;
+}
+
+interface RuntimeGitHubCredentialInput {
+  command?: string;
+  subcommand?: string;
+  appId?: string | string[];
+  privateKeyStdin?: string | string[];
+  stdin: NodeJS.ReadableStream;
+}
+
+const storage = new AsyncLocalStorage<RuntimeGitHubCredentials>();
+
+export async function resolveRuntimeGitHubCredentials(
+  input: RuntimeGitHubCredentialInput
+): Promise<RuntimeGitHubCredentials | undefined> {
+  const hasAppId = input.appId !== undefined;
+  const hasPrivateKeyStdin = input.privateKeyStdin !== undefined;
+  if (!hasAppId && !hasPrivateKeyStdin) return undefined;
+
+  const supportedCommand = input.command === "review-pr"
+    || (input.command === "daemon" && input.subcommand === undefined);
+  if (!supportedCommand) {
+    throw new Error(
+      "GitHub App private-key stdin is supported only for review-pr or the raw daemon process"
+    );
+  }
+  if (Array.isArray(input.appId) || input.appId === undefined) {
+    throw new Error("--github-app-id must be supplied exactly once");
+  }
+  if (Array.isArray(input.privateKeyStdin) || input.privateKeyStdin !== "true") {
+    throw new Error("--github-app-private-key-stdin must be supplied exactly once with value true");
+  }
+  const appId = input.appId.trim();
+  if (!/^[1-9][0-9]{0,19}$/.test(appId)) {
+    throw new Error("--github-app-id must be one positive ASCII numeric App ID of at most 20 digits");
+  }
+
+  let privateKey: string;
+  try {
+    privateKey = await readSecretFromStdin(input.stdin, 64 * 1024, 5_000);
+  } catch (error) {
+    throw new Error((error instanceof Error
+      ? error.message
+      : "GitHub App private-key stdin could not be read")
+      .replaceAll("provider secret", "GitHub App private-key"));
+  }
+  validatePrivateKey(privateKey);
+  return { appId, privateKey };
+}
+
+export async function resolveRuntimeCredentialEnvelope(input: {
+  command?: string;
+  subcommand?: string;
+  runtimeCredentialsStdin?: string | string[];
+  stdin: NodeJS.ReadableStream;
+}): Promise<RuntimeGitHubCredentials | undefined> {
+  if (input.runtimeCredentialsStdin === undefined) return undefined;
+  const supportedCommand = input.command === "review-pr"
+    || (input.command === "daemon" && input.subcommand === undefined);
+  if (!supportedCommand) {
+    throw new Error(
+      "runtime credential stdin is supported only for review-pr or the raw daemon process"
+    );
+  }
+  if (Array.isArray(input.runtimeCredentialsStdin)
+    || input.runtimeCredentialsStdin !== "true") {
+    throw new Error("--runtime-credentials-stdin must be supplied exactly once with value true");
+  }
+  const raw = await readSecretFromStdin(input.stdin, 72 * 1024, 5_000);
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(raw);
+  } catch {
+    throw new Error("runtime credential stdin must be one valid JSON envelope");
+  }
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+    throw new Error("runtime credential stdin must be one JSON object");
+  }
+  const record = envelope as Record<string, unknown>;
+  if (Object.keys(record).length !== 4
+    || ![
+      "schemaVersion",
+      "githubAppId",
+      "githubPrivateKey",
+      "licenseKey"
+    ].every((key) => Object.prototype.hasOwnProperty.call(record, key))
+    || record.schemaVersion !== 1
+    || typeof record.githubAppId !== "string"
+    || typeof record.githubPrivateKey !== "string"
+    || typeof record.licenseKey !== "string") {
+    throw new Error("runtime credential stdin has an unsupported schema");
+  }
+  const appId = record.githubAppId.trim();
+  if (!/^[1-9][0-9]{0,19}$/.test(appId)) {
+    throw new Error("runtime credential App ID must be one positive ASCII numeric value");
+  }
+  const privateKey = record.githubPrivateKey.trim();
+  validatePrivateKey(privateKey);
+  const licenseKey = record.licenseKey.trim();
+  if (!/^nd_live_[A-Za-z0-9_-]{8,}$/.test(licenseKey)) {
+    throw new Error("runtime credential license key must be one valid production key");
+  }
+  return {
+    appId,
+    privateKey,
+    licenseKey
+  };
+}
+
+export async function withRuntimeGitHubCredentials<T>(
+  credentials: RuntimeGitHubCredentials | undefined,
+  operation: () => Promise<T>
+): Promise<T> {
+  if (!credentials) return operation();
+  return storage.run(credentials, operation);
+}
+
+export function applyRuntimeGitHubCredentials(
+  github: {
+    appId?: string;
+    privateKey?: string;
+    privateKeyPath?: string;
+    token?: string;
+  }
+): void {
+  const credentials = storage.getStore();
+  if (!credentials) return;
+  github.appId = credentials.appId;
+  github.privateKeyPath = undefined;
+  github.token = undefined;
+  Object.defineProperty(github, "privateKey", {
+    value: credentials.privateKey,
+    enumerable: false,
+    configurable: false,
+    writable: false
+  });
+}
+
+export function readRuntimeLicenseKey(): string | undefined {
+  return storage.getStore()?.licenseKey;
+}
+
+function validatePrivateKey(privateKey: string): void {
+  const privateKeyLabel = "PRIVATE" + " KEY";
+  const rsaPrivateKeyLabel = "RSA " + privateKeyLabel;
+  const supportedBoundaries = [
+    [`-----BEGIN ${privateKeyLabel}-----`, `-----END ${privateKeyLabel}-----`],
+    [`-----BEGIN ${rsaPrivateKeyLabel}-----`, `-----END ${rsaPrivateKeyLabel}-----`]
+  ] as const;
+  if (!supportedBoundaries.some(
+    ([header, footer]) => privateKey.startsWith(header) && privateKey.endsWith(footer)
+  )) {
+    throw new Error("GitHub App private-key stdin must be one unencrypted PKCS#1 or PKCS#8 PEM");
+  }
+  try {
+    const parsed = createPrivateKey(privateKey);
+    if (parsed.asymmetricKeyType !== "rsa") throw new Error("unsupported key type");
+  } catch {
+    throw new Error("GitHub App private-key stdin must be one valid unencrypted RSA private key");
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -121,6 +121,7 @@ import { runSelfConsistencyRecheck, type SelfConsistencySecondDrawResult } from 
 import type { DeterministicReviewGateResult } from "./review-gate.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
 import type { DroppedFinding, Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
+import { applyRuntimeGitHubCredentials } from "./runtime-github-credentials.js";
 
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_TTL_MS = 10 * 60_000;
 const LICENSE_GATE_UNKNOWN_REPO_VISIBILITY_CACHE_TTL_MS = 2 * 60_000;
@@ -3240,10 +3241,12 @@ export async function buildGitHubRelatedContext(input: {
 export function createGitHubRelatedContextReader(config: BotConfig, fallback: GitHubRelatedContextReader): GitHubRelatedContextReader {
   const relatedConfig = config.githubRelatedContext;
   if (!relatedConfig?.enabled) return fallback;
-  return new GitHubApi({
+  const githubConfig = {
     ...config.github,
     requestTimeoutMs: relatedConfig.requestTimeoutMs
-  });
+  };
+  applyRuntimeGitHubCredentials(githubConfig);
+  return new GitHubApi(githubConfig);
 }
 
 export function writeDryRunOutcomeLedgerEvidence(input: {

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -117,6 +117,8 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(job?.defaults?.run?.["working-directory"]).toBe("apps/neondiff-desktop");
 
     for (const command of [
+      "node-version: 26",
+      "npm ci --ignore-scripts",
       "scripts/run-required-swift-test-suite.sh NeonDiffDesktopCoreTests",
       "scripts/run-required-swift-test-suite.sh NeonDiffDesktopAppCoreTests",
       "scripts/run-required-swift-test-suite.sh NeonDiffDesktopEvaluationSupportTests",
@@ -138,7 +140,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     );
     expect(fixtureBoundaryStep?.["working-directory"]).toBe(".");
     expect(fixtureBoundaryStep?.run).toBe(
-      "npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiffDesktop.app"
+      "npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiff.app"
     );
     expect(workflow).toContain("unsigned");
     expect(workflow).toMatch(/macOS 15 Keychain contract compilation/);
@@ -210,6 +212,32 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(bundler).toContain('find "$APP_BUNDLE" -mindepth 1 -maxdepth 1 ! -name Contents');
     expect(bundler).toContain('"$SCRIPT_DIR/release-rpaths.sh" sanitize "$APP_BINARY"');
     expect(bundler).toContain('"$SCRIPT_DIR/release-rpaths.sh" assert "$APP_BINARY"');
+    expect(bundler).toContain("build-desktop-sealed-worker.mjs");
+    expect(bundler).toContain('"$APP_HELPERS/NeonDiffWorker" --version');
+  });
+
+  it("builds the credential-bearing worker as one pinned sealed executable", () => {
+    const script = read("scripts/build-desktop-sealed-worker.mjs");
+    const entitlements = read(
+      "apps/neondiff-desktop/script/worker-runtime.entitlements.plist"
+    );
+
+    expect(script).toContain("https://nodejs.org/dist/");
+    expect(script).toContain(
+      "7ee659a7768e641bbfd5360940660b8e8fd0052f77488f365562bac522fc15d4"
+    );
+    expect(script).toContain("--build-sea");
+    expect(script).toContain('mainFormat: "module"');
+    expect(script).toContain('format: "esm"');
+    expect(script).toContain("/usr/bin/codesign");
+    expect(script).toContain("/usr/bin/otool");
+    expect(entitlements).toContain(
+      "com.apple.security.cs.allow-jit"
+    );
+    expect(entitlements).not.toContain("get-task-allow");
+    expect(entitlements).not.toContain(
+      "disable-library-validation"
+    );
   });
 
   it("removes machine-local release rpaths and fails closed on inspection errors", () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -4000,6 +4000,25 @@ exit 0
     });
   });
 
+  it("rejects credential stdin flags on daemon control subcommands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-daemon-control-credentials-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+
+    await expect(runCli([
+      "daemon",
+      "status",
+      "--config",
+      configPath,
+      "--runtime-credentials-stdin",
+      "true"
+    ], { env: darwinDaemonEnv })).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        "credential stdin is supported only for the raw daemon process"
+      )
+    });
+  });
+
   it("degrades launchd daemon controls on Linux with systemd guidance", async () => {
     const startError = await runCli([
       "daemon",

--- a/tests/runtime-github-credentials.test.ts
+++ b/tests/runtime-github-credentials.test.ts
@@ -139,4 +139,22 @@ describe("runtime GitHub credentials", () => {
       expect(reader.canPostAsApp()).toBe(true);
     });
   });
+
+  it("keeps repeated config loads scoped when the file omits GitHub settings", async () => {
+    const credentials = await resolveRuntimeGitHubCredentials({
+      command: "review-pr",
+      subcommand: undefined,
+      appId: "4184532",
+      privateKeyStdin: "true",
+      stdin: Readable.from([privateKey])
+    });
+
+    await withRuntimeGitHubCredentials(credentials, async () => {
+      const first = loadConfigFromObject({});
+      const second = loadConfigFromObject({});
+      expect(first.github.privateKey).toBe(privateKey.trim());
+      expect(second.github.privateKey).toBe(privateKey.trim());
+    });
+    expect(loadConfigFromObject({}).github.privateKey).toBeUndefined();
+  });
 });

--- a/tests/runtime-github-credentials.test.ts
+++ b/tests/runtime-github-credentials.test.ts
@@ -1,0 +1,113 @@
+import { generateKeyPairSync } from "node:crypto";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+import { productionLicenseSecretReader } from "../src/license-secret-store.js";
+import {
+  resolveRuntimeGitHubCredentials,
+  resolveRuntimeCredentialEnvelope,
+  readRuntimeLicenseKey,
+  withRuntimeGitHubCredentials
+} from "../src/runtime-github-credentials.js";
+
+const privateKey = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" }
+}).privateKey;
+
+describe("runtime GitHub credentials", () => {
+  it("binds bounded stdin credentials only to raw daemon and review-pr execution", async () => {
+    const credentials = await resolveRuntimeGitHubCredentials({
+      command: "daemon",
+      subcommand: undefined,
+      appId: "4184532",
+      privateKeyStdin: "true",
+      stdin: Readable.from([privateKey])
+    });
+
+    await withRuntimeGitHubCredentials(credentials, async () => {
+      const config = loadConfigFromObject({
+        github: {
+          privateKeyPath: "/must/not/be/read.pem",
+          token: "must-not-win"
+        }
+      });
+      expect(config.github.appId).toBe("4184532");
+      expect(config.github.privateKey).toBe(privateKey.trim());
+      expect(config.github.privateKeyPath).toBeUndefined();
+      expect(config.github.token).toBeUndefined();
+      expect(JSON.stringify(config)).not.toContain(privateKey.trim());
+    });
+
+    const reviewCredentials = await resolveRuntimeGitHubCredentials({
+      command: "review-pr",
+      subcommand: undefined,
+      appId: "4184532",
+      privateKeyStdin: "true",
+      stdin: Readable.from([privateKey])
+    });
+    expect(reviewCredentials?.appId).toBe("4184532");
+  });
+
+  it("rejects daemon controls and invalid App IDs before reading stdin", async () => {
+    let reads = 0;
+    const stdin = new Readable({
+      read() {
+        reads += 1;
+        this.push(privateKey);
+        this.push(null);
+      }
+    });
+
+    await expect(resolveRuntimeGitHubCredentials({
+      command: "daemon",
+      subcommand: "start",
+      appId: "4184532",
+      privateKeyStdin: "true",
+      stdin
+    })).rejects.toThrow(/raw daemon/i);
+    expect(reads).toBe(0);
+
+    await expect(resolveRuntimeGitHubCredentials({
+      command: "review-pr",
+      subcommand: undefined,
+      appId: "not-numeric",
+      privateKeyStdin: "true",
+      stdin
+    })).rejects.toThrow(/positive ASCII numeric/i);
+    expect(reads).toBe(0);
+  });
+
+  it("rejects inline private keys in config files", () => {
+    expect(() => loadConfigFromObject({
+      github: { privateKey }
+    })).toThrow(/must not contain github\.privateKey/i);
+  });
+
+  it("binds the signed-app credential envelope to GitHub and license admission", async () => {
+    const credentials = await resolveRuntimeCredentialEnvelope({
+      command: "review-pr",
+      subcommand: undefined,
+      runtimeCredentialsStdin: "true",
+      stdin: Readable.from([JSON.stringify({
+        schemaVersion: 1,
+        githubAppId: "4184532",
+        githubPrivateKey: privateKey,
+        licenseKey: "nd_live_runtime_fixture_1234"
+      })])
+    });
+
+    await withRuntimeGitHubCredentials(credentials, async () => {
+      const config = loadConfigFromObject({ github: {} });
+      expect(config.github.appId).toBe("4184532");
+      expect(config.github.privateKey).toBe(privateKey.trim());
+      expect(readRuntimeLicenseKey()).toBe("nd_live_runtime_fixture_1234");
+      expect(productionLicenseSecretReader.read(config.license!))
+        .toBe("nd_live_runtime_fixture_1234");
+      expect(JSON.stringify(config)).not.toContain(privateKey.trim());
+      expect(JSON.stringify(config)).not.toContain("nd_live_runtime_fixture_1234");
+    });
+    expect(readRuntimeLicenseKey()).toBeUndefined();
+  });
+});

--- a/tests/runtime-github-credentials.test.ts
+++ b/tests/runtime-github-credentials.test.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { loadConfigFromObject } from "../src/config.js";
 import { productionLicenseSecretReader } from "../src/license-secret-store.js";
+import { createGitHubRelatedContextReader } from "../src/worker.js";
 import {
   resolveRuntimeGitHubCredentials,
   resolveRuntimeCredentialEnvelope,
@@ -109,5 +110,33 @@ describe("runtime GitHub credentials", () => {
       expect(JSON.stringify(config)).not.toContain("nd_live_runtime_fixture_1234");
     });
     expect(readRuntimeLicenseKey()).toBeUndefined();
+  });
+
+  it("preserves runtime App credentials when related-context options are copied", async () => {
+    const credentials = await resolveRuntimeCredentialEnvelope({
+      command: "review-pr",
+      subcommand: undefined,
+      runtimeCredentialsStdin: "true",
+      stdin: Readable.from([JSON.stringify({
+        schemaVersion: 1,
+        githubAppId: "4184532",
+        githubPrivateKey: privateKey,
+        licenseKey: "nd_live_runtime_fixture_1234"
+      })])
+    });
+
+    await withRuntimeGitHubCredentials(credentials, async () => {
+      const config = loadConfigFromObject({
+        github: {},
+        githubRelatedContext: {
+          enabled: true,
+          requestTimeoutMs: 1_000
+        }
+      });
+      const reader = createGitHubRelatedContextReader(config, {
+        getIssueOrPull: async () => undefined
+      }) as unknown as { canPostAsApp(): boolean };
+      expect(reader.canPostAsApp()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Outcome

Run the BYO review worker from one sealed executable inside the signed `NeonDiff.app`, while keeping the GitHub private key and API-backed activation credential in the app-owned Keychain.

Related: #759  
Tracker: #610

## Root cause

The earlier Keychain-backed LaunchAgent still routed credential-bearing execution through a same-user mutable Node/JavaScript worker tree. That did not provide a trustworthy recipient for both Keychain secrets. It also broke the exact legacy-agent review path and left daemon-control, launchd-readiness, and runtime related-context credential seams incomplete.

## What changed

- Builds the worker as one Node 26 SEA executable from the current source, using a pinned official Node archive and exact SHA-256.
- Embeds that executable at `NeonDiff.app/Contents/Helpers/NeonDiffWorker`.
- Requires the exact Developer ID app identity, team, sealed nested code, fixed installed path, safe file properties, and a dynamically validated child process before writing any credential bytes.
- Keeps the LaunchAgent secret-free; it invokes the installed signed app in bounded headless mode.
- Reads the BYO GitHub private key and activation credential noninteractively from Keychain and sends one bounded JSON envelope over stdin.
- Rejects credential stdin on daemon start/stop/status and rejects credential delivery to any non-sealed worker.
- Replaces a valid same-label legacy plist only through the native manager and rolls back failed launchd activation.
- Requires two stable running-PID samples before reporting the new LaunchAgent started.
- Preserves the exact legacy existing-agent dry/live review path without routing its credentials through the new envelope.
- Reapplies non-enumerable runtime GitHub credentials after related-context option copies.
- Produces the customer-facing bundle as `NeonDiff.app` and updates the release smoke/package/runbook paths.

## Acceptance criteria

- Credential-bearing desktop commands execute only through the sealed worker in the signed installed app.
- A rejected or untrusted child receives zero credential bytes.
- The LaunchAgent contains no private key, activation key, key path, or secret environment.
- The raw daemon receives the bounded envelope; daemon control subcommands reject credential flags.
- Existing local-agent reviews remain usable and receive no new secret stdin.
- The native manager can replace a valid app-owned same-label wrapper and rolls back a failed activation.
- Launchd readiness requires a stable positive running PID.
- Runtime App credentials survive related-context configuration copies.
- Release build and smoke paths produce `NeonDiff.app`.
- Current-head remote CI and the bounded independent credential/launchd delta review pass before merge.

## Non-goals

- No public beta, GitHub Release, tag, checkout/download enablement, or customer-readiness claim.
- No official managed NeonDiff GitHub App work.
- No full Sparkle/appcast implementation.
- No ZCode repair or reinstall.
- No generic credential-export helper, raw key file, credential-bearing plist, or environment-variable handoff.
- No broad #517 or GA matrix closure.
- Existing checksum-managed worker update/rollback hardening remains tracked in #755; this PR does not claim that separate path complete.

## Focused local proof at `c0b8ebdbcda049c47cf591970601aa8a5310d998`

- TypeScript focused suites: 118/118
- Swift credential/LaunchAgent/onboarding/reconciliation suites: 88/88
- `npm run build`: pass
- Real Release bundle build: pass
- `release-bundle-check`: pass; output is `apps/neondiff-desktop/dist/NeonDiff.app` and sealed worker reports `1.0.4`
- Bash syntax, sealed-worker Node syntax, and `git diff --check`: pass
- Base sync from `origin/main` `56f9b13` merged without conflict; the affected TypeScript suites and build passed again.
- The first synchronized remote Swift run exposed only the deterministic Core assertion inventory drift; the ledger was rebound to the two new credential-delivery assertions and its focused test passed 2/2.

## Proof boundary

This PR is source, focused-local, review, and CI proof only. Merge will not prove Developer ID signing, notarization, installed LaunchAgent runtime, dry/live review, quit/relaunch, beta publication, or customer readiness. Those gates require the exact post-merge signed candidate and installed customer-path evidence.
