### PR TITLE
fix(release): skip desktop-only RCs in npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -120,6 +120,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # The policy reads the exact desktop-only marker from the checked-out
+          # annotated tag before applying package/release compatibility gates.
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           RELEASE_LEVEL="$(node -p "require('./docs/public-release-manifest.json').releaseLevel")"
           SKIPPED_VERSIONS="$(node -p "JSON.stringify(require('./docs/public-release-manifest.json').packageArtifact?.skippedPublicPackageVersions ?? [])")"
@@ -137,6 +139,10 @@ jobs:
             --skipped-versions-json "$SKIPPED_VERSIONS" \
             "${RELEASE_METADATA_ARGS[@]}" \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Exit Desktop-only release without npm work
+        if: steps.package_release.outputs.release_kind == 'desktop-only'
+        run: echo "Desktop-only release; npm authentication, install, build, and publication are skipped."
 
       - name: Verify npm publish token is configured
         if: steps.package_release.outputs.should_publish == 'true'

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -13,6 +13,8 @@ const V104_PROVENANCE_RECOVERY = Object.freeze({
   commit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
   predecessor: "1.0.3"
 });
+const DESKTOP_ONLY_RC_TAG = /^v\d+\.\d+\.\d+-rc\.\d+$/;
+const DESKTOP_ONLY_TAG_ANNOTATION = "NeonDiff-Release-Class: desktop-only";
 
 function fail(message) {
   console.error(message);
@@ -55,6 +57,17 @@ function isAncestor(ancestor, descendant) {
   }
 }
 
+function isDesktopOnlyTag(tag) {
+  if (!DESKTOP_ONLY_RC_TAG.test(tag)) return false;
+  try {
+    if (git(["cat-file", "-t", tag]) !== "tag") return false;
+    const annotation = git(["for-each-ref", "--format=%(contents)", `refs/tags/${tag}`]);
+    return annotation.split(/\r?\n/).some((line) => line.trim() === DESKTOP_ONLY_TAG_ANNOTATION);
+  } catch {
+    return false;
+  }
+}
+
 function classify(args) {
   const eventName = required(args, "event-name");
   const releasePrerelease = parseBoolean(required(args, "release-prerelease"), "release-prerelease");
@@ -72,19 +85,13 @@ function classify(args) {
   }
 
   const npmTag = packageVersion.includes("-") ? "beta" : "latest";
-  if (eventName === "release" && releasePrerelease && npmTag === "latest") {
-    fail("stable npm packages require a non-prerelease GitHub Release");
-  }
-  if (eventName === "release" && !releasePrerelease && npmTag === "beta") {
-    fail("beta npm packages require a prerelease GitHub Release");
-  }
+  let releaseMetadata;
   if (eventName === "workflow_dispatch") {
     const releaseMetadataPath = args.get("release-metadata");
     if (!releaseMetadataPath && npmTag === "latest") {
       fail("manual stable publish requires an existing non-prerelease GitHub Release");
     }
     if (!releaseMetadataPath) fail("manual npm publish requires existing GitHub Release metadata");
-    let releaseMetadata;
     try {
       releaseMetadata = JSON.parse(readFileSync(releaseMetadataPath, "utf8"));
     } catch {
@@ -93,6 +100,26 @@ function classify(args) {
     if (releaseMetadata.tag_name !== tag || releaseMetadata.draft !== false) {
       fail("manual npm publish requires matching published GitHub Release metadata");
     }
+  }
+  const effectiveReleasePrerelease = eventName === "workflow_dispatch"
+    ? releaseMetadata?.prerelease
+    : releasePrerelease;
+  if (effectiveReleasePrerelease === true && isDesktopOnlyTag(tag)) {
+    const result = { shouldPublish: false, npmTag, releaseKind: "desktop-only" };
+    const githubOutput = args.get("github-output");
+    if (githubOutput) {
+      appendFileSync(githubOutput, `should_publish=false\nnpm_tag=${npmTag}\nrelease_kind=desktop-only\n`, { encoding: "utf8" });
+    }
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (eventName === "release" && releasePrerelease && npmTag === "latest") {
+    fail("stable npm packages require a non-prerelease GitHub Release");
+  }
+  if (eventName === "release" && !releasePrerelease && npmTag === "beta") {
+    fail("beta npm packages require a prerelease GitHub Release");
+  }
+  if (eventName === "workflow_dispatch") {
     if (npmTag === "latest" && releaseMetadata.prerelease !== false) {
       fail("manual stable publish requires an existing non-prerelease GitHub Release");
     }

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -13,7 +13,7 @@ const V104_PROVENANCE_RECOVERY = Object.freeze({
   commit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
   predecessor: "1.0.3"
 });
-const DESKTOP_ONLY_RC_TAG = /^v\d+\.\d+\.\d+-rc\.\d+$/;
+const DESKTOP_ONLY_RC_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:[1-9]\d*)$/;
 const DESKTOP_ONLY_TAG_ANNOTATION = "NeonDiff-Release-Class: desktop-only";
 
 function fail(message) {

--- a/tests/npm-release-policy.test.mjs
+++ b/tests/npm-release-policy.test.mjs
@@ -1,0 +1,42 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots = [];
+const policy = resolve("scripts/npm-release-policy.mjs");
+const marker = "NeonDiff-Release-Class: desktop-only";
+
+afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
+
+function taggedRepo(tag) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-semver-"));
+  roots.push(root);
+  execFileSync("git", ["init", "-q", "-b", "main", root]);
+  for (const [key, value] of [["user.email", "release-policy@example.invalid"], ["user.name", "Release Policy Test"]]) {
+    execFileSync("git", ["-C", root, "config", key, value]);
+  }
+  writeFileSync(join(root, "release.txt"), "release\n");
+  execFileSync("git", ["-C", root, "add", "release.txt"]);
+  execFileSync("git", ["-C", root, "commit", "-q", "-m", "release"]);
+  execFileSync("git", ["-C", root, "tag", "-a", tag, "-m", marker]);
+  return root;
+}
+
+function classify(root, tag) {
+  return spawnSync(process.execPath, [policy, "classify", "--event-name", "release", "--release-prerelease", "true", "--tag", tag, "--package-version", "1.0.4", "--release-level", "stable", "--skipped-versions-json", "[]"], { cwd: root, encoding: "utf8" });
+}
+
+describe("canonical Desktop-only RC identities", () => {
+  it.each(["v1.1.0-rc.01", "v01.1.0-rc.1", "v1.01.0-rc.1", "v1.1.01-rc.1", "v1.1.0-rc.0"])("fails closed for %s", (tag) => {
+    const result = classify(taggedRepo(tag), tag);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("stable npm packages require a non-prerelease GitHub Release");
+  });
+
+  it.each(["v0.0.0-rc.1", "v1.0.0-rc.1", "v1.1.0-rc.1"])("keeps canonical %s as a Desktop-only no-op", (tag) => {
+    const result = classify(taggedRepo(tag), tag);
+    expect(JSON.parse(result.stdout)).toEqual({ shouldPublish: false, npmTag: "latest", releaseKind: "desktop-only" });
+  });
+});

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -99,6 +99,101 @@ describe("npm release policy", () => {
     expect(JSON.parse(output)).toEqual({ shouldPublish: true, npmTag: "latest" });
   });
 
+  it("skips an annotated desktop-only RC before stable-package prerelease validation", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-desktop-only-rc-"));
+    roots.push(root);
+    execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "release-policy@example.invalid"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Release Policy Test"], { cwd: root });
+    writeFileSync(join(root, "release.txt"), "desktop release\n");
+    execFileSync("git", ["add", "release.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "desktop release"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["tag", "-a", "v1.1.0-rc.1", "-m", "NeonDiff-Release-Class: desktop-only"], { cwd: root });
+
+    const output = execFileSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "release",
+      "--release-prerelease", "true",
+      "--tag", "v1.1.0-rc.1",
+      "--package-version", "1.0.4",
+      "--release-level", "stable",
+      "--skipped-versions-json", "[]"
+    ], { cwd: root, encoding: "utf8" });
+
+    expect(JSON.parse(output)).toEqual({
+      shouldPublish: false,
+      npmTag: "latest",
+      releaseKind: "desktop-only"
+    });
+  });
+
+  it("does not classify an annotated RC without the desktop-only marker", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-unmarked-rc-"));
+    roots.push(root);
+    execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "release-policy@example.invalid"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Release Policy Test"], { cwd: root });
+    writeFileSync(join(root, "release.txt"), "release\n");
+    execFileSync("git", ["add", "release.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "release"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["tag", "-a", "v1.1.0-rc.1", "-m", "CLI release"], { cwd: root });
+
+    const result = spawnSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "release",
+      "--release-prerelease", "true",
+      "--tag", "v1.1.0-rc.1",
+      "--package-version", "1.0.4",
+      "--release-level", "stable",
+      "--skipped-versions-json", "[]"
+    ], { cwd: root, encoding: "utf8" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("stable npm packages require a non-prerelease GitHub Release");
+  });
+
+  it("keeps a true CLI beta release on the existing beta publish path", () => {
+    const output = execFileSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "release",
+      "--release-prerelease", "true",
+      "--tag", "v1.0.4-beta.1",
+      "--package-version", "1.0.4-beta.1",
+      "--release-level", "beta",
+      "--skipped-versions-json", "[]"
+    ], { encoding: "utf8" });
+
+    expect(JSON.parse(output)).toEqual({ shouldPublish: true, npmTag: "beta" });
+  });
+
+  it("rejects a lightweight desktop-only RC tag in verify-git", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-lightweight-rc-"));
+    roots.push(root);
+    execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "release-policy@example.invalid"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Release Policy Test"], { cwd: root });
+    writeFileSync(join(root, "release.txt"), "release\n");
+    execFileSync("git", ["add", "release.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "release"], { cwd: root, stdio: "ignore" });
+    const candidate = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: root });
+    execFileSync("git", ["tag", "v1.1.0-rc.1"], { cwd: root });
+
+    const result = spawnSync(process.execPath, [
+      policyScript,
+      "verify-git",
+      "--tag", "v1.1.0-rc.1",
+      "--candidate-head", candidate,
+      "--main-ref", "refs/remotes/origin/main"
+    ], { cwd: root, encoding: "utf8" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("release tag must be annotated");
+  });
+
   it("requires the release tag and declared candidate to be ancestors of protected main", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-npm-release-policy-"));
     roots.push(root);


### PR DESCRIPTION
Related: #610

## Summary
- classify an annotated `v<semver>-rc.<n>` tag as Desktop-only only when its tag annotation contains the exact `NeonDiff-Release-Class: desktop-only` line
- return the no-op classification before stable package prerelease validation
- keep every npm auth, install, build, pack, publish, and promotion step behind the existing `should_publish == 'true'` guards
- preserve annotated-tag enforcement and existing CLI stable/beta rules

## Validation
- `node --check scripts/npm-release-policy.mjs`
- direct policy probes: marked annotated RC no-op; unmarked RC rejection; CLI beta publish; lightweight RC `verify-git` rejection
- `git diff --check`
- manifest/package SHA-256 unchanged from base: `docs/public-release-manifest.json` `9e5aae15c24da42c7197133dfe1b3c9cbc52e9e6578fd2a662b83d55fd4c8b4a`, `package.json` `1ae3ed81bafdac56f658bc8ac048f72d9310643daad07d8bdfe5483410a9c067`

Focused Vitest could not run locally because this worktree has no dependencies and the shared install fails loading the Team-ID-invalid Rollup native binary; CI remains the authoritative full gate.

## Safety boundary
No package version, manifest, npm publication, release/tag creation, signing/notarization, deployment, installed app, worker, config, DB, or Keychain state was changed. No merge performed.
