### PR TITLE
fix(desktop): allow measured launchd startup window

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -114,7 +114,7 @@ package enum DesktopKeychainWorkerLaunchAgentRestartOutcome: Equatable {
 
 package enum DesktopKeychainWorkerLaunchAgentContract {
     package static let headlessFlag = "--neondiff-worker-daemon"
-    package static let restartObservationAttempts = 24
+    package static let restartObservationAttempts = 60
     package static let restartObservationIntervalMicroseconds: UInt32 = 250_000
 
     package static func restartCommands(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -69,7 +69,7 @@ import NeonDiffDesktopCore
                     .restartObservationIntervalMicroseconds
             )
 
-        #expect(observationWindowMicroseconds >= 6_000_000)
+        #expect(observationWindowMicroseconds >= 15_000_000)
     }
 
     @Test func plistContainsOnlyPublicExactCoordinates() throws {


### PR DESCRIPTION
## Purpose
Beta.73 proved launchd can start the exact replacement worker about 6.055 seconds after service removal, just beyond the current six-second native observer deadline. The worker itself was healthy, but the app reported a false rejection.

## Change
- extend the bounded exact-target observation window from 6 seconds to 15 seconds
- retain 250ms sampling and the requirement for two consecutive matching positive launchd PIDs
- update the focused contract test to pin the 15-second minimum

## Does not change
Plist shape, ProgramArguments, credentials, Keychain access, config, provider, repository/allowlist state, launchctl sequencing, bootstrap-status classification, rollback, or review behavior.

## Proof
- RED: `swift test --skip-update --filter DesktopKeychainWorkerLaunchAgentTests` failed only the delayed-spawn assertion at 6,000,000us
- GREEN: same focused suite 19/19 passed
- `git diff --check` clean

Agent-authored bounded fix. Related #774.