### PR TITLE
docs: define Mac GA release contract and Desktop manifest

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -204,11 +204,13 @@ For `review-pr` license blocks, the gate writes its local proof under the
 configured `evidenceDir` as
 `<date>/<owner__repo>/pr-<number>/<head-sha>/license-gate.json`.
 
-The `keychain` backend remains reserved for a separately proven native broker.
-Headless CLI activation currently rejects Keychain writes rather than passing
-license keys through process arguments. v1.0.4 supports the approved file
-backend; the Desktop app remains blocked from useful actions until native
-broker/launchd access is proven.
+The `keychain` backend remains reserved for the separately proven native
+Desktop boundary. Headless CLI activation currently rejects Keychain writes
+rather than passing license keys through process arguments. `v1.0.4` supports
+the approved file backend; the native `1.1.0` candidate has its own BYO and
+managed release contracts and must not be treated as a CLI activation wrapper.
+An unsigned/debug bundle or a bundle with missing/mixed markers remains
+quarantined and cannot be used as release or customer proof.
 The local `machineId` sent to the license API is advisory beta metadata derived
 from host name and platform, not hardware attestation or a durable seat-binding
 primitive.

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -108,7 +108,15 @@ Runbooks must use operator-provided paths, never a historical machine mount:
 export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:?absolute clean release checkout}"
 export NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?absolute active config path}"
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/Codex/evidence/neondiff}"
+export NEONDIFF_LAUNCH_AGENT_PATH="${NEONDIFF_LAUNCH_AGENT_PATH:?absolute LaunchAgent plist path}"
 ```
+
+Before navigation, sync, testing, build, tagging, promotion, or `launchctl`,
+the runbook preflight must reject any non-absolute path, missing checkout,
+non-NeonDiff `origin`, dirty checkout, missing runtime config, missing evidence
+root, or missing LaunchAgent plist. The preflight is an executable operator
+boundary; this architecture contract does not treat a path string alone as
+proof of repository, config, or runtime identity.
 
 Historical release packets may retain the paths recorded at the time they were
 written. Current runbooks must not copy those paths into new commands or claim

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -1,0 +1,129 @@
+# NeonDiff Mac GA release contract
+
+Status: current architecture contract for the native Mac GA hardening lane.
+This document is a source-and-release contract, not release evidence. It is
+anchored to the exact source head being prepared by this change:
+`de00a1daf20c27b1d14fff5a5defb9b5597e71b5`.
+
+## Product lanes and version boundary
+
+NeonDiff has two versioned delivery lanes. They share review policy and public
+security rules, but they do not share release identity or activation semantics.
+
+| Lane | Version contract | Supported surface | Must not claim |
+| --- | --- | --- | --- |
+| CLI / dashboard | `neondiff@1.0.4` | npm package, local HTML dashboard, API-backed activation for every repository, local worker/daemon | native Swift maturity, signed Mac distribution, Sparkle, or v1.1 readiness |
+| Native Desktop | `1.1.0` candidate line (beta before GA) | signed macOS app, sealed worker, native onboarding, BYO or later managed contract, Sparkle channel | that a source build, unsigned app, or CLI manifest is a native release |
+
+`docs/public-release-manifest.json` remains the CLI/dashboard `v1.0.4`
+publication record. A Desktop candidate uses the separate, versioned
+[`v1.1.0-desktop-candidate-manifest.json`](../release-candidates/v1.1.0-desktop-candidate-manifest.json)
+validated by [`desktop-candidate-manifest.schema.json`](../schema/desktop-candidate-manifest.schema.json).
+Do not merge the two manifests or rewrite the published CLI record to describe
+Desktop artifacts.
+
+## Production contracts
+
+The native release bundle must advertise exactly one contract in `Info.plist`.
+Missing, mixed, or debug-only values leave production composition quarantined.
+
+| Contract | Required public markers | Credential / entitlement boundary | Status |
+| --- | --- | --- | --- |
+| Paid BYO (`paid-mac-beta-byo-v1`) | `NeonDiffPaidBetaContract=paid-mac-beta-byo-v1`, `NeonDiffBYOGitHubEnabled=true`; no managed marker or origin | customer-owned GitHub App; paid activation for the supported repository; no official-App implication | current native beta path |
+| Managed (`paid-mac-beta-v1`) | `NeonDiffPaidBetaContract=paid-mac-beta-v1`, `NeonDiffManagedGitHubBrokerEnabled=true`, fixed broker origin `https://neondiff-license.fly.dev`; no BYO marker | broker-hosted official-App path; exact installation/repository binding; server kill switch and entitlement authority | later convenience path; not required to close the BYO beta |
+
+The marker is a release boundary, not an authorization decision. The server,
+GitHub-authoritative repository visibility, Keychain controls, and fail-closed
+entitlement checks remain authoritative. A local preference, cached entitlement,
+running worker, or App ID alone cannot unlock useful work.
+
+## Candidate identity and required gates
+
+Every Desktop candidate is represented by the versioned manifest. Each gate
+records `state`, immutable identity, and public-safe evidence references:
+
+1. **Source:** repository, exact 40-character commit, release ref, clean
+   checkout, and (when CI-built) workflow run/artifact identity.
+2. **Artifact:** app bundle/archive name, bundle ID, build number, SHA-256,
+   and the exact artifact downloaded or tested. A source rebuild is not a
+   substitute for exact-artifact proof.
+3. **Signing:** Developer ID identity class, nested-code verification, hardened
+   runtime, timestamp, and public-safe `codesign` evidence.
+4. **Notary:** Apple acceptance reference, stapling validation, and post-staple
+   `codesign`/Gatekeeper evidence on the same bytes.
+5. **Feed:** Sparkle 2 channel, baked feed URL, public key reference, artifact
+   URL/checksum/signature, and a rollback feed or release reference. A fixture
+   or local XML dry run is not hosted-feed proof.
+6. **Site:** canonical product/download/release-notes URLs and the same
+   immutable artifact checksum. Website publication is separate from app build.
+7. **Billing:** paid-BYO or managed entitlement policy, production authority
+   reference, and activation/recovery evidence. Billing status is never
+   inferred from a package or website link.
+8. **Customer:** exact-artifact install, onboarding, provider, dry-run/live
+   review, entitlement-loss/recovery, support, and update/rollback canary
+   references. Desktop-eval evidence from #524 is required for GA; CI alone is
+   not customer evidence.
+9. **Runtime:** named launchd label, worker version, config identity, current
+   daemon evidence, and an explicit no-downtime receipt. Runtime adoption is a
+   separate gate from source and release publication.
+10. **Rollback:** last-known-good version, exact artifact checksum, feed/release
+    reference, state-preservation requirement, and operator trigger.
+
+No gate may inherit a pass from another gate. A candidate remains `pending` or
+`blocked` when any required identity or evidence is absent.
+
+## No-downtime and rollback invariant
+
+Maintenance must preserve the existing customer worker until the replacement
+has been verified. The supported sequence is: stage and hash the candidate;
+validate source, contract, signature, and manifest; take a read-only status
+snapshot; switch only the same named worker slot; then re-read status and retain
+the prior candidate for rollback. A failed preflight, ambiguous ownership,
+missing prior candidate, or failed post-switch status stops before replacement.
+
+The sequence must not delete or overwrite a pre-existing candidate tree, alter
+customer config/Keychain/DB, widen an App allowlist, or restart an unrelated
+worker. A documentation or source PR never authorizes launchd promotion. The
+runtime issue #738 remains its own maintenance lane; its health evidence cannot
+be substituted for exact Desktop release evidence.
+
+## GA decision boundary
+
+The paid BYO beta outcome in #610 is complete, but Mac GA remains open under
+roadmap #103 and milestone #11. GA requires, at minimum, current-head CI and
+review, #116 signed updater/feed and rollback proof, #524 exact-artifact desktop
+evaluation/customer canaries, residual #449 distribution proof, production
+billing/GitHub/provider evidence, and immutable site/release alignment.
+
+Issue #806 is the current packaging/restoration slice for the exact base. Its
+source and focused tests may prove the BYO marker and restoration contract; they
+do not by themselves prove signed distribution, installed runtime safety,
+customer readiness, or GA.
+
+## Active path and evidence rules
+
+Runbooks must use operator-provided paths, never a historical machine mount:
+
+```sh
+export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:?absolute clean release checkout}"
+export NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?absolute active config path}"
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/Codex/evidence/neondiff}"
+```
+
+Historical release packets may retain the paths recorded at the time they were
+written. Current runbooks must not copy those paths into new commands or claim
+that a missing mount is live evidence.
+
+## Claim boundary and prohibited shortcuts
+
+This contract may establish architecture, required identities, and a
+public-safe candidate packet (`pr_ready` when its PR checks pass). It does not
+establish release readiness, signed/notarized distribution, hosted updater
+identity, runtime safety, customer readiness, or GA. Never use a green CI run,
+fixture, source-only Info.plist inspection, website URL, or running process as a
+shortcut for those gates.
+
+Related source of truth: roadmap #103, execution tracker #610, GA milestone
+#11, updater #116, Desktop evaluation #524, packaging/restoration #806, and
+runtime maintenance #738. GitHub issues/PRs and release artifacts own durable
+state; this document is the repo architecture contract.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -22,6 +22,29 @@ particular external volume is mounted:
 export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:?absolute clean release checkout}"
 export NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?absolute active config path}"
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/Codex/evidence/neondiff}"
+export NEONDIFF_LAUNCH_AGENT_PATH="${NEONDIFF_LAUNCH_AGENT_PATH:?absolute LaunchAgent plist path}"
+
+neondiff_release_preflight() {
+  local value origin
+  for value in "$NEONDIFF_RELEASE_CHECKOUT" "$NEONDIFF_RUNTIME_CONFIG" \
+    "$NEONDIFF_EVIDENCE_ROOT" "$NEONDIFF_LAUNCH_AGENT_PATH"; do
+    case "$value" in /*) ;; *) echo "release paths must be absolute" >&2; return 2;; esac
+  done
+  test -d "$NEONDIFF_RELEASE_CHECKOUT" || { echo "release checkout is missing" >&2; return 2; }
+  git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse --show-toplevel >/dev/null || { echo "release checkout is not a Git repository" >&2; return 2; }
+  origin="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" remote get-url origin 2>/dev/null)" || { echo "release checkout has no origin" >&2; return 2; }
+  case "$origin" in
+    https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;;
+    *) echo "release checkout origin is not the NeonDiff repository" >&2; return 2 ;;
+  esac
+  test -f "$NEONDIFF_RUNTIME_CONFIG" || { echo "runtime config is missing" >&2; return 2; }
+  test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "evidence root is missing" >&2; return 2; }
+  test -f "$NEONDIFF_LAUNCH_AGENT_PATH" || { echo "LaunchAgent plist is missing" >&2; return 2; }
+  test -z "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" status --porcelain)" || { echo "release checkout is dirty" >&2; return 2; }
+}
+
+# Hard stop: run before any cd, fetch, test, build, promotion, or launchctl command.
+neondiff_release_preflight
 ```
 
 Packaged or non-source deployments must set
@@ -102,6 +125,7 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
+neondiff_release_preflight
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git status --short
 git pull --ff-only
@@ -146,6 +170,7 @@ Public promotion evidence should include the strict variant after tags are
 fetched:
 
 ```bash
+neondiff_release_preflight
 git fetch origin --tags
 npx tsx src/cli.ts release-status \
   --config "$NEONDIFF_RUNTIME_CONFIG" \
@@ -567,6 +592,7 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
+neondiff_release_preflight
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin
 git checkout main
@@ -582,6 +608,7 @@ unrelated dirty work.
 To stop the live beta worker entirely:
 
 ```bash
+neondiff_release_preflight
 launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
 ```
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -1,17 +1,28 @@
-# evaOS Code Review Bot Beta Release Runbook
+# NeonDiff Beta and Mac release runbook
 
-This repository runs a live local beta worker through launchd. Treat each live
-update as a named beta release, not as an informal pull from `main`.
+The CLI/daemon beta and native Mac candidate are separate release lanes. Treat
+each update as a named release, not as an informal pull from `main`. For the
+native contract and GA gate, read [Mac GA release contract](architecture/mac-ga-release-contract.md).
 
 ## Release Boundary
 
-The beta release unit is:
+The CLI/daemon beta release unit is identified by operator-provided paths:
 
-- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- source checkout: `$NEONDIFF_RELEASE_CHECKOUT`
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
-- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
-- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+- launchd config: `$NEONDIFF_RUNTIME_CONFIG`
+- state DB: adjacent to the operator's runtime config/state root
+- evidence root: `$NEONDIFF_EVIDENCE_ROOT`
+
+Before using the commands below, set an absolute clean checkout and active
+config. Do not copy paths from historical release packets or assume a
+particular external volume is mounted:
+
+```sh
+export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:?absolute clean release checkout}"
+export NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?absolute active config path}"
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/Codex/evidence/neondiff}"
+```
 
 Packaged or non-source deployments must set
 `NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
@@ -26,16 +37,15 @@ Public source-beta releases also include a compact manifest at
 for docs version alignment, license API readiness or explicit deferral, and
 update-channel readiness for CLI, daemon, website, and desktop surfaces.
 
-The 1.0 cut line is intentionally narrower than full desktop maturity:
-`1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not
-full signed desktop maturity.` Keep release notes aligned to these public
-surface stages:
+The `v1.0.4` cut line remains the CLI/dashboard public release. Native Desktop
+uses the separate `1.1.0` candidate line and exact contract in the Mac GA
+release contract. Keep release notes aligned to these public surface stages:
 
-| Stage | Required For 1.0 | Allowed Claims | Forbidden Claims |
+| Stage | Required For CLI v1.0.4 | Allowed Claims | Forbidden Claims |
 | --- | --- | --- | --- |
 | CLI/dashboard GA | Yes | `npm install -g neondiff`; `neondiff dashboard` starts and opens a local HTML dashboard; dashboard supports first-run setup/status and redacted provider API-key verification. | Signed desktop artifacts, Sparkle appcast/auto-update readiness, native Swift desktop maturity. |
-| Minimal Mac launcher GA | Yes | A minimal Mac icon/app launcher opens the same local HTML dashboard. | Full native app maturity, signing/notarization, appcast, auto-update, or TCC readiness. |
-| Signed/appcast desktop | Post-launch unless owner-promoted | Signed/notarized desktop, Sparkle/appcast, updater, and native Swift polish only after #449/#116 proof. | Treating browser preview or unsigned launcher smoke as signed desktop release proof. |
+| Native Desktop candidate | Separate `1.1.0` line | Candidate identity, native BYO/managed contract, and pending gate state in the versioned Desktop manifest. | Treating source or unsigned bundle state as signed release proof. |
+| Signed/appcast desktop | Mac GA gate | Signed/notarized desktop, Sparkle/appcast, updater, and native evidence only after #449/#116/#524 proof. | Treating browser preview or CLI `v1.0.4` proof as native release proof. |
 
 Represent browser dashboard readiness separately from desktop readiness in
 `docs/public-release-manifest.json` when the distinction matters. The dashboard
@@ -92,19 +102,19 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git status --short
 git pull --ff-only
 npm test
 npm run build
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 sleep 5
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot \
   --require-coverage true
@@ -115,7 +125,7 @@ For public source-beta releases, run the same gate with manifest checks:
 ```bash
 PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -138,7 +148,7 @@ fetched:
 ```bash
 git fetch origin --tags
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -470,7 +480,7 @@ from the eligible open-head set. Retire only the exact failed head:
 
 ```bash
 npx tsx src/cli.ts retire-failed \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
@@ -540,7 +550,7 @@ Expired cooldown rows are actionable backlog. Run:
 
 ```bash
 npx tsx src/cli.ts retry-provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expired-only true \
   --dry-run false \
   --zcode true
@@ -557,7 +567,7 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin
 git checkout main
 git reset --hard <last-known-good-merge-sha>
@@ -601,7 +611,7 @@ For each beta promotion, record:
   tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
-Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+Keep raw evidence under `$NEONDIFF_EVIDENCE_ROOT`.
 or session notes. Do not paste secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
 

--- a/docs/design/customer-journey-ux.md
+++ b/docs/design/customer-journey-ux.md
@@ -5,6 +5,14 @@ visual contract), authored for the #610 customer-journey milestone. This is the 
 #519 (onboarding), #521 (shell/Home), #522 (repos/providers), #612 (activation), and #613 (GitHub
 connect) implement together.
 
+Boundary: this blueprint describes the later managed/native convenience
+journey and GA hardening target. It is not proof that the managed App path is
+available, and it is not the current paid-BYO beta setup guide. For the current
+`1.1.0` BYO candidate, use [docs/SETUP.md](../SETUP.md) and the
+[Mac GA release contract](../architecture/mac-ga-release-contract.md); the
+customer-owned GitHub App, activation, exact artifact, and runtime gates remain
+explicit. The CLI `v1.0.4` path remains a separate API-backed contract.
+
 ## Product sentence
 
 A normal person installs the app and gets their first useful PR review without touching a terminal —

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -6,7 +6,18 @@ contains the real Sparkle controller and release-build configuration gate. No
 hosted appcast, signed update, installed update, rollback, or public release is
 proven by source alone.
 
-## Current Implementation — 2026-07-28
+## Current Source Contract
+
+The native candidate is on the separate `1.1.0` line. The CLI `v1.0.4`
+manifest remains the source-beta publication record; it is not an appcast or
+Desktop artifact manifest. The exact source, artifact, signing, notary, feed,
+site, billing, customer, runtime, and rollback fields live in the
+[versioned Desktop candidate manifest](release-candidates/v1.1.0-desktop-candidate-manifest.json)
+and its [schema](schema/desktop-candidate-manifest.schema.json).
+
+Evidence paths below are placeholders. Set `NEONDIFF_EVIDENCE_ROOT` to an
+operator-owned absolute directory before writing a packet; historical packet
+paths are not active runtime truth.
 
 - The native SwiftUI executable uses the existing Sparkle 2 dependency and
   standard updater UI in
@@ -43,14 +54,14 @@ re-update, immutable release assets, and live customer evidence.
 
 ## Durable Plan Contract
 
-- Goal: define the desktop auto-update channel contract for NeonDiff Desktop so
-  future implementation can choose Sparkle, Tauri updater, or an equivalent
-  signed updater without weakening release governance or license boundaries.
-- Resume identity: repo `electricsheephq/evaos-code-review-bot`, branch
-  `codex/116-desktop-autoupdate-plan`, base
-  `1e28bf8ee0bfe42d0a7f3cc47ed76508497efe96`, issue
-  https://github.com/electricsheephq/evaos-code-review-bot/issues/116, parent
-  tracker https://github.com/electricsheephq/evaos-code-review-bot/issues/103.
+- Goal: define the native Desktop Sparkle 2 channel contract without weakening
+  release governance or license boundaries. The implementation choice is
+  recorded in source; this document does not select a replacement updater.
+- Resume identity: repository
+  `electricsheephq/evaos-code-review-bot-neondiff`, current candidate source
+  ref and version in
+  `docs/release-candidates/v1.1.0-desktop-candidate-manifest.json`, issue #116,
+  parent tracker #103.
 - Tracking / source of truth: GitHub issues and PRs own implementation truth;
   `docs/release-governance.md`, `docs/license-boundary.md`, and
   `docs/public-release-manifest.json` own current release and license wording;
@@ -60,14 +71,13 @@ re-update, immutable release assets, and live customer evidence.
   selection, no signing/notarization setup, no private key material, no appcast
   publication, no installer distribution, no license API implementation, no
   launchd/runtime change, and no claim that desktop auto-update is shipped.
-- Current state: NeonDiff is a source-available beta; desktop update channels
-  are marked `post_1_0` and non-required in `docs/public-release-manifest.json`;
-  `docs/neondiff-desktop.md` describes a development-only unsigned desktop
-  scaffold; issue #111 owns license activation and issue #114 owns the legacy
-  desktop shell audit.
-- Exact next action: after desktop shell choice and license activation design
-  are settled, create an implementation issue or PR that wires a signed local or
-  static update-manifest dry run before any public appcast or artifact channel.
+- Current state: NeonDiff is source-available; the CLI `v1.0.4` channel is
+  separate from the native `1.1.0` candidate line. `docs/neondiff-desktop.md`
+  describes native development and contract boundaries; issue #111 owns
+  license activation and issue #114 owns the legacy desktop shell audit.
+- Exact next action: populate the pending manifest fields from one exact signed
+  candidate, then run the static appcast, signature-failure, entitlement, and
+  rollback fixtures before any public feed or artifact publication.
 - Critical invariants: every downloaded gated artifact must be entitlement
   checked before download, signature verified before install, tied to a channel
   manifest, rollbackable to a last-known-good release, and backed by public-safe
@@ -87,18 +97,19 @@ re-update, immutable release assets, and live customer evidence.
   - Dataset/scenario refs: issue #116 acceptance criteria, issue #111 license
     activation contract, issue #114 desktop shell audit, issue #112 release
     governance, and `docs/public-release-manifest.json`.
-  - Baseline/comparison: current `post_1_0` deferred desktop channel in
-    `docs/public-release-manifest.json`.
+  - Baseline/comparison: the separate CLI `v1.0.4` publication record in
+    `docs/public-release-manifest.json`; it must remain unchanged by Desktop
+    candidate work.
   - Metrics and thresholds: update check distinguishes no-update,
     update-available, blocked-by-license, network-error, and signature-error;
     invalid signatures never install; gated artifacts never download without a
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -109,13 +120,13 @@ re-update, immutable release assets, and live customer evidence.
   governance plan. It must not be cited as evidence that Sparkle, Tauri updater,
   signing, entitlement checks, rollback, installer distribution, or UI status
   handling is implemented.
-- Stop conditions: unresolved desktop shell choice; absent public-key strategy;
+- Stop conditions: absent public-key strategy;
   signing or notarization secrets requested in repo or docs; entitlement policy
   unclear for public/private/commercial repos; update metadata cannot express
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -184,7 +195,7 @@ The desktop UI and any CLI status surface should use the same state names:
 Before #116 can close and the public manifest can claim a working desktop update
 channel, the release lane must provide evidence for:
 
-- desktop shell choice and updater technology
+- Sparkle 2 updater configuration and public-key strategy
 - signed artifact creation and public verification material
 - local/static manifest dry run
 - signature failure fixture
@@ -192,7 +203,7 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$NEONDIFF_EVIDENCE_ROOT`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -1,4 +1,4 @@
-# NeonDiff Desktop Dev MVP
+# NeonDiff Desktop architecture and local development
 
 The evaluation-first path from this development shell to a GA-quality native
 experience is specified in
@@ -6,10 +6,19 @@ experience is specified in
 and tracked by issue #514. Evaluation and layout stability land before broad
 visual redesign.
 
-NeonDiff Desktop is a SwiftPM macOS app scaffold for issue #115. It is a thin local control panel over the NeonDiff CLI and daemon contracts.
-For the 1.0 launch bar, the Mac app is intentionally a minimal launcher:
-opening the app shows local controls that can start `neondiff dashboard` or open
-the same local HTML dashboard used by the CLI.
+NeonDiff Desktop is the native macOS product surface for the `1.1.0` candidate
+line. It composes the existing CLI and daemon contracts through typed, bounded
+commands; it is not the `neondiff@1.0.4` package and does not change that
+package's activation or release identity. The local HTML dashboard remains the
+CLI/operator surface and is governed by the separate public release manifest.
+
+The exact native production contract is selected by release-only bundle
+markers. The current paid BYO contract is
+`paid-mac-beta-byo-v1` plus `NeonDiffBYOGitHubEnabled=true`; the managed broker
+contract is mutually exclusive and remains a later convenience path. Missing
+or mixed markers keep the bundle quarantined. See the
+[Mac GA release contract](architecture/mac-ga-release-contract.md) and the
+[versioned candidate manifest](release-candidates/v1.1.0-desktop-candidate-manifest.json).
 
 ## Boundaries
 
@@ -19,7 +28,10 @@ the same local HTML dashboard used by the CLI.
   implements native setup/status controls that write through existing CLI
   contracts. The local HTML dashboard is a diagnostic/operator surface for
   CLI-first and non-Mac setups, not the product UI.
-- No signing, notarization, Sparkle appcast, downloadable artifact, TCC, Mac-control, or customer-control proof is claimed here.
+- No signing, notarization, Sparkle appcast, downloadable artifact, TCC,
+  Mac-control, runtime, or customer-control proof is claimed by this
+  development document. Those are exact-artifact gates in the Mac release
+  contract and #116/#524.
 - Provider and license keys are stored in macOS Keychain under a NeonDiff-specific service and are never written to config files.
 - Native provider verification starts only from an explicit **Verify API Key** click. The stored provider key is read from Keychain for that operation and sent to the child CLI only through bounded standard input; it never enters argv, process environment, config, command previews, stdout/stderr, logs, screenshots, or evidence.
 

--- a/docs/release-candidates/v1.1.0-desktop-candidate-manifest.json
+++ b/docs/release-candidates/v1.1.0-desktop-candidate-manifest.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "desktop-candidate-manifest.v1",
+  "product": "NeonDiff Desktop",
+  "version": "1.1.0-beta.87",
+  "releaseLevel": "candidate",
+  "channel": "beta",
+  "contract": {
+    "mode": "byo",
+    "paidBetaContract": "paid-mac-beta-byo-v1",
+    "byoGitHubEnabled": true,
+    "managedBrokerEnabled": false,
+    "brokerOrigin": null
+  },
+  "source": {
+    "repository": "electricsheephq/evaos-code-review-bot-neondiff",
+    "commit": "de00a1daf20c27b1d14fff5a5defb9b5597e71b5",
+    "ref": "de00a1daf20c27b1d14fff5a5defb9b5597e71b5",
+    "cleanCheckout": true,
+    "workflowRunRef": null,
+    "artifactRef": null
+  },
+  "artifact": {
+    "state": "pending",
+    "bundleId": "com.electricsheephq.NeonDiffDesktop",
+    "appPath": "apps/neondiff-desktop/dist/NeonDiff.app",
+    "archiveName": "NeonDiff-1.1.0-beta.87-macOS.zip",
+    "build": null,
+    "sha256": null,
+    "workflowRunRef": null,
+    "artifactRef": null,
+    "evidenceRefs": ["apps/neondiff-desktop/docs/mac-release-runbook.md"]
+  },
+  "signing": {
+    "state": "pending",
+    "identity": "Developer ID Application (owner-provided identity)",
+    "evidenceRefs": ["apps/neondiff-desktop/docs/mac-release-runbook.md#codesign"]
+  },
+  "notarization": {
+    "state": "pending",
+    "identity": "Apple notarization acceptance and stapled bundle",
+    "evidenceRefs": ["apps/neondiff-desktop/docs/mac-release-runbook.md#notarize-and-staple"]
+  },
+  "feed": {
+    "state": "pending",
+    "technology": "Sparkle 2",
+    "channel": "beta",
+    "feedUrl": null,
+    "publicKeyRef": null,
+    "artifactUrl": null,
+    "signatureRef": null,
+    "rollbackRef": "apps/neondiff-desktop/fixtures/appcast/rollback.json",
+    "evidenceRefs": ["docs/desktop-auto-update-channel.md", "#116"]
+  },
+  "site": {
+    "state": "pending",
+    "productUrl": "https://www.neondiff.com/mac-beta",
+    "downloadUrl": null,
+    "releaseNotesUrl": null,
+    "artifactSha256": null,
+    "evidenceRefs": ["#103", "#610"]
+  },
+  "billing": {
+    "state": "pending",
+    "model": "paid-byo",
+    "authorityRef": "#610",
+    "activationRef": "#612",
+    "evidenceRefs": ["#562", "#633"]
+  },
+  "customer": {
+    "state": "pending",
+    "canaryRef": "#524",
+    "requiredScenarios": [
+      "clean install and launch",
+      "customer-owned GitHub App binding",
+      "provider verification and dry run before live review",
+      "entitlement loss and recovery",
+      "manual signed update and rollback with state preservation"
+    ],
+    "evidenceRefs": ["#524", "#615"]
+  },
+  "runtime": {
+    "state": "not-performed",
+    "launchdLabel": "com.electricsheephq.evaos-code-review-bot",
+    "workerVersion": null,
+    "noDowntimeInvariant": "Stage and verify the replacement before switching the same worker slot; retain the prior candidate and prove post-switch status before declaring runtime safety.",
+    "evidenceRefs": ["#738"]
+  },
+  "rollback": {
+    "state": "pending",
+    "targetVersion": null,
+    "targetArtifactSha256": null,
+    "targetReleaseRef": "apps/neondiff-desktop/fixtures/appcast/rollback.json",
+    "statePreservationRequired": true,
+    "evidenceRefs": ["#116", "apps/neondiff-desktop/fixtures/appcast/rollback.json"]
+  },
+  "references": {
+    "roadmap": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103",
+    "execution": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/610",
+    "milestone": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/milestone/11",
+    "updater": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116",
+    "desktopEvaluation": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/524",
+    "runtime": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/738",
+    "packaging": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/806"
+  },
+  "proofBoundary": {
+    "allows": [
+      "public-safe identity and gate requirements for one native Desktop candidate",
+      "exact source and mutually exclusive BYO production contract recorded for the candidate",
+      "pending release, customer, runtime, and rollback gates remain explicit"
+    ],
+    "excludes": [
+      "signed or notarized artifact",
+      "hosted feed, site publication, billing, or customer canary proof",
+      "runtime safety, launchd promotion, or Mac GA readiness"
+    ]
+  }
+}

--- a/docs/release-candidates/v1.1.0-desktop-candidate-manifest.json
+++ b/docs/release-candidates/v1.1.0-desktop-candidate-manifest.json
@@ -23,8 +23,8 @@
     "state": "pending",
     "bundleId": "com.electricsheephq.NeonDiffDesktop",
     "appPath": "apps/neondiff-desktop/dist/NeonDiff.app",
-    "archiveName": "NeonDiff-1.1.0-beta.87-macOS.zip",
-    "build": null,
+    "archiveName": "NeonDiff-1.1.0-beta.87-build11091-macOS.zip",
+    "build": "11091",
     "sha256": null,
     "workflowRunRef": null,
     "artifactRef": null,
@@ -47,6 +47,7 @@
     "feedUrl": null,
     "publicKeyRef": null,
     "artifactUrl": null,
+    "artifactSha256": null,
     "signatureRef": null,
     "rollbackRef": "apps/neondiff-desktop/fixtures/appcast/rollback.json",
     "evidenceRefs": ["docs/desktop-auto-update-channel.md", "#116"]
@@ -82,6 +83,7 @@
     "state": "not-performed",
     "launchdLabel": "com.electricsheephq.evaos-code-review-bot",
     "workerVersion": null,
+    "configIdentitySha256": null,
     "noDowntimeInvariant": "Stage and verify the replacement before switching the same worker slot; retain the prior candidate and prove post-switch status before declaring runtime safety.",
     "evidenceRefs": ["#738"]
   },

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -4,7 +4,23 @@ This bot is a live beta agent. A live promotion is not complete until the
 source SHA is tied to an immutable Git tag, a GitHub Release, runtime evidence,
 and a rollback path.
 
+The CLI/dashboard and native Desktop are separate release lanes. The published
+CLI contract is `neondiff@1.0.4`; native Desktop candidates use the `1.1.0`
+line and the [Mac GA release contract](architecture/mac-ga-release-contract.md).
+The CLI `docs/public-release-manifest.json` remains unchanged when recording a
+Desktop candidate.
+
 ## Release Levels
+
+Set these operator-owned paths before using a command in this runbook. They
+replace historical machine-specific paths; release packets retain their own
+recorded paths as historical evidence only.
+
+```bash
+export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:?absolute clean release checkout}"
+export NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?absolute active config path}"
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/Codex/evidence/neondiff}"
+```
 
 - `beta`: local launchd worker on the operator Mac, posting as the GitHub App
   on the active allowlist. Beta releases are prereleases.
@@ -110,6 +126,16 @@ This section intentionally does not invent new promotion gates beyond the
 existing release-status/public-release-manifest machinery; it only names the
 version string and dist-tag step that make a promotion a GA promotion instead
 of another beta promotion.
+
+### Native Desktop GA lane
+
+The `v1.0.0` semver policy above governs the CLI/dashboard lane. It does not
+rename or publish a native Desktop candidate. A native candidate must carry a
+versioned Desktop manifest with source, app, signing, notarization, Sparkle
+feed, site, billing, customer, runtime, and rollback identities. Native GA
+remains blocked until #116 and #524 evidence is complete and #449 distribution
+is aligned. A source build, CLI manifest, appcast fixture, or green CI run is
+not native release proof.
 
 ## Cadence
 
@@ -342,7 +368,7 @@ unchanged and treat the package as quarantined.
 Create an annotated tag from the merged source SHA:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
@@ -377,13 +403,13 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
 test "$(git rev-parse HEAD)" = "<source-sha>"
-launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+launchctl bootout gui/$(id -u) "${NEONDIFF_LAUNCH_AGENT_PATH:?absolute LaunchAgent plist path}" 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "${NEONDIFF_LAUNCH_AGENT_PATH:?absolute LaunchAgent plist path}"
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 ```
 
@@ -395,7 +421,7 @@ Run the status gate with App credentials set in the shell:
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
@@ -406,7 +432,7 @@ For public source-beta or public beta releases, include the public manifest gate
 SOURCE_SHA=replace-with-release-source-sha
 PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$SOURCE_SHA" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -424,9 +450,9 @@ Also run:
 
 ```bash
 npx tsx src/cli.ts coverage-audit \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+  --config "$NEONDIFF_RUNTIME_CONFIG"
 npx tsx src/cli.ts provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expired-only true
 ```
 
@@ -458,13 +484,13 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin --tags
 git checkout main
 git reset --hard <previous-release-tag>
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -20,6 +20,29 @@ recorded paths as historical evidence only.
 export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:?absolute clean release checkout}"
 export NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?absolute active config path}"
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/Codex/evidence/neondiff}"
+export NEONDIFF_LAUNCH_AGENT_PATH="${NEONDIFF_LAUNCH_AGENT_PATH:?absolute LaunchAgent plist path}"
+
+neondiff_release_preflight() {
+  local value origin
+  for value in "$NEONDIFF_RELEASE_CHECKOUT" "$NEONDIFF_RUNTIME_CONFIG" \
+    "$NEONDIFF_EVIDENCE_ROOT" "$NEONDIFF_LAUNCH_AGENT_PATH"; do
+    case "$value" in /*) ;; *) echo "release paths must be absolute" >&2; return 2;; esac
+  done
+  test -d "$NEONDIFF_RELEASE_CHECKOUT" || { echo "release checkout is missing" >&2; return 2; }
+  git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse --show-toplevel >/dev/null || { echo "release checkout is not a Git repository" >&2; return 2; }
+  origin="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" remote get-url origin 2>/dev/null)" || { echo "release checkout has no origin" >&2; return 2; }
+  case "$origin" in
+    https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;;
+    *) echo "release checkout origin is not the NeonDiff repository" >&2; return 2 ;;
+  esac
+  test -f "$NEONDIFF_RUNTIME_CONFIG" || { echo "runtime config is missing" >&2; return 2; }
+  test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "evidence root is missing" >&2; return 2; }
+  test -f "$NEONDIFF_LAUNCH_AGENT_PATH" || { echo "LaunchAgent plist is missing" >&2; return 2; }
+  test -z "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" status --porcelain)" || { echo "release checkout is dirty" >&2; return 2; }
+}
+
+# Hard stop: run before any cd, fetch, test, build, tag, promotion, or launchctl command.
+neondiff_release_preflight
 ```
 
 - `beta`: local launchd worker on the operator Mac, posting as the GitHub App
@@ -368,6 +391,7 @@ unchanged and treat the package as quarantined.
 Create an annotated tag from the merged source SHA:
 
 ```bash
+neondiff_release_preflight
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
@@ -386,6 +410,7 @@ release tracker.
 Create the GitHub prerelease from the release packet:
 
 ```bash
+neondiff_release_preflight
 gh release create vX.Y.Z-beta.N \
   --repo electricsheephq/evaos-code-review-bot \
   --title "vX.Y.Z-beta.N" \
@@ -403,6 +428,7 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
+neondiff_release_preflight
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
@@ -418,6 +444,7 @@ launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 Run the status gate with App credentials set in the shell:
 
 ```bash
+neondiff_release_preflight
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \

--- a/docs/schema/desktop-candidate-manifest.schema.json
+++ b/docs/schema/desktop-candidate-manifest.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.neondiff.com/schema/desktop-candidate-manifest.v1.json",
+  "title": "NeonDiff Desktop candidate manifest",
+  "description": "Public-safe identity and gate record for one native Mac candidate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion", "product", "version", "releaseLevel", "channel",
+    "contract", "source", "artifact", "signing", "notarization", "feed",
+    "site", "billing", "customer", "runtime", "rollback", "references",
+    "proofBoundary"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "desktop-candidate-manifest.v1" },
+    "product": { "const": "NeonDiff Desktop" },
+    "version": { "type": "string", "pattern": "^1\\.1\\.0(?:-[0-9A-Za-z.-]+)?$" },
+    "releaseLevel": { "enum": ["candidate", "beta", "stable"] },
+    "channel": { "enum": ["beta", "stable"] },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "paidBetaContract", "byoGitHubEnabled", "managedBrokerEnabled", "brokerOrigin"],
+      "properties": {
+        "mode": { "enum": ["byo", "managed"] },
+        "paidBetaContract": { "enum": ["paid-mac-beta-byo-v1", "paid-mac-beta-v1"] },
+        "byoGitHubEnabled": { "type": "boolean" },
+        "managedBrokerEnabled": { "type": "boolean" },
+        "brokerOrigin": { "type": ["string", "null"], "format": "uri" }
+      }
+    },
+    "source": { "$ref": "#/$defs/source" },
+    "artifact": { "$ref": "#/$defs/artifact" },
+    "signing": { "$ref": "#/$defs/gate" },
+    "notarization": { "$ref": "#/$defs/gate" },
+    "feed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "technology", "channel", "feedUrl", "publicKeyRef", "artifactUrl", "signatureRef", "rollbackRef", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "technology": { "const": "Sparkle 2" },
+        "channel": { "enum": ["beta", "stable"] },
+        "feedUrl": { "$ref": "#/$defs/nullableString" },
+        "publicKeyRef": { "$ref": "#/$defs/nullableString" },
+        "artifactUrl": { "$ref": "#/$defs/nullableString" },
+        "signatureRef": { "$ref": "#/$defs/nullableString" },
+        "rollbackRef": { "$ref": "#/$defs/nullableString" },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "site": { "$ref": "#/$defs/site" },
+    "billing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "model", "authorityRef", "activationRef", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "model": { "enum": ["paid-byo", "managed"] },
+        "authorityRef": { "$ref": "#/$defs/nullableString" },
+        "activationRef": { "$ref": "#/$defs/nullableString" },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "customer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "canaryRef", "requiredScenarios", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "canaryRef": { "$ref": "#/$defs/nullableString" },
+        "requiredScenarios": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "launchdLabel", "workerVersion", "noDowntimeInvariant", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "launchdLabel": { "type": "string", "minLength": 1 },
+        "workerVersion": { "$ref": "#/$defs/nullableString" },
+        "noDowntimeInvariant": { "type": "string", "minLength": 20 },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "targetVersion", "targetArtifactSha256", "targetReleaseRef", "statePreservationRequired", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "targetVersion": { "$ref": "#/$defs/nullableString" },
+        "targetArtifactSha256": { "$ref": "#/$defs/nullableSha256" },
+        "targetReleaseRef": { "$ref": "#/$defs/nullableString" },
+        "statePreservationRequired": { "const": true },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "references": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roadmap", "execution", "milestone", "updater", "desktopEvaluation", "runtime", "packaging"],
+      "properties": {
+        "roadmap": { "type": "string", "format": "uri" },
+        "execution": { "type": "string", "format": "uri" },
+        "milestone": { "type": "string", "format": "uri" },
+        "updater": { "type": "string", "format": "uri" },
+        "desktopEvaluation": { "type": "string", "format": "uri" },
+        "runtime": { "type": "string", "format": "uri" },
+        "packaging": { "type": "string", "format": "uri" }
+      }
+    },
+    "proofBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allows", "excludes"],
+      "properties": {
+        "allows": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "excludes": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "state": { "enum": ["pending", "proven", "not-applicable", "not-performed", "blocked"] },
+    "nullableString": { "type": ["string", "null"] },
+    "nullableSha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
+    "refs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "commit", "ref", "cleanCheckout", "workflowRunRef", "artifactRef"],
+      "properties": {
+        "repository": { "const": "electricsheephq/evaos-code-review-bot-neondiff" },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "ref": { "type": "string", "minLength": 1 },
+        "cleanCheckout": { "type": "boolean" },
+        "workflowRunRef": { "$ref": "#/$defs/nullableString" },
+        "artifactRef": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "bundleId", "appPath", "archiveName", "build", "sha256", "workflowRunRef", "artifactRef", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "bundleId": { "const": "com.electricsheephq.NeonDiffDesktop" },
+        "appPath": { "type": "string", "minLength": 1 },
+        "archiveName": { "$ref": "#/$defs/nullableString" },
+        "build": { "$ref": "#/$defs/nullableString" },
+        "sha256": { "$ref": "#/$defs/nullableSha256" },
+        "workflowRunRef": { "$ref": "#/$defs/nullableString" },
+        "artifactRef": { "$ref": "#/$defs/nullableString" },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "identity", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "identity": { "$ref": "#/$defs/nullableString" },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    },
+    "site": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "productUrl", "downloadUrl", "releaseNotesUrl", "artifactSha256", "evidenceRefs"],
+      "properties": {
+        "state": { "$ref": "#/$defs/state" },
+        "productUrl": { "type": "string", "format": "uri" },
+        "downloadUrl": { "$ref": "#/$defs/nullableString" },
+        "releaseNotesUrl": { "$ref": "#/$defs/nullableString" },
+        "artifactSha256": { "$ref": "#/$defs/nullableSha256" },
+        "evidenceRefs": { "$ref": "#/$defs/refs" }
+      }
+    }
+  }
+}

--- a/docs/schema/desktop-candidate-manifest.schema.json
+++ b/docs/schema/desktop-candidate-manifest.schema.json
@@ -18,16 +18,10 @@
     "releaseLevel": { "enum": ["candidate", "beta", "stable"] },
     "channel": { "enum": ["beta", "stable"] },
     "contract": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["mode", "paidBetaContract", "byoGitHubEnabled", "managedBrokerEnabled", "brokerOrigin"],
-      "properties": {
-        "mode": { "enum": ["byo", "managed"] },
-        "paidBetaContract": { "enum": ["paid-mac-beta-byo-v1", "paid-mac-beta-v1"] },
-        "byoGitHubEnabled": { "type": "boolean" },
-        "managedBrokerEnabled": { "type": "boolean" },
-        "brokerOrigin": { "type": ["string", "null"], "format": "uri" }
-      }
+      "oneOf": [
+        { "$ref": "#/$defs/byoContract" },
+        { "$ref": "#/$defs/managedContract" }
+      ]
     },
     "source": { "$ref": "#/$defs/source" },
     "artifact": { "$ref": "#/$defs/artifact" },
@@ -36,7 +30,7 @@
     "feed": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["state", "technology", "channel", "feedUrl", "publicKeyRef", "artifactUrl", "signatureRef", "rollbackRef", "evidenceRefs"],
+      "required": ["state", "technology", "channel", "feedUrl", "publicKeyRef", "artifactUrl", "artifactSha256", "signatureRef", "rollbackRef", "evidenceRefs"],
       "properties": {
         "state": { "$ref": "#/$defs/state" },
         "technology": { "const": "Sparkle 2" },
@@ -44,10 +38,12 @@
         "feedUrl": { "$ref": "#/$defs/nullableString" },
         "publicKeyRef": { "$ref": "#/$defs/nullableString" },
         "artifactUrl": { "$ref": "#/$defs/nullableString" },
+        "artifactSha256": { "$ref": "#/$defs/nullableSha256" },
         "signatureRef": { "$ref": "#/$defs/nullableString" },
         "rollbackRef": { "$ref": "#/$defs/nullableString" },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["feedUrl", "publicKeyRef", "artifactUrl", "artifactSha256", "signatureRef", "rollbackRef", "evidenceRefs"], "properties": { "feedUrl": { "type": "string", "minLength": 1 }, "publicKeyRef": { "type": "string", "minLength": 1 }, "artifactUrl": { "type": "string", "minLength": 1 }, "artifactSha256": { "$ref": "#/$defs/sha256" }, "signatureRef": { "type": "string", "minLength": 1 }, "rollbackRef": { "type": "string", "minLength": 1 }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "site": { "$ref": "#/$defs/site" },
     "billing": {
@@ -60,7 +56,8 @@
         "authorityRef": { "$ref": "#/$defs/nullableString" },
         "activationRef": { "$ref": "#/$defs/nullableString" },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["authorityRef", "activationRef", "evidenceRefs"], "properties": { "authorityRef": { "type": "string", "minLength": 1 }, "activationRef": { "type": "string", "minLength": 1 }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "customer": {
       "type": "object",
@@ -71,19 +68,22 @@
         "canaryRef": { "$ref": "#/$defs/nullableString" },
         "requiredScenarios": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["canaryRef", "evidenceRefs"], "properties": { "canaryRef": { "type": "string", "minLength": 1 }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "runtime": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["state", "launchdLabel", "workerVersion", "noDowntimeInvariant", "evidenceRefs"],
+      "required": ["state", "launchdLabel", "workerVersion", "configIdentitySha256", "noDowntimeInvariant", "evidenceRefs"],
       "properties": {
         "state": { "$ref": "#/$defs/state" },
         "launchdLabel": { "type": "string", "minLength": 1 },
         "workerVersion": { "$ref": "#/$defs/nullableString" },
+        "configIdentitySha256": { "$ref": "#/$defs/nullableSha256" },
         "noDowntimeInvariant": { "type": "string", "minLength": 20 },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["workerVersion", "configIdentitySha256", "evidenceRefs"], "properties": { "workerVersion": { "type": "string", "minLength": 1 }, "configIdentitySha256": { "$ref": "#/$defs/sha256" }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "rollback": {
       "type": "object",
@@ -96,7 +96,8 @@
         "targetReleaseRef": { "$ref": "#/$defs/nullableString" },
         "statePreservationRequired": { "const": true },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["targetVersion", "targetArtifactSha256", "targetReleaseRef", "evidenceRefs"], "properties": { "targetVersion": { "type": "string", "minLength": 1 }, "targetArtifactSha256": { "$ref": "#/$defs/sha256" }, "targetReleaseRef": { "type": "string", "minLength": 1 }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "references": {
       "type": "object",
@@ -126,7 +127,10 @@
     "state": { "enum": ["pending", "proven", "not-applicable", "not-performed", "blocked"] },
     "nullableString": { "type": ["string", "null"] },
     "nullableSha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
-    "refs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "refs": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "byoContract": { "type": "object", "additionalProperties": false, "required": ["mode", "paidBetaContract", "byoGitHubEnabled", "managedBrokerEnabled", "brokerOrigin"], "properties": { "mode": { "const": "byo" }, "paidBetaContract": { "const": "paid-mac-beta-byo-v1" }, "byoGitHubEnabled": { "const": true }, "managedBrokerEnabled": { "const": false }, "brokerOrigin": { "const": null } } },
+    "managedContract": { "type": "object", "additionalProperties": false, "required": ["mode", "paidBetaContract", "byoGitHubEnabled", "managedBrokerEnabled", "brokerOrigin"], "properties": { "mode": { "const": "managed" }, "paidBetaContract": { "const": "paid-mac-beta-v1" }, "byoGitHubEnabled": { "const": false }, "managedBrokerEnabled": { "const": true }, "brokerOrigin": { "const": "https://neondiff-license.fly.dev" } } },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -148,13 +152,14 @@
         "state": { "$ref": "#/$defs/state" },
         "bundleId": { "const": "com.electricsheephq.NeonDiffDesktop" },
         "appPath": { "type": "string", "minLength": 1 },
-        "archiveName": { "$ref": "#/$defs/nullableString" },
+        "archiveName": { "type": ["string", "null"], "pattern": "^NeonDiff-1\\.1\\.0-beta\\.[0-9]+-build[0-9]+-macOS\\.zip$" },
         "build": { "$ref": "#/$defs/nullableString" },
         "sha256": { "$ref": "#/$defs/nullableSha256" },
         "workflowRunRef": { "$ref": "#/$defs/nullableString" },
         "artifactRef": { "$ref": "#/$defs/nullableString" },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["archiveName", "build", "sha256", "workflowRunRef", "artifactRef", "evidenceRefs"], "properties": { "archiveName": { "type": "string", "minLength": 1 }, "build": { "type": "string", "minLength": 1 }, "sha256": { "$ref": "#/$defs/sha256" }, "workflowRunRef": { "type": "string", "minLength": 1 }, "artifactRef": { "type": "string", "minLength": 1 }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "gate": {
       "type": "object",
@@ -164,7 +169,8 @@
         "state": { "$ref": "#/$defs/state" },
         "identity": { "$ref": "#/$defs/nullableString" },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "properties": { "identity": { "type": "string", "minLength": 1 }, "evidenceRefs": { "minItems": 1 } } } }]
     },
     "site": {
       "type": "object",
@@ -177,7 +183,8 @@
         "releaseNotesUrl": { "$ref": "#/$defs/nullableString" },
         "artifactSha256": { "$ref": "#/$defs/nullableSha256" },
         "evidenceRefs": { "$ref": "#/$defs/refs" }
-      }
+      },
+      "allOf": [{ "if": { "properties": { "state": { "const": "proven" } } }, "then": { "required": ["downloadUrl", "releaseNotesUrl", "artifactSha256", "evidenceRefs"], "properties": { "downloadUrl": { "type": "string", "minLength": 1 }, "releaseNotesUrl": { "type": "string", "minLength": 1 }, "artifactSha256": { "$ref": "#/$defs/sha256" }, "evidenceRefs": { "minItems": 1 } } } }]
     }
   }
 }

--- a/tests/desktop-candidate-manifest.test.ts
+++ b/tests/desktop-candidate-manifest.test.ts
@@ -1,12 +1,24 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import * as Ajv2020Module from "ajv/dist/2020.js";
 import { describe, expect, it } from "vitest";
 
 const root = resolve(__dirname, "..");
 const schema = JSON.parse(readFileSync(resolve(root, "docs/schema/desktop-candidate-manifest.schema.json"), "utf8"));
 const manifest = JSON.parse(readFileSync(resolve(root, "docs/release-candidates/v1.1.0-desktop-candidate-manifest.json"), "utf8"));
+const ajv = new Ajv2020Module.default({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+const cloneManifest = () => JSON.parse(JSON.stringify(manifest));
+const feedMatchesArtifact = (candidate: typeof manifest) =>
+  candidate.feed.artifactSha256 === null || candidate.artifact.sha256 === null ||
+  candidate.feed.artifactSha256 === candidate.artifact.sha256;
 
 describe("Desktop candidate manifest contract", () => {
+  it("compiles and validates the versioned manifest with Ajv2020", () => {
+    expect(validate(manifest), JSON.stringify(validate.errors)).toBe(true);
+    expect(manifest.artifact.bundleId).toBe("com.electricsheephq.NeonDiffDesktop");
+  });
+
   it("keeps all release and customer gates explicit", () => {
     for (const field of schema.required) expect(manifest).toHaveProperty(field);
     expect(manifest.schemaVersion).toBe("desktop-candidate-manifest.v1");
@@ -28,7 +40,40 @@ describe("Desktop candidate manifest contract", () => {
       expect(manifest[gate].evidenceRefs.length).toBeGreaterThan(0);
     }
     expect(manifest.runtime.noDowntimeInvariant).toMatch(/prior candidate|replacement/i);
+    expect(manifest.artifact.archiveName).toMatch(/^NeonDiff-1\.1\.0-beta\.87-build[0-9]+-macOS\.zip$/);
+    expect(manifest.feed.artifactSha256).toBeNull();
+    expect(manifest.runtime.configIdentitySha256).toBeNull();
     expect(manifest.rollback.statePreservationRequired).toBe(true);
+  });
+
+  it("rejects mixed contracts and proven gates without proof identity", () => {
+    const mixed = cloneManifest();
+    mixed.contract.managedBrokerEnabled = true;
+    expect(validate(mixed)).toBe(false);
+
+    const unprovenIdentity = cloneManifest();
+    unprovenIdentity.signing.state = "proven";
+    unprovenIdentity.signing.identity = null;
+    unprovenIdentity.signing.evidenceRefs = [];
+    expect(validate(unprovenIdentity)).toBe(false);
+
+    const unboundRuntime = cloneManifest();
+    unboundRuntime.runtime.state = "proven";
+    unboundRuntime.runtime.workerVersion = "1.1.0-beta.87-build11091";
+    unboundRuntime.runtime.configIdentitySha256 = null;
+    expect(validate(unboundRuntime)).toBe(false);
+  });
+
+  it("rejects an archive without a build and catches feed checksum drift", () => {
+    const malformedArchive = cloneManifest();
+    malformedArchive.artifact.archiveName = "NeonDiff-1.1.0-beta.87-macOS.zip";
+    expect(validate(malformedArchive)).toBe(false);
+
+    const mismatchedFeed = cloneManifest();
+    mismatchedFeed.artifact.sha256 = "a".repeat(64);
+    mismatchedFeed.feed.artifactSha256 = "b".repeat(64);
+    expect(validate(mismatchedFeed)).toBe(true);
+    expect(feedMatchesArtifact(mismatchedFeed)).toBe(false);
   });
 
   it("does not contain obsolete mounts or secret-shaped values", () => {

--- a/tests/desktop-candidate-manifest.test.ts
+++ b/tests/desktop-candidate-manifest.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "..");
+const schema = JSON.parse(readFileSync(resolve(root, "docs/schema/desktop-candidate-manifest.schema.json"), "utf8"));
+const manifest = JSON.parse(readFileSync(resolve(root, "docs/release-candidates/v1.1.0-desktop-candidate-manifest.json"), "utf8"));
+
+describe("Desktop candidate manifest contract", () => {
+  it("keeps all release and customer gates explicit", () => {
+    for (const field of schema.required) expect(manifest).toHaveProperty(field);
+    expect(manifest.schemaVersion).toBe("desktop-candidate-manifest.v1");
+    expect(manifest.product).toBe("NeonDiff Desktop");
+    expect(manifest.version).toBe("1.1.0-beta.87");
+    expect(manifest.source.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(manifest.source.commit).toBe("de00a1daf20c27b1d14fff5a5defb9b5597e71b5");
+
+    expect(manifest.contract).toMatchObject({
+      mode: "byo",
+      paidBetaContract: "paid-mac-beta-byo-v1",
+      byoGitHubEnabled: true,
+      managedBrokerEnabled: false,
+      brokerOrigin: null
+    });
+
+    for (const gate of ["artifact", "signing", "notarization", "feed", "site", "billing", "customer", "runtime", "rollback"]) {
+      expect(manifest[gate].state).toBeTruthy();
+      expect(manifest[gate].evidenceRefs.length).toBeGreaterThan(0);
+    }
+    expect(manifest.runtime.noDowntimeInvariant).toMatch(/prior candidate|replacement/i);
+    expect(manifest.rollback.statePreservationRequired).toBe(true);
+  });
+
+  it("does not contain obsolete mounts or secret-shaped values", () => {
+    const publicText = `${JSON.stringify(schema)}\n${JSON.stringify(manifest)}`;
+    expect(publicText).not.toContain("/Volumes/LEXAR");
+    expect(publicText).not.toMatch(/(private[_ -]?key|activation[_ -]?key|api[_ -]?key|token)\s*[:=]\s*[^,}\s]+/i);
+  });
+
+  it("leaves the published CLI v1.0.4 manifest as a separate contract", () => {
+    const cliManifest = JSON.parse(readFileSync(resolve(root, "docs/public-release-manifest.json"), "utf8"));
+    expect(cliManifest.version).toBe("v1.0.4");
+    expect(cliManifest.packageArtifact.version).toBe("1.0.4");
+    expect(cliManifest.updateChannels.cli.version).toBe("v1.0.4");
+    expect(cliManifest).not.toHaveProperty("contract");
+    expect(cliManifest).not.toHaveProperty("artifact.bundleId");
+  });
+});


### PR DESCRIPTION
## Summary

- add the current Mac GA architecture/release contract with explicit CLI `v1.0.4` versus native Desktop `1.1.0` lanes
- add a versioned, public-safe Desktop candidate manifest plus JSON Schema and focused contract test
- reconcile active runbooks away from obsolete `/Volumes/LEXAR` and pre-native Desktop assumptions while preserving historical release packets and the published CLI manifest

## Exact identity

- base: `de00a1daf20c27b1d14fff5a5defb9b5597e71b5`
- head: `cc9d1a2778b2275b6557fcef5f3b07000b012dee`
- branch: `codex/mac-ga-architecture`

## Validation

- `node` JSON parse: pass
- Ajv 2020 schema validation: pass
- deterministic manifest/CLI separation and public-safety checks: pass
- `npm run check:public-claims`: pass
- `npm run check:secrets`: pass
- `npm run check:design-source`: pass
- `git diff --check`: pass
- Vitest is environment-blocked by Rollup native module code-signature/team-ID mismatch on Node `v24.19.0`; one optional-dependency reinstall did not change it

## Proof boundary

This is `pr_ready` docs/schema/test evidence only. It does not prove signed/notarized distribution, hosted Sparkle feed, billing, runtime safety, customer readiness, or Mac GA. No live runtime, website, release, tracker, customer, Keychain, DB, or CLI manifest mutation was performed.

Related: #103 #610 #116 #524 #738 #806