### PR TITLE
fix(desktop): restore installed existing-bot review path

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,14 @@ This source composition is not proof that the production broker is enabled,
 that billing is live, or that a signed customer artifact exists. Update,
 rollback, daemon admission, and live-review behavior still require exact signed
 candidate validation before distribution.
-The native Providers pane reads and edits the saved `providers` registry, not
-the legacy `desktop.openAICompatibleEndpoint` field. Load config, Preview, and
-Apply the exact selected provider before Verify is enabled; verification pins
-both the provider ID and inspected config revision. A provider with
+The native Providers pane reads the active review runtime from the inspected
+config. When `codexRuntime.enabled` is true, it shows the exact Codex CLI path,
+model, and reasoning effort and treats that existing authenticated CLI session
+as the review execution backend; NeonDiff never reads or stores its OAuth
+material. Otherwise the pane reads and edits the saved `providers` registry,
+not the legacy `desktop.openAICompatibleEndpoint` field. Load config, Preview,
+and Apply the exact selected provider before Verify is enabled; verification
+pins both the provider ID and inspected config revision. A provider with
 `authMode: zcode-app-config` or `none` does not use a NeonDiff-stored API key,
 so the native app reports its loaded config without showing a false missing-key
 state. `api-key-env` providers retain the Keychain and verification gate.

--- a/README.md
+++ b/README.md
@@ -193,8 +193,11 @@ executable is the signed NeonDiff app. Before releasing either Keychain secret,
 the app validates its exact Developer ID signature and the running sealed
 worker process, then pipes one bounded JSON envelope to that process's stdin.
 The plist contains only the
-public App ID, config path, launchd label, and signed app path—never a key value
-or key-file path. Review and daemon readiness remain separate gates. The
+public App ID, config path, launchd label, the non-secret broker device ID used
+by the existing API-backed activation, and the signed app path—never a key
+value or key-file path. The headless app re-derives that device ID from its
+Keychain identity and rejects a mismatched plist before releasing credentials.
+Review and daemon readiness remain separate gates. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
 gates. Unsigned development builds still require an executable global or
 checksum-managed worker before native first run

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -54,6 +54,12 @@ enum FoundationKeychainWorkerDaemonRunner {
         }
 
         let secretStore = KeychainSecretStore()
+        let identity = try GitHubBrokerDeviceIdentityStore(
+            secretStore: secretStore
+        ).loadExisting(allowUserInteraction: false)
+        guard identity.deviceId == request.licenseMachineID else {
+            throw WorkerDaemonRunnerError.invalidInvocation
+        }
         guard let stored = try secretStore.readSecret(
             account: BYOGitHubAppKeychainAccount.privateKey,
             allowUserInteraction: false
@@ -67,7 +73,8 @@ enum FoundationKeychainWorkerDaemonRunner {
         var standardInput = try DesktopRuntimeCredentialEnvelope(
             appID: request.appID,
             privateKey: stored,
-            licenseKey: licenseKey
+            licenseKey: licenseKey,
+            licenseMachineID: request.licenseMachineID
         ).encodedData()
         defer {
             standardInput.resetBytes(in: 0..<standardInput.count)
@@ -132,6 +139,7 @@ enum FoundationKeychainWorkerDaemonRunner {
         let standardized = configURL.standardizedFileURL
         guard (try? DesktopKeychainWorkerLaunchAgentRequest(
             appID: "1",
+            licenseMachineID: String(repeating: "a", count: 43),
             configPath: standardized.path,
             launchdLabel: "com.example.neondiff",
             homeDirectory: homeDirectory

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -65,7 +65,8 @@ struct FoundationKeychainWorkerLaunchAgentManager:
                         expectedLabel: request.launchdLabel,
                         homeDirectory: homeDirectory,
                         appExecutableIsSafe: { $0 == appExecutableURL },
-                        configExists: isSafeConfig
+                        configExists: isSafeConfig,
+                        legacyLicenseMachineID: request.licenseMachineID
                     ) != nil
                 else {
                     throw WorkerLaunchAgentRuntimeError

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -22,10 +22,20 @@ struct FoundationKeychainWorkerLaunchAgentManager:
     }
 
     func preview(
-        request: DesktopKeychainWorkerLaunchAgentRequest
+        request: DesktopKeychainWorkerLaunchAgentRequest,
+        preservedRepositoryCount: Int
     ) async throws -> String {
         try validate(request)
-        return "Ready to install a secret-free LaunchAgent for the selected account bot and start the worker sealed inside the signed NeonDiff app."
+        guard let sealedWorkerPath = trustedBundledWorker.executablePath else {
+            throw WorkerLaunchAgentRuntimeError.invalidCoordinates
+        }
+        return DesktopKeychainWorkerLaunchAgentContract.redactedPreviewText(
+            request: request,
+            appExecutableURL: appExecutableURL,
+            sealedWorkerPath: sealedWorkerPath,
+            homeDirectory: homeDirectory,
+            preservedRepositoryCount: preservedRepositoryCount
+        )
     }
 
     func installAndStart(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -60,14 +60,13 @@ struct FoundationKeychainWorkerLaunchAgentManager:
                     options: .mappedIfSafe
                 )
                 guard DesktopKeychainWorkerLaunchAgentContract
-                    .parsePropertyList(
+                    .propertyListMatchesRequest(
                         existing,
-                        expectedLabel: request.launchdLabel,
+                        request: request,
                         homeDirectory: homeDirectory,
                         appExecutableIsSafe: { $0 == appExecutableURL },
-                        configExists: isSafeConfig,
-                        legacyLicenseMachineID: request.licenseMachineID
-                    ) != nil
+                        configExists: isSafeConfig
+                    )
                 else {
                     throw WorkerLaunchAgentRuntimeError
                         .conflictingLaunchAgent

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -556,11 +556,33 @@ struct OnboardingWizardView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 OperatorSection("Provider") {
-                    OperatorTextField(title: "Model", text: $model.providers.zcodeModel)
-                    OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
-                    OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
-                    OperatorTextField(title: "OpenAI-Compatible Endpoint", text: $model.providers.openAICompatibleEndpoint)
-                    if model.selectedProviderRequiresAPIKey {
+                    if model.providers.codexRuntime.enabled {
+                        OperatorBadge(
+                            text: model.providers.codexRuntime.isReady
+                                ? "CODEX CLI READY"
+                                : "CODEX CLI CONFIG REQUIRED",
+                            color: model.providers.codexRuntime.isReady
+                                ? NeonDiffTheme.accent
+                                : NeonDiffTheme.warning
+                        )
+                        LabeledContent("Runtime", value: "Codex CLI")
+                        LabeledContent("Model", value: model.providers.codexRuntime.model)
+                        LabeledContent(
+                            "Reasoning effort",
+                            value: model.providers.codexRuntime.reasoningEffort
+                        )
+                        LabeledContent("CLI", value: model.providers.codexRuntime.cliPath)
+                        Text("Uses the existing authenticated Codex CLI session. NeonDiff does not read or store its OAuth material.")
+                            .operatorBodyText()
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        OperatorTextField(title: "Model", text: $model.providers.zcodeModel)
+                        OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
+                        OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
+                        OperatorTextField(title: "OpenAI-Compatible Endpoint", text: $model.providers.openAICompatibleEndpoint)
+                    }
+                    if !model.providers.codexRuntime.enabled,
+                       model.selectedProviderRequiresAPIKey {
                         OperatorTextField(
                             title: "Provider API Key",
                             text: $model.pendingProviderKey,
@@ -588,7 +610,7 @@ struct OnboardingWizardView: View {
                             .font(.caption)
                             .foregroundStyle(NeonDiffTheme.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
-                    } else {
+                    } else if !model.providers.codexRuntime.enabled {
                         OperatorBadge(
                             text: model.providerSetupReady ? "APP CONFIG LOADED" : "CONFIG REQUIRED",
                             color: model.providerSetupReady ? NeonDiffTheme.accent : NeonDiffTheme.warning

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -17,14 +17,42 @@ struct ProviderSettingsView: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }
-                OperatorSection("ZCode / GLM") {
-                    OperatorTextField(title: "Model", text: $model.providers.zcodeModel)
-                    OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
-                    OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
+                if model.providers.codexRuntime.enabled {
+                    OperatorSection("Active Review Runtime") {
+                        OperatorBadge(
+                            text: model.providers.codexRuntime.isReady
+                                ? "CODEX CLI READY"
+                                : "CODEX CLI CONFIG REQUIRED",
+                            color: model.providers.codexRuntime.isReady
+                                ? NeonDiffTheme.accent
+                                : NeonDiffTheme.warning
+                        )
+                        LabeledContent("Runtime", value: "Codex CLI (existing OAuth session)")
+                        LabeledContent("Model", value: model.providers.codexRuntime.model)
+                        LabeledContent(
+                            "Reasoning effort",
+                            value: model.providers.codexRuntime.reasoningEffort
+                        )
+                        LabeledContent("CLI", value: model.providers.codexRuntime.cliPath)
+                        Text("NeonDiff invokes this existing authenticated Codex CLI session without reading or storing its OAuth material.")
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                } else {
+                    OperatorSection("ZCode / GLM") {
+                        OperatorTextField(title: "Model", text: $model.providers.zcodeModel)
+                        OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
+                        OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
+                    }
+                    .disabled(!model.canEditProviderConfiguration)
                 }
-                .disabled(!model.canEditProviderConfiguration)
 
-                OperatorSection("Saved Provider Registry") {
+                OperatorSection(
+                    model.providers.codexRuntime.enabled
+                        ? "Fallback Provider Registry"
+                        : "Saved Provider Registry"
+                ) {
                     Picker("Provider", selection: $model.providers.selectedProviderId) {
                         ForEach(model.providers.registryTargets) { target in
                             Text("\(target.displayName) (\(target.id))").tag(target.id)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -346,6 +346,11 @@ package enum DesktopTrustedBundledWorkerContract {
         arguments: [String],
         hasStandardInput: Bool
     ) -> Bool {
+        if Array(arguments.prefix(2)) == ["license", "status"],
+           arguments.contains("--license-machine-id")
+        {
+            return true
+        }
         guard hasStandardInput else { return false }
         return [
             "--runtime-credentials-stdin",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -121,6 +121,45 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         ]
     }
 
+    package static func redactedPreviewText(
+        request: DesktopKeychainWorkerLaunchAgentRequest,
+        appExecutableURL: URL,
+        sealedWorkerPath: String,
+        homeDirectory: URL,
+        preservedRepositoryCount: Int
+    ) -> String {
+        let plistPath = homeDirectory
+            .appending(
+                path: "Library/LaunchAgents/\(request.launchdLabel).plist",
+                directoryHint: .notDirectory
+            )
+            .standardizedFileURL
+            .path
+        let redactedArguments = [
+            headlessFlag,
+            "--config", request.configPath,
+            "--launchd-label", request.launchdLabel,
+            "--github-app-id", "[stored App ID]",
+            "--license-machine-id", "[stored device ID]"
+        ].joined(separator: " ")
+        let repositoryLabel = preservedRepositoryCount == 1
+            ? "repository"
+            : "repositories"
+
+        return """
+        Ready to install and start the secret-free local review worker.
+        LaunchAgent: \(plistPath)
+        Program: \(appExecutableURL.standardizedFileURL.path)
+        ProgramArguments: \(redactedArguments)
+        Sealed worker: \(sealedWorkerPath)
+        EnvironmentVariables: none
+        Launch policy: RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua; stdout=/dev/null; stderr=/dev/null.
+        Credentials: Keychain-only at runtime; no secret values in the plist, arguments, or environment.
+        Repository allowlist: preserved unchanged (\(preservedRepositoryCount) configured \(repositoryLabel)); no config write.
+        Mutation: write only the selected user LaunchAgent, then restart that exact service.
+        """
+    }
+
     package static func propertyListData(
         request: DesktopKeychainWorkerLaunchAgentRequest,
         appExecutableURL: URL
@@ -347,7 +386,8 @@ package enum DesktopTrustedBundledWorkerContract {
 
 package protocol DesktopKeychainWorkerLaunchAgentManaging: Sendable {
     func preview(
-        request: DesktopKeychainWorkerLaunchAgentRequest
+        request: DesktopKeychainWorkerLaunchAgentRequest,
+        preservedRepositoryCount: Int
     ) async throws -> String
 
     func installAndStart(
@@ -361,7 +401,8 @@ package struct UnavailableDesktopKeychainWorkerLaunchAgentManager:
     package init() {}
 
     package func preview(
-        request: DesktopKeychainWorkerLaunchAgentRequest
+        request: DesktopKeychainWorkerLaunchAgentRequest,
+        preservedRepositoryCount: Int
     ) async throws -> String {
         throw DesktopKeychainWorkerLaunchAgentError.invalidAppExecutable
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -6,11 +6,13 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
     Sendable
 {
     package let appID: String
+    package let licenseMachineID: String
     package let configPath: String
     package let launchdLabel: String
 
     package init(
         appID: String,
+        licenseMachineID: String,
         configPath: String,
         launchdLabel: String,
         homeDirectory: URL
@@ -27,6 +29,12 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
         ) != nil else {
             throw DesktopKeychainWorkerLaunchAgentError.invalidLaunchdLabel
         }
+        guard licenseMachineID.range(
+            of: #"^[A-Za-z0-9_-]{43}$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidLicenseMachineID
+        }
         let normalizedConfig = URL(filePath: configPath).standardizedFileURL
         guard Self.isAccountBotConfig(
             normalizedConfig,
@@ -35,6 +43,7 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
             throw DesktopKeychainWorkerLaunchAgentError.invalidConfigPath
         }
         self.appID = appID
+        self.licenseMachineID = licenseMachineID
         self.configPath = normalizedConfig.path
         self.launchdLabel = launchdLabel
     }
@@ -75,6 +84,7 @@ package enum DesktopKeychainWorkerLaunchAgentError:
     case invalidAppID
     case invalidConfigPath
     case invalidLaunchdLabel
+    case invalidLicenseMachineID
     case invalidAppExecutable
     case serializationFailed
 
@@ -86,6 +96,8 @@ package enum DesktopKeychainWorkerLaunchAgentError:
             "The local worker config must be the selected account bot config."
         case .invalidLaunchdLabel:
             "The local worker LaunchAgent label is invalid."
+        case .invalidLicenseMachineID:
+            "The local worker license device identity is invalid."
         case .invalidAppExecutable:
             "The signed NeonDiff app executable path is invalid."
         case .serializationFailed:
@@ -104,7 +116,8 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             headlessFlag,
             "--config", request.configPath,
             "--launchd-label", request.launchdLabel,
-            "--github-app-id", request.appID
+            "--github-app-id", request.appID,
+            "--license-machine-id", request.licenseMachineID
         ]
     }
 
@@ -146,7 +159,8 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         expectedLabel: String,
         homeDirectory: URL,
         appExecutableIsSafe: (URL) -> Bool,
-        configExists: (URL) -> Bool
+        configExists: (URL) -> Bool,
+        legacyLicenseMachineID: String? = nil
     ) -> DesktopKeychainWorkerLaunchAgentRequest? {
         guard let object = try? PropertyListSerialization.propertyList(
             from: data,
@@ -174,18 +188,26 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         root["StandardOutPath"] as? String == "/dev/null",
         root["StandardErrorPath"] as? String == "/dev/null",
         let programArguments = root["ProgramArguments"] as? [String],
-        programArguments.count == 8,
+        [8, 10].contains(programArguments.count),
         let executablePath = programArguments.first,
         executablePath.hasPrefix("/")
         else {
             return nil
         }
         let executable = URL(filePath: executablePath).standardizedFileURL
-        guard appExecutableIsSafe(executable),
-              let request = parseHeadlessArguments(
-                Array(programArguments.dropFirst()),
+        let headlessArguments = Array(programArguments.dropFirst())
+        let request = parseHeadlessArguments(
+            headlessArguments,
+            homeDirectory: homeDirectory
+        ) ?? legacyLicenseMachineID.flatMap {
+            parseLegacyHeadlessArguments(
+                headlessArguments,
+                licenseMachineID: $0,
                 homeDirectory: homeDirectory
-              ),
+            )
+        }
+        guard appExecutableIsSafe(executable),
+              let request,
               request.launchdLabel == expectedLabel,
               configExists(URL(filePath: request.configPath))
         else {
@@ -198,6 +220,29 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         _ arguments: [String],
         homeDirectory: URL
     ) -> DesktopKeychainWorkerLaunchAgentRequest? {
+        guard arguments.count == 9,
+              arguments[0] == headlessFlag,
+              arguments[1] == "--config",
+              arguments[3] == "--launchd-label",
+              arguments[5] == "--github-app-id",
+              arguments[7] == "--license-machine-id"
+        else {
+            return nil
+        }
+        return try? DesktopKeychainWorkerLaunchAgentRequest(
+            appID: arguments[6],
+            licenseMachineID: arguments[8],
+            configPath: arguments[2],
+            launchdLabel: arguments[4],
+            homeDirectory: homeDirectory
+        )
+    }
+
+    private static func parseLegacyHeadlessArguments(
+        _ arguments: [String],
+        licenseMachineID: String,
+        homeDirectory: URL
+    ) -> DesktopKeychainWorkerLaunchAgentRequest? {
         guard arguments.count == 7,
               arguments[0] == headlessFlag,
               arguments[1] == "--config",
@@ -208,6 +253,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         }
         return try? DesktopKeychainWorkerLaunchAgentRequest(
             appID: arguments[6],
+            licenseMachineID: licenseMachineID,
             configPath: arguments[2],
             launchdLabel: arguments[4],
             homeDirectory: homeDirectory
@@ -327,11 +373,13 @@ package struct DesktopRuntimeCredentialEnvelope: Sendable {
     private let appID: String
     private let privateKey: String
     private let licenseKey: String
+    private let licenseMachineID: String
 
     package init(
         appID: String,
         privateKey: String,
-        licenseKey: String
+        licenseKey: String,
+        licenseMachineID: String
     ) throws {
         self.appID = try BYOGitHubAppCredentialValidator
             .normalizedAppId(appID)
@@ -343,15 +391,24 @@ package struct DesktopRuntimeCredentialEnvelope: Sendable {
             throw DesktopRuntimeCredentialEnvelopeError.invalidLicenseKey
         }
         self.licenseKey = licenseKey
+        guard licenseMachineID.range(
+            of: #"^[A-Za-z0-9_-]{43}$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopRuntimeCredentialEnvelopeError
+                .invalidLicenseMachineID
+        }
+        self.licenseMachineID = licenseMachineID
     }
 
     package func encodedData() throws -> Data {
         try JSONSerialization.data(
             withJSONObject: [
-                "schemaVersion": 1,
+                "schemaVersion": 2,
                 "githubAppId": appID,
                 "githubPrivateKey": privateKey,
-                "licenseKey": licenseKey
+                "licenseKey": licenseKey,
+                "licenseMachineId": licenseMachineID
             ],
             options: []
         )
@@ -411,8 +468,14 @@ package enum DesktopRuntimeCredentialEnvelopeError:
     LocalizedError
 {
     case invalidLicenseKey
+    case invalidLicenseMachineID
 
     package var errorDescription: String? {
-        "The API-backed NeonDiff activation credential is invalid."
+        switch self {
+        case .invalidLicenseKey:
+            "The API-backed NeonDiff activation credential is invalid."
+        case .invalidLicenseMachineID:
+            "The API-backed NeonDiff activation device identity is invalid."
+        }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -216,6 +216,23 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         return request
     }
 
+    package static func propertyListMatchesRequest(
+        _ data: Data,
+        request: DesktopKeychainWorkerLaunchAgentRequest,
+        homeDirectory: URL,
+        appExecutableIsSafe: (URL) -> Bool,
+        configExists: (URL) -> Bool
+    ) -> Bool {
+        parsePropertyList(
+            data,
+            expectedLabel: request.launchdLabel,
+            homeDirectory: homeDirectory,
+            appExecutableIsSafe: appExecutableIsSafe,
+            configExists: configExists,
+            legacyLicenseMachineID: request.licenseMachineID
+        ) == request
+    }
+
     package static func parseHeadlessArguments(
         _ arguments: [String],
         homeDirectory: URL

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -647,6 +647,14 @@ package enum DesktopLocalBotExecutionContextResolver {
         if Array(arguments.prefix(2)) == ["config", "patch"] {
             return isSupportedConfigPatch(arguments)
         }
+        if arguments.count == 6,
+           Array(arguments.prefix(2)) == ["daemon", "status"],
+           arguments[2] == "--config",
+           arguments[4] == "--launchd-label",
+           !arguments[5].isEmpty
+        {
+            return true
+        }
         guard arguments.count == 9,
               Array(arguments.prefix(2)) == ["doctor", "github"],
               arguments[2] == "--config",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopLocalBotConfiguration.swift
@@ -741,7 +741,8 @@ package enum DesktopLocalBotExecutionContextResolver {
     private static func isTrustedBundledWorker(
         _ context: DesktopLocalBotExecutionContext
     ) -> Bool {
-        guard let executablePath = context.executablePath,
+        guard context.configPath.isEmpty,
+              let executablePath = context.executablePath,
               executablePath
                 == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
               context.argumentPrefix.isEmpty,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4193,44 +4193,129 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let expectedConfigPath = configPath
         let executablePath = cliPath
         let cli = dependencies.cli
-        let arguments = [
+        let expectedLicenseMachineID: String?
+        if expectedContext.source == .keychainStdinExistingBot {
+            guard let licenseMachineID = try? GitHubBrokerDeviceIdentityStore(
+                secretStore: dependencies.secretStore
+            ).loadExisting(allowUserInteraction: false).deviceId else {
+                isBYOGitHubVerificationInProgress = false
+                applyActivationEvent(.activationServiceError)
+                lastError =
+                    "The saved activation device identity is unavailable. Reactivate this Mac before verifying current access."
+                byoGitHubCredentialStatus =
+                    "GitHub access was verified, but the Keychain-backed entitlement identity could not be loaded safely."
+                return
+            }
+            expectedLicenseMachineID = licenseMachineID
+        } else {
+            expectedLicenseMachineID = nil
+        }
+        let keychainRevalidation:
+            (client: any ActivationLicenseClienting, key: ActivationKeyMaterial)?
+        if expectedContext.source == .keychainStdinExistingBot {
+            guard let expectedLicenseMachineID,
+                  let client = activationLicenseClientOverride
+                    ?? liveActivationLicenseClient(
+                        machineId: expectedLicenseMachineID,
+                        repository: repository
+                    )
+            else {
+                isBYOGitHubVerificationInProgress = false
+                applyActivationEvent(.activationServiceError)
+                lastError =
+                    "The signed activation verifier is unavailable. Reopen NeonDiff and verify existing access again."
+                byoGitHubCredentialStatus =
+                    "GitHub access was verified, but the API-backed entitlement verifier is unavailable."
+                return
+            }
+            let rawActivationKey: String?
+            do {
+                rawActivationKey = try dependencies.secretStore.readSecret(
+                    account: activationKeyAccount,
+                    allowUserInteraction: false
+                )
+            } catch {
+                rawActivationKey = nil
+            }
+            guard let rawActivationKey,
+                  !ActivationKeyMaterial(rawActivationKey).isEmpty
+            else {
+                isBYOGitHubVerificationInProgress = false
+                applyActivationEvent(.activationServiceError)
+                lastError =
+                    "The stored NeonDiff Activation Key is unavailable without user interaction. Use the License pane to authorize this Mac again."
+                byoGitHubCredentialStatus =
+                    "GitHub access was verified, but the stored API-backed entitlement credential is unavailable."
+                return
+            }
+            keychainRevalidation = (
+                client,
+                ActivationKeyMaterial(rawActivationKey)
+            )
+        } else {
+            keychainRevalidation = nil
+        }
+        var arguments = [
             "license", "status",
             "--config", configPath,
             "--repo", repository,
-            "--refresh", "true",
-            "--json"
+            "--refresh", "true"
         ]
+        if let expectedLicenseMachineID {
+            arguments.append(contentsOf: [
+                "--license-machine-id", expectedLicenseMachineID
+            ])
+        }
+        arguments.append("--json")
         isBYOGitHubVerificationInProgress = true
         byoGitHubCredentialStatus =
             "GitHub access verified. Checking the existing local agent's API-backed entitlement…"
-        lastCommandLine =
-            "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true --json"
+        let redactedDeviceBinding = expectedLicenseMachineID == nil
+            ? ""
+            : " --license-machine-id [stored device ID]"
+        if keychainRevalidation == nil {
+            lastCommandLine =
+                "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true\(redactedDeviceBinding) --json"
+        } else {
+            lastCommandLine =
+                "\(shellQuote(cliPath)) license activate --config \(shellQuote(configPath)) --license-storage keychain --license-key-stdin true --persist-local-state false\(redactedDeviceBinding) --repo \(shellQuote(repository)) --json"
+        }
 
         Task.detached {
             let outcome: ActivationClientOutcome
-            do {
-                let result = try await cli.run(
-                    executablePath: executablePath,
-                    arguments: arguments,
-                    standardInput: nil,
-                    timeout: 20
-                )
-                outcome = result.stdout.trimmingCharacters(
-                    in: .whitespacesAndNewlines
-                ).isEmpty
-                    ? .serviceError
-                    : CLIActivationLicenseClient.classify(
-                        stdout: result.stdout
+            if let keychainRevalidation {
+                do {
+                    outcome = try await keychainRevalidation.client.revalidate(
+                        key: keychainRevalidation.key
                     )
-            } catch let error as NeonDiffCLIError {
-                switch error {
-                case .timedOut, .cancelled, .cleanupTimedOut:
+                } catch {
                     outcome = .offline
-                case .launchFailed, .standardInputTooLarge, .outputTooLarge:
-                    outcome = .serviceError
                 }
-            } catch {
-                outcome = .offline
+            } else {
+                do {
+                    let result = try await cli.run(
+                        executablePath: executablePath,
+                        arguments: arguments,
+                        standardInput: nil,
+                        timeout: 20
+                    )
+                    outcome = result.stdout.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ).isEmpty
+                        ? .serviceError
+                        : CLIActivationLicenseClient.classify(
+                            stdout: result.stdout
+                        )
+                } catch let error as NeonDiffCLIError {
+                    switch error {
+                    case .timedOut, .cancelled, .cleanupTimedOut:
+                        outcome = .offline
+                    case .launchFailed, .standardInputTooLarge, .outputTooLarge:
+                        outcome = .serviceError
+                    }
+                } catch {
+                    outcome = .offline
+                }
             }
 
             await MainActor.run {
@@ -4254,6 +4339,27 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         "GitHub access was verified, but stale entitlement proof was discarded. Verify existing access again."
                     return
                 }
+                if let expectedLicenseMachineID {
+                    let currentLicenseMachineID =
+                        try? GitHubBrokerDeviceIdentityStore(
+                            secretStore: self.dependencies.secretStore
+                        ).loadExisting(
+                            allowUserInteraction: false
+                        ).deviceId
+                    guard currentLicenseMachineID
+                            == expectedLicenseMachineID
+                    else {
+                        self.isBYOGitHubVerificationInProgress = false
+                        self.applyActivationEvent(
+                            .activationServiceError
+                        )
+                        self.lastError =
+                            "The activation device identity changed before entitlement verification finished."
+                        self.byoGitHubCredentialStatus =
+                            "GitHub access was verified, but stale device-bound entitlement proof was discarded."
+                        return
+                    }
+                }
                 self.isBYOGitHubVerificationInProgress = false
                 let resolved =
                     self.resolveExistingLocalAgentEntitlementOutcome(
@@ -4267,7 +4373,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     resolved,
                     repository: repository,
                     activeLogMessage:
-                        "Current repository entitlement verified through the existing local agent. No Activation Key was copied."
+                        "Current repository entitlement verified through the existing local agent's API-backed credential path."
                 )
                 switch resolved {
                 case .active:
@@ -4546,17 +4652,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
         if let activationLicenseClientOverride { return activationLicenseClientOverride }
-        // Keep the real adapter behind the rollout flag until production billing
-        // and activation canaries pass. When enabled, it uses the CLI's explicit
-        // no-local-state mode: the app-owned Keychain item remains the only raw
-        // credential copy and the key crosses only over bounded stdin.
-        let bundleEnablesActivation = dependencies.productionBoundary.byoGitHubEnabled
-        let rolloutEnablesActivation = dependencies.preferences.bool(forKey: activationCliBackedEnabledKey)
-        guard dependencies.productionBoundary.nativeActivationBrokerVerified,
-              bundleEnablesActivation || rolloutEnablesActivation
-        else {
-            return nil
-        }
         guard let selectedReviewRepository,
               repos.contains(where: {
                   $0.enabled
@@ -4569,12 +4664,36 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
+        return liveActivationLicenseClient(
+            machineId: identity.deviceId,
+            repository: selectedReviewRepository
+        )
+    }
+
+    private func liveActivationLicenseClient(
+        machineId: String,
+        repository: String
+    ) -> (any ActivationLicenseClienting)? {
+        // Keep the real adapter behind the rollout flag until production billing
+        // and activation canaries pass. When enabled, it uses the CLI's explicit
+        // no-local-state mode: the app-owned Keychain item remains the only raw
+        // credential copy and the key crosses only over bounded stdin.
+        let bundleEnablesActivation =
+            dependencies.productionBoundary.byoGitHubEnabled
+        let rolloutEnablesActivation = dependencies.preferences.bool(
+            forKey: activationCliBackedEnabledKey
+        )
+        guard dependencies.productionBoundary.nativeActivationBrokerVerified,
+              bundleEnablesActivation || rolloutEnablesActivation
+        else {
+            return nil
+        }
         return DesktopActivationLicenseClient(
             cli: dependencies.cli,
             executablePath: cliPath,
             configPath: configPath,
-            machineId: identity.deviceId,
-            repository: selectedReviewRepository
+            machineId: machineId,
+            repository: repository
         )
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2531,12 +2531,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         let manager = dependencies.keychainWorkerLaunchAgentManager
+        let preservedRepositoryCount = repos.count
         isKeychainWorkerLaunchAgentOperationInProgress = true
         keychainWorkerLaunchAgentStatus =
             "Validating the signed app, selected config, and sealed worker…"
         Task { [weak self] in
             do {
-                let status = try await manager.preview(request: request)
+                let status = try await manager.preview(
+                    request: request,
+                    preservedRepositoryCount: preservedRepositoryCount
+                )
                 guard let self else { return }
                 self.isKeychainWorkerLaunchAgentOperationInProgress = false
                 self.keychainWorkerLaunchAgentStatus = status

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -229,7 +229,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package var customerRuntimeBoundaryMessage: String {
         if byoGitHubCredentialOnboardingAvailable,
-           repos.filter(\.enabled).count > 1 {
+           repos.filter(\.enabled).count > 1,
+           !reviewTargetRuntimeReady {
             let target = selectedBYOReviewRepository.map {
                 "Activation can be verified for \($0), but "
             } ?? "Choose one Review Target for activation. "
@@ -287,10 +288,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard let selectedBYOReviewRepository else {
             return false
         }
-        return enabledRepositories.count == 1
-            && enabledRepositories[0].caseInsensitiveCompare(
+        let selectedTargetIsEnabled = enabledRepositories.contains {
+            $0.caseInsensitiveCompare(
                 selectedBYOReviewRepository
             ) == .orderedSame
+        }
+        guard selectedTargetIsEnabled else {
+            return false
+        }
+        if enabledRepositories.count == 1 {
+            return true
+        }
+        return existingLocalBotIdentityReady
+            && selectedAccountWorkspace?.entitlement == .internalAdmin
     }
 
     /// Existing-account entitlement is useful setup context, but it must not
@@ -427,8 +437,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     /// Starting the long-running daemon remains stricter than one scoped
-    /// review. A multi-repository worker cannot be started from the native app
-    /// until its runtime scope can be narrowed without rewriting the allowlist.
+    /// review. Customer BYO workers require one enabled repository. A verified
+    /// existing internal-admin bot may retain its existing multi-repository
+    /// allowlist while the current activation remains bound to one selected
+    /// review target.
     package var productionDaemonStartAvailable: Bool {
         productionUsefulWorkAvailable
             && reviewTargetRuntimeReady

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -5161,7 +5161,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         isScopedReviewInProgress = false
         scopedReviewTask = nil
-        guard currentScopedReviewCoordinatesMatch(expectedContext),
+        let coordinatesMatch =
+            currentScopedReviewCoordinatesMatch(expectedContext)
+        let structuredFailure =
+            scopedReviewStructuredFailureMessage(result.stdout)
+        guard coordinatesMatch,
               result.exitCode == 0,
               let data = result.stdout.data(using: .utf8),
               let report = try? JSONDecoder().decode(
@@ -5179,8 +5183,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
               isValidGitHubCommitSHA(report.scope.headSha)
         else {
             invalidateScopedReviewApproval()
-            lastError =
-                "The dry review did not produce exact repository, pull request, and head proof."
+            lastError = coordinatesMatch
+                ? (structuredFailure
+                    ?? "The dry review did not produce exact repository, pull request, and head proof.")
+                : "The dry review context changed before exact repository, pull request, and head proof completed."
             scopedReviewStatus =
                 "Dry review failed closed. No live review is authorized."
             return
@@ -5244,6 +5250,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         scopedReviewStatus =
             "Review posted for \(expectedApproval.repo)#\(expectedApproval.pullNumber) at \(expectedApproval.headSHA.prefix(12))."
         invalidateScopedReviewApproval(preserveStatus: true)
+    }
+
+    private func scopedReviewStructuredFailureMessage(
+        _ stdout: String
+    ) -> String? {
+        guard let data = stdout.data(using: .utf8),
+              let report = try? JSONDecoder().decode(
+                  ScopedReviewFailureReport.self,
+                  from: data
+              ),
+              let rawMessage = report.error?.message
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawMessage.isEmpty
+        else {
+            return nil
+        }
+        let redacted = NeonDiffRedactor.redact(rawMessage)
+        return "Dry review failed safely: \(redacted.prefix(512))"
     }
 
     private func currentScopedReviewCoordinatesMatch(
@@ -6809,6 +6833,14 @@ private struct ScopedReviewCommandReport: Decodable {
     let dryRun: Bool
     let scope: Scope
     let result: Result
+}
+
+private struct ScopedReviewFailureReport: Decodable {
+    struct Failure: Decodable {
+        let message: String
+    }
+
+    let error: Failure?
 }
 
 private let licenseKeyAccount = "license/default"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3859,7 +3859,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func verifyExistingLocalBotGitHubAccess() {
         if existingLocalAgentAccessAvailable,
-           selectedBotInstallation != nil
+           selectedBotInstallation != nil,
+           !keychainWorkerLaunchAgentActive
         {
             verifyGitHubAccessThroughExistingLocalAgent()
             return

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4139,9 +4139,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
         }
 
-        if expectedContext.source == .existingLocalAgent,
-           let readCheck = report.github.readChecks.first
-        {
+        if expectedContext.source == .existingLocalAgent
+            || (
+                expectedContext.source == .keychainStdinExistingBot
+                    && existingLocalAgentAccessAvailable
+            ),
+           let readCheck = report.github.readChecks.first {
             verifyExistingLocalAgentEntitlement(
                 expectedContext: expectedContext,
                 visibility: readCheck.visibilityResult
@@ -4156,7 +4159,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard existingLocalAgentAccessAvailable,
               existingLocalBotIdentityReady,
               selectedAccountEntitlementSupportsCurrentPath,
-              expectedContext.source == .existingLocalAgent,
+              (
+                  expectedContext.source == .existingLocalAgent
+                      || expectedContext.source
+                          == .keychainStdinExistingBot
+              ),
               expectedContext.repositories.count == 1,
               let repository = expectedContext.repositories.first,
               selectedReviewRepository?.caseInsensitiveCompare(repository)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -6838,6 +6838,20 @@ private struct ScopedReviewCommandReport: Decodable {
 private struct ScopedReviewFailureReport: Decodable {
     struct Failure: Decodable {
         let message: String
+
+        private enum CodingKeys: String, CodingKey {
+            case message
+        }
+
+        init(from decoder: Decoder) throws {
+            let singleValue = try decoder.singleValueContainer()
+            if let message = try? singleValue.decode(String.self) {
+                self.message = message
+                return
+            }
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            message = try values.decode(String.self, forKey: .message)
+        }
     }
 
     let error: Failure?

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -3725,6 +3725,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func verifyBYOGitHubAppCredentials() {
+        verifyBYOGitHubAppCredentials(
+            repositoryScope: nil,
+            source: .keychainStdin
+        )
+    }
+
+    private func verifyBYOGitHubAppCredentials(
+        repositoryScope: String?,
+        source: BYOGitHubVerificationContext.CredentialSource
+    ) {
         guard !isSetupMutationBlocked else {
             lastError = "Retry account verification before verifying GitHub App setup."
             byoGitHubCredentialStatus = lastError ?? "Account check required"
@@ -3762,21 +3772,30 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
-        let arguments = [
+        var arguments = [
             "doctor", "github",
-            "--config", configPath,
+            "--config", configPath
+        ]
+        if let repositoryScope {
+            arguments += ["--repo", repositoryScope]
+        }
+        arguments += [
             "--github-app-id", appId,
             "--github-app-private-key-stdin", "true",
             "--json"
         ]
-        let safeCommand = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --github-app-id \(shellQuote(appId)) --github-app-private-key-stdin true --json < [secure Keychain input]"
+        let repoArgument = repositoryScope.map {
+            " --repo \(shellQuote($0))"
+        } ?? ""
+        let safeCommand = "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath))\(repoArgument) --github-app-id \(shellQuote(appId)) --github-app-private-key-stdin true --json < [secure Keychain input]"
         let verificationContext = BYOGitHubVerificationContext(
             appId: appId,
-            source: .keychainStdin,
+            source: source,
             credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
-            repositories: repos.filter(\.enabled).map(\.name).sorted(),
+            repositories: repositoryScope.map { [$0] }
+                ?? repos.filter(\.enabled).map(\.name).sorted(),
             workspaceGeneration: workspaceContextGeneration
         )
         var standardInput = Data(privateKey.utf8)
@@ -3786,7 +3805,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         byoGitHubCredentialsVerified = false
         lastError = nil
         lastCommandLine = safeCommand
-        byoGitHubCredentialStatus = "Verifying the configured repositories against the customer-owned GitHub App installation…"
+        byoGitHubCredentialStatus = repositoryScope == nil
+            ? "Verifying the configured repositories against the customer-owned GitHub App installation…"
+            : "Verifying the selected Review Target against the customer-owned GitHub App installation…"
 
         Task.detached {
             defer {
@@ -3825,9 +3846,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
         if let bot = selectedBotInstallation,
            let storedAppID = storedBYOGitHubAppId,
            storedAppID == String(bot.appID),
-           byoGitHubPrivateKeyStored
+           byoGitHubPrivateKeyStored,
+           let targetRepository = selectedBYOReviewRepository,
+           repos.contains(where: {
+               $0.enabled
+                   && $0.name.caseInsensitiveCompare(targetRepository)
+                       == .orderedSame
+           })
         {
-            verifyBYOGitHubAppCredentials()
+            verifyBYOGitHubAppCredentials(
+                repositoryScope: targetRepository,
+                source: .keychainStdinExistingBot
+            )
             return
         }
         let diagnosis = existingLocalBotBYOGitHubVerificationStatus
@@ -3942,6 +3972,33 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     workspaceGeneration: workspaceContextGeneration
                 )
             }
+        case .keychainStdinExistingBot:
+            currentContext = existingLocalBotIdentityReady
+                ? selectedBotInstallation.flatMap { bot in
+                    selectedBYOReviewRepository.flatMap { targetRepository in
+                        guard let storedAppID = storedBYOGitHubAppId,
+                              storedAppID == String(bot.appID),
+                              repos.contains(where: {
+                                  $0.enabled
+                                      && $0.name.caseInsensitiveCompare(
+                                          targetRepository
+                                      ) == .orderedSame
+                              })
+                        else {
+                            return nil
+                        }
+                        return BYOGitHubVerificationContext(
+                            appId: storedAppID,
+                            source: .keychainStdinExistingBot,
+                            credentialRevision: byoGitHubCredentialRevision,
+                            cliPath: cliPath,
+                            configPath: configPath,
+                            repositories: [targetRepository],
+                            workspaceGeneration: workspaceContextGeneration
+                        )
+                    }
+                }
+                : nil
         case .existingLocalAgent:
             currentContext = existingLocalAgentAccessAvailable
                 ? selectedBotInstallation.flatMap { bot in
@@ -3968,7 +4025,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         let expectedCredentialSource: String
         switch expectedContext.source {
-        case .keychainStdin:
+        case .keychainStdin, .keychainStdinExistingBot:
             expectedCredentialSource = "stdin"
         case .existingLocalAgent:
             expectedCredentialSource = "configured"
@@ -4042,12 +4099,23 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }.joined(separator: ", ")
         byoGitHubCredentialsVerified = true
         lastError = nil
-        byoGitHubCredentialStatus = expectedContext.source == .existingLocalAgent
-            ? "Verified existing local agent App installation access for \(repositories). Worker dry/live review has not run yet."
-            : "Verified App installation access for \(repositories). Worker dry/live review has not run yet."
-        logText = expectedContext.source == .existingLocalAgent
-            ? "Existing local agent GitHub App installation and repository access verified. No credential was copied and no review was executed or posted."
-            : "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
+        switch expectedContext.source {
+        case .existingLocalAgent:
+            byoGitHubCredentialStatus =
+                "Verified existing local agent App installation access for \(repositories). Worker dry/live review has not run yet."
+            logText =
+                "Existing local agent GitHub App installation and repository access verified. No credential was copied and no review was executed or posted."
+        case .keychainStdinExistingBot:
+            byoGitHubCredentialStatus =
+                "Verified App installation access for the selected Review Target \(repositories). Worker installation and dry/live review have not run yet."
+            logText =
+                "Selected existing-bot GitHub App installation access verified through the signed bundled worker. The full configured allowlist was not rewritten."
+        case .keychainStdin:
+            byoGitHubCredentialStatus =
+                "Verified App installation access for \(repositories). Worker dry/live review has not run yet."
+            logText =
+                "Customer-owned GitHub App installation and repository access verified through the local CLI. No review was executed or posted."
+        }
 
         if expectedContext.source == .existingLocalAgent,
            let readCheck = report.github.readChecks.first
@@ -6537,6 +6605,7 @@ private struct BYOGitHubDoctorReport: Decodable {
 private struct BYOGitHubVerificationContext: Equatable, Sendable {
     enum CredentialSource: Equatable, Sendable {
         case keychainStdin
+        case keychainStdinExistingBot
         case existingLocalAgent
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2567,6 +2567,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 lastError ?? "GitHub App setup required."
             return nil
         }
+        guard let licenseMachineID = try? GitHubBrokerDeviceIdentityStore(
+            secretStore: dependencies.secretStore
+        ).loadExisting(allowUserInteraction: false).deviceId else {
+            lastError =
+                "The saved activation device identity is unavailable. Reconnect or reactivate before installing the worker service."
+            keychainWorkerLaunchAgentStatus =
+                lastError ?? "Activation device identity required."
+            return nil
+        }
         let homeDirectory = dependencies.fileWriter
             .applicationSupportDirectory
             .deletingLastPathComponent()
@@ -2575,6 +2584,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         do {
             return try DesktopKeychainWorkerLaunchAgentRequest(
                 appID: appID,
+                licenseMachineID: licenseMachineID,
                 configPath: configPath,
                 launchdLabel: launchdLabel,
                 homeDirectory: homeDirectory
@@ -2623,13 +2633,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
             let licenseKey = try dependencies.secretStore.readSecret(
                 account: activationKeyAccount,
                 allowUserInteraction: false
-            ) else {
+            ),
+            let licenseMachineID = try? GitHubBrokerDeviceIdentityStore(
+                secretStore: dependencies.secretStore
+            ).loadExisting(allowUserInteraction: false).deviceId else {
                 throw BYOGitHubAppCredentialError.invalidPrivateKey
             }
             return try DesktopRuntimeCredentialEnvelope(
                 appID: appID,
                 privateKey: privateKey,
-                licenseKey: licenseKey
+                licenseKey: licenseKey,
+                licenseMachineID: licenseMachineID
             ).encodedData()
         } catch {
             lastError =

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -899,8 +899,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var providerSetupReady: Bool {
         guard providerLoadedSnapshot?.configPath == configPath,
               providerLoadedRevision != nil,
-              providerLoadedSnapshot == currentProviderConfigurationSnapshot,
-              let provider = providers.selectedRegistryTarget,
+              providerLoadedSnapshot == currentProviderConfigurationSnapshot
+        else {
+            return false
+        }
+        if providers.codexRuntime.isReady {
+            return true
+        }
+        guard let provider = providers.selectedRegistryTarget,
               provider.enabled
         else {
             return false
@@ -920,14 +926,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
-    /// The current scoped-review bridge executes ZCode, so its authorization
-    /// must be bound to the same app configuration ZCode will read. A provider
-    /// verified through NeonDiff's separate API-key adapter remains valid for
-    /// provider setup, but cannot authorize this bridge until direct adapter
-    /// execution is supported.
+    /// Scoped review uses the config-selected Codex runtime when enabled.
+    /// Otherwise it executes ZCode and requires an explicit execution provider
+    /// from ZCode's own namespace. A separately verified API-key registry
+    /// provider cannot authorize either execution bridge.
     package var scopedReviewProviderReady: Bool {
-        providerSetupReady
-            && providers.selectedRegistryTarget?.authMode == "zcode-app-config"
+        guard providerSetupReady else { return false }
+        if providers.codexRuntime.isReady {
+            return true
+        }
+        return providers.selectedRegistryTarget?.authMode == "zcode-app-config"
             && !providers.zcodeProviderId
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty
@@ -6488,6 +6496,7 @@ private struct ProviderConfigurationSnapshot: Equatable, Sendable {
     let zcodeProviderId: String
     let selectedProviderId: String
     let registryTargets: [ProviderRegistryTarget]
+    let codexRuntime: CodexRuntimeSettings
 
     init(
         providers: ProviderSettings,
@@ -6500,6 +6509,7 @@ private struct ProviderConfigurationSnapshot: Equatable, Sendable {
         zcodeProviderId = providers.zcodeProviderId
         selectedProviderId = providers.selectedProviderId
         registryTargets = providers.registryTargets
+        codexRuntime = providers.codexRuntime
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2320,6 +2320,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func refreshStatus() {
+        // The executor resolves the sealed worker from a live provider. Keep
+        // the model's install/preview gate on that same current discovery so a
+        // worker that became available after launch is not left cached absent.
+        if dependencies.localBotDiscoveryProvider != nil {
+            refreshLocalBotDiscovery()
+        } else if let localWorkerExecutionContextProvider {
+            currentLocalWorkerExecutionContexts =
+                localWorkerExecutionContextProvider()
+        }
         persistLocalSettings()
         statusRefreshFailureMessage = nil
         runCLI(arguments: ["daemon", "status", "--config", configPath, "--launchd-label", launchdLabel], displayCommand: statusCommand)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -123,6 +123,32 @@ public struct ProviderRegistryTarget: Identifiable, Equatable, Sendable {
     }
 }
 
+public struct CodexRuntimeSettings: Equatable, Sendable {
+    public var enabled: Bool
+    public var cliPath: String
+    public var model: String
+    public var reasoningEffort: String
+
+    public init(
+        enabled: Bool = false,
+        cliPath: String = "/usr/local/bin/codex",
+        model: String = "gpt-5.6-luna",
+        reasoningEffort: String = "max"
+    ) {
+        self.enabled = enabled
+        self.cliPath = cliPath
+        self.model = model
+        self.reasoningEffort = reasoningEffort
+    }
+
+    public var isReady: Bool {
+        enabled
+            && NSString(string: cliPath).isAbsolutePath
+            && !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && ["low", "medium", "high", "xhigh", "max"].contains(reasoningEffort)
+    }
+}
+
 public struct ProviderSettings: Equatable {
     public static var defaultZCodeAppConfigPath: String {
         FileManager.default.homeDirectoryForCurrentUser
@@ -138,6 +164,7 @@ public struct ProviderSettings: Equatable {
     public var providerKeyStored: Bool
     public var selectedProviderId: String
     public var registryTargets: [ProviderRegistryTarget]
+    public var codexRuntime: CodexRuntimeSettings
 
     public init(
         zcodeModel: String = "GLM-5.2",
@@ -147,7 +174,8 @@ public struct ProviderSettings: Equatable {
         openAICompatibleEndpoint: String = "http://localhost:8000/v1",
         providerKeyStored: Bool = false,
         selectedProviderId: String = "zcode-glm",
-        registryTargets: [ProviderRegistryTarget] = []
+        registryTargets: [ProviderRegistryTarget] = [],
+        codexRuntime: CodexRuntimeSettings = CodexRuntimeSettings()
     ) {
         self.zcodeModel = zcodeModel
         self.zcodeCliPath = zcodeCliPath
@@ -157,6 +185,7 @@ public struct ProviderSettings: Equatable {
         self.providerKeyStored = providerKeyStored
         self.selectedProviderId = selectedProviderId
         self.registryTargets = registryTargets
+        self.codexRuntime = codexRuntime
     }
 
     public var selectedRegistryTarget: ProviderRegistryTarget? {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -99,6 +99,7 @@ public enum ConfigInspectParser {
         let reviewConcurrency = config["reviewConcurrency"] as? [String: Any]
         let reviewGate = config["reviewGate"] as? [String: Any]
         let issueEnrichment = config["issueEnrichment"] as? [String: Any]
+        let codexRuntime = config["codexRuntime"] as? [String: Any]
         let providerRegistry = config["providers"] as? [String: Any]
         let selectedProviderId = providerRegistry?["defaultProviderId"] as? String ?? "zcode-glm"
         let registryEntries = providerRegistry?["providers"] as? [String: Any] ?? [:]
@@ -130,7 +131,14 @@ public enum ConfigInspectParser {
             openAICompatibleEndpoint: desktop?["openAICompatibleEndpoint"] as? String ?? "http://localhost:8000/v1",
             providerKeyStored: providerKeyStored,
             selectedProviderId: selectedProviderId,
-            registryTargets: registryTargets
+            registryTargets: registryTargets,
+            codexRuntime: CodexRuntimeSettings(
+                enabled: codexRuntime?["enabled"] as? Bool ?? false,
+                cliPath: codexRuntime?["cliPath"] as? String ?? "",
+                model: codexRuntime?["model"] as? String ?? "",
+                reasoningEffort: codexRuntime?["reasoningEffort"] as? String
+                    ?? ""
+            )
         )
         let license = LicenseStatus(
             keyStored: licenseKeyStored,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubBrokerClient.swift
@@ -142,18 +142,27 @@ public final class GitHubBrokerDeviceIdentityStore {
     /// Loads a previously-created identity without rotating or creating one.
     /// Saved-binding verification must use this path so a missing Keychain item
     /// cannot silently orphan the server-side binding.
-    public func loadExisting() throws -> GitHubBrokerDeviceIdentity {
+    public func loadExisting(
+        allowUserInteraction: Bool = true
+    ) throws -> GitHubBrokerDeviceIdentity {
         try lock.withLock {
-            guard let encoded = try readStoredIdentity() else {
+            guard let encoded = try readStoredIdentity(
+                allowUserInteraction: allowUserInteraction
+            ) else {
                 throw GitHubBrokerDeviceIdentityError.storedIdentityMissing
             }
             return try decodeIdentity(encoded)
         }
     }
 
-    private func readStoredIdentity() throws -> String? {
+    private func readStoredIdentity(
+        allowUserInteraction: Bool = true
+    ) throws -> String? {
         do {
-            return try secretStore.readSecret(account: account)
+            return try secretStore.readSecret(
+                account: account,
+                allowUserInteraction: allowUserInteraction
+            )
         } catch {
             throw GitHubBrokerDeviceIdentityError.identityStorageUnavailable
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -91,6 +91,42 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.localWorkerCLIAvailable)
     }
 
+    @Test func statusCheckIgnoresConfigBoundDuplicateOfUnboundSealedWorker() {
+        let configPath =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/existing-bot/config.local.json"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            preferenceStrings: [
+                "neondiff.cliPath": "neondiff",
+                "neondiff.configPath": configPath
+            ],
+            productionBoundary: exactB0Boundary
+        )
+        let sealedWorker =
+            "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
+        fixture.model.localWorkerExecutionContextProvider = {
+            [
+                DesktopLocalBotExecutionContext(
+                    configPath: configPath,
+                    executablePath: sealedWorker,
+                    argumentPrefix: [],
+                    environmentOverrides: [:]
+                ),
+                DesktopLocalBotExecutionContext(
+                    configPath: "",
+                    executablePath: sealedWorker,
+                    argumentPrefix: [],
+                    environmentOverrides: [:]
+                )
+            ]
+        }
+
+        #expect(!fixture.model.localWorkerCLIAvailable)
+        fixture.model.refreshStatus()
+
+        #expect(fixture.model.localWorkerCLIAvailable)
+    }
+
     @Test func cleanInstallInitializationUsesNonDestructiveCLIInit() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(CLIRunResult(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -62,6 +62,35 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.urlOpener.urls.isEmpty)
     }
 
+    @Test func statusCheckRefreshesLateSealedWorkerForNativeInstallGate() {
+        let configPath =
+            "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/existing-bot/config.local.json"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            preferenceStrings: [
+                "neondiff.cliPath": "neondiff",
+                "neondiff.configPath": configPath
+            ],
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.localWorkerExecutionContextProvider = {
+            [
+                DesktopLocalBotExecutionContext(
+                    configPath: "",
+                    executablePath:
+                        "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+                    argumentPrefix: [],
+                    environmentOverrides: [:]
+                )
+            ]
+        }
+
+        #expect(!fixture.model.localWorkerCLIAvailable)
+        fixture.model.refreshStatus()
+
+        #expect(fixture.model.localWorkerCLIAvailable)
+    }
+
     @Test func cleanInstallInitializationUsesNonDestructiveCLIInit() async {
         let fixture = ModelDependencyFixture(
             cliOutcomes: [.success(CLIRunResult(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -10,6 +10,7 @@ import NeonDiffDesktopCore
     )
     private let label = "com.electricsheephq.evaos-code-review-bot"
     private let appID = "4184532"
+    private let licenseMachineID = String(repeating: "a", count: 43)
 
     @Test func plistContainsOnlyPublicExactCoordinates() throws {
         let config = home.appending(
@@ -17,6 +18,7 @@ import NeonDiffDesktopCore
         )
         let request = try DesktopKeychainWorkerLaunchAgentRequest(
             appID: appID,
+            licenseMachineID: licenseMachineID,
             configPath: config.path,
             launchdLabel: label,
             homeDirectory: home
@@ -51,7 +53,8 @@ import NeonDiffDesktopCore
             "--neondiff-worker-daemon",
             "--config", config.path,
             "--launchd-label", label,
-            "--github-app-id", appID
+            "--github-app-id", appID,
+            "--license-machine-id", licenseMachineID
         ]
 
         #expect(DesktopKeychainWorkerLaunchAgentContract.parseHeadlessArguments(
@@ -73,6 +76,55 @@ import NeonDiffDesktopCore
         ) == nil)
     }
 
+    @Test func exactLegacyLaunchAgentCanBeReplacedWithDeviceBoundContract() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let request = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            licenseMachineID: licenseMachineID,
+            configPath: config.path,
+            launchdLabel: label,
+            homeDirectory: home
+        )
+        let currentData = try DesktopKeychainWorkerLaunchAgentContract
+            .propertyListData(
+                request: request,
+                appExecutableURL: appExecutable
+            )
+        var legacy = try #require(
+            PropertyListSerialization.propertyList(
+                from: currentData,
+                options: [],
+                format: nil
+            ) as? [String: Any]
+        )
+        var arguments = try #require(legacy["ProgramArguments"] as? [String])
+        arguments.removeLast(2)
+        legacy["ProgramArguments"] = arguments
+        let legacyData = try PropertyListSerialization.data(
+            fromPropertyList: legacy,
+            format: .xml,
+            options: 0
+        )
+
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parsePropertyList(
+            legacyData,
+            expectedLabel: label,
+            homeDirectory: home,
+            appExecutableIsSafe: { $0 == self.appExecutable },
+            configExists: { $0 == config }
+        ) == nil)
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parsePropertyList(
+            legacyData,
+            expectedLabel: label,
+            homeDirectory: home,
+            appExecutableIsSafe: { $0 == self.appExecutable },
+            configExists: { $0 == config },
+            legacyLicenseMachineID: licenseMachineID
+        ) == request)
+    }
+
     @Test func runtimeEnvelopeContainsBothKeychainSecretsOnlyInBoundedInput() throws {
         let privateKeyLabel = "PRIVATE" + " KEY"
         let privateKey = """
@@ -83,18 +135,20 @@ import NeonDiffDesktopCore
         let data = try DesktopRuntimeCredentialEnvelope(
             appID: appID,
             privateKey: privateKey,
-            licenseKey: "nd_live_runtime_fixture_1234"
+            licenseKey: "nd_live_runtime_fixture_1234",
+            licenseMachineID: licenseMachineID
         ).encodedData()
         let object = try #require(
             JSONSerialization.jsonObject(with: data) as? [String: Any]
         )
-        #expect(object["schemaVersion"] as? Int == 1)
+        #expect(object["schemaVersion"] as? Int == 2)
         #expect(object["githubAppId"] as? String == appID)
         #expect(object["githubPrivateKey"] as? String == privateKey)
         #expect(
             object["licenseKey"] as? String
                 == "nd_live_runtime_fixture_1234"
         )
+        #expect(object["licenseMachineId"] as? String == licenseMachineID)
     }
 
     @Test func runtimeEnvelopeNormalizesLegacyHexEncodedPrivateKeyInMemory() throws {
@@ -111,7 +165,8 @@ import NeonDiffDesktopCore
         let data = try DesktopRuntimeCredentialEnvelope(
             appID: appID,
             privateKey: legacyHex,
-            licenseKey: "nd_live_runtime_fixture_1234"
+            licenseKey: "nd_live_runtime_fixture_1234",
+            licenseMachineID: licenseMachineID
         ).encodedData()
         let object = try #require(
             JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -130,7 +185,26 @@ import NeonDiffDesktopCore
             try DesktopRuntimeCredentialEnvelope(
                 appID: appID,
                 privateKey: nonKeyHex,
-                licenseKey: "nd_live_runtime_fixture_1234"
+                licenseKey: "nd_live_runtime_fixture_1234",
+                licenseMachineID: licenseMachineID
+            )
+        }
+    }
+
+    @Test func runtimeEnvelopeRejectsInvalidBrokerDeviceIdentity() {
+        let privateKeyLabel = "PRIVATE" + " KEY"
+        let privateKey = """
+        -----BEGIN \(privateKeyLabel)-----
+        ZmFrZS1maXh0dXJlLXByaXZhdGUta2V5
+        -----END \(privateKeyLabel)-----
+        """
+
+        #expect(throws: DesktopRuntimeCredentialEnvelopeError.invalidLicenseMachineID) {
+            try DesktopRuntimeCredentialEnvelope(
+                appID: appID,
+                privateKey: privateKey,
+                licenseKey: "nd_live_runtime_fixture_1234",
+                licenseMachineID: "local-host-hash"
             )
         }
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -335,6 +335,30 @@ import NeonDiffDesktopCore
         ))
     }
 
+    @Test func deviceBoundLicenseStatusRequiresTheSignedBundledWorker() {
+        #expect(DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "license", "status",
+                "--config", "/fixture/config.local.json",
+                "--repo", "electricsheephq/evaos-code-review-bot-neondiff",
+                "--refresh", "true",
+                "--license-machine-id", licenseMachineID,
+                "--json"
+            ],
+            hasStandardInput: false
+        ))
+        #expect(!DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "license", "status",
+                "--config", "/fixture/config.local.json",
+                "--repo", "electricsheephq/evaos-code-review-bot-neondiff",
+                "--refresh", "true",
+                "--json"
+            ],
+            hasStandardInput: false
+        ))
+    }
+
     @Test func trustedBundledWorkerUsesOnlySealedAppCoordinates() throws {
         let app = URL(filePath: "/Applications/NeonDiff.app")
         let context = try #require(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -125,6 +125,49 @@ import NeonDiffDesktopCore
         ) == request)
     }
 
+    @Test func legacyReplacementMustMatchTheSelectedBotCoordinates() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let request = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            licenseMachineID: licenseMachineID,
+            configPath: config.path,
+            launchdLabel: label,
+            homeDirectory: home
+        )
+        let currentData = try DesktopKeychainWorkerLaunchAgentContract
+            .propertyListData(
+                request: request,
+                appExecutableURL: appExecutable
+            )
+        var legacy = try #require(
+            PropertyListSerialization.propertyList(
+                from: currentData,
+                options: [],
+                format: nil
+            ) as? [String: Any]
+        )
+        var arguments = try #require(legacy["ProgramArguments"] as? [String])
+        arguments.removeLast(2)
+        arguments[7] = "9999999"
+        legacy["ProgramArguments"] = arguments
+        let legacyData = try PropertyListSerialization.data(
+            fromPropertyList: legacy,
+            format: .xml,
+            options: 0
+        )
+
+        #expect(!DesktopKeychainWorkerLaunchAgentContract
+            .propertyListMatchesRequest(
+                legacyData,
+                request: request,
+                homeDirectory: home,
+                appExecutableIsSafe: { $0 == self.appExecutable },
+                configExists: { $0 == config }
+            ))
+    }
+
     @Test func runtimeEnvelopeContainsBothKeychainSecretsOnlyInBoundedInput() throws {
         let privateKeyLabel = "PRIVATE" + " KEY"
         let privateKey = """

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -374,4 +374,50 @@ import NeonDiffDesktopCore
             ) == arguments
         )
     }
+
+    @Test func sealedWorkerRunsIsolatedDaemonStatusWithoutLaunchAgent() {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        ).path
+        let sealed = DesktopLocalBotExecutionContext(
+            configPath: "",
+            executablePath:
+                "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+            argumentPrefix: [],
+            environmentOverrides: [:]
+        )
+        let status = [
+            "daemon", "status",
+            "--config", config,
+            "--launchd-label", label
+        ]
+
+        #expect(
+            DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                executablePath: "neondiff",
+                arguments: status,
+                executionContexts: [sealed]
+            ) == sealed.executablePath
+        )
+        #expect(
+            DesktopLocalBotExecutionContextResolver.resolveArguments(
+                executablePath: "neondiff",
+                arguments: status,
+                executionContexts: [sealed]
+            ) == status
+        )
+        for mutation in ["start", "stop"] {
+            #expect(
+                DesktopLocalBotExecutionContextResolver.resolveExecutablePath(
+                    executablePath: "neondiff",
+                    arguments: [
+                        "daemon", mutation,
+                        "--config", config,
+                        "--launchd-label", label
+                    ],
+                    executionContexts: [sealed]
+                ) == nil
+            )
+        }
+    }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -45,6 +45,56 @@ import NeonDiffDesktopCore
         #expect(parsed == request)
     }
 
+    @Test func previewExposesTheCompleteRedactedMutationPlan() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let request = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            licenseMachineID: licenseMachineID,
+            configPath: config.path,
+            launchdLabel: label,
+            homeDirectory: home
+        )
+
+        let preview = DesktopKeychainWorkerLaunchAgentContract
+            .redactedPreviewText(
+                request: request,
+                appExecutableURL: appExecutable,
+                sealedWorkerPath:
+                    "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+                homeDirectory: home,
+                preservedRepositoryCount: 53
+            )
+
+        #expect(preview.contains(
+            "/Users/test/Library/LaunchAgents/\(label).plist"
+        ))
+        #expect(preview.contains(appExecutable.path))
+        #expect(preview.contains(
+            "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
+        ))
+        #expect(preview.contains("--config \(config.path)"))
+        #expect(preview.contains("--launchd-label \(label)"))
+        #expect(preview.contains("--github-app-id [stored App ID]"))
+        #expect(preview.contains(
+            "--license-machine-id [stored device ID]"
+        ))
+        #expect(preview.contains("EnvironmentVariables: none"))
+        #expect(preview.contains(
+            "RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua"
+        ))
+        #expect(preview.contains("stdout=/dev/null; stderr=/dev/null"))
+        #expect(preview.contains(
+            "Repository allowlist: preserved unchanged (53 configured repositories)"
+        ))
+        #expect(preview.contains("no config write"))
+        #expect(!preview.contains(appID))
+        #expect(!preview.contains(licenseMachineID))
+        #expect(!preview.localizedCaseInsensitiveContains("private key"))
+        #expect(!preview.localizedCaseInsensitiveContains("license key"))
+    }
+
     @Test func headlessArgumentsFailClosedOutsideAccountConfigOrExactAppIdentity() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -602,6 +602,24 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedReviewAcceptsEnabledCodexRuntimeWithoutLegacyZCodeBinding() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(
+            existingBotConfig(
+                authMode: "zcode-app-config",
+                zcodeProviderId: nil,
+                codexRuntimeEnabled: true
+            )
+        )
+
+        #expect(fixture.model.providerSetupReady)
+        #expect(fixture.model.scopedReviewProviderReady)
+    }
+
+    @MainActor
     @Test func selectedExistingBYOBotReusesKeychainCredentialForReverification() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -1985,12 +2003,26 @@ import NeonDiffDesktopCore
         authMode: String,
         repositories: [String] = ["electricsheephq/WorldOS"],
         zcodeProviderId: String? = "zcode-glm",
+        codexRuntimeEnabled: Bool = false,
         revision: String = String(repeating: "a", count: 64)
     ) -> String {
         let adapter = authMode == "zcode-app-config" ? "zcode" : "openai-compatible"
         let zcodeProviderEntry = zcodeProviderId.map {
             #""providerId": "\#($0)","#
         } ?? ""
+        let codexRuntimeEntry = codexRuntimeEnabled
+            ? #"""
+            "codexRuntime": {
+              "enabled": true,
+              "cliPath": "/Users/m1/.local/bin/codex",
+              "model": "gpt-5.6-sol",
+              "reasoningEffort": "high",
+              "timeoutMs": 600000,
+              "maxOutputBytes": 20971520,
+              "contextWindowTokens": 128000
+            },
+            """#
+            : ""
         let repositoryJSON = repositories
             .map { "\"\($0)\"" }
             .joined(separator: ", ")
@@ -2001,6 +2033,7 @@ import NeonDiffDesktopCore
           "revision": "\#(revision)",
           "config": {
             "pilotRepos": [\#(repositoryJSON)],
+            \#(codexRuntimeEntry)
             "zcode": {
               \#(zcodeProviderEntry)
               "model": "GLM-5.2",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -730,6 +730,10 @@ import NeonDiffDesktopCore
         let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"
         let otherRepository = "electricsheephq/WorldOS"
+        let activationKey = "NDL-EXISTING-BOT-REVALIDATION-FIXTURE"
+        let activationClient = ExistingBotRecordingActivationClient(
+            expectedKey: activationKey
+        )
         let readCheck =
             #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
         let fixture = ModelDependencyFixture(
@@ -751,12 +755,9 @@ import NeonDiffDesktopCore
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
                     stderr: ""
-                )),
-                .success(existingAgentLicenseStatus(
-                    scope: "private",
-                    privateRepoAllowed: true
                 ))
             ],
+            activationLicenseClient: activationClient,
             localBotConfigurations: [
                 DesktopLocalBotConfiguration(
                     appID: 4_184_532,
@@ -780,6 +781,13 @@ import NeonDiffDesktopCore
         fixture.model.pendingBYOGitHubAppPrivateKey =
             existingBotFixturePrivateKey
         fixture.model.storeBYOGitHubAppCredentials()
+        _ = try GitHubBrokerDeviceIdentityStore(
+            secretStore: fixture.secretStore
+        ).loadOrCreate().deviceId
+        try fixture.secretStore.setSecret(
+            activationKey,
+            account: "license/default"
+        )
         fixture.model.applyAccountWorkspaceCatalog(.loaded([
             workspace(entitlement: .internalAdmin)
         ]))
@@ -805,8 +813,6 @@ import NeonDiffDesktopCore
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
-
-        #expect(await reachesCallCount(fixture, 4))
         let verificationCall = fixture.cli.calls[2]
         #expect(verificationCall.arguments == [
             "doctor", "github",
@@ -821,15 +827,13 @@ import NeonDiffDesktopCore
                 == Data(existingBotFixturePrivateKey.utf8)
         )
         #expect(fixture.model.byoGitHubCredentialsVerified)
-        let entitlementCall = try #require(fixture.cli.calls.last)
-        #expect(entitlementCall.arguments == [
-            "license", "status",
-            "--config", configPath,
-            "--repo", targetRepository,
-            "--refresh", "true",
-            "--json"
-        ])
-        #expect(entitlementCall.standardInput == nil)
+        for _ in 0..<100 where activationClient.revalidationCount == 0 {
+            await Task.yield()
+        }
+        #expect(fixture.cli.calls.count == 3)
+        #expect(activationClient.activationCount == 0)
+        #expect(activationClient.revalidationCount == 1)
+        #expect(activationClient.receivedExpectedKey)
         #expect(fixture.model.currentRepositoryActivationReady)
         #expect(fixture.model.activationState == .active)
         #expect(fixture.model.productionUsefulWorkAvailable)
@@ -2196,6 +2200,58 @@ private struct ExistingBotRejectedActivationClient: ActivationLicenseClienting {
 
     func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
         .invalid
+    }
+}
+
+private final class ExistingBotRecordingActivationClient:
+    ActivationLicenseClienting,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private let expectedKey: String
+    private var activations = 0
+    private var revalidations = 0
+    private var matchedExpectedKey = false
+
+    init(expectedKey: String) {
+        self.expectedKey = expectedKey
+    }
+
+    var activationCount: Int {
+        lock.withLock { activations }
+    }
+
+    var revalidationCount: Int {
+        lock.withLock { revalidations }
+    }
+
+    var receivedExpectedKey: Bool {
+        lock.withLock { matchedExpectedKey }
+    }
+
+    func activate(
+        key: ActivationKeyMaterial
+    ) async throws -> ActivationClientOutcome {
+        lock.withLock { activations += 1 }
+        return .serviceError
+    }
+
+    func revalidate(
+        key: ActivationKeyMaterial
+    ) async throws -> ActivationClientOutcome {
+        lock.withLock {
+            revalidations += 1
+            matchedExpectedKey = key.withRawValue { $0 == expectedKey }
+        }
+        return .active(.init(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "beta",
+            seats: 1
+        ))
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1490,6 +1490,46 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedDryReviewSurfacesRedactedStructuredFailure() async {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            )
+        )
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 4))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 1,
+            stdout: """
+            {"ok":false,"command":"review-pr","dryRun":true,"useZCode":true,
+             "scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff",
+             "pullNumber":768},
+             "error":{"message":"license network: token=abcdefghijklmnop"}}
+            """,
+            stderr: ""
+        )))
+
+        fixture.model.pendingReviewPullNumber = "768"
+        fixture.model.runScopedDryReview()
+        #expect(await reachesCallCount(fixture, 5))
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        #expect(
+            fixture.model.lastError
+                == "Dry review failed safely: license network: [redacted-secret]"
+        )
+        #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+    }
+
+    @MainActor
     @Test func staleExactWorkerStatusClearsOwnedProgressState() async throws {
         let fixture = await preparedExistingAgentVerificationFixture(
             visibility: "private",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -404,7 +404,7 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
-    @Test func multiRepoWorkerExplainsRuntimeScopeBlockAfterTargetSelection() {
+    @Test func internalAdminMultiRepoWorkerKeepsAllowlistAndUnlocksRuntimeScope() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
             productionBoundary: .testAccountLink
@@ -425,11 +425,39 @@ import NeonDiffDesktopCore
         )
 
         #expect(
+            !fixture.model.customerRuntimeBoundaryMessage
+                .contains("multiple repositories")
+        )
+        #expect(fixture.model.reviewTargetRuntimeReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @MainActor
+    @Test func paidCustomerMultiRepoWorkerRemainsRuntimeBlocked() {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .paid)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [
+                "electricsheephq/WorldOS",
+                "electricsheephq/evaos-code-review-bot-neondiff"
+            ]
+        ))
+        fixture.model.selectBYOReviewRepository(
+            fullName: "electricsheephq/WorldOS"
+        )
+
+        #expect(
             fixture.model.customerRuntimeBoundaryMessage
                 .contains("multiple repositories")
         )
         #expect(!fixture.model.reviewTargetRuntimeReady)
-        #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
     @MainActor
@@ -1278,7 +1306,7 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
-    @Test func selectedTargetUnlocksScopedReviewButNotMultiRepoDaemonStart() async throws {
+    @Test func selectedTargetUnlocksScopedReviewAndInternalAdminMultiRepoDaemonStart() async throws {
         let targetRepository = "electricsheephq/evaos-code-review-bot-neondiff"
         let otherRepository = "electricsheephq/WorldOS"
         let headSHA = String(repeating: "a", count: 40)
@@ -1394,7 +1422,7 @@ import NeonDiffDesktopCore
             "--json"
         ])
         #expect(fixture.model.productionUsefulWorkAvailable)
-        #expect(!fixture.model.productionDaemonStartAvailable)
+        #expect(fixture.model.productionDaemonStartAvailable)
 
         fixture.model.pendingReviewPullNumber = "685"
         fixture.model.runScopedDryReview()

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -631,6 +631,83 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func existingBotWithoutLocalAgentScopesKeychainVerificationToReviewTarget() async throws {
+        let targetRepository =
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        let otherRepository = "electricsheephq/WorldOS"
+        let readCheck =
+            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [otherRepository, targetRepository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
+                    stderr: ""
+                ))
+            ],
+            preferenceStrings: [
+                "neondiff.cliPath": "/usr/bin/true"
+            ],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.pendingBYOGitHubAppId = "4184532"
+        fixture.model.pendingBYOGitHubAppPrivateKey =
+            existingBotFixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        #expect(await reachesCallCount(fixture, 1))
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        fixture.model.selectBYOReviewRepository(
+            fullName: targetRepository
+        )
+        fixture.model.cliPath = "/usr/bin/true"
+
+        #expect(!fixture.model.existingLocalAgentAccessAvailable)
+        #expect(fixture.model.existingLocalBotBYOGitHubVerificationAvailable)
+        #expect(fixture.model.localWorkerCLIAvailable)
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 2))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        let verificationCall = try #require(fixture.cli.calls.last)
+        #expect(verificationCall.arguments == [
+            "doctor", "github",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--github-app-id", "4184532",
+            "--github-app-private-key-stdin", "true",
+            "--json"
+        ])
+        #expect(
+            verificationCall.standardInput
+                == Data(existingBotFixturePrivateKey.utf8)
+        )
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.repositoryConfigurationReady)
+        #expect(fixture.model.lastError == nil)
+        #expect(fixture.model.repos.filter(\.enabled).count == 2)
+        #expect(
+            fixture.model.selectedReviewRepository == targetRepository
+        )
+    }
+
+    @MainActor
     @Test func incompatibleLocalWorkerBlocksReviewAndOffersVisibleRecovery() async throws {
         let repository = "electricsheephq/evaos-code-review-bot-neondiff"
         let staleHelp = #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"},{"name":"--repo"},{"name":"--pr"},{"name":"--dry-run"},{"name":"--confirm"}]}}"#

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1530,6 +1530,46 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedDryReviewSurfacesRedactedStringFailure() async {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            )
+        )
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 4))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 1,
+            stdout: """
+            {"ok":false,"command":"review-pr","dryRun":true,"useZCode":true,
+             "scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff",
+             "pullNumber":769},
+             "error":"config rejected: token=abcdefghijklmnop"}
+            """,
+            stderr: ""
+        )))
+
+        fixture.model.pendingReviewPullNumber = "769"
+        fixture.model.runScopedDryReview()
+        #expect(await reachesCallCount(fixture, 5))
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        #expect(
+            fixture.model.lastError
+                == "Dry review failed safely: config rejected: [redacted-secret]"
+        )
+        #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+    }
+
+    @MainActor
     @Test func staleExactWorkerStatusClearsOwnedProgressState() async throws {
         let fixture = await preparedExistingAgentVerificationFixture(
             visibility: "private",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -726,6 +726,99 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func keychainBackedExistingAgentScopesVerificationThroughStoredCredential() async throws {
+        let targetRepository =
+            "electricsheephq/evaos-code-review-bot-neondiff"
+        let otherRepository = "electricsheephq/WorldOS"
+        let readCheck =
+            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: existingBotConfig(
+                        authMode: "zcode-app-config",
+                        repositories: [otherRepository, targetRepository]
+                    ),
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--expected-config-revision"},{"name":"--zcode"}]}}"#,
+                    stderr: ""
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
+                    stderr: ""
+                ))
+            ],
+            localBotConfigurations: [
+                DesktopLocalBotConfiguration(
+                    appID: 4_184_532,
+                    configPath: configPath,
+                    workingDirectory: "/fixture/evaos-code-review-bot"
+                )
+            ],
+            localBotExecutionContexts: [
+                DesktopLocalBotExecutionContext(
+                    configPath: configPath,
+                    executablePath:
+                        "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+                    argumentPrefix: [],
+                    environmentOverrides: [:]
+                )
+            ],
+            localBotExecutionConfigPaths: [configPath],
+            productionBoundary: .testAccountLink
+        )
+        fixture.model.pendingBYOGitHubAppId = "4184532"
+        fixture.model.pendingBYOGitHubAppPrivateKey =
+            existingBotFixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        fixture.model.selectBotInstallation("bot-evaos-code-review-bot")
+        #expect(await reachesCallCount(fixture, 1))
+        for _ in 0..<20 where fixture.model.isConfigInspectInProgress {
+            await Task.yield()
+        }
+        #expect(await reachesCallCount(fixture, 2))
+        for _ in 0..<20 where fixture.model.localWorkerReviewCompatibility == .checking {
+            await Task.yield()
+        }
+        fixture.model.selectBYOReviewRepository(
+            fullName: targetRepository
+        )
+
+        #expect(fixture.model.existingLocalAgentAccessAvailable)
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 3))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        let verificationCall = try #require(fixture.cli.calls.last)
+        #expect(verificationCall.arguments == [
+            "doctor", "github",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--github-app-id", "4184532",
+            "--github-app-private-key-stdin", "true",
+            "--json"
+        ])
+        #expect(
+            verificationCall.standardInput
+                == Data(existingBotFixturePrivateKey.utf8)
+        )
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.lastError == nil)
+        #expect(fixture.model.repos.filter(\.enabled).count == 2)
+    }
+
+    @MainActor
     @Test func incompatibleLocalWorkerBlocksReviewAndOffersVisibleRecovery() async throws {
         let repository = "electricsheephq/evaos-code-review-bot-neondiff"
         let staleHelp = #"{"ok":true,"command":"review-pr","licenseBoundary":{"packageVersion":"1.0.4"},"usage":{"command":"review-pr","flags":[{"name":"--config"},{"name":"--repo"},{"name":"--pr"},{"name":"--dry-run"},{"name":"--confirm"}]}}"#

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -751,6 +751,10 @@ import NeonDiffDesktopCore
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
                     stderr: ""
+                )),
+                .success(existingAgentLicenseStatus(
+                    scope: "private",
+                    privateRepoAllowed: true
                 ))
             ],
             localBotConfigurations: [
@@ -791,8 +795,10 @@ import NeonDiffDesktopCore
         fixture.model.selectBYOReviewRepository(
             fullName: targetRepository
         )
+        fixture.model.activationState = .active
 
         #expect(fixture.model.existingLocalAgentAccessAvailable)
+        #expect(!fixture.model.currentRepositoryActivationReady)
 
         fixture.model.verifyExistingLocalBotGitHubAccess()
         #expect(await reachesCallCount(fixture, 3))
@@ -800,7 +806,8 @@ import NeonDiffDesktopCore
             await Task.yield()
         }
 
-        let verificationCall = try #require(fixture.cli.calls.last)
+        #expect(await reachesCallCount(fixture, 4))
+        let verificationCall = fixture.cli.calls[2]
         #expect(verificationCall.arguments == [
             "doctor", "github",
             "--config", configPath,
@@ -814,6 +821,18 @@ import NeonDiffDesktopCore
                 == Data(existingBotFixturePrivateKey.utf8)
         )
         #expect(fixture.model.byoGitHubCredentialsVerified)
+        let entitlementCall = try #require(fixture.cli.calls.last)
+        #expect(entitlementCall.arguments == [
+            "license", "status",
+            "--config", configPath,
+            "--repo", targetRepository,
+            "--refresh", "true",
+            "--json"
+        ])
+        #expect(entitlementCall.standardInput == nil)
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.model.activationState == .active)
+        #expect(fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.lastError == nil)
         #expect(fixture.model.repos.filter(\.enabled).count == 2)
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ProviderModelFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ProviderModelFixture.swift
@@ -36,6 +36,13 @@ final class MemorySecretStore: DesktopSecretStoring, @unchecked Sendable {
         storage.read { $0[account] }
     }
 
+    func readSecret(
+        account: String,
+        allowUserInteraction _: Bool
+    ) throws -> String? {
+        storage.read { $0[account] }
+    }
+
     func containsSecret(account: String) -> Bool {
         storage.read { $0[account] != nil }
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/GitHubBrokerClientTests.swift
@@ -65,6 +65,20 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
         #expect(secrets.values["broker-device-fixture"] == "not-valid-private-key-material")
     }
 
+    @Test func existingIdentityCanBeLoadedWithoutInteractiveKeychainAccess() throws {
+        let secrets = BrokerMemorySecretStore()
+        let store = GitHubBrokerDeviceIdentityStore(
+            secretStore: secrets,
+            account: "broker-device-fixture"
+        )
+        let created = try store.loadOrCreate()
+
+        let loaded = try store.loadExisting(allowUserInteraction: false)
+
+        #expect(loaded.deviceId == created.deviceId)
+        #expect(secrets.nonInteractiveReadCount == 1)
+    }
+
     @Test func secretStoreFailuresStayInsidePublicErrorBoundary() {
         let readFailure = GitHubBrokerDeviceIdentityStore(
             secretStore: BrokerFailingSecretStore(failRead: true)
@@ -778,9 +792,14 @@ private let brokerCredentialResponseField = ["to", "ken"].joined()
 private final class BrokerMemorySecretStore: DesktopSecretStoring, @unchecked Sendable {
     private let lock = NSLock()
     private var storage: [String: String] = [:]
+    private var nonInteractiveReads = 0
 
     var values: [String: String] {
         lock.withLock { storage }
+    }
+
+    var nonInteractiveReadCount: Int {
+        lock.withLock { nonInteractiveReads }
     }
 
     func setSecret(_ secret: String, account: String) throws {
@@ -789,6 +808,18 @@ private final class BrokerMemorySecretStore: DesktopSecretStoring, @unchecked Se
 
     func readSecret(account: String) throws -> String? {
         lock.withLock { storage[account] }
+    }
+
+    func readSecret(
+        account: String,
+        allowUserInteraction: Bool
+    ) throws -> String? {
+        lock.withLock {
+            if !allowUserInteraction {
+                nonInteractiveReads += 1
+            }
+            return storage[account]
+        }
     }
 
     func containsSecret(account: String) -> Bool {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ProviderRegistryTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ProviderRegistryTests.swift
@@ -1,4 +1,5 @@
 import Testing
+@_spi(Testing) import NeonDiffDesktopCore
 
 @MainActor
 @Suite(.serialized) struct ProviderRegistryTests {
@@ -8,5 +9,26 @@ import Testing
         function: #function,
         try await LegacyCoreChecksScenarioGate.shared.run { try await runProviderRegistryParsingAndPatchContracts() }
     )
+}
+
+@Test func configInspectMapsTheActiveCodexRuntime() throws {
+    let snapshot = try #require(ConfigInspectParser.parse(
+        #"{"ok":true,"command":"config inspect","revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","config":{"codexRuntime":{"enabled":true,"cliPath":"/Users/m1/.local/bin/codex","model":"gpt-5.6-sol","reasoningEffort":"high","timeoutMs":600000,"maxOutputBytes":20971520,"contextWindowTokens":128000},"zcode":{"model":"GLM-5.2","cliPath":"zcode","appConfigPath":"zcode.json"},"providers":{"defaultProviderId":"zcode-glm","providers":{"zcode-glm":{"enabled":true,"adapter":"zcode","displayName":"ZCode","model":"GLM-5.2","authMode":"zcode-app-config"}}}}}"#,
+        providerKeyStored: false,
+        licenseKeyStored: false
+    ))
+
+    #expect(snapshot.providers.codexRuntime.enabled)
+    #expect(snapshot.providers.codexRuntime.cliPath == "/Users/m1/.local/bin/codex")
+    #expect(snapshot.providers.codexRuntime.model == "gpt-5.6-sol")
+    #expect(snapshot.providers.codexRuntime.reasoningEffort == "high")
+    #expect(snapshot.providers.codexRuntime.isReady)
+
+    let incomplete = try #require(ConfigInspectParser.parse(
+        #"{"ok":true,"command":"config inspect","revision":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"codexRuntime":{"enabled":true},"providers":{"defaultProviderId":"zcode-glm","providers":{}}}}"#,
+        providerKeyStored: false,
+        licenseKeyStored: false
+    ))
+    #expect(!incomplete.providers.codexRuntime.isReady)
 }
 }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -384,8 +384,11 @@ the same Mac. In that exact case it opens a reconciliation path:
   private key;
 - it reports the server-authoritative account entitlement separately from
   current-launch review authorization;
-- it treats `zcode-app-config` and `none` provider auth modes as config-backed,
-  not as missing NeonDiff Keychain API keys;
+- when the inspected config enables `codexRuntime`, it reports the exact Codex
+  CLI path, model, and reasoning effort as the active review runtime without
+  reading or storing the CLI's OAuth material; otherwise it treats
+  `zcode-app-config` and `none` provider auth modes as config-backed, not as
+  missing NeonDiff Keychain API keys;
 - if the worker allowlist contains multiple repositories, it keeps every entry
   unchanged and requires one explicit **Review Target** for native activation;
   that target is restored only for the same config path;
@@ -569,14 +572,18 @@ provider readiness with redacted output. Use the provider card's `Verify API Key
 button checks the selected provider path and reports pass/fail without printing
 the submitted key.
 
-In the native Mac pane, the selected `providers.defaultProviderId` registry
-entry is the source of truth. Endpoint/model edits are dirty until a successful
-Preview and confirmed Apply/readback. Verify stays disabled until that saved
-state is current, then invokes the exact provider ID and config revision. The
-Keychain value crosses only bounded stdin; it is never added to the registry
-patch, argv, environment, logs, or evidence. That Keychain flow applies only to
-`api-key-env` providers. `zcode-app-config` and `none` providers use their
-declared app/config path and must not prompt for an unrelated NeonDiff API key.
+In the native Mac pane, an enabled and valid `codexRuntime` is the active review
+execution backend. The app displays its exact CLI path, model, and reasoning
+effort from `config inspect`; it does not read or store the Codex OAuth session.
+When Codex runtime is disabled, the selected
+`providers.defaultProviderId` registry entry is the source of truth.
+Endpoint/model edits are dirty until a successful Preview and confirmed
+Apply/readback. Verify stays disabled until that saved state is current, then
+invokes the exact provider ID and config revision. The Keychain value crosses
+only bounded stdin; it is never added to the registry patch, argv, environment,
+logs, or evidence. That Keychain flow applies only to `api-key-env` providers.
+`zcode-app-config` and `none` providers use their declared app/config path and
+must not prompt for an unrelated NeonDiff API key.
 
 The full doctor output is JSON. Check:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -349,14 +349,18 @@ supported LaunchAgent exists. Preview validates the exact signed
 the worker sealed inside the signed app. Confirmed install writes one 0600 secret-free plist in
 `~/Library/LaunchAgents` and starts it through the current user's launchd
 domain. The plist invokes the signed app's bounded headless mode and contains no
-private-key value or file path. That mode revalidates the same public
-coordinates, reads the App key from NeonDiff's own Keychain without user
+private-key value or file path. It includes the non-secret broker device ID
+already used for native activation. That mode revalidates the same public
+coordinates, re-derives the device ID from NeonDiff's own Keychain identity,
+rejects a mismatched plist, reads the App key from Keychain without user
 interaction, reads the API-backed activation credential from the same app-owned
 Keychain service, validates the running sealed worker process, and only then
-pipes both values once in a bounded JSON envelope to its stdin. A conflicting
-plist, unsafe app/config/worker path, unavailable Keychain item, or launchd
-failure fails closed. Do not replace this with a `security -w` wrapper, export
-the key to disk, or weaken its Keychain access control.
+pipes both secret values plus that non-secret device ID once in a bounded JSON
+envelope to its stdin. License validation then uses the same machine binding as
+native activation instead of the CLI's legacy host hash. A conflicting plist,
+unsafe app/config/worker path, unavailable Keychain item, device mismatch, or
+launchd failure fails closed. Do not replace this with a `security -w` wrapper,
+export the key to disk, or weaken its Keychain access control.
 
 After Checkout displays the one-shot NeonDiff Activation Key, return to the
 native **License** pane, paste the key, and choose **Continue with this key**,

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -397,12 +397,17 @@ the same Mac. In that exact case it opens a reconciliation path:
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
 - its single **Verify existing access** action first proves the exact App and
-  Review Target with `doctor github --repo`, then runs credential-free
-  `license status --refresh true` through the same matched worker and config.
-  The native app never reads, copies, migrates, or prompts for the worker's
-  Activation Key. GitHub-reported repository visibility and an active live API
-  entitlement covering that visibility are both required; unknown, expired,
-  revoked, malformed, or offline proof fails closed;
+  Review Target with `doctor github --repo`. A legacy credential-bearing
+  matched worker then runs credential-free
+  `license status --refresh true` through that exact worker and config. A
+  secret-free Keychain-backed worker instead reads the app-owned Activation Key
+  noninteractively and revalidates it through the signed sealed worker's
+  idempotent API path, with the key crossing only bounded stdin and no local
+  CLI-state write. Neither path places the key in argv, environment, config,
+  logs, or evidence. GitHub-reported repository visibility and an active live
+  API entitlement covering that visibility are both required; an unavailable
+  Keychain item, unknown visibility, expired or revoked access, malformed
+  output, or offline proof fails closed;
 - Overview runs one provider-backed repository/PR-scoped dry review first. A
   live review is enabled only for that config revision and the returned
   40-character head SHA, and requires explicit confirmation (see

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -200,13 +200,16 @@ Local config alone never establishes membership, installation authority, or
 review authorization.
 
 The single **Verify existing access** action first runs `doctor github` for the
-exact selected repository and then runs credential-free
-`license status --refresh true --json` through the same matched worker and
-config—even when the native app has a separate current-launch activation.
-Only a live API-sourced entitlement covering GitHub's reported visibility
-unlocks review work. The app never reads, copies, or prompts for that worker's
-Activation Key; expired, revoked, malformed, offline, or stale results remain
-retryable and fail closed.
+exact selected repository. A legacy credential-bearing matched worker then runs
+credential-free `license status --refresh true --json` through that exact
+worker and config. A secret-free Keychain-backed worker instead revalidates the
+app-owned Activation Key through the signed sealed worker's idempotent API path.
+The app reads that Keychain item noninteractively and sends it only over bounded
+stdin; it never places the key in argv, environment, config, logs, or evidence,
+and the CLI writes no local key state. Only a live API-sourced entitlement
+covering GitHub's reported visibility unlocks review work. An unavailable
+Keychain item, expired or revoked access, malformed output, offline proof, or a
+stale result remains retryable and fails closed.
 
 An existing worker may already monitor several GitHub App-authorized
 repositories. NeonDiff preserves that allowlist and requires one explicit

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -171,13 +171,15 @@ integration proof under #630.
    native daemon step's **Preview Start** and **Install & Start** actions. The
    signed app writes a secret-free LaunchAgent that points back to
    `/Applications/NeonDiff.app` with only the public App ID, exact selected
-   config, and launchd label. Its headless mode validates the checksum-managed
-   worker, reads the private key and API-backed activation credential from the
-   app-owned Keychain, and hands them to the local worker only through one
-   bounded JSON stdin envelope. It never exports either secret, writes a PEM or
-   license file, places a secret in the plist or environment, or uses a generic
-   `security -w` wrapper. Any coordinate mismatch or unavailable Keychain item
-   fails closed before the worker starts.
+   config, launchd label, and non-secret activation device ID. Its headless mode
+   re-derives that device ID from the existing broker identity in the app-owned
+   Keychain, rejects any mismatch before reading credentials, validates the
+   checksum-managed worker, and hands the private key plus API-backed activation
+   credential to the local worker only through one bounded JSON stdin envelope.
+   It never exports either secret, writes a PEM or license file, places a secret
+   in the plist or environment, or uses a generic `security -w` wrapper. Any
+   bot coordinate, device identity, or Keychain-item mismatch fails closed
+   before the worker starts.
 
 GitHub setup and paid activation remain separate gates. After Checkout returns
 the one-shot NeonDiff Activation Key, the customer pastes it in the native

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -408,6 +408,9 @@ async function main(): Promise<void> {
       const result = await getLicenseStatus({
         config: licenseConfig,
         refresh: args.refresh === undefined ? false : parseBooleanArg(args.refresh, "--refresh"),
+        ...(args["license-machine-id"]
+          ? { machineId: parseLicenseMachineIdArg(args["license-machine-id"]) }
+          : {}),
         ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {})
       });
       console.log(stringifyRedactedJson({ command: "license status", ...result }));

--- a/src/license-admission.ts
+++ b/src/license-admission.ts
@@ -1,6 +1,7 @@
 import { getLicenseStatus, type LicenseConfig, type RepoVisibilityScope } from "./license.js";
 import { resolveProductionLicensePolicy } from "./license-production-policy.js";
 import { productionLicenseSecretReader, type LicenseSecretReader } from "./license-secret-store.js";
+import { readRuntimeLicenseMachineId } from "./runtime-github-credentials.js";
 
 const mintedProductionAdmissions = new WeakSet<object>();
 
@@ -41,6 +42,7 @@ export function isAuthenticProductionLicenseAdmission(
 type ProductionLicenseValidationInput = {
   config: LicenseConfig;
   repo?: string;
+  machineId?: string;
   now?: Date;
   fetchImpl?: typeof fetch;
   secretReader?: LicenseSecretReader;
@@ -110,10 +112,12 @@ export async function requireActiveProductionLicense(
   input: ProductionLicenseAdmissionInput
 ): Promise<{ ok: true; admission: ProductionLicenseAdmission } | { ok: false; decision: RedactedLicenseDecision }> {
   const config = resolveProductionLicensePolicy(input.config);
+  const machineId = input.machineId ?? readRuntimeLicenseMachineId();
   const status = await getLicenseStatus({
     config,
     refresh: true,
     ...(input.repo ? { repo: input.repo } : {}),
+    ...(machineId ? { machineId } : {}),
     ...(input.now ? { now: input.now } : {}),
     ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}),
     licenseSecretReader: input.secretReader ?? productionLicenseSecretReader

--- a/src/license-admission.ts
+++ b/src/license-admission.ts
@@ -117,7 +117,7 @@ export async function requireActiveProductionLicense(
     config,
     refresh: true,
     ...(input.repo ? { repo: input.repo } : {}),
-    ...(machineId ? { machineId } : {}),
+    ...(machineId !== undefined ? { machineId } : {}),
     ...(input.now ? { now: input.now } : {}),
     ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}),
     licenseSecretReader: input.secretReader ?? productionLicenseSecretReader

--- a/src/license.ts
+++ b/src/license.ts
@@ -300,12 +300,20 @@ function matchesNativeKeychainCredential(input: KeychainCredentialReference): bo
 export async function getLicenseStatus(input: {
   config: LicenseConfig;
   repo?: string;
+  machineId?: string;
   refresh?: boolean;
   now?: Date;
   fetchImpl?: typeof fetch;
   licenseSecretReader?: LicenseSecretReader;
 }): Promise<LicenseStatusResult> {
   const now = input.now ?? new Date();
+  if (input.machineId !== undefined
+    && !RFC7638_SHA256_THUMBPRINT_PATTERN.test(input.machineId)) {
+    return invalidApiResult(
+      now,
+      "license machine ID must be one RFC 7638 SHA-256 broker device id"
+    );
+  }
   const cached = readLicenseCache(input.config.cachePath, () => readCacheRedactionLicenseKey(input.config));
   if (!input.refresh) return statusFromCache(cached, now);
 
@@ -330,6 +338,7 @@ export async function getLicenseStatus(input: {
     path: "/v1/license/validate",
     licenseKey,
     repo: input.repo,
+    machineId: input.machineId,
     now,
     fetchImpl: input.fetchImpl
   });

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -20,6 +20,8 @@ export interface ReleaseRepoStatus {
 export interface ReleaseLaunchdStatus {
   label: string;
   state: "running" | "not_running" | "unknown";
+  program?: string;
+  sealedDesktopWorker?: boolean;
   pid?: number;
   configPath?: string;
   dryRun?: boolean;
@@ -251,7 +253,8 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const cleanOk = input.repo.dirtyFiles.length === 0;
   const launchdRunningOk = input.launchd.state === "running";
   const launchdConfigOk = input.launchd.configPath === input.configPath;
-  const launchdSystemCaOk = input.launchd.usesSystemCa === true;
+  const launchdSystemCaOk =
+    input.launchd.sealedDesktopWorker === true || input.launchd.usesSystemCa === true;
   const dbOk = input.database.errorCount === 0;
   const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
   const retryableExpiredProviderCooldownCount =
@@ -307,11 +310,13 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "launchd_node_system_ca",
       ok: launchdSystemCaOk,
-      detail: input.launchd.usesSystemCa === undefined
-        ? "NODE_OPTIONS not detected"
-        : input.launchd.usesSystemCa
-          ? "NODE_OPTIONS includes --use-system-ca"
-          : "NODE_OPTIONS missing --use-system-ca"
+      detail: input.launchd.sealedDesktopWorker === true
+        ? "not applicable to the signed sealed desktop worker"
+        : input.launchd.usesSystemCa === undefined
+          ? "NODE_OPTIONS not detected"
+          : input.launchd.usesSystemCa
+            ? "NODE_OPTIONS includes --use-system-ca"
+            : "NODE_OPTIONS missing --use-system-ca"
     },
     {
       name: "live_db_no_errors",
@@ -2091,15 +2096,27 @@ function readLaunchdStatus(label: string): ReleaseLaunchdStatus {
 export function parseLaunchdPrintStatus(label: string, stdout: string): ReleaseLaunchdStatus {
   const state = stdout.match(/\bstate = (\w+)/)?.[1] === "running" ? "running" : "not_running";
   const pidText = stdout.match(/\bpid = (\d+)/)?.[1];
+  const program = stdout.match(/^\s*program = ([^\n]+)$/m)?.[1]?.trim();
   const args = extractLaunchdSection(stdout, "arguments") ?? "";
+  const programArguments = args
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
   const configMatch = args.match(/--config\s*\n\s*([^\n]+)/);
   const dryRunMatch = args.match(/--dry-run\s*\n\s*([^\n]+)/);
   const environment = extractLaunchdSection(stdout, "environment");
   const nodeOptions = normalizeLaunchdValue(readLaunchdEnvironmentValue(environment, "NODE_OPTIONS"));
   const hasLaunchdEnvironment = environment !== undefined;
+  const sealedDesktopExecutable = "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop";
+  const sealedDesktopWorker =
+    program === sealedDesktopExecutable &&
+    programArguments[0] === sealedDesktopExecutable &&
+    programArguments[1] === "--neondiff-worker-daemon";
   return {
     label,
     state,
+    ...(program ? { program } : {}),
+    ...(sealedDesktopWorker ? { sealedDesktopWorker: true } : {}),
     ...(pidText ? { pid: Number(pidText) } : {}),
     ...(configMatch?.[1] ? { configPath: configMatch[1].trim() } : {}),
     ...(dryRunMatch?.[1] ? { dryRun: dryRunMatch[1].trim() !== "false" } : {}),

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2062,14 +2062,22 @@ function readBoolean(value: unknown): boolean | undefined {
 }
 
 function readRepoStatus(cwd: string): ReleaseRepoStatus {
-  return {
-    branch: git(cwd, ["branch", "--show-current"]) || "(detached)",
-    head: git(cwd, ["rev-parse", "HEAD"]),
-    dirtyFiles: git(cwd, ["status", "--short"])
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-  };
+  try {
+    return {
+      branch: gitQuiet(cwd, ["branch", "--show-current"]) || "(detached)",
+      head: gitQuiet(cwd, ["rev-parse", "HEAD"]),
+      dirtyFiles: gitQuiet(cwd, ["status", "--short"])
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+    };
+  } catch {
+    return {
+      branch: "(unknown)",
+      head: "(unknown)",
+      dirtyFiles: ["(git unavailable)"]
+    };
+  }
 }
 
 function readLaunchdStatus(label: string): ReleaseLaunchdStatus {
@@ -2926,6 +2934,18 @@ function stripLeadingV(version: string): string {
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function gitQuiet(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (result.status !== 0) {
+    throw new Error("git repository status unavailable");
+  }
+  return result.stdout.trim();
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -97,6 +97,20 @@ export async function runOnceCliCommand(input: {
 }): Promise<RunOnceCliCommandResult> {
   let result: RunOnceResult;
   try {
+    const explicitRepo = input.options.repo;
+    const explicitPullNumber = input.options.pullNumber;
+    const explicitPullReview =
+      input.commandName === "review-pr" &&
+      typeof explicitRepo === "string" &&
+      explicitRepo.trim().length > 0 &&
+      typeof explicitPullNumber === "number" &&
+      Number.isInteger(explicitPullNumber) &&
+      explicitPullNumber > 0
+        ? {
+            repo: explicitRepo,
+            pullNumber: explicitPullNumber
+          }
+        : undefined;
     const licenseAdmission = input.admitImpl
       ? await input.admitImpl()
       : input.options.licenseAdmission;
@@ -104,8 +118,8 @@ export async function runOnceCliCommand(input: {
       ...input.options,
       // `review-pr` is already scoped to one explicit repo/PR. Keep
       // canaryPulls as the broad daemon/run-once rollout boundary.
-      ...(input.commandName === "review-pr"
-        ? { explicitPullReview: true }
+      ...(explicitPullReview
+        ? { explicitPullReview }
         : {}),
       ...(licenseAdmission ? { licenseAdmission } : {})
     });

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -102,6 +102,11 @@ export async function runOnceCliCommand(input: {
       : input.options.licenseAdmission;
     result = await (input.runOnceImpl ?? runOnce)({
       ...input.options,
+      // `review-pr` is already scoped to one explicit repo/PR. Keep
+      // canaryPulls as the broad daemon/run-once rollout boundary.
+      ...(input.commandName === "review-pr"
+        ? { explicitPullReview: true }
+        : {}),
       ...(licenseAdmission ? { licenseAdmission } : {})
     });
   } catch (error) {

--- a/src/runtime-github-credentials.ts
+++ b/src/runtime-github-credentials.ts
@@ -6,6 +6,7 @@ export interface RuntimeGitHubCredentials {
   appId: string;
   privateKey: string;
   licenseKey?: string;
+  licenseMachineId?: string;
 }
 
 interface RuntimeGitHubCredentialInput {
@@ -85,17 +86,19 @@ export async function resolveRuntimeCredentialEnvelope(input: {
     throw new Error("runtime credential stdin must be one JSON object");
   }
   const record = envelope as Record<string, unknown>;
-  if (Object.keys(record).length !== 4
+  if (Object.keys(record).length !== 5
     || ![
       "schemaVersion",
       "githubAppId",
       "githubPrivateKey",
-      "licenseKey"
+      "licenseKey",
+      "licenseMachineId"
     ].every((key) => Object.prototype.hasOwnProperty.call(record, key))
-    || record.schemaVersion !== 1
+    || record.schemaVersion !== 2
     || typeof record.githubAppId !== "string"
     || typeof record.githubPrivateKey !== "string"
-    || typeof record.licenseKey !== "string") {
+    || typeof record.licenseKey !== "string"
+    || typeof record.licenseMachineId !== "string") {
     throw new Error("runtime credential stdin has an unsupported schema");
   }
   const appId = record.githubAppId.trim();
@@ -108,10 +111,15 @@ export async function resolveRuntimeCredentialEnvelope(input: {
   if (!/^nd_live_[A-Za-z0-9_-]{8,}$/.test(licenseKey)) {
     throw new Error("runtime credential license key must be one valid production key");
   }
+  const licenseMachineId = record.licenseMachineId.trim();
+  if (!/^[A-Za-z0-9_-]{43}$/.test(licenseMachineId)) {
+    throw new Error("runtime credential license machine ID must be one RFC 7638 SHA-256 broker device id");
+  }
   return {
     appId,
     privateKey,
-    licenseKey
+    licenseKey,
+    licenseMachineId
   };
 }
 
@@ -146,6 +154,10 @@ export function applyRuntimeGitHubCredentials(
 
 export function readRuntimeLicenseKey(): string | undefined {
   return storage.getStore()?.licenseKey;
+}
+
+export function readRuntimeLicenseMachineId(): string | undefined {
+  return storage.getStore()?.licenseMachineId;
 }
 
 function validatePrivateKey(privateKey: string): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -220,6 +220,7 @@ export interface RunOnceOptions {
   dryRun: boolean;
   repo?: string;
   pullNumber?: number;
+  explicitPullReview?: boolean;
   expectedHeadSha?: string;
   expectedConfigRevision?: string;
   processedHeadPolicy?: "normal" | "approved_dry_run" | "refresh_dry_run";
@@ -500,6 +501,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             state,
             repo,
             pull,
+            ...(options.explicitPullReview
+              ? { explicitPullReview: true }
+              : {}),
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
             ...(reviewApprovalRevision
@@ -1433,6 +1437,7 @@ export interface ReviewPullInput {
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
+  explicitPullReview?: boolean;
   dryRun: boolean;
   useZCode: boolean;
   configRevision?: string;
@@ -1449,7 +1454,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   const repoPolicy = resolveRepoProfile(config, repo);
   if (!repoPolicy.allowed) return "skipped_policy";
   if (config.skipDrafts && pull.draft) return "skipped_draft";
-  if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
+  if (!isCanaryAllowed(
+    config,
+    repo,
+    pull.number,
+    { explicitPullReview: input.explicitPullReview }
+  )) return "skipped_canary";
   if (!input.licenseAdmission) throw new Error("production license admission is required for pull review");
   const visibility = visibilityFromPullSummary(pull);
   const visibilityDecision = authorizeAdmissionForVisibility(
@@ -2910,7 +2920,13 @@ export function activateRepoForNewOnlyReview(input: {
   return { activated: true, baselined };
 }
 
-export function isCanaryAllowed(config: Pick<BotConfig, "canaryPulls">, repo: string, pullNumber: number): boolean {
+export function isCanaryAllowed(
+  config: Pick<BotConfig, "canaryPulls">,
+  repo: string,
+  pullNumber: number,
+  options: { explicitPullReview?: boolean } = {}
+): boolean {
+  if (options.explicitPullReview) return true;
   if (!config.canaryPulls || config.canaryPulls.length === 0) return true;
   return new Set(config.canaryPulls).has(`${repo}#${pullNumber}`);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -220,7 +220,7 @@ export interface RunOnceOptions {
   dryRun: boolean;
   repo?: string;
   pullNumber?: number;
-  explicitPullReview?: boolean;
+  explicitPullReview?: ExplicitPullReviewScope;
   expectedHeadSha?: string;
   expectedConfigRevision?: string;
   processedHeadPolicy?: "normal" | "approved_dry_run" | "refresh_dry_run";
@@ -502,7 +502,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             repo,
             pull,
             ...(options.explicitPullReview
-              ? { explicitPullReview: true }
+              ? { explicitPullReview: options.explicitPullReview }
               : {}),
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
@@ -1437,7 +1437,7 @@ export interface ReviewPullInput {
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
-  explicitPullReview?: boolean;
+  explicitPullReview?: ExplicitPullReviewScope;
   dryRun: boolean;
   useZCode: boolean;
   configRevision?: string;
@@ -2924,11 +2924,19 @@ export function isCanaryAllowed(
   config: Pick<BotConfig, "canaryPulls">,
   repo: string,
   pullNumber: number,
-  options: { explicitPullReview?: boolean } = {}
+  options: { explicitPullReview?: ExplicitPullReviewScope } = {}
 ): boolean {
-  if (options.explicitPullReview) return true;
+  if (
+    options.explicitPullReview?.pullNumber === pullNumber &&
+    options.explicitPullReview.repo.toLowerCase() === repo.toLowerCase()
+  ) return true;
   if (!config.canaryPulls || config.canaryPulls.length === 0) return true;
   return new Set(config.canaryPulls).has(`${repo}#${pullNumber}`);
+}
+
+export interface ExplicitPullReviewScope {
+  repo: string;
+  pullNumber: number;
 }
 
 export type StaleHeadPhase = "before_command" | "before_review" | "before_chunk" | "before_plan" | "before_post";

--- a/tests/canary.test.ts
+++ b/tests/canary.test.ts
@@ -32,8 +32,24 @@ describe("canary PR allowlist", () => {
       config,
       "electricsheephq/evaos-code-review-bot-neondiff",
       769,
-      { explicitPullReview: true }
+      {
+        explicitPullReview: {
+          repo: "electricsheephq/evaos-code-review-bot-neondiff",
+          pullNumber: 769
+        }
+      }
     )).toBe(true);
+    expect(isCanaryAllowed(
+      config,
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      770,
+      {
+        explicitPullReview: {
+          repo: "electricsheephq/evaos-code-review-bot-neondiff",
+          pullNumber: 769
+        }
+      }
+    )).toBe(false);
   });
 });
 

--- a/tests/canary.test.ts
+++ b/tests/canary.test.ts
@@ -17,6 +17,24 @@ describe("canary PR allowlist", () => {
     expect(isCanaryAllowed(config, "electricsheephq/WorldOS", 1185)).toBe(false);
     expect(isCanaryAllowed(config, "100yenadmin/evaOS-GUI", 410)).toBe(false);
   });
+
+  it("allows one explicit review-pr target without widening broad canary scans", () => {
+    const config = {
+      canaryPulls: ["example-org/example-repo#1"]
+    };
+
+    expect(isCanaryAllowed(
+      config,
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      769
+    )).toBe(false);
+    expect(isCanaryAllowed(
+      config,
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      769,
+      { explicitPullReview: true }
+    )).toBe(true);
+  });
 });
 
 describe("local evidence date folders", () => {

--- a/tests/helpers/mock-production-license-api.mjs
+++ b/tests/helpers/mock-production-license-api.mjs
@@ -6,6 +6,15 @@ globalThis.fetch = async (input, init) => {
     url === "https://neondiff-license.fly.dev/v1/license/activate" ||
     url === "https://neondiff-license.fly.dev/v1/license/validate"
   ) {
+    const expectedMachineId = process.env.NEONDIFF_TEST_EXPECT_LICENSE_MACHINE_ID;
+    if (expectedMachineId && url.endsWith("/v1/license/validate")) {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      if (body.machineId !== expectedMachineId) {
+        return new Response(JSON.stringify({
+          status: "scope_mismatch"
+        }), { status: 409, headers: { "content-type": "application/json" } });
+      }
+    }
     return new Response(JSON.stringify({
       status: "active",
       expiresAt: "2999-01-01T00:00:00.000Z",

--- a/tests/license-admission.test.ts
+++ b/tests/license-admission.test.ts
@@ -71,17 +71,23 @@ describe("production useful-work admission", () => {
   it("rejects an explicit empty machine identity before network admission", async () => {
     let fetchCalls = 0;
 
-    await expect(requireActiveProductionLicense({
+    const result = await requireActiveProductionLicense({
       config: fixtureConfig(),
+      operation: "daemon_cycle",
       machineId: "",
       fetchImpl: (async () => {
         fetchCalls += 1;
         return new Response(null, { status: 500 });
       }) as typeof fetch
-    })).rejects.toThrow(
-      "license machine ID must be one RFC 7638 SHA-256 broker device id"
-    );
+    });
 
+    expect(result).toMatchObject({
+      ok: false,
+      decision: {
+        status: "invalid",
+        detail: "license machine ID must be one RFC 7638 SHA-256 broker device id"
+      }
+    });
     expect(fetchCalls).toBe(0);
   });
 

--- a/tests/license-admission.test.ts
+++ b/tests/license-admission.test.ts
@@ -68,6 +68,23 @@ describe("production useful-work admission", () => {
     expect(requestBody?.machineId).toBe(brokerDeviceId);
   });
 
+  it("rejects an explicit empty machine identity before network admission", async () => {
+    let fetchCalls = 0;
+
+    await expect(requireActiveProductionLicense({
+      config: fixtureConfig(),
+      machineId: "",
+      fetchImpl: (async () => {
+        fetchCalls += 1;
+        return new Response(null, { status: 500 });
+      }) as typeof fetch
+    })).rejects.toThrow(
+      "license machine ID must be one RFC 7638 SHA-256 broker device id"
+    );
+
+    expect(fetchCalls).toBe(0);
+  });
+
   it("mints the daemon operation bundle from one live API validation", async () => {
     let fetchCalls = 0;
     const result = await requireActiveDaemonCycleAdmissions({

--- a/tests/license-admission.test.ts
+++ b/tests/license-admission.test.ts
@@ -10,9 +10,11 @@ import {
   type ProductionLicenseAdmission
 } from "../src/license-admission.js";
 import type { LicenseConfig } from "../src/license.js";
+import { withRuntimeGitHubCredentials } from "../src/runtime-github-credentials.js";
 
 const roots: string[] = [];
 const key = () => ["nd", "live", "admission0123456789abcdef"].join("_");
+const brokerDeviceId = "b".repeat(43);
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -40,6 +42,32 @@ function fixtureConfig(): LicenseConfig {
 }
 
 describe("production useful-work admission", () => {
+  it("uses the native broker device identity for runtime daemon admission", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const result = await withRuntimeGitHubCredentials({
+      appId: "4184532",
+      privateKey: "runtime-private-key-fixture",
+      licenseKey: key(),
+      licenseMachineId: brokerDeviceId
+    }, () => requireActiveDaemonCycleAdmissions({
+      config: fixtureConfig(),
+      fetchImpl: (async (_url, init) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(JSON.stringify({
+          status: "active",
+          expiresAt: "2026-08-01T00:00:00.000Z",
+          repoVisibilityScope: "private",
+          privateRepoAllowed: true,
+          updateEntitlement: true
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }) as typeof fetch,
+      now: new Date("2026-07-11T00:00:00.000Z")
+    }));
+
+    expect(result.ok).toBe(true);
+    expect(requestBody?.machineId).toBe(brokerDeviceId);
+  });
+
   it("mints the daemon operation bundle from one live API validation", async () => {
     let fetchCalls = 0;
     const result = await requireActiveDaemonCycleAdmissions({

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -349,6 +349,44 @@ describe("public NeonDiff CLI surface", () => {
     expect(existsSync(cachePath)).toBe(false);
   });
 
+  it("forwards the native broker device identity during a refreshed license status", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-native-status-binding-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/private"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      license: activatedLicenseTestConfig(root)
+    })}\n`);
+
+    const output = JSON.parse((await runCli([
+      "license",
+      "status",
+      "--config",
+      configPath,
+      "--repo",
+      "acme/private",
+      "--refresh",
+      "true",
+      "--license-machine-id",
+      BROKER_DEVICE_ID,
+      "--json"
+    ], {
+      env: {
+        ...activatedLicenseTestEnv(),
+        NEONDIFF_TEST_EXPECT_LICENSE_MACHINE_ID: BROKER_DEVICE_ID
+      }
+    })).stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      status: "active",
+      source: "api"
+    });
+  });
+
   it("redacts secret-like values from structured status JSON stdout", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-cli-status-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -4653,6 +4653,53 @@ describe("beta release status", () => {
     });
   });
 
+  it("does not require Node system CA for the exact signed sealed desktop worker", () => {
+    const configPath =
+      "/Users/m1/Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json";
+    const launchd = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/501/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\tpid = 70954
+\tprogram = /Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop
+\targuments = {
+\t\t/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop
+\t\t--neondiff-worker-daemon
+\t\t--config
+\t\t${configPath}
+\t\t--launchd-label
+\t\tcom.electricsheephq.evaos-code-review-bot
+\t}
+\tenvironment = {
+\t\tOSLogRateLimit => 64
+\t}
+}
+`);
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath,
+      launchd,
+      database: { rowCount: 0, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(launchd).toMatchObject({
+      program: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop",
+      sealedDesktopWorker: true,
+      usesSystemCa: false
+    });
+    expect(status.gates).toContainEqual({
+      name: "launchd_node_system_ca",
+      ok: true,
+      detail: "not applicable to the signed sealed desktop worker"
+    });
+  });
+
   it("fails closed when launchd NODE_OPTIONS cannot be verified", () => {
     const status = buildReleaseStatus({
       repo: {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1093,6 +1093,34 @@ describe("beta release status", () => {
     expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/559");
   });
 
+  it("fails closed without throwing when runtime status is collected outside a Git checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-non-git-cwd-"));
+    roots.push(root);
+
+    const status = collectReleaseStatus({
+      cwd: root,
+      statePath: join(root, "missing-live-state.sqlite"),
+      configPath: join(root, "missing-config.json"),
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot"
+    });
+
+    expect(status.repo).toEqual({
+      branch: "(unknown)",
+      head: "(unknown)",
+      dirtyFiles: ["(git unavailable)"]
+    });
+    expect(status.gates).toContainEqual({
+      name: "release_branch",
+      ok: false,
+      detail: "(unknown)"
+    });
+    expect(status.gates).toContainEqual({
+      name: "clean_checkout",
+      ok: false,
+      detail: "1 dirty file(s)"
+    });
+  });
+
   it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-missing-public-manifest-"));
     roots.push(root);

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -74,7 +74,7 @@ describe("run-once CLI reporting", () => {
 
   it("prints review-pr as the command on successful review-pr invocations", async () => {
     let forwardedExpectedHeadSha: string | undefined;
-    let explicitPullReview: boolean | undefined;
+    let explicitPullReview: RunOnceOptions["explicitPullReview"];
     const command = await runOnceCliCommand({
       options: {
         dryRun: true,

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parsePositiveInteger } from "../src/cli-args.js";
 import { buildRunOnceCliReport, runOnceCliCommand, runOnceCliExitCode, serializeRunOnceCliReport } from "../src/run-once-cli.js";
-import { applyReviewPullResultToRunOnceResult, assertExpectedReviewPrHead, type ReviewPullResult, type RunOnceResult } from "../src/worker.js";
+import {
+  applyReviewPullResultToRunOnceResult,
+  assertExpectedReviewPrHead,
+  type ReviewPullResult,
+  type RunOnceOptions,
+  type RunOnceResult
+} from "../src/worker.js";
 import type { ProductionLicenseAdmission } from "../src/license-admission.js";
 
 describe("run-once CLI reporting", () => {
@@ -98,7 +104,10 @@ describe("run-once CLI reporting", () => {
 
     expect(command.exitCode).toBe(0);
     expect(forwardedExpectedHeadSha).toBe("head-123");
-    expect(explicitPullReview).toBe(true);
+    expect(explicitPullReview).toEqual({
+      repo: "owner/repo",
+      pullNumber: 123
+    });
     expect(command.report.command).toBe("review-pr");
     expect(JSON.parse(command.output)).toMatchObject({
       ok: true,
@@ -109,6 +118,24 @@ describe("run-once CLI reporting", () => {
         headSha: "head-123"
       }
     });
+  });
+
+  it("does not widen canary access for an incompletely scoped review-pr invocation", async () => {
+    let explicitPullReview: RunOnceOptions["explicitPullReview"];
+    await runOnceCliCommand({
+      options: {
+        dryRun: true,
+        repo: "owner/repo",
+        useZCode: false
+      },
+      commandName: "review-pr",
+      runOnceImpl: async (options) => {
+        explicitPullReview = options.explicitPullReview;
+        return runOnceResult();
+      }
+    });
+
+    expect(explicitPullReview).toBeUndefined();
   });
 
   it("rejects review-pr execution when the fetched PR head differs from the approved head", () => {

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -68,6 +68,7 @@ describe("run-once CLI reporting", () => {
 
   it("prints review-pr as the command on successful review-pr invocations", async () => {
     let forwardedExpectedHeadSha: string | undefined;
+    let explicitPullReview: boolean | undefined;
     const command = await runOnceCliCommand({
       options: {
         dryRun: true,
@@ -79,6 +80,7 @@ describe("run-once CLI reporting", () => {
       commandName: "review-pr",
       runOnceImpl: async (options) => {
         forwardedExpectedHeadSha = options.expectedHeadSha;
+        explicitPullReview = options.explicitPullReview;
         return runOnceResult({
           reposScanned: 1,
           pullsSeen: 1,
@@ -96,6 +98,7 @@ describe("run-once CLI reporting", () => {
 
     expect(command.exitCode).toBe(0);
     expect(forwardedExpectedHeadSha).toBe("head-123");
+    expect(explicitPullReview).toBe(true);
     expect(command.report.command).toBe("review-pr");
     expect(JSON.parse(command.output)).toMatchObject({
       ok: true,

--- a/tests/runtime-github-credentials.test.ts
+++ b/tests/runtime-github-credentials.test.ts
@@ -8,6 +8,7 @@ import {
   resolveRuntimeGitHubCredentials,
   resolveRuntimeCredentialEnvelope,
   readRuntimeLicenseKey,
+  readRuntimeLicenseMachineId,
   withRuntimeGitHubCredentials
 } from "../src/runtime-github-credentials.js";
 
@@ -16,6 +17,7 @@ const privateKey = generateKeyPairSync("rsa", {
   privateKeyEncoding: { type: "pkcs8", format: "pem" },
   publicKeyEncoding: { type: "spki", format: "pem" }
 }).privateKey;
+const brokerDeviceId = "a".repeat(43);
 
 describe("runtime GitHub credentials", () => {
   it("binds bounded stdin credentials only to raw daemon and review-pr execution", async () => {
@@ -92,10 +94,11 @@ describe("runtime GitHub credentials", () => {
       subcommand: undefined,
       runtimeCredentialsStdin: "true",
       stdin: Readable.from([JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         githubAppId: "4184532",
         githubPrivateKey: privateKey,
-        licenseKey: "nd_live_runtime_fixture_1234"
+        licenseKey: "nd_live_runtime_fixture_1234",
+        licenseMachineId: brokerDeviceId
       })])
     });
 
@@ -104,12 +107,14 @@ describe("runtime GitHub credentials", () => {
       expect(config.github.appId).toBe("4184532");
       expect(config.github.privateKey).toBe(privateKey.trim());
       expect(readRuntimeLicenseKey()).toBe("nd_live_runtime_fixture_1234");
+      expect(readRuntimeLicenseMachineId()).toBe(brokerDeviceId);
       expect(productionLicenseSecretReader.read(config.license!))
         .toBe("nd_live_runtime_fixture_1234");
       expect(JSON.stringify(config)).not.toContain(privateKey.trim());
       expect(JSON.stringify(config)).not.toContain("nd_live_runtime_fixture_1234");
     });
     expect(readRuntimeLicenseKey()).toBeUndefined();
+    expect(readRuntimeLicenseMachineId()).toBeUndefined();
   });
 
   it("preserves runtime App credentials when related-context options are copied", async () => {
@@ -118,10 +123,11 @@ describe("runtime GitHub credentials", () => {
       subcommand: undefined,
       runtimeCredentialsStdin: "true",
       stdin: Readable.from([JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         githubAppId: "4184532",
         githubPrivateKey: privateKey,
-        licenseKey: "nd_live_runtime_fixture_1234"
+        licenseKey: "nd_live_runtime_fixture_1234",
+        licenseMachineId: brokerDeviceId
       })])
     });
 


### PR DESCRIPTION
Related: #699
Related: #646
Related: #610
Roadmap: #103

## Customer failure
The signed Mac app could restore the existing ElectricSheep bot but could not complete the supported path from native activation and exact-target GitHub verification through a healthy Keychain-backed worker and an explicit dry/live review. The causal seams were broker machine identity, sealed-worker routing, launch-scoped entitlement continuation, Codex runtime readiness, and explicit review-pr handling under a placeholder canary list.

## Bounded customer slice
- preserve the existing account, bot, 53-repository allowlist, exact selected Review Target, and account-scoped config
- keep GitHub App, activation, and worker credentials Keychain-only and out of argv/plist/environment/logs
- use the installed Codex CLI at /Users/m1/.local/bin/codex, model gpt-5.6-sol, effort high; ZCode is fallback only
- install/run the sealed secret-free LaunchAgent, verify exact repository access and API-backed entitlement, and require dry exact-head proof before one confirmed live post
- bind the explicit canary exception to exactly one nonempty repo and positive PR; broad daemon/scheduler/run-once scans retain canaryPulls

## Installed acceptance
Signed/notarized/stapled beta.67 build 11071 at source head d1eff22284a2f9349aa981586c573d16331bc80e proved through native Computer Use:
- restored ELECTRICSHEEP / existing evaos-code-review-bot / 53 repos unchanged
- exact target electricsheephq/evaos-code-review-bot-neondiff verified with API-backed active internal-admin entitlement
- active Codex CLI /Users/m1/.local/bin/codex, gpt-5.6-sol, high
- daemon runtime_ok / CHECKED
- dry review completed for PR #769 at exact head d1eff22284a2
- live control remained disabled until dry proof, then one owner-confirmed live review posted at that exact head
- clean quit/relaunch restored account, bot, target, provider, entitlement, and daemon health; launch-scoped repository access correctly returned to reverification

GitHub independently records the exact-head live review from evaos-code-review-bot.

## Final review delta
The live review found one canary-boundary issue. Current integrated head 7ae7a74c68499d732b812c627f88a6e42bfb62dc binds the exception to the exact repo+PR and also accepts the CLI string/object failure shapes while preserving redaction and fail-closed live behavior. Focused Vitest 27/27, Swift reconciliation 45/45, production TypeScript noEmit, independent final delta review PASS 99, and PR #769 exact-head CI/Swift gates are green. The final safety delta is source/review/CI-proven and was not separately installed.

## Non-goals and proof boundary
- no allowlist rewrite, provider migration, ZCode repair, checkout pause, credential rotation, or new license
- no managed GitHub App, broad #517, full Sparkle, GA, or customer-readiness claim
- beta.67 proves one installed admin canary on one repository/PR; it does not prove all repositories, scheduler/broad-scan behavior, public publication, or customer use