### PR TITLE
fix: close final public output guard gaps

### DIFF
--- a/src/issue-analysis.ts
+++ b/src/issue-analysis.ts
@@ -686,7 +686,11 @@ export function findIssueAnalysisPublicLeaks(
   text: string,
   repoPolicy: IssueAnalysisPolicyContext
 ): string[] {
-  const normalizedMarkerText = text.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+  const normalizedMarkerText = text
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
   const leaks = hasRepoPolicyHeading(text) ? ["repo_policy_heading"] : [];
   leaks.push(...PUBLIC_CONFIG_LEAK_PATTERNS
     .filter((entry) => entry.pattern.test(normalizedMarkerText))
@@ -710,7 +714,8 @@ export function findIssueAnalysisPublicLeaks(
 }
 
 function hasRepoPolicyHeading(text: string): boolean {
-  return /^\s*(?:#{1,6}\s*)?repo[^a-z0-9\r\n]+policy(?:\s*:\s*.*)?\s*$/imu.test(text);
+  return /^\s*(?:#{1,6}\s*)?repo[^a-z0-9\r\n]+policy(?:\s*:\s*.*)?\s*$/imu.test(text) ||
+    /^\s*(?:#{1,6}\s*)?[rR]epoPolicy(?:\s*:\s*.*)?\s*$/mu.test(text);
 }
 
 function hasSharedPolicyFragment(text: string, policy: string, wordCount: number): boolean {

--- a/src/issue-analysis.ts
+++ b/src/issue-analysis.ts
@@ -284,17 +284,17 @@ const ISSUE_ANALYSIS_TEXT_KEYS = [
   "nextGate"
 ] as const;
 const GENERIC_NEXT_GATE_PATTERN = /^(investigate|investigate further|review|review further|needs review|needs investigation|todo|tbd)[.!]?$/i;
-const PUBLIC_CONFIG_LEAK_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
-  { label: "review_settings_preview", pattern: /review settings preview/i },
-  { label: "advisory_policy_key", pattern: /\badvisory policy\b/i },
-  { label: "validation_suggestions_key", pattern: /\bvalidation suggestions\b/i },
-  { label: "enabled_sections", pattern: /\benabled sections\b/i },
-  { label: "path_instructions", pattern: /\bpath instructions\b/i },
-  { label: "suggestion_behavior", pattern: /\bsuggestion behavior\b/i },
-  { label: "roadmap_settings", pattern: /\broadmap only settings\b/i },
-  { label: "agent_start_packet", pattern: /\bagent start packet\b/i },
-  { label: "planner_scaffolding", pattern: /\bbuild borrow buy scan\b/i },
-  { label: "context_source_taxonomy", pattern: /\bcontext source taxonomy\b/i }
+const PUBLIC_CONFIG_LEAK_MARKERS: Array<{ label: string; marker: string }> = [
+  { label: "review_settings_preview", marker: "review settings preview" },
+  { label: "advisory_policy_key", marker: "advisory policy" },
+  { label: "validation_suggestions_key", marker: "validation suggestions" },
+  { label: "enabled_sections", marker: "enabled sections" },
+  { label: "path_instructions", marker: "path instructions" },
+  { label: "suggestion_behavior", marker: "suggestion behavior" },
+  { label: "roadmap_settings", marker: "roadmap only settings" },
+  { label: "agent_start_packet", marker: "agent start packet" },
+  { label: "planner_scaffolding", marker: "build borrow buy scan" },
+  { label: "context_source_taxonomy", marker: "context source taxonomy" }
 ];
 const ISSUE_STOPWORDS = new Set([
   "about",
@@ -686,14 +686,9 @@ export function findIssueAnalysisPublicLeaks(
   text: string,
   repoPolicy: IssueAnalysisPolicyContext
 ): string[] {
-  const normalizedMarkerText = text
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
   const leaks = hasRepoPolicyHeading(text) ? ["repo_policy_heading"] : [];
-  leaks.push(...PUBLIC_CONFIG_LEAK_PATTERNS
-    .filter((entry) => entry.pattern.test(normalizedMarkerText))
+  leaks.push(...PUBLIC_CONFIG_LEAK_MARKERS
+    .filter((entry) => containsCanonicalPublicConfigMarker(text, entry.marker))
     .map((entry) => entry.label));
   const normalizedText = normalizeComparableText(text);
   const policySources = [
@@ -714,8 +709,42 @@ export function findIssueAnalysisPublicLeaks(
 }
 
 function hasRepoPolicyHeading(text: string): boolean {
-  return /^\s*(?:#{1,6}\s*)?repo[^a-z0-9\r\n]+policy(?:\s*:\s*.*)?\s*$/imu.test(text) ||
-    /^\s*(?:#{1,6}\s*)?[rR]epoPolicy(?:\s*:\s*.*)?\s*$/mu.test(text);
+  return text.split(/\r?\n/).some((rawLine) => {
+    const trimmed = rawLine.trim();
+    const markdownHeading = /^#{1,6}\s*/.test(trimmed);
+    let content = trimmed.replace(/^#{1,6}\s*/, "").trim();
+    const quoted = /^`+.*`+$/.test(content);
+    if (quoted) content = content.replace(/^`+|`+$/g, "").trim();
+    const colonIndex = content.indexOf(":");
+    const key = colonIndex >= 0 ? content.slice(0, colonIndex) : content;
+    if (compactPublicConfigMarkerText(key) !== "repopolicy") return false;
+    return colonIndex >= 0 || markdownHeading || quoted ||
+      compactPublicConfigMarkerText(content) === "repopolicy";
+  });
+}
+
+function normalizePublicConfigMarkerText(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function compactPublicConfigMarkerText(value: string): string {
+  return normalizePublicConfigMarkerText(value).replaceAll(" ", "");
+}
+
+function containsCanonicalPublicConfigMarker(value: string, marker: string): boolean {
+  const tokens = normalizePublicConfigMarkerText(value).split(" ").filter(Boolean);
+  const compactMarker = compactPublicConfigMarkerText(marker);
+  return tokens.some((_, start) => {
+    let candidate = "";
+    for (let index = start; index < tokens.length && candidate.length < compactMarker.length; index += 1) {
+      candidate += tokens[index];
+    }
+    return candidate === compactMarker;
+  });
 }
 
 function hasSharedPolicyFragment(text: string, policy: string, wordCount: number): boolean {

--- a/src/issue-analysis.ts
+++ b/src/issue-analysis.ts
@@ -285,10 +285,9 @@ const ISSUE_ANALYSIS_TEXT_KEYS = [
 ] as const;
 const GENERIC_NEXT_GATE_PATTERN = /^(investigate|investigate further|review|review further|needs review|needs investigation|todo|tbd)[.!]?$/i;
 const PUBLIC_CONFIG_LEAK_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
-  { label: "repo_policy_heading", pattern: /\brepo policy\b/i },
   { label: "review_settings_preview", pattern: /review settings preview/i },
-  { label: "advisory_policy_key", pattern: /\badvisoryPolicy\b/i },
-  { label: "validation_suggestions_key", pattern: /\bvalidationSuggestions\b/i },
+  { label: "advisory_policy_key", pattern: /\badvisory policy\b/i },
+  { label: "validation_suggestions_key", pattern: /\bvalidation suggestions\b/i },
   { label: "enabled_sections", pattern: /\benabled sections\b/i },
   { label: "path_instructions", pattern: /\bpath instructions\b/i },
   { label: "suggestion_behavior", pattern: /\bsuggestion behavior\b/i },
@@ -688,9 +687,10 @@ export function findIssueAnalysisPublicLeaks(
   repoPolicy: IssueAnalysisPolicyContext
 ): string[] {
   const normalizedMarkerText = text.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
-  const leaks = PUBLIC_CONFIG_LEAK_PATTERNS
+  const leaks = hasRepoPolicyHeading(text) ? ["repo_policy_heading"] : [];
+  leaks.push(...PUBLIC_CONFIG_LEAK_PATTERNS
     .filter((entry) => entry.pattern.test(normalizedMarkerText))
-    .map((entry) => entry.label);
+    .map((entry) => entry.label));
   const normalizedText = normalizeComparableText(text);
   const policySources = [
     repoPolicy.advisoryPolicy ?? "",
@@ -707,6 +707,10 @@ export function findIssueAnalysisPublicLeaks(
     }
   }
   return [...new Set(leaks)];
+}
+
+function hasRepoPolicyHeading(text: string): boolean {
+  return /^\s*(?:#{1,6}\s*)?repo[^a-z0-9\r\n]+policy(?:\s*:\s*.*)?\s*$/imu.test(text);
 }
 
 function hasSharedPolicyFragment(text: string, policy: string, wordCount: number): boolean {

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -431,11 +431,11 @@ const PUBLIC_REVIEW_CONFIG_LEAK_PATTERNS = [
   /\bsuggestion behavior\b/i,
   /\broadmap only settings\b/i,
   /\brepo specific instruction\b/i,
-  /\bpromptNote\b/i,
-  /\breviewRiskLens\b/i,
-  /\bproofExpectations\b/i,
-  /\bvalidationHints\b/i,
-  /\breadinessHints\b/i
+  /\bprompt note\b/i,
+  /\breview risk lens\b/i,
+  /\bproof expectations\b/i,
+  /\bvalidation hints\b/i,
+  /\breadiness hints\b/i
 ] as const;
 
 export function assertPublicReviewOutputSafe(

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -424,18 +424,18 @@ export function buildRepoProfilePromptSection(
   return lines.join("\n");
 }
 
-const PUBLIC_REVIEW_CONFIG_LEAK_PATTERNS = [
-  /review settings preview/i,
-  /\benabled sections\b/i,
-  /\bpath instructions\b/i,
-  /\bsuggestion behavior\b/i,
-  /\broadmap only settings\b/i,
-  /\brepo specific instruction\b/i,
-  /\bprompt note\b/i,
-  /\breview risk lens\b/i,
-  /\bproof expectations\b/i,
-  /\bvalidation hints\b/i,
-  /\breadiness hints\b/i
+const PUBLIC_REVIEW_CONFIG_LEAK_MARKERS = [
+  "review settings preview",
+  "enabled sections",
+  "path instructions",
+  "suggestion behavior",
+  "roadmap only settings",
+  "repo specific instruction",
+  "prompt note",
+  "review risk lens",
+  "proof expectations",
+  "validation hints",
+  "readiness hints"
 ] as const;
 
 export function assertPublicReviewOutputSafe(
@@ -444,7 +444,7 @@ export function assertPublicReviewOutputSafe(
   sharedWordWindow = 0
 ): void {
   const normalized = normalizePublicLeakText(text);
-  if (PUBLIC_REVIEW_CONFIG_LEAK_PATTERNS.some((pattern) => pattern.test(normalized))) {
+  if (PUBLIC_REVIEW_CONFIG_LEAK_MARKERS.some((marker) => containsCanonicalPublicLeakMarker(text, marker))) {
     throw new Error("public_review_config_leak_rejected");
   }
   if (forbiddenFragments.some((fragment) => {
@@ -464,6 +464,22 @@ function normalizePublicLeakText(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
+}
+
+function compactPublicLeakText(value: string): string {
+  return normalizePublicLeakText(value).replaceAll(" ", "");
+}
+
+function containsCanonicalPublicLeakMarker(value: string, marker: string): boolean {
+  const tokens = normalizePublicLeakText(value).split(" ").filter(Boolean);
+  const compactMarker = compactPublicLeakText(marker);
+  return tokens.some((_, start) => {
+    let candidate = "";
+    for (let index = start; index < tokens.length && candidate.length < compactMarker.length; index += 1) {
+      candidate += tokens[index];
+    }
+    return candidate === compactMarker;
+  });
 }
 
 function hasSharedForbiddenWordWindow(text: string, forbidden: string, wordCount: number): boolean {

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -459,7 +459,11 @@ export function assertPublicReviewOutputSafe(
 }
 
 function normalizePublicLeakText(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
 }
 
 function hasSharedForbiddenWordWindow(text: string, forbidden: string, wordCount: number): boolean {

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -132,10 +132,24 @@ describe("review and issue-enrichment quality v2", () => {
       "pathInstructions: hidden configuration",
       "suggestionBehavior: hidden configuration",
       "roadmapOnlySettings: hidden configuration",
-      "repoSpecificInstruction: hidden configuration"
+      "repoSpecificInstruction: hidden configuration",
+      "PROMPTNOTE: hidden configuration",
+      "REVIEWRISKLENS: hidden configuration",
+      "PROOFEXPECTATIONS: hidden configuration",
+      "VALIDATIONHINTS: hidden configuration",
+      "READINESSHINTS: hidden configuration",
+      "REVIEWSETTINGSPREVIEW: hidden configuration",
+      "ENABLEDSECTIONS: hidden configuration",
+      "PATHINSTRUCTIONS: hidden configuration",
+      "SUGGESTIONBEHAVIOR: hidden configuration",
+      "ROADMAPONLYSETTINGS: hidden configuration",
+      "REPOSPECIFICINSTRUCTION: hidden configuration"
     ]) {
       expect(() => assertPublicReviewOutputSafe(leaked)).toThrow("public_review_config_leak_rejected");
     }
+    expect(() => assertPublicReviewOutputSafe(
+      "The PROMPTNOTEBOOK helper was renamed and the previewer remains unchanged."
+    )).not.toThrow();
 
     const profile: ResolvedRepoProfile = {
       repo: "electricsheephq/lcm-x",
@@ -191,7 +205,20 @@ describe("review and issue-enrichment quality v2", () => {
       "roadmapOnlySettings: hidden configuration",
       "agentStartPacket: hidden configuration",
       "buildBorrowBuyScan: hidden configuration",
-      "contextSourceTaxonomy: hidden configuration"
+      "contextSourceTaxonomy: hidden configuration",
+      "REPOPOLICY: hidden configuration",
+      "ADVISORYPOLICY: hidden configuration",
+      "VALIDATIONSUGGESTIONS: hidden configuration",
+      "REVIEWSETTINGSPREVIEW: hidden configuration",
+      "ENABLEDSECTIONS: hidden configuration",
+      "PATHINSTRUCTIONS: hidden configuration",
+      "SUGGESTIONBEHAVIOR: hidden configuration",
+      "ROADMAPONLYSETTINGS: hidden configuration",
+      "AGENTSTARTPACKET: hidden configuration",
+      "BUILDBORROWBUYSCAN: hidden configuration",
+      "CONTEXTSOURCETAXONOMY: hidden configuration",
+      "### `RepoPolicy`",
+      "`Repo policy`"
     ]) {
       expect(() => assertIssueAnalysisPublicSafe(
         leaked,
@@ -200,6 +227,10 @@ describe("review and issue-enrichment quality v2", () => {
     }
     expect(() => assertIssueAnalysisPublicSafe(
       "Source: src/repo-policy.ts:1-2",
+      { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
+    )).not.toThrow();
+    expect(() => assertIssueAnalysisPublicSafe(
+      "The REPOPOLICYMODULE parser resolves that source path.",
       { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
     )).not.toThrow();
   });

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -121,7 +121,18 @@ describe("review and issue-enrichment quality v2", () => {
       "review-Risk-Lens: hidden configuration",
       "proof-Expectations: hidden configuration",
       "validation-Hints: hidden configuration",
-      "readiness-Hints: hidden configuration"
+      "readiness-Hints: hidden configuration",
+      "promptNote: hidden configuration",
+      "reviewRiskLens: hidden configuration",
+      "proofExpectations: hidden configuration",
+      "validationHints: hidden configuration",
+      "readinessHints: hidden configuration",
+      "reviewSettingsPreview: hidden configuration",
+      "enabledSections: hidden configuration",
+      "pathInstructions: hidden configuration",
+      "suggestionBehavior: hidden configuration",
+      "roadmapOnlySettings: hidden configuration",
+      "repoSpecificInstruction: hidden configuration"
     ]) {
       expect(() => assertPublicReviewOutputSafe(leaked)).toThrow("public_review_config_leak_rejected");
     }
@@ -169,7 +180,18 @@ describe("review and issue-enrichment quality v2", () => {
     for (const leaked of [
       "advisory-Policy: hidden configuration",
       "validation-Suggestions: hidden configuration",
-      "Repo-policy: hidden configuration"
+      "Repo-policy: hidden configuration",
+      "repoPolicy: hidden configuration",
+      "advisoryPolicy: hidden configuration",
+      "validationSuggestions: hidden configuration",
+      "reviewSettingsPreview: hidden configuration",
+      "enabledSections: hidden configuration",
+      "pathInstructions: hidden configuration",
+      "suggestionBehavior: hidden configuration",
+      "roadmapOnlySettings: hidden configuration",
+      "agentStartPacket: hidden configuration",
+      "buildBorrowBuyScan: hidden configuration",
+      "contextSourceTaxonomy: hidden configuration"
     ]) {
       expect(() => assertIssueAnalysisPublicSafe(
         leaked,

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -116,7 +116,12 @@ describe("review and issue-enrichment quality v2", () => {
       "Roadmap-only settings",
       "Repo-specific instruction: hidden policy",
       "Review-settings-preview",
-      "Path\u2011instructions"
+      "Path\u2011instructions",
+      "prompt-Note: hidden configuration",
+      "review-Risk-Lens: hidden configuration",
+      "proof-Expectations: hidden configuration",
+      "validation-Hints: hidden configuration",
+      "readiness-Hints: hidden configuration"
     ]) {
       expect(() => assertPublicReviewOutputSafe(leaked)).toThrow("public_review_config_leak_rejected");
     }
@@ -161,6 +166,20 @@ describe("review and issue-enrichment quality v2", () => {
       "Suggestion-behavior",
       { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
     )).toThrow("issue_analysis_public_leak_rejected");
+    for (const leaked of [
+      "advisory-Policy: hidden configuration",
+      "validation-Suggestions: hidden configuration",
+      "Repo-policy: hidden configuration"
+    ]) {
+      expect(() => assertIssueAnalysisPublicSafe(
+        leaked,
+        { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
+      )).toThrow("issue_analysis_public_leak_rejected");
+    }
+    expect(() => assertIssueAnalysisPublicSafe(
+      "Source: src/repo-policy.ts:1-2",
+      { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
+    )).not.toThrow();
   });
 
   it("defers preservation promotion to the authenticated cycle and rejects stale issue snapshots", () => {


### PR DESCRIPTION
Stacked follow-up for #790 and #795.

Closes exactly the two verified P1s from the final #795 adversarial pass:
- normalize remaining camelCase config markers before public-output matching;
- make Repo policy detection heading-aware so legitimate src/repo-policy.ts citations remain valid.

Focused proof: review/enrichment regression suite 21/21, build PASS, diff check clean.

Gate: exact-head CI plus two fresh blind AI reviewers at 95 or higher with no verified P0/P1. Human-gold and comparator-superiority claims remain out of scope.