### PR TITLE
fix(desktop): make sealed worker cwd-independent

### DIFF
--- a/scripts/build-desktop-sealed-worker.mjs
+++ b/scripts/build-desktop-sealed-worker.mjs
@@ -44,6 +44,21 @@ function sha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
+function packageVersion(repoRoot) {
+  const packageJson = JSON.parse(
+    readFileSync(join(repoRoot, "package.json"), "utf8")
+  );
+  if (
+    typeof packageJson.version !== "string"
+    || !/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(
+      packageJson.version
+    )
+  ) {
+    fail("package.json has an invalid version");
+  }
+  return packageJson.version;
+}
+
 function main() {
   if (process.platform !== "darwin") {
     fail("the sealed desktop worker can be built only on macOS");
@@ -58,6 +73,7 @@ function main() {
   }
 
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const sealedPackageVersion = packageVersion(repoRoot);
   const staging = mkdtempSync(join(tmpdir(), "neondiff-sealed-worker-"));
   const cacheDirectory = join(
     homedir(),
@@ -97,6 +113,10 @@ function main() {
       platform: "node",
       format: "esm",
       target: "node26",
+      define: {
+        __NEONDIFF_SEA_PACKAGE_VERSION__:
+          JSON.stringify(sealedPackageVersion)
+      },
       sourcemap: false,
       logLevel: "silent"
     });
@@ -145,7 +165,10 @@ function main() {
       "-",
       output
     ], { stdio: ["ignore", "ignore", "pipe"] });
+    const portabilityDirectory = join(staging, "portability-cwd");
+    mkdirSync(portabilityDirectory, { mode: 0o700 });
     const reportedVersion = execFileSync(output, ["--version"], {
+      cwd: portabilityDirectory,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
     }).trim();

--- a/scripts/build-desktop-sealed-worker.mjs
+++ b/scripts/build-desktop-sealed-worker.mjs
@@ -114,7 +114,7 @@ function main() {
       format: "esm",
       target: "node26",
       define: {
-        __NEONDIFF_SEA_PACKAGE_VERSION__:
+        "import.meta.neondiffPackageVersion":
           JSON.stringify(sealedPackageVersion)
       },
       sourcemap: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,8 +143,6 @@ import {
   type RuntimeGitHubCredentials
 } from "./runtime-github-credentials.js";
 
-declare const __NEONDIFF_SEA_PACKAGE_VERSION__: string | undefined;
-
 const LAUNCHCTL_TIMEOUT_MS = 15_000;
 const PLUTIL_TIMEOUT_MS = 5_000;
 
@@ -2607,11 +2605,16 @@ function resolvePackageRoot(): string {
 }
 
 function resolvePackageVersion(): string {
+  const sealedPackageVersion = (
+    import.meta as ImportMeta & {
+      neondiffPackageVersion?: unknown;
+    }
+  ).neondiffPackageVersion;
   if (
-    typeof __NEONDIFF_SEA_PACKAGE_VERSION__ === "string"
-    && __NEONDIFF_SEA_PACKAGE_VERSION__.length > 0
+    typeof sealedPackageVersion === "string"
+    && sealedPackageVersion.length > 0
   ) {
-    return __NEONDIFF_SEA_PACKAGE_VERSION__;
+    return sealedPackageVersion;
   }
   const packageJson = JSON.parse(readFileSync(join(resolvePackageRoot(), "package.json"), "utf8"));
   if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,8 @@ import {
   type RuntimeGitHubCredentials
 } from "./runtime-github-credentials.js";
 
+declare const __NEONDIFF_SEA_PACKAGE_VERSION__: string | undefined;
+
 const LAUNCHCTL_TIMEOUT_MS = 15_000;
 const PLUTIL_TIMEOUT_MS = 5_000;
 
@@ -2605,6 +2607,12 @@ function resolvePackageRoot(): string {
 }
 
 function resolvePackageVersion(): string {
+  if (
+    typeof __NEONDIFF_SEA_PACKAGE_VERSION__ === "string"
+    && __NEONDIFF_SEA_PACKAGE_VERSION__.length > 0
+  ) {
+    return __NEONDIFF_SEA_PACKAGE_VERSION__;
+  }
   const packageJson = JSON.parse(readFileSync(join(resolvePackageRoot(), "package.json"), "utf8"));
   if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
     throw new Error("package.json is missing a version string");

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -45,7 +45,11 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(inputs?.release_tag?.required).toBe(true);
     expect(inputs?.artifact_name?.required).toBe(true);
     expect(inputs?.artifact_sha256?.required).toBe(true);
-    expect(parsed.permissions).toEqual({ contents: "read" });
+    expect(parsed.permissions).toEqual({
+      contents: "read",
+      issues: "read",
+      "pull-requests": "read"
+    });
 
     const job = parsed.jobs?.["public-download-install-canary"];
     expect(job?.strategy?.["fail-fast"]).toBe(false);
@@ -219,6 +223,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
 
   it("builds the credential-bearing worker as one pinned sealed executable", () => {
     const script = read("scripts/build-desktop-sealed-worker.mjs");
+    const cli = read("src/cli.ts");
     const entitlements = read(
       "apps/neondiff-desktop/script/worker-runtime.entitlements.plist"
     );
@@ -230,6 +235,11 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(script).toContain("--build-sea");
     expect(script).toContain('mainFormat: "module"');
     expect(script).toContain('format: "esm"');
+    expect(script).toContain("__NEONDIFF_SEA_PACKAGE_VERSION__");
+    expect(script).toContain("portabilityDirectory");
+    expect(cli).toContain(
+      "typeof __NEONDIFF_SEA_PACKAGE_VERSION__ === \"string\""
+    );
     expect(script).toContain("/usr/bin/codesign");
     expect(script).toContain("/usr/bin/otool");
     expect(entitlements).toContain(

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -235,10 +235,15 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(script).toContain("--build-sea");
     expect(script).toContain('mainFormat: "module"');
     expect(script).toContain('format: "esm"');
-    expect(script).toContain("__NEONDIFF_SEA_PACKAGE_VERSION__");
+    expect(script).toContain(
+      '"import.meta.neondiffPackageVersion"'
+    );
     expect(script).toContain("portabilityDirectory");
     expect(cli).toContain(
-      "typeof __NEONDIFF_SEA_PACKAGE_VERSION__ === \"string\""
+      "typeof sealedPackageVersion === \"string\""
+    );
+    expect(cli).not.toContain(
+      "declare const __NEONDIFF_SEA_PACKAGE_VERSION__"
     );
     expect(script).toContain("/usr/bin/codesign");
     expect(script).toContain("/usr/bin/otool");


### PR DESCRIPTION
## Outcome

Fix the exact installed beta.47 blocker where the signed app's sealed credential-bearing worker depended on the caller's working directory for package identity.

Related: #646

## Reproduction

At exact signed/notarized source `c28a295`, both:

- `NeonDiffWorker --version`
- `NeonDiffWorker daemon --config <account bot config> --runtime-credentials-stdin true`

failed before credential input while trying to read `<cwd>/package.json`.

## Change

- Inject the reviewed package version into the SEA bundle at build time.
- Preserve ordinary source/npm package-root version resolution when that build-time constant is absent.
- Build and execute the SEA's `--version` check from a fresh empty directory.
- Repair the exact stale public-canary permission assertion already failing on current main after `1cf7b4d`.

## Acceptance criteria

- [x] Failing-first release-pipeline expectation captured the missing SEA version injection.
- [x] Exact built SEA reports `1.0.4` from a directory with no NeonDiff checkout.
- [x] Exact built SEA daemon path reaches `provider secret stdin must be non-empty` instead of reading `<cwd>/package.json`.
- [x] Source CLI still reports `1.0.4` from the repository package root.
- [x] Focused desktop release-pipeline tests pass.
- [x] Script syntax and diff checks pass.
- [ ] One independent semantic review passes on the stable head.
- [ ] Current-head remote CI and Swift release-bundle gates pass.

## Non-goals

No provider, GitHub App, billing, entitlement, review-posting, Keychain, LaunchAgent mutation, UI, managed-App, Sparkle/appcast, publication, or customer-canary change.

## Local proof

- `npm test -- --run tests/desktop-release-pipeline.test.ts`: 8/8 passed
- `node --check scripts/build-desktop-sealed-worker.mjs`: passed
- exact SEA build from pinned Node 26.7.0 archive: passed
- empty-directory SEA `--version`: `1.0.4`
- account-config-directory daemon/no-stdin negative control: expected bounded stdin failure, no package-root failure
- `npx tsx src/cli.ts --version`: `1.0.4`
- `git diff --check`: passed

## Proof boundary

This PR can prove source, focused local SEA execution, review, and remote CI. It cannot prove a new signed/notarized artifact, installed runtime, Keychain/launchd operation, dry/live review, public beta, or customer readiness. Beta.47 remains held; a new exact candidate is required after merge.
