### PR TITLE
fix: bind issue canaries to runtime credentials

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1337,6 +1337,13 @@ async function main(): Promise<void> {
   }
 
   if (command === "issue-enrichment-run") {
+    const runtimeCredentials = await resolveRuntimeCredentialEnvelope({
+      command,
+      subcommand: undefined,
+      runtimeCredentialsStdin: args["runtime-credentials-stdin"],
+      stdin: process.stdin
+    });
+    await withRuntimeGitHubCredentials(runtimeCredentials, async () => {
     if (!args.repo) throw new Error("--repo is required for issue-enrichment-run");
     const repo = parseSingleArg(args.repo, "--repo");
     const issueNumbers = parseIssueNumberArgs(args.issue);
@@ -1488,6 +1495,7 @@ async function main(): Promise<void> {
       if (preacquiredLease && !leaseTransferredToCycle) state.releaseIssueEnrichmentRunLease(preacquiredLease.leaseId);
       state.close();
     }
+    });
     return;
   }
 

--- a/src/runtime-github-credentials.ts
+++ b/src/runtime-github-credentials.ts
@@ -65,10 +65,11 @@ export async function resolveRuntimeCredentialEnvelope(input: {
 }): Promise<RuntimeGitHubCredentials | undefined> {
   if (input.runtimeCredentialsStdin === undefined) return undefined;
   const supportedCommand = input.command === "review-pr"
+    || input.command === "issue-enrichment-run"
     || (input.command === "daemon" && input.subcommand === undefined);
   if (!supportedCommand) {
     throw new Error(
-      "runtime credential stdin is supported only for review-pr or the raw daemon process"
+      "runtime credential stdin is supported only for review-pr, issue-enrichment-run, or the raw daemon process"
     );
   }
   if (Array.isArray(input.runtimeCredentialsStdin)

--- a/tests/runtime-github-credentials.test.ts
+++ b/tests/runtime-github-credentials.test.ts
@@ -139,6 +139,7 @@ describe("runtime GitHub credentials", () => {
         .toBe("nd_live_runtime_fixture_1234");
       expect(readRuntimeLicenseMachineId()).toBe(brokerDeviceId);
     });
+    expect(readRuntimeLicenseMachineId()).toBeUndefined();
   });
 
   it("preserves runtime App credentials when related-context options are copied", async () => {

--- a/tests/runtime-github-credentials.test.ts
+++ b/tests/runtime-github-credentials.test.ts
@@ -117,6 +117,30 @@ describe("runtime GitHub credentials", () => {
     expect(readRuntimeLicenseMachineId()).toBeUndefined();
   });
 
+  it("accepts the signed-app credential envelope for a selected issue-enrichment run", async () => {
+    const credentials = await resolveRuntimeCredentialEnvelope({
+      command: "issue-enrichment-run",
+      subcommand: undefined,
+      runtimeCredentialsStdin: "true",
+      stdin: Readable.from([JSON.stringify({
+        schemaVersion: 2,
+        githubAppId: "4184532",
+        githubPrivateKey: privateKey,
+        licenseKey: "nd_live_runtime_fixture_1234",
+        licenseMachineId: brokerDeviceId
+      })])
+    });
+
+    await withRuntimeGitHubCredentials(credentials, async () => {
+      const config = loadConfigFromObject({ github: {} });
+      expect(config.github.appId).toBe("4184532");
+      expect(config.github.privateKey).toBe(privateKey.trim());
+      expect(productionLicenseSecretReader.read(config.license!))
+        .toBe("nd_live_runtime_fixture_1234");
+      expect(readRuntimeLicenseMachineId()).toBe(brokerDeviceId);
+    });
+  });
+
   it("preserves runtime App credentials when related-context options are copied", async () => {
     const credentials = await resolveRuntimeCredentialEnvelope({
       command: "review-pr",


### PR DESCRIPTION
Related: #788\n\nBeta.79's first live LCM-X issue canary failed closed before any GitHub write because `issue-enrichment-run` did not enter the signed desktop runtime-credential context. This narrow follow-up permits the existing bounded App-key/license-key stdin envelope for the selected issue command, matching the already-supported daemon and `review-pr` paths without persisting credentials.\n\nEvidence:\n- RED: the new runtime-credential test failed with `runtime credential stdin is supported only for review-pr or the raw daemon process`.\n- GREEN: `npx vitest run tests/runtime-github-credentials.test.ts tests/enrichment-cli.test.ts` — 39/39 passed.\n- `npm run build` passed.\n- Candidate dry-run on LCM-X #153 reached the authenticated preservation gate and returned `preservation_only_upstream_intake` with zero comment intent.\n- No LCM-X GitHub write occurred.\n\nScope boundary: no changes to prompts, analysis schemas, publication rendering, labels, assignments, approvals, merges, or project fields. Target release after gates: v1.1.0-beta.80 build 11084.