### PR TITLE
docs: beta.77 production review canary

### DIFF
--- a/docs/canaries/beta77-public-review-canary.md
+++ b/docs/canaries/beta77-public-review-canary.md
@@ -1,0 +1,16 @@
+# Beta.77 public review canary
+
+This temporary pull request exercises the production NeonDiff reviewer after
+the beta.77 public-output privacy repair tracked in issue #783.
+
+The canary is successful only when one review for the exact pull-request head:
+
+- explains this documentation-only scope and its relationship to issue #783;
+- retains useful walkthrough, proof, and readiness guidance;
+- omits internal review profiles, enabled-section settings, path instructions,
+  label or reviewer configuration, suggestion behavior, roadmap settings,
+  prompts, and repository policy text; and
+- proposes no automatic label, assignment, approval, merge, or gate bypass.
+
+This file is test evidence only. It does not change runtime behavior and is not
+intended for merge.


### PR DESCRIPTION
Production canary for #783 and the released beta.77 renderer.

Expected result: one NeonDiff review for exact head 5e2c7eb27e3476de97f4228cf5b90b668c2db9d4 with useful walkthrough/proof/readiness content and no Review Settings Preview or internal profile, section, path, label, reviewer, suggestion, roadmap, prompt, or policy dump.

This documentation-only PR is evidence and is not intended for merge. No runtime behavior changes.