### PR TITLE
fix(desktop): restore exact BYO launch contract

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -53,12 +53,16 @@ jobs:
 
       - name: Build unsigned Release app bundle
         env:
+          NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: paid-mac-beta-byo-v1
+          NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true"
           NEONDIFF_SPARKLE_FEED_URL: https://ci.invalid/neondiff/appcast-beta.xml
           NEONDIFF_SPARKLE_PUBLIC_ED_KEY: CI_ONLY_NOT_A_RELEASE_KEY
         run: script/build_and_run.sh release-build
 
       - name: Check unsigned Release app bundle
         env:
+          NEONDIFF_DESKTOP_PAID_BETA_CONTRACT: paid-mac-beta-byo-v1
+          NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED: "true"
           NEONDIFF_SPARKLE_FEED_URL: https://ci.invalid/neondiff/appcast-beta.xml
           NEONDIFF_SPARKLE_PUBLIC_ED_KEY: CI_ONLY_NOT_A_RELEASE_KEY
         run: script/build_and_run.sh release-bundle-check

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1636,9 +1636,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let restoresExactMatch = hasPersistedActivationJourney
             && initial.id == saved
             && initial.bots.contains(where: {
-                $0.id == savedBotID
-                    && $0.status == .verified
-                    && $0.localConfigPath.map(normalizedPath) == savedConfigPath.map(normalizedPath)
+                guard $0.id == savedBotID,
+                      $0.status == .verified,
+                      let localConfigPath = $0.localConfigPath,
+                      let savedConfigPath
+                else {
+                    return false
+                }
+                return normalizedPath(localConfigPath)
+                    == normalizedPath(savedConfigPath)
             })
         selectAccountWorkspace(
             initial.id,
@@ -1926,7 +1932,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
-        dependencies.preferences.set("", forKey: activationRepositoryKey)
+        if !preservingActivationJourney {
+            dependencies.preferences.set("", forKey: activationRepositoryKey)
+        }
         activationState = preservedActivationState
             ?? ActivationStateMachine.initialState
         dependencies.preferences.set(activationState.rawValue, forKey: activationStateKey)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1627,7 +1627,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let saved = dependencies.preferences.string(forKey: accountWorkspacePreferenceKey)
         let initial = catalog.accounts.first(where: { $0.id == saved }) ?? catalog.accounts[0]
         let savedBotID = dependencies.preferences.string(forKey: accountBotPreferenceKey)
-        selectAccountWorkspace(initial.id, clearSavedBot: false)
+        let savedConfigPath = dependencies.preferences.string(
+            forKey: Self.configPathPreferenceKey
+        )
+        let hasPersistedActivationJourney = dependencies.preferences.string(
+            forKey: activationStateKey
+        ).flatMap(ActivationState.init(rawValue:)) != nil
+        let restoresExactMatch = hasPersistedActivationJourney
+            && initial.id == saved
+            && initial.bots.contains(where: {
+                $0.id == savedBotID
+                    && $0.status == .verified
+                    && $0.localConfigPath.map(normalizedPath) == savedConfigPath.map(normalizedPath)
+            })
+        selectAccountWorkspace(
+            initial.id,
+            clearSavedBot: false,
+            preservingActivationJourney: restoresExactMatch
+        )
         if let restoredPlan = restoredPendingNewBotPlan(
             account: initial,
             savedBotID: savedBotID
@@ -1653,7 +1670,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             ) != nil
             selectBotInstallation(
                 savedBotID,
-                preservesPendingNewBotPlan: preservesPendingPlan
+                preservesPendingNewBotPlan: preservesPendingPlan,
+                restoringExactMatch: restoresExactMatch
             )
         } else {
             dependencies.preferences.removeValue(forKey: accountBotPreferenceKey)
@@ -1667,17 +1685,27 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func selectAccountWorkspace(_ accountID: String) {
-        selectAccountWorkspace(accountID, clearSavedBot: true)
+        selectAccountWorkspace(
+            accountID,
+            clearSavedBot: true,
+            preservingActivationJourney: false
+        )
     }
 
-    private func selectAccountWorkspace(_ accountID: String, clearSavedBot: Bool) {
+    private func selectAccountWorkspace(
+        _ accountID: String,
+        clearSavedBot: Bool,
+        preservingActivationJourney: Bool
+    ) {
         guard accountWorkspaceCatalog.accounts.contains(where: { $0.id == accountID }) else {
             accountWorkspaceStatus = "That account is not available to this signed-in user."
             return
         }
         guard accountWorkspaceSelection.accountID != accountID else { return }
 
-        resetWorkspaceBoundRuntimeState()
+        resetWorkspaceBoundRuntimeState(
+            preservingActivationJourney: preservingActivationJourney
+        )
         accountWorkspaceSelection.selectAccount(accountID)
         pendingNewBotPlan = nil
         dependencies.preferences.set(accountID, forKey: accountWorkspacePreferenceKey)
@@ -1699,12 +1727,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
             )
             return
         }
-        selectBotInstallation(botID, preservesPendingNewBotPlan: false)
+        selectBotInstallation(
+            botID,
+            preservesPendingNewBotPlan: false,
+            restoringExactMatch: false
+        )
     }
 
     private func selectBotInstallation(
         _ botID: String,
-        preservesPendingNewBotPlan: Bool
+        preservesPendingNewBotPlan: Bool,
+        restoringExactMatch: Bool
     ) {
         guard let account = selectedAccountWorkspace,
               let bot = account.bots.first(where: { $0.id == botID }),
@@ -1715,7 +1748,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         guard accountWorkspaceSelection.botID != botID else { return }
 
-        resetWorkspaceBoundRuntimeState()
+        resetWorkspaceBoundRuntimeState(
+            preservingActivationJourney: restoringExactMatch
+        )
         accountWorkspaceSelection.selectBot(botID)
         pendingNewBotPlan = nil
         if !preservesPendingNewBotPlan {
@@ -1725,11 +1760,28 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         dependencies.preferences.set(botID, forKey: accountBotPreferenceKey)
         if let localConfigPath = bot.localConfigPath {
+            let restoredActivationJourney = restoringExactMatch
+                ? activationState
+                : nil
             configPath = localConfigPath
+            if let restoredActivationJourney {
+                activationState = restoredActivationJourney
+                dependencies.preferences.set(
+                    activationState.rawValue,
+                    forKey: activationStateKey
+                )
+            }
             accountWorkspaceStatus = "Local bot selected. Verify its config and GitHub binding before use."
             inspectConfig(
                 allowDuringAccountRestore: isAccountLinkInProgress
             )
+            if restoringExactMatch {
+                statusRefreshFailureMessage = nil
+                runCLI(
+                    arguments: ["daemon", "status", "--config", configPath, "--launchd-label", launchdLabel],
+                    displayCommand: statusCommand
+                )
+            }
         } else {
             configPath = isolatedBotConfigPath(
                 accountID: account.id,
@@ -1815,7 +1867,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     /// Runtime proof is account-bound. Switching accounts or bots invalidates
     /// it without deleting Keychain material; credentials must be reselected
     /// and reverified for the new context before useful work is available.
-    private func resetWorkspaceBoundRuntimeState() {
+    private func resetWorkspaceBoundRuntimeState(
+        preservingActivationJourney: Bool = false
+    ) {
+        let preservedActivationState = preservingActivationJourney
+            ? activationState
+            : nil
         workspaceContextGeneration &+= 1
         activationRequestGeneration &+= 1
         githubAuthorizationTask?.cancel()
@@ -1869,7 +1926,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
-        activationState = ActivationStateMachine.initialState
+        dependencies.preferences.set("", forKey: activationRepositoryKey)
+        activationState = preservedActivationState
+            ?? ActivationStateMachine.initialState
         dependencies.preferences.set(activationState.rawValue, forKey: activationStateKey)
         activationKeyRedactedPrefix = nil
         pendingActivationKey = ""
@@ -3145,7 +3204,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         invalidateScopedReviewApproval()
-        invalidateActivationForRepositoryChange()
+        invalidateActivationForRepositoryChange(fullReset: true)
         selectedBYOReviewRepository = repository.name
         dependencies.preferences.set(
             repository.name,
@@ -6592,12 +6651,26 @@ package final class NeonDiffDesktopModel: ObservableObject {
         pendingRepoPatchProof = nil
     }
 
-    private func invalidateActivationForRepositoryChange() {
+    private func invalidateActivationForRepositoryChange(
+        fullReset: Bool = false
+    ) {
         activationRequestGeneration &+= 1
         if activationState == .activationPending {
             applyActivationEvent(.checkoutCancelled)
             onboardingFlow.licenseActivation = .servicePending
             lastError = "Repository context changed during activation. Review the current target, then retry safely."
+        }
+        if fullReset {
+            activationVerifiedThisLaunch = false
+            activationVerifiedRepositoryThisLaunch = nil
+            dependencies.preferences.set("", forKey: activationRepositoryKey)
+            activationState = ActivationStateMachine.initialState
+            dependencies.preferences.set(
+                activationState.rawValue,
+                forKey: activationStateKey
+            )
+            onboardingFlow.licenseActivation = .servicePending
+            return
         }
         guard activationVerifiedThisLaunch
                 || activationVerifiedRepositoryThisLaunch != nil

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -7,6 +7,87 @@ import NeonDiffDesktopCore
     private let configPath = "/fixture/evaos-code-review-bot/config.local.json"
 
     @MainActor
+    @Test func automaticExactMatchRestorePreservesJourneyAndOnlyReadsDaemonStatus() async {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": "account-electric-sheep",
+                "neondiff.accountBotID": "bot-evaos-code-review-bot",
+                "neondiff.configPath": configPath,
+                "neondiff.activationState.v1": ActivationState.checkoutPaused.rawValue
+            ],
+            productionBoundary: .testAccountLink
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        #expect(await reachesCallCount(fixture, 2))
+
+        #expect(fixture.model.activationState == .checkoutPaused)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+        #expect(fixture.cli.calls.filter {
+            $0.arguments.prefix(2) == ["config", "inspect"]
+        }.count == 1)
+        #expect(fixture.cli.calls.filter {
+            $0.arguments.prefix(2) == ["daemon", "status"]
+        }.count == 1)
+        #expect(!fixture.cli.calls.contains {
+            ["start", "stop", "install", "bootstrap", "bootout", "restart"]
+                .contains(where: $0.arguments.contains)
+        })
+
+        fixture.cli.resumeSuspendedRuns()
+    }
+
+    @MainActor
+    @Test func automaticRestoreConfigMismatchFullyResetsAndSkipsDaemonStatus() async {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": "account-electric-sheep",
+                "neondiff.accountBotID": "bot-evaos-code-review-bot",
+                "neondiff.configPath": "/fixture/different/config.local.json",
+                "neondiff.activationState.v1": ActivationState.checkoutPaused.rawValue
+            ],
+            productionBoundary: .testAccountLink
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(entitlement: .internalAdmin)
+        ]))
+        await fixture.cli.waitUntilCallCount(1)
+
+        #expect(fixture.model.activationState == .purchaseRequired)
+        #expect(!fixture.cli.calls.contains {
+            $0.arguments.prefix(2) == ["daemon", "status"]
+        })
+
+        fixture.cli.resumeSuspendedRuns()
+    }
+
+    @MainActor
+    @Test func explicitRepositorySwitchClearsPersistedActivationJourney() {
+        let firstRepository = "electricsheephq/WorldOS"
+        let secondRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            productionBoundary: .testAccountLink
+        )
+        fixture.loadConfig(existingBotConfig(
+            authMode: "zcode-app-config",
+            repositories: [firstRepository, secondRepository]
+        ))
+        fixture.model.selectBYOReviewRepository(fullName: firstRepository)
+        fixture.model.activationState = .checkoutPaused
+
+        fixture.model.selectBYOReviewRepository(fullName: secondRepository)
+
+        #expect(fixture.model.activationState == .purchaseRequired)
+        #expect(!fixture.model.currentRepositoryActivationReady)
+    }
+
+    @MainActor
     @Test func verifiedExistingBotReconcilesSetupWithoutUnlockingUsefulWork() {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -373,7 +454,7 @@ import NeonDiffDesktopCore
         await fixture.model.submitActivation()
         fixture.model.selectBYOReviewRepository(fullName: secondRepository)
 
-        #expect(fixture.model.activationState == .invalid)
+        #expect(fixture.model.activationState == .purchaseRequired)
         #expect(fixture.model.selectedBYOReviewRepository == secondRepository)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -14,7 +14,8 @@ import NeonDiffDesktopCore
                 "neondiff.accountWorkspaceID": "account-electric-sheep",
                 "neondiff.accountBotID": "bot-evaos-code-review-bot",
                 "neondiff.configPath": configPath,
-                "neondiff.activationState.v1": ActivationState.checkoutPaused.rawValue
+                "neondiff.activationState.v1": ActivationState.activationPending.rawValue,
+                "neondiff.activationRepository.v1": "electricsheephq/WorldOS"
             ],
             productionBoundary: .testAccountLink
         )
@@ -24,7 +25,10 @@ import NeonDiffDesktopCore
         ]))
         #expect(await reachesCallCount(fixture, 2))
 
-        #expect(fixture.model.activationState == .checkoutPaused)
+        #expect(fixture.model.activationState == .activationPending)
+        #expect(fixture.preferences.string(
+            forKey: "neondiff.activationRepository.v1"
+        ) == "electricsheephq/WorldOS")
         #expect(!fixture.model.currentRepositoryActivationReady)
         #expect(fixture.cli.calls.filter {
             $0.arguments.prefix(2) == ["config", "inspect"]
@@ -41,6 +45,32 @@ import NeonDiffDesktopCore
     }
 
     @MainActor
+    @Test func automaticRestoreRequiresTwoPresentLocalConfigPaths() async {
+        let fixture = ModelDependencyFixture(
+            suspendCLIRuns: true,
+            preferenceStrings: [
+                "neondiff.accountWorkspaceID": "account-electric-sheep",
+                "neondiff.accountBotID": "bot-evaos-code-review-bot",
+                "neondiff.activationState.v1": ActivationState.checkoutPaused.rawValue
+            ],
+            productionBoundary: .testAccountLink
+        )
+
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([
+            workspace(
+                entitlement: .internalAdmin,
+                localConfigPath: nil
+            )
+        ]))
+
+        #expect(fixture.model.activationState == .purchaseRequired)
+        #expect(!fixture.cli.calls.contains {
+            $0.arguments.prefix(2) == ["daemon", "status"]
+        })
+        #expect(fixture.model.configPath != configPath)
+    }
+
+    @MainActor
     @Test func automaticRestoreConfigMismatchFullyResetsAndSkipsDaemonStatus() async {
         let fixture = ModelDependencyFixture(
             suspendCLIRuns: true,
@@ -48,7 +78,8 @@ import NeonDiffDesktopCore
                 "neondiff.accountWorkspaceID": "account-electric-sheep",
                 "neondiff.accountBotID": "bot-evaos-code-review-bot",
                 "neondiff.configPath": "/fixture/different/config.local.json",
-                "neondiff.activationState.v1": ActivationState.checkoutPaused.rawValue
+                "neondiff.activationState.v1": ActivationState.checkoutPaused.rawValue,
+                "neondiff.activationRepository.v1": "electricsheephq/WorldOS"
             ],
             productionBoundary: .testAccountLink
         )
@@ -59,6 +90,9 @@ import NeonDiffDesktopCore
         await fixture.cli.waitUntilCallCount(1)
 
         #expect(fixture.model.activationState == .purchaseRequired)
+        #expect(fixture.preferences.string(
+            forKey: "neondiff.activationRepository.v1"
+        )?.isEmpty == true)
         #expect(!fixture.cli.calls.contains {
             $0.arguments.prefix(2) == ["daemon", "status"]
         })
@@ -2255,6 +2289,13 @@ import NeonDiffDesktopCore
     private func workspace(
         entitlement: DesktopAccountEntitlement
     ) -> DesktopAccountWorkspace {
+        workspace(entitlement: entitlement, localConfigPath: configPath)
+    }
+
+    private func workspace(
+        entitlement: DesktopAccountEntitlement,
+        localConfigPath: String?
+    ) -> DesktopAccountWorkspace {
         DesktopAccountWorkspace(
             id: "account-electric-sheep",
             kind: .organization,
@@ -2270,7 +2311,7 @@ import NeonDiffDesktopCore
                     githubInstallationID: 72_001,
                     githubAccountLogin: "electricsheephq",
                     status: .verified,
-                    localConfigPath: configPath
+                    localConfigPath: localConfigPath
                 )
             ]
         )

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -2,6 +2,26 @@ import Testing
 @testable import NeonDiffDesktopAppCore
 
 @Suite struct ProductionBoundaryContractTests {
+    @Test func releaseProofRequiresExactBYOOutputMarkers() throws {
+        let releaseProof = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot()
+                .appendingPathComponent("script/release-proof.sh")
+        )
+
+        #expect(releaseProof.contains(
+            #"Print :NeonDiffPaidBetaContract"#
+        ))
+        #expect(releaseProof.contains(
+            #"paid-mac-beta-byo-v1"#
+        ))
+        #expect(releaseProof.contains(
+            #"Print :NeonDiffBYOGitHubEnabled"#
+        ))
+        #expect(releaseProof.contains(
+            #"assert_byo_production_contract "$INFO_PLIST""#
+        ))
+    }
+
     @MainActor
     @Test func quarantinedProductionModelBlocksUsefulWorkAndPseudoActivation() throws {
         let fixture = ModelDependencyFixture(productionBoundary: .quarantined)

--- a/apps/neondiff-desktop/script/release-proof.sh
+++ b/apps/neondiff-desktop/script/release-proof.sh
@@ -44,6 +44,25 @@ normalize_bool() {
   esac
 }
 
+assert_byo_production_contract() {
+  local info_plist="$1"
+  local contract
+  local byo_enabled
+  local managed_enabled
+  local managed_origin
+  contract="$(/usr/libexec/PlistBuddy -c "Print :NeonDiffPaidBetaContract" "$info_plist" 2>/dev/null || true)"
+  byo_enabled="$(/usr/libexec/PlistBuddy -c "Print :NeonDiffBYOGitHubEnabled" "$info_plist" 2>/dev/null || true)"
+  managed_enabled="$(/usr/libexec/PlistBuddy -c "Print :NeonDiffManagedGitHubBrokerEnabled" "$info_plist" 2>/dev/null || true)"
+  managed_origin="$(/usr/libexec/PlistBuddy -c "Print :NeonDiffGitHubBrokerOrigin" "$info_plist" 2>/dev/null || true)"
+  if [ "$contract" != "paid-mac-beta-byo-v1" ] \
+    || [ "$byo_enabled" != "true" ] \
+    || [ -n "$managed_enabled" ] \
+    || [ -n "$managed_origin" ]; then
+    echo "release artifact is missing the exact BYO production contract" >&2
+    exit 1
+  fi
+}
+
 ensure_clean_source_tree() {
   if ! git -C "$REPO_ROOT" diff --quiet --ignore-submodules --; then
     echo "source tree has unstaged changes; set SOURCE_SHA and SOURCE_REF explicitly or commit/stash before release proof" >&2
@@ -109,6 +128,7 @@ mkdir -p "$RELEASE_SMOKE_DIR"
 rm -rf "$APP_BUNDLE"
 rm -f "$ARTIFACT_PATH" "$METADATA_PATH"
 ditto "$SOURCE_APP_BUNDLE" "$APP_BUNDLE"
+assert_byo_production_contract "$INFO_PLIST"
 
 if [ "$UI_LAUNCH" = "true" ]; then
   verify_existing_app_launch

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -104,6 +104,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
             name?: string;
             uses?: string;
             run?: string;
+            env?: Record<string, string>;
             with?: Record<string, string>;
             "working-directory"?: string;
           }>;
@@ -147,6 +148,16 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(fixtureBoundaryStep?.run).toBe(
       "npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/dist/NeonDiff.app"
     );
+    for (const stepName of [
+      "Build unsigned Release app bundle",
+      "Check unsigned Release app bundle"
+    ]) {
+      const step = job?.steps?.find((candidate) => candidate.name === stepName);
+      expect(step?.env?.NEONDIFF_DESKTOP_PAID_BETA_CONTRACT).toBe(
+        "paid-mac-beta-byo-v1"
+      );
+      expect(step?.env?.NEONDIFF_DESKTOP_BYO_GITHUB_ENABLED).toBe("true");
+    }
     expect(workflow).toContain("unsigned");
     expect(workflow).toMatch(/macOS 15 Keychain contract compilation/);
     expect(workflow).toMatch(/persist-credentials:\s*false/);


### PR DESCRIPTION
## Summary

- require the copied release artifact to carry the exact BYO production markers and no managed-broker markers
- preserve a persisted activation journey only when the saved account, verified bot, config path, and activation state exactly match authoritative launch restoration
- clear current-launch and repository proof, run one read-only `daemon status`, and keep full reset behavior for explicit identity changes, mismatch, lost authority, and server errors
- add failing-first restoration and release-proof contract coverage

Closes #806
Related: #610

## Failing-first proof

The initial focused run compiled successfully and failed on the three intended gaps:

- exact-match restore reset `.checkoutPaused` to `.purchaseRequired` and issued no daemon status
- explicit repository switch retained the prior journey
- `release-proof.sh` did not inspect the BYO output markers

The config-mismatch control already passed.

## Validation

- `swift test --filter 'ExistingLocalBotReconciliationTests|ProductionBoundaryContractTests|AccountWorkspaceSelectionTests'` — PASS, 98 tests
- `bash -n apps/neondiff-desktop/script/release-proof.sh` — PASS
- exact release-only BYO `production-contract-check` — PASS, output `byo`
- mixed BYO/managed `production-contract-check` — expected rejection, exit 2
- `git diff --check` — PASS

The broader TypeScript suite is left to canonical GitHub CI because this isolated worktree has no installed Node dependencies.

## Safety and proof boundary

Agent-authored change. No installed app was launched, replaced, or edited. No launchd, worker, Keychain, live config, database, signing, notarization, release, website, billing, customer, or credential state was read or mutated.

This PR may prove source and deterministic test behavior at exact head `267baee11018e850a0a40affd1ac97f69de107d8`. It does not prove merge readiness before required CI and independent review, nor a signed artifact, installed acceptance, runtime safety, customer readiness, Mac GA, or release readiness.
