### PR TITLE
fix(status): separate active health from failure history

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,6 +98,7 @@ import {
   collectOperatorReviewQueue,
   explainPullStatus,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorDurableQueueSnapshot,
@@ -724,7 +725,7 @@ async function main(): Promise<void> {
       }),
       issueEnrichmentRuntime
     });
-    console.log(stringifyRedactedJson(status));
+    console.log(args.human === "true" ? formatOperatorStatusHuman(status) : stringifyRedactedJson(status));
     if (!status.ok) process.exitCode = 1;
     return;
   }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -616,6 +616,7 @@ export function buildRuntimeInventory(input: {
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs = input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
@@ -644,8 +645,10 @@ export function buildRuntimeInventory(input: {
     },
     {
       name: "runtime_no_failed_queue_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "runtime_no_zcode_timeout_failed_queue_jobs",
@@ -744,7 +747,7 @@ export function buildRuntimeInventory(input: {
     ...(uncoveredPendingHeads.length > 0 ? ["wait for daemon cycle or run scoped run-once for uncovered pending heads"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.activeTotal > 0
       ? zcodeTimeoutRetryActions
       : []),

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -414,6 +414,7 @@ export function buildOperatorStatus(input: {
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs = input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
@@ -455,8 +456,10 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "durable_queue_no_failed_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
@@ -504,7 +507,7 @@ export function buildOperatorStatus(input: {
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
       ? zcodeTimeoutRetryActions
       : []),
@@ -554,6 +557,21 @@ export function buildOperatorStatus(input: {
     ...(issueEnrichment ? { issueEnrichment } : {}),
     ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {})
   };
+}
+
+export function formatOperatorStatusHuman(status: OperatorStatus): string {
+  const health = status.release.health;
+  const failedGates = status.gates.filter((gate) => !gate.ok);
+  return [
+    `status: ${health?.state ?? (status.ok ? "green" : "red")} - ${health?.reason ?? (status.ok ? "current gates pass" : "current gates failed")}`,
+    `current: activeFailedQueueJobs=${status.release.health?.active.failedQueueJobs ?? "unknown"} ` +
+      `recentUnrecoveredReviewErrors=${status.release.health?.recent.unrecoveredReviewErrors ?? "unknown"}`,
+    `history: reviewErrors=${status.summary.failedRows} failedQueueJobs=${status.summary.failedQueueJobs}`,
+    ...(failedGates.length > 0
+      ? failedGates.map((gate) => `actionable: ${gate.name} - ${gate.detail}`)
+      : ["actionable: none"]),
+    ...status.recommendedActions.map((action) => `next: ${action}`)
+  ].join("\n");
 }
 
 export function buildRuntimeInventory(input: {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -463,10 +463,13 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
-      detail:
-        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+      ok: zcodeTimeoutQueue.activeTotal === 0,
+      detail: zcodeTimeoutQueue.activeTotal === zcodeTimeoutQueue.total
+        ? `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+        : `${zcodeTimeoutQueue.activeTotal} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutQueue.total}; retryable=${zcodeTimeoutQueue.retryable} ` +
+          `exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "durable_queue_no_retryable_provider_deferred_jobs",
@@ -508,7 +511,7 @@ export function buildOperatorStatus(input: {
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
     ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(zcodeTimeoutQueue.activeTotal > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -646,10 +649,13 @@ export function buildRuntimeInventory(input: {
     },
     {
       name: "runtime_no_zcode_timeout_failed_queue_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
-      detail:
-        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+      ok: zcodeTimeoutQueue.activeTotal === 0,
+      detail: zcodeTimeoutQueue.activeTotal === zcodeTimeoutQueue.total
+        ? `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+        : `${zcodeTimeoutQueue.activeTotal} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutQueue.total}; retryable=${zcodeTimeoutQueue.retryable} ` +
+          `exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "runtime_no_retryable_provider_deferred_jobs",
@@ -739,7 +745,7 @@ export function buildRuntimeInventory(input: {
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(zcodeTimeoutQueue.activeTotal > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -1756,19 +1762,21 @@ function uniqueStrings(values: string[]): string[] {
 function zcodeTimeoutQueueCounts(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
-): { total: number; retryable: number; exhausted: number } {
+): { total: number; activeTotal: number; retryable: number; exhausted: number } {
   if (release.database.zcodeTimeoutFailedReviewQueueJobCount !== undefined) {
     return {
       total: release.database.zcodeTimeoutFailedReviewQueueJobCount,
+      activeTotal: release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? release.database.zcodeTimeoutFailedReviewQueueJobCount,
       retryable: release.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0,
       exhausted: release.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0
     };
   }
-  return summarizeZCodeTimeoutErrors(
+  const counts = summarizeZCodeTimeoutErrors(
     (durableQueue?.jobs ?? [])
       .filter((job) => job.state === "failed")
       .map((job) => job.lastError)
   );
+  return { ...counts, activeTotal: counts.total };
 }
 
 function zcodeTimeoutRecommendedActions(

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -32,6 +32,8 @@ export interface ReleaseLaunchdStatus {
 export interface ReleaseDatabaseStatus {
   rowCount: number;
   errorCount: number;
+  recentUnrecoveredErrorCount?: number;
+  lastErrorAt?: string;
   skippedCount?: number;
   reviewerSessionCount?: number;
   activeReviewerSessionCount?: number;
@@ -53,6 +55,7 @@ export interface ReleaseDatabaseStatus {
   providerDeferredReviewQueueJobCount?: number;
   retryableProviderDeferredReviewQueueJobCount?: number;
   failedReviewQueueJobCount?: number;
+  activeFailedReviewQueueJobCount?: number;
   zcodeTimeoutFailedReviewQueueJobCount?: number;
   retryableZCodeTimeoutFailedReviewQueueJobCount?: number;
   exhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
@@ -60,6 +63,14 @@ export interface ReleaseDatabaseStatus {
   staleReviewRunLeaseCount?: number;
   staleActiveReviewQueueJobCount?: number;
   reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
+}
+
+export interface ReleaseHealthStatus {
+  state: "green" | "amber" | "red";
+  reason: string;
+  active: { failedQueueJobs: number; staleReviewLeases: number };
+  recent: { unrecoveredReviewErrors: number };
+  history: { reviewErrors: number; failedQueueJobs: number };
 }
 
 export interface ReviewerSessionRepoStatus {
@@ -166,6 +177,7 @@ export interface PublicReleaseChannelStatus {
 export interface ReleaseStatus {
   ok: boolean;
   checkedAt: string;
+  health?: ReleaseHealthStatus;
   summary: {
     blockingErrorRows: number;
     failedQueueJobs: number;
@@ -246,6 +258,8 @@ const OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATE_OVERRIDES = new Map([
   ["website", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "pending-site-sync"])],
   ["desktop", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "post_1_0"])]
 ]);
+const FAILURE_HEALTH_WINDOW_HOURS = 24;
+const FAILURE_HEALTH_WINDOW_MS = FAILURE_HEALTH_WINDOW_HOURS * 60 * 60 * 1_000;
 
 export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const expectedHeadOk = !input.expectedHead || input.repo.head === input.expectedHead;
@@ -255,7 +269,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const launchdSystemCaOk =
     input.launchd.sealedDesktopWorker === true || input.launchd.usesSystemCa === true;
-  const dbOk = input.database.errorCount === 0;
+  const failureWindowHours = FAILURE_HEALTH_WINDOW_HOURS;
+  const recentUnrecoveredErrorCount = input.database.recentUnrecoveredErrorCount ?? input.database.errorCount;
+  const dbOk = recentUnrecoveredErrorCount === 0;
   const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
   const retryableExpiredProviderCooldownCount =
     input.database.retryableExpiredProviderCooldownCount ??
@@ -264,11 +280,13 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       (input.database.expiredProviderCooldownCount ?? 0) - (input.database.coveredExpiredProviderCooldownCount ?? 0)
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
-  const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const failedQueueJobs = input.database.failedReviewQueueJobCount ?? 0;
+  const activeFailedQueueJobs = input.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
+  const failedQueueJobsOk = activeFailedQueueJobs === 0;
   const zcodeTimeoutFailedQueueJobCount = input.database.zcodeTimeoutFailedReviewQueueJobCount ?? 0;
   const retryableZCodeTimeoutFailedQueueJobCount = input.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0;
   const exhaustedZCodeTimeoutFailedQueueJobCount = input.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0;
-  const zcodeTimeoutFailedQueueJobsOk = zcodeTimeoutFailedQueueJobCount === 0;
+  const zcodeTimeoutFailedQueueJobsOk = activeFailedQueueJobs === 0;
   const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
     (input.database.staleActiveReviewQueueJobCount ?? 0);
   const staleReviewLeasesOk = staleReviewLeaseCount === 0;
@@ -322,7 +340,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "live_db_no_errors",
       ok: dbOk,
       detail:
-        `${input.database.errorCount} blocking error row(s)` +
+        (input.database.recentUnrecoveredErrorCount === undefined
+          ? `${input.database.errorCount} blocking error row(s)`
+          : `${recentUnrecoveredErrorCount} recent unrecovered blocking error row(s) in ${failureWindowHours}h; ` +
+            `${input.database.errorCount} retained history; last failure ${input.database.lastErrorAt ?? "unknown"}`) +
         describeProviderCooldownCounts(input.database)
     },
     {
@@ -335,14 +356,19 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "queue_no_failed_jobs",
       ok: failedQueueJobsOk,
-      detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "queue_no_zcode_timeout_failed_jobs",
       ok: zcodeTimeoutFailedQueueJobsOk,
-      detail:
-        `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); retained ZCode timeout history=${zcodeTimeoutFailedQueueJobCount}; ` +
+          `retained=${zcodeTimeoutFailedQueueJobCount}; retryable=${retryableZCodeTimeoutFailedQueueJobCount} ` +
+          `exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
     },
     {
       name: "queue_no_stale_review_leases",
@@ -390,13 +416,21 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     ...runtimeGates,
     ...publicReleaseGates
   ];
+  const health = classifyReleaseHealth({
+    gates,
+    database: input.database,
+    recentUnrecoveredErrorCount,
+    activeFailedQueueJobs,
+    staleReviewLeaseCount
+  });
 
   return {
     ok: gates.every((gate) => gate.ok),
     checkedAt: (input.now ?? new Date()).toISOString(),
+    health,
     summary: {
       blockingErrorRows: input.database.errorCount,
-      failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0,
+      failedQueueJobs,
       staleReviewLeases: staleReviewLeaseCount,
       providerDeferredQueueJobs: input.database.providerDeferredReviewQueueJobCount ?? 0,
       retryableProviderDeferredQueueJobs: input.database.retryableProviderDeferredReviewQueueJobCount ?? 0,
@@ -444,6 +478,30 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
       unloadCommand: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${input.launchd.label}.plist`
     }
+  };
+}
+
+function classifyReleaseHealth(input: {
+  gates: Array<{ name: string; ok: boolean }>;
+  database: ReleaseDatabaseStatus;
+  recentUnrecoveredErrorCount: number;
+  activeFailedQueueJobs: number;
+  staleReviewLeaseCount: number;
+}): ReleaseHealthStatus {
+  const failedGates = input.gates.filter((gate) => !gate.ok).map((gate) => gate.name);
+  const state: ReleaseHealthStatus["state"] = failedGates.length ? "red" :
+    input.database.errorCount || input.database.failedReviewQueueJobCount ? "amber" : "green";
+  const reason = state === "red"
+    ? `current or recent actionable gate(s) failed: ${failedGates.join(", ")}`
+    : state === "amber"
+      ? `current gates pass; retained history has ${input.database.errorCount} review error(s) and ${input.database.failedReviewQueueJobCount ?? 0} failed queue job(s)`
+      : "current gates pass with no recorded review or queue failure history";
+  return {
+    state,
+    reason,
+    active: { failedQueueJobs: input.activeFailedQueueJobs, staleReviewLeases: input.staleReviewLeaseCount },
+    recent: { unrecoveredReviewErrors: input.recentUnrecoveredErrorCount },
+    history: { reviewErrors: input.database.errorCount, failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0 }
   };
 }
 
@@ -2292,6 +2350,17 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
         providerCooldownCount?: number | null;
         errorCount?: number | null;
       };
+    const errorRows = db.prepare(`select repo,pull_number,status,error,created_at from processed_reviews where status='failed' or status='posted' or (status!='skipped' and error is not null and error!='')`).all() as unknown as Array<{ repo: string; pull_number: number; status: string; error: string | null; created_at: string }>;
+    const recentUnrecoveredErrorCount = errorRows.filter((errorRow) => {
+      const recovered = errorRows.some((row) => row.status === "posted" && row.repo === errorRow.repo && row.pull_number === errorRow.pull_number && Date.parse(row.created_at) > Date.parse(errorRow.created_at));
+      return (errorRow.status === "failed" || (errorRow.status !== "skipped" && errorRow.error !== null && errorRow.error !== "")) && !recovered && (!Number.isFinite(Date.parse(errorRow.created_at)) || Date.parse(errorRow.created_at) >= now.getTime() - FAILURE_HEALTH_WINDOW_MS);
+    }).length;
+    const lastErrorRow = db.prepare(
+      `select created_at from processed_reviews
+       where status = 'failed' or (status != 'skipped' and error is not null and error != '')
+       order by (julianday(created_at) is not null) desc, julianday(created_at) desc, rowid desc limit 1`
+    ).get() as { created_at?: string } | undefined;
+    const lastErrorAt = lastErrorRow?.created_at;
     const providerCooldownRows = db
       .prepare(
         `select repo, pull_number, head_sha, error
@@ -2363,6 +2432,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
       retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
       failedReviewQueueJobCount: reviewQueue.failed,
+      activeFailedReviewQueueJobCount: reviewQueue.activeFailed,
       zcodeTimeoutFailedReviewQueueJobCount: reviewQueue.zcodeTimeoutFailed,
       retryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.retryableZCodeTimeoutFailed,
       exhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.exhaustedZCodeTimeoutFailed,
@@ -2370,7 +2440,9 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       staleReviewRunLeaseCount: reviewRunLeases.stale,
       staleActiveReviewQueueJobCount,
       reviewQueueJobsByRepo: reviewQueue.byRepo,
-      errorCount: row.errorCount ?? 0
+      errorCount: row.errorCount ?? 0,
+      recentUnrecoveredErrorCount,
+      ...(lastErrorAt ? { lastErrorAt } : {})
     };
   } finally {
     db.close();
@@ -2388,6 +2460,7 @@ function readReviewQueueCounts(
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  activeFailed: number;
   zcodeTimeoutFailed: number;
   retryableZCodeTimeoutFailed: number;
   exhaustedZCodeTimeoutFailed: number;
@@ -2405,6 +2478,7 @@ function readReviewQueueCounts(
       providerDeferred: 0,
       retryableProviderDeferred: 0,
       failed: 0,
+      activeFailed: 0,
       zcodeTimeoutFailed: 0,
       retryableZCodeTimeoutFailed: 0,
       exhaustedZCodeTimeoutFailed: 0,
@@ -2441,14 +2515,9 @@ function readReviewQueueCounts(
        order by repo`
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
-  const timeoutRows = db
-    .prepare(
-      `select last_error
-       from review_queue_jobs
-       where state = 'failed' and last_error like ?`
-    )
-    .all(`${ZCODE_TIMEOUT_ERROR_PREFIX}%`) as unknown as Array<{ last_error: string | null }>;
-  const timeoutCounts = summarizeZCodeTimeoutErrors(timeoutRows.map((timeoutRow) => timeoutRow.last_error));
+  const failedRows = db.prepare(`select q.last_error,q.updated_at,exists(select 1 from processed_reviews p where p.repo=q.repo and p.pull_number=q.pull_number and p.status='posted' and (p.error is null or p.error='') and julianday(p.created_at)>julianday(q.updated_at)) as recovered from review_queue_jobs q where q.state='failed'`).all() as unknown as Array<{ last_error: string | null; updated_at: string; recovered: number }>;
+  const activeFailedRows = failedRows.filter((row) => row.recovered !== 1);
+  const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -2457,6 +2526,7 @@ function readReviewQueueCounts(
     providerDeferred: row.providerDeferred ?? 0,
     retryableProviderDeferred: row.retryableProviderDeferred ?? 0,
     failed: row.failed ?? 0,
+    activeFailed: activeFailedRows.length,
     zcodeTimeoutFailed: timeoutCounts.total,
     retryableZCodeTimeoutFailed: timeoutCounts.retryable,
     exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -57,6 +57,7 @@ export interface ReleaseDatabaseStatus {
   failedReviewQueueJobCount?: number;
   activeFailedReviewQueueJobCount?: number;
   zcodeTimeoutFailedReviewQueueJobCount?: number;
+  activeZCodeTimeoutFailedReviewQueueJobCount?: number;
   retryableZCodeTimeoutFailedReviewQueueJobCount?: number;
   exhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
   reviewRunLeaseCount?: number;
@@ -284,9 +285,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const activeFailedQueueJobs = input.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
   const failedQueueJobsOk = activeFailedQueueJobs === 0;
   const zcodeTimeoutFailedQueueJobCount = input.database.zcodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const activeZCodeTimeoutFailedQueueJobCount = input.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? zcodeTimeoutFailedQueueJobCount;
   const retryableZCodeTimeoutFailedQueueJobCount = input.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0;
   const exhaustedZCodeTimeoutFailedQueueJobCount = input.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0;
-  const zcodeTimeoutFailedQueueJobsOk = activeFailedQueueJobs === 0;
+  const zcodeTimeoutFailedQueueJobsOk = activeZCodeTimeoutFailedQueueJobCount === 0;
   const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
     (input.database.staleActiveReviewQueueJobCount ?? 0);
   const staleReviewLeasesOk = staleReviewLeaseCount === 0;
@@ -363,10 +365,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "queue_no_zcode_timeout_failed_jobs",
       ok: zcodeTimeoutFailedQueueJobsOk,
-      detail: activeFailedQueueJobs === failedQueueJobs
+      detail: activeZCodeTimeoutFailedQueueJobCount === zcodeTimeoutFailedQueueJobCount
         ? `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
           `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
-        : `${activeFailedQueueJobs} active failed durable queue job(s); retained ZCode timeout history=${zcodeTimeoutFailedQueueJobCount}; ` +
+        : `${activeZCodeTimeoutFailedQueueJobCount} active ZCode timeout failed durable queue job(s); ` +
           `retained=${zcodeTimeoutFailedQueueJobCount}; retryable=${retryableZCodeTimeoutFailedQueueJobCount} ` +
           `exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
     },
@@ -2434,6 +2436,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       failedReviewQueueJobCount: reviewQueue.failed,
       activeFailedReviewQueueJobCount: reviewQueue.activeFailed,
       zcodeTimeoutFailedReviewQueueJobCount: reviewQueue.zcodeTimeoutFailed,
+      activeZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.activeZcodeTimeoutFailed,
       retryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.retryableZCodeTimeoutFailed,
       exhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.exhaustedZCodeTimeoutFailed,
       reviewRunLeaseCount: reviewRunLeases.total,
@@ -2462,6 +2465,7 @@ function readReviewQueueCounts(
   failed: number;
   activeFailed: number;
   zcodeTimeoutFailed: number;
+  activeZcodeTimeoutFailed: number;
   retryableZCodeTimeoutFailed: number;
   exhaustedZCodeTimeoutFailed: number;
   byRepo: ReviewQueueRepoStatus[];
@@ -2480,6 +2484,7 @@ function readReviewQueueCounts(
       failed: 0,
       activeFailed: 0,
       zcodeTimeoutFailed: 0,
+      activeZcodeTimeoutFailed: 0,
       retryableZCodeTimeoutFailed: 0,
       exhaustedZCodeTimeoutFailed: 0,
       byRepo: []
@@ -2518,6 +2523,7 @@ function readReviewQueueCounts(
   const failedRows = db.prepare(`select q.last_error,q.updated_at,exists(select 1 from processed_reviews p where p.repo=q.repo and p.pull_number=q.pull_number and p.status='posted' and (p.error is null or p.error='') and julianday(p.created_at)>julianday(q.updated_at)) as recovered from review_queue_jobs q where q.state='failed'`).all() as unknown as Array<{ last_error: string | null; updated_at: string; recovered: number }>;
   const activeFailedRows = failedRows.filter((row) => row.recovered !== 1);
   const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
+  const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -2528,6 +2534,7 @@ function readReviewQueueCounts(
     failed: row.failed ?? 0,
     activeFailed: activeFailedRows.length,
     zcodeTimeoutFailed: timeoutCounts.total,
+    activeZcodeTimeoutFailed: activeTimeoutCounts.total,
     retryableZCodeTimeoutFailed: timeoutCounts.retryable,
     exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,
     byRepo: byRepoRows.map((repoRow) => ({

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -149,6 +149,22 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).not.toContain(expect.stringContaining("retry-failed"));
   });
 
+  it("keeps runtime inventory non-red for retained failed queue history", () => {
+    const queue = durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), total: 1, failed: 1 }, jobs: [durableJob({ repo: "owner/repo", pullNumber: 7, headSha: "historical-timeout", state: "failed", lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1" })] });
+    const release = (activeFailed: number) => releaseStatus({ ok: true, database: { failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: activeFailed, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: activeFailed } });
+    const historical = buildRuntimeInventory({ release: release(0), agents: agentInventory({}), durableQueue: queue });
+    const active = buildRuntimeInventory({ release: release(1), agents: agentInventory({}), durableQueue: queue });
+
+    expect(historical.ok).toBe(true);
+    expect(historical.runtimeState).toBe("healthy_idle");
+    expect(historical.summary.failedQueueJobs).toBe(1);
+    expect(historical.gates).toContainEqual(expect.objectContaining({ name: "runtime_no_failed_queue_jobs", ok: true }));
+    expect(historical.recommendedActions).not.toContain("inspect operator queue failed jobs before promotion");
+    expect(active.ok).toBe(false);
+    expect(active.runtimeState).toBe("blocked");
+    expect(active.gates).toContainEqual(expect.objectContaining({ name: "runtime_no_failed_queue_jobs", ok: false }));
+  });
+
   it("passes required release monitoring coverage when all coverage gates are green", () => {
     const coverage = buildReleaseMonitoringCoverage({
       required: true,

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -139,6 +139,16 @@ describe("operator CLI summaries", () => {
     expect(human).toContain("actionable: none");
   });
 
+  it("does not block on retained ZCode timeout history", () => {
+    const release = releaseStatus({ ok: true, database: { failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: 0, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: 0, retryableZCodeTimeoutFailedReviewQueueJobCount: 1 } });
+    const status = buildOperatorStatus({ release, agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), total: 1, failed: 1 }, jobs: [durableJob({ repo: "owner/repo", pullNumber: 7, headSha: "historical-timeout", state: "failed", lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1" })] }) });
+
+    expect(status.ok).toBe(true);
+    expect(status.summary.zcodeTimeoutFailedQueueJobs).toBe(1);
+    expect(status.gates).toContainEqual(expect.objectContaining({ name: "durable_queue_no_zcode_timeout_failed_jobs", ok: true }));
+    expect(status.recommendedActions).not.toContain(expect.stringContaining("retry-failed"));
+  });
+
   it("passes required release monitoring coverage when all coverage gates are green", () => {
     const coverage = buildReleaseMonitoringCoverage({
       required: true,

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -19,6 +19,7 @@ import {
   explainPullStatus,
   filterBotProcessRows,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorAgentInventory,
@@ -123,6 +124,19 @@ describe("operator CLI summaries", () => {
       ok: false,
       detail: "coverage was required but no coverage report was supplied"
     });
+  });
+
+  it("uses active queue failures for status while human output preserves history and cause", () => {
+    const release = releaseStatus({ ok: true, database: { errorCount: 1, recentUnrecoveredErrorCount: 0, failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: 0 } });
+    release.health = { state: "amber", reason: "current gates pass; retained history", active: { failedQueueJobs: 0, staleReviewLeases: 0 }, recent: { unrecoveredReviewErrors: 0 }, history: { reviewErrors: 1, failedQueueJobs: 1 } };
+    const status = buildOperatorStatus({ release, agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), total: 1, failed: 1 }, jobs: [] }) });
+
+    expect(status.ok).toBe(true);
+    expect(status.release.health?.state).toBe("amber");
+    const human = formatOperatorStatusHuman(status);
+    expect(human).toContain("status: amber");
+    expect(human).toContain("history: reviewErrors=1 failedQueueJobs=1");
+    expect(human).toContain("actionable: none");
   });
 
   it("passes required release monitoring coverage when all coverage gates are green", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6768,6 +6768,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     });
     expect(status.database).toMatchObject({
       zcodeTimeoutFailedReviewQueueJobCount: 1,
+      activeZCodeTimeoutFailedReviewQueueJobCount: 1,
       retryableZCodeTimeoutFailedReviewQueueJobCount: 1,
       exhaustedZCodeTimeoutFailedReviewQueueJobCount: 0
     });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -220,6 +220,55 @@ describe("beta release status", () => {
     expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
   });
 
+  it("keeps recovered review and queue failures visible without making health red", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-active-health-recovered-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const store = new ReviewStateStore(dbPath);
+    store.recordProcessed({ repo: "owner/repo", pullNumber: 7, headSha: "failed-head", status: "failed", error: "provider timeout" });
+    store.recordProcessed({ repo: "owner/repo", pullNumber: 7, headSha: "posted-head", status: "posted" });
+    store.close();
+    const db = new DatabaseSync(dbPath);
+    db.exec(`update processed_reviews set created_at='2026-08-22T12:00:00.100Z' where head_sha='failed-head';
+      update processed_reviews set created_at='2026-08-22T12:00:00.900Z' where head_sha='posted-head';`);
+    insertQueueJob(db, "failed", "owner/repo", "failed-head", undefined, { pullNumber: 7 });
+    db.prepare("update review_queue_jobs set updated_at='2026-08-22T12:00:00.100Z' where head_sha='failed-head'").run();
+    db.close();
+
+    const status = collectReleaseStatus({
+      cwd: repoRoot,
+      configPath: join(root, "missing-config.json"),
+      statePath: dbPath,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-08-23T00:00:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({ errorCount: 1, recentUnrecoveredErrorCount: 0, failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: 0 });
+    const healthy = buildReleaseStatus({
+      repo: { branch: "main", head: "head", dirtyFiles: [] }, expectedHead: "head", configPath: "/config/live.json",
+      launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", configPath: "/config/live.json", usesSystemCa: true },
+      database: status.database, heartbeat: freshHeartbeat(), now: new Date("2026-08-23T00:00:00.000Z")
+    });
+    expect(healthy.ok).toBe(true);
+    expect(healthy.health).toMatchObject({ state: "amber", active: { failedQueueJobs: 0, staleReviewLeases: 0 }, recent: { unrecoveredReviewErrors: 0 }, history: { reviewErrors: 1, failedQueueJobs: 1 } });
+  });
+
+  it("keeps a recent unrecovered failure red", () => {
+    const status = buildReleaseStatus({
+      repo: { branch: "main", head: "head", dirtyFiles: [] },
+      expectedHead: "head",
+      configPath: "/config/live.json",
+      launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", configPath: "/config/live.json", usesSystemCa: true },
+      database: { rowCount: 1, errorCount: 1, recentUnrecoveredErrorCount: 1, lastErrorAt: "2026-08-22T23:30:00.000Z", failedReviewQueueJobCount: 0 },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-08-23T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.health).toMatchObject({ state: "red", recent: { unrecoveredReviewErrors: 1 }, history: { reviewErrors: 1 } });
+    expect(status.health?.reason).toContain("live_db_no_errors");
+  });
+
   it("adds public release manifest gates while allowing an explicit source beta license API deferral", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-green-"));
     roots.push(root);


### PR DESCRIPTION
Closes #741

## Summary
- classify release health from active queue/stale lease and recent unrecovered failures
- preserve all-time review error and failed queue counts plus last failure evidence
- add additive JSON health fields and concise `status --human true` output
- add recovered-history, recent-failure, and operator presentation tests

## Validation
- `PATH=/opt/homebrew/bin:$PATH npm test -- --run tests/release-status.test.ts tests/operator-cli.test.ts` (164 passed)
- `PATH=/opt/homebrew/bin:$PATH npm run build`
- `git diff --check`

Supersedes stale PR #744; no live runtime, database, launchd, config, or customer state was changed.