### PR TITLE
Fix signed-app issue enrichment canary handoff

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerDaemonRunner.swift
@@ -10,8 +10,11 @@ enum FoundationKeychainWorkerDaemonRunner {
         arguments: [String] = Array(CommandLine.arguments.dropFirst()),
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
     ) {
-        guard arguments.first
-            == DesktopKeychainWorkerLaunchAgentContract.headlessFlag
+        guard let flag = arguments.first,
+              [
+                DesktopKeychainWorkerLaunchAgentContract.headlessFlag,
+                DesktopKeychainWorkerLaunchAgentContract.issueRunFlag
+              ].contains(flag)
         else {
             return
         }
@@ -31,16 +34,20 @@ enum FoundationKeychainWorkerDaemonRunner {
         arguments: [String],
         homeDirectory: URL
     ) throws -> Int32 {
-        guard let request =
-            DesktopKeychainWorkerLaunchAgentContract
-                .parseHeadlessArguments(
-                    arguments,
-                    homeDirectory: homeDirectory
-                ),
+        let daemonRequest = DesktopKeychainWorkerLaunchAgentContract
+            .parseHeadlessArguments(arguments, homeDirectory: homeDirectory)
+        let issueRequest = DesktopKeychainWorkerLaunchAgentContract
+            .parseIssueRunArguments(arguments, homeDirectory: homeDirectory)
+        guard (daemonRequest == nil) != (issueRequest == nil),
+              let appID = daemonRequest?.appID ?? issueRequest?.appID,
+              let licenseMachineID = daemonRequest?.licenseMachineID
+                ?? issueRequest?.licenseMachineID,
+              let configPath = daemonRequest?.configPath
+                ?? issueRequest?.configPath,
               UserDefaults.standard.string(forKey: appIDPreferenceKey)
-                == request.appID,
+                == appID,
               isSafeConfig(
-                URL(filePath: request.configPath),
+                URL(filePath: configPath),
                 homeDirectory: homeDirectory
               ),
               let context =
@@ -57,7 +64,7 @@ enum FoundationKeychainWorkerDaemonRunner {
         let identity = try GitHubBrokerDeviceIdentityStore(
             secretStore: secretStore
         ).loadExisting(allowUserInteraction: false)
-        guard identity.deviceId == request.licenseMachineID else {
+        guard identity.deviceId == licenseMachineID else {
             throw WorkerDaemonRunnerError.invalidInvocation
         }
         guard let stored = try secretStore.readSecret(
@@ -71,10 +78,10 @@ enum FoundationKeychainWorkerDaemonRunner {
             throw WorkerDaemonRunnerError.keychainUnavailable
         }
         var standardInput = try DesktopRuntimeCredentialEnvelope(
-            appID: request.appID,
+            appID: appID,
             privateKey: stored,
             licenseKey: licenseKey,
-            licenseMachineID: request.licenseMachineID
+            licenseMachineID: licenseMachineID
         ).encodedData()
         defer {
             standardInput.resetBytes(in: 0..<standardInput.count)
@@ -97,14 +104,22 @@ enum FoundationKeychainWorkerDaemonRunner {
             terminationSource.cancel()
         }
         process.executableURL = URL(filePath: workerPath)
-        process.arguments =
-            DesktopKeychainWorkerLaunchAgentContract
-                .sealedWorkerDaemonArguments(request: request)
+        if let issueRequest {
+            process.arguments = DesktopKeychainWorkerLaunchAgentContract
+                .sealedWorkerIssueRunArguments(request: issueRequest)
+        } else if let daemonRequest {
+            process.arguments = DesktopKeychainWorkerLaunchAgentContract
+                .sealedWorkerDaemonArguments(request: daemonRequest)
+        } else {
+            throw WorkerDaemonRunnerError.invalidInvocation
+        }
         process.environment = boundedEnvironment(homeDirectory: homeDirectory)
         process.currentDirectoryURL =
-            URL(filePath: request.configPath).deletingLastPathComponent()
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+            URL(filePath: configPath).deletingLastPathComponent()
+        process.standardOutput = issueRequest == nil
+            ? FileHandle.nullDevice : FileHandle.standardOutput
+        process.standardError = issueRequest == nil
+            ? FileHandle.nullDevice : FileHandle.standardError
         let inputPipe = Pipe()
         process.standardInput = inputPipe
         try process.run()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -77,6 +77,45 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
     }
 }
 
+package struct DesktopKeychainWorkerIssueRunRequest: Equatable, Sendable {
+    package let appID: String
+    package let licenseMachineID: String
+    package let configPath: String
+    package let repository: String
+    package let issueNumber: Int
+
+    package init(
+        appID: String,
+        licenseMachineID: String,
+        configPath: String,
+        repository: String,
+        issueNumber: Int,
+        homeDirectory: URL
+    ) throws {
+        let validated = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            licenseMachineID: licenseMachineID,
+            configPath: configPath,
+            launchdLabel: "com.electricsheephq.NeonDiffDesktop.issue-run",
+            homeDirectory: homeDirectory
+        )
+        guard repository.range(
+            of: #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidRepository
+        }
+        guard issueNumber > 0 else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidIssueNumber
+        }
+        self.appID = validated.appID
+        self.licenseMachineID = validated.licenseMachineID
+        self.configPath = validated.configPath
+        self.repository = repository
+        self.issueNumber = issueNumber
+    }
+}
+
 package enum DesktopKeychainWorkerLaunchAgentError:
     Error,
     LocalizedError
@@ -85,6 +124,8 @@ package enum DesktopKeychainWorkerLaunchAgentError:
     case invalidConfigPath
     case invalidLaunchdLabel
     case invalidLicenseMachineID
+    case invalidRepository
+    case invalidIssueNumber
     case invalidAppExecutable
     case serializationFailed
 
@@ -98,6 +139,10 @@ package enum DesktopKeychainWorkerLaunchAgentError:
             "The local worker LaunchAgent label is invalid."
         case .invalidLicenseMachineID:
             "The local worker license device identity is invalid."
+        case .invalidRepository:
+            "The selected issue repository is invalid."
+        case .invalidIssueNumber:
+            "The selected issue number must be positive."
         case .invalidAppExecutable:
             "The signed NeonDiff app executable path is invalid."
         case .serializationFailed:
@@ -114,6 +159,7 @@ package enum DesktopKeychainWorkerLaunchAgentRestartOutcome: Equatable {
 
 package enum DesktopKeychainWorkerLaunchAgentContract {
     package static let headlessFlag = "--neondiff-worker-daemon"
+    package static let issueRunFlag = "--neondiff-worker-issue-run"
     package static let restartObservationAttempts = 120
     package static let restartObservationIntervalMicroseconds: UInt32 = 250_000
 
@@ -163,6 +209,49 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             "--runtime-credentials-stdin", "true",
             "--dry-run", "false"
         ]
+    }
+
+    package static func sealedWorkerIssueRunArguments(
+        request: DesktopKeychainWorkerIssueRunRequest
+    ) -> [String] {
+        [
+            "issue-enrichment-run",
+            "--config", request.configPath,
+            "--repo", request.repository,
+            "--issue", String(request.issueNumber),
+            "--dry-run", "false",
+            "--confirm", "true",
+            "--runtime-credentials-stdin", "true"
+        ]
+    }
+
+    package static func parseIssueRunArguments(
+        _ arguments: [String],
+        homeDirectory: URL
+    ) -> DesktopKeychainWorkerIssueRunRequest? {
+        guard arguments.count == 15,
+              arguments[0] == issueRunFlag,
+              arguments[1] == "--config",
+              arguments[3] == "--github-app-id",
+              arguments[5] == "--license-machine-id",
+              arguments[7] == "--repo",
+              arguments[9] == "--issue",
+              arguments[11] == "--dry-run",
+              arguments[12] == "false",
+              arguments[13] == "--confirm",
+              arguments[14] == "true",
+              let issueNumber = Int(arguments[10])
+        else {
+            return nil
+        }
+        return try? DesktopKeychainWorkerIssueRunRequest(
+            appID: arguments[4],
+            licenseMachineID: arguments[6],
+            configPath: arguments[2],
+            repository: arguments[8],
+            issueNumber: issueNumber,
+            homeDirectory: homeDirectory
+        )
     }
 
     package static func redactedPreviewText(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -130,6 +130,57 @@ import NeonDiffDesktopCore
         #expect(!arguments.contains(licenseMachineID))
     }
 
+    @Test func signedAppIssueRunIsExactLiveAndSecretFree() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let publicArguments = [
+            "--neondiff-worker-issue-run",
+            "--config", config.path,
+            "--github-app-id", appID,
+            "--license-machine-id", licenseMachineID,
+            "--repo", "electricsheephq/lcm-x",
+            "--issue", "153",
+            "--dry-run", "false",
+            "--confirm", "true"
+        ]
+        let request = try #require(
+            DesktopKeychainWorkerLaunchAgentContract.parseIssueRunArguments(
+                publicArguments,
+                homeDirectory: home
+            )
+        )
+
+        #expect(DesktopKeychainWorkerLaunchAgentContract
+            .sealedWorkerIssueRunArguments(request: request) == [
+                "issue-enrichment-run",
+                "--config", config.path,
+                "--repo", "electricsheephq/lcm-x",
+                "--issue", "153",
+                "--dry-run", "false",
+                "--confirm", "true",
+                "--runtime-credentials-stdin", "true"
+            ])
+        #expect(!DesktopKeychainWorkerLaunchAgentContract
+            .sealedWorkerIssueRunArguments(request: request).contains(appID))
+        var dryRun = publicArguments
+        dryRun[12] = "true"
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseIssueRunArguments(
+            dryRun,
+            homeDirectory: home
+        ) == nil)
+        var invalidRepository = publicArguments
+        invalidRepository[8] = "bad repo"
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseIssueRunArguments(
+            invalidRepository,
+            homeDirectory: home
+        ) == nil)
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseIssueRunArguments(
+            publicArguments + ["--private-key", "forbidden"],
+            homeDirectory: home
+        ) == nil)
+    }
+
     @Test func previewExposesTheCompleteRedactedMutationPlan() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"


### PR DESCRIPTION
Closes the release blocker recorded on #788 after the beta.80 installed canary.\n\nThe signed desktop now exposes one strict one-shot issue-enrichment runner that:\n- accepts only an account-scoped config, exact App ID/device identity, one owner/repo, one positive issue number, `--dry-run false`, and `--confirm true`;\n- reads the existing app-owned GitHub App and license credentials from Keychain without exposing them in arguments, environment, files, or logs;\n- passes one bounded runtime envelope to the sealed bundled worker;\n- preserves the existing daemon path and adds no label, assignment, reviewer, approval, merge, project, prompt, renderer, or policy changes.\n\nProof:\n- focused Swift contract suite: 20/20 passed;\n- `git diff --check`: passed;\n- delta: 3 files, +174/-19 (193 changed lines, under the 200-line governor stop).\n\nThe production gate remains blocked until exact-head CI/review, signed beta.81 release, installed LCM-X #153/#35/#39 canaries, and public-output/cleanup evidence pass.