### PR TITLE
ci: extend Mac public canary to immutable RC assets

### DIFF
--- a/.github/workflows/paid-beta-public-download-canary.yml
+++ b/.github/workflows/paid-beta-public-download-canary.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       artifact_name:
-        description: Exact signed and notarized Mac app ZIP asset
+        description: Exact signed and notarized build-named Mac app ZIP asset
         required: true
         type: string
       artifact_sha256:
@@ -51,15 +51,48 @@ jobs:
           ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
         run: |
           set -euo pipefail
-          [[ "$RELEASE_TAG" =~ ^v1\.1\.0-beta\.([0-9]+)$ ]]
-          release_beta="${BASH_REMATCH[1]}"
-          [[ "$ARTIFACT_NAME" =~ ^NeonDiff-1\.1\.0-beta\.([0-9]+)-build[0-9]+-macOS\.zip$ ]]
-          artifact_beta="${BASH_REMATCH[1]}"
-          test "$release_beta" = "$artifact_beta"
+          [[ "$RELEASE_TAG" =~ ^v1\.1\.0-(beta|rc)\.([0-9]+)$ ]]
+          release_channel="${BASH_REMATCH[1]}"
+          release_number="${BASH_REMATCH[2]}"
+          release_version="1.1.0-${release_channel}.${release_number}"
+          [[ "$ARTIFACT_NAME" =~ ^NeonDiff-1\.1\.0-(beta|rc)\.([0-9]+)-build([0-9]+)-macOS\.zip$ ]]
+          artifact_channel="${BASH_REMATCH[1]}"
+          artifact_number="${BASH_REMATCH[2]}"
+          artifact_build="${BASH_REMATCH[3]}"
+          test "$release_channel" = "$artifact_channel"
+          test "$release_number" = "$artifact_number"
+          test "$release_version" = "1.1.0-${artifact_channel}.${artifact_number}"
           [[ "$ARTIFACT_SHA256" =~ ^[a-f0-9]{64}$ ]]
           test "$(uname -m)" = "arm64"
+          printf 'release_channel=%s\nrelease_version=%s\nartifact_build=%s\n' \
+            "$release_channel" "$release_version" "$artifact_build" >> "$GITHUB_OUTPUT"
           printf 'url=https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/%s/%s\n' \
             "$RELEASE_TAG" "$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Verify annotated tag and immutable release digest
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+        run: |
+          set -euo pipefail
+          api_base="https://api.github.com/repos/electricsheephq/evaos-code-review-bot-neondiff"
+          api_headers=(--header "Authorization: Bearer $GITHUB_TOKEN" --header 'Accept: application/vnd.github+json')
+          tag_metadata="$(curl --fail --location --proto '=https' --tlsv1.2 "${api_headers[@]}" \
+            "$api_base/git/ref/tags/$RELEASE_TAG")"
+          test "$(jq -r '.ref' <<<"$tag_metadata")" = "refs/tags/$RELEASE_TAG"
+          test "$(jq -r '.object.type' <<<"$tag_metadata")" = "tag"
+          release_metadata="$(curl --fail --location --proto '=https' --tlsv1.2 "${api_headers[@]}" \
+            "$api_base/releases/tags/$RELEASE_TAG")"
+          test "$(jq -r '.tag_name' <<<"$release_metadata")" = "$RELEASE_TAG"
+          test "$(jq -r '.draft' <<<"$release_metadata")" = "false"
+          test "$(jq -r '.prerelease' <<<"$release_metadata")" = "true"
+          asset_digest="$(jq -er --arg name "$ARTIFACT_NAME" \
+            '[.assets[] | select(.name == $name) | .digest] | if length == 1 then .[0] else error("exactly one matching release asset is required") end' \
+            <<<"$release_metadata")"
+          test "$asset_digest" = "sha256:$ARTIFACT_SHA256"
 
       - name: Download exact public release asset
         shell: bash
@@ -100,6 +133,31 @@ jobs:
           xcrun stapler validate "$extract_root/NeonDiff.app"
           spctl --assess --type execute "$extract_root/NeonDiff.app"
 
+      - name: Verify version build feed and Sparkle signature agreement
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.release.outputs.url }}
+          ARTIFACT_BUILD: ${{ steps.release.outputs.artifact_build }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
+          PUBLIC_FEED_URL: https://www.neondiff.com/updates/beta/appcast.xml
+        run: |
+          set -euo pipefail
+          app="$RUNNER_TEMP/neondiff-download/extracted/NeonDiff.app"
+          info_plist="$app/Contents/Info.plist"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info_plist")" = "$RELEASE_VERSION"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$info_plist")" = "$ARTIFACT_BUILD"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$info_plist")" = "$PUBLIC_FEED_URL"
+          sparkle_key="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$info_plist")"
+          [[ "$sparkle_key" =~ ^[A-Za-z0-9+/=]{32,}$ ]]
+          feed="$RUNNER_TEMP/neondiff-download/appcast.xml"
+          curl --fail --location --proto '=https' --tlsv1.2 --retry 3 \
+            --output "$feed" "$PUBLIC_FEED_URL"
+          grep -Fq "<link>$PUBLIC_FEED_URL</link>" "$feed"
+          grep -Fq "url=\"$ARTIFACT_URL\"" "$feed"
+          grep -Fq "sparkle:version=\"$ARTIFACT_BUILD\"" "$feed"
+          grep -Fq "sparkle:shortVersionString=\"$RELEASE_VERSION\"" "$feed"
+          grep -Eq 'sparkle:edSignature="[A-Za-z0-9+/=_-]{32,}"' "$feed"
+
       - name: Install exact app on clean runner
         shell: bash
         run: |
@@ -119,6 +177,9 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
           ARTIFACT_NAME: ${{ inputs.artifact_name }}
           ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          RELEASE_CHANNEL: ${{ steps.release.outputs.release_channel }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
+          ARTIFACT_BUILD: ${{ steps.release.outputs.artifact_build }}
           RUNNER_LABEL: ${{ matrix.runner }}
         run: |
           set -euo pipefail
@@ -127,6 +188,9 @@ jobs:
             --arg releaseTag "$RELEASE_TAG" \
             --arg artifactName "$ARTIFACT_NAME" \
             --arg artifactSha256 "$ARTIFACT_SHA256" \
+            --arg releaseChannel "$RELEASE_CHANNEL" \
+            --arg releaseVersion "$RELEASE_VERSION" \
+            --arg artifactBuild "$ARTIFACT_BUILD" \
             --arg runnerLabel "$RUNNER_LABEL" \
             --arg macOSVersion "$(sw_vers -productVersion)" \
             --arg architecture "$(uname -m)" \
@@ -134,13 +198,18 @@ jobs:
             '{
               schemaVersion: $schemaVersion,
               releaseTag: $releaseTag,
+              releaseChannel: $releaseChannel,
+              releaseVersion: $releaseVersion,
               artifactName: $artifactName,
+              artifactBuild: $artifactBuild,
               artifactSha256: $artifactSha256,
               runnerLabel: $runnerLabel,
               macOSVersion: $macOSVersion,
               architecture: $architecture,
               publicDownload: $result,
               checksum: $result,
+              feed: $result,
+              sparkleSignature: $result,
               developerIdSignature: $result,
               notarizationTicket: $result,
               gatekeeper: $result,

--- a/.github/workflows/paid-beta-public-download-canary.yml
+++ b/.github/workflows/paid-beta-public-download-canary.yml
@@ -62,7 +62,8 @@ jobs:
           test "$release_channel" = "$artifact_channel"
           test "$release_number" = "$artifact_number"
           test "$release_version" = "1.1.0-${artifact_channel}.${artifact_number}"
-          [[ "$ARTIFACT_SHA256" =~ ^[a-f0-9]{64}$ ]]
+          test "${#ARTIFACT_SHA256}" -eq 64
+          test -z "$(printf '%s' "$ARTIFACT_SHA256" | tr -d 'a-f0-9')"
           test "$(uname -m)" = "arm64"
           printf 'release_channel=%s\nrelease_version=%s\nartifact_build=%s\n' \
             "$release_channel" "$release_version" "$artifact_build" >> "$GITHUB_OUTPUT"
@@ -148,15 +149,75 @@ jobs:
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$info_plist")" = "$ARTIFACT_BUILD"
           test "$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$info_plist")" = "$PUBLIC_FEED_URL"
           sparkle_key="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$info_plist")"
-          [[ "$sparkle_key" =~ ^[A-Za-z0-9+/=]{32,}$ ]]
           feed="$RUNNER_TEMP/neondiff-download/appcast.xml"
           curl --fail --location --proto '=https' --tlsv1.2 --retry 3 \
             --output "$feed" "$PUBLIC_FEED_URL"
-          grep -Fq "<link>$PUBLIC_FEED_URL</link>" "$feed"
-          grep -Fq "url=\"$ARTIFACT_URL\"" "$feed"
-          grep -Fq "sparkle:version=\"$ARTIFACT_BUILD\"" "$feed"
-          grep -Fq "sparkle:shortVersionString=\"$RELEASE_VERSION\"" "$feed"
-          grep -Eq 'sparkle:edSignature="[A-Za-z0-9+/=_-]{32,}"' "$feed"
+          sparkle_signature="$(
+            python3 - "$feed" "$ARTIFACT_URL" "$ARTIFACT_BUILD" "$RELEASE_VERSION" "$PUBLIC_FEED_URL" "$sparkle_key" <<'PY'
+          import base64
+          import sys
+          import xml.etree.ElementTree as ET
+
+          SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+          def fail(message):
+              raise SystemExit(message)
+
+          feed, expected_url, expected_build, expected_version, expected_feed, public_key = sys.argv[1:]
+          try:
+              if len(base64.b64decode(public_key, validate=True)) != 32:
+                  fail("SUPublicEDKey must decode to 32 bytes")
+              root = ET.parse(feed).getroot()
+          except (ET.ParseError, ValueError) as error:
+              fail(f"invalid feed or public key: {error}")
+
+          def local_name(tag):
+              return tag.rsplit("}", 1)[-1]
+
+          channels = [child for child in root if local_name(child.tag) == "channel"]
+          if len(channels) != 1:
+              fail("feed must contain exactly one channel")
+          channel = channels[0]
+          links = [child for child in channel if local_name(child.tag) == "link"]
+          if len(links) != 1 or (links[0].text or "").strip() != expected_feed:
+              fail("feed link does not match the app's SUFeedURL")
+          matches = []
+          for item in channel:
+              if local_name(item.tag) != "item":
+                  continue
+              enclosures = [child for child in item if local_name(child.tag) == "enclosure"]
+              for enclosure in enclosures:
+                  if enclosure.attrib.get("url") == expected_url:
+                      matches.append((item, enclosure, len(enclosures)))
+          if len(matches) != 1 or matches[0][2] != 1:
+              fail("exactly one item must contain the expected archive enclosure")
+          _, enclosure, _ = matches[0]
+          if enclosure.attrib.get(f"{{{SPARKLE_NS}}}version") != expected_build:
+              fail("feed build does not match the immutable archive")
+          if enclosure.attrib.get(f"{{{SPARKLE_NS}}}shortVersionString") != expected_version:
+              fail("feed version does not match the extracted app")
+          signature = enclosure.attrib.get(f"{{{SPARKLE_NS}}}edSignature", "")
+          try:
+              if len(base64.b64decode(signature, validate=True)) != 64:
+                  fail("Sparkle signature must decode to 64 bytes")
+          except ValueError as error:
+              fail(f"invalid Sparkle signature: {error}")
+          print(signature, end="")
+          PY
+          )"
+          swift - "$sparkle_key" "$sparkle_signature" "$RUNNER_TEMP/neondiff-download/NeonDiff.zip" <<'SWIFT'
+          import CryptoKit
+          import Foundation
+
+          guard CommandLine.arguments.count == 4,
+                let keyData = Data(base64Encoded: CommandLine.arguments[1]),
+                let signature = Data(base64Encoded: CommandLine.arguments[2]),
+                let archive = try? Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[3])),
+                let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: keyData),
+                publicKey.isValidSignature(signature, for: archive) else {
+              exit(1)
+          }
+          SWIFT
 
       - name: Install exact app on clean runner
         shell: bash

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   existsSync,
   mkdtempSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   writeFileSync
@@ -16,9 +17,101 @@ function read(path: string): string {
   return readFileSync(path, "utf8");
 }
 
+function immutableReleaseInputValidation(workflow: string): string {
+  const parsed = YAML.parse(workflow) as {
+    jobs?: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+  };
+  const step = parsed.jobs?.["public-download-install-canary"]?.steps?.find(
+    (candidate) => candidate.name === "Validate immutable release input"
+  );
+  if (!step?.run) throw new Error("missing immutable release validation step");
+  return step.run;
+}
+
+function runImmutableReleaseInputValidation(
+  validationScript: string,
+  input: { releaseTag: string; artifactName: string; artifactSha256: string }
+) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-release-input-"));
+  const outputPath = join(root, "github-output");
+  const bin = join(root, "bin");
+  const uname = join(bin, "uname");
+  mkdirSync(bin);
+  writeFileSync(uname, "#!/bin/sh\nprintf '%s\\n' arm64\n");
+  chmodSync(uname, 0o755);
+  const result = spawnSync("bash", ["-euo", "pipefail", "-c", validationScript], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      RELEASE_TAG: input.releaseTag,
+      ARTIFACT_NAME: input.artifactName,
+      ARTIFACT_SHA256: input.artifactSha256,
+      GITHUB_OUTPUT: outputPath
+    }
+  });
+  return { result, outputPath };
+}
+
 const retiredCoreChecksTarget = ["NeonDiffDesktopCore", "Checks"].join("");
 
 describe("NeonDiff desktop release-smoke pipeline", () => {
+  it("accepts exact beta and annotated-style RC identities while rejecting drift", () => {
+    const workflow = read(".github/workflows/paid-beta-public-download-canary.yml");
+    const validationScript = immutableReleaseInputValidation(workflow);
+    const digest = "a".repeat(64);
+
+    for (const input of [
+      {
+        releaseTag: "v1.1.0-beta.7",
+        artifactName: "NeonDiff-1.1.0-beta.7-build42-macOS.zip"
+      },
+      {
+        releaseTag: "v1.1.0-rc.1",
+        artifactName: "NeonDiff-1.1.0-rc.1-build42-macOS.zip"
+      }
+    ]) {
+      const { result, outputPath } = runImmutableReleaseInputValidation(validationScript, {
+        ...input,
+        artifactSha256: digest
+      });
+      expect(result.status, `${input.releaseTag} ${input.artifactName}: ${result.stderr}`).toBe(0);
+      expect(readFileSync(outputPath, "utf8")).toMatch(
+        /(?:release_channel|version|artifact_build)=/
+      );
+    }
+
+    for (const input of [
+      {
+        releaseTag: "v1.1.0-rc",
+        artifactName: "NeonDiff-1.1.0-rc-build42-macOS.zip"
+      },
+      {
+        releaseTag: "v1.1.0-rc.1",
+        artifactName: "NeonDiff-1.1.0-beta.1-build42-macOS.zip"
+      },
+      {
+        releaseTag: "v1.1.0-rc.1",
+        artifactName: "NeonDiff-1.1.0-rc.2-build42-macOS.zip"
+      },
+      {
+        releaseTag: "v1.1.0-rc.1",
+        artifactName: "NeonDiff-1.1.0-rc.1-macOS.zip"
+      },
+      {
+        releaseTag: "v1.1.0-rc.1",
+        artifactName: "NeonDiff-1.1.0-rc.1-build42-macOS.zip",
+        artifactSha256: "A".repeat(64)
+      }
+    ]) {
+      const { result } = runImmutableReleaseInputValidation(validationScript, {
+        ...input,
+        artifactSha256: input.artifactSha256 ?? digest
+      });
+      expect(result.status, `${input.releaseTag} ${input.artifactName}`).not.toBe(0);
+    }
+  });
+
   it("defines a three-clean-Mac public download and install canary", () => {
     const workflowPath = ".github/workflows/paid-beta-public-download-canary.yml";
 
@@ -69,7 +162,15 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
       "spctl --assess --type execute",
       "/Applications/NeonDiff.app",
       'test "$(uname -m)" = "arm64"',
-      'test "$release_beta" = "$artifact_beta"'
+      'test "$release_channel" = "$artifact_channel"',
+      'test "$release_number" = "$artifact_number"',
+      "git/ref/tags",
+      "'.object.type'",
+      "sha256:$ARTIFACT_SHA256",
+      "CFBundleShortVersionString",
+      "CFBundleVersion",
+      "SUPublicEDKey",
+      "sparkle:edSignature"
     ]) {
       expect(workflow).toContain(command);
     }
@@ -80,6 +181,8 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).not.toContain("spctl -a -vv");
     expect(workflow).not.toContain("open -n");
     expect(workflow).not.toContain("NeonDiffDesktop");
+    expect(workflow).toContain("https://www.neondiff.com/updates/beta/appcast.xml");
+    expect(workflow).toContain("<link>$PUBLIC_FEED_URL</link>");
   });
 
   it("defines an unsigned macOS release-smoke workflow with the required desktop gates", () => {

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -28,6 +28,18 @@ function immutableReleaseInputValidation(workflow: string): string {
   return step.run;
 }
 
+function feedItemParser(workflow: string): string {
+  const parsed = YAML.parse(workflow) as {
+    jobs?: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+  };
+  const step = parsed.jobs?.["public-download-install-canary"]?.steps?.find(
+    (candidate) => candidate.name === "Verify version build feed and Sparkle signature agreement"
+  );
+  const match = step?.run?.match(/python3 - [^\n]+ <<'PY'\n([\s\S]*?)\nPY/);
+  if (!match) throw new Error("missing exact feed XML parser");
+  return match[1];
+}
+
 function runImmutableReleaseInputValidation(
   validationScript: string,
   input: { releaseTag: string; artifactName: string; artifactSha256: string }
@@ -112,6 +124,35 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     }
   });
 
+  it("binds feed metadata to one exact enclosure and rejects sibling or URL drift", () => {
+    const workflow = read(".github/workflows/paid-beta-public-download-canary.yml");
+    const parser = feedItemParser(workflow);
+    const root = mkdtempSync(join(tmpdir(), "neondiff-feed-fixture-"));
+    const feedPath = join(root, "appcast.xml");
+    const feedUrl = "https://www.neondiff.com/updates/beta/appcast.xml";
+    const artifactUrl = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/v1.1.0-rc.1/NeonDiff-1.1.0-rc.1-build42-macOS.zip";
+    const signature = Buffer.alloc(64, 7).toString("base64");
+    const publicKey = Buffer.alloc(32, 9).toString("base64");
+    const runParser = (xml: string) => {
+      writeFileSync(feedPath, xml);
+      return spawnSync(
+        "python3",
+        ["-", feedPath, artifactUrl, "42", "1.1.0-rc.1", feedUrl, publicKey],
+        { encoding: "utf8", input: parser }
+      );
+    };
+    try {
+      const valid = runParser(`<?xml version="1.0"?><rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><link>${feedUrl}</link><item><description>${artifactUrl} sparkle:version="42"</description><enclosure url="https://stale.invalid/old.zip"/></item><item><enclosure url="${artifactUrl}" sparkle:version="42" sparkle:shortVersionString="1.1.0-rc.1" sparkle:edSignature="${signature}"/></item></channel></rss>`);
+      expect(valid.status, valid.stderr).toBe(0);
+      expect(valid.stdout.trim()).toBe(signature);
+
+      const wrongEnclosure = runParser(`<?xml version="1.0"?><rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><link>${feedUrl}</link><item><description>${artifactUrl} sparkle:version="42" sparkle:edSignature="${signature}"</description><enclosure url="https://wrong.invalid/NeonDiff.zip" sparkle:version="42" sparkle:shortVersionString="1.1.0-rc.1" sparkle:edSignature="${signature}"/></item></channel></rss>`);
+      expect(wrongEnclosure.status).not.toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("defines a three-clean-Mac public download and install canary", () => {
     const workflowPath = ".github/workflows/paid-beta-public-download-canary.yml";
 
@@ -170,7 +211,11 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
       "CFBundleShortVersionString",
       "CFBundleVersion",
       "SUPublicEDKey",
-      "sparkle:edSignature"
+      "edSignature",
+      "xml.etree.ElementTree",
+      "len(matches) != 1",
+      "Curve25519.Signing.PublicKey",
+      "isValidSignature"
     ]) {
       expect(workflow).toContain(command);
     }
@@ -182,7 +227,8 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).not.toContain("open -n");
     expect(workflow).not.toContain("NeonDiffDesktop");
     expect(workflow).toContain("https://www.neondiff.com/updates/beta/appcast.xml");
-    expect(workflow).toContain("<link>$PUBLIC_FEED_URL</link>");
+    expect(workflow).not.toContain("grep -Fq \"<link>$PUBLIC_FEED_URL</link>\"");
+    expect(workflow).not.toMatch(/\[\[\s*"\$sparkle_key"\s*=~/);
   });
 
   it("defines an unsigned macOS release-smoke workflow with the required desktop gates", () => {


### PR DESCRIPTION
Related: #103\n\n## Summary\n- accept exact v1.1.0-beta.N and v1.1.0-rc.N tags with matching build-named ZIPs\n- require annotated tag objects, prerelease release metadata, and GitHub asset digest agreement\n- verify baked version/build/feed/public-key identity and canonical signed feed entry before clean install\n- add deterministic red-first beta/RC/mismatch contract coverage\n\n## Validation\n- PATH=/opt/homebrew/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0PzzuIC:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm test -- --run tests/desktop-release-pipeline.test.ts\n- PATH=/opt/homebrew/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0PzzuIC:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm run check:public-claims\n- PATH=/opt/homebrew/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0PzzuIC:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm run check:secrets\n- actionlint .github/workflows/paid-beta-public-download-canary.yml\n- git diff --check\n\nNo release, tag, feed, site, customer artifact, signing, notarization, or live app mutation was performed. Agent-authored change; merge and publication remain owner gates.