### PR TITLE
fix(desktop): reuse stored activation key

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4526,6 +4526,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 lastError = "Enter your \(ActivationTerminology.activationKey) to continue."
                 return
             }
+            pendingActivationKey = ""
         } else {
             guard persistPendingActivationKey(requireNonEmpty: true) else { return }
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4521,7 +4521,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// Existing keys still activate while checkout is paused. The key is stored in
     /// the Keychain only; only a redacted prefix is retained in memory for display.
     package func provideExistingActivationKey() {
-        guard persistPendingActivationKey(requireNonEmpty: true) else { return }
+        if ActivationKeyMaterial(pendingActivationKey).isEmpty {
+            guard dependencies.secretStore.containsSecret(account: activationKeyAccount) else {
+                lastError = "Enter your \(ActivationTerminology.activationKey) to continue."
+                return
+            }
+        } else {
+            guard persistPendingActivationKey(requireNonEmpty: true) else { return }
+        }
         lastError = nil
         applyActivationEvent(.provideExistingKey)
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -174,6 +174,19 @@ import NeonDiffDesktopCore
         #expect(model.activationKeyRedactedPrefix?.contains("EXISTING") == false)
     }
 
+    @Test func provideExistingKeyUsesAlreadyStoredKeyWithoutReentry() throws {
+        let keychain = RecordingKeychain()
+        try keychain.setSecret("NDL-STORED-0123456789", account: activationKeyAccount)
+        let model = makeModel(secretStore: keychain)
+        model.activationState = .checkoutPaused
+
+        model.provideExistingActivationKey()
+
+        #expect(model.activationState == .keyReady)
+        #expect(model.pendingActivationKey.isEmpty)
+        #expect(keychain.readAccounts.isEmpty, "recovery must not decrypt the key before activation")
+    }
+
     @Test func submitActivationSuccessUnlocksAndPersists() async {
         let prefs = MemoryPreferences()
         let keychain = RecordingKeychain()

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -174,17 +174,32 @@ import NeonDiffDesktopCore
         #expect(model.activationKeyRedactedPrefix?.contains("EXISTING") == false)
     }
 
-    @Test func provideExistingKeyUsesAlreadyStoredKeyWithoutReentry() throws {
+    @Test func provideExistingKeyUsesAlreadyStoredKeyWithoutReentry() async throws {
         let keychain = RecordingKeychain()
         try keychain.setSecret("NDL-STORED-0123456789", account: activationKeyAccount)
-        let model = makeModel(secretStore: keychain)
+        let client = FakeActivationClient(activeSummary())
+        let model = makeModel(secretStore: keychain, client: client)
         model.activationState = .checkoutPaused
+        model.pendingActivationKey = " \n"
 
         model.provideExistingActivationKey()
 
         #expect(model.activationState == .keyReady)
         #expect(model.pendingActivationKey.isEmpty)
         #expect(keychain.readAccounts.isEmpty, "recovery must not decrypt the key before activation")
+        await model.submitActivation()
+        #expect(model.activationState == .active)
+        #expect(keychain.readAccounts.contains(activationKeyAccount))
+    }
+
+    @Test func provideExistingKeyWithoutStoredKeyStaysAtEntry() {
+        let model = makeModel()
+        model.activationState = .checkoutPaused
+
+        model.provideExistingActivationKey()
+
+        #expect(model.activationState == .checkoutPaused)
+        #expect(model.lastError == "Enter your \(ActivationTerminology.activationKey) to continue.")
     }
 
     @Test func submitActivationSuccessUnlocksAndPersists() async {


### PR DESCRIPTION
Related: #699

## Customer failure
The signed app already owns a production activation credential in Keychain, but **Use existing activation key** requires the user to paste the same secret again. The secure field stays empty and the native recovery action is a no-op.

## Acceptance criteria
- When an activation key is already present in NeonDiff Keychain, existing-key recovery advances to `key_ready` without decrypting it.
- Activation still reads the key only at the explicit Activate action.
- When no key is stored, the existing entry error remains fail-closed.
- Pasted replacement keys retain the existing Keychain-only storage and memory-clearing behavior.

## Non-goals
- No billing, license API, entitlement-policy, Keychain schema, daemon, GitHub, provider, or release-contract change.
- No release or customer-readiness claim.

## Failing-first and focused proof
- RED: `swift test --skip-update --filter ActivationHandoffModelTests.provideExistingKeyUsesAlreadyStoredKeyWithoutReentry` failed because state remained `checkoutPaused`.
- GREEN: the same focused test passed.
- GREEN: `swift test --skip-update --filter ActivationHandoffModelTests` passed 23/23.
- `git diff --check` passed.

Agent-authored. No secrets were read, printed, copied, or added to source/evidence.