### PR TITLE
Fix main desktop release-boundary scan after app rename

### DIFF
--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -417,14 +417,14 @@ jobs:
           release_bin="$(cd apps/neondiff-desktop && swift build -c release --show-bin-path)"
           npm run check:secret-corpus-boundary -- \
             "$RELEASE_ARCHIVE" \
-            "apps/neondiff-desktop/dist-release/NeonDiffDesktop.app"
+            "apps/neondiff-desktop/dist-release/NeonDiff.app"
           npm run check:desktop-fixture-boundary -- \
             "$release_bin/NeonDiffDesktop" \
             "$release_bin/NeonDiffDesktopCore.build" \
             "$release_bin/NeonDiffDesktopAppCore.build" \
             "$release_bin/Modules/NeonDiffDesktopCore.swiftmodule" \
             "$release_bin/Modules/NeonDiffDesktopAppCore.swiftmodule" \
-            "apps/neondiff-desktop/dist-release/NeonDiffDesktop.app" \
+            "apps/neondiff-desktop/dist-release/NeonDiff.app" \
             "$RELEASE_ARCHIVE"
 
   swift-desktop-candidate-gate:

--- a/scripts/check-desktop-fixture-boundary.mjs
+++ b/scripts/check-desktop-fixture-boundary.mjs
@@ -4,7 +4,7 @@ import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path
 
 const MAX_FILES = 20_000;
 const MAX_TRAVERSAL_ENTRIES = MAX_FILES * 2;
-const MAX_FILE_BYTES = 128 * 1024 * 1024;
+const MAX_FILE_BYTES = 192 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 512 * 1024 * 1024;
 const FORBIDDEN_MARKERS = [
   "--ui-testing",

--- a/tests/desktop-evaluation-boundary.test.ts
+++ b/tests/desktop-evaluation-boundary.test.ts
@@ -80,7 +80,7 @@ describe("desktop evaluation production boundary", () => {
     expect(gate).toMatch(/release_bin\/NeonDiffDesktop/);
     expect(gate).toMatch(/NEONDIFF_DESKTOP_DIST_DIR=.*dist-release/);
     expect(gate).toMatch(/release-bundle-check/);
-    expect(gate).toMatch(/dist-release\/NeonDiffDesktop\.app/);
+    expect(gate).toMatch(/dist-release\/NeonDiff\.app/);
 
     const bundleBuilder = readFileSync("apps/neondiff-desktop/script/build_and_run.sh", "utf8");
     expect(bundleBuilder).toMatch(/NEONDIFF_DESKTOP_BUILD_CONFIGURATION/);

--- a/tests/desktop-fixture-boundary.test.ts
+++ b/tests/desktop-fixture-boundary.test.ts
@@ -403,14 +403,16 @@ describe("desktop fixture release-artifact boundary", () => {
 
   it("scans only release fixture surfaces and all debug/release Core and AppCore secret surfaces", () => {
     const gate = readFileSync(".github/workflows/swift-desktop-gate.yml", "utf8");
+    const scanner = readFileSync("scripts/check-desktop-fixture-boundary.mjs", "utf8");
 
     expect(gate).toMatch(/npm run check:desktop-fixture-boundary --[\s\S]*?"\$release_bin\/NeonDiffDesktop"/);
     expect(gate).toContain('"$release_bin/NeonDiffDesktopCore.build"');
     expect(gate).toContain('"$release_bin/NeonDiffDesktopAppCore.build"');
     expect(gate).toContain('"$release_bin/Modules/NeonDiffDesktopCore.swiftmodule"');
     expect(gate).toContain('"$release_bin/Modules/NeonDiffDesktopAppCore.swiftmodule"');
-    expect(gate).toContain('"apps/neondiff-desktop/dist-release/NeonDiffDesktop.app"');
+    expect(gate).toContain('"apps/neondiff-desktop/dist-release/NeonDiff.app"');
     expect(gate).toContain('"$RELEASE_ARCHIVE"');
+    expect(scanner).toContain("const MAX_FILE_BYTES = 192 * 1024 * 1024;");
     expect(gate).not.toMatch(/npm run check:desktop-fixture-boundary --[\s\S]*?"\$debug_bin\/NeonDiffDesktop/);
     expect(gate).toMatch(
       /Archive Release fixture boundary[\s\S]*?npm run check:secret-corpus-boundary --[\s\S]*?"\$RELEASE_ARCHIVE"/


### PR DESCRIPTION
## What changed

- point both main-only release-boundary scanners at the renamed `NeonDiff.app` bundle
- raise the per-file fixture scanner ceiling from 128 MiB to 192 MiB so the 145 MiB sealed Node SEA worker is scanned instead of rejected
- bind the corrected bundle name and bounded ceiling in focused contract tests

## Root cause

PR #760 renamed the customer app bundle to `NeonDiff.app`, but the main-only release-boundary workflow and two test assertions still referenced `NeonDiffDesktop.app`. After correcting that path locally, the real sealed worker reproduced a second deterministic failure because it is larger than the scanner's pre-SEA 128 MiB per-file cap.

## Acceptance criteria

- the main release-boundary job scans `dist-release/NeonDiff.app`
- the sealed worker remains content-scanned under a finite per-file and 512 MiB total bound
- no scanner path is skipped
- focused workflow and fixture-boundary contracts pass

## Non-goals

- no product/runtime behavior change
- no signing, notarization, billing, entitlement, updater, or customer-flow change
- no public release claim

## Proof

- `tests/desktop-fixture-boundary.test.ts`: 18/18 passed
- `tests/desktop-evaluation-boundary.test.ts` + `tests/desktop-release-pipeline.test.ts`: 17/17 passed
- exact local beta.47 app scan: 275 files, 165,333,630 bytes, zero violations
- `git diff --check`: passed

Relates to #759 and #610.
