### PR TITLE
feat(eval): add strict issue corpus admission

### DIFF
--- a/src/issue-corpus-admission.ts
+++ b/src/issue-corpus-admission.ts
@@ -35,6 +35,18 @@ function identifier(value: unknown, label: string, pattern: RegExp): string {
   return result;
 }
 
+function gitBranch(value: unknown, label: string): string {
+  const result = text(value, label);
+  const components = result.split("/");
+  if (result === "@" || result.startsWith("-") || result.startsWith("/") || result.endsWith("/") ||
+      result.endsWith(".") || result.includes("//") || result.includes("..") || result.includes("@{") ||
+      /[\x00-\x20\x7f~^:?*\[\\]/.test(result) ||
+      components.some((component) => component.length === 0 || component.startsWith(".") || component.endsWith(".lock"))) {
+    return invalid(`${label} is not a valid Git branch name`);
+  }
+  return result;
+}
+
 function digest(value: unknown, label: string): string {
   const result = text(value, label);
   if (!SHA256.test(result)) return invalid(`${label} must be lowercase sha256`);
@@ -58,7 +70,7 @@ function parseScenario(value: unknown, index: number) {
   const repository = record(item.repository, `${label}.repository`, ["owner", "name", "defaultBranch", "headSha", "metadataSha256"]);
   const owner = identifier(repository.owner, `${label}.repository.owner`, /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/);
   const name = identifier(repository.name, `${label}.repository.name`, /^[A-Za-z0-9._-]{1,100}$/);
-  const defaultBranch = identifier(repository.defaultBranch, `${label}.repository.defaultBranch`, /^(?!\/)(?!.*(?:\/\/|\.\.|@\{))[A-Za-z0-9._\/-]+(?<!\/)$/);
+  const defaultBranch = gitBranch(repository.defaultBranch, `${label}.repository.defaultBranch`);
   const headSha = text(repository.headSha, `${label}.repository.headSha`);
   if (!COMMIT.test(headSha)) invalid(`${label}.repository.headSha must be lowercase commit sha`);
   const issue = record(item.issue, `${label}.issue`, ["number", "nodeId", "url", "snapshotSha256"]);

--- a/src/issue-corpus-admission.ts
+++ b/src/issue-corpus-admission.ts
@@ -23,8 +23,16 @@ function record(value: unknown, label: string, keys: readonly string[]): Record<
 }
 
 function text(value: unknown, label: string): string {
-  if (typeof value !== "string" || value.length === 0 || value.length > 1_000) return invalid(`${label} must be bounded text`);
+  if (typeof value !== "string" || value.length === 0 || value.length > 1_000 || value.trim() !== value) {
+    return invalid(`${label} must be canonical bounded text`);
+  }
   return value;
+}
+
+function identifier(value: unknown, label: string, pattern: RegExp): string {
+  const result = text(value, label);
+  if (!pattern.test(result)) return invalid(`${label} has invalid syntax`);
+  return result;
 }
 
 function digest(value: unknown, label: string): string {
@@ -48,14 +56,14 @@ function parseScenario(value: unknown, index: number) {
   const item = record(value, label, ["schemaVersion", "id", "repository", "issue", "category", "controls", "artifacts", "gold"]);
   literal(item.schemaVersion, "neondiff-issue-corpus-scenario/v1", `${label}.schemaVersion`);
   const repository = record(item.repository, `${label}.repository`, ["owner", "name", "defaultBranch", "headSha", "metadataSha256"]);
-  const owner = text(repository.owner, `${label}.repository.owner`);
-  const name = text(repository.name, `${label}.repository.name`);
-  const defaultBranch = text(repository.defaultBranch, `${label}.repository.defaultBranch`);
+  const owner = identifier(repository.owner, `${label}.repository.owner`, /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/);
+  const name = identifier(repository.name, `${label}.repository.name`, /^[A-Za-z0-9._-]{1,100}$/);
+  const defaultBranch = identifier(repository.defaultBranch, `${label}.repository.defaultBranch`, /^(?!\/)(?!.*(?:\/\/|\.\.|@\{))[A-Za-z0-9._\/-]+(?<!\/)$/);
   const headSha = text(repository.headSha, `${label}.repository.headSha`);
   if (!COMMIT.test(headSha)) invalid(`${label}.repository.headSha must be lowercase commit sha`);
   const issue = record(item.issue, `${label}.issue`, ["number", "nodeId", "url", "snapshotSha256"]);
   if (!Number.isSafeInteger(issue.number) || (issue.number as number) < 1) invalid(`${label}.issue.number must be positive`);
-  const nodeId = text(issue.nodeId, `${label}.issue.nodeId`);
+  const nodeId = identifier(issue.nodeId, `${label}.issue.nodeId`, /^[A-Za-z0-9_+/=-]+$/);
   const url = text(issue.url, `${label}.issue.url`);
   const issueSnapshotSha256 = digest(issue.snapshotSha256, `${label}.issue.snapshotSha256`);
   if (url !== `https://github.com/${owner}/${name}/issues/${issue.number}`) invalid(`${label}.issue.url must match identity`);
@@ -67,7 +75,7 @@ function parseScenario(value: unknown, index: number) {
   const artifacts = item.artifacts.map((entry, artifactIndex) => {
     const artifact = record(entry, `${label}.artifacts[${artifactIndex}]`, ["id", "kind", "sha256", "complete"]);
     return {
-      id: text(artifact.id, `${label}.artifacts[${artifactIndex}].id`),
+      id: identifier(artifact.id, `${label}.artifacts[${artifactIndex}].id`, /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/),
       kind: oneOf(artifact.kind, ARTIFACT_KINDS, `${label}.artifacts[${artifactIndex}].kind`),
       sha256: digest(artifact.sha256, `${label}.artifacts[${artifactIndex}].sha256`),
       complete: literal(artifact.complete, true, `${label}.artifacts[${artifactIndex}].complete`)
@@ -83,12 +91,16 @@ function parseScenario(value: unknown, index: number) {
   const gold = record(item.gold, `${label}.gold`, ["provenance", "protocolSha256", "receiptSha256", "comparatorDerived"]);
   return {
     schemaVersion: "neondiff-issue-corpus-scenario/v1" as const,
-    id: text(item.id, `${label}.id`),
+    id: identifier(item.id, `${label}.id`, /^[a-z0-9][a-z0-9._-]{0,127}$/),
     repository: { owner, name, defaultBranch, headSha, metadataSha256: digest(repository.metadataSha256, `${label}.repository.metadataSha256`) },
     issue: { number: issue.number as number, nodeId, url, snapshotSha256: issueSnapshotSha256 },
     category,
-    controls: controls as { preservationNoWrite: boolean; promptInjection: boolean; policyExfiltration: boolean },
-    artifacts,
+    controls: {
+      preservationNoWrite: controls.preservationNoWrite as boolean,
+      promptInjection: controls.promptInjection as boolean,
+      policyExfiltration: controls.policyExfiltration as boolean
+    },
+    artifacts: artifacts.sort((left, right) => ARTIFACT_KINDS.indexOf(left.kind) - ARTIFACT_KINDS.indexOf(right.kind)),
     gold: {
       provenance: literal(gold.provenance, "human_adjudication", `${label}.gold.provenance`),
       protocolSha256: digest(gold.protocolSha256, `${label}.gold.protocolSha256`),
@@ -110,9 +122,8 @@ export function admitIssueCorpus(value: unknown): {
   if (!Array.isArray(root.scenarios) || root.scenarios.length !== 60) invalid("corpus must contain exactly 60 scenarios");
   const scenarios = root.scenarios.map(parseScenario);
   if (new Set(scenarios.map((scenario) => scenario.id)).size !== 60) invalid("scenario ids must be unique");
-  if (new Set(scenarios.map((scenario) => `${scenario.repository.owner}/${scenario.repository.name}:${scenario.issue.nodeId}`)).size !== 60) {
-    invalid("issue identities must be unique");
-  }
+  if (new Set(scenarios.map((scenario) => scenario.issue.nodeId)).size !== 60) invalid("issue node ids must be globally unique");
+  if (new Set(scenarios.map((scenario) => scenario.issue.url)).size !== 60) invalid("issue urls must be unique");
   if (new Set(scenarios.map((scenario) => scenario.gold.receiptSha256)).size !== 60) invalid("gold receipts must be unique");
   if (new Set(scenarios.map((scenario) => `${scenario.repository.owner}/${scenario.repository.name}`)).size < 5) invalid("corpus must cover at least five repositories");
   const categoryCounts = Object.fromEntries(CATEGORIES.map((category) => [category, scenarios.filter((scenario) => scenario.category === category).length])) as Record<Category, number>;
@@ -124,6 +135,10 @@ export function admitIssueCorpus(value: unknown): {
       invalid(`category ${category} must include prompt-injection and policy-exfiltration controls`);
     }
   }
-  const canonical = JSON.stringify({ schemaVersion: "neondiff-issue-corpus/v1", frozenAt, scenarios });
+  const canonical = JSON.stringify({
+    schemaVersion: "neondiff-issue-corpus/v1",
+    frozenAt,
+    scenarios: [...scenarios].sort((left, right) => left.id.localeCompare(right.id))
+  });
   return { scenarioCount: 60, categoryCounts, corpusSha256: createHash("sha256").update(canonical).digest("hex") };
 }

--- a/src/issue-corpus-admission.ts
+++ b/src/issue-corpus-admission.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+
+const SHA256 = /^[a-f0-9]{64}$/;
+const COMMIT = /^[a-f0-9]{40}$/;
+const CATEGORIES = ["actionable", "duplicate_or_superseded", "needs_repro_or_defer", "preservation"] as const;
+const ARTIFACT_KINDS = ["issue", "comments", "timeline", "linked_items", "source_snapshot"] as const;
+type Category = typeof CATEGORIES[number];
+
+function invalid(label: string): never {
+  throw new Error(`issue_corpus_invalid: ${label}`);
+}
+
+function record(value: unknown, label: string, keys: readonly string[]): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+    return invalid(`${label} must be a plain object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    return invalid(`${label} fields must match the schema exactly`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function text(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 1_000) return invalid(`${label} must be bounded text`);
+  return value;
+}
+
+function digest(value: unknown, label: string): string {
+  const result = text(value, label);
+  if (!SHA256.test(result)) return invalid(`${label} must be lowercase sha256`);
+  return result;
+}
+
+function literal<T extends string | boolean>(value: unknown, expected: T, label: string): T {
+  if (value !== expected) return invalid(`${label} must equal ${String(expected)}`);
+  return expected;
+}
+
+function oneOf<T extends string>(value: unknown, allowed: readonly T[], label: string): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) return invalid(`${label} is not allowlisted`);
+  return value as T;
+}
+
+function parseScenario(value: unknown, index: number) {
+  const label = `scenarios[${index}]`;
+  const item = record(value, label, ["schemaVersion", "id", "repository", "issue", "category", "controls", "artifacts", "gold"]);
+  literal(item.schemaVersion, "neondiff-issue-corpus-scenario/v1", `${label}.schemaVersion`);
+  const repository = record(item.repository, `${label}.repository`, ["owner", "name", "defaultBranch", "headSha", "metadataSha256"]);
+  const owner = text(repository.owner, `${label}.repository.owner`);
+  const name = text(repository.name, `${label}.repository.name`);
+  const defaultBranch = text(repository.defaultBranch, `${label}.repository.defaultBranch`);
+  const headSha = text(repository.headSha, `${label}.repository.headSha`);
+  if (!COMMIT.test(headSha)) invalid(`${label}.repository.headSha must be lowercase commit sha`);
+  const issue = record(item.issue, `${label}.issue`, ["number", "nodeId", "url", "snapshotSha256"]);
+  if (!Number.isSafeInteger(issue.number) || (issue.number as number) < 1) invalid(`${label}.issue.number must be positive`);
+  const nodeId = text(issue.nodeId, `${label}.issue.nodeId`);
+  const url = text(issue.url, `${label}.issue.url`);
+  const issueSnapshotSha256 = digest(issue.snapshotSha256, `${label}.issue.snapshotSha256`);
+  if (url !== `https://github.com/${owner}/${name}/issues/${issue.number}`) invalid(`${label}.issue.url must match identity`);
+  const category = oneOf(item.category, CATEGORIES, `${label}.category`);
+  const controls = record(item.controls, `${label}.controls`, ["preservationNoWrite", "promptInjection", "policyExfiltration"]);
+  for (const key of Object.keys(controls)) if (typeof controls[key] !== "boolean") invalid(`${label}.controls.${key} must be boolean`);
+  if ((category === "preservation") !== controls.preservationNoWrite) invalid(`${label}.controls.preservationNoWrite must match category`);
+  if (!Array.isArray(item.artifacts) || item.artifacts.length !== ARTIFACT_KINDS.length) invalid(`${label}.artifacts must bind every evidence kind`);
+  const artifacts = item.artifacts.map((entry, artifactIndex) => {
+    const artifact = record(entry, `${label}.artifacts[${artifactIndex}]`, ["id", "kind", "sha256", "complete"]);
+    return {
+      id: text(artifact.id, `${label}.artifacts[${artifactIndex}].id`),
+      kind: oneOf(artifact.kind, ARTIFACT_KINDS, `${label}.artifacts[${artifactIndex}].kind`),
+      sha256: digest(artifact.sha256, `${label}.artifacts[${artifactIndex}].sha256`),
+      complete: literal(artifact.complete, true, `${label}.artifacts[${artifactIndex}].complete`)
+    };
+  });
+  if (new Set(artifacts.map((artifact) => artifact.id)).size !== artifacts.length ||
+      new Set(artifacts.map((artifact) => artifact.kind)).size !== ARTIFACT_KINDS.length) {
+    invalid(`${label}.artifacts must have unique ids and kinds`);
+  }
+  if (artifacts.find((artifact) => artifact.kind === "issue")?.sha256 !== issueSnapshotSha256) {
+    invalid(`${label}.issue.snapshotSha256 must bind the issue artifact`);
+  }
+  const gold = record(item.gold, `${label}.gold`, ["provenance", "protocolSha256", "receiptSha256", "comparatorDerived"]);
+  return {
+    schemaVersion: "neondiff-issue-corpus-scenario/v1" as const,
+    id: text(item.id, `${label}.id`),
+    repository: { owner, name, defaultBranch, headSha, metadataSha256: digest(repository.metadataSha256, `${label}.repository.metadataSha256`) },
+    issue: { number: issue.number as number, nodeId, url, snapshotSha256: issueSnapshotSha256 },
+    category,
+    controls: controls as { preservationNoWrite: boolean; promptInjection: boolean; policyExfiltration: boolean },
+    artifacts,
+    gold: {
+      provenance: literal(gold.provenance, "human_adjudication", `${label}.gold.provenance`),
+      protocolSha256: digest(gold.protocolSha256, `${label}.gold.protocolSha256`),
+      receiptSha256: digest(gold.receiptSha256, `${label}.gold.receiptSha256`),
+      comparatorDerived: literal(gold.comparatorDerived, false, `${label}.gold.comparatorDerived`)
+    }
+  };
+}
+
+export function admitIssueCorpus(value: unknown): {
+  scenarioCount: 60;
+  categoryCounts: Record<Category, number>;
+  corpusSha256: string;
+} {
+  const root = record(value, "corpus", ["schemaVersion", "frozenAt", "scenarios"]);
+  literal(root.schemaVersion, "neondiff-issue-corpus/v1", "corpus.schemaVersion");
+  const frozenAt = text(root.frozenAt, "corpus.frozenAt");
+  if (!Number.isFinite(Date.parse(frozenAt)) || new Date(frozenAt).toISOString() !== frozenAt) invalid("corpus.frozenAt must be canonical ISO-8601");
+  if (!Array.isArray(root.scenarios) || root.scenarios.length !== 60) invalid("corpus must contain exactly 60 scenarios");
+  const scenarios = root.scenarios.map(parseScenario);
+  if (new Set(scenarios.map((scenario) => scenario.id)).size !== 60) invalid("scenario ids must be unique");
+  if (new Set(scenarios.map((scenario) => `${scenario.repository.owner}/${scenario.repository.name}:${scenario.issue.nodeId}`)).size !== 60) {
+    invalid("issue identities must be unique");
+  }
+  if (new Set(scenarios.map((scenario) => scenario.gold.receiptSha256)).size !== 60) invalid("gold receipts must be unique");
+  if (new Set(scenarios.map((scenario) => `${scenario.repository.owner}/${scenario.repository.name}`)).size < 5) invalid("corpus must cover at least five repositories");
+  const categoryCounts = Object.fromEntries(CATEGORIES.map((category) => [category, scenarios.filter((scenario) => scenario.category === category).length])) as Record<Category, number>;
+  if (categoryCounts.actionable !== 30 || categoryCounts.duplicate_or_superseded !== 10 ||
+      categoryCounts.needs_repro_or_defer !== 10 || categoryCounts.preservation !== 10) invalid("category counts must be 30/10/10/10");
+  for (const category of CATEGORIES) {
+    const group = scenarios.filter((scenario) => scenario.category === category);
+    if (!group.some((scenario) => scenario.controls.promptInjection) || !group.some((scenario) => scenario.controls.policyExfiltration)) {
+      invalid(`category ${category} must include prompt-injection and policy-exfiltration controls`);
+    }
+  }
+  const canonical = JSON.stringify({ schemaVersion: "neondiff-issue-corpus/v1", frozenAt, scenarios });
+  return { scenarioCount: 60, categoryCounts, corpusSha256: createHash("sha256").update(canonical).digest("hex") };
+}

--- a/tests/issue-corpus-admission.test.ts
+++ b/tests/issue-corpus-admission.test.ts
@@ -81,10 +81,14 @@ describe("issue corpus admission", () => {
     ["bad digest", (value: any) => { value.scenarios[0].gold.receiptSha256 = "bad"; }],
     ["unbound issue snapshot", (value: any) => { value.scenarios[0].issue.snapshotSha256 = "c".repeat(64); }],
     ["duplicate gold receipt", (value: any) => { value.scenarios[1].gold.receiptSha256 = value.scenarios[0].gold.receiptSha256; }],
-    ["duplicate issue identity", (value: any) => {
+    ["duplicate global node id", (value: any) => { value.scenarios[1].issue.nodeId = value.scenarios[0].issue.nodeId; }],
+    ["duplicate issue url", (value: any) => {
       value.scenarios[1].repository = structuredClone(value.scenarios[0].repository);
-      value.scenarios[1].issue.nodeId = value.scenarios[0].issue.nodeId;
+      value.scenarios[1].issue.number = value.scenarios[0].issue.number;
+      value.scenarios[1].issue.url = value.scenarios[0].issue.url;
     }],
+    ["whitespace scenario id", (value: any) => { value.scenarios[0].id = "   "; }],
+    ["malformed default branch", (value: any) => { value.scenarios[0].repository.defaultBranch = "bad branch"; }],
     ["wrong category counts", (value: any) => { value.scenarios[29].category = "duplicate_or_superseded"; }],
     ["preservation control bypass", (value: any) => { value.scenarios[59].controls.preservationNoWrite = false; }],
     ["non-preservation write control", (value: any) => { value.scenarios[0].controls.preservationNoWrite = true; }],
@@ -93,5 +97,18 @@ describe("issue corpus admission", () => {
     const value: any = corpus();
     mutate(value);
     expect(() => admitIssueCorpus(value)).toThrow(/issue_corpus_invalid/);
+  });
+
+  it("hashes semantic corpus content independently of array and object insertion order", () => {
+    const first: any = corpus();
+    const second: any = corpus();
+    second.scenarios.reverse();
+    second.scenarios[0].artifacts.reverse();
+    second.scenarios[0].controls = {
+      policyExfiltration: second.scenarios[0].controls.policyExfiltration,
+      promptInjection: second.scenarios[0].controls.promptInjection,
+      preservationNoWrite: second.scenarios[0].controls.preservationNoWrite
+    };
+    expect(admitIssueCorpus(second).corpusSha256).toBe(admitIssueCorpus(first).corpusSha256);
   });
 });

--- a/tests/issue-corpus-admission.test.ts
+++ b/tests/issue-corpus-admission.test.ts
@@ -71,6 +71,12 @@ describe("issue corpus admission", () => {
     expect(admitted.corpusSha256).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("admits valid Git branch names containing plus signs", () => {
+    const value: any = corpus();
+    value.scenarios[0].repository.defaultBranch = "feature/foo+bar";
+    expect(admitIssueCorpus(value).scenarioCount).toBe(60);
+  });
+
   it.each([
     ["unknown top-level field", (value: any) => { value.extra = true; }],
     ["unknown nested field", (value: any) => { value.scenarios[0].issue.extra = true; }],

--- a/tests/issue-corpus-admission.test.ts
+++ b/tests/issue-corpus-admission.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { admitIssueCorpus } from "../src/issue-corpus-admission.js";
+
+const SHA = "a".repeat(64);
+const kinds = ["issue", "comments", "timeline", "linked_items", "source_snapshot"] as const;
+
+function scenario(index: number) {
+  const category = index < 30
+    ? "actionable"
+    : index < 40
+      ? "duplicate_or_superseded"
+      : index < 50
+        ? "needs_repro_or_defer"
+        : "preservation";
+  const categoryStart = category === "actionable" ? 0 : category === "duplicate_or_superseded" ? 30 : category === "needs_repro_or_defer" ? 40 : 50;
+  return {
+    schemaVersion: "neondiff-issue-corpus-scenario/v1",
+    id: `scenario-${index}`,
+    repository: {
+      owner: "example",
+      name: `repo-${index % 5}`,
+      defaultBranch: "main",
+      headSha: "b".repeat(40),
+      metadataSha256: SHA
+    },
+    issue: {
+      number: index + 1,
+      nodeId: `I_${index}`,
+      url: `https://github.com/example/repo-${index % 5}/issues/${index + 1}`,
+      snapshotSha256: SHA
+    },
+    category,
+    controls: {
+      preservationNoWrite: category === "preservation",
+      promptInjection: index === categoryStart,
+      policyExfiltration: index === categoryStart + 1
+    },
+    artifacts: kinds.map((kind) => ({
+      id: `${kind}-${index}`,
+      kind,
+      sha256: SHA,
+      complete: true
+    })),
+    gold: {
+      provenance: "human_adjudication",
+      protocolSha256: SHA,
+      receiptSha256: (index + 1).toString(16).padStart(64, "0"),
+      comparatorDerived: false
+    }
+  };
+}
+
+function corpus() {
+  return {
+    schemaVersion: "neondiff-issue-corpus/v1",
+    frozenAt: "2026-08-16T00:00:00.000Z",
+    scenarios: Array.from({ length: 60 }, (_, index) => scenario(index))
+  };
+}
+
+describe("issue corpus admission", () => {
+  it("admits only the frozen 30/10/10/10 corpus with complete immutable evidence", () => {
+    const admitted = admitIssueCorpus(corpus());
+    expect(admitted.scenarioCount).toBe(60);
+    expect(admitted.categoryCounts).toEqual({
+      actionable: 30,
+      duplicate_or_superseded: 10,
+      needs_repro_or_defer: 10,
+      preservation: 10
+    });
+    expect(admitted.corpusSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it.each([
+    ["unknown top-level field", (value: any) => { value.extra = true; }],
+    ["unknown nested field", (value: any) => { value.scenarios[0].issue.extra = true; }],
+    ["truthy non-boolean completeness", (value: any) => { value.scenarios[0].artifacts[0].complete = "true"; }],
+    ["comparator-derived gold", (value: any) => { value.scenarios[0].gold.comparatorDerived = true; }],
+    ["missing evidence kind", (value: any) => { value.scenarios[0].artifacts.pop(); }],
+    ["duplicate evidence kind", (value: any) => { value.scenarios[0].artifacts[1].kind = "issue"; }],
+    ["bad digest", (value: any) => { value.scenarios[0].gold.receiptSha256 = "bad"; }],
+    ["unbound issue snapshot", (value: any) => { value.scenarios[0].issue.snapshotSha256 = "c".repeat(64); }],
+    ["duplicate gold receipt", (value: any) => { value.scenarios[1].gold.receiptSha256 = value.scenarios[0].gold.receiptSha256; }],
+    ["duplicate issue identity", (value: any) => {
+      value.scenarios[1].repository = structuredClone(value.scenarios[0].repository);
+      value.scenarios[1].issue.nodeId = value.scenarios[0].issue.nodeId;
+    }],
+    ["wrong category counts", (value: any) => { value.scenarios[29].category = "duplicate_or_superseded"; }],
+    ["preservation control bypass", (value: any) => { value.scenarios[59].controls.preservationNoWrite = false; }],
+    ["non-preservation write control", (value: any) => { value.scenarios[0].controls.preservationNoWrite = true; }],
+    ["missing injection category", (value: any) => { value.scenarios[0].controls.promptInjection = false; }]
+  ])("rejects %s", (_name, mutate) => {
+    const value: any = corpus();
+    mutate(value);
+    expect(() => admitIssueCorpus(value)).toThrow(/issue_corpus_invalid/);
+  });
+});


### PR DESCRIPTION
Related: #790

## Summary

Adds the first split delivery slice for the frozen issue-enrichment corpus: strict, fail-closed admission of exactly 60 immutable scenarios.

This PR is stacked on `fix/788-review-enrichment-quality-v2`. It intentionally excludes evaluator scoring, provider execution, GitHub posting, runtime configuration, corpus population, and release behavior.

## Contract

- Exact 30 actionable / 10 duplicate-or-superseded / 10 needs-repro-or-defer / 10 preservation composition
- At least five repositories and unique scenario/issue identities
- Complete hash-bound issue, comments, timeline, linked-item, and source-snapshot artifacts
- Exact boolean control fields with preservation/category equivalence
- Human-adjudicated, comparator-independent, unique gold receipts
- Prompt-injection and policy-exfiltration controls in every category
- Canonical corpus digest independent of scenario, artifact, and object insertion order
- Git-compatible default-branch syntax plus global node-ID and issue-URL uniqueness

## Proof

- RED: focused test initially failed because the admission module did not exist
- `npm test -- --run tests/issue-corpus-admission.test.ts` — 20/20 passed
- `npx tsc --noEmit -p tsconfig.build.json` — passed
- `git diff --cached --check` — passed before commit
- Exact-head Build, test, and package — passed at `584df0010b81c163f3edbdee2e2826a183df1b65`
- Blind acceptance check — PASS, 98% confidence
- Blind adversarial check — PASS, 97% confidence

## Proof boundary

Source-only admission contract. This does not prove corpus gold quality, metric correctness, provider quality, merge readiness, beta.79 release readiness, runtime safety, or customer readiness.
