### PR TITLE
fix(desktop): observe accepted launchd bootstrap

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -242,10 +242,18 @@ private func restartLaunchAgent(label: String, plistURL: URL) throws {
         plistPath: plistURL.path,
         isLoaded: status == 0
     )
-    for command in commands {
+    guard let bootstrapCommand = commands.last else {
+        throw WorkerLaunchAgentRuntimeError.launchctlFailed
+    }
+    for command in commands.dropLast() {
         _ = try runLaunchctl(command)
     }
+    let bootstrapStatus = try runLaunchctl(
+        bootstrapCommand,
+        acceptsFailure: true
+    )
     var previousPID: Int32?
+    var stablePIDObserved = false
     for _ in 0..<12 {
         usleep(250_000)
         let sample = try runLaunchctlCapture(
@@ -262,11 +270,22 @@ private func restartLaunchAgent(label: String, plistURL: URL) throws {
             continue
         }
         if previousPID == pid {
-            return
+            stablePIDObserved = true
+            break
         }
         previousPID = pid
     }
-    throw WorkerLaunchAgentRuntimeError.launchctlNotReady
+    switch DesktopKeychainWorkerLaunchAgentContract.restartOutcome(
+        bootstrapStatus: bootstrapStatus,
+        stablePIDObserved: stablePIDObserved
+    ) {
+    case .accepted:
+        return
+    case .launchctlRejected:
+        throw WorkerLaunchAgentRuntimeError.launchctlFailed
+    case .notReady:
+        throw WorkerLaunchAgentRuntimeError.launchctlNotReady
+    }
 }
 
 private func bootoutLaunchAgent(label: String) throws {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -106,6 +106,12 @@ package enum DesktopKeychainWorkerLaunchAgentError:
     }
 }
 
+package enum DesktopKeychainWorkerLaunchAgentRestartOutcome: Equatable {
+    case accepted
+    case launchctlRejected
+    case notReady
+}
+
 package enum DesktopKeychainWorkerLaunchAgentContract {
     package static let headlessFlag = "--neondiff-worker-daemon"
 
@@ -122,6 +128,16 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         }
         commands.append(["bootstrap", domain, plistPath])
         return commands
+    }
+
+    package static func restartOutcome(
+        bootstrapStatus: Int32,
+        stablePIDObserved: Bool
+    ) -> DesktopKeychainWorkerLaunchAgentRestartOutcome {
+        if stablePIDObserved {
+            return .accepted
+        }
+        return bootstrapStatus == 0 ? .notReady : .launchctlRejected
     }
 
     package static func headlessArguments(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -39,6 +39,27 @@ import NeonDiffDesktopCore
         )
     }
 
+    @Test func stableServiceWinsOverTransientBootstrapExitFailure() {
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.restartOutcome(
+                bootstrapStatus: 5,
+                stablePIDObserved: true
+            ) == .accepted
+        )
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.restartOutcome(
+                bootstrapStatus: 5,
+                stablePIDObserved: false
+            ) == .launchctlRejected
+        )
+        #expect(
+            DesktopKeychainWorkerLaunchAgentContract.restartOutcome(
+                bootstrapStatus: 0,
+                stablePIDObserved: false
+            ) == .notReady
+        )
+    }
+
     @Test func plistContainsOnlyPublicExactCoordinates() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"


### PR DESCRIPTION
## Installed failure
Signed/notarized beta.71 reproduced the native launchd rejection even though launchd registered the exact service. The system trace showed the first bootstrap process returning nonzero, followed four milliseconds later by rollback. That rollback bootstrap and two stable PID samples succeeded. OS readback then proved one new wrapper, one sealed child, and a fresh successful daemon heartbeat.

## Fix
Treat bootstrap exit as provisional until the existing stable-PID sampler completes. A stable positive PID observed twice accepts the exact launchd target even after a transient nonzero bootstrap exit. Without stable PID proof, nonzero bootstrap still fails as launchctl rejection and zero-status instability still fails as not-ready.

No plist, Keychain, config, repository allowlist, worker argument, or credential boundary changes.

## Proof
- Failing-first focused regression: restartOutcome was absent before implementation
- swift test --filter DesktopKeychainWorkerLaunchAgentTests: 18/18 passed
- git diff --check passed
- GitNexus impact and post-change detection: LOW risk, one direct installAndStart caller, 3 files changed

Closes #774

This source proof does not establish signed installed acceptance, release readiness, or customer readiness. A corrected signed candidate must still pass the one native Start/Restart gate.