### PR TITLE
Hide issue suggestion configuration from public output

### DIFF
--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -41,7 +41,7 @@ export interface EnrichmentConfig {
 
 export type EnrichmentComment = PlanEnrichmentComment;
 export type EnrichmentCommentPostResult = PlanEnrichmentCommentPostResult;
-export const ISSUE_ANALYSIS_PUBLIC_RENDERER_VERSION = 1;
+export const ISSUE_ANALYSIS_PUBLIC_RENDERER_VERSION = 2;
 type IssueEnrichmentSkipReason =
   | "stale_issue_closed"
   | "issue_is_pull_request"
@@ -330,28 +330,6 @@ export function buildIssueAnalysisEnrichmentComment(input: {
     throw new Error(`Cannot build issue analysis for ${input.repo}#${input.issue.number}: ${eligibility.skip.reason}`);
   }
   const marker = buildIssueEnrichmentMarker({ repo: input.repo, issueNumber: input.issue.number });
-  const existingLabels = uniqueCaseInsensitive(normalizeIssueLabels(input.issue.labels));
-  const existingLabelKeys = new Set(existingLabels.map(normalizedSuggestionKey));
-  const allowedLabelKeys = input.allowedLabels === undefined || input.allowedLabels.length === 0
-    ? undefined
-    : new Set(uniqueCaseInsensitive(input.allowedLabels).map(normalizedSuggestionKey));
-  const allowedOwnerKeys = input.allowedOwners === undefined || input.allowedOwners.length === 0
-    ? undefined
-    : new Set(uniqueCaseInsensitive(input.allowedOwners).map(normalizedSuggestionKey));
-  const suggestedLabels = uniqueCaseInsensitive(applyIssueLabelAliases([
-    ...input.repoPolicy.suggestedLabels,
-    ...(input.suggestedLabels ?? []),
-    ...suggestLabelsFromIssue(input.issue)
-  ], input.repoPolicy.labelAliases)).filter((label) => {
-    const key = normalizedSuggestionKey(label);
-    return !existingLabelKeys.has(key) && (allowedLabelKeys === undefined || allowedLabelKeys.has(key));
-  }).slice(0, input.maxSuggestions ?? 8);
-  const owners = uniqueCaseInsensitive(input.suggestedOwners ?? []).filter((owner) =>
-    allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(owner))
-  ).slice(0, input.maxSuggestions ?? 8);
-  const reviewers = uniqueCaseInsensitive(input.repoPolicy.suggestedReviewers).filter((reviewer) =>
-    allowedOwnerKeys === undefined || allowedOwnerKeys.has(normalizedSuggestionKey(reviewer))
-  ).slice(0, input.maxSuggestions ?? 8);
   const impactHeading = input.repo.toLowerCase() === "electricsheephq/lcm-x"
     ? "### LCM-X impact"
     : "### Repository impact";
@@ -389,13 +367,6 @@ export function buildIssueAnalysisEnrichmentComment(input: {
     "### Next gate",
     "",
     formatPublicText(input.analysis.nextGate, input.publicConfidencePolicy),
-    "",
-    "### Suggestions",
-    "",
-    `Existing labels: ${existingLabels.length ? existingLabels.join(", ") : "none"}.`,
-    `Suggested labels: ${suggestedLabels.length ? suggestedLabels.join(", ") : "none"}.`,
-    `Suggested owners: ${owners.length ? owners.join(", ") : "none"}.`,
-    `Suggested reviewers: ${reviewers.length ? reviewers.join(", ") : "none"}.`,
     "",
     "Suggestions only. No labels, owners, reviewers, approvals, merges, or roadmap fields were changed by this bot."
   ].join("\n");

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1879,7 +1879,7 @@ describe("sticky enrichment comments", () => {
     }
   });
 
-  it("derives idempotency from the exact capped body and reposts meaningful cap changes", async () => {
+  it("derives idempotency from public model-backed output and ignores private suggestion cap changes", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-dry-run-to-live-"));
     try {
       const configPath = join(root, "config.json");
@@ -2003,9 +2003,10 @@ describe("sticky enrichment comments", () => {
         });
         expect(live.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
         expect(unchanged.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
-        expect(changedCap.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
-        expect(posted.map((entry) => entry.issueNumber)).toEqual([32, 32]);
-        expect(posted[0]?.body).toContain("Suggested reviewers: first-reviewer.");
+        expect(changedCap.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+        expect(posted.map((entry) => entry.issueNumber)).toEqual([32]);
+        expect(posted[0]?.body).not.toContain("Suggested reviewers:");
+        expect(posted[0]?.body).not.toContain("first-reviewer");
         expect(posted[0]?.body).not.toContain("second-reviewer");
         expect(posted[0]?.body).toContain(`hash=${liveRecord?.bodyHash}`);
         expect(liveRecord).toMatchObject({
@@ -2015,9 +2016,7 @@ describe("sticky enrichment comments", () => {
           commentUrl: "https://github.test/owner/issue-repo/issues/32#issuecomment-32"
         });
         expect(liveRecord?.bodyHash).not.toBe(liveRecord?.analysisInputHash);
-        expect(posted[1]?.body).toContain("Suggested reviewers: first-reviewer, second-reviewer.");
-        expect(posted[1]?.body).toContain(`hash=${changedCapRecord?.bodyHash}`);
-        expect(changedCapRecord?.bodyHash).not.toBe(liveRecord?.bodyHash);
+        expect(changedCapRecord?.bodyHash).toBe(liveRecord?.bodyHash);
       } finally {
         state.close();
       }
@@ -2903,9 +2902,10 @@ describe("sticky enrichment comments", () => {
         expect(posts).toHaveLength(2);
         expect(posts[0]!.marker).toContain("issue=41");
         expect(posts[0]!.body).toContain("## evaOS issue enrichment");
-        expect(posts[0]!.body).toContain("Suggested labels: docs.");
-        expect(posts[0]!.body).not.toContain("Suggested labels: docs, security");
-        expect(posts[0]!.body).toContain("Suggested owners: none.");
+        expect(posts[0]!.body).toContain("### Current-main applicability");
+        expect(posts[0]!.body).toContain("### Evidence");
+        expect(posts[0]!.body).not.toContain("Suggested labels:");
+        expect(posts[0]!.body).not.toContain("Suggested owners:");
         expect(posts[0]!.body).not.toContain("issue-owner");
         expect(posts[0]!.body).not.toContain("incident-reviewer");
         expect(firstRecord).toMatchObject({

--- a/tests/issue-analysis.test.ts
+++ b/tests/issue-analysis.test.ts
@@ -262,6 +262,7 @@ describe("model-backed issue analysis", () => {
       repoPolicy,
       allowedLabels: ["data-integrity", "needs-repro"],
       allowedOwners: ["Tosko4"],
+      suggestedOwners: ["runtime-owner"],
       postIssueComment: true
     });
 
@@ -284,9 +285,12 @@ describe("model-backed issue analysis", () => {
     expect(comment.body).not.toContain("Context-source taxonomy");
     expect(comment.body).not.toContain("### Suggestions");
     expect(comment.body).not.toContain("Suggested labels:");
+    expect(comment.body).not.toContain("Suggested owners:");
     expect(comment.body).not.toContain("Suggested reviewers:");
     expect(comment.body).not.toContain("needs-repro");
+    expect(comment.body).not.toContain("runtime-owner");
     expect(comment.body).not.toContain("Tosko4");
+    expect(ISSUE_ANALYSIS_PUBLIC_RENDERER_VERSION).toBe(2);
 
     const changedPrivateIdentity = buildIssueAnalysisInputHash({
       repo: "electricsheephq/lcm-x",

--- a/tests/issue-analysis.test.ts
+++ b/tests/issue-analysis.test.ts
@@ -282,6 +282,11 @@ describe("model-backed issue analysis", () => {
     expect(comment.body).not.toContain("### Agent-start packet");
     expect(comment.body).not.toContain("Build / borrow / buy scan");
     expect(comment.body).not.toContain("Context-source taxonomy");
+    expect(comment.body).not.toContain("### Suggestions");
+    expect(comment.body).not.toContain("Suggested labels:");
+    expect(comment.body).not.toContain("Suggested reviewers:");
+    expect(comment.body).not.toContain("needs-repro");
+    expect(comment.body).not.toContain("Tosko4");
 
     const changedPrivateIdentity = buildIssueAnalysisInputHash({
       repo: "electricsheephq/lcm-x",

--- a/tests/issue-analysis.test.ts
+++ b/tests/issue-analysis.test.ts
@@ -205,7 +205,7 @@ describe("model-backed issue analysis", () => {
       issue,
       repoPolicy,
       allowedLabels: ["data-integrity", "needs-repro"],
-      allowedOwners: ["Tosko4"],
+      allowedOwners: ["Tosko4", "runtime-owner"],
       suggestedOwners: [],
       publicConfidencePolicy: { mode: "hidden" },
       rendererVersion: ISSUE_ANALYSIS_PUBLIC_RENDERER_VERSION,


### PR DESCRIPTION
## What changed\n\n- removes the public Suggestions block from model-backed issue enrichment\n- prevents configured labels, reviewers, and owners from appearing in public issue comments\n- bumps the public renderer version so sticky comments refresh with the safe shape\n- adds regression assertions for the production beta.77 false-label canary\n\n## Why\n\nThe beta.77 LCM-X production canary produced issue-specific analysis without prompt or policy leakage, but its label line echoed the full configured suggestion set. That exposed internal configuration and created false-label guidance.\n\n## Impact\n\nActionable issue comments keep classification, priority, repository impact, current-main applicability, evidence, reproduction gap, related work, migration disposition, and next gate. Suggestions remain non-mutating; NeonDiff still does not apply labels, assign reviewers, approve, or merge.\n\n## Validation\n\n- 
> neondiff@1.0.4 test
> vitest run --run tests/issue-analysis.test.ts


 RUN  v3.2.6 /Users/m1/repos/work/neondiff-lcm-x-release

 ✓ tests/issue-analysis.test.ts (11 tests) 9ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  15:11:12
   Duration  143ms (transform 57ms, setup 0ms, collect 63ms, tests 9ms, environment 0ms, prepare 23ms)\n- 
> neondiff@1.0.4 build
> node scripts/prepare-build-output.mjs && tsc -p tsconfig.build.json


> neondiff@1.0.4 postbuild
> chmod +x dist/src/cli.js && node scripts/generate-secret-rules.mjs --check-node\n- \n\nCloses #783