### PR TITLE
Fix signed issue canary recovery

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -83,6 +83,7 @@ package struct DesktopKeychainWorkerIssueRunRequest: Equatable, Sendable {
     package let configPath: String
     package let repository: String
     package let issueNumber: Int
+    package let force: Bool
 
     package init(
         appID: String,
@@ -90,6 +91,7 @@ package struct DesktopKeychainWorkerIssueRunRequest: Equatable, Sendable {
         configPath: String,
         repository: String,
         issueNumber: Int,
+        force: Bool = false,
         homeDirectory: URL
     ) throws {
         let validated = try DesktopKeychainWorkerLaunchAgentRequest(
@@ -113,6 +115,7 @@ package struct DesktopKeychainWorkerIssueRunRequest: Equatable, Sendable {
         self.configPath = validated.configPath
         self.repository = repository
         self.issueNumber = issueNumber
+        self.force = force
     }
 }
 
@@ -214,7 +217,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
     package static func sealedWorkerIssueRunArguments(
         request: DesktopKeychainWorkerIssueRunRequest
     ) -> [String] {
-        [
+        var arguments = [
             "issue-enrichment-run",
             "--config", request.configPath,
             "--repo", request.repository,
@@ -223,13 +226,18 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             "--confirm", "true",
             "--runtime-credentials-stdin", "true"
         ]
+        if request.force {
+            arguments.append(contentsOf: ["--force", "true"])
+        }
+        return arguments
     }
 
     package static func parseIssueRunArguments(
         _ arguments: [String],
         homeDirectory: URL
     ) -> DesktopKeychainWorkerIssueRunRequest? {
-        guard arguments.count == 15,
+        let force = arguments.count == 17
+        guard (arguments.count == 15 || force),
               arguments[0] == issueRunFlag,
               arguments[1] == "--config",
               arguments[3] == "--github-app-id",
@@ -240,6 +248,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
               arguments[12] == "false",
               arguments[13] == "--confirm",
               arguments[14] == "true",
+              (!force || (arguments[15] == "--force" && arguments[16] == "true")),
               let issueNumber = Int(arguments[10])
         else {
             return nil
@@ -250,6 +259,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             configPath: arguments[2],
             repository: arguments[8],
             issueNumber: issueNumber,
+            force: force,
             homeDirectory: homeDirectory
         )
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -179,6 +179,22 @@ import NeonDiffDesktopCore
             publicArguments + ["--private-key", "forbidden"],
             homeDirectory: home
         ) == nil)
+
+        let forcedPublicArguments = publicArguments + ["--force", "true"]
+        let forcedRequest = try #require(
+            DesktopKeychainWorkerLaunchAgentContract.parseIssueRunArguments(
+                forcedPublicArguments,
+                homeDirectory: home
+            )
+        )
+        #expect(DesktopKeychainWorkerLaunchAgentContract
+            .sealedWorkerIssueRunArguments(request: forcedRequest).suffix(2) == [
+                "--force", "true"
+            ])
+        #expect(DesktopKeychainWorkerLaunchAgentContract.parseIssueRunArguments(
+            publicArguments + ["--force", "false"],
+            homeDirectory: home
+        ) == nil)
     }
 
     @Test func previewExposesTheCompleteRedactedMutationPlan() throws {


### PR DESCRIPTION
Related: #788

## Outcome

Expose the existing operator-gated `issue-enrichment-run --force true` recovery through the signed desktop one-shot runner. This lets an authenticated maintainer rerun a selected actionable issue whose earlier failed/skipped receipt would otherwise suppress the production canary.

## Safety

- Only exact trailing `--force true` is accepted.
- `--force false`, extra arguments, invalid repository/issue/config coordinates, and secret-bearing arguments fail closed.
- Credentials remain in the bounded stdin envelope; no GitHub mutation type is added.
- Suggestions remain advisory.

## Validation

- RED: focused Swift suite rejected the required forced runner shape.
- GREEN: `swift test --package-path apps/neondiff-desktop --filter DesktopKeychainWorkerLaunchAgentTests` (20/20).
- `git diff --check`.

Agent-authored narrow production-canary recovery delta.