### PR TITLE
fix(desktop): cover delayed launchd registration

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -114,7 +114,7 @@ package enum DesktopKeychainWorkerLaunchAgentRestartOutcome: Equatable {
 
 package enum DesktopKeychainWorkerLaunchAgentContract {
     package static let headlessFlag = "--neondiff-worker-daemon"
-    package static let restartObservationAttempts = 60
+    package static let restartObservationAttempts = 120
     package static let restartObservationIntervalMicroseconds: UInt32 = 250_000
 
     package static func restartCommands(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -69,7 +69,7 @@ import NeonDiffDesktopCore
                     .restartObservationIntervalMicroseconds
             )
 
-        #expect(observationWindowMicroseconds >= 15_000_000)
+        #expect(observationWindowMicroseconds >= 30_000_000)
     }
 
     @Test func plistContainsOnlyPublicExactCoordinates() throws {


### PR DESCRIPTION
Related: #774

## What changed
- extend the exact-target launchd restart observer from 15 seconds to 30 seconds
- keep the 250 ms cadence and early success after two matching positive PIDs
- update the focused contract test to require the measured 30-second floor

## Why
Installed beta.74 reproduced a 15.971-second gap between old-service removal and replacement registration. The native 15-second observer returned a false rejection immediately before launchd registered the healthy replacement.

## Validation
- RED: `swift test --filter DesktopKeychainWorkerLaunchAgentTests` — 18 pass / 1 expected failure (`15,000,000 < 30,000,000`)
- GREEN: same focused suite — 19/19 pass
- `git diff --check`

## Boundaries
No plist, arguments, credentials, Keychain, config, provider, repository, allowlist, rollback, review, or posting behavior changed. This source/test proof does not establish merge, signed artifact, installed-runtime, release, or customer readiness.