### PR TITLE
Fix Codex-active doctor after ZCode migration

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -436,11 +436,16 @@ async function main(): Promise<void> {
       if (!result.ok) process.exitCode = 1;
       return;
     }
-    const zcode = resolveZCodeProviderEnv({
-      appConfigPath: config.zcode.appConfigPath,
-      model: config.zcode.model,
-      providerId: config.zcode.providerId
-    });
+    const codexRuntime = config.codexRuntime?.enabled
+      ? config.codexRuntime
+      : undefined;
+    const zcode = codexRuntime
+      ? undefined
+      : resolveZCodeProviderEnv({
+          appConfigPath: config.zcode.appConfigPath,
+          model: config.zcode.model,
+          providerId: config.zcode.providerId
+        });
     const github = new GitHubApi(config.github);
     const readChecks = [];
     const monitoredRepos = listReposToScan(config);
@@ -483,7 +488,17 @@ async function main(): Promise<void> {
       commandsEnabled: config.commands.enabled,
       statePath: config.statePath,
       workRoot: config.workRoot,
-      zcode: zcode.redacted,
+      ...(codexRuntime
+        ? {
+            activeRuntime: {
+              providerId: "codex-cli-oauth",
+              adapter: "codex-cli",
+              model: codexRuntime.model,
+              reasoningEffort: codexRuntime.reasoningEffort,
+              auth: "existing-codex-session"
+            }
+          }
+        : { zcode: zcode!.redacted }),
       github: {
         canPostAsApp: github.canPostAsApp(),
         readMode: github.canPostAsApp() ? "app_installation" : "fallback_token",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -830,6 +830,49 @@ exit 1
     expect(list.proofBoundary).not.toMatch(/remains ZCode-backed/i);
   });
 
+  it("doctors the active Codex runtime without reading the retired ZCode config", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-codex-cli-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const missingZCodeConfigPath = join(root, "retired-zcode-config.json");
+    writeFileSync(configPath, JSON.stringify({
+      pilotRepos: [],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      codexRuntime: {
+        enabled: true,
+        cliPath: "/Users/test/.local/bin/codex",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        timeoutMs: 300_000,
+        maxOutputBytes: 20 * 1024 * 1024,
+        contextWindowTokens: 128_000
+      },
+      zcode: {
+        appConfigPath: missingZCodeConfigPath
+      }
+    }));
+
+    const doctor = JSON.parse((await runCli([
+      "doctor",
+      "--config",
+      configPath
+    ])).stdout);
+
+    expect(doctor).toMatchObject({
+      ok: true,
+      activeRuntime: {
+        providerId: "codex-cli-oauth",
+        adapter: "codex-cli",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        auth: "existing-codex-session"
+      }
+    });
+    expect(doctor).not.toHaveProperty("zcode");
+  });
+
   it("blocks providers doctor smoke before contacting a configured endpoint without activation", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cli-"));
     roots.push(root);


### PR DESCRIPTION
## Outcome

Keep the supported CLI diagnostic path usable after a bot migrates from ZCode
to Codex CLI.

Related: #646

## Root cause

`providers list` and live review already treated an enabled `codexRuntime` as
the active adapter, but full `doctor` unconditionally loaded
`config.zcode.appConfigPath`. On the current installed ElectricSheep bot that
path still points at the retired Lexar/ZCode setup, so `doctor` failed before
reporting repository or GitHub readiness.

## Change

- Skip ZCode app-config resolution only when `codexRuntime.enabled` is true.
- Report the active Codex CLI model, reasoning effort, and existing-session auth
  boundary in `doctor` output.
- Preserve the existing ZCode diagnostic path when Codex is not active.
- Add a failing-first CLI regression whose ZCode config path does not exist.

## Acceptance criteria

- Codex-active `doctor` never opens the retired ZCode config.
- The output truthfully identifies `codex-cli-oauth`, the selected model, and
  reasoning effort.
- ZCode-active behavior and GitHub/repository diagnostics remain unchanged.
- No activation, provider credential, or review-posting gate is weakened.

## Non-goals

- No ZCode reinstall or path repair.
- No activation or billing change.
- No review-pr, provider selection, GitHub App, or daemon behavior change.
- No installed-app, release, or customer-readiness claim.

## Proof

- RED: the new focused test failed with `ENOENT` on the missing retired ZCode
  config at base `04afbb2`.
- GREEN:
  - `npm test -- --run tests/public-cli.test.ts -t 'doctors the active Codex runtime without reading the retired ZCode config'`
  - `npm test -- --run tests/public-cli.test.ts` — 105/105 passed
  - `npm run build`
  - `git diff --check`

Agent-authored change. Broad validation remains the repository's remote CI
gate.
