### PR TITLE
fix: hide review runtime metadata

### DIFF
--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -56,8 +56,6 @@ export function buildWalkthroughComment(input: {
   const omittedFileCount = Math.max(0, files.length - visibleFiles.length);
   const effort = estimateReviewEffort(input.files, input.comments);
   const relatedRefs = extractRelatedRefs(`${input.pull.title}\n${input.pull.body ?? ""}`);
-  const suggestedLabels = suggestLabels(input.files, input.comments);
-  const suggestedReviewers = input.pull.requested_reviewers?.map((reviewer) => reviewer.login).filter(Boolean) ?? [];
   const severityCounts = countSeverities(input.comments);
   const modelSummary = input.modelSummary ?? {
     changedBehavior: [],
@@ -73,8 +71,6 @@ export function buildWalkthroughComment(input: {
     "",
     `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title, input.publicConfidencePolicy)}`,
     `Head: \`${input.pull.head.sha}\` into \`${input.pull.base.ref}\`. Review event: \`${input.event}\`.`,
-    `Provider: ${formatProviderMetadata(input.provider, input.publicConfidencePolicy)}.`,
-    "",
     `Estimated review effort: ${effort.score}/5 (~${effort.minutes} min)`,
     "",
     "### Changed Files",
@@ -118,8 +114,6 @@ export function buildWalkthroughComment(input: {
     "### Related Context",
     "",
     `Related issues/PRs: ${relatedRefs.length > 0 ? relatedRefs.join(", ") : "none detected from PR metadata"}.`,
-    `Suggested labels: ${suggestedLabels.length > 0 ? suggestedLabels.join(", ") : "none"}.`,
-    `Suggested reviewers: ${suggestedReviewers.length > 0 ? suggestedReviewers.join(", ") : "none from current metadata"}.`,
     "",
     "### Pre-merge checklist",
     "",
@@ -129,8 +123,7 @@ export function buildWalkthroughComment(input: {
       input.event !== "REQUEST_CHANGES" || requestChangesEligible > 0,
       "REQUEST_CHANGES is only used when eligible P0/P1 findings survive validation."
     ),
-    checklistItem(proofChecklistPassed(input.validation, input.proof), "Required behavior proof is present or not applicable."),
-    checklistItem(true, "Labels and reviewers are suggestions only; the bot did not auto-apply them.")
+    checklistItem(proofChecklistPassed(input.validation, input.proof), "Required behavior proof is present or not applicable.")
   ].join("\n");
   const redactedBody = redactSecrets(visibleBody);
   assertPublicReviewOutputSafe(redactedBody);
@@ -157,17 +150,6 @@ function formatModelSummaryList(
 ): string[] {
   if (values.length === 0) return [`- ${fallback}`];
   return values.map((value) => `- ${sanitizePublicConfidenceText(value, publicConfidencePolicy)}`);
-}
-
-function formatProviderMetadata(
-  provider: ReviewProviderMetadata | undefined,
-  publicConfidencePolicy?: PublicConfidenceDisplayPolicy
-): string {
-  if (!provider) return "not recorded";
-  const displayName = provider.displayName
-    ? `${formatInlinePublicText(provider.displayName, publicConfidencePolicy)} `
-    : "";
-  return `${displayName}(${formatInlineCodePublicText(provider.providerId, publicConfidencePolicy)}, ${formatInlinePublicText(provider.adapter, publicConfidencePolicy)}, model ${formatInlineCodePublicText(provider.model, publicConfidencePolicy)})`;
 }
 
 function buildWalkthroughStateMarker(input: {
@@ -210,22 +192,6 @@ function formatInlinePublicText(value: string | undefined, publicConfidencePolic
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
-}
-
-function formatInlineCodePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  return formatMarkdownCodeSpan(formatInlinePublicText(value, publicConfidencePolicy));
-}
-
-function formatMarkdownCodeSpan(value: string): string {
-  let longestBacktickRun = 0;
-  for (const match of value.matchAll(/`+/g)) {
-    longestBacktickRun = Math.max(longestBacktickRun, match[0].length);
-  }
-  const delimiter = "`".repeat(longestBacktickRun + 1);
-  const padding = value.startsWith("`") || value.endsWith("`")
-    ? " "
-    : "";
-  return `${delimiter}${padding}${value}${padding}${delimiter}`;
 }
 
 function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {
@@ -286,15 +252,6 @@ function extractRelatedRefs(text: string): string[] {
   const refs = new Set<string>();
   for (const match of text.matchAll(/#(\d+)/g)) refs.add(`#${match[1]}`);
   return [...refs].slice(0, 8);
-}
-
-function suggestLabels(files: PullFilePatch[], comments: ReviewComment[]): string[] {
-  const labels = new Set<string>();
-  if (comments.some((comment) => comment.severity === "P0" || comment.severity === "P1")) labels.add("bug");
-  if (files.some((file) => file.filename.toLowerCase().startsWith("assets/") || file.filename.endsWith(".cs"))) labels.add("unity");
-  if (files.some((file) => file.filename.toLowerCase().startsWith("docs/") || file.filename.endsWith(".md"))) labels.add("docs");
-  if (files.some((file) => file.filename.toLowerCase().includes("/test") || file.filename.includes(".test."))) labels.add("tests");
-  return [...labels].slice(0, 6);
 }
 
 function countSeverities(comments: ReviewComment[]): Record<Severity, number> {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -477,10 +477,13 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("### Maintainer Analysis");
     for (const forbidden of [
       "Provider:",
+      "Codex CLI (existing OAuth session)",
       "codex-cli-oauth",
+      "codex-cli",
       "gpt-5.6-sol",
       "Suggested labels:",
       "Suggested reviewers:",
+      "Tosko4",
       "Labels and reviewers are suggestions only"
     ]) {
       expect(walkthrough.body).not.toContain(forbidden);

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -151,10 +151,11 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("## Walkthrough");
     expect(walkthrough.body).toContain("| `Assets/Scripts/SaveGameController.cs` | modified | +44/-8 | Unity/gameplay state | Elevated: validated P1 finding |");
     expect(walkthrough.body).toContain("Estimated review effort: 2/5");
-    expect(walkthrough.body).toContain("Provider: GLM / Z.ai (`zcode-glm`, zcode, model `GLM-5.2`).");
+    expect(walkthrough.body).not.toContain("Provider:");
     expect(walkthrough.body).toContain("Related issues/PRs: #17, #12");
-    expect(walkthrough.body).toContain("Suggested reviewers: reviewer-one");
-    expect(walkthrough.body).toContain("Suggested labels: bug, unity");
+    expect(walkthrough.body).not.toContain("Suggested reviewers:");
+    expect(walkthrough.body).not.toContain("Suggested labels:");
+    expect(walkthrough.body).not.toContain("Labels and reviewers are suggestions only");
     expect(walkthrough.body).toContain("Risk Taxonomy");
     expect(walkthrough.body).toContain("- Data loss: 1");
     expect(walkthrough.body).toContain("Validation and Proof");
@@ -234,7 +235,8 @@ describe("walkthrough comment rendering", () => {
     );
     expect(walkthrough.postIssueComment).toBe(true);
     expect(walkthrough.body).toContain("PR: electricsheephq/evaos-code-review-bot#110 - Review UX fixture");
-    expect(walkthrough.body).toContain("Provider: (`zcode-glm`, zcode, model `GLM-5.2`).");
+    expect(walkthrough.body).not.toContain("Provider:");
+    expect(walkthrough.body).toContain("### Maintainer Analysis");
     expect(walkthrough.body).toContain("| `src/save.ts` | modified | +2/-0 | Runtime code | Elevated: validated P1 finding |");
     expect(walkthrough.body).toContain("Validated inline findings: 1 (P0: 0, P1: 1, P2: 0, P3: 0).");
     expect(walkthrough.body).toContain("Dropped findings before posting: 2.");
@@ -378,8 +380,8 @@ describe("walkthrough comment rendering", () => {
     });
 
     expect(walkthrough.body).not.toContain(secretLikeToken);
-    expect(walkthrough.body).toContain("[redacted-secret]");
-    expect(walkthrough.body).toContain("Provider: Gateway [redacted-secret] (`openai-compatible`, openai-compatible, model `review-[redacted-secret]`).");
+    expect(walkthrough.body).not.toContain("Provider:");
+    expect(walkthrough.body).not.toContain("openai-compatible");
     expect(walkthrough.body).not.toContain("Path instructions:");
     expect(walkthrough.body).not.toContain("Label suggestions:");
     expect(walkthrough.body).not.toContain("Reviewer suggestions:");
@@ -445,8 +447,44 @@ describe("walkthrough comment rendering", () => {
     });
 
     expect(walkthrough.body).not.toContain("### Review Settings Preview");
-    expect(walkthrough.body).toContain("Suggested reviewers: reviewer-one.\n\n### Pre-merge checklist");
-    expect(walkthrough.body).not.toMatch(/Suggested reviewers:[^\n]*\n\n\n### Pre-merge checklist/);
+    expect(walkthrough.body).toContain("Related issues/PRs: #17, #12.\n\n### Pre-merge checklist");
+    expect(walkthrough.body).not.toContain("Suggested reviewers:");
+    expect(walkthrough.body).not.toContain("Suggested labels:");
+  });
+
+  it("keeps provider sessions and label or reviewer suggestion behavior out of public walkthroughs", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/lcm-x",
+      pull: {
+        ...pull,
+        requested_reviewers: [{ login: "Tosko4" }],
+        head: { ...pull.head, repo: { full_name: "electricsheephq/lcm-x" } },
+        base: { ...pull.base, repo: { full_name: "electricsheephq/lcm-x" } }
+      },
+      files: [{ filename: "tests/test_lcm_core.py", status: "modified", additions: 4, deletions: 0 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT",
+      provider: {
+        providerId: "codex-cli-oauth",
+        adapter: "codex-cli",
+        displayName: "Codex CLI (existing OAuth session)",
+        model: "gpt-5.6-sol"
+      }
+    });
+
+    expect(walkthrough.body).toContain("## Walkthrough");
+    expect(walkthrough.body).toContain("### Maintainer Analysis");
+    for (const forbidden of [
+      "Provider:",
+      "codex-cli-oauth",
+      "gpt-5.6-sol",
+      "Suggested labels:",
+      "Suggested reviewers:",
+      "Labels and reviewers are suggestions only"
+    ]) {
+      expect(walkthrough.body).not.toContain(forbidden);
+    }
   });
 
   it("uses one sticky walkthrough marker per PR while updating head-specific state metadata", () => {

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -97,7 +97,9 @@ describe("worker review settings preview evidence", () => {
       instructions: ["Do not quote [redacted-secret] in public comments."]
     });
     expect(walkthrough).not.toContain("### Review Settings Preview");
-    expect(walkthrough).toContain("Provider: GLM/Z.ai through ZCode (`zcode-glm`, zcode, model `GLM-5.2`).");
+    expect(walkthrough).not.toContain("Provider:");
+    expect(walkthrough).not.toContain("zcode-glm");
+    expect(walkthrough).not.toContain("GLM-5.2");
     expect(walkthrough).toContain("### Changed Files");
     expect(walkthrough).toContain("### Review Signal");
     expect(walkthrough).toContain("### Maintainer Analysis");
@@ -107,6 +109,9 @@ describe("worker review settings preview evidence", () => {
     expect(walkthrough).not.toContain("Path instructions:");
     expect(walkthrough).not.toContain("Label suggestions:");
     expect(walkthrough).not.toContain("Reviewer suggestions:");
+    expect(walkthrough).not.toContain("Suggested labels:");
+    expect(walkthrough).not.toContain("Suggested reviewers:");
+    expect(walkthrough).not.toContain("Labels and reviewers are suggestions only");
     expect(walkthrough).not.toContain("Suggestion behavior:");
     expect(walkthrough).not.toContain("Roadmap-only settings:");
     expect(walkthrough).not.toContain("Repo-specific instruction:");


### PR DESCRIPTION
## Summary

- remove provider/session/model metadata from public walkthrough reviews
- remove public label/reviewer suggestion lines and suggestion-behavior checklist text
- retain the useful Walkthrough, Maintainer Analysis, related context, findings, proof, and readiness content
- add an exact LCM-X-style negative regression fixture

## Production evidence

Beta.86 review https://github.com/electricsheephq/lcm-x/pull/227#pullrequestreview-4947445543 still exposed `codex-cli-oauth`, `gpt-5.6-sol`, suggested labels/reviewers, and the suggestion-only checklist. The final production adversarial gate returned BLOCKED 99/100.

## Validation

- RED: `npx vitest run tests/walkthrough.test.ts` failed on all forbidden live strings
- GREEN: `npx vitest run tests/walkthrough.test.ts tests/review-enrichment-quality-v2.test.ts` — 22/22
- `npx tsc -p tsconfig.build.json --noEmit`
- `git diff --check`

## Safety boundary

This changes only public walkthrough rendering and focused tests. It does not change provider execution, review scoring, findings, GitHub write permissions, labels, assignees, reviewer requests, approvals, merges, projects, issue enrichment, daemon configuration, release configuration, or customer runtime behavior.

Agent-authored change. Related: #803
