### PR TITLE
fix(desktop): start native activation synchronously

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ActivationStateView.swift
@@ -62,7 +62,11 @@ struct ActivationStateView: View {
                     .accessibilityIdentifier("neondiff.activation.choose-review-target")
                 } else if let recovery = presentation.recovery {
                     Button(recovery.label) {
-                        Task { await model.performActivationRecovery() }
+                        if recovery.event == .submitActivation {
+                            model.beginActivationSubmission()
+                        } else {
+                            Task { await model.performActivationRecovery() }
+                        }
                     }
                     .buttonStyle(NDBracketButtonStyle())
                     .accessibilityLabel(recovery.accessibilityLabel)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -335,8 +335,7 @@ package struct DesktopRuntimeCredentialEnvelope: Sendable {
     ) throws {
         self.appID = try BYOGitHubAppCredentialValidator
             .normalizedAppId(appID)
-        self.privateKey = try BYOGitHubAppCredentialValidator
-            .normalizedPrivateKey(privateKey)
+        self.privateKey = try Self.normalizedPrivateKey(privateKey)
         guard licenseKey.range(
             of: #"^nd_live_[A-Za-z0-9_-]{8,}$"#,
             options: .regularExpression
@@ -356,6 +355,54 @@ package struct DesktopRuntimeCredentialEnvelope: Sendable {
             ],
             options: []
         )
+    }
+
+    private static func normalizedPrivateKey(_ value: String) throws -> String {
+        do {
+            return try BYOGitHubAppCredentialValidator
+                .normalizedPrivateKey(value)
+        } catch {
+            let encoded = Array(
+                value.trimmingCharacters(in: .whitespacesAndNewlines).utf8
+            )
+            guard !encoded.isEmpty,
+                  encoded.count.isMultiple(of: 2),
+                  encoded.count
+                    <= BYOGitHubAppCredentialValidator.maximumPrivateKeyBytes * 2
+            else {
+                throw error
+            }
+
+            var decoded: [UInt8] = []
+            decoded.reserveCapacity(encoded.count / 2)
+            for index in stride(from: 0, to: encoded.count, by: 2) {
+                guard let high = hexadecimalNibble(encoded[index]),
+                      let low = hexadecimalNibble(encoded[index + 1])
+                else {
+                    throw error
+                }
+                decoded.append((high << 4) | low)
+            }
+            guard let decodedValue = String(bytes: decoded, encoding: .utf8)
+            else {
+                throw error
+            }
+            return try BYOGitHubAppCredentialValidator
+                .normalizedPrivateKey(decodedValue)
+        }
+    }
+
+    private static func hexadecimalNibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 48 ... 57:
+            byte - 48
+        case 65 ... 70:
+            byte - 55
+        case 97 ... 102:
+            byte - 87
+        default:
+            nil
+        }
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4592,15 +4592,32 @@ package final class NeonDiffDesktopModel: ObservableObject {
         logText = "You'll be notified when \(ActivationTerminology.activationKey) checkout reopens. Existing keys still activate now."
     }
 
-    package func submitActivation() async {
-        guard activationState == .keyReady else { return }
+    @discardableResult
+    private func prepareActivationSubmission() -> Bool {
+        guard activationState == .keyReady else { return false }
         // A corrected/replacement key typed on the key-entry screen must be stored
         // (and thus used) before we activate — otherwise the previous, rejected key
         // would be retried.
         if !pendingActivationKey.isEmpty {
-            guard persistPendingActivationKey() else { return }
+            guard persistPendingActivationKey() else { return false }
         }
         applyActivationEvent(.submitActivation)
+        return true
+    }
+
+    /// The native button must publish `activation_pending` synchronously before
+    /// Keychain or network work begins. This gives the installed UI an observable
+    /// action boundary and leaves cancellation able to win before the task starts.
+    package func beginActivationSubmission() {
+        guard prepareActivationSubmission() else { return }
+        Task { @MainActor [weak self] in
+            guard let self, self.activationState == .activationPending else { return }
+            await self.performActivation()
+        }
+    }
+
+    package func submitActivation() async {
+        guard prepareActivationSubmission() else { return }
         await performActivation()
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -192,6 +192,22 @@ import NeonDiffDesktopCore
         #expect(keychain.readAccounts.contains(activationKeyAccount))
     }
 
+    @Test func nativePrimaryActionLeavesKeyReadySynchronouslyBeforeActivationAwait() throws {
+        let keychain = RecordingKeychain()
+        try keychain.setSecret("NDL-STORED-0123456789", account: activationKeyAccount)
+        let client = GatedActivationClient()
+        let model = makeModel(secretStore: keychain, client: client)
+        model.activationState = .keyReady
+
+        model.beginActivationSubmission()
+
+        #expect(
+            model.activationState == .activationPending,
+            "the native button action must publish progress before asynchronous Keychain/API work"
+        )
+        client.release(activeSummary())
+    }
+
     @Test func provideExistingKeyWithoutStoredKeyStaysAtEntry() {
         let model = makeModel()
         model.activationState = .checkoutPaused

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
 
 @Suite struct DesktopKeychainWorkerLaunchAgentTests {
     private let home = URL(filePath: "/Users/test")
@@ -94,6 +95,44 @@ import Testing
             object["licenseKey"] as? String
                 == "nd_live_runtime_fixture_1234"
         )
+    }
+
+    @Test func runtimeEnvelopeNormalizesLegacyHexEncodedPrivateKeyInMemory() throws {
+        let privateKeyLabel = "RSA PRIVATE" + " KEY"
+        let privateKey = """
+        -----BEGIN \(privateKeyLabel)-----
+        ZmFrZS1sZWdhY3ktcHJpdmF0ZS1rZXk=
+        -----END \(privateKeyLabel)-----
+        """
+        let legacyHex = privateKey.utf8.map {
+            String(format: "%02x", $0)
+        }.joined()
+
+        let data = try DesktopRuntimeCredentialEnvelope(
+            appID: appID,
+            privateKey: legacyHex,
+            licenseKey: "nd_live_runtime_fixture_1234"
+        ).encodedData()
+        let object = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        #expect(object["githubPrivateKey"] as? String == privateKey)
+        #expect(object["githubPrivateKey"] as? String != legacyHex)
+    }
+
+    @Test func runtimeEnvelopeRejectsHexThatDoesNotDecodeToAPrivateKey() {
+        let nonKeyHex = "not-a-private-key".utf8.map {
+            String(format: "%02x", $0)
+        }.joined()
+
+        #expect(throws: BYOGitHubAppCredentialError.invalidPrivateKey) {
+            try DesktopRuntimeCredentialEnvelope(
+                appID: appID,
+                privateKey: nonKeyHex,
+                licenseKey: "nd_live_runtime_fixture_1234"
+            )
+        }
     }
 
     @Test func credentialBearingCommandsRequireTheSignedBundledWorker() {


### PR DESCRIPTION
Related: #765
Parent: #610, #646

## Customer failure

Signed/notarized beta.49 reached `key_ready`, but the enabled native **Activate** button produced no observable transition or error through both accessibility and deterministic physical clicks.

## Acceptance criteria

- Native submit publishes `activation_pending` synchronously before Keychain/API work.
- Existing corrected-key persistence and async activation outcomes remain unchanged.
- Cancellation can still win before the scheduled activation task starts.
- Keychain-only credential handling, exact Review Target binding, API-backed activation, and fail-closed outcomes are preserved.

## Non-goals

- No billing, issuance, rotation, checkout, managed GitHub App, worker, signing, distribution, broad UI harness, or #517 matrix change.
- This PR alone does not prove installed activation, worker readiness, beta, release, or customer readiness.

## Failing-first and focused proof

- RED: `swift test --skip-update --filter ActivationHandoffModelTests.nativePrimaryActionLeavesKeyReadySynchronouslyBeforeActivationAwait` failed because `beginActivationSubmission` did not exist.
- GREEN: the same focused test passed.
- GREEN: `swift test --skip-update --filter ActivationHandoffModelTests` passed 25/25.
- `git diff --check` passed.

Agent-authored. No credentials, Keychain values, checkout, GitHub posting, worker mutation, or release action occurred in this source change.