### PR TITLE
docs: beta.78 production review canary

### DIFF
--- a/docs/canaries/beta78-public-review-canary.md
+++ b/docs/canaries/beta78-public-review-canary.md
@@ -1,0 +1,14 @@
+# Beta.78 public review canary
+
+This temporary documentation-only pull request verifies the installed NeonDiff
+beta.78 public review renderer against the exact pull-request head shown by
+GitHub.
+
+The review should explain this one-file documentation change, identify its
+relationship to issue #783, and report useful proof or readiness guidance. It
+must not publish internal review profiles, enabled-section configuration, path
+instructions, label or reviewer configuration, suggestion behavior, roadmap
+settings, prompts, or repository policy.
+
+This canary must not be merged. It does not change runtime behavior, labels,
+reviewers, approvals, repository settings, or release state.


### PR DESCRIPTION
Temporary documentation-only production canary for installed NeonDiff beta.78. Acceptance: the exact-head public review remains useful and contains no Review Settings Preview or internal profile, section, path, label/reviewer, suggestion, roadmap, prompt, or policy configuration. Related to #783. Do not merge; close after evidence is captured.