### PR TITLE
fix(runtime): bound Git preparation and GitHub requests

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,8 +1,28 @@
 import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join, resolve } from "node:path";
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { assertPathOutsideProtectedRoot } from "./path-safety.js";
+import { redactSecrets } from "./secrets.js";
+
+export const DEFAULT_GIT_COMMAND_TIMEOUT_MS = 120_000;
+const gitMirrorTails = new Map<string, Promise<void>>();
+
+export class GitCommandError extends Error {
+  readonly failureKind: "timeout" | "spawn_error" | "exit_nonzero";
+  readonly timeoutMs: number;
+
+  constructor(input: {
+    failureKind: "timeout" | "spawn_error" | "exit_nonzero";
+    timeoutMs: number;
+    detail?: string;
+  }) {
+    super(`git command ${input.failureKind}${input.detail ? `: ${redactSecrets(input.detail).slice(0, 400)}` : ""}`);
+    this.name = "GitCommandError";
+    this.failureKind = input.failureKind;
+    this.timeoutMs = input.timeoutMs;
+  }
+}
 
 export interface PreparedWorktree {
   path: string;
@@ -22,6 +42,7 @@ export interface PullWorktreeInput {
   workRoot: string;
   protectedCheckoutRoot?: string;
   protectedCheckoutRoots?: string[];
+  gitCommandTimeoutMs?: number;
 }
 
 export interface BranchWorktreeInput {
@@ -31,9 +52,11 @@ export interface BranchWorktreeInput {
   workRoot: string;
   protectedCheckoutRoot?: string;
   protectedCheckoutRoots?: string[];
+  gitCommandTimeoutMs?: number;
 }
 
-export function prepareBranchWorktree(input: BranchWorktreeInput): PreparedWorktree {
+export async function prepareBranchWorktree(input: BranchWorktreeInput): Promise<PreparedWorktree> {
+  const timeoutMs = input.gitCommandTimeoutMs ?? DEFAULT_GIT_COMMAND_TIMEOUT_MS;
   const safeRepo = input.repo.replace(/[^A-Za-z0-9_.-]+/g, "__");
   const mirrorPath = join(input.workRoot, "mirrors", `${safeRepo}.git`);
   const repoUrl = input.repoUrl ?? `https://github.com/${input.repo}.git`;
@@ -44,23 +67,24 @@ export function prepareBranchWorktree(input: BranchWorktreeInput): PreparedWorkt
     pathLabel: "workRoot",
     protectedRootLabel: "the protected live checkout"
   });
-  run("git", ["check-ref-format", `refs/heads/${input.branch}`]);
+  await run(["check-ref-format", `refs/heads/${input.branch}`], timeoutMs);
+  return withGitMirrorLock(mirrorPath, async () => {
   mkdirSync(join(input.workRoot, "mirrors"), { recursive: true });
   mkdirSync(join(input.workRoot, "worktrees"), { recursive: true });
-  if (!existsAsGitMirror(mirrorPath)) {
-    run("git", ["clone", "--mirror", repoUrl, mirrorPath]);
+  if (!await existsAsGitMirror(mirrorPath, timeoutMs)) {
+    await run(["clone", "--mirror", repoUrl, mirrorPath], timeoutMs);
   } else {
-    run("git", ["--git-dir", mirrorPath, "remote", "set-url", "origin", repoUrl]);
+    await run(["--git-dir", mirrorPath, "remote", "set-url", "origin", repoUrl], timeoutMs);
   }
-  run("git", [
+  await run([
     "--git-dir",
     mirrorPath,
     "fetch",
     "--prune",
     "origin",
     `+refs/heads/${input.branch}:refs/heads/${input.branch}`
-  ]);
-  const headSha = run("git", ["--git-dir", mirrorPath, "rev-parse", `refs/heads/${input.branch}`]).stdout.trim();
+  ], timeoutMs);
+  const headSha = (await run(["--git-dir", mirrorPath, "rev-parse", `refs/heads/${input.branch}`], timeoutMs)).stdout.trim();
   const worktreePath = join(input.workRoot, "worktrees", branchWorktreeName(input.repo, input.branch, headSha));
   assertPathOutsideProtectedRoot({
     path: worktreePath,
@@ -69,18 +93,20 @@ export function prepareBranchWorktree(input: BranchWorktreeInput): PreparedWorkt
     pathLabel: "worktreePath",
     protectedRootLabel: "the protected live checkout"
   });
-  repairExistingReviewWorktreePathForCheckout({
+  await repairExistingReviewWorktreePathForCheckout({
     worktreePath,
     mirrorPath,
     protectedCheckoutRoot: input.protectedCheckoutRoot,
-    protectedCheckoutRoots: input.protectedCheckoutRoots
+    protectedCheckoutRoots: input.protectedCheckoutRoots,
+    gitCommandTimeoutMs: timeoutMs
   });
-  run("git", ["--git-dir", mirrorPath, "worktree", "add", "--detach", worktreePath, headSha]);
-  const actualHeadSha = run("git", ["-C", worktreePath, "rev-parse", "HEAD"]).stdout.trim();
+  await run(["--git-dir", mirrorPath, "worktree", "add", "--detach", worktreePath, headSha], timeoutMs);
+  const actualHeadSha = (await run(["-C", worktreePath, "rev-parse", "HEAD"], timeoutMs)).stdout.trim();
   if (actualHeadSha !== headSha) {
     throw new Error(`Worktree head mismatch for ${input.repo}@${input.branch}: ${actualHeadSha} !== ${headSha}`);
   }
   return { path: worktreePath, headSha: actualHeadSha };
+  });
 }
 
 export function branchWorktreeName(repo: string, branch: string, headSha: string): string {
@@ -101,19 +127,21 @@ export function planPullWorktreePaths(input: PullWorktreeInput): PullWorktreePat
   return { mirrorPath, worktreePath, repoUrl };
 }
 
-export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree {
+export async function preparePullWorktree(input: PullWorktreeInput): Promise<PreparedWorktree> {
+  const timeoutMs = input.gitCommandTimeoutMs ?? DEFAULT_GIT_COMMAND_TIMEOUT_MS;
   const { mirrorPath, worktreePath, repoUrl } = planPullWorktreePaths(input);
 
+  return withGitMirrorLock(mirrorPath, async () => {
   mkdirSync(join(input.workRoot, "mirrors"), { recursive: true });
   mkdirSync(join(input.workRoot, "worktrees"), { recursive: true });
 
-  if (!existsAsGitMirror(mirrorPath)) {
-    run("git", ["clone", "--mirror", repoUrl, mirrorPath]);
+  if (!await existsAsGitMirror(mirrorPath, timeoutMs)) {
+    await run(["clone", "--mirror", repoUrl, mirrorPath], timeoutMs);
   } else {
-    run("git", ["--git-dir", mirrorPath, "remote", "set-url", "origin", repoUrl]);
+    await run(["--git-dir", mirrorPath, "remote", "set-url", "origin", repoUrl], timeoutMs);
   }
 
-  run("git", [
+  await run([
     "--git-dir",
     mirrorPath,
     "fetch",
@@ -121,15 +149,16 @@ export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree 
     "origin",
     `+refs/pull/${input.pullNumber}/head:refs/pull/${input.pullNumber}/head`,
     "+refs/heads/*:refs/heads/*"
-  ]);
+  ], timeoutMs);
 
-  repairExistingReviewWorktreePathForCheckout({
+  await repairExistingReviewWorktreePathForCheckout({
     worktreePath,
     mirrorPath,
     protectedCheckoutRoot: input.protectedCheckoutRoot,
-    protectedCheckoutRoots: input.protectedCheckoutRoots
+    protectedCheckoutRoots: input.protectedCheckoutRoots,
+    gitCommandTimeoutMs: timeoutMs
   });
-  run("git", [
+  await run([
     "--git-dir",
     mirrorPath,
     "worktree",
@@ -137,22 +166,25 @@ export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree 
     "--detach",
     worktreePath,
     `refs/pull/${input.pullNumber}/head`
-  ]);
+  ], timeoutMs);
 
-  const actualHeadSha = run("git", ["-C", worktreePath, "rev-parse", "HEAD"]).stdout.trim();
+  const actualHeadSha = (await run(["-C", worktreePath, "rev-parse", "HEAD"], timeoutMs)).stdout.trim();
   if (actualHeadSha !== input.expectedHeadSha) {
     throw new Error(`Worktree head mismatch for ${input.repo}#${input.pullNumber}: ${actualHeadSha} !== ${input.expectedHeadSha}`);
   }
 
   return { path: worktreePath, headSha: actualHeadSha };
+  });
 }
 
-export function repairExistingReviewWorktreePathForCheckout(input: {
+export async function repairExistingReviewWorktreePathForCheckout(input: {
   worktreePath: string;
   mirrorPath: string;
   protectedCheckoutRoot?: string;
   protectedCheckoutRoots?: string[];
-}): void {
+  gitCommandTimeoutMs?: number;
+}): Promise<void> {
+  const timeoutMs = input.gitCommandTimeoutMs ?? DEFAULT_GIT_COMMAND_TIMEOUT_MS;
   assertPathOutsideProtectedRoot({
     path: input.worktreePath,
     protectedRoot: input.protectedCheckoutRoot,
@@ -166,13 +198,13 @@ export function repairExistingReviewWorktreePathForCheckout(input: {
     if (stat.isSymbolicLink()) {
       throw new Error(`checkout preparation failed for ${input.worktreePath}: existing_symlink`);
     }
-    const existingGitWorktree = existsAsGitWorktree(input.worktreePath);
+    const existingGitWorktree = await existsAsGitWorktree(input.worktreePath, timeoutMs);
 
     if (existingGitWorktree) {
-      if (!isGitWorktreeOwnedByMirror(input)) {
+      if (!await isGitWorktreeOwnedByMirror(input, timeoutMs)) {
         throw new Error(`checkout preparation failed for ${input.worktreePath}: existing_git_worktree_not_owned`);
       }
-      run("git", ["--git-dir", input.mirrorPath, "worktree", "remove", "--force", input.worktreePath]);
+      await run(["--git-dir", input.mirrorPath, "worktree", "remove", "--force", input.worktreePath], timeoutMs);
     } else if (stat.isDirectory()) {
       const entries = readdirSync(input.worktreePath);
       const nonIgnorableEntries = entries.filter((entry) => !isIgnorableEmptyWorktreeEntry(entry));
@@ -187,7 +219,7 @@ export function repairExistingReviewWorktreePathForCheckout(input: {
     }
   }
 
-  run("git", ["--git-dir", input.mirrorPath, "worktree", "prune"]);
+  await run(["--git-dir", input.mirrorPath, "worktree", "prune"], timeoutMs);
 }
 
 function assertReviewPathOutsideProtectedCheckout(pathLabel: string, path: string, input: PullWorktreeInput): void {
@@ -200,38 +232,30 @@ function assertReviewPathOutsideProtectedCheckout(pathLabel: string, path: strin
   });
 }
 
-export function assertGitClean(worktreePath: string): void {
-  run("git", ["-C", worktreePath, "diff", "--exit-code"]);
-  run("git", ["-C", worktreePath, "diff", "--cached", "--exit-code"]);
-  const status = run("git", ["-C", worktreePath, "status", "--porcelain=v1", "--untracked-files=all"]).stdout.trim();
+export async function assertGitClean(worktreePath: string): Promise<void> {
+  await run(["-C", worktreePath, "diff", "--exit-code"], DEFAULT_GIT_COMMAND_TIMEOUT_MS);
+  await run(["-C", worktreePath, "diff", "--cached", "--exit-code"], DEFAULT_GIT_COMMAND_TIMEOUT_MS);
+  const status = (await run(["-C", worktreePath, "status", "--porcelain=v1", "--untracked-files=all"], DEFAULT_GIT_COMMAND_TIMEOUT_MS)).stdout.trim();
   if (status) {
     throw new Error(`Worktree has untracked or modified files after review:\n${status}`);
   }
 }
 
-function existsAsGitMirror(path: string): boolean {
-  const result = spawnSync("git", ["--git-dir", path, "rev-parse", "--is-bare-repository"], { encoding: "utf8" });
-  return result.status === 0 && result.stdout.trim() === "true";
+async function existsAsGitMirror(path: string, timeoutMs: number): Promise<boolean> {
+  const result = await probe(["--git-dir", path, "rev-parse", "--is-bare-repository"], timeoutMs);
+  return result?.stdout.trim() === "true";
 }
 
-function existsAsGitWorktree(path: string): boolean {
-  const result = spawnSync("git", ["-C", path, "rev-parse", "--is-inside-work-tree"], { encoding: "utf8" });
-  if (result.status === null) {
-    const message = result.error instanceof Error ? result.error.message : "git failed before returning a status";
-    throw new Error(`checkout preparation failed for ${path}: git_worktree_probe_failed: ${message}`);
-  }
-  return result.status === 0 && result.stdout.trim() === "true";
+async function existsAsGitWorktree(path: string, timeoutMs: number): Promise<boolean> {
+  const result = await probe(["-C", path, "rev-parse", "--is-inside-work-tree"], timeoutMs);
+  return result?.stdout.trim() === "true";
 }
 
-function isGitWorktreeOwnedByMirror(input: { mirrorPath: string; worktreePath: string }): boolean {
-  const result = spawnSync("git", ["--git-dir", input.mirrorPath, "worktree", "list", "--porcelain"], { encoding: "utf8" });
-  if (result.status === null) {
-    const message = result.error instanceof Error ? result.error.message : "git failed before returning a status";
-    throw new Error(`checkout preparation failed for ${input.worktreePath}: git_worktree_list_failed: ${message}`);
-  }
-  if (result.status !== 0) {
-    throw new Error(`checkout preparation failed for ${input.worktreePath}: git_worktree_list_failed`);
-  }
+async function isGitWorktreeOwnedByMirror(
+  input: { mirrorPath: string; worktreePath: string },
+  timeoutMs: number
+): Promise<boolean> {
+  const result = await run(["--git-dir", input.mirrorPath, "worktree", "list", "--porcelain"], timeoutMs);
 
   const existingRawPath = resolve(input.worktreePath);
   const existingRealPath = maybeRealpath(input.worktreePath);
@@ -268,13 +292,47 @@ function isIgnorableEmptyWorktreeEntry(entry: string): boolean {
   return entry === ".DS_Store";
 }
 
-function run(command: string, args: string[]): { stdout: string; stderr: string } {
-  const result = spawnSync(command, args, {
-    encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024
-  });
-  if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+async function withGitMirrorLock<T>(mirrorPath: string, action: () => Promise<T>): Promise<T> {
+  const predecessor = gitMirrorTails.get(mirrorPath) ?? Promise.resolve();
+  let release!: () => void;
+  const tail = new Promise<void>((resolve) => { release = resolve; });
+  gitMirrorTails.set(mirrorPath, tail);
+  await predecessor;
+  try {
+    return await action();
+  } finally {
+    release();
+    if (gitMirrorTails.get(mirrorPath) === tail) gitMirrorTails.delete(mirrorPath);
   }
-  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+async function probe(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string } | undefined> {
+  try {
+    return await run(args, timeoutMs);
+  } catch (error) {
+    if (error instanceof GitCommandError && error.failureKind === "exit_nonzero") return undefined;
+    throw error;
+  }
+}
+
+function run(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile("git", args, { encoding: "utf8", maxBuffer: 10 * 1024 * 1024, timeout: timeoutMs }, (error, stdout, stderr) => {
+      if (!error) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      const processError = error as typeof error & { killed?: boolean; code?: string | number };
+      const failureKind = processError.killed
+        ? "timeout"
+        : typeof processError.code === "number"
+          ? "exit_nonzero"
+          : "spawn_error";
+      reject(new GitCommandError({
+        failureKind,
+        timeoutMs,
+        detail: stderr || stdout || error.message
+      }));
+    });
+  });
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -17,6 +17,7 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  * is found well within this window; exceeding it truncates rather than paging forever.
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
+export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface GitHubApiOptions {
   appId?: string;
@@ -79,13 +80,26 @@ export class GitHubApiRequestError extends Error {
   }
 }
 
+export class GitHubApiTimeoutError extends Error {
+  readonly failureKind = "timeout" as const;
+  readonly path: string;
+  readonly timeoutMs: number;
+
+  constructor(input: { path: string; timeoutMs: number }) {
+    super(`GitHub API request timed out after ${input.timeoutMs}ms for ${input.path}`);
+    this.name = "GitHubApiTimeoutError";
+    this.path = input.path;
+    this.timeoutMs = input.timeoutMs;
+  }
+}
+
 export class GitHubApi {
   private readonly appId?: string;
   private readonly privateKey?: string;
   private readonly token?: string;
   private readonly apiBaseUrl: URL;
   private readonly botLogin: string;
-  private readonly requestTimeoutMs?: number;
+  private readonly requestTimeoutMs: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
 
@@ -98,7 +112,7 @@ export class GitHubApi {
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
     this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
-    this.requestTimeoutMs = options.requestTimeoutMs;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
   }
 
   canPostAsApp(): boolean {
@@ -515,16 +529,13 @@ export class GitHubApi {
     options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
-    let response: Response;
-    const controller = this.requestTimeoutMs ? new AbortController() : undefined;
-    const timeout = controller
-      ? setTimeout(() => controller.abort(new Error(`GitHub API request timed out after ${this.requestTimeoutMs}ms for ${path}`)), this.requestTimeoutMs)
-      : undefined;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.requestTimeoutMs);
     try {
-      response = await fetch(buildApiUrl(this.apiBaseUrl, path, "GitHub API request path"), {
+      const response = await fetch(buildApiUrl(this.apiBaseUrl, path, "GitHub API request path"), {
         method: options.method ?? "GET",
         ...(options.followRedirects === false ? { redirect: "manual" } : {}),
-        signal: controller?.signal,
+        signal: controller.signal,
         headers: {
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
@@ -533,23 +544,25 @@ export class GitHubApi {
         },
         body: options.body === undefined ? undefined : JSON.stringify(options.body)
       });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new GitHubApiRequestError({
+          status: response.status,
+          statusText: response.statusText,
+          path,
+          responseText: text
+        });
+      }
+      return (await response.json()) as T;
     } catch (error) {
+      if (error instanceof GitHubApiRequestError) throw error;
+      if (controller.signal.aborted) {
+        throw new GitHubApiTimeoutError({ path, timeoutMs: this.requestTimeoutMs });
+      }
       throw new Error(`GitHub API fetch failed for ${path}: ${describeFetchError(error)}`);
     } finally {
-      if (timeout) clearTimeout(timeout);
+      clearTimeout(timeout);
     }
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new GitHubApiRequestError({
-        status: response.status,
-        statusText: response.statusText,
-        path,
-        responseText: text
-      });
-    }
-
-    return (await response.json()) as T;
   }
 }
 

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -924,7 +924,7 @@ export async function runIssueEnrichmentCycle(input: {
         const metadata = await input.github.getRepo(repo);
         const defaultBranch = metadata.default_branch?.trim();
         if (!defaultBranch) throw new Error(`issue_enrichment_default_branch_missing: ${repo}`);
-        sourceSnapshots.set(repo.toLowerCase(), prepareBranchWorktree({
+        sourceSnapshots.set(repo.toLowerCase(), await prepareBranchWorktree({
           repo,
           branch: defaultBranch,
           ...(metadata.clone_url ? { repoUrl: metadata.clone_url } : {}),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1610,7 +1610,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       commentId: finishingTouchDecision.commandId,
       author: finishingTouchDecision.command.author,
       trustedAuthors: config.commands.trustedAuthors,
-      worktreeClean: isExistingPullWorktreeClean(config, repo, pull),
+      worktreeClean: await isExistingPullWorktreeClean(config, repo, pull),
       action: finishingTouchAction,
       proposedOutput: draft
     });
@@ -1836,7 +1836,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       profile: repoPolicy.profile
     });
     const proof = evaluateProofRequirements({ pull, validation });
-    const worktree = preparePullWorktree({
+    const worktree = await preparePullWorktree({
       repo,
       pullNumber: pull.number,
       expectedHeadSha: pull.head.sha,
@@ -2027,7 +2027,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     }
     const zcodeResult = zcodeExecution.result;
 
-    assertGitClean(worktree.path);
+    await assertGitClean(worktree.path);
 
     const liveBeforePlan = await github.getPull(repo, pull.number);
     const staleBeforePlan = detectStalePullHead({ expected: pull, live: liveBeforePlan, phase: "before_plan" });
@@ -3037,7 +3037,7 @@ function recordLicenseAdmissionBlock(input: {
   });
 }
 
-function isExistingPullWorktreeClean(config: BotConfig, repo: string, pull: PullRequestSummary): boolean {
+async function isExistingPullWorktreeClean(config: BotConfig, repo: string, pull: PullRequestSummary): Promise<boolean> {
   const paths = planPullWorktreePaths({
     repo,
     pullNumber: pull.number,
@@ -3047,7 +3047,7 @@ function isExistingPullWorktreeClean(config: BotConfig, repo: string, pull: Pull
   });
   if (!existsSync(paths.worktreePath)) return true;
   try {
-    assertGitClean(paths.worktreePath);
+    await assertGitClean(paths.worktreePath);
     return true;
   } catch {
     return false;

--- a/tests/git-clean.test.ts
+++ b/tests/git-clean.test.ts
@@ -12,13 +12,13 @@ describe("assertGitClean", () => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
-  it("fails on untracked files left by a review run", () => {
+  it("fails on untracked files left by a review run", async () => {
     const root = mkdtempSync(join(tmpdir(), "git-clean-"));
     roots.push(root);
     const init = spawnSync("git", ["init"], { cwd: root, encoding: "utf8" });
     expect(init.status).toBe(0);
     writeFileSync(join(root, "left-behind.txt"), "mutation\n");
 
-    expect(() => assertGitClean(root)).toThrow(/untracked or modified files/);
+    await expect(assertGitClean(root)).rejects.toThrow(/untracked or modified files/);
   });
 });

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,9 +1,9 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { planPullWorktreePaths, repairExistingReviewWorktreePathForCheckout } from "../src/git.js";
+import { planPullWorktreePaths, prepareBranchWorktree, repairExistingReviewWorktreePathForCheckout } from "../src/git.js";
 
 describe("pull worktree path planning", () => {
   const roots: string[] = [];
@@ -23,6 +23,40 @@ describe("pull worktree path planning", () => {
       workRoot: join(liveCheckout, "runtime"),
       protectedCheckoutRoot: liveCheckout
     })).toThrow(/workRoot must be outside the protected live checkout/);
+  });
+
+  it("bounds slow git without blocking the event loop", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-slow-git-"));
+    roots.push(root);
+    const binDir = join(root, "bin");
+    mkdirSync(binDir);
+    const gitPath = join(binDir, "git");
+    writeFileSync(gitPath, "#!/bin/sh\nsleep 1\nexit 1\n");
+    chmodSync(gitPath, 0o755);
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+
+    try {
+      const preparation = Promise.resolve().then(() => prepareBranchWorktree({
+        repo: "owner/repo",
+        branch: "main",
+        workRoot: join(root, "runtime"),
+        gitCommandTimeoutMs: 25
+      }));
+      const winner = await Promise.race([
+        preparation.then(() => "git", () => "git"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timer"), 0))
+      ]);
+
+      expect(winner).toBe("timer");
+      await expect(preparation).rejects.toMatchObject({
+        name: "GitCommandError",
+        failureKind: "timeout",
+        timeoutMs: 25
+      });
+    } finally {
+      process.env.PATH = originalPath;
+    }
   });
 
   it("keeps self-repo review paths outside the protected live checkout", () => {
@@ -121,7 +155,7 @@ describe("pull worktree path planning", () => {
     })).toThrow(/mirrorPath must be outside the protected live checkout/);
   });
 
-  it("repairs an empty existing non-git worktree directory before checkout", () => {
+  it("repairs an empty existing non-git worktree directory before checkout", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const mirrorPath = join(root, "mirror.git");
@@ -129,7 +163,7 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
     mkdirSync(worktreePath);
 
-    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+    await repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
 
     expect(existsSync(worktreePath)).toBe(false);
     const worktrees = execFileSync("git", ["--git-dir", mirrorPath, "worktree", "list", "--porcelain"], {
@@ -138,7 +172,7 @@ describe("pull worktree path planning", () => {
     expect(worktrees).not.toContain(`worktree ${worktreePath}`);
   });
 
-  it("repairs an existing git worktree directory before checkout", () => {
+  it("repairs an existing git worktree directory before checkout", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const sourcePath = join(root, "source");
@@ -153,12 +187,12 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["clone", "--mirror", sourcePath, mirrorPath], { stdio: "ignore" });
     execFileSync("git", ["--git-dir", mirrorPath, "worktree", "add", "--detach", worktreePath, "HEAD"], { stdio: "ignore" });
 
-    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+    await repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
 
     expect(existsSync(worktreePath)).toBe(false);
   });
 
-  it("prunes stale mirror worktree metadata when the worktree path is absent", () => {
+  it("prunes stale mirror worktree metadata when the worktree path is absent", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const sourcePath = join(root, "source");
@@ -174,7 +208,7 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["--git-dir", mirrorPath, "worktree", "add", "--detach", worktreePath, "HEAD"], { stdio: "ignore" });
     rmSync(worktreePath, { recursive: true, force: true });
 
-    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+    await repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
 
     const worktrees = execFileSync("git", ["--git-dir", mirrorPath, "worktree", "list", "--porcelain"], {
       encoding: "utf8"
@@ -182,7 +216,7 @@ describe("pull worktree path planning", () => {
     expect(worktrees).not.toContain(`worktree ${worktreePath}`);
   });
 
-  it("rejects an existing git checkout not owned by the mirror", () => {
+  it("rejects an existing git checkout not owned by the mirror", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const mirrorPath = join(root, "mirror.git");
@@ -195,13 +229,13 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["-C", worktreePath, "add", "README.md"], { stdio: "ignore" });
     execFileSync("git", ["-C", worktreePath, "commit", "-m", "initial"], { stdio: "ignore" });
 
-    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(
+    await expect(repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).rejects.toThrow(
       /existing_git_worktree_not_owned/
     );
     expect(existsSync(join(worktreePath, "README.md"))).toBe(true);
   });
 
-  it("rejects a symlink repair target before git-worktree deletion", () => {
+  it("rejects a symlink repair target before git-worktree deletion", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const mirrorPath = join(root, "mirror.git");
@@ -211,11 +245,11 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["init", gitTarget], { stdio: "ignore" });
     symlinkSync(gitTarget, worktreePath, "dir");
 
-    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(/existing_symlink/);
+    await expect(repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).rejects.toThrow(/existing_symlink/);
     expect(existsSync(gitTarget)).toBe(true);
   });
 
-  it("repairs a non-git worktree directory containing only ignorable macOS metadata", () => {
+  it("repairs a non-git worktree directory containing only ignorable macOS metadata", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const mirrorPath = join(root, "mirror.git");
@@ -224,12 +258,12 @@ describe("pull worktree path planning", () => {
     mkdirSync(worktreePath);
     writeFileSync(join(worktreePath, ".DS_Store"), "metadata");
 
-    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+    await repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
 
     expect(existsSync(worktreePath)).toBe(false);
   });
 
-  it("fails closed for a non-empty existing non-git worktree directory", () => {
+  it("fails closed for a non-empty existing non-git worktree directory", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const mirrorPath = join(root, "mirror.git");
@@ -238,13 +272,13 @@ describe("pull worktree path planning", () => {
     mkdirSync(worktreePath);
     writeFileSync(join(worktreePath, "leftover.txt"), "not a git checkout");
 
-    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(
+    await expect(repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).rejects.toThrow(
       /checkout preparation failed.*existing_non_git_non_empty/
     );
     expect(existsSync(join(worktreePath, "leftover.txt"))).toBe(true);
   });
 
-  it("fails closed for an existing regular file at the worktree path", () => {
+  it("fails closed for an existing regular file at the worktree path", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     roots.push(root);
     const mirrorPath = join(root, "mirror.git");
@@ -252,13 +286,13 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
     writeFileSync(worktreePath, "do not delete");
 
-    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(
+    await expect(repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).rejects.toThrow(
       /existing_non_directory/
     );
     expect(existsSync(worktreePath)).toBe(true);
   });
 
-  it("rejects a repair target symlinked into the protected live checkout", () => {
+  it("rejects a repair target symlinked into the protected live checkout", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
     const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
     roots.push(root, liveCheckout);
@@ -267,13 +301,13 @@ describe("pull worktree path planning", () => {
     execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
     symlinkSync(liveCheckout, worktreePath, "dir");
 
-    expect(() =>
+    await expect(
       repairExistingReviewWorktreePathForCheckout({
         mirrorPath,
         worktreePath,
         protectedCheckoutRoot: liveCheckout
       })
-    ).toThrow(/worktreePath must be outside the protected live checkout/);
+    ).rejects.toThrow(/worktreePath must be outside the protected live checkout/);
     expect(existsSync(liveCheckout)).toBe(true);
   });
 });

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -46,6 +46,32 @@ describe("GitHub App read authentication", () => {
     expect(readCall?.authorization).not.toBe("Bearer fallback-token");
   });
 
+  it("applies a finite default request timeout", async () => {
+    let signal: AbortSignal | null | undefined;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      signal = init?.signal;
+      return jsonResponse({ full_name: "owner/repo", private: false });
+    }) as typeof fetch;
+
+    await new GitHubApi({ token: "fallback-token" }).getRepo("owner/repo");
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("classifies a bounded GitHub timeout", async () => {
+    globalThis.fetch = vi.fn((_url, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    })) as typeof fetch;
+
+    const request = new GitHubApi({ token: "fallback-token", requestTimeoutMs: 10 }).getRepo("owner/repo");
+
+    await expect(request).rejects.toMatchObject({
+      name: "GitHubApiTimeoutError",
+      failureKind: "timeout",
+      timeoutMs: 10
+    });
+  });
+
   it("binds a created review to the validated expected commit", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-create-review-head-"));
     roots.push(root);


### PR DESCRIPTION
Related: #808
Parent tracker: #738

## Outcome

Git worktree preparation and cleanliness checks now run asynchronously with a finite 120-second default command timeout and typed `GitCommandError` outcomes. GitHub requests now always carry an abort signal, use the configured timeout or a finite 30-second default, and return typed `GitHubApiTimeoutError` outcomes. Review and issue-enrichment work for the same mirror remain serialized in-process so the existing idempotency boundary is preserved without blocking the Node event loop.

The existing daemon starts issue enrichment independently and records the cycle-start heartbeat before review discovery. Removing synchronous Git from the affected path lets those existing observability paths advance while review preparation is slow. No daemon persistence or schema changed.

## Failing-first proof

On base `de00a1daf20c27b1d14fff5a5defb9b5597e71b5`, the focused run reproduced three failures:

- a fake slow Git command beat the event-loop timer;
- a default GitHub request had no `AbortSignal`;
- an explicit GitHub timeout returned an untyped generic error.

## Validation

- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/git.test.ts tests/git-clean.test.ts tests/github-app-read.test.ts tests/daemon-loop.test.ts tests/issue-enrichment-policy.test.ts tests/worker-failure.test.ts` — 143 passed.
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin /opt/homebrew/bin/npm run build` — passed (`tsc -p tsconfig.build.json`).
- `git diff --check` — passed.

## Existing PR reconciliation

- #743: stale/conflicting elapsed-cleanup lane; unrelated to this causal repair and not imported or superseded here.
- #744: stale/conflicting active-vs-historical health implementation; intentionally excluded and requires a fresh successor after this PR.
- #745: stale/conflicting launchd log-retention lane; unrelated and not imported or superseded here.
- #746: stale/conflicting runtime-authority lane; unrelated and not imported or superseded here.

## Delivery checkpoint and boundaries

The 243-addition/112-deletion diff exceeds the normal 200-line signal because every Git subprocess in the affected prep/clean path was converted coherently and the existing safety tests were updated to await it. The delivery checkpoint kept the candidate together: splitting Git and GitHub would leave #808 only partially bounded. No dependency, schema, service, scheduler redesign, or public contract was added.

This is an agent-authored source and focused-test change. It does not merge, release, install, restart or reconfigure the worker, mutate live config/DB/Keychain/queue state, delete historical records, prove installed-runtime adoption, or establish Mac GA/customer readiness. Active-vs-historical health presentation remains a separate #744 successor gate. GitNexus was registered only for an older `e41e9c9` checkout, so exact-head impact proof uses current source, focused tests, and canonical remote CI instead of claiming a fresh graph.