### PR TITLE
fix: avoid false-positive public review leak rejection

### DIFF
--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -438,6 +438,8 @@ const PUBLIC_REVIEW_CONFIG_LEAK_MARKERS = [
   "readiness hints"
 ] as const;
 
+export const PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW = 8;
+
 export function assertPublicReviewOutputSafe(
   text: string,
   forbiddenFragments: string[] = [],

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1916,7 +1916,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     const forbiddenPromptFragments = reviewPromptForbiddenFragments();
     const assertReviewOutputSafe = (text: string) => {
       assertPublicReviewOutputSafe(text, forbiddenPromptFragments);
-      assertPublicReviewOutputSafe(text, forbiddenProfileFragments, 3);
+      assertPublicReviewOutputSafe(text, forbiddenProfileFragments, 8);
     };
     writeRedactedJson(join(evidenceDir, "review-settings-preview.json"), settingsPreview);
     if (commandDecision.action !== "none") {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -48,6 +48,7 @@ import {
   buildReviewSettingsPreview,
   filterPullFilesForProfile,
   listReposToScan,
+  PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW,
   publicReviewForbiddenProfileFragments,
   resolveRepoProfile
 } from "./repo-policy.js";
@@ -1916,7 +1917,11 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     const forbiddenPromptFragments = reviewPromptForbiddenFragments();
     const assertReviewOutputSafe = (text: string) => {
       assertPublicReviewOutputSafe(text, forbiddenPromptFragments);
-      assertPublicReviewOutputSafe(text, forbiddenProfileFragments, 8);
+      assertPublicReviewOutputSafe(
+        text,
+        forbiddenProfileFragments,
+        PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
+      );
     };
     writeRedactedJson(join(evidenceDir, "review-settings-preview.json"), settingsPreview);
     if (commandDecision.action !== "none") {

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   assertPublicReviewOutputSafe,
   buildRepoProfilePromptSection,
+  PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW,
   publicReviewForbiddenProfileFragments,
   type ResolvedRepoProfile
 } from "../src/repo-policy.js";
@@ -185,22 +186,22 @@ describe("review and issue-enrichment quality v2", () => {
     expect(() => assertPublicReviewOutputSafe(
       "Check lossless ordering",
       publicReviewForbiddenProfileFragments(profile),
-      8
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).not.toThrow();
     expect(() => assertPublicReviewOutputSafe(
       "Check-lossless-ordering",
       publicReviewForbiddenProfileFragments(profile),
-      8
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).not.toThrow();
     expect(() => assertPublicReviewOutputSafe(
       "Check lossless ordering provenance and crash safe SQLite",
       publicReviewForbiddenProfileFragments(profile),
-      8
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).toThrow("public_review_config_leak_rejected");
     expect(() => assertPublicReviewOutputSafe(
       "Assistant messages with a null tool-call field now serialize without crashing; the diff adds direct regression coverage.",
       publicReviewForbiddenProfileFragments(profile),
-      8
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).not.toThrow();
     const canaryProfile: ResolvedRepoProfile = {
       ...profile,
@@ -209,12 +210,12 @@ describe("review and issue-enrichment quality v2", () => {
     expect(() => assertPublicReviewOutputSafe(
       "Tool-call/result grouping is unchanged for valid non-empty tool_calls lists; the modified branch only normalizes falsy values.",
       publicReviewForbiddenProfileFragments(canaryProfile),
-      8
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).not.toThrow();
     expect(() => assertPublicReviewOutputSafe(
       "session and profile isolation source coverage and fresh tail",
       publicReviewForbiddenProfileFragments(canaryProfile),
-      8
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).toThrow("public_review_config_leak_rejected");
     expect(() => assertPublicReviewOutputSafe(
       "Do not modify files",

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -185,12 +185,36 @@ describe("review and issue-enrichment quality v2", () => {
     expect(() => assertPublicReviewOutputSafe(
       "Check lossless ordering",
       publicReviewForbiddenProfileFragments(profile),
-      3
-    )).toThrow("public_review_config_leak_rejected");
+      8
+    )).not.toThrow();
     expect(() => assertPublicReviewOutputSafe(
       "Check-lossless-ordering",
       publicReviewForbiddenProfileFragments(profile),
-      3
+      8
+    )).not.toThrow();
+    expect(() => assertPublicReviewOutputSafe(
+      "Check lossless ordering provenance and crash safe SQLite",
+      publicReviewForbiddenProfileFragments(profile),
+      8
+    )).toThrow("public_review_config_leak_rejected");
+    expect(() => assertPublicReviewOutputSafe(
+      "Assistant messages with a null tool-call field now serialize without crashing; the diff adds direct regression coverage.",
+      publicReviewForbiddenProfileFragments(profile),
+      8
+    )).not.toThrow();
+    const canaryProfile: ResolvedRepoProfile = {
+      ...profile,
+      reviewRiskLens: "Focus on lossless ordering and provenance; session and profile isolation; source coverage and fresh-tail behavior; tool-call and result grouping; SQLite concurrency, crash recovery, and import idempotency."
+    };
+    expect(() => assertPublicReviewOutputSafe(
+      "Tool-call/result grouping is unchanged for valid non-empty tool_calls lists; the modified branch only normalizes falsy values.",
+      publicReviewForbiddenProfileFragments(canaryProfile),
+      8
+    )).not.toThrow();
+    expect(() => assertPublicReviewOutputSafe(
+      "session and profile isolation source coverage and fresh tail",
+      publicReviewForbiddenProfileFragments(canaryProfile),
+      8
     )).toThrow("public_review_config_leak_rejected");
     expect(() => assertPublicReviewOutputSafe(
       "Do not modify files",


### PR DESCRIPTION
Closes #803.

## What changed

- Raises the fuzzy public-profile overlap guard from three to eight contiguous normalized words.
- Keeps canonical settings markers and full normalized prompt/profile-fragment rejection unchanged.
- Adds regression coverage for the exact LCM-X `tool-call/result grouping` canary language, short issue-specific overlap, punctuation normalization, and an eight-word partial policy disclosure.

## Why

The signed beta.85 PR canary generated a grounded, useful review for LCM-X #227 but rejected it before publication because three common words overlapped the private risk lens. No public review was posted. Three-word overlap is not evidence of configuration disclosure; eight contiguous normalized words retain a meaningful near-verbatim leak boundary while allowing issue-specific reasoning.

## Proof

- RED: the short grounded overlap regression failed under the three-word guard.
- GREEN: 28 focused tests across review safety, settings-preview, walkthrough rendering, and posting.
- `npm run build`
- Exact candidate dry-run for LCM-X #227 at `647806eaff03b9e85ce914c12287ec05aae8b82c`: reviewed 1, failed 0, no GitHub mutation.
- Production config restored byte-for-byte at SHA-256 `e5765e590311ed7c8fedbcc8458960ea58a82b13c54555c65d2128a76ddc371a`; daemon remained stopped.

## Boundaries

This preserves fail-closed publication, canonical prompt/config marker rejection, full/near-verbatim fragment rejection, secret redaction, exact-head binding, and advisory-only behavior. It does not claim human-gold Corpus v1 results, statistical independence, universal reviewer superiority, customer correctness, or absence of undiscovered defects.
