### PR TITLE
Keep supported issue facts when entailment is partial

### DIFF
--- a/src/issue-analysis.ts
+++ b/src/issue-analysis.ts
@@ -272,17 +272,28 @@ export async function runIssueAnalysis(input: {
     parse: (value) => parseIssueFactEntailment(value, result.value.verifiedFacts.length)
   }, dependencies);
   const unsupported = entailment.value.filter((fact) => !fact.entailed);
+  const unsupportedIndexes = new Set(unsupported.map((fact) => fact.index));
+  const supportedFacts = result.value.verifiedFacts.filter((_fact, index) => !unsupportedIndexes.has(index));
+  const acceptedAnalysis = supportedFacts.length > 0
+    ? { ...result.value, verifiedFacts: supportedFacts }
+    : result.value;
   writeSecureFileSync(
     join(input.evidenceDir, "issue-analysis-fact-entailment.json"),
-    `${JSON.stringify({ ok: unsupported.length === 0, facts: entailment.value }, null, 2)}\n`
+    `${JSON.stringify({
+      ok: supportedFacts.length > 0,
+      originalFactCount: result.value.verifiedFacts.length,
+      publishedFactCount: supportedFacts.length,
+      removedFacts: unsupported.map((fact) => ({ index: fact.index, rationale: fact.rationale })),
+      facts: entailment.value
+    }, null, 2)}\n`
   );
-  if (unsupported.length > 0) {
+  if (supportedFacts.length === 0) {
     throw new Error(`issue_analysis_fact_not_entailed: ${unsupported.map((fact) => `verifiedFacts[${fact.index}]`).join(",")}`);
   }
   const scorecard = evaluateIssueAnalysisQuality({
     repo: input.repo,
     issue: input.issue,
-    analysis: result.value,
+    analysis: acceptedAnalysis,
     repoPolicy: input.repoPolicy,
     suggestedLabels: input.suggestedLabels,
     allowedLabels: input.allowedLabels
@@ -296,7 +307,7 @@ export async function runIssueAnalysis(input: {
     throw new Error(`issue_analysis_quality_rejected: ${failed.join(",")}`);
   }
   return {
-    analysis: result.value,
+    analysis: acceptedAnalysis,
     scorecard,
     rawResponse: result.rawResponse
   };

--- a/tests/issue-analysis.test.ts
+++ b/tests/issue-analysis.test.ts
@@ -443,4 +443,66 @@ describe("model-backed issue analysis", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("publishes only facts that pass entailment when at least one verified fact remains", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-issue-entailment-filter-"));
+    try {
+      const evidenceDir = join(root, "evidence");
+      const workspacePath = join(root, "workspace");
+      mkdirSync(join(workspacePath, "src"), { recursive: true });
+      writeFileSync(join(workspacePath, "src/importer.py"), "def replay(message):\n    insert_replay_row(message)\n");
+      const partlyUnsupported = {
+        ...analysis,
+        verifiedFacts: [
+          analysis.verifiedFacts[0]!,
+          {
+            claim: "The importer encrypts every replay row before persistence.",
+            sourceRef: analysis.verifiedFacts[0]!.sourceRef
+          }
+        ]
+      } satisfies IssueAnalysis;
+
+      const result = await runIssueAnalysis({
+        repo: "electricsheephq/lcm-x",
+        issue,
+        repoPolicy,
+        allowedLabels: ["data-integrity", "needs-repro"],
+        suggestedLabels: ["needs-repro"],
+        workspacePath,
+        headSha: HEAD_SHA,
+        evidenceDir,
+        cliPath: "/Users/test/.local/bin/codex",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        timeoutMs: 30_000,
+        maxOutputBytes: 1024 * 1024
+      }, {
+        captureWorktreeState: () => "clean",
+        runProcess: async (invocation) => {
+          writeFileSync(invocation.outputPath, JSON.stringify(
+            invocation.outputPath.includes("fact-adjudication")
+              ? {
+                  facts: [
+                    { index: 0, entailed: true, rationale: "The call supports the claim." },
+                    { index: 1, entailed: false, rationale: "The excerpt contains no encryption behavior." }
+                  ]
+                }
+              : partlyUnsupported
+          ));
+          return { stdout: "", stderr: "", status: 0, signal: null };
+        }
+      });
+
+      expect(result.analysis.verifiedFacts).toEqual([analysis.verifiedFacts[0]]);
+      expect(JSON.parse(readFileSync(join(evidenceDir, "issue-analysis-fact-entailment.json"), "utf8")))
+        .toMatchObject({
+          ok: true,
+          originalFactCount: 2,
+          publishedFactCount: 1,
+          removedFacts: [{ index: 1, rationale: "The excerpt contains no encryption behavior." }]
+        });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Related: #788

## Production failure

Beta.83 proved preservation-only issue #153 skips before model/posting, but actionable LCM-X canaries #35 and #39 both failed closed after source verification because one or two otherwise nonessential model claims were broader than their cited excerpts. No GitHub comment was posted.

## Change

- retain exact source identity, path, line, excerpt, schema, and independent entailment checks
- exclude any fact rejected by entailment from the publishable structured result
- preserve rejected indexes and rationales in the local evidence ledger
- fail closed when no supported verified fact remains

This does not weaken prompt/config leak rejection or authorize labels, owners, reviewers, approvals, merges, or project writes.

## Proof

- RED: the new partial-entailment scenario failed with `issue_analysis_fact_not_entailed: verifiedFacts[1]`
- GREEN: `npx vitest run tests/issue-analysis.test.ts tests/issue-enrichment-policy.test.ts tests/review-enrichment-quality-v2.test.ts` (30 passed)
- `npm run build`
- `git diff --check`

Agent-authored change. Production canaries and any release remain separate gates.
