### PR TITLE
feat: add repo-specific issue enrichment policy

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -1,5 +1,6 @@
 {
   "pilotRepos": [
+    "electricsheephq/lcm-x",
     "electricsheephq/WorldOS",
     "electricsheephq/evaos-code-review-bot-neondiff",
     "electricsheephq/electric-sheep-website-dashboard-6158a244",
@@ -2455,7 +2456,33 @@
         ],
         "suggestedReviewers": [
           "Tosko4"
-        ]
+        ],
+        "finishingTouches": {
+          "docs": {
+            "enabled": false
+          },
+          "docstrings": {
+            "enabled": false
+          },
+          "unitTests": {
+            "enabled": false
+          },
+          "simplifySuggestion": {
+            "enabled": false
+          },
+          "changelogDraft": {
+            "enabled": false
+          },
+          "riskExplanation": {
+            "enabled": false
+          },
+          "reviewReady": {
+            "enabled": false
+          },
+          "stackedPr": {
+            "enabled": false
+          }
+        }
       }
     }
   }

--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -78,6 +78,7 @@
     "enabled": false,
     "postIssueComment": false,
     "allowlist": [
+      "electricsheephq/lcm-x",
       "electricsheephq/WorldOS",
       "electricsheephq/evaos-code-review-bot-neondiff",
       "electricsheephq/electric-sheep-website-dashboard-6158a244",
@@ -122,6 +123,38 @@
     "lookbackMs": 600000,
     "processExistingOpenIssuesOnActivation": false,
     "repos": {
+      "electricsheephq/lcm-x": {
+        "enabled": true,
+        "maxIssuesPerCycle": 3,
+        "maxCommentsPerCycle": 1,
+        "cooldownMs": 3600000,
+        "burstWindowMs": 3600000,
+        "maxIssuesPerBurst": 6,
+        "lookbackMs": 600000,
+        "processExistingOpenIssuesOnActivation": false,
+        "advisoryPolicy": "LCM-X is an independent Hermes ContextEngine extension for lossless context memory, not OpenClaw. Prioritize data loss/duplication, chronology/provenance, profile/session contamination, source coverage, tool-call/result grouping, fresh tail, SQLite/concurrency/crash safety, import idempotency, and unsupported Hermes host assumptions. Require current-main reproduction or a named mandatory invariant, and distinguish NeonDiff severity from LCM-X P0-P4.",
+        "validationSuggestions": [
+          "Require current-main reproduction or a named mandatory invariant before treating a concern as verified.",
+          "Check lossless ordering, provenance, session/profile isolation, fresh-tail behavior, and tool-call/result grouping.",
+          "Exercise SQLite concurrency, crash recovery, and import idempotency where the change touches persistence."
+        ],
+        "suggestedLabels": [
+          "data-integrity",
+          "security",
+          "performance",
+          "needs-repro",
+          "test",
+          "documentation",
+          "upstream-evidence"
+        ],
+        "suggestedReviewers": [
+          "Tosko4"
+        ],
+        "labelAliases": {
+          "docs": "documentation",
+          "tests": "test"
+        }
+      },
       "electricsheephq/WorldOS": {
         "maxIssuesPerCycle": 3,
         "maxCommentsPerCycle": 1,
@@ -2392,6 +2425,37 @@
             "enabled": false
           }
         }
+      },
+      "electricsheephq/lcm-x": {
+        "displayName": "LCM-X",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "LCM-X is an independent Hermes ContextEngine extension for lossless context memory, not OpenClaw. Prioritize data loss/duplication, chronology/provenance, profile/session contamination, source coverage, tool-call/result grouping, fresh tail, SQLite/concurrency/crash safety, import idempotency, and unsupported Hermes host assumptions. Require current-main reproduction or a named mandatory invariant, and distinguish NeonDiff severity from LCM-X P0-P4.",
+        "proofExpectations": [
+          "Require current-main reproduction or a named mandatory invariant before treating a concern as verified.",
+          "Check lossless ordering, provenance, session/profile isolation, fresh-tail behavior, and tool-call/result grouping.",
+          "Exercise SQLite concurrency, crash recovery, and import idempotency where the change touches persistence."
+        ],
+        "validationHints": [
+          "Suggested labels: data-integrity, security, performance, needs-repro, test, documentation, upstream-evidence.",
+          "Suggested reviewer: Tosko4. Label aliases map docs to documentation and tests to test before allowlist filtering.",
+          "Do not conflate NeonDiff severity with LCM-X P0-P4."
+        ],
+        "readinessHints": [
+          "Keep this profile advisory and suggestion-only; no labels or reviewers are mutated by issue enrichment."
+        ],
+        "suggestedLabels": [
+          "data-integrity",
+          "security",
+          "performance",
+          "needs-repro",
+          "test",
+          "documentation",
+          "upstream-evidence"
+        ],
+        "suggestedReviewers": [
+          "Tosko4"
+        ]
       }
     }
   }

--- a/docs/issue-enrichment.md
+++ b/docs/issue-enrichment.md
@@ -2,7 +2,16 @@
 
 Issue enrichment is a separate lane from PR review monitoring. `pilotRepos`, `canaryPulls`, `repoProfiles.repos`, and `repoProfiles.suggestedLabels` or `suggestedReviewers` do not opt a repo into issue enrichment.
 
-Use `issueEnrichment.allowlist` for issue scanning and comment eligibility. Use `issueEnrichment.allowedLabels` and `issueEnrichment.allowedReviewers` for issue suggestions only; repo-level `issueEnrichment.repos.<owner/repo>.allowedLabels` and `allowedReviewers` override those suggestion allowlists for that issue repo.
+Use `issueEnrichment.allowlist` for issue scanning and comment eligibility. Use `issueEnrichment.allowedLabels` and `issueEnrichment.allowedReviewers` for issue suggestions only; repo-level `issueEnrichment.repos.<owner/repo>.allowedLabels` and `allowedReviewers` override those suggestion allowlists for that issue repo. Repo overrides may also carry `advisoryPolicy`, `validationSuggestions`, `suggestedLabels`, `suggestedReviewers`, and `labelAliases`. These fields shape the rendered advisory comment only: labels and reviewers are never mutated.
+
+The tracked LCM-X profile (`electricsheephq/lcm-x`) is intentionally explicit:
+
+- LCM-X is an independent Hermes ContextEngine extension for lossless context memory, not OpenClaw.
+- Review data loss/duplication, chronology/provenance, profile/session contamination, source coverage, tool-call/result grouping, fresh-tail behavior, SQLite/concurrency/crash safety, import idempotency, and unsupported Hermes host assumptions.
+- Require current-main reproduction or a named mandatory invariant, and distinguish NeonDiff severity from LCM-X P0-P4.
+- Suggested labels are `data-integrity`, `security`, `performance`, `needs-repro`, `test`, `documentation`, and `upstream-evidence`; `docs` aliases to `documentation` and `tests` aliases to `test`; suggested reviewer is `Tosko4`.
+
+Aliases apply to inferred and configured suggestions before the issue allowlist filter. `processExistingOpenIssuesOnActivation` remains explicitly `false` in the tracked example, and no path filters are used for this issue policy.
 
 Live issue comments are blocked until all of these are true:
 
@@ -31,7 +40,12 @@ Keep new rollouts dry-run first:
         "burstWindowMs": 3600000,
         "maxIssuesPerBurst": 6,
         "lookbackMs": 600000,
-        "processExistingOpenIssuesOnActivation": false
+        "processExistingOpenIssuesOnActivation": false,
+        "advisoryPolicy": "Keep this repo's issue guidance explicit and suggestion-only.",
+        "validationSuggestions": ["Require current-main reproduction or a named mandatory invariant."],
+        "suggestedLabels": ["documentation"],
+        "suggestedReviewers": ["maintainer-login"],
+        "labelAliases": { "docs": "documentation", "tests": "test" }
       }
     }
   }

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -90,6 +90,16 @@ evidence are recorded.
 - `suggestedLabels` / `suggestedReviewers`: reserved for later enrichment; they
   do not auto-apply labels or reviewers.
 
+For issue enrichment, keep repo-specific policy in the separate
+`issueEnrichment.repos.<owner/repo>` object. It may define `advisoryPolicy`,
+`validationSuggestions`, `suggestedLabels`, `suggestedReviewers`, and
+`labelAliases`. The issue-enrichment renderer applies aliases (for example,
+`docs` to `documentation` and `tests` to `test`) before filtering suggestions,
+then prints the policy and suggestions without mutating GitHub labels or
+reviewer assignments. The tracked `electricsheephq/lcm-x` example describes
+Hermes ContextEngine lossless memory, not OpenClaw, and keeps this policy
+separate from PR profile path filters.
+
 ## Review Settings Preview
 
 Each review now records a `review-settings-preview.json` evidence file and, when

--- a/docs/schema/neondiff-config.schema.json
+++ b/docs/schema/neondiff-config.schema.json
@@ -408,6 +408,13 @@
               "default": 60
             }
           }
+        },
+        "repos": {
+          "description": "Optional repo-specific advisory issue policy. Suggestions are rendered only; labels and reviewers are never mutated.",
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/repoSlug" },
+          "additionalProperties": { "$ref": "#/$defs/issueEnrichmentRepoPolicy" },
+          "default": {}
         }
       }
     },
@@ -475,6 +482,67 @@
     "repoSlug": {
       "type": "string",
       "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,98}[A-Za-z0-9])?$"
+    },
+    "issueEnrichmentRepoPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowedLabels": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "allowedReviewers": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "advisoryPolicy": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": ".*\\S.*"
+        },
+        "validationSuggestions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "suggestedLabels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "suggestedReviewers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "labelAliases": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": ".*\\S.*"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": ".*\\S.*"
+          }
+        },
+        "maxIssuesPerCycle": { "type": "integer", "minimum": 1 },
+        "maxCommentsPerCycle": { "type": "integer", "minimum": 0 },
+        "cooldownMs": { "type": "integer", "minimum": 1 },
+        "burstWindowMs": { "type": "integer", "minimum": 1 },
+        "maxIssuesPerBurst": { "type": "integer", "minimum": 1 },
+        "lookbackMs": { "type": "integer", "minimum": 1 },
+        "processExistingOpenIssuesOnActivation": { "type": "boolean" }
+      }
     }
   }
 }

--- a/docs/schema/neondiff-config.schema.json
+++ b/docs/schema/neondiff-config.schema.json
@@ -499,39 +499,49 @@
         "advisoryPolicy": {
           "type": "string",
           "minLength": 1,
+          "maxLength": 4000,
           "pattern": ".*\\S.*"
         },
         "validationSuggestions": {
           "type": "array",
+          "maxItems": 20,
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 500
           }
         },
         "suggestedLabels": {
           "type": "array",
+          "maxItems": 20,
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 80
           }
         },
         "suggestedReviewers": {
           "type": "array",
+          "maxItems": 20,
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 80
           }
         },
         "labelAliases": {
           "type": "object",
+          "maxProperties": 50,
           "propertyNames": {
             "type": "string",
             "minLength": 1,
+            "maxLength": 80,
             "pattern": ".*\\S.*"
           },
           "additionalProperties": {
             "type": "string",
             "minLength": 1,
+            "maxLength": 80,
             "pattern": ".*\\S.*"
           }
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1240,9 +1240,12 @@ async function main(): Promise<void> {
       const output = buildIssueEnrichmentDryRunOutput({
         repo,
         issue,
+        repoPolicy: issuePolicy.repoPolicy,
         allowedLabels: issuePolicy.suggestions.allowedLabels,
         allowedOwners: issuePolicy.suggestions.allowedReviewers,
-        validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
+        validationSuggestions: [
+          "Confirm owner, acceptance criteria, and validation evidence before implementation."
+        ],
         maxRelatedRefs: enrichmentConfig.maxRelatedRefs,
         maxSuggestions: enrichmentConfig.maxSuggestions,
         publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
@@ -1395,6 +1398,7 @@ async function main(): Promise<void> {
         const preview = buildIssueEnrichmentDryRunOutput({
           repo,
           issue,
+          repoPolicy: policy.repoPolicy,
           allowedLabels: policy.suggestions.allowedLabels,
           allowedOwners: policy.suggestions.allowedReviewers,
           validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,9 @@ import type { SkillPackContextConfig } from "./skill-packs.js";
 import { applyRuntimeGitHubCredentials } from "./runtime-github-credentials.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
+const MAX_ISSUE_POLICY_TEXT_LENGTH = 4_000;
+const MAX_ISSUE_POLICY_ITEMS = 20;
+const MAX_ISSUE_POLICY_ALIASES = 50;
 
 export interface BotConfig {
   pilotRepos: string[];
@@ -1287,16 +1290,23 @@ function validateIssueEnrichmentRepoOverride(value: unknown, label: string): voi
   if (typeof value.advisoryPolicy === "string" && value.advisoryPolicy.trim().length === 0) {
     throw new Error(`${label}.advisoryPolicy must be a non-empty string`);
   }
-  validateOptionalStringArray(value.validationSuggestions, `${label}.validationSuggestions`);
-  validateOptionalStringArray(value.suggestedLabels, `${label}.suggestedLabels`);
-  validateOptionalStringArray(value.suggestedReviewers, `${label}.suggestedReviewers`);
+  if (typeof value.advisoryPolicy === "string" && value.advisoryPolicy.length > MAX_ISSUE_POLICY_TEXT_LENGTH) {
+    throw new Error(`${label}.advisoryPolicy must be at most ${MAX_ISSUE_POLICY_TEXT_LENGTH} characters`);
+  }
+  validateBoundedOptionalStringArray(value.validationSuggestions, `${label}.validationSuggestions`, 500);
+  validateBoundedOptionalStringArray(value.suggestedLabels, `${label}.suggestedLabels`, 80);
+  validateBoundedOptionalStringArray(value.suggestedReviewers, `${label}.suggestedReviewers`, 80);
   if (value.labelAliases !== undefined) {
     if (!isRecord(value.labelAliases)) throw new Error(`${label}.labelAliases must be an object`);
+    if (Object.keys(value.labelAliases).length > MAX_ISSUE_POLICY_ALIASES) {
+      throw new Error(`${label}.labelAliases must contain at most ${MAX_ISSUE_POLICY_ALIASES} entries`);
+    }
     for (const [from, to] of Object.entries(value.labelAliases)) {
       if (from.trim().length === 0) throw new Error(`${label}.labelAliases keys must be non-empty strings`);
       if (typeof to !== "string" || to.trim().length === 0) {
         throw new Error(`${label}.labelAliases.${from} must be a non-empty string`);
       }
+      if (from.length > 80 || to.length > 80) throw new Error(`${label}.labelAliases entries must be at most 80 characters`);
     }
   }
   if (value.maxIssuesPerCycle !== undefined) validatePositiveInteger(value.maxIssuesPerCycle, `${label}.maxIssuesPerCycle`);
@@ -1748,6 +1758,13 @@ function validateStringArray(value: unknown, label: string): void {
 function validateOptionalStringArray(value: unknown, label: string): void {
   if (value === undefined) return;
   validateStringArray(value, label);
+}
+
+function validateBoundedOptionalStringArray(value: unknown, label: string, maxLength: number): void {
+  validateOptionalStringArray(value, label);
+  if (!Array.isArray(value)) return;
+  if (value.length > MAX_ISSUE_POLICY_ITEMS) throw new Error(`${label} must contain at most ${MAX_ISSUE_POLICY_ITEMS} items`);
+  if (value.some((entry) => entry.length > maxLength)) throw new Error(`${label} entries must be at most ${maxLength} characters`);
 }
 
 function validateBoolean(value: unknown, label: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1272,9 +1272,33 @@ function validateIssueEnrichmentConfig(value: unknown, label: string): void {
 
 function validateIssueEnrichmentRepoOverride(value: unknown, label: string): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const allowedKeys = new Set([
+    "enabled", "allowedLabels", "allowedReviewers", "advisoryPolicy", "validationSuggestions",
+    "suggestedLabels", "suggestedReviewers", "labelAliases", "maxIssuesPerCycle", "maxCommentsPerCycle",
+    "cooldownMs", "burstWindowMs", "maxIssuesPerBurst", "lookbackMs", "processExistingOpenIssuesOnActivation"
+  ]);
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) throw new Error(`${label} has unknown key "${key}"`);
+  }
   if (value.enabled !== undefined) validateBoolean(value.enabled, `${label}.enabled`);
   validateOptionalStringArray(value.allowedLabels, `${label}.allowedLabels`);
   validateOptionalStringArray(value.allowedReviewers, `${label}.allowedReviewers`);
+  validateOptionalString(value.advisoryPolicy, `${label}.advisoryPolicy`);
+  if (typeof value.advisoryPolicy === "string" && value.advisoryPolicy.trim().length === 0) {
+    throw new Error(`${label}.advisoryPolicy must be a non-empty string`);
+  }
+  validateOptionalStringArray(value.validationSuggestions, `${label}.validationSuggestions`);
+  validateOptionalStringArray(value.suggestedLabels, `${label}.suggestedLabels`);
+  validateOptionalStringArray(value.suggestedReviewers, `${label}.suggestedReviewers`);
+  if (value.labelAliases !== undefined) {
+    if (!isRecord(value.labelAliases)) throw new Error(`${label}.labelAliases must be an object`);
+    for (const [from, to] of Object.entries(value.labelAliases)) {
+      if (from.trim().length === 0) throw new Error(`${label}.labelAliases keys must be non-empty strings`);
+      if (typeof to !== "string" || to.trim().length === 0) {
+        throw new Error(`${label}.labelAliases.${from} must be a non-empty string`);
+      }
+    }
+  }
   if (value.maxIssuesPerCycle !== undefined) validatePositiveInteger(value.maxIssuesPerCycle, `${label}.maxIssuesPerCycle`);
   if (value.maxCommentsPerCycle !== undefined) validateNonNegativeInteger(value.maxCommentsPerCycle, `${label}.maxCommentsPerCycle`);
   if (value.cooldownMs !== undefined) validatePositiveInteger(value.cooldownMs, `${label}.cooldownMs`);

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -213,20 +213,22 @@ export function buildIssueEnrichmentComment(input: {
   const reviewers = uniqueCaseInsensitive(input.repoPolicy?.suggestedReviewers ?? []).filter((reviewer) => {
     return allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(reviewer));
   }).slice(0, input.maxSuggestions ?? 8);
+  const policyValidationSuggestions = unique(input.repoPolicy?.validationSuggestions ?? [])
+    .slice(0, input.maxSuggestions ?? 8);
   const validationSuggestions = unique([
-    ...(input.repoPolicy?.validationSuggestions ?? []),
+    ...policyValidationSuggestions,
     ...(input.validationSuggestions ?? [])
   ]).slice(0, input.maxSuggestions ?? 8);
-  const repoPolicySection = input.repoPolicy?.advisoryPolicy || input.repoPolicy?.validationSuggestions.length
+  const repoPolicySection = input.repoPolicy?.advisoryPolicy || policyValidationSuggestions.length
     ? [
         "",
         "### Repo policy",
         "",
-        ...(input.repoPolicy.advisoryPolicy
+        ...(input.repoPolicy?.advisoryPolicy
           ? [`Advisory policy: ${formatPublicText(input.repoPolicy.advisoryPolicy, input.publicConfidencePolicy)}`]
           : []),
-        ...(input.repoPolicy.validationSuggestions.length
-          ? ["", "Policy validation guidance:", ...input.repoPolicy.validationSuggestions.map((item) => `- ${formatPublicText(item, input.publicConfidencePolicy)}`)]
+        ...(policyValidationSuggestions.length
+          ? ["", "Policy validation guidance:", ...policyValidationSuggestions.map((item) => `- ${formatPublicText(item, input.publicConfidencePolicy)}`)]
           : [])
       ]
     : [];

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -213,12 +213,15 @@ export function buildIssueEnrichmentComment(input: {
   const reviewers = uniqueCaseInsensitive(input.repoPolicy?.suggestedReviewers ?? []).filter((reviewer) => {
     return allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(reviewer));
   }).slice(0, input.maxSuggestions ?? 8);
-  const policyValidationSuggestions = unique(input.repoPolicy?.validationSuggestions ?? [])
+  const policyValidationSuggestions = unique(
+    input.repoPolicy?.validationSuggestions ?? [],
+    input.publicConfidencePolicy
+  )
     .slice(0, input.maxSuggestions ?? 8);
   const validationSuggestions = unique([
     ...policyValidationSuggestions,
     ...(input.validationSuggestions ?? [])
-  ]).slice(0, input.maxSuggestions ?? 8);
+  ], input.publicConfidencePolicy).slice(0, input.maxSuggestions ?? 8);
   const repoPolicySection = input.repoPolicy?.advisoryPolicy || policyValidationSuggestions.length
     ? [
         "",
@@ -734,8 +737,8 @@ function formatPublicText(value: string | undefined, publicConfidencePolicy?: Pu
   ).trim();
 }
 
-function unique(values: string[]): string[] {
-  return [...new Set(values.map((value) => formatPublicText(value)).filter(Boolean))];
+function unique(values: string[], publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string[] {
+  return [...new Set(values.map((value) => formatPublicText(value, publicConfidencePolicy)).filter(Boolean))];
 }
 
 function uniqueCaseInsensitive(values: string[]): string[] {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -11,6 +11,7 @@ import {
 import { buildReviewLensIssueSections, type ReviewLensPacket } from "./review-lenses.js";
 import { writeSecureFileSync } from "./temp-files.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import type { IssueEnrichmentRepoPolicy } from "./issue-enrichment.js";
 import type {
   EnrichmentComment as PlanEnrichmentComment,
   EnrichmentCommentPostResult as PlanEnrichmentCommentPostResult,
@@ -170,6 +171,7 @@ export function buildEnrichmentComment(input: {
 export function buildIssueEnrichmentComment(input: {
   repo: string;
   issue: GitHubRelatedIssueOrPull;
+  repoPolicy?: IssueEnrichmentRepoPolicy;
   suggestedLabels?: string[];
   suggestedOwners?: string[];
   allowedLabels?: string[];
@@ -197,17 +199,37 @@ export function buildIssueEnrichmentComment(input: {
   const allowedOwnerKeys = input.allowedOwners === undefined || input.allowedOwners.length === 0
     ? undefined
     : new Set(uniqueCaseInsensitive(input.allowedOwners).map(normalizedSuggestionKey));
-  const suggestedLabels = uniqueCaseInsensitive([
+  const suggestedLabels = uniqueCaseInsensitive(applyIssueLabelAliases([
+    ...(input.repoPolicy?.suggestedLabels ?? []),
     ...(input.suggestedLabels ?? []),
     ...suggestLabelsFromIssue(input.issue)
-  ]).filter((label) => {
+  ], input.repoPolicy?.labelAliases)).filter((label) => {
     const key = normalizedSuggestionKey(label);
     return !existingLabelKeys.has(key) && (allowedLabelKeys === undefined || allowedLabelKeys.has(key));
   }).slice(0, input.maxSuggestions ?? 8);
   const owners = uniqueCaseInsensitive(input.suggestedOwners ?? []).filter((owner) => {
     return allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(owner));
   }).slice(0, input.maxSuggestions ?? 8);
-  const validationSuggestions = unique(input.validationSuggestions ?? []).slice(0, input.maxSuggestions ?? 8);
+  const reviewers = uniqueCaseInsensitive(input.repoPolicy?.suggestedReviewers ?? []).filter((reviewer) => {
+    return allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(reviewer));
+  }).slice(0, input.maxSuggestions ?? 8);
+  const validationSuggestions = unique([
+    ...(input.repoPolicy?.validationSuggestions ?? []),
+    ...(input.validationSuggestions ?? [])
+  ]).slice(0, input.maxSuggestions ?? 8);
+  const repoPolicySection = input.repoPolicy?.advisoryPolicy || input.repoPolicy?.validationSuggestions.length
+    ? [
+        "",
+        "### Repo policy",
+        "",
+        ...(input.repoPolicy.advisoryPolicy
+          ? [`Advisory policy: ${formatPublicText(input.repoPolicy.advisoryPolicy, input.publicConfidencePolicy)}`]
+          : []),
+        ...(input.repoPolicy.validationSuggestions.length
+          ? ["", "Policy validation guidance:", ...input.repoPolicy.validationSuggestions.map((item) => `- ${formatPublicText(item, input.publicConfidencePolicy)}`)]
+          : [])
+      ]
+    : [];
   const gaps = inferIssueAcceptanceGaps(input.issue);
   const planner = buildIssuePlannerPacket({
     issue: input.issue,
@@ -225,6 +247,8 @@ export function buildIssueEnrichmentComment(input: {
     `Existing labels: ${existingLabels.length ? existingLabels.join(", ") : "none"}.`,
     `Suggested labels: ${suggestedLabels.length ? suggestedLabels.join(", ") : "none"}.`,
     `Suggested owners: ${owners.length ? owners.join(", ") : "none"}.`,
+    `Suggested reviewers: ${reviewers.length ? reviewers.join(", ") : "none"}.`,
+    ...repoPolicySection,
     "",
     "### Related context",
     "",
@@ -319,6 +343,7 @@ function buildIssueLifecycleFields(
 export function buildIssueEnrichmentDryRunOutput(input: {
   repo: string;
   issue: GitHubRelatedIssueOrPull;
+  repoPolicy?: IssueEnrichmentRepoPolicy;
   suggestedLabels?: string[];
   suggestedOwners?: string[];
   allowedLabels?: string[];
@@ -346,6 +371,7 @@ export function buildIssueEnrichmentDryRunOutput(input: {
   const enrichment = buildIssueEnrichmentComment({
     repo: input.repo,
     issue: input.issue,
+    repoPolicy: input.repoPolicy,
     suggestedLabels: input.suggestedLabels,
     suggestedOwners: input.suggestedOwners,
     allowedLabels: input.allowedLabels,
@@ -366,6 +392,12 @@ export function buildIssueEnrichmentDryRunOutput(input: {
     ...(input.issue.html_url ? { url: redactSecrets(input.issue.html_url) } : {}),
     body: enrichment.body
   };
+}
+
+function applyIssueLabelAliases(labels: string[], aliases: Record<string, string> | undefined): string[] {
+  if (!aliases || Object.keys(aliases).length === 0) return labels;
+  const normalizedAliases = new Map(Object.entries(aliases).map(([from, to]) => [normalizedSuggestionKey(from), to]));
+  return labels.map((label) => normalizedAliases.get(normalizedSuggestionKey(label)) ?? label);
 }
 
 export async function postEnrichmentComment(input: {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -500,7 +500,11 @@ export async function collectIssueEnrichmentScan(input: {
 }
 
 export async function runIssueEnrichmentCycle(input: {
-  config: { issueEnrichment?: IssueEnrichmentConfig; reviewLenses?: ReviewLensConfig };
+  config: {
+    issueEnrichment?: IssueEnrichmentConfig;
+    reviewLenses?: ReviewLensConfig;
+    enrichment?: { maxSuggestions?: number };
+  };
   state: Pick<
     ReviewStateStore,
     "getIssueEnrichmentRecord" |
@@ -652,7 +656,14 @@ export async function runIssueEnrichmentCycle(input: {
       if (cached) return cached;
       const issue = issuesByKey.get(key);
       if (!issue) return undefined;
-      const enrichment = buildIssueEnrichmentForCycle(config, item.repo, issue, undefined, reviewLensPacket);
+      const enrichment = buildIssueEnrichmentForCycle(
+        config,
+        item.repo,
+        issue,
+        input.config.enrichment?.maxSuggestions,
+        undefined,
+        reviewLensPacket
+      );
       plannedEnrichmentByIssue.set(key, enrichment);
       return enrichment;
     };
@@ -814,7 +825,14 @@ export async function runIssueEnrichmentCycle(input: {
         // #263: attach the mapped lifecycle state (`enriched`) to the marker at post time. This is a
         // renaming of the decision already made (status=posted) and rides the diagnostic state marker
         // only; bodyHash excludes the marker, so idempotency is unaffected.
-        const enrichment = buildIssueEnrichmentForCycle(config, item.repo, issue, { state: "enriched" }, reviewLensPacket);
+        const enrichment = buildIssueEnrichmentForCycle(
+          config,
+          item.repo,
+          issue,
+          input.config.enrichment?.maxSuggestions,
+          { state: "enriched" },
+          reviewLensPacket
+        );
         const postBodyHash = plannedBodyHashForItem(item) ?? enrichment.bodyHash;
         const post = await postEnrichmentComment({
           enabled: true,
@@ -1256,6 +1274,7 @@ function buildIssueEnrichmentForCycle(
   config: IssueEnrichmentConfig,
   repo: string,
   issue: GitHubRelatedIssueOrPull,
+  maxSuggestions?: number,
   lifecycle?: IssueEnrichmentLifecycleInput,
   reviewLensPacket?: ReviewLensPacket
 ): EnrichmentComment {
@@ -1267,6 +1286,7 @@ function buildIssueEnrichmentForCycle(
     repoPolicy: policy.repoPolicy,
     allowedLabels: allowlists.allowedLabels,
     allowedOwners: allowlists.allowedOwners,
+    ...(maxSuggestions !== undefined ? { maxSuggestions } : {}),
     postIssueComment: true,
     ...(reviewLensPacket ? { reviewLensPacket } : {}),
     ...(lifecycle ? { lifecycle } : {})

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -60,6 +60,11 @@ export interface IssueEnrichmentRepoOverride {
   enabled?: boolean;
   allowedLabels?: string[];
   allowedReviewers?: string[];
+  advisoryPolicy?: string;
+  validationSuggestions?: string[];
+  suggestedLabels?: string[];
+  suggestedReviewers?: string[];
+  labelAliases?: Record<string, string>;
   maxIssuesPerCycle?: number;
   maxCommentsPerCycle?: number;
   cooldownMs?: number;
@@ -67,6 +72,14 @@ export interface IssueEnrichmentRepoOverride {
   maxIssuesPerBurst?: number;
   lookbackMs?: number;
   processExistingOpenIssuesOnActivation?: boolean;
+}
+
+export interface IssueEnrichmentRepoPolicy {
+  advisoryPolicy?: string;
+  validationSuggestions: string[];
+  suggestedLabels: string[];
+  suggestedReviewers: string[];
+  labelAliases: Record<string, string>;
 }
 
 export interface IssueEnrichmentStatus {
@@ -875,6 +888,7 @@ export function resolveIssueEnrichmentRepoPolicy(
   reason?: "not_issue_enrichment_allowlisted" | "issue_enrichment_repo_disabled";
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
+  repoPolicy: IssueEnrichmentRepoPolicy;
 } {
   const override = config.repos?.[repo];
   const throttle = {
@@ -891,9 +905,16 @@ export function resolveIssueEnrichmentRepoPolicy(
     allowedLabels: resolveIssueSuggestionAllowlist(config.allowedLabels, override?.allowedLabels),
     allowedReviewers: resolveIssueSuggestionAllowlist(config.allowedReviewers, override?.allowedReviewers)
   };
-  if (!config.allowlist.includes(repo)) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle, suggestions };
-  if (override?.enabled === false) return { allowed: false, reason: "issue_enrichment_repo_disabled", throttle, suggestions };
-  return { allowed: true, throttle, suggestions };
+  const repoPolicy: IssueEnrichmentRepoPolicy = {
+    ...(override?.advisoryPolicy !== undefined ? { advisoryPolicy: override.advisoryPolicy } : {}),
+    validationSuggestions: [...(override?.validationSuggestions ?? [])],
+    suggestedLabels: [...(override?.suggestedLabels ?? [])],
+    suggestedReviewers: [...(override?.suggestedReviewers ?? [])],
+    labelAliases: { ...(override?.labelAliases ?? {}) }
+  };
+  if (!config.allowlist.includes(repo)) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle, suggestions, repoPolicy };
+  if (override?.enabled === false) return { allowed: false, reason: "issue_enrichment_repo_disabled", throttle, suggestions, repoPolicy };
+  return { allowed: true, throttle, suggestions, repoPolicy };
 }
 
 function resolveIssueSuggestionAllowlist(globalAllowlist: string[], repoOverride: string[] | undefined): string[] {
@@ -1240,6 +1261,7 @@ function buildIssueEnrichmentForCycle(
   return buildIssueEnrichmentComment({
     repo,
     issue,
+    repoPolicy: policy.repoPolicy,
     allowedLabels: allowlists.allowedLabels,
     allowedOwners: allowlists.allowedOwners,
     postIssueComment: true,

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,6 +12,7 @@ import {
   type ReviewLensConfig,
   type ReviewLensPacket
 } from "./review-lenses.js";
+import type { PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { redactSecrets } from "./secrets.js";
 import type { IssueEnrichmentRecord, IssueEnrichmentRecordStatus, ReviewStateStore } from "./state.js";
 import { isAuthenticProductionLicenseAdmission, type ProductionLicenseAdmission } from "./license-admission.js";
@@ -353,7 +354,11 @@ function reposMissingLiveIssueEnrichmentThresholds(config: IssueEnrichmentConfig
 }
 
 export async function collectIssueEnrichmentScan(input: {
-  config: { issueEnrichment?: IssueEnrichmentConfig };
+  config: {
+    issueEnrichment?: IssueEnrichmentConfig;
+    enrichment?: { maxSuggestions?: number };
+    confidenceCalibration?: { publicDisplay: PublicConfidenceDisplayPolicy };
+  };
   reader: IssueEnrichmentReader;
   dryRun: boolean;
   repos?: string[];
@@ -368,6 +373,7 @@ export async function collectIssueEnrichmentScan(input: {
 }): Promise<IssueEnrichmentScanResult> {
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const renderPolicy = resolveIssueEnrichmentRenderPolicy(input.config);
   const status = buildIssueEnrichmentStatus({
     config: input.config,
     canPostAsApp: input.canPostAsApp ?? false,
@@ -442,6 +448,7 @@ export async function collectIssueEnrichmentScan(input: {
       throttle: policy.throttle,
       suggestions: policy.suggestions,
       repoPolicy: policy.repoPolicy,
+      renderPolicy,
       postIssueComment: config.postIssueComment,
       checkedAt,
       shouldCountItem: input.shouldCountItem
@@ -504,6 +511,7 @@ export async function runIssueEnrichmentCycle(input: {
     issueEnrichment?: IssueEnrichmentConfig;
     reviewLenses?: ReviewLensConfig;
     enrichment?: { maxSuggestions?: number };
+    confidenceCalibration?: { publicDisplay: PublicConfidenceDisplayPolicy };
   };
   state: Pick<
     ReviewStateStore,
@@ -531,6 +539,7 @@ export async function runIssueEnrichmentCycle(input: {
   }
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const renderPolicy = resolveIssueEnrichmentRenderPolicy(input.config);
   const releasePreacquiredLeaseBeforeRun = () => {
     if (!input.dryRun && input.preacquiredLease) {
       input.state.releaseIssueEnrichmentRunLease(input.preacquiredLease.leaseId);
@@ -660,7 +669,7 @@ export async function runIssueEnrichmentCycle(input: {
         config,
         item.repo,
         issue,
-        input.config.enrichment?.maxSuggestions,
+        renderPolicy,
         undefined,
         reviewLensPacket
       );
@@ -681,7 +690,7 @@ export async function runIssueEnrichmentCycle(input: {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      const bodyHash = issue && shouldCompareIssueEnrichmentBodyHash(existing, issueUpdatedAt)
+      const bodyHash = issue && shouldCompareIssueEnrichmentBodyHash(existing)
         ? plannedBodyHashForItem(item)
         : undefined;
       return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, bodyHash, item.action));
@@ -746,7 +755,7 @@ export async function runIssueEnrichmentCycle(input: {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      const bodyHash = shouldCompareIssueEnrichmentBodyHash(existing, issueUpdatedAt) ||
+      const bodyHash = shouldCompareIssueEnrichmentBodyHash(existing) ||
         shouldBackfillIssueEnrichmentBodyHash(existing, issueUpdatedAt, item.action)
         ? plannedBodyHashForItem(item)
         : undefined;
@@ -829,11 +838,11 @@ export async function runIssueEnrichmentCycle(input: {
           config,
           item.repo,
           issue,
-          input.config.enrichment?.maxSuggestions,
+          renderPolicy,
           { state: "enriched" },
           reviewLensPacket
         );
-        const postBodyHash = plannedBodyHashForItem(item) ?? enrichment.bodyHash;
+        const postBodyHash = enrichment.bodyHash;
         const post = await postEnrichmentComment({
           enabled: true,
           dryRun: false,
@@ -947,6 +956,7 @@ function planRepoIssueScan(input: {
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
+  renderPolicy: IssueEnrichmentRenderPolicy;
   postIssueComment: boolean;
   checkedAt: string;
   shouldCountItem?: (item: IssueEnrichmentScanItem) => boolean;
@@ -959,7 +969,7 @@ function planRepoIssueScan(input: {
     allowedOwners: allowlists.allowedOwners,
     repoPolicy: input.repoPolicy,
     maxRelatedRefs: 8,
-    maxSuggestions: 8
+    ...input.renderPolicy
   }));
   const eligible = planned.filter((output) => !output.skipped);
   const countableEligible = input.shouldCountItem
@@ -1243,12 +1253,10 @@ function shouldSkipIssueEnrichmentRecord(
 }
 
 function shouldCompareIssueEnrichmentBodyHash(
-  existing: IssueEnrichmentRecord | undefined,
-  issueUpdatedAt: string
+  existing: IssueEnrichmentRecord | undefined
 ): boolean {
   return existing?.status === "posted" &&
-    Boolean(existing.bodyHash) &&
-    existing.issueUpdatedAt !== issueUpdatedAt;
+    Boolean(existing.bodyHash);
 }
 
 function shouldBackfillIssueEnrichmentBodyHash(
@@ -1274,7 +1282,7 @@ function buildIssueEnrichmentForCycle(
   config: IssueEnrichmentConfig,
   repo: string,
   issue: GitHubRelatedIssueOrPull,
-  maxSuggestions?: number,
+  renderPolicy: IssueEnrichmentRenderPolicy,
   lifecycle?: IssueEnrichmentLifecycleInput,
   reviewLensPacket?: ReviewLensPacket
 ): EnrichmentComment {
@@ -1286,11 +1294,30 @@ function buildIssueEnrichmentForCycle(
     repoPolicy: policy.repoPolicy,
     allowedLabels: allowlists.allowedLabels,
     allowedOwners: allowlists.allowedOwners,
-    ...(maxSuggestions !== undefined ? { maxSuggestions } : {}),
+    ...renderPolicy,
     postIssueComment: true,
     ...(reviewLensPacket ? { reviewLensPacket } : {}),
     ...(lifecycle ? { lifecycle } : {})
   });
+}
+
+interface IssueEnrichmentRenderPolicy {
+  maxSuggestions?: number;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
+}
+
+function resolveIssueEnrichmentRenderPolicy(config: {
+  enrichment?: { maxSuggestions?: number };
+  confidenceCalibration?: { publicDisplay: PublicConfidenceDisplayPolicy };
+}): IssueEnrichmentRenderPolicy {
+  return {
+    ...(config.enrichment?.maxSuggestions !== undefined
+      ? { maxSuggestions: config.enrichment.maxSuggestions }
+      : {}),
+    ...(config.confidenceCalibration?.publicDisplay
+      ? { publicConfidencePolicy: config.confidenceCalibration.publicDisplay }
+      : {})
+  };
 }
 
 function buildIssueEnrichmentReviewLensPacket(config?: ReviewLensConfig): ReviewLensPacket | undefined {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -441,6 +441,7 @@ export async function collectIssueEnrichmentScan(input: {
       issues,
       throttle: policy.throttle,
       suggestions: policy.suggestions,
+      repoPolicy: policy.repoPolicy,
       postIssueComment: config.postIssueComment,
       checkedAt,
       shouldCountItem: input.shouldCountItem
@@ -927,6 +928,7 @@ function planRepoIssueScan(input: {
   issues: GitHubRelatedIssueOrPull[];
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
+  repoPolicy: IssueEnrichmentRepoPolicy;
   postIssueComment: boolean;
   checkedAt: string;
   shouldCountItem?: (item: IssueEnrichmentScanItem) => boolean;
@@ -937,6 +939,7 @@ function planRepoIssueScan(input: {
     issue,
     allowedLabels: allowlists.allowedLabels,
     allowedOwners: allowlists.allowedOwners,
+    repoPolicy: input.repoPolicy,
     maxRelatedRefs: 8,
     maxSuggestions: 8
   }));

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -63,6 +63,50 @@ describe("build-enrichment-comment issue CLI", () => {
     });
   });
 
+  it("threads the resolved repo issue policy through the existing build command", async () => {
+    await withMockGitHub(async ({ apiBaseUrl }) => {
+      const root = createRoot(roots);
+      const evidenceDir = join(root, "evidence");
+      const outputDir = join(evidenceDir, "issue-policy");
+      const configPath = writeConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, any>;
+      config.issueEnrichment.repos = {
+        "owner/repo": {
+          advisoryPolicy: "Hermes ContextEngine lossless memory policy",
+          validationSuggestions: ["Reproduce on current main or name a mandatory invariant."],
+          suggestedLabels: ["docs", "tests"],
+          suggestedReviewers: ["Tosko4"],
+          labelAliases: { docs: "documentation", tests: "test" }
+        }
+      };
+      config.issueEnrichment.allowedLabels = ["documentation", "test"];
+      config.issueEnrichment.allowedReviewers = ["Tosko4"];
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      await runCli([
+        "build-enrichment-comment",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/repo",
+        "--issue",
+        "17",
+        "--output-dir",
+        outputDir
+      ]);
+
+      const markdown = readFileSync(join(outputDir, "enrichment.md"), "utf8");
+      expect(markdown).toContain("### Repo policy");
+      expect(markdown).toContain("Hermes ContextEngine lossless memory policy");
+      expect(markdown).toContain("Suggested labels: documentation, test.");
+      expect(markdown).toContain("Suggested reviewers: Tosko4.");
+      expect(markdown).not.toContain("Suggested owners: Tosko4.");
+      expect(markdown.match(/Tosko4/g)).toHaveLength(1);
+      expect(markdown).toContain("- Reproduce on current main or name a mandatory invariant.");
+      expect(markdown).toContain("No labels, owners, reviewers, or roadmap fields were changed by this bot.");
+    });
+  });
+
   it("writes only JSON for skipped issue dry runs", async () => {
     await withMockGitHub(async ({ apiBaseUrl }) => {
       const root = createRoot(roots);

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1672,14 +1672,14 @@ describe("sticky enrichment comments", () => {
     }
   });
 
-  it("does not let a dry-run-only body hash suppress the first live issue comment", async () => {
+  it("derives idempotency from the exact capped body and reposts meaningful cap changes", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-dry-run-to-live-"));
     try {
       const configPath = join(root, "config.json");
       const statePath = join(root, "state.sqlite");
-      const writeConfig = (postIssueComment: boolean) => writeFileSync(configPath, `${JSON.stringify({
+      const writeConfig = (postIssueComment: boolean, maxSuggestions: number) => writeFileSync(configPath, `${JSON.stringify({
         statePath,
-        enrichment: { maxSuggestions: 1 },
+        enrichment: { maxSuggestions },
         issueEnrichment: {
           enabled: true,
           postIssueComment,
@@ -1700,7 +1700,7 @@ describe("sticky enrichment comments", () => {
           }
         }
       })}\n`);
-      writeConfig(false);
+      writeConfig(false, 1);
       const state = new ReviewStateStore(statePath);
       try {
         const issue: GitHubRelatedIssueOrPull = {
@@ -1727,7 +1727,7 @@ describe("sticky enrichment comments", () => {
           checkedAt: "2026-07-03T01:05:00.000Z"
         });
         const dryRunRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 32);
-        writeConfig(true);
+        writeConfig(true, 1);
         const live = await runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
@@ -1747,18 +1747,161 @@ describe("sticky enrichment comments", () => {
           includeExisting: true,
           checkedAt: "2026-07-03T01:06:00.000Z"
         });
+        const liveRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 32);
+        const unchanged = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            ...reader,
+            canPostAsApp: () => true,
+            upsertIssueComment: async (input: { issueNumber: number; body: string }) => {
+              posted.push(input);
+              return {
+                action: "updated" as const,
+                id: input.issueNumber,
+                html_url: `https://github.test/owner/issue-repo/issues/${input.issueNumber}#issuecomment-${input.issueNumber}`
+              };
+            }
+          },
+          dryRun: false,
+          includeExisting: true,
+          checkedAt: "2026-07-03T01:07:00.000Z"
+        });
+        writeConfig(true, 2);
+        const changedCap = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            ...reader,
+            canPostAsApp: () => true,
+            upsertIssueComment: async (input: { issueNumber: number; body: string }) => {
+              posted.push(input);
+              return {
+                action: "updated" as const,
+                id: input.issueNumber,
+                html_url: `https://github.test/owner/issue-repo/issues/${input.issueNumber}#issuecomment-${input.issueNumber}`
+              };
+            }
+          },
+          dryRun: false,
+          includeExisting: true,
+          checkedAt: "2026-07-03T01:08:00.000Z"
+        });
+        const changedCapRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 32);
 
         expect(dryRunOnly.summary).toMatchObject({ dryRunRecorded: 1, alreadyProcessed: 0, posted: 0, failed: 0 });
         expect(dryRunRecord).toMatchObject({ status: "dry_run", bodyHash: expect.stringMatching(/^[a-f0-9]{64}$/) });
         expect(live.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
-        expect(posted.map((entry) => entry.issueNumber)).toEqual([32]);
+        expect(unchanged.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+        expect(changedCap.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+        expect(posted.map((entry) => entry.issueNumber)).toEqual([32, 32]);
         expect(posted[0]?.body).toContain("Suggested reviewers: first-reviewer.");
         expect(posted[0]?.body).not.toContain("second-reviewer");
-        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 32)).toMatchObject({
+        expect(posted[0]?.body).toContain(`hash=${liveRecord?.bodyHash}`);
+        expect(liveRecord).toMatchObject({
           status: "posted",
           bodyHash: dryRunRecord?.bodyHash,
           commentUrl: "https://github.test/owner/issue-repo/issues/32#issuecomment-32"
         });
+        expect(posted[1]?.body).toContain("Suggested reviewers: first-reviewer, second-reviewer.");
+        expect(posted[1]?.body).toContain(`hash=${changedCapRecord?.bodyHash}`);
+        expect(changedCapRecord?.bodyHash).not.toBe(liveRecord?.bodyHash);
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps calibrated repo-policy confidence identical between preview and live issue rendering", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-confidence-parity-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        confidenceCalibration: {
+          publicDisplay: {
+            mode: "calibrated",
+            evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+            datasetId: "confidence-calibration-v1",
+            labeledFindings: 100,
+            minLabeledFindings: 100,
+            p0p1Labels: 30,
+            minP0P1Labels: 30,
+            negativeControlScenarios: 10,
+            minNegativeControlScenarios: 10,
+            wilsonLowerBound: 0.95,
+            minWilsonLowerBound: 0.95
+          }
+        },
+        enrichment: { maxSuggestions: 1 },
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 60_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000,
+              advisoryPolicy: "Review confidence 97% after calibrated evidence."
+            }
+          }
+        }
+      })}\n`);
+      const config = loadConfig(configPath);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const issue: GitHubRelatedIssueOrPull = {
+          number: 33,
+          title: "Preserve calibrated confidence",
+          state: "open",
+          updated_at: "2026-07-03T01:00:00.000Z",
+          body: "Acceptance criteria and owner present."
+        };
+        const policy = resolveIssueEnrichmentRepoPolicy(config.issueEnrichment!, "owner/issue-repo");
+        const preview = buildIssueEnrichmentDryRunOutput({
+          repo: "owner/issue-repo",
+          issue,
+          repoPolicy: policy.repoPolicy,
+          allowedLabels: policy.suggestions.allowedLabels,
+          allowedOwners: policy.suggestions.allowedReviewers,
+          maxSuggestions: config.enrichment?.maxSuggestions,
+          publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
+        });
+        if (preview.skipped) throw new Error("expected preview body");
+        let postedBody = "";
+        const live = await runIssueEnrichmentCycle({
+          config,
+          state,
+          github: {
+            listIssuesForEnrichment: async () => [issue],
+            canPostAsApp: () => true,
+            upsertIssueComment: async (input: { issueNumber: number; body: string }) => {
+              postedBody = input.body;
+              return {
+                action: "created" as const,
+                id: input.issueNumber,
+                html_url: `https://github.test/owner/issue-repo/issues/${input.issueNumber}#issuecomment-${input.issueNumber}`
+              };
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T01:05:00.000Z"
+        });
+
+        expect(live.summary).toMatchObject({ posted: 1, failed: 0 });
+        expect(preview.body).toContain("Review confidence 97% after calibrated evidence.");
+        expect(postedBody).toContain("Review confidence 97% after calibrated evidence.");
+        expect(postedBody).not.toContain("[confidence not calibrated]");
+        expect(postedBody.split("\n").slice(2)).toEqual(preview.body.split("\n").slice(2));
+        expect(postedBody).toContain(`hash=${state.getIssueEnrichmentRecord("owner/issue-repo", 33)?.bodyHash}`);
       } finally {
         state.close();
       }

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -447,6 +447,54 @@ describe("sticky enrichment comments", () => {
     expect(comment.body).not.toContain("ghp_fake_token");
   });
 
+  it("renders an explicit repo policy and applies label aliases before allowlist filtering", () => {
+    const issue: GitHubRelatedIssueOrPull = {
+      number: 780,
+      title: "Review LCM-X context memory",
+      state: "open",
+      body: "Validate current-main behavior and preserve lossless context memory.",
+      labels: []
+    };
+
+    const comment = buildIssueEnrichmentComment({
+      repo: "electricsheephq/lcm-x",
+      issue,
+      allowedLabels: ["documentation", "test", "data-integrity"],
+      repoPolicy: {
+        advisoryPolicy: "LCM-X is an independent Hermes ContextEngine extension for lossless context memory, not OpenClaw. Require current-main reproduction or a named mandatory invariant; distinguish NeonDiff severity from LCM-X P0-P4.",
+        validationSuggestions: ["Reproduce on current main or name a mandatory invariant."],
+        suggestedLabels: ["docs", "tests", "data-integrity"],
+        suggestedReviewers: ["Tosko4"],
+        labelAliases: { docs: "documentation", tests: "test" }
+      }
+    });
+
+    expect(comment.body).toContain("### Repo policy");
+    expect(comment.body).toContain("Hermes ContextEngine extension for lossless context memory");
+    expect(comment.body).toContain("not OpenClaw");
+    expect(comment.body).toContain("current-main reproduction or a named mandatory invariant");
+    expect(comment.body).toContain("NeonDiff severity from LCM-X P0-P4");
+    expect(comment.body).toContain("Suggested labels: documentation, test, data-integrity");
+    expect(comment.body).toContain("Suggested reviewers: Tosko4");
+    expect(comment.body).toContain("- Reproduce on current main or name a mandatory invariant.");
+    expect(comment.body).toContain("No labels, owners, reviewers, or roadmap fields were changed by this bot.");
+  });
+
+  it("does not add an empty repo policy section to generic issue enrichment", () => {
+    const comment = buildIssueEnrichmentComment({
+      repo: "owner/generic",
+      issue: {
+        number: 781,
+        title: "Document the supported setup",
+        state: "open",
+        body: "Add validation evidence before implementation.",
+        labels: []
+      }
+    });
+
+    expect(comment.body).not.toContain("### Repo policy");
+  });
+
   it("adds a build-borrow-buy planner packet for research-triggered issue classes", () => {
     const issue: GitHubRelatedIssueOrPull = {
       number: 89,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -495,6 +495,28 @@ describe("sticky enrichment comments", () => {
     expect(comment.body).not.toContain("### Repo policy");
   });
 
+  it("caps repo policy validation guidance with the issue suggestion limit", () => {
+    const comment = buildIssueEnrichmentComment({
+      repo: "electricsheephq/lcm-x",
+      issue: {
+        number: 782,
+        title: "Bound policy output",
+        state: "open",
+        body: "Keep dry-run and live comments within the configured suggestion limit."
+      },
+      repoPolicy: {
+        validationSuggestions: ["first policy check", "second policy check"],
+        suggestedLabels: [],
+        suggestedReviewers: [],
+        labelAliases: {}
+      },
+      maxSuggestions: 1
+    });
+
+    expect(comment.body).toContain("- first policy check");
+    expect(comment.body).not.toContain("second policy check");
+  });
+
   it("adds a build-borrow-buy planner packet for research-triggered issue classes", () => {
     const issue: GitHubRelatedIssueOrPull = {
       number: 89,
@@ -954,7 +976,13 @@ describe("sticky enrichment comments", () => {
           maxIssuesPerCycle: 3,
           maxCommentsPerCycle: 1,
           maxIssuesPerBurst: 10,
-          processExistingOpenIssuesOnActivation: false
+          processExistingOpenIssuesOnActivation: false,
+          repos: {
+            "owner/issue-repo": {
+              advisoryPolicy: "Render this policy in cycle dry-run planning.",
+              validationSuggestions: ["Keep the dry-run policy aligned with live output."]
+            }
+          }
         }
       })}\n`);
       const reposScanned: string[] = [];

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1850,7 +1850,8 @@ describe("sticky enrichment comments", () => {
               burstWindowMs: 3_600_000,
               maxIssuesPerBurst: 10,
               lookbackMs: 600_000,
-              advisoryPolicy: "Review confidence 97% after calibrated evidence."
+              advisoryPolicy: "Review confidence 97% after calibrated evidence.",
+              validationSuggestions: ["Validation confidence 96% after calibrated evidence."]
             }
           }
         }
@@ -1898,7 +1899,9 @@ describe("sticky enrichment comments", () => {
 
         expect(live.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(preview.body).toContain("Review confidence 97% after calibrated evidence.");
+        expect(preview.body).toContain("Validation confidence 96% after calibrated evidence.");
         expect(postedBody).toContain("Review confidence 97% after calibrated evidence.");
+        expect(postedBody).toContain("Validation confidence 96% after calibrated evidence.");
         expect(postedBody).not.toContain("[confidence not calibrated]");
         expect(postedBody.split("\n").slice(2)).toEqual(preview.body.split("\n").slice(2));
         expect(postedBody).toContain(`hash=${state.getIssueEnrichmentRecord("owner/issue-repo", 33)?.bodyHash}`);

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1679,6 +1679,7 @@ describe("sticky enrichment comments", () => {
       const statePath = join(root, "state.sqlite");
       const writeConfig = (postIssueComment: boolean) => writeFileSync(configPath, `${JSON.stringify({
         statePath,
+        enrichment: { maxSuggestions: 1 },
         issueEnrichment: {
           enabled: true,
           postIssueComment,
@@ -1693,7 +1694,8 @@ describe("sticky enrichment comments", () => {
               cooldownMs: 60_000,
               burstWindowMs: 3_600_000,
               maxIssuesPerBurst: 10,
-              lookbackMs: 600_000
+              lookbackMs: 600_000,
+              suggestedReviewers: ["first-reviewer", "second-reviewer"]
             }
           }
         }
@@ -1709,7 +1711,7 @@ describe("sticky enrichment comments", () => {
           body: "Acceptance criteria and owner present."
         };
         const reader = { listIssuesForEnrichment: async () => [issue] };
-        const posted: number[] = [];
+        const posted: Array<{ issueNumber: number; body: string }> = [];
 
         const dryRunOnly = await runIssueEnrichmentCycle({
           config: loadConfig(configPath),
@@ -1732,8 +1734,8 @@ describe("sticky enrichment comments", () => {
           github: {
             ...reader,
             canPostAsApp: () => true,
-            upsertIssueComment: async (input: { issueNumber: number }) => {
-              posted.push(input.issueNumber);
+            upsertIssueComment: async (input: { issueNumber: number; body: string }) => {
+              posted.push(input);
               return {
                 action: "created" as const,
                 id: input.issueNumber,
@@ -1749,7 +1751,9 @@ describe("sticky enrichment comments", () => {
         expect(dryRunOnly.summary).toMatchObject({ dryRunRecorded: 1, alreadyProcessed: 0, posted: 0, failed: 0 });
         expect(dryRunRecord).toMatchObject({ status: "dry_run", bodyHash: expect.stringMatching(/^[a-f0-9]{64}$/) });
         expect(live.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
-        expect(posted).toEqual([32]);
+        expect(posted.map((entry) => entry.issueNumber)).toEqual([32]);
+        expect(posted[0]?.body).toContain("Suggested reviewers: first-reviewer.");
+        expect(posted[0]?.body).not.toContain("second-reviewer");
         expect(state.getIssueEnrichmentRecord("owner/issue-repo", 32)).toMatchObject({
           status: "posted",
           bodyHash: dryRunRecord?.bodyHash,

--- a/tests/issue-enrichment-policy.test.ts
+++ b/tests/issue-enrichment-policy.test.ts
@@ -105,6 +105,13 @@ describe("issue enrichment rollout policy", () => {
         }
       }
     })).toThrow("validationSuggestions must contain at most 20 items");
+    expect(() => loadConfigFromObject({
+      issueEnrichment: {
+        repos: {
+          "electricsheephq/lcm-x": { suggestedReviewers: [""] }
+        }
+      }
+    })).toThrow("suggestedReviewers must be an array of non-empty strings");
   });
 
   it("blocks live issue comments until every allowlisted repo has explicit repo throttle thresholds", () => {

--- a/tests/issue-enrichment-policy.test.ts
+++ b/tests/issue-enrichment-policy.test.ts
@@ -42,6 +42,57 @@ describe("issue enrichment rollout policy", () => {
     });
   });
 
+  it("resolves repo-specific advisory policy and suggestion aliases without opting into PR review", () => {
+    const config = loadConfigFromObject({
+      pilotRepos: ["owner/pr-review-repo"],
+      repoProfiles: { repos: { "owner/pr-review-repo": { enabled: true } } },
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: false,
+        allowlist: ["electricsheephq/lcm-x"],
+        repos: {
+          "electricsheephq/lcm-x": {
+            advisoryPolicy: "Hermes ContextEngine lossless memory policy",
+            validationSuggestions: ["Reproduce on current main or name a mandatory invariant."],
+            suggestedLabels: ["data-integrity", "docs", "tests"],
+            suggestedReviewers: ["Tosko4"],
+            labelAliases: { docs: "documentation", tests: "test" }
+          }
+        }
+      }
+    });
+
+    expect(resolveIssueEnrichmentRepoPolicy(config.issueEnrichment!, "electricsheephq/lcm-x")).toMatchObject({
+      allowed: true,
+      repoPolicy: {
+        advisoryPolicy: "Hermes ContextEngine lossless memory policy",
+        validationSuggestions: ["Reproduce on current main or name a mandatory invariant."],
+        suggestedLabels: ["data-integrity", "docs", "tests"],
+        suggestedReviewers: ["Tosko4"],
+        labelAliases: { docs: "documentation", tests: "test" }
+      }
+    });
+  });
+
+  it("rejects malformed repo policy fields at the runtime config boundary", () => {
+    expect(() => loadConfigFromObject({
+      issueEnrichment: {
+        repos: {
+          "electricsheephq/lcm-x": {
+            suggestedReviewers: "Tosko4"
+          }
+        }
+      }
+    })).toThrow("config.issueEnrichment.repos.electricsheephq/lcm-x.suggestedReviewers must be an array");
+    expect(() => loadConfigFromObject({
+      issueEnrichment: {
+        repos: {
+          "electricsheephq/lcm-x": { unknownPolicyKey: true }
+        }
+      }
+    })).toThrow('config.issueEnrichment.repos.electricsheephq/lcm-x has unknown key "unknownPolicyKey"');
+  });
+
   it("blocks live issue comments until every allowlisted repo has explicit repo throttle thresholds", () => {
     const config = loadConfigFromObject({
       issueEnrichment: {

--- a/tests/issue-enrichment-policy.test.ts
+++ b/tests/issue-enrichment-policy.test.ts
@@ -91,6 +91,20 @@ describe("issue enrichment rollout policy", () => {
         }
       }
     })).toThrow('config.issueEnrichment.repos.electricsheephq/lcm-x has unknown key "unknownPolicyKey"');
+    expect(() => loadConfigFromObject({
+      issueEnrichment: {
+        repos: {
+          "electricsheephq/lcm-x": { advisoryPolicy: "x".repeat(4_001) }
+        }
+      }
+    })).toThrow("advisoryPolicy must be at most 4000 characters");
+    expect(() => loadConfigFromObject({
+      issueEnrichment: {
+        repos: {
+          "electricsheephq/lcm-x": { validationSuggestions: Array.from({ length: 21 }, () => "check") }
+        }
+      }
+    })).toThrow("validationSuggestions must contain at most 20 items");
   });
 
   it("blocks live issue comments until every allowlisted repo has explicit repo throttle thresholds", () => {

--- a/tests/neondiff-config-schema.test.ts
+++ b/tests/neondiff-config-schema.test.ts
@@ -230,6 +230,23 @@ describe("NeonDiff config schema draft", () => {
     expect(errorPaths(invalidErrors)).toContain(
       "/issueEnrichment/repos/electricsheephq~1lcm-x/suggestedLabels"
     );
+
+    const oversizedErrors = validateConfig(validate, {
+      ...baseConfig,
+      issueEnrichment: {
+        ...issueEnrichment,
+        repos: {
+          "electricsheephq/lcm-x": {
+            advisoryPolicy: "x".repeat(4_001),
+            validationSuggestions: Array.from({ length: 21 }, () => "check")
+          }
+        }
+      }
+    });
+    expect(errorPaths(oversizedErrors)).toEqual(expect.arrayContaining([
+      "/issueEnrichment/repos/electricsheephq~1lcm-x/advisoryPolicy",
+      "/issueEnrichment/repos/electricsheephq~1lcm-x/validationSuggestions"
+    ]));
   });
 
   it("validates JSON fixtures against the published JSON Schema", () => {

--- a/tests/neondiff-config-schema.test.ts
+++ b/tests/neondiff-config-schema.test.ts
@@ -186,6 +186,52 @@ describe("NeonDiff config schema draft", () => {
     }
   });
 
+  it("accepts repo-specific issue policy fields and rejects wrong field types", () => {
+    const validate = compileSchema();
+    const baseConfig = readJson(join(fixtureRoot, "valid-minimal.json"));
+    const issueEnrichment = asRecord(baseConfig.issueEnrichment);
+    const repos = {
+      "electricsheephq/lcm-x": {
+        enabled: true,
+        allowedLabels: ["issue-label"],
+        allowedReviewers: ["issue-reviewer"],
+        advisoryPolicy: "Hermes ContextEngine lossless memory policy",
+        validationSuggestions: ["Reproduce on current main or name a mandatory invariant."],
+        suggestedLabels: ["documentation", "test"],
+        suggestedReviewers: ["Tosko4"],
+        labelAliases: { docs: "documentation", tests: "test" },
+        maxIssuesPerCycle: 3,
+        maxCommentsPerCycle: 1,
+        cooldownMs: 3_600_000,
+        burstWindowMs: 3_600_000,
+        maxIssuesPerBurst: 6,
+        lookbackMs: 600_000,
+        processExistingOpenIssuesOnActivation: false
+      }
+    };
+
+    expectValidFixture(validate, "repo-specific issue policy", {
+      ...baseConfig,
+      issueEnrichment: { ...issueEnrichment, repos }
+    });
+
+    const invalidErrors = validateConfig(validate, {
+      ...baseConfig,
+      issueEnrichment: {
+        ...issueEnrichment,
+        repos: {
+          "electricsheephq/lcm-x": {
+            ...repos["electricsheephq/lcm-x"],
+            suggestedLabels: "documentation"
+          }
+        }
+      }
+    });
+    expect(errorPaths(invalidErrors)).toContain(
+      "/issueEnrichment/repos/electricsheephq~1lcm-x/suggestedLabels"
+    );
+  });
+
   it("validates JSON fixtures against the published JSON Schema", () => {
     const validate = compileSchema();
     const validFixtures = fixtureNames("valid", ".json");

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -811,6 +811,7 @@ const pull: PullRequestSummary = {
 };
 
 const activeMonitorRepos = [
+  "electricsheephq/lcm-x",
   "electricsheephq/WorldOS",
   "electricsheephq/evaos-code-review-bot-neondiff",
   "electricsheephq/electric-sheep-website-dashboard-6158a244",


### PR DESCRIPTION
## What Problem This Solves

Closes #780

Issue enrichment currently supports only generic per-repo enablement, allowlists, and throttles. It cannot carry the repository-specific advisory policy that PR review profiles already support, so LCM-X issue output misses its Hermes/lossless/current-main rules.

## User Impact

Operators can attach bounded per-repo issue-enrichment guidance, validation suggestions, label aliases, label suggestions, and reviewer suggestions. LCM-X now has tracked PR-review and issue-enrichment profiles without path filters or automatic label/reviewer mutation.

## Implementation Notes

- Add `advisoryPolicy`, `validationSuggestions`, `suggestedLabels`, `suggestedReviewers`, and `labelAliases` to issue-enrichment repo overrides.
- Validate the new fields at runtime and in the JSON Schema; reject unknown override keys.
- Resolve aliases before allowlist filtering and render the resolved repo policy only when configured.
- Track an LCM-X PR profile and issue-enrichment profile in the public active-profiles example.
- Preserve `processExistingOpenIssuesOnActivation: false`; the example remains disabled for live posting.

## Validation

- [x] Failing test, smoke, or eval was added/updated first.
- [x] Focused validation:
  - Initial feature head: `npx vitest run tests/issue-enrichment-policy.test.ts tests/enrichment.test.ts tests/enrichment-cli.test.ts tests/neondiff-config-schema.test.ts` — 4 files, 122 tests passed.
  - Final rendering-identity repair: `npx vitest run tests/enrichment.test.ts` — 66 tests passed.
  - `npx tsc -p tsconfig.build.json --noEmit` — passed.
  - `git diff --check origin/main...HEAD` — passed.
- [x] Exact-head GitHub CI: authoritative build and required Swift desktop gate passed on `ae50eb002427bc45a1bed8c99f8d907278bf9168`; all other reported checks passed or were intentionally skipped.
- [x] Exact-head NeonDiff semantic delta review: [no validated inline findings](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/781#pullrequestreview-4944236644).
- [x] The two later supported-path blockers were fixed through stacked PR #782:
  - the tracked LCM-X PR profile is not selected by normal monitoring because the example's non-empty `pilotRepos` omits `electricsheephq/lcm-x`;
  - calibrated confidence in repo-policy validation suggestions is redacted before policy-aware rendering.
- [x] Repository merge state: all threads are resolved; the obsolete CodeRabbit decision on `24a0b004` was dismissed with an audit reason only after exact-head CI and semantic-review proof passed. GitHub reports `CLEAN`.

Dry-run evaluation:

- LCM-X issues #28 and #7: baseline vs customized rendering passed; customized output included Hermes ContextEngine, lossless memory, not-OpenClaw, current-main-or-mandatory-invariant, severity distinction, aliases, and `Tosko4`, with zero writes.
- LCM-X PR #17 at `0913b5d8697234786d3f5fbf57ee02b2c8d764d1`: 7/7 files included. Baseline produced two P2 findings; customized output produced a P1 `data_loss` finding tied to LCM-X's mandatory lossless-source invariant plus one P2 runtime-correctness finding.
- LCM-X PR #29 at `f50ff88ac70961d940785073de41ed5f0705a43c`: 8/8 files included; both baseline and customized arms produced zero findings.
- All four PR ledgers passed current-head, duplicate-same-head, and coordinate validation. Provider attempts were exactly one per arm; no public comments were posted.

## Proof Boundary

This PR proves:

- Repo-specific issue policy resolves, validates, renders, and remains quiet when absent.
- The tracked LCM-X profiles influence deterministic issue output and configured PR-review output on selected exact heads.
- No changed files were hidden in the selected PR evals, and the negative control remained quiet.

This PR does not prove:

- LCM-X source correctness, release readiness, Hermes runtime behavior, or customer readiness.
- A published/installed beta, active Desktop config adoption, daemon behavior, or live issue-comment quality.

## Safety Boundary

- [x] No GitHub App permission expansion.
- [x] No live worker restart, launchd mutation, or beta promotion.
- [x] No package publish, GitHub Release, or repo visibility change.
- [x] No secrets, tokens, credentials, raw private diffs, or customer data in the PR.
- [x] Claims stay within the source-available beta boundary.
- [x] Provider status claims distinguish tested, compatible-by-interface, planned, and untested/resource-only states.

## Restricted Actions Not Performed

- No merge, tag, package publish, GitHub Release, app install, live-config write, daemon restart, backlog processing, LCM-X tracker mutation, or LCM-X public comment was performed.

## Evidence

- Source head: `ae50eb002427bc45a1bed8c99f8d907278bf9168`
- Base head: `ff6451878bfce5a88a0cea6c26ab33fc4c32931e`
- Exact-head CI: required build and Swift desktop gate passed; all other reported checks are successful or intentionally skipped.
- Exact-head semantic review: [NeonDiff clean review](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/781#pullrequestreview-4944273112); no validated inline findings.
- Stacked repair: [PR #782](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/782), exact-head CI green and independent delta review PASS.
- Merge gate: 0 open threads; GitHub `mergeStateStatus=CLEAN`.
- Issue-enrichment eval targets: `electricsheephq/lcm-x#28`, `electricsheephq/lcm-x#7`
- PR-review eval targets: `electricsheephq/lcm-x#17`, `electricsheephq/lcm-x#29`
- PR-review eval receipt SHA-256: `f5d99c98f9bffdf630d86f58f529fd7af40c8295c1be8535b8e728b96c91163a`
- Dry-run GitHub writes: 0
- Active-config writes: 0

## Agent-Authored PR

- [x] This PR was authored or materially edited by an AI agent.
- [x] The agent updated issue #780 before handoff/pause and listed restricted actions not performed.
