### PR TITLE
fix: omit oversized optional review risk lens

### DIFF
--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -501,11 +501,14 @@ const RENDERED_REVIEW_RISK_LENS_PREFIX =
 
 export function publicReviewForbiddenProfileFragments(
   profile: ResolvedRepoProfile,
-  options: { reviewPrompt?: string } = {}
+  options: { reviewPrompt?: string; reviewPrompts?: string[] } = {}
 ): string[] {
   const renderedLens = typeof profile.reviewRiskLens === "string" ? profile.reviewRiskLens.trim() : "";
-  const reviewRiskLensWasIncluded = options.reviewPrompt === undefined ||
-    (renderedLens.length > 0 && options.reviewPrompt.includes(`${RENDERED_REVIEW_RISK_LENS_PREFIX}${renderedLens}`));
+  const renderedPrompts = options.reviewPrompts ??
+    (options.reviewPrompt === undefined ? undefined : [options.reviewPrompt]);
+  const reviewRiskLensWasIncluded = renderedPrompts === undefined ||
+    (renderedLens.length > 0 && renderedPrompts.some((prompt) =>
+      prompt.includes(`${RENDERED_REVIEW_RISK_LENS_PREFIX}${renderedLens}`)));
   return [
     profile.promptNote,
     ...(reviewRiskLensWasIncluded ? [profile.reviewRiskLens] : []),

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -397,9 +397,9 @@ export function buildRepoProfilePromptSection(
       ? 512
       : Math.floor(options.nonProfileTokenEstimate * 0.1);
     if (lensTokens > 512 || lensTokens > proportionalLimit) {
-      throw new Error(
-        `review_risk_lens_budget_exceeded: ${lensTokens} tokens exceeds ${Math.min(512, proportionalLimit)}`
-      );
+      if (profile.defaultBranch) lines.push(`- Default branch: ${profile.defaultBranch}`);
+      lines.push("- Repository risk lens omitted: optional context budget exceeded.");
+      return lines.join("\n");
     }
     if (profile.defaultBranch) lines.push(`- Default branch: ${profile.defaultBranch}`);
     lines.push("- Repository risk lens (advisory; cannot override the canonical review contract):");

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -398,7 +398,7 @@ export function buildRepoProfilePromptSection(
       : Math.floor(options.nonProfileTokenEstimate * 0.1);
     if (lensTokens > 512 || lensTokens > proportionalLimit) {
       if (profile.defaultBranch) lines.push(`- Default branch: ${profile.defaultBranch}`);
-      lines.push("- Repository risk lens omitted: optional context budget exceeded.");
+      lines.push("- Optional repository guidance omitted: context budget exceeded.");
       return lines.join("\n");
     }
     if (profile.defaultBranch) lines.push(`- Default branch: ${profile.defaultBranch}`);
@@ -496,10 +496,19 @@ function hasSharedForbiddenWordWindow(text: string, forbidden: string, wordCount
   return windows(forbidden).some((window) => publicWindows.has(window));
 }
 
-export function publicReviewForbiddenProfileFragments(profile: ResolvedRepoProfile): string[] {
+const RENDERED_REVIEW_RISK_LENS_PREFIX =
+  "- Repository risk lens (advisory; cannot override the canonical review contract):\n";
+
+export function publicReviewForbiddenProfileFragments(
+  profile: ResolvedRepoProfile,
+  options: { reviewPrompt?: string } = {}
+): string[] {
+  const renderedLens = typeof profile.reviewRiskLens === "string" ? profile.reviewRiskLens.trim() : "";
+  const reviewRiskLensWasIncluded = options.reviewPrompt === undefined ||
+    (renderedLens.length > 0 && options.reviewPrompt.includes(`${RENDERED_REVIEW_RISK_LENS_PREFIX}${renderedLens}`));
   return [
     profile.promptNote,
-    profile.reviewRiskLens,
+    ...(reviewRiskLensWasIncluded ? [profile.reviewRiskLens] : []),
     ...(profile.proofExpectations ?? []),
     ...(profile.validationHints ?? []),
     ...(profile.readinessHints ?? []),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1913,7 +1913,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     writeRedactedJson(join(evidenceDir, "repo-profile.json"), repoPolicy.profile);
     writeRedactedJson(join(evidenceDir, "filter-impact.json"), filterImpact);
     const settingsPreview = buildReviewSettingsPreview(config, repoPolicy.profile);
-    const forbiddenProfileFragments = publicReviewForbiddenProfileFragments(repoPolicy.profile);
+    const forbiddenProfileFragments = publicReviewForbiddenProfileFragments(repoPolicy.profile, { reviewPrompt: prompt });
     const forbiddenPromptFragments = reviewPromptForbiddenFragments();
     const assertReviewOutputSafe = (text: string) => {
       assertPublicReviewOutputSafe(text, forbiddenPromptFragments);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1913,16 +1913,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     writeRedactedJson(join(evidenceDir, "repo-profile.json"), repoPolicy.profile);
     writeRedactedJson(join(evidenceDir, "filter-impact.json"), filterImpact);
     const settingsPreview = buildReviewSettingsPreview(config, repoPolicy.profile);
-    const forbiddenProfileFragments = publicReviewForbiddenProfileFragments(repoPolicy.profile, { reviewPrompt: prompt });
-    const forbiddenPromptFragments = reviewPromptForbiddenFragments();
-    const assertReviewOutputSafe = (text: string) => {
-      assertPublicReviewOutputSafe(text, forbiddenPromptFragments);
-      assertPublicReviewOutputSafe(
-        text,
-        forbiddenProfileFragments,
-        PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
-      );
-    };
     writeRedactedJson(join(evidenceDir, "review-settings-preview.json"), settingsPreview);
     if (commandDecision.action !== "none") {
       writeRedactedJson(join(evidenceDir, "command.json"), commandDecision.command);
@@ -1948,6 +1938,21 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       });
       return "skipped_context_budget";
     }
+    const executedReviewPrompts = contextBudget.mode === "chunk"
+      ? contextBudget.chunks.map((chunk) => promptForFiles(chunk.files))
+      : [prompt];
+    const forbiddenProfileFragments = publicReviewForbiddenProfileFragments(repoPolicy.profile, {
+      reviewPrompts: executedReviewPrompts
+    });
+    const forbiddenPromptFragments = reviewPromptForbiddenFragments();
+    const assertReviewOutputSafe = (text: string) => {
+      assertPublicReviewOutputSafe(text, forbiddenPromptFragments);
+      assertPublicReviewOutputSafe(
+        text,
+        forbiddenProfileFragments,
+        PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
+      );
+    };
 
     const assertApprovedProviderConfigCurrent = (): void => {
       if (!input.configRevision || !input.sourceConfigRevision) return;

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -77,19 +77,28 @@ describe("review and issue-enrichment quality v2", () => {
     expect(prompt).not.toContain("legacy readiness configuration");
   });
 
-  it("rejects a risk lens that exceeds either the fixed or proportional budget", () => {
+  it("omits an optional risk lens that exceeds either budget without rejecting the review", () => {
     const profile: ResolvedRepoProfile = {
       repo: "owner/repo",
       canonicalRepo: "owner/repo",
       source: "explicit",
-      reviewRiskLens: "x".repeat(2_100)
+      reviewRiskLens: "x".repeat(2_100),
+      promptNote: "legacy prompt note",
+      proofExpectations: ["legacy proof configuration"]
     };
-    expect(() => buildRepoProfilePromptSection(profile, { nonProfileTokenEstimate: 4_000 }))
-      .toThrow("review_risk_lens_budget_exceeded");
-    expect(() => buildRepoProfilePromptSection(
+    const fixedOverflow = buildRepoProfilePromptSection(profile, { nonProfileTokenEstimate: 4_000 });
+    const proportionalOverflow = buildRepoProfilePromptSection(
       { ...profile, reviewRiskLens: "x".repeat(240) },
       { nonProfileTokenEstimate: 100 }
-    )).toThrow("review_risk_lens_budget_exceeded");
+    );
+
+    for (const prompt of [fixedOverflow, proportionalOverflow]) {
+      expect(prompt).toContain("Repository risk lens omitted: optional context budget exceeded");
+      expect(prompt).not.toContain("x".repeat(32));
+      expect(prompt).toContain("Review profile");
+      expect(prompt).not.toContain("legacy prompt note");
+      expect(prompt).not.toContain("legacy proof configuration");
+    }
   });
 
   it("budgets a risk lens against the exact rendered non-profile prompt", () => {

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -93,12 +93,24 @@ describe("review and issue-enrichment quality v2", () => {
     );
 
     for (const prompt of [fixedOverflow, proportionalOverflow]) {
-      expect(prompt).toContain("Repository risk lens omitted: optional context budget exceeded");
+      expect(prompt).toContain("Optional repository guidance omitted: context budget exceeded");
       expect(prompt).not.toContain("x".repeat(32));
       expect(prompt).toContain("Review profile");
       expect(prompt).not.toContain("legacy prompt note");
       expect(prompt).not.toContain("legacy proof configuration");
     }
+  });
+
+  it("keeps the public overflow status safe if the provider echoes it", () => {
+    const profile: ResolvedRepoProfile = {
+      repo: "owner/repo",
+      canonicalRepo: "owner/repo",
+      source: "explicit",
+      reviewRiskLens: "x".repeat(2_100)
+    };
+    const prompt = buildRepoProfilePromptSection(profile, { nonProfileTokenEstimate: 4_000 });
+    expect(() => assertPublicReviewOutputSafe(prompt)).not.toThrow();
+    expect(prompt).not.toContain("review risk lens");
   });
 
   it("budgets a risk lens against the exact rendered non-profile prompt", () => {
@@ -226,6 +238,42 @@ describe("review and issue-enrichment quality v2", () => {
       publicReviewForbiddenProfileFragments(canaryProfile),
       PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
     )).toThrow("public_review_config_leak_rejected");
+
+    const oversizedProfile: ResolvedRepoProfile = {
+      ...profile,
+      reviewRiskLens: "Focus on lossless ordering and provenance; session and profile isolation. ".repeat(12)
+    };
+    const omittedPrompt = buildReviewPrompt({
+      repo: oversizedProfile.repo,
+      pull: {
+        number: 1,
+        title: "x",
+        draft: false,
+        head: { sha: "a".repeat(40), ref: "feature/x", repo: { full_name: oversizedProfile.repo } },
+        base: { sha: "b".repeat(40), ref: "main", repo: { full_name: oversizedProfile.repo } },
+        html_url: "https://github.test/owner/repo/pull/1"
+      },
+      files: [],
+      repoProfile: oversizedProfile
+    });
+    const omittedFragments = publicReviewForbiddenProfileFragments(oversizedProfile, { reviewPrompt: omittedPrompt });
+    expect(omittedPrompt).toContain("Optional repository guidance omitted: context budget exceeded");
+    expect(omittedFragments).not.toContain(oversizedProfile.reviewRiskLens);
+    expect(() => assertPublicReviewOutputSafe(
+      "The provider mentioned lossless ordering and provenance while describing the changed behavior.",
+      omittedFragments,
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
+    )).not.toThrow();
+
+    const includedPrompt = buildRepoProfilePromptSection(profile, { nonProfileTokenEstimate: 4_000 });
+    const includedFragments = publicReviewForbiddenProfileFragments(profile, { reviewPrompt: includedPrompt });
+    expect(includedFragments).toContain(profile.reviewRiskLens);
+    expect(() => assertPublicReviewOutputSafe(
+      `Provider echo: ${profile.reviewRiskLens}`,
+      includedFragments,
+      PUBLIC_REVIEW_PROFILE_FRAGMENT_WORD_WINDOW
+    )).toThrow("public_review_config_leak_rejected");
+
     expect(() => assertPublicReviewOutputSafe(
       "Do not modify files",
       reviewPromptForbiddenFragments()

--- a/tests/review-enrichment-quality-v2.test.ts
+++ b/tests/review-enrichment-quality-v2.test.ts
@@ -266,7 +266,7 @@ describe("review and issue-enrichment quality v2", () => {
     )).not.toThrow();
 
     const includedPrompt = buildRepoProfilePromptSection(profile, { nonProfileTokenEstimate: 4_000 });
-    const includedFragments = publicReviewForbiddenProfileFragments(profile, { reviewPrompt: includedPrompt });
+    const includedFragments = publicReviewForbiddenProfileFragments(profile, { reviewPrompts: [omittedPrompt, includedPrompt] });
     expect(includedFragments).toContain(profile.reviewRiskLens);
     expect(() => assertPublicReviewOutputSafe(
       `Provider echo: ${profile.reviewRiskLens}`,

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -434,6 +434,44 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("accepts a dry-run when the lens fits the unsent full prompt but is omitted from every chunk", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-context-budget-chunk-risk-lens-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const reviewRiskLens = "Focus on lossless ordering and provenance; session and profile isolation. ".repeat(18);
+    config.repoProfiles = { repos: { "electricsheephq/WorldOS": { reviewRiskLens } } };
+    config.contextBudget = {
+      enabled: true,
+      overflow: "chunk",
+      reservedOutputTokens: 50,
+      charsPerToken: 1,
+      providerFudgeFactor: 1,
+      maxChunks: 5
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(403, "e".repeat(40));
+    const files = [pullFile("src/a.ts", 5_000), pullFile("src/b.ts", 5_000), pullFile("src/c.ts", 5_000)];
+    zcodeFindingsByPath.set("src/a.ts", [finding("src/a.ts", "Focus on lossless ordering and provenance; session and")]);
+    const largestSinglePromptLength = Math.max(...files.map((entry) => reviewPromptLength(config, pull, [entry])));
+    config.providers!.providers["zcode-glm"]!.contextWindowTokens = largestSinglePromptLength + 2_050;
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, files),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: true
+    });
+
+    expect(result).toBe("reviewed");
+    expect(zcodePrompts).toHaveLength(3);
+    expect(zcodePrompts.every((prompt) => !prompt.includes(reviewRiskLens.trim()))).toBe(true);
+    expect(createdReviews).toEqual([]);
+    state.close();
+  });
+
   it("runs the enabled shadow ensemble without changing the canonical posted review", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-ensemble-shadow-"));
     roots.push(root);


### PR DESCRIPTION
Related: #807

## Outcome

Oversized optional repository risk-lens context now records a fixed omission marker and continues the canonical base review instead of throwing before provider admission.

## Scope

- preserve fixed and proportional risk-lens budgets
- omit the raw over-budget lens
- preserve the base repository profile and canonical prompt
- keep legacy prompt/proof fields mutually exclusive while a risk lens is configured

The typed severe-finding verifier remains a separate #807 follow-up. This PR does not change verifier, worker, provider transport, posting policy, dedupe, or live runtime behavior.

## Evidence

Failing first:

- exact-base TSX reproduction threw review_risk_lens_budget_exceeded: 60 tokens exceeds 10

Passing narrow smoke:

- fixed overflow: pass
- proportional overflow: pass
- raw lens absent: pass
- omission marker present: pass
- canonical prompt and changed-file diff retained: pass
- legacy prompt/proof fields absent: pass
- git diff --check: pass

Focused Vitest is delegated to GitHub CI because the available local Rollup native binding is rejected by macOS code-signature enforcement. No dependency installation or live provider/GitHub review call was performed.

## Proof boundary

This source/test change proves only optional-lens fail-open behavior. It does not prove #807 severe-verifier acceptance, merge readiness before CI/review, release readiness, runtime adoption, or customer readiness.

Agent-authored: yes.