### PR TITLE
Fix native LaunchAgent restart false failure

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -236,11 +236,15 @@ private func restartLaunchAgent(label: String, plistURL: URL) throws {
     let domain = "gui/\(getuid())"
     let target = "\(domain)/\(label)"
     let status = try runLaunchctl(["print", target], acceptsFailure: true)
-    if status == 0 {
-        _ = try runLaunchctl(["bootout", target])
+    let commands = DesktopKeychainWorkerLaunchAgentContract.restartCommands(
+        domain: domain,
+        label: label,
+        plistPath: plistURL.path,
+        isLoaded: status == 0
+    )
+    for command in commands {
+        _ = try runLaunchctl(command)
     }
-    _ = try runLaunchctl(["bootstrap", domain, plistURL.path])
-    _ = try runLaunchctl(["kickstart", "-k", target])
     var previousPID: Int32?
     for _ in 0..<12 {
         usleep(250_000)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -109,6 +109,21 @@ package enum DesktopKeychainWorkerLaunchAgentError:
 package enum DesktopKeychainWorkerLaunchAgentContract {
     package static let headlessFlag = "--neondiff-worker-daemon"
 
+    package static func restartCommands(
+        domain: String,
+        label: String,
+        plistPath: String,
+        isLoaded: Bool
+    ) -> [[String]] {
+        let target = "\(domain)/\(label)"
+        var commands: [[String]] = []
+        if isLoaded {
+            commands.append(["bootout", target])
+        }
+        commands.append(["bootstrap", domain, plistPath])
+        return commands
+    }
+
     package static func headlessArguments(
         request: DesktopKeychainWorkerLaunchAgentRequest
     ) -> [String] {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -12,6 +12,33 @@ import NeonDiffDesktopCore
     private let appID = "4184532"
     private let licenseMachineID = String(repeating: "a", count: 43)
 
+    @Test func restartPlanDoesNotKillTheFreshlyBootstrappedService() {
+        let domain = "gui/501"
+        let plistPath = "/Users/test/Library/LaunchAgents/\(label).plist"
+
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.restartCommands(
+                domain: domain,
+                label: label,
+                plistPath: plistPath,
+                isLoaded: true
+            ) == [
+                ["bootout", "\(domain)/\(label)"],
+                ["bootstrap", domain, plistPath]
+            ]
+        )
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.restartCommands(
+                domain: domain,
+                label: label,
+                plistPath: plistPath,
+                isLoaded: false
+            ) == [
+                ["bootstrap", domain, plistPath]
+            ]
+        )
+    }
+
     @Test func plistContainsOnlyPublicExactCoordinates() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"


### PR DESCRIPTION
Closes #774

## What changed
- model the exact loaded/unloaded launchctl restart plan in the reviewed AppCore contract
- after bootout, bootstrap the RunAtLoad/KeepAlive plist and observe its stable PID
- remove the redundant `kickstart -k` that killed the freshly bootstrapped relay-aware worker and surfaced a false launchd rejection

## Failing-first proof
`swift test --skip-update --filter DesktopKeychainWorkerLaunchAgentTests.restartPlanDoesNotKillTheFreshlyBootstrappedService` failed to compile because the restart-plan contract did not exist.

## Green proof
- `swift test --skip-update --filter DesktopKeychainWorkerLaunchAgentTests.restartPlanDoesNotKillTheFreshlyBootstrappedService` — 1/1 passed
- `swift test --skip-update --filter DesktopKeychainWorkerLaunchAgentTests` — 17/17 passed
- `git diff --check` — passed

## Safety boundary
The plist, exact app/config/label coordinates, Keychain-only credential flow, repository allowlist, and rollback behavior are unchanged. This source proof does not itself prove installed launchd behavior, release readiness, or customer readiness; the signed installed canary remains required.