### PR TITLE
fix(desktop): expose redacted scoped-review failure cause

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -5161,7 +5161,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         isScopedReviewInProgress = false
         scopedReviewTask = nil
-        guard currentScopedReviewCoordinatesMatch(expectedContext),
+        let coordinatesMatch =
+            currentScopedReviewCoordinatesMatch(expectedContext)
+        let structuredFailure =
+            scopedReviewStructuredFailureMessage(result.stdout)
+        guard coordinatesMatch,
               result.exitCode == 0,
               let data = result.stdout.data(using: .utf8),
               let report = try? JSONDecoder().decode(
@@ -5179,8 +5183,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
               isValidGitHubCommitSHA(report.scope.headSha)
         else {
             invalidateScopedReviewApproval()
-            lastError =
-                "The dry review did not produce exact repository, pull request, and head proof."
+            lastError = coordinatesMatch
+                ? (structuredFailure
+                    ?? "The dry review did not produce exact repository, pull request, and head proof.")
+                : "The dry review context changed before exact repository, pull request, and head proof completed."
             scopedReviewStatus =
                 "Dry review failed closed. No live review is authorized."
             return
@@ -5244,6 +5250,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         scopedReviewStatus =
             "Review posted for \(expectedApproval.repo)#\(expectedApproval.pullNumber) at \(expectedApproval.headSHA.prefix(12))."
         invalidateScopedReviewApproval(preserveStatus: true)
+    }
+
+    private func scopedReviewStructuredFailureMessage(
+        _ stdout: String
+    ) -> String? {
+        guard let data = stdout.data(using: .utf8),
+              let report = try? JSONDecoder().decode(
+                  ScopedReviewFailureReport.self,
+                  from: data
+              ),
+              let rawMessage = report.error?.message
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawMessage.isEmpty
+        else {
+            return nil
+        }
+        let redacted = NeonDiffRedactor.redact(rawMessage)
+        return "Dry review failed safely: \(redacted.prefix(512))"
     }
 
     private func currentScopedReviewCoordinatesMatch(
@@ -6809,6 +6833,14 @@ private struct ScopedReviewCommandReport: Decodable {
     let dryRun: Bool
     let scope: Scope
     let result: Result
+}
+
+private struct ScopedReviewFailureReport: Decodable {
+    struct Failure: Decodable {
+        let message: String
+    }
+
+    let error: Failure?
 }
 
 private let licenseKeyAccount = "license/default"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -6838,6 +6838,20 @@ private struct ScopedReviewCommandReport: Decodable {
 private struct ScopedReviewFailureReport: Decodable {
     struct Failure: Decodable {
         let message: String
+
+        private enum CodingKeys: String, CodingKey {
+            case message
+        }
+
+        init(from decoder: Decoder) throws {
+            let singleValue = try decoder.singleValueContainer()
+            if let message = try? singleValue.decode(String.self) {
+                self.message = message
+                return
+            }
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            message = try values.decode(String.self, forKey: .message)
+        }
     }
 
     let error: Failure?

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1490,6 +1490,46 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedDryReviewSurfacesRedactedStructuredFailure() async {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            )
+        )
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 4))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 1,
+            stdout: """
+            {"ok":false,"command":"review-pr","dryRun":true,"useZCode":true,
+             "scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff",
+             "pullNumber":768},
+             "error":{"message":"license network: token=abcdefghijklmnop"}}
+            """,
+            stderr: ""
+        )))
+
+        fixture.model.pendingReviewPullNumber = "768"
+        fixture.model.runScopedDryReview()
+        #expect(await reachesCallCount(fixture, 5))
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        #expect(
+            fixture.model.lastError
+                == "Dry review failed safely: license network: [redacted-secret]"
+        )
+        #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+    }
+
+    @MainActor
     @Test func staleExactWorkerStatusClearsOwnedProgressState() async throws {
         let fixture = await preparedExistingAgentVerificationFixture(
             visibility: "private",

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1530,6 +1530,46 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func scopedDryReviewSurfacesRedactedStringFailure() async {
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            )
+        )
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        #expect(await reachesCallCount(fixture, 4))
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+        fixture.cli.enqueue(.success(CLIRunResult(
+            exitCode: 1,
+            stdout: """
+            {"ok":false,"command":"review-pr","dryRun":true,"useZCode":true,
+             "scope":{"repo":"electricsheephq/evaos-code-review-bot-neondiff",
+             "pullNumber":769},
+             "error":"config rejected: token=abcdefghijklmnop"}
+            """,
+            stderr: ""
+        )))
+
+        fixture.model.pendingReviewPullNumber = "769"
+        fixture.model.runScopedDryReview()
+        #expect(await reachesCallCount(fixture, 5))
+        for _ in 0..<20 where fixture.model.isScopedReviewInProgress {
+            await Task.yield()
+        }
+
+        #expect(
+            fixture.model.lastError
+                == "Dry review failed safely: config rejected: [redacted-secret]"
+        )
+        #expect(fixture.model.scopedReviewStatus.contains("failed closed"))
+        #expect(!fixture.model.scopedLiveReviewConfirmationAvailable)
+    }
+
+    @MainActor
     @Test func staleExactWorkerStatusClearsOwnedProgressState() async throws {
         let fixture = await preparedExistingAgentVerificationFixture(
             visibility: "private",

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -97,6 +97,20 @@ export async function runOnceCliCommand(input: {
 }): Promise<RunOnceCliCommandResult> {
   let result: RunOnceResult;
   try {
+    const explicitRepo = input.options.repo;
+    const explicitPullNumber = input.options.pullNumber;
+    const explicitPullReview =
+      input.commandName === "review-pr" &&
+      typeof explicitRepo === "string" &&
+      explicitRepo.trim().length > 0 &&
+      typeof explicitPullNumber === "number" &&
+      Number.isInteger(explicitPullNumber) &&
+      explicitPullNumber > 0
+        ? {
+            repo: explicitRepo,
+            pullNumber: explicitPullNumber
+          }
+        : undefined;
     const licenseAdmission = input.admitImpl
       ? await input.admitImpl()
       : input.options.licenseAdmission;
@@ -104,8 +118,8 @@ export async function runOnceCliCommand(input: {
       ...input.options,
       // `review-pr` is already scoped to one explicit repo/PR. Keep
       // canaryPulls as the broad daemon/run-once rollout boundary.
-      ...(input.commandName === "review-pr"
-        ? { explicitPullReview: true }
+      ...(explicitPullReview
+        ? { explicitPullReview }
         : {}),
       ...(licenseAdmission ? { licenseAdmission } : {})
     });

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -102,6 +102,11 @@ export async function runOnceCliCommand(input: {
       : input.options.licenseAdmission;
     result = await (input.runOnceImpl ?? runOnce)({
       ...input.options,
+      // `review-pr` is already scoped to one explicit repo/PR. Keep
+      // canaryPulls as the broad daemon/run-once rollout boundary.
+      ...(input.commandName === "review-pr"
+        ? { explicitPullReview: true }
+        : {}),
       ...(licenseAdmission ? { licenseAdmission } : {})
     });
   } catch (error) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -220,6 +220,7 @@ export interface RunOnceOptions {
   dryRun: boolean;
   repo?: string;
   pullNumber?: number;
+  explicitPullReview?: boolean;
   expectedHeadSha?: string;
   expectedConfigRevision?: string;
   processedHeadPolicy?: "normal" | "approved_dry_run" | "refresh_dry_run";
@@ -500,6 +501,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             state,
             repo,
             pull,
+            ...(options.explicitPullReview
+              ? { explicitPullReview: true }
+              : {}),
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
             ...(reviewApprovalRevision
@@ -1433,6 +1437,7 @@ export interface ReviewPullInput {
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
+  explicitPullReview?: boolean;
   dryRun: boolean;
   useZCode: boolean;
   configRevision?: string;
@@ -1449,7 +1454,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   const repoPolicy = resolveRepoProfile(config, repo);
   if (!repoPolicy.allowed) return "skipped_policy";
   if (config.skipDrafts && pull.draft) return "skipped_draft";
-  if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
+  if (!isCanaryAllowed(
+    config,
+    repo,
+    pull.number,
+    { explicitPullReview: input.explicitPullReview }
+  )) return "skipped_canary";
   if (!input.licenseAdmission) throw new Error("production license admission is required for pull review");
   const visibility = visibilityFromPullSummary(pull);
   const visibilityDecision = authorizeAdmissionForVisibility(
@@ -2910,7 +2920,13 @@ export function activateRepoForNewOnlyReview(input: {
   return { activated: true, baselined };
 }
 
-export function isCanaryAllowed(config: Pick<BotConfig, "canaryPulls">, repo: string, pullNumber: number): boolean {
+export function isCanaryAllowed(
+  config: Pick<BotConfig, "canaryPulls">,
+  repo: string,
+  pullNumber: number,
+  options: { explicitPullReview?: boolean } = {}
+): boolean {
+  if (options.explicitPullReview) return true;
   if (!config.canaryPulls || config.canaryPulls.length === 0) return true;
   return new Set(config.canaryPulls).has(`${repo}#${pullNumber}`);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -220,7 +220,7 @@ export interface RunOnceOptions {
   dryRun: boolean;
   repo?: string;
   pullNumber?: number;
-  explicitPullReview?: boolean;
+  explicitPullReview?: ExplicitPullReviewScope;
   expectedHeadSha?: string;
   expectedConfigRevision?: string;
   processedHeadPolicy?: "normal" | "approved_dry_run" | "refresh_dry_run";
@@ -502,7 +502,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             repo,
             pull,
             ...(options.explicitPullReview
-              ? { explicitPullReview: true }
+              ? { explicitPullReview: options.explicitPullReview }
               : {}),
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
@@ -1437,7 +1437,7 @@ export interface ReviewPullInput {
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
-  explicitPullReview?: boolean;
+  explicitPullReview?: ExplicitPullReviewScope;
   dryRun: boolean;
   useZCode: boolean;
   configRevision?: string;
@@ -2924,11 +2924,19 @@ export function isCanaryAllowed(
   config: Pick<BotConfig, "canaryPulls">,
   repo: string,
   pullNumber: number,
-  options: { explicitPullReview?: boolean } = {}
+  options: { explicitPullReview?: ExplicitPullReviewScope } = {}
 ): boolean {
-  if (options.explicitPullReview) return true;
+  if (
+    options.explicitPullReview?.pullNumber === pullNumber &&
+    options.explicitPullReview.repo.toLowerCase() === repo.toLowerCase()
+  ) return true;
   if (!config.canaryPulls || config.canaryPulls.length === 0) return true;
   return new Set(config.canaryPulls).has(`${repo}#${pullNumber}`);
+}
+
+export interface ExplicitPullReviewScope {
+  repo: string;
+  pullNumber: number;
 }
 
 export type StaleHeadPhase = "before_command" | "before_review" | "before_chunk" | "before_plan" | "before_post";

--- a/tests/canary.test.ts
+++ b/tests/canary.test.ts
@@ -32,8 +32,24 @@ describe("canary PR allowlist", () => {
       config,
       "electricsheephq/evaos-code-review-bot-neondiff",
       769,
-      { explicitPullReview: true }
+      {
+        explicitPullReview: {
+          repo: "electricsheephq/evaos-code-review-bot-neondiff",
+          pullNumber: 769
+        }
+      }
     )).toBe(true);
+    expect(isCanaryAllowed(
+      config,
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      770,
+      {
+        explicitPullReview: {
+          repo: "electricsheephq/evaos-code-review-bot-neondiff",
+          pullNumber: 769
+        }
+      }
+    )).toBe(false);
   });
 });
 

--- a/tests/canary.test.ts
+++ b/tests/canary.test.ts
@@ -17,6 +17,24 @@ describe("canary PR allowlist", () => {
     expect(isCanaryAllowed(config, "electricsheephq/WorldOS", 1185)).toBe(false);
     expect(isCanaryAllowed(config, "100yenadmin/evaOS-GUI", 410)).toBe(false);
   });
+
+  it("allows one explicit review-pr target without widening broad canary scans", () => {
+    const config = {
+      canaryPulls: ["example-org/example-repo#1"]
+    };
+
+    expect(isCanaryAllowed(
+      config,
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      769
+    )).toBe(false);
+    expect(isCanaryAllowed(
+      config,
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      769,
+      { explicitPullReview: true }
+    )).toBe(true);
+  });
 });
 
 describe("local evidence date folders", () => {

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -74,7 +74,7 @@ describe("run-once CLI reporting", () => {
 
   it("prints review-pr as the command on successful review-pr invocations", async () => {
     let forwardedExpectedHeadSha: string | undefined;
-    let explicitPullReview: boolean | undefined;
+    let explicitPullReview: RunOnceOptions["explicitPullReview"];
     const command = await runOnceCliCommand({
       options: {
         dryRun: true,

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parsePositiveInteger } from "../src/cli-args.js";
 import { buildRunOnceCliReport, runOnceCliCommand, runOnceCliExitCode, serializeRunOnceCliReport } from "../src/run-once-cli.js";
-import { applyReviewPullResultToRunOnceResult, assertExpectedReviewPrHead, type ReviewPullResult, type RunOnceResult } from "../src/worker.js";
+import {
+  applyReviewPullResultToRunOnceResult,
+  assertExpectedReviewPrHead,
+  type ReviewPullResult,
+  type RunOnceOptions,
+  type RunOnceResult
+} from "../src/worker.js";
 import type { ProductionLicenseAdmission } from "../src/license-admission.js";
 
 describe("run-once CLI reporting", () => {
@@ -98,7 +104,10 @@ describe("run-once CLI reporting", () => {
 
     expect(command.exitCode).toBe(0);
     expect(forwardedExpectedHeadSha).toBe("head-123");
-    expect(explicitPullReview).toBe(true);
+    expect(explicitPullReview).toEqual({
+      repo: "owner/repo",
+      pullNumber: 123
+    });
     expect(command.report.command).toBe("review-pr");
     expect(JSON.parse(command.output)).toMatchObject({
       ok: true,
@@ -109,6 +118,24 @@ describe("run-once CLI reporting", () => {
         headSha: "head-123"
       }
     });
+  });
+
+  it("does not widen canary access for an incompletely scoped review-pr invocation", async () => {
+    let explicitPullReview: RunOnceOptions["explicitPullReview"];
+    await runOnceCliCommand({
+      options: {
+        dryRun: true,
+        repo: "owner/repo",
+        useZCode: false
+      },
+      commandName: "review-pr",
+      runOnceImpl: async (options) => {
+        explicitPullReview = options.explicitPullReview;
+        return runOnceResult();
+      }
+    });
+
+    expect(explicitPullReview).toBeUndefined();
   });
 
   it("rejects review-pr execution when the fetched PR head differs from the approved head", () => {

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -68,6 +68,7 @@ describe("run-once CLI reporting", () => {
 
   it("prints review-pr as the command on successful review-pr invocations", async () => {
     let forwardedExpectedHeadSha: string | undefined;
+    let explicitPullReview: boolean | undefined;
     const command = await runOnceCliCommand({
       options: {
         dryRun: true,
@@ -79,6 +80,7 @@ describe("run-once CLI reporting", () => {
       commandName: "review-pr",
       runOnceImpl: async (options) => {
         forwardedExpectedHeadSha = options.expectedHeadSha;
+        explicitPullReview = options.explicitPullReview;
         return runOnceResult({
           reposScanned: 1,
           pullsSeen: 1,
@@ -96,6 +98,7 @@ describe("run-once CLI reporting", () => {
 
     expect(command.exitCode).toBe(0);
     expect(forwardedExpectedHeadSha).toBe("head-123");
+    expect(explicitPullReview).toBe(true);
     expect(command.report.command).toBe("review-pr");
     expect(JSON.parse(command.output)).toMatchObject({
       ok: true,


### PR DESCRIPTION
## Outcome
Surface the already-redacted structured `review-pr` failure in the native dry-review gate instead of collapsing every pre-proof failure to a generic missing-proof message.

## Installed failure
On beta.65, the exact native dry review for `electricsheephq/evaos-code-review-bot-neondiff#768` failed before creating any processed row, claim, lease, cooldown, or readiness record. The current desktop discarded the CLI error, preventing a causal repair.

## Boundaries
- No retry or live GitHub post.
- No credential, Keychain, worker, repository, provider, or activation mutation.
- Live review remains fail-closed and disabled.
- Native redaction is applied again and the displayed detail is capped at 512 characters.

## Proof
- Failing-first focused test captured the prior generic message.
- `swift test --filter ExistingLocalBotReconciliationTests.scopedDryReviewSurfacesRedactedStructuredFailure` passes.
- `swift test --filter ExistingLocalBotReconciliationTests` passes 44/44.
- `git diff --check` passes.

This is source/focused-test proof only. It does not yet prove the installed dry review, live review, release, or customer readiness.