### PR TITLE
fix: bind issue adjudications to frozen gold protocol

### DIFF
--- a/src/issue-corpus-admission.ts
+++ b/src/issue-corpus-admission.ts
@@ -130,6 +130,7 @@ export function admitIssueCorpus(value: unknown): {
     id: string;
     category: Category;
     artifactSha256s: string[];
+    goldProtocolSha256: string;
     goldReceiptSha256: string;
   }>;
 } {
@@ -166,6 +167,7 @@ export function admitIssueCorpus(value: unknown): {
       id: scenario.id,
       category: scenario.category,
       artifactSha256s: scenario.artifacts.map((artifact) => artifact.sha256),
+      goldProtocolSha256: scenario.gold.protocolSha256,
       goldReceiptSha256: scenario.gold.receiptSha256
     }))
   };

--- a/src/issue-corpus-evaluator.ts
+++ b/src/issue-corpus-evaluator.ts
@@ -72,7 +72,7 @@ function sha(value: unknown): string {
   return createHash("sha256").update(stable(value)).digest("hex");
 }
 
-function adjudicationPair(value: unknown, targetSha256: string, label: string, allowed: readonly string[]): string {
+function adjudicationPair(value: unknown, targetSha256: string, protocolSha256: string, label: string, allowed: readonly string[]): string {
   if (!Array.isArray(value) || value.length !== 2) return invalid(`${label} requires two adjudications`);
   const parsed = value.map((entry, index) => {
     const item = record(entry, `${label}[${index}]`, [
@@ -84,7 +84,7 @@ function adjudicationPair(value: unknown, targetSha256: string, label: string, a
     if (digest(item.targetSha256, `${label}[${index}].targetSha256`) !== targetSha256) invalid(`${label}[${index}] target mismatch`);
     const decision = string(item.decision, `${label}[${index}].decision`);
     if (!allowed.includes(decision)) invalid(`${label}[${index}] decision`);
-    const protocolSha256 = digest(item.protocolSha256, `${label}[${index}].protocolSha256`);
+    if (digest(item.protocolSha256, `${label}[${index}].protocolSha256`) !== protocolSha256) invalid(`${label}[${index}] protocol mismatch`);
     if (item.blind !== true) invalid(`${label}[${index}] must be blind`);
     if (item.comparatorDerived !== false) invalid(`${label}[${index}] comparator-derived adjudication`);
     const basis = { schemaVersion: item.schemaVersion, adjudicator, targetSha256, decision, protocolSha256, blind: true, comparatorDerived: false };
@@ -157,7 +157,7 @@ export function evaluateIssueCorpusRun(corpus: unknown, value: unknown) {
       if (seenFactIds.has(basis.id)) invalid(`${factLabel} duplicate fact id`);
       seenFactIds.add(basis.id);
       if (!binding.artifactSha256s.includes(basis.sourceArtifactSha256)) invalid(`${factLabel} source reference is unresolved`);
-      const decision = adjudicationPair(fact.adjudications, sha({ scenarioId, fact: basis }), `${factLabel}.adjudications`, ["entailed", "unsupported"]);
+      const decision = adjudicationPair(fact.adjudications, sha({ scenarioId, fact: basis }), binding.goldProtocolSha256, `${factLabel}.adjudications`, ["entailed", "unsupported"]);
       factCount += 1;
       if (decision !== "entailed") unsupportedFactCount += 1;
       if (decision === "entailed" && basis.novel) hasNovelEntailedFact = true;
@@ -181,7 +181,7 @@ export function evaluateIssueCorpusRun(corpus: unknown, value: unknown) {
       };
       if (seenJudgmentIds.has(basis.id)) invalid(`${judgmentLabel} duplicate judgment id`);
       seenJudgmentIds.add(basis.id);
-      if (adjudicationPair(judgment.adjudications, sha({ scenarioId, judgment: basis }), `${judgmentLabel}.adjudications`, ["accepted", "rejected"]) !== "accepted") {
+      if (adjudicationPair(judgment.adjudications, sha({ scenarioId, judgment: basis }), binding.goldProtocolSha256, `${judgmentLabel}.adjudications`, ["accepted", "rejected"]) !== "accepted") {
         invalid(`${judgmentLabel} was not independently accepted`);
       }
       units.get(metric)!.push({ predicted: basis.predictedPositive, gold: basis.goldPositive });
@@ -195,7 +195,7 @@ export function evaluateIssueCorpusRun(corpus: unknown, value: unknown) {
     const { auditReceiptSha256: _auditReceipt, adjudications: auditAdjudications, ...rawAuditBasis } = audit;
     const auditTarget = sha({ scenarioId, goldReceiptSha256: binding.goldReceiptSha256, audit: rawAuditBasis });
     if (digest(audit.auditReceiptSha256, `${label}.audit.auditReceiptSha256`) !== auditTarget) invalid(`${label} audit receipt mismatch`);
-    if (adjudicationPair(auditAdjudications, auditTarget, `${label}.audit.adjudications`, ["accepted", "rejected"]) !== "accepted") {
+    if (adjudicationPair(auditAdjudications, auditTarget, binding.goldProtocolSha256, `${label}.audit.adjudications`, ["accepted", "rejected"]) !== "accepted") {
       invalid(`${label} audit was not independently accepted`);
     }
     if (audit.schemaVersion !== "neondiff-issue-operation-audit/v1") invalid(`${label} audit schemaVersion`);

--- a/tests/issue-corpus-evaluator.test.ts
+++ b/tests/issue-corpus-evaluator.test.ts
@@ -186,6 +186,16 @@ describe("issue corpus evaluator", () => {
     expect(() => evaluateIssueCorpusRun(corpus, run)).toThrow(/blind/);
   });
 
+  it("rejects adjudication under a protocol other than the scenario gold protocol", () => {
+    const { corpus, run }: any = packet();
+    const fact = run.results[0].facts[0];
+    fact.adjudications[0].protocolSha256 = "c".repeat(64);
+    const { receiptSha256: _receipt, ...basis } = fact.adjudications[0];
+    fact.adjudications[0].receiptSha256 = hash(basis);
+    sealRun(run);
+    expect(() => evaluateIssueCorpusRun(corpus, run)).toThrow(/protocol mismatch/);
+  });
+
   it("fails the benchmark when an independently scored fact is unsupported", () => {
     const { corpus, run }: any = packet();
     const result = run.results[0];


### PR DESCRIPTION
Related: #790

## Summary

Closes a corpus-sealing bypass found while populating the 60-scenario issue benchmark: fact, metric, and audit adjudications previously accepted any syntactically valid protocol hash, even when it differed from the scenario's frozen gold protocol.

This PR is stacked on `fix/788-review-enrichment-quality-v2`. It adds no provider calls, output changes, GitHub writes, configuration changes, or production behavior.

## Change

- expose each scenario's admitted `gold.protocolSha256` in its evaluator binding
- require every fact, metric, and operation-audit adjudication to match that exact protocol hash
- retain the existing distinct-human, blind, comparator-independent, target-bound receipt checks

## Proof

- RED: a re-sealed fact adjudication using a different protocol hash passed before the fix
- GREEN: `npx vitest run tests/issue-corpus-evaluator.test.ts tests/issue-corpus-admission.test.ts` — 31/31 passed
- GREEN: `npx tsc --noEmit -p tsconfig.build.json`
- GREEN: `git diff --check`
- Exact-head `Build, test, and package` — PASS at `8348c5a1448a7b0067e0871f5afd72ef3c03f7f6`: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/31956299242/job/95187346763
- Blind acceptance review — PASS, 98% confidence
- Blind adversarial review — PASS, 96% confidence; mixed-human, cross-class, cross-scenario, and re-sealed protocol attacks rejected
- Final review state before readiness: 0 review threads, 0 unresolved

## Proof boundary

Source-only protocol binding. This does not authenticate either human, populate or seal gold, invoke a provider, prove benchmark quality, release beta.79, change runtime state, or establish customer readiness.
