### PR TITLE
fix(desktop): allow delayed launchd readiness

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -254,8 +254,13 @@ private func restartLaunchAgent(label: String, plistURL: URL) throws {
     )
     var previousPID: Int32?
     var stablePIDObserved = false
-    for _ in 0..<12 {
-        usleep(250_000)
+    for _ in 0..<DesktopKeychainWorkerLaunchAgentContract
+        .restartObservationAttempts
+    {
+        usleep(
+            DesktopKeychainWorkerLaunchAgentContract
+                .restartObservationIntervalMicroseconds
+        )
         let sample = try runLaunchctlCapture(
             ["print", target],
             acceptsFailure: true

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -114,6 +114,8 @@ package enum DesktopKeychainWorkerLaunchAgentRestartOutcome: Equatable {
 
 package enum DesktopKeychainWorkerLaunchAgentContract {
     package static let headlessFlag = "--neondiff-worker-daemon"
+    package static let restartObservationAttempts = 24
+    package static let restartObservationIntervalMicroseconds: UInt32 = 250_000
 
     package static func restartCommands(
         domain: String,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -60,6 +60,18 @@ import NeonDiffDesktopCore
         )
     }
 
+    @Test func restartObservationCoversDelayedLaunchdSpawn() {
+        let observationWindowMicroseconds =
+            DesktopKeychainWorkerLaunchAgentContract
+                .restartObservationAttempts
+            * Int(
+                DesktopKeychainWorkerLaunchAgentContract
+                    .restartObservationIntervalMicroseconds
+            )
+
+        #expect(observationWindowMicroseconds >= 6_000_000)
+    }
+
     @Test func plistContainsOnlyPublicExactCoordinates() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"


### PR DESCRIPTION
Related: #774

## What changed

- Extend the native LaunchAgent readiness observation from 12 to 24 samples at the existing 250 ms interval.
- Keep the same fail-closed requirement: two consecutive `launchctl print` samples must report the same positive running PID.
- Add a regression requiring a minimum six-second observation window.

## Installed evidence

Beta.72 still reported a native launchd rejection even though the old wrapper/helper exited, exactly one replacement pair was running, and a fresh daemon cycle completed without error. Redacted launch timing showed registration at 08:57:54.353 and wrapper spawn at 08:57:57.570, just beyond the previous nominal three-second window.

## Validation

- Failing first: focused test did not compile because the observation contract was absent.
- `swift test --skip-update --filter DesktopKeychainWorkerLaunchAgentTests` — 19/19 passed.
- `git diff --check` — passed.

## Boundaries

No plist, program arguments, credentials, Keychain behavior, config, provider, repository, allowlist, worker command, or launchd mutation sequence changed. This is source/test evidence only until a signed installed candidate passes the native restart gate.