### PR TITLE
Fix sealed worker cleanup on native restart

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -81,6 +81,21 @@ enum FoundationKeychainWorkerDaemonRunner {
         }
 
         let process = Process()
+        let terminationRelay = NeonDiffChildProcessSignalRelay()
+        _ = Darwin.signal(SIGTERM, SIG_IGN)
+        let terminationSource = DispatchSource.makeSignalSource(
+            signal: SIGTERM,
+            queue: DispatchQueue(
+                label: "com.electricsheephq.neondiff.worker-termination"
+            )
+        )
+        terminationSource.setEventHandler {
+            terminationRelay.receive(SIGTERM)
+        }
+        terminationSource.resume()
+        defer {
+            terminationSource.cancel()
+        }
         process.executableURL = URL(filePath: workerPath)
         process.arguments =
             DesktopKeychainWorkerLaunchAgentContract
@@ -93,6 +108,14 @@ enum FoundationKeychainWorkerDaemonRunner {
         let inputPipe = Pipe()
         process.standardInput = inputPipe
         try process.run()
+        terminationRelay.bind(
+            processIdentifier: process.processIdentifier
+        )
+        defer {
+            terminationRelay.unbind(
+                processIdentifier: process.processIdentifier
+            )
+        }
         guard FoundationTrustedBundledWorker.runningProcessIsTrusted(
             process.processIdentifier
         ) else {
@@ -108,6 +131,7 @@ enum FoundationKeychainWorkerDaemonRunner {
             standardInput.resetBytes(in: 0..<standardInput.count)
         } catch {
             process.terminate()
+            process.waitUntilExit()
             throw WorkerDaemonRunnerError.stdinFailed
         }
         process.waitUntilExit()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffChildProcessSignalRelay.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffChildProcessSignalRelay.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Foundation
+
+package final class NeonDiffChildProcessSignalRelay:
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private let sendSignal: (Int32, Int32) -> Void
+    private var processIdentifier: Int32?
+    private var pendingSignal: Int32?
+
+    package init(
+        sendSignal: @escaping (Int32, Int32) -> Void = { pid, signal in
+            _ = Darwin.kill(pid, signal)
+        }
+    ) {
+        self.sendSignal = sendSignal
+    }
+
+    package func bind(processIdentifier: Int32) {
+        lock.lock()
+        self.processIdentifier = processIdentifier
+        let signal = pendingSignal
+        pendingSignal = nil
+        lock.unlock()
+
+        if let signal {
+            sendSignal(processIdentifier, signal)
+        }
+    }
+
+    package func receive(_ signal: Int32) {
+        lock.lock()
+        guard let processIdentifier else {
+            pendingSignal = signal
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+
+        sendSignal(processIdentifier, signal)
+    }
+
+    package func unbind(processIdentifier: Int32) {
+        lock.lock()
+        if self.processIdentifier == processIdentifier {
+            self.processIdentifier = nil
+            pendingSignal = nil
+        }
+        lock.unlock()
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ChildProcessSignalRelayTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ChildProcessSignalRelayTests.swift
@@ -1,0 +1,36 @@
+import Darwin
+import Testing
+@testable import NeonDiffDesktopCore
+
+@Suite struct ChildProcessSignalRelayTests {
+    @Test func signalBeforeLaunchIsForwardedWhenChildBinds() {
+        var forwarded: [(Int32, Int32)] = []
+        let relay = NeonDiffChildProcessSignalRelay { pid, signal in
+            forwarded.append((pid, signal))
+        }
+
+        relay.receive(SIGTERM)
+        #expect(forwarded.isEmpty)
+
+        relay.bind(processIdentifier: 42)
+        #expect(forwarded.count == 1)
+        #expect(forwarded.first?.0 == 42)
+        #expect(forwarded.first?.1 == SIGTERM)
+    }
+
+    @Test func signalAfterLaunchTargetsOnlyTheBoundChild() {
+        var forwarded: [(Int32, Int32)] = []
+        let relay = NeonDiffChildProcessSignalRelay { pid, signal in
+            forwarded.append((pid, signal))
+        }
+
+        relay.bind(processIdentifier: 43)
+        relay.receive(SIGTERM)
+        relay.unbind(processIdentifier: 43)
+        relay.receive(SIGTERM)
+
+        #expect(forwarded.count == 1)
+        #expect(forwarded.first?.0 == 43)
+        #expect(forwarded.first?.1 == SIGTERM)
+    }
+}


### PR DESCRIPTION
Closes #772.

## What changed
- install a bounded SIGTERM dispatch source in the headless desktop wrapper;
- forward wrapper termination to the exact bound sealed-worker child, including a signal received in the pre-bind race window;
- keep the wrapper alive in `waitUntilExit()` so it reaps the child instead of leaving it at PPID 1;
- reap the worker on stdin failure as well;
- add focused failure-first relay coverage.

## Local proof
- RED: `swift test --skip-update --filter ChildProcessSignalRelayTests` failed because `NeonDiffChildProcessSignalRelay` did not exist.
- GREEN: the same focused command passed 2/2 and rebuilt the desktop executable.
- `git diff --check` passed.

## Proof boundary
Source and focused local proof only. This PR does not yet prove current-head CI, merge, signed beta installation, native Start/Restart, or installed single-worker persistence.