### PR TITLE
fix(license): bind existing-bot refresh to broker device

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -346,6 +346,11 @@ package enum DesktopTrustedBundledWorkerContract {
         arguments: [String],
         hasStandardInput: Bool
     ) -> Bool {
+        if Array(arguments.prefix(2)) == ["license", "status"],
+           arguments.contains("--license-machine-id")
+        {
+            return true
+        }
         guard hasStandardInput else { return false }
         return [
             "--runtime-credentials-stdin",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4210,6 +4210,51 @@ package final class NeonDiffDesktopModel: ObservableObject {
         } else {
             expectedLicenseMachineID = nil
         }
+        let keychainRevalidation:
+            (client: any ActivationLicenseClienting, key: ActivationKeyMaterial)?
+        if expectedContext.source == .keychainStdinExistingBot {
+            guard let expectedLicenseMachineID,
+                  let client = activationLicenseClientOverride
+                    ?? liveActivationLicenseClient(
+                        machineId: expectedLicenseMachineID,
+                        repository: repository
+                    )
+            else {
+                isBYOGitHubVerificationInProgress = false
+                applyActivationEvent(.activationServiceError)
+                lastError =
+                    "The signed activation verifier is unavailable. Reopen NeonDiff and verify existing access again."
+                byoGitHubCredentialStatus =
+                    "GitHub access was verified, but the API-backed entitlement verifier is unavailable."
+                return
+            }
+            let rawActivationKey: String?
+            do {
+                rawActivationKey = try dependencies.secretStore.readSecret(
+                    account: activationKeyAccount,
+                    allowUserInteraction: false
+                )
+            } catch {
+                rawActivationKey = nil
+            }
+            guard let rawActivationKey,
+                  !ActivationKeyMaterial(rawActivationKey).isEmpty
+            else {
+                isBYOGitHubVerificationInProgress = false
+                applyActivationEvent(.activationServiceError)
+                lastError =
+                    "The stored NeonDiff Activation Key is unavailable without user interaction. Use the License pane to authorize this Mac again."
+                byoGitHubCredentialStatus =
+                    "GitHub access was verified, but the stored API-backed entitlement credential is unavailable."
+                return
+            }
+            keychainRevalidation = (
+                client,
+                ActivationKeyMaterial(rawActivationKey)
+            )
+        } else {
+            keychainRevalidation = nil
+        }
         var arguments = [
             "license", "status",
             "--config", configPath,
@@ -4228,34 +4273,49 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let redactedDeviceBinding = expectedLicenseMachineID == nil
             ? ""
             : " --license-machine-id [stored device ID]"
-        lastCommandLine =
-            "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true\(redactedDeviceBinding) --json"
+        if keychainRevalidation == nil {
+            lastCommandLine =
+                "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true\(redactedDeviceBinding) --json"
+        } else {
+            lastCommandLine =
+                "\(shellQuote(cliPath)) license activate --config \(shellQuote(configPath)) --license-storage keychain --license-key-stdin true --persist-local-state false\(redactedDeviceBinding) --repo \(shellQuote(repository)) --json"
+        }
 
         Task.detached {
             let outcome: ActivationClientOutcome
-            do {
-                let result = try await cli.run(
-                    executablePath: executablePath,
-                    arguments: arguments,
-                    standardInput: nil,
-                    timeout: 20
-                )
-                outcome = result.stdout.trimmingCharacters(
-                    in: .whitespacesAndNewlines
-                ).isEmpty
-                    ? .serviceError
-                    : CLIActivationLicenseClient.classify(
-                        stdout: result.stdout
+            if let keychainRevalidation {
+                do {
+                    outcome = try await keychainRevalidation.client.revalidate(
+                        key: keychainRevalidation.key
                     )
-            } catch let error as NeonDiffCLIError {
-                switch error {
-                case .timedOut, .cancelled, .cleanupTimedOut:
+                } catch {
                     outcome = .offline
-                case .launchFailed, .standardInputTooLarge, .outputTooLarge:
-                    outcome = .serviceError
                 }
-            } catch {
-                outcome = .offline
+            } else {
+                do {
+                    let result = try await cli.run(
+                        executablePath: executablePath,
+                        arguments: arguments,
+                        standardInput: nil,
+                        timeout: 20
+                    )
+                    outcome = result.stdout.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ).isEmpty
+                        ? .serviceError
+                        : CLIActivationLicenseClient.classify(
+                            stdout: result.stdout
+                        )
+                } catch let error as NeonDiffCLIError {
+                    switch error {
+                    case .timedOut, .cancelled, .cleanupTimedOut:
+                        outcome = .offline
+                    case .launchFailed, .standardInputTooLarge, .outputTooLarge:
+                        outcome = .serviceError
+                    }
+                } catch {
+                    outcome = .offline
+                }
             }
 
             await MainActor.run {
@@ -4313,7 +4373,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     resolved,
                     repository: repository,
                     activeLogMessage:
-                        "Current repository entitlement verified through the existing local agent. No Activation Key was copied."
+                        "Current repository entitlement verified through the existing local agent's API-backed credential path."
                 )
                 switch resolved {
                 case .active:
@@ -4592,17 +4652,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
         if let activationLicenseClientOverride { return activationLicenseClientOverride }
-        // Keep the real adapter behind the rollout flag until production billing
-        // and activation canaries pass. When enabled, it uses the CLI's explicit
-        // no-local-state mode: the app-owned Keychain item remains the only raw
-        // credential copy and the key crosses only over bounded stdin.
-        let bundleEnablesActivation = dependencies.productionBoundary.byoGitHubEnabled
-        let rolloutEnablesActivation = dependencies.preferences.bool(forKey: activationCliBackedEnabledKey)
-        guard dependencies.productionBoundary.nativeActivationBrokerVerified,
-              bundleEnablesActivation || rolloutEnablesActivation
-        else {
-            return nil
-        }
         guard let selectedReviewRepository,
               repos.contains(where: {
                   $0.enabled
@@ -4615,12 +4664,36 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return nil
         }
+        return liveActivationLicenseClient(
+            machineId: identity.deviceId,
+            repository: selectedReviewRepository
+        )
+    }
+
+    private func liveActivationLicenseClient(
+        machineId: String,
+        repository: String
+    ) -> (any ActivationLicenseClienting)? {
+        // Keep the real adapter behind the rollout flag until production billing
+        // and activation canaries pass. When enabled, it uses the CLI's explicit
+        // no-local-state mode: the app-owned Keychain item remains the only raw
+        // credential copy and the key crosses only over bounded stdin.
+        let bundleEnablesActivation =
+            dependencies.productionBoundary.byoGitHubEnabled
+        let rolloutEnablesActivation = dependencies.preferences.bool(
+            forKey: activationCliBackedEnabledKey
+        )
+        guard dependencies.productionBoundary.nativeActivationBrokerVerified,
+              bundleEnablesActivation || rolloutEnablesActivation
+        else {
+            return nil
+        }
         return DesktopActivationLicenseClient(
             cli: dependencies.cli,
             executablePath: cliPath,
             configPath: configPath,
-            machineId: identity.deviceId,
-            repository: selectedReviewRepository
+            machineId: machineId,
+            repository: repository
         )
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4193,18 +4193,43 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let expectedConfigPath = configPath
         let executablePath = cliPath
         let cli = dependencies.cli
-        let arguments = [
+        let expectedLicenseMachineID: String?
+        if expectedContext.source == .keychainStdinExistingBot {
+            guard let licenseMachineID = try? GitHubBrokerDeviceIdentityStore(
+                secretStore: dependencies.secretStore
+            ).loadExisting(allowUserInteraction: false).deviceId else {
+                isBYOGitHubVerificationInProgress = false
+                applyActivationEvent(.activationServiceError)
+                lastError =
+                    "The saved activation device identity is unavailable. Reactivate this Mac before verifying current access."
+                byoGitHubCredentialStatus =
+                    "GitHub access was verified, but the Keychain-backed entitlement identity could not be loaded safely."
+                return
+            }
+            expectedLicenseMachineID = licenseMachineID
+        } else {
+            expectedLicenseMachineID = nil
+        }
+        var arguments = [
             "license", "status",
             "--config", configPath,
             "--repo", repository,
-            "--refresh", "true",
-            "--json"
+            "--refresh", "true"
         ]
+        if let expectedLicenseMachineID {
+            arguments.append(contentsOf: [
+                "--license-machine-id", expectedLicenseMachineID
+            ])
+        }
+        arguments.append("--json")
         isBYOGitHubVerificationInProgress = true
         byoGitHubCredentialStatus =
             "GitHub access verified. Checking the existing local agent's API-backed entitlement…"
+        let redactedDeviceBinding = expectedLicenseMachineID == nil
+            ? ""
+            : " --license-machine-id [stored device ID]"
         lastCommandLine =
-            "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true --json"
+            "\(shellQuote(cliPath)) license status --config \(shellQuote(configPath)) --repo \(shellQuote(repository)) --refresh true\(redactedDeviceBinding) --json"
 
         Task.detached {
             let outcome: ActivationClientOutcome
@@ -4253,6 +4278,27 @@ package final class NeonDiffDesktopModel: ObservableObject {
                     self.byoGitHubCredentialStatus =
                         "GitHub access was verified, but stale entitlement proof was discarded. Verify existing access again."
                     return
+                }
+                if let expectedLicenseMachineID {
+                    let currentLicenseMachineID =
+                        try? GitHubBrokerDeviceIdentityStore(
+                            secretStore: self.dependencies.secretStore
+                        ).loadExisting(
+                            allowUserInteraction: false
+                        ).deviceId
+                    guard currentLicenseMachineID
+                            == expectedLicenseMachineID
+                    else {
+                        self.isBYOGitHubVerificationInProgress = false
+                        self.applyActivationEvent(
+                            .activationServiceError
+                        )
+                        self.lastError =
+                            "The activation device identity changed before entitlement verification finished."
+                        self.byoGitHubCredentialStatus =
+                            "GitHub access was verified, but stale device-bound entitlement proof was discarded."
+                        return
+                    }
                 }
                 self.isBYOGitHubVerificationInProgress = false
                 let resolved =

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -335,6 +335,30 @@ import NeonDiffDesktopCore
         ))
     }
 
+    @Test func deviceBoundLicenseStatusRequiresTheSignedBundledWorker() {
+        #expect(DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "license", "status",
+                "--config", "/fixture/config.local.json",
+                "--repo", "electricsheephq/evaos-code-review-bot-neondiff",
+                "--refresh", "true",
+                "--license-machine-id", licenseMachineID,
+                "--json"
+            ],
+            hasStandardInput: false
+        ))
+        #expect(!DesktopTrustedBundledWorkerContract.requiresTrustedWorker(
+            arguments: [
+                "license", "status",
+                "--config", "/fixture/config.local.json",
+                "--repo", "electricsheephq/evaos-code-review-bot-neondiff",
+                "--refresh", "true",
+                "--json"
+            ],
+            hasStandardInput: false
+        ))
+    }
+
     @Test func trustedBundledWorkerUsesOnlySealedAppCoordinates() throws {
         let app = URL(filePath: "/Applications/NeonDiff.app")
         let context = try #require(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -730,6 +730,10 @@ import NeonDiffDesktopCore
         let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"
         let otherRepository = "electricsheephq/WorldOS"
+        let activationKey = "NDL-EXISTING-BOT-REVALIDATION-FIXTURE"
+        let activationClient = ExistingBotRecordingActivationClient(
+            expectedKey: activationKey
+        )
         let readCheck =
             #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
         let fixture = ModelDependencyFixture(
@@ -751,12 +755,9 @@ import NeonDiffDesktopCore
                     exitCode: 0,
                     stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
                     stderr: ""
-                )),
-                .success(existingAgentLicenseStatus(
-                    scope: "private",
-                    privateRepoAllowed: true
                 ))
             ],
+            activationLicenseClient: activationClient,
             localBotConfigurations: [
                 DesktopLocalBotConfiguration(
                     appID: 4_184_532,
@@ -780,9 +781,13 @@ import NeonDiffDesktopCore
         fixture.model.pendingBYOGitHubAppPrivateKey =
             existingBotFixturePrivateKey
         fixture.model.storeBYOGitHubAppCredentials()
-        let licenseMachineID = try GitHubBrokerDeviceIdentityStore(
+        _ = try GitHubBrokerDeviceIdentityStore(
             secretStore: fixture.secretStore
         ).loadOrCreate().deviceId
+        try fixture.secretStore.setSecret(
+            activationKey,
+            account: "license/default"
+        )
         fixture.model.applyAccountWorkspaceCatalog(.loaded([
             workspace(entitlement: .internalAdmin)
         ]))
@@ -808,8 +813,6 @@ import NeonDiffDesktopCore
         for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
             await Task.yield()
         }
-
-        #expect(await reachesCallCount(fixture, 4))
         let verificationCall = fixture.cli.calls[2]
         #expect(verificationCall.arguments == [
             "doctor", "github",
@@ -824,16 +827,13 @@ import NeonDiffDesktopCore
                 == Data(existingBotFixturePrivateKey.utf8)
         )
         #expect(fixture.model.byoGitHubCredentialsVerified)
-        let entitlementCall = try #require(fixture.cli.calls.last)
-        #expect(entitlementCall.arguments == [
-            "license", "status",
-            "--config", configPath,
-            "--repo", targetRepository,
-            "--refresh", "true",
-            "--license-machine-id", licenseMachineID,
-            "--json"
-        ])
-        #expect(entitlementCall.standardInput == nil)
+        for _ in 0..<100 where activationClient.revalidationCount == 0 {
+            await Task.yield()
+        }
+        #expect(fixture.cli.calls.count == 3)
+        #expect(activationClient.activationCount == 0)
+        #expect(activationClient.revalidationCount == 1)
+        #expect(activationClient.receivedExpectedKey)
         #expect(fixture.model.currentRepositoryActivationReady)
         #expect(fixture.model.activationState == .active)
         #expect(fixture.model.productionUsefulWorkAvailable)
@@ -2200,6 +2200,58 @@ private struct ExistingBotRejectedActivationClient: ActivationLicenseClienting {
 
     func revalidate(key: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
         .invalid
+    }
+}
+
+private final class ExistingBotRecordingActivationClient:
+    ActivationLicenseClienting,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private let expectedKey: String
+    private var activations = 0
+    private var revalidations = 0
+    private var matchedExpectedKey = false
+
+    init(expectedKey: String) {
+        self.expectedKey = expectedKey
+    }
+
+    var activationCount: Int {
+        lock.withLock { activations }
+    }
+
+    var revalidationCount: Int {
+        lock.withLock { revalidations }
+    }
+
+    var receivedExpectedKey: Bool {
+        lock.withLock { matchedExpectedKey }
+    }
+
+    func activate(
+        key: ActivationKeyMaterial
+    ) async throws -> ActivationClientOutcome {
+        lock.withLock { activations += 1 }
+        return .serviceError
+    }
+
+    func revalidate(
+        key: ActivationKeyMaterial
+    ) async throws -> ActivationClientOutcome {
+        lock.withLock {
+            revalidations += 1
+            matchedExpectedKey = key.withRawValue { $0 == expectedKey }
+        }
+        return .active(.init(
+            status: .active,
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            expiresAt: nil,
+            plan: "beta",
+            seats: 1
+        ))
     }
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -780,6 +780,9 @@ import NeonDiffDesktopCore
         fixture.model.pendingBYOGitHubAppPrivateKey =
             existingBotFixturePrivateKey
         fixture.model.storeBYOGitHubAppCredentials()
+        let licenseMachineID = try GitHubBrokerDeviceIdentityStore(
+            secretStore: fixture.secretStore
+        ).loadOrCreate().deviceId
         fixture.model.applyAccountWorkspaceCatalog(.loaded([
             workspace(entitlement: .internalAdmin)
         ]))
@@ -827,6 +830,7 @@ import NeonDiffDesktopCore
             "--config", configPath,
             "--repo", targetRepository,
             "--refresh", "true",
+            "--license-machine-id", licenseMachineID,
             "--json"
         ])
         #expect(entitlementCall.standardInput == nil)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ProviderModelFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ProviderModelFixture.swift
@@ -36,6 +36,13 @@ final class MemorySecretStore: DesktopSecretStoring, @unchecked Sendable {
         storage.read { $0[account] }
     }
 
+    func readSecret(
+        account: String,
+        allowUserInteraction _: Bool
+    ) throws -> String? {
+        storage.read { $0[account] }
+    }
+
     func containsSecret(account: String) -> Bool {
         storage.read { $0[account] != nil }
     }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -397,12 +397,17 @@ the same Mac. In that exact case it opens a reconciliation path:
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
 - its single **Verify existing access** action first proves the exact App and
-  Review Target with `doctor github --repo`, then runs credential-free
-  `license status --refresh true` through the same matched worker and config.
-  The native app never reads, copies, migrates, or prompts for the worker's
-  Activation Key. GitHub-reported repository visibility and an active live API
-  entitlement covering that visibility are both required; unknown, expired,
-  revoked, malformed, or offline proof fails closed;
+  Review Target with `doctor github --repo`. A legacy credential-bearing
+  matched worker then runs credential-free
+  `license status --refresh true` through that exact worker and config. A
+  secret-free Keychain-backed worker instead reads the app-owned Activation Key
+  noninteractively and revalidates it through the signed sealed worker's
+  idempotent API path, with the key crossing only bounded stdin and no local
+  CLI-state write. Neither path places the key in argv, environment, config,
+  logs, or evidence. GitHub-reported repository visibility and an active live
+  API entitlement covering that visibility are both required; an unavailable
+  Keychain item, unknown visibility, expired or revoked access, malformed
+  output, or offline proof fails closed;
 - Overview runs one provider-backed repository/PR-scoped dry review first. A
   live review is enabled only for that config revision and the returned
   40-character head SHA, and requires explicit confirmation (see

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -200,13 +200,16 @@ Local config alone never establishes membership, installation authority, or
 review authorization.
 
 The single **Verify existing access** action first runs `doctor github` for the
-exact selected repository and then runs credential-free
-`license status --refresh true --json` through the same matched worker and
-config—even when the native app has a separate current-launch activation.
-Only a live API-sourced entitlement covering GitHub's reported visibility
-unlocks review work. The app never reads, copies, or prompts for that worker's
-Activation Key; expired, revoked, malformed, offline, or stale results remain
-retryable and fail closed.
+exact selected repository. A legacy credential-bearing matched worker then runs
+credential-free `license status --refresh true --json` through that exact
+worker and config. A secret-free Keychain-backed worker instead revalidates the
+app-owned Activation Key through the signed sealed worker's idempotent API path.
+The app reads that Keychain item noninteractively and sends it only over bounded
+stdin; it never places the key in argv, environment, config, logs, or evidence,
+and the CLI writes no local key state. Only a live API-sourced entitlement
+covering GitHub's reported visibility unlocks review work. An unavailable
+Keychain item, expired or revoked access, malformed output, offline proof, or a
+stale result remains retryable and fails closed.
 
 An existing worker may already monitor several GitHub App-authorized
 repositories. NeonDiff preserves that allowlist and requires one explicit

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -408,6 +408,9 @@ async function main(): Promise<void> {
       const result = await getLicenseStatus({
         config: licenseConfig,
         refresh: args.refresh === undefined ? false : parseBooleanArg(args.refresh, "--refresh"),
+        ...(args["license-machine-id"]
+          ? { machineId: parseLicenseMachineIdArg(args["license-machine-id"]) }
+          : {}),
         ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {})
       });
       console.log(stringifyRedactedJson({ command: "license status", ...result }));

--- a/tests/helpers/mock-production-license-api.mjs
+++ b/tests/helpers/mock-production-license-api.mjs
@@ -6,6 +6,15 @@ globalThis.fetch = async (input, init) => {
     url === "https://neondiff-license.fly.dev/v1/license/activate" ||
     url === "https://neondiff-license.fly.dev/v1/license/validate"
   ) {
+    const expectedMachineId = process.env.NEONDIFF_TEST_EXPECT_LICENSE_MACHINE_ID;
+    if (expectedMachineId && url.endsWith("/v1/license/validate")) {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      if (body.machineId !== expectedMachineId) {
+        return new Response(JSON.stringify({
+          status: "scope_mismatch"
+        }), { status: 409, headers: { "content-type": "application/json" } });
+      }
+    }
     return new Response(JSON.stringify({
       status: "active",
       expiresAt: "2999-01-01T00:00:00.000Z",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -349,6 +349,44 @@ describe("public NeonDiff CLI surface", () => {
     expect(existsSync(cachePath)).toBe(false);
   });
 
+  it("forwards the native broker device identity during a refreshed license status", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-native-status-binding-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/private"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      license: activatedLicenseTestConfig(root)
+    })}\n`);
+
+    const output = JSON.parse((await runCli([
+      "license",
+      "status",
+      "--config",
+      configPath,
+      "--repo",
+      "acme/private",
+      "--refresh",
+      "true",
+      "--license-machine-id",
+      BROKER_DEVICE_ID,
+      "--json"
+    ], {
+      env: {
+        ...activatedLicenseTestEnv(),
+        NEONDIFF_TEST_EXPECT_LICENSE_MACHINE_ID: BROKER_DEVICE_ID
+      }
+    })).stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      status: "active",
+      source: "api"
+    });
+  });
+
   it("redacts secret-like values from structured status JSON stdout", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-cli-status-"));
     roots.push(root);


### PR DESCRIPTION
Related: #699

## Outcome

Fix the exact beta.62 installed failure where existing-bot GitHub verification reached APP VERIFIED but the automatic repository-scoped entitlement continuation returned non-active.

This stacked PR binds only the Keychain-backed existing-bot `license status --refresh true` call to the already-stored non-secret RFC 7638 broker device ID, and makes the CLI forward that value to the license validation API. It is stacked on PR #767 so that PR remains within its completed review budget.

## Acceptance criteria

- Keychain-backed existing-bot status uses the stored broker device ID without reading or exposing the Activation Key.
- The CLI forwards `--license-machine-id` to `/v1/license/validate`.
- Missing or changed identity fails closed.
- The legacy exact-agent path remains unchanged.
- The selected Review Target and full existing repository allowlist remain unchanged.

## Non-goals

- No billing, checkout, GitHub App registration, provider, worker-install, signing, release, website, or GA change.
- No ZCode repair or managed-App work.
- No claim of installed/runtime/customer readiness from source or CI.

## Failing-first proof

- Swift regression failed because the entitlement call omitted `--license-machine-id`.
- CLI regression failed because the canonical validation mock received the fallback local machine ID instead of the supplied broker device ID.

## Focused proof

- `swift test --skip-update --filter ExistingLocalBotReconciliationTests.keychainBackedExistingAgentScopesVerificationThroughStoredCredential`
- `swift test --skip-update --filter ExistingLocalBotReconciliationTests` — 43/43 passed
- `npm test -- --run tests/public-cli.test.ts -t "forwards the native broker device identity during a refreshed license status"` — 1/1 passed
- `git diff --check`

Claim class: source/focused-test proof only. This does not prove merge, installed activation, worker runtime, review execution, release readiness, or customer readiness.