### PR TITLE
fix(desktop): run approved Keychain daemon live

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -83,11 +83,8 @@ enum FoundationKeychainWorkerDaemonRunner {
         let process = Process()
         process.executableURL = URL(filePath: workerPath)
         process.arguments =
-            [
-                "daemon",
-                "--config", request.configPath,
-                "--runtime-credentials-stdin", "true"
-            ]
+            DesktopKeychainWorkerLaunchAgentContract
+                .sealedWorkerDaemonArguments(request: request)
         process.environment = boundedEnvironment(homeDirectory: homeDirectory)
         process.currentDirectoryURL =
             URL(filePath: request.configPath).deletingLastPathComponent()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -121,6 +121,17 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         ]
     }
 
+    package static func sealedWorkerDaemonArguments(
+        request: DesktopKeychainWorkerLaunchAgentRequest
+    ) -> [String] {
+        [
+            "daemon",
+            "--config", request.configPath,
+            "--runtime-credentials-stdin", "true",
+            "--dry-run", "false"
+        ]
+    }
+
     package static func redactedPreviewText(
         request: DesktopKeychainWorkerLaunchAgentRequest,
         appExecutableURL: URL,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -45,6 +45,31 @@ import NeonDiffDesktopCore
         #expect(parsed == request)
     }
 
+    @Test func sealedWorkerDaemonRunsLiveAfterExplicitNativeInstall() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let request = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            licenseMachineID: licenseMachineID,
+            configPath: config.path,
+            launchdLabel: label,
+            homeDirectory: home
+        )
+
+        let arguments = DesktopKeychainWorkerLaunchAgentContract
+            .sealedWorkerDaemonArguments(request: request)
+
+        #expect(arguments == [
+            "daemon",
+            "--config", config.path,
+            "--runtime-credentials-stdin", "true",
+            "--dry-run", "false"
+        ])
+        #expect(!arguments.contains(appID))
+        #expect(!arguments.contains(licenseMachineID))
+    }
+
     @Test func previewExposesTheCompleteRedactedMutationPlan() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"


### PR DESCRIPTION
Closes #770.

Outcome: after the user completes the native Keychain-backed Install and Start flow, the signed app wrapper now invokes the sealed worker daemon with explicit --dry-run false. The CLI previously defaulted this long-running worker to dry-run forever, preventing persistent issue-enrichment watermarks and automatic live review operation.

Safety boundary:
- LaunchAgent remains secret-free.
- Raw GitHub private key and license key remain bounded to stdin.
- Exact signed app/helper, account-bot config, App ID, broker device ID, and trust checks are unchanged.
- Repository and posting behavior remains governed by the existing config, allowlists, activation, exact-head, and live-post gates.

Proof:
- failing-first focused test: missing sealedWorkerDaemonArguments contract
- DesktopKeychainWorkerLaunchAgentTests: 16/16 pass
- git diff --check: pass
- independent credential/runtime review: pending

Not proven here: signed installed runtime, issue-enrichment comment, replay idempotency, release readiness, or customer readiness. Those remain the post-merge beta gate.