### PR TITLE
fix: canonicalize public config marker matching

### DIFF
--- a/src/issue-analysis.ts
+++ b/src/issue-analysis.ts
@@ -284,17 +284,17 @@ const ISSUE_ANALYSIS_TEXT_KEYS = [
   "nextGate"
 ] as const;
 const GENERIC_NEXT_GATE_PATTERN = /^(investigate|investigate further|review|review further|needs review|needs investigation|todo|tbd)[.!]?$/i;
-const PUBLIC_CONFIG_LEAK_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
-  { label: "review_settings_preview", pattern: /review settings preview/i },
-  { label: "advisory_policy_key", pattern: /\badvisory policy\b/i },
-  { label: "validation_suggestions_key", pattern: /\bvalidation suggestions\b/i },
-  { label: "enabled_sections", pattern: /\benabled sections\b/i },
-  { label: "path_instructions", pattern: /\bpath instructions\b/i },
-  { label: "suggestion_behavior", pattern: /\bsuggestion behavior\b/i },
-  { label: "roadmap_settings", pattern: /\broadmap only settings\b/i },
-  { label: "agent_start_packet", pattern: /\bagent start packet\b/i },
-  { label: "planner_scaffolding", pattern: /\bbuild borrow buy scan\b/i },
-  { label: "context_source_taxonomy", pattern: /\bcontext source taxonomy\b/i }
+const PUBLIC_CONFIG_LEAK_MARKERS: Array<{ label: string; marker: string }> = [
+  { label: "review_settings_preview", marker: "review settings preview" },
+  { label: "advisory_policy_key", marker: "advisory policy" },
+  { label: "validation_suggestions_key", marker: "validation suggestions" },
+  { label: "enabled_sections", marker: "enabled sections" },
+  { label: "path_instructions", marker: "path instructions" },
+  { label: "suggestion_behavior", marker: "suggestion behavior" },
+  { label: "roadmap_settings", marker: "roadmap only settings" },
+  { label: "agent_start_packet", marker: "agent start packet" },
+  { label: "planner_scaffolding", marker: "build borrow buy scan" },
+  { label: "context_source_taxonomy", marker: "context source taxonomy" }
 ];
 const ISSUE_STOPWORDS = new Set([
   "about",
@@ -686,14 +686,9 @@ export function findIssueAnalysisPublicLeaks(
   text: string,
   repoPolicy: IssueAnalysisPolicyContext
 ): string[] {
-  const normalizedMarkerText = text
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
   const leaks = hasRepoPolicyHeading(text) ? ["repo_policy_heading"] : [];
-  leaks.push(...PUBLIC_CONFIG_LEAK_PATTERNS
-    .filter((entry) => entry.pattern.test(normalizedMarkerText))
+  leaks.push(...PUBLIC_CONFIG_LEAK_MARKERS
+    .filter((entry) => containsCanonicalPublicConfigMarker(text, entry.marker))
     .map((entry) => entry.label));
   const normalizedText = normalizeComparableText(text);
   const policySources = [
@@ -714,8 +709,42 @@ export function findIssueAnalysisPublicLeaks(
 }
 
 function hasRepoPolicyHeading(text: string): boolean {
-  return /^\s*(?:#{1,6}\s*)?repo[^a-z0-9\r\n]+policy(?:\s*:\s*.*)?\s*$/imu.test(text) ||
-    /^\s*(?:#{1,6}\s*)?[rR]epoPolicy(?:\s*:\s*.*)?\s*$/mu.test(text);
+  return text.split(/\r?\n/).some((rawLine) => {
+    const trimmed = rawLine.trim();
+    const markdownHeading = /^#{1,6}\s*/.test(trimmed);
+    let content = trimmed.replace(/^#{1,6}\s*/, "").trim();
+    const quoted = /^`+.*`+$/.test(content);
+    if (quoted) content = content.replace(/^`+|`+$/g, "").trim();
+    const colonIndex = content.indexOf(":");
+    const key = colonIndex >= 0 ? content.slice(0, colonIndex) : content;
+    if (compactPublicConfigMarkerText(key) !== "repopolicy") return false;
+    return colonIndex >= 0 || markdownHeading || quoted ||
+      compactPublicConfigMarkerText(content) === "repopolicy";
+  });
+}
+
+function normalizePublicConfigMarkerText(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function compactPublicConfigMarkerText(value: string): string {
+  return normalizePublicConfigMarkerText(value).replaceAll(" ", "");
+}
+
+function containsCanonicalPublicConfigMarker(value: string, marker: string): boolean {
+  const tokens = normalizePublicConfigMarkerText(value).split(" ").filter(Boolean);
+  const compactMarker = compactPublicConfigMarkerText(marker);
+  return tokens.some((_, start) => {
+    let candidate = "";
+    for (let index = start; index < tokens.length && candidate.length < compactMarker.length; index += 1) {
+      candidate += tokens[index];
+    }
+    return candidate === compactMarker;
+  });
 }
 
 function hasSharedPolicyFragment(text: string, policy: string, wordCount: number): boolean {

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -424,18 +424,18 @@ export function buildRepoProfilePromptSection(
   return lines.join("\n");
 }
 
-const PUBLIC_REVIEW_CONFIG_LEAK_PATTERNS = [
-  /review settings preview/i,
-  /\benabled sections\b/i,
-  /\bpath instructions\b/i,
-  /\bsuggestion behavior\b/i,
-  /\broadmap only settings\b/i,
-  /\brepo specific instruction\b/i,
-  /\bprompt note\b/i,
-  /\breview risk lens\b/i,
-  /\bproof expectations\b/i,
-  /\bvalidation hints\b/i,
-  /\breadiness hints\b/i
+const PUBLIC_REVIEW_CONFIG_LEAK_MARKERS = [
+  "review settings preview",
+  "enabled sections",
+  "path instructions",
+  "suggestion behavior",
+  "roadmap only settings",
+  "repo specific instruction",
+  "prompt note",
+  "review risk lens",
+  "proof expectations",
+  "validation hints",
+  "readiness hints"
 ] as const;
 
 export function assertPublicReviewOutputSafe(
@@ -444,7 +444,7 @@ export function assertPublicReviewOutputSafe(
   sharedWordWindow = 0
 ): void {
   const normalized = normalizePublicLeakText(text);
-  if (PUBLIC_REVIEW_CONFIG_LEAK_PATTERNS.some((pattern) => pattern.test(normalized))) {
+  if (PUBLIC_REVIEW_CONFIG_LEAK_MARKERS.some((marker) => containsCanonicalPublicLeakMarker(text, marker))) {
     throw new Error("public_review_config_leak_rejected");
   }
   if (forbiddenFragments.some((fragment) => {
@@ -464,6 +464,22 @@ function normalizePublicLeakText(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
+}
+
+function compactPublicLeakText(value: string): string {
+  return normalizePublicLeakText(value).replaceAll(" ", "");
+}
+
+function containsCanonicalPublicLeakMarker(value: string, marker: string): boolean {
+  const tokens = normalizePublicLeakText(value).split(" ").filter(Boolean);
+  const compactMarker = compactPublicLeakText(marker);
+  return tokens.some((_, start) => {
+    let candidate = "";
+    for (let index = start; index < tokens.length && candidate.length < compactMarker.length; index += 1) {
+      candidate += tokens[index];
+    }
+    return candidate === compactMarker;
+  });
 }
 
 function hasSharedForbiddenWordWindow(text: string, forbidden: string, wordCount: number): boolean {

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -132,10 +132,24 @@ describe("review and issue-enrichment quality v2", () => {
       "pathInstructions: hidden configuration",
       "suggestionBehavior: hidden configuration",
       "roadmapOnlySettings: hidden configuration",
-      "repoSpecificInstruction: hidden configuration"
+      "repoSpecificInstruction: hidden configuration",
+      "PROMPTNOTE: hidden configuration",
+      "REVIEWRISKLENS: hidden configuration",
+      "PROOFEXPECTATIONS: hidden configuration",
+      "VALIDATIONHINTS: hidden configuration",
+      "READINESSHINTS: hidden configuration",
+      "REVIEWSETTINGSPREVIEW: hidden configuration",
+      "ENABLEDSECTIONS: hidden configuration",
+      "PATHINSTRUCTIONS: hidden configuration",
+      "SUGGESTIONBEHAVIOR: hidden configuration",
+      "ROADMAPONLYSETTINGS: hidden configuration",
+      "REPOSPECIFICINSTRUCTION: hidden configuration"
     ]) {
       expect(() => assertPublicReviewOutputSafe(leaked)).toThrow("public_review_config_leak_rejected");
     }
+    expect(() => assertPublicReviewOutputSafe(
+      "The PROMPTNOTEBOOK helper was renamed and the previewer remains unchanged."
+    )).not.toThrow();
 
     const profile: ResolvedRepoProfile = {
       repo: "electricsheephq/lcm-x",
@@ -191,7 +205,20 @@ describe("review and issue-enrichment quality v2", () => {
       "roadmapOnlySettings: hidden configuration",
       "agentStartPacket: hidden configuration",
       "buildBorrowBuyScan: hidden configuration",
-      "contextSourceTaxonomy: hidden configuration"
+      "contextSourceTaxonomy: hidden configuration",
+      "REPOPOLICY: hidden configuration",
+      "ADVISORYPOLICY: hidden configuration",
+      "VALIDATIONSUGGESTIONS: hidden configuration",
+      "REVIEWSETTINGSPREVIEW: hidden configuration",
+      "ENABLEDSECTIONS: hidden configuration",
+      "PATHINSTRUCTIONS: hidden configuration",
+      "SUGGESTIONBEHAVIOR: hidden configuration",
+      "ROADMAPONLYSETTINGS: hidden configuration",
+      "AGENTSTARTPACKET: hidden configuration",
+      "BUILDBORROWBUYSCAN: hidden configuration",
+      "CONTEXTSOURCETAXONOMY: hidden configuration",
+      "### `RepoPolicy`",
+      "`Repo policy`"
     ]) {
       expect(() => assertIssueAnalysisPublicSafe(
         leaked,
@@ -200,6 +227,10 @@ describe("review and issue-enrichment quality v2", () => {
     }
     expect(() => assertIssueAnalysisPublicSafe(
       "Source: src/repo-policy.ts:1-2",
+      { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
+    )).not.toThrow();
+    expect(() => assertIssueAnalysisPublicSafe(
+      "The REPOPOLICYMODULE parser resolves that source path.",
       { validationSuggestions: [], suggestedLabels: [], suggestedReviewers: [], labelAliases: {} }
     )).not.toThrow();
   });


### PR DESCRIPTION
Stacked final remediation for #790 and #796.

Replaces variant-specific public config leak matching with canonical whole-token-window matching. It rejects spaced, punctuation-separated, camelCase, and contiguous uppercase forms without substring false positives. Repo policy detection now handles quoted and Markdown headings while allowing legitimate source paths and ordinary module prose.

Focused proof: review/enrichment regression suite 21/21, TypeScript build PASS, diff check clean.

Gate: exact-head CI plus two blind AI reviewers at 95 or higher with no verified reachable P0/P1. Human-gold and comparator-superiority claims remain out of scope.