### PR TITLE
fix: complete LCM-X selection and confidence parity

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -1,5 +1,6 @@
 {
   "pilotRepos": [
+    "electricsheephq/lcm-x",
     "electricsheephq/WorldOS",
     "electricsheephq/evaos-code-review-bot-neondiff",
     "electricsheephq/electric-sheep-website-dashboard-6158a244",
@@ -2455,7 +2456,33 @@
         ],
         "suggestedReviewers": [
           "Tosko4"
-        ]
+        ],
+        "finishingTouches": {
+          "docs": {
+            "enabled": false
+          },
+          "docstrings": {
+            "enabled": false
+          },
+          "unitTests": {
+            "enabled": false
+          },
+          "simplifySuggestion": {
+            "enabled": false
+          },
+          "changelogDraft": {
+            "enabled": false
+          },
+          "riskExplanation": {
+            "enabled": false
+          },
+          "reviewReady": {
+            "enabled": false
+          },
+          "stackedPr": {
+            "enabled": false
+          }
+        }
       }
     }
   }

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -213,12 +213,15 @@ export function buildIssueEnrichmentComment(input: {
   const reviewers = uniqueCaseInsensitive(input.repoPolicy?.suggestedReviewers ?? []).filter((reviewer) => {
     return allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(reviewer));
   }).slice(0, input.maxSuggestions ?? 8);
-  const policyValidationSuggestions = unique(input.repoPolicy?.validationSuggestions ?? [])
+  const policyValidationSuggestions = unique(
+    input.repoPolicy?.validationSuggestions ?? [],
+    input.publicConfidencePolicy
+  )
     .slice(0, input.maxSuggestions ?? 8);
   const validationSuggestions = unique([
     ...policyValidationSuggestions,
     ...(input.validationSuggestions ?? [])
-  ]).slice(0, input.maxSuggestions ?? 8);
+  ], input.publicConfidencePolicy).slice(0, input.maxSuggestions ?? 8);
   const repoPolicySection = input.repoPolicy?.advisoryPolicy || policyValidationSuggestions.length
     ? [
         "",
@@ -734,8 +737,8 @@ function formatPublicText(value: string | undefined, publicConfidencePolicy?: Pu
   ).trim();
 }
 
-function unique(values: string[]): string[] {
-  return [...new Set(values.map((value) => formatPublicText(value)).filter(Boolean))];
+function unique(values: string[], publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string[] {
+  return [...new Set(values.map((value) => formatPublicText(value, publicConfidencePolicy)).filter(Boolean))];
 }
 
 function uniqueCaseInsensitive(values: string[]): string[] {

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1850,7 +1850,8 @@ describe("sticky enrichment comments", () => {
               burstWindowMs: 3_600_000,
               maxIssuesPerBurst: 10,
               lookbackMs: 600_000,
-              advisoryPolicy: "Review confidence 97% after calibrated evidence."
+              advisoryPolicy: "Review confidence 97% after calibrated evidence.",
+              validationSuggestions: ["Validation confidence 96% after calibrated evidence."]
             }
           }
         }
@@ -1898,7 +1899,9 @@ describe("sticky enrichment comments", () => {
 
         expect(live.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(preview.body).toContain("Review confidence 97% after calibrated evidence.");
+        expect(preview.body).toContain("Validation confidence 96% after calibrated evidence.");
         expect(postedBody).toContain("Review confidence 97% after calibrated evidence.");
+        expect(postedBody).toContain("Validation confidence 96% after calibrated evidence.");
         expect(postedBody).not.toContain("[confidence not calibrated]");
         expect(postedBody.split("\n").slice(2)).toEqual(preview.body.split("\n").slice(2));
         expect(postedBody).toContain(`hash=${state.getIssueEnrichmentRecord("owner/issue-repo", 33)?.bodyHash}`);

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -811,6 +811,7 @@ const pull: PullRequestSummary = {
 };
 
 const activeMonitorRepos = [
+  "electricsheephq/lcm-x",
   "electricsheephq/WorldOS",
   "electricsheephq/evaos-code-review-bot-neondiff",
   "electricsheephq/electric-sheep-website-dashboard-6158a244",


### PR DESCRIPTION
## Purpose

Stacked repair for two verified current-head blockers on #781. This PR targets `feature/780-lcm-x-issue-policy` and contains no unrelated feature work.

## Changes

- Add `electricsheephq/lcm-x` to the existing active-profile example's `pilotRepos` so the already-tracked PR profile participates in normal selection.
- Keep all LCM-X finishing touches explicitly disabled, matching the active-monitor template contract.
- Preserve the configured calibrated public-confidence policy while deduplicating repo-policy `validationSuggestions`.
- Extend the existing selection and preview/live parity regressions.

## Validation

- `npx vitest run tests/enrichment.test.ts tests/repo-policy.test.ts -t 'keeps calibrated repo-policy confidence|keeps the active monitor profile template'` — 2 tests passed.
- `npx tsc -p tsconfig.build.json --noEmit` — passed.
- `git diff --check` — passed.

## Safety / Non-goals

- No new repo other than the already-scoped LCM-X profile was added.
- No issue-enrichment allowlist expansion, path filter, label/reviewer mutation, backlog processing, live-config write, restart, merge, release, or installation.
- No general re-review of unchanged #781 surfaces is requested; semantic review is limited to this stacked delta.

## Proof Boundary

This PR proves only the stacked source delta and focused local checks. It does not prove #781 merge readiness, a published or installed beta, active config adoption, daemon behavior, LCM-X runtime correctness, or customer readiness.

## Evidence

- Base: `90994f66dfbf66b35832d45ac3e333a07f2a76c6`
- Head: `a44af07cfdd3efbd35913ec3a558c2467e08c2c4`
- Parent PR: #781
- Tracker: #780

## Agent-Authored PR

- [x] Authored by an AI agent under the bounded stacked-repair authority.
