### PR TITLE
docs: add fail-fast Mac GA runbook successor

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -206,7 +206,7 @@ configured `evidenceDir` as
 
 The `keychain` backend is reserved for the native sealed-worker boundary.
 Headless CLI activation rejects Keychain writes; `v1.0.4` uses the approved
-file backend. The native `1.1.0` BYO candidate has a separate
+file backend. The native `1.1.0` BYO GA has a separate
 [Mac GA architecture contract](architecture/mac-ga-release-contract.md), and
 unsigned or mixed-marker bundles remain quarantined.
 The local `machineId` sent to the license API is advisory beta metadata derived

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -204,11 +204,11 @@ For `review-pr` license blocks, the gate writes its local proof under the
 configured `evidenceDir` as
 `<date>/<owner__repo>/pr-<number>/<head-sha>/license-gate.json`.
 
-The `keychain` backend remains reserved for a separately proven native broker.
-Headless CLI activation currently rejects Keychain writes rather than passing
-license keys through process arguments. v1.0.4 supports the approved file
-backend; the Desktop app remains blocked from useful actions until native
-broker/launchd access is proven.
+The `keychain` backend is reserved for the native sealed-worker boundary.
+Headless CLI activation rejects Keychain writes; `v1.0.4` uses the approved
+file backend. The native `1.1.0` BYO candidate has a separate
+[Mac GA architecture contract](architecture/mac-ga-release-contract.md), and
+unsigned or mixed-marker bundles remain quarantined.
 The local `machineId` sent to the license API is advisory beta metadata derived
 from host name and platform, not hardware attestation or a durable seat-binding
 primitive.

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -10,9 +10,9 @@ CLI/dashboard `neondiff@1.0.4` and native Desktop `1.1.0` share security and rev
 | Lane | Supported surface | Must not claim |
 | --- | --- | --- |
 | CLI/dashboard | npm package, local HTML dashboard, API-backed activation, local worker | native Swift maturity, signed distribution, Sparkle, or Desktop GA |
-| Native Desktop | signed macOS app, native onboarding, sealed worker, paid BYO (managed later), Sparkle channel | that source, an unsigned bundle, or the CLI manifest is a native release |
+| Native Desktop GA | signed macOS app, native onboarding, sealed worker, paid BYO (managed later), Sparkle channel | that source, an unsigned bundle, or the CLI manifest is a native release |
 
-`docs/public-release-manifest.json` remains the CLI record. Desktop candidates use a versioned manifest/schema; do not merge or rewrite these records.
+`docs/public-release-manifest.json` remains the CLI record. Desktop GA uses the shared repository tag/release `v1.1.0`, not an npm publish; npm stays `1.0.4` unless CLI bytes change. Pre-GA fixtures may use `v1.1.0-beta.N`, but never create a second Desktop tag/release.
 
 ## Native production contract
 

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -1,0 +1,63 @@
+# NeonDiff Mac GA architecture and release contract
+
+Status: current architecture for the native Mac GA lane, not release evidence. A candidate records exact source-head and artifact identities in its versioned Desktop
+manifest; the CLI publication manifest is separate.
+
+## Separate delivery lanes
+
+CLI/dashboard `neondiff@1.0.4` and native Desktop `1.1.0` share security and review policy, but not release identity or activation:
+
+| Lane | Supported surface | Must not claim |
+| --- | --- | --- |
+| CLI/dashboard | npm package, local HTML dashboard, API-backed activation, local worker | native Swift maturity, signed distribution, Sparkle, or Desktop GA |
+| Native Desktop | signed macOS app, native onboarding, sealed worker, paid BYO (managed later), Sparkle channel | that source, an unsigned bundle, or the CLI manifest is a native release |
+
+`docs/public-release-manifest.json` remains the CLI record. Desktop candidates use a versioned manifest/schema; do not merge or rewrite these records.
+
+## Native production contract
+
+The signed bundle advertises exactly one release-only `Info.plist` contract;
+missing or mixed markers quarantine it before useful work:
+
+- Paid BYO: `NeonDiffPaidBetaContract=paid-mac-beta-byo-v1` plus `NeonDiffBYOGitHubEnabled=true`, with no managed marker/origin.
+- Managed: `NeonDiffPaidBetaContract=paid-mac-beta-v1` plus `NeonDiffManagedGitHubBrokerEnabled=true`, fixed origin `https://neondiff-license.fly.dev`, and no BYO marker.
+
+Markers select composition; they do not grant access. GitHub visibility, Keychain controls, server entitlement, and fail-closed checks remain authoritative;
+BYO and managed activation are mutually exclusive.
+
+## Sealed worker and Codex boundary
+
+The signed app contains one executable worker. Credential-bearing operations route through it and pass secrets once through bounded stdin; keys never enter argv,
+environment, config, logs, or evidence. It validates the signed app, plist, config identity, Keychain items, and launchd ownership before starting.
+
+With `codexRuntime`, `config inspect` is the source of truth for exact Codex CLI
+path/model/reasoning; the app never stores OAuth material. Disabled Codex uses the selected provider registry and bounded stdin.
+
+## Candidate gates and claim boundary
+
+Keep separate `pending`, `blocked`, and `proven` state for exact source head,
+artifact checksum, signing/notarization, feed, site, billing, customer,
+runtime, and rollback. CI, source inspection, fixtures, URLs, or a running
+process cannot inherit another gate's proof. GA also needs #524 exact-artifact
+customer evidence, #116 updater/rollback, #449 distribution, and current
+billing/provider/site/review/runtime evidence. This docs PR is `pr_ready` only;
+it does not establish release, runtime, customer, signed-artifact, or GA readiness.
+
+## No-downtime and rollback
+
+Stage/hash the candidate; validate source, contract, signature, and manifest;
+take a read-only snapshot; switch only the same named worker slot; then re-read
+status while retaining last-known-good. A failed preflight, ambiguous owner,
+missing prior candidate, or failed post-switch status stops before replacement.
+Never delete a candidate tree, alter customer config/Keychain/DB, widen an App
+allowlist, or restart an unrelated worker. A source/docs PR never authorizes
+launchd promotion.
+
+## Operator paths and preflight contract
+
+Runbooks use `/Users/m1/repos` for clean checkouts and `/Users/m1/Codex` for
+evidence. They validate absolute paths, NeonDiff identity, clean exact-head,
+runtime config, evidence root, and LaunchAgent plist before navigation, sync,
+test, build, tag, promotion, or `launchctl`. The preflight exits on failure;
+returning from a helper is insufficient. Historical packets must not be copied
+into new commands.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -5,13 +5,19 @@ update as a named beta release, not as an informal pull from `main`.
 
 ## Release Boundary
 
-The beta release unit is:
+The CLI/daemon beta release unit uses operator-owned paths:
 
-- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- source checkout: `$NEONDIFF_RELEASE_CHECKOUT` (normally under `/Users/m1/repos`)
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
-- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
-- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+- launchd config: `$NEONDIFF_RUNTIME_CONFIG` (normally under `/Users/m1/Codex`)
+- state DB: adjacent to the operator's runtime config/state root
+- evidence root: `$NEONDIFF_EVIDENCE_ROOT` (normally under `/Users/m1/Codex/evidence`)
+
+Before any navigation, sync, test, build, tag, promotion, or `launchctl`
+command, run the executable preflight in [release governance](release-governance.md)
+in the same shell. It exits on invalid paths, identity, or state; a helper
+`return` is not sufficient. Each command block below repeats
+`neondiff_release_preflight || exit $?` as the fail-fast boundary.
 
 Packaged or non-source deployments must set
 `NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
@@ -92,19 +98,20 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+neondiff_release_preflight || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git status --short
 git pull --ff-only
 npm test
 npm run build
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 sleep 5
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot \
   --require-coverage true
@@ -113,9 +120,10 @@ npm run release:status -- \
 For public source-beta releases, run the same gate with manifest checks:
 
 ```bash
+neondiff_release_preflight || exit $?
 PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -136,9 +144,10 @@ Public promotion evidence should include the strict variant after tags are
 fetched:
 
 ```bash
+neondiff_release_preflight || exit $?
 git fetch origin --tags
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -179,6 +188,7 @@ export GITNEXUS_EMBEDDING_DIMS=<current-index-dimensions>
 Then run the preflight from the clean release checkout:
 
 ```bash
+neondiff_release_preflight || exit $?
 npx tsx src/cli.ts gitnexus-refresh-preflight \
   --repo-path . \
   --repo-alias evaos-code-review-bot-neondiff
@@ -194,6 +204,7 @@ dimension evidence and rerun the preflight, or use the explicit fallback when th
 release only needs commit freshness:
 
 ```bash
+neondiff_release_preflight || exit $?
 npx tsx src/cli.ts gitnexus-refresh-preflight \
   --repo-path . \
   --repo-alias evaos-code-review-bot-neondiff \
@@ -469,8 +480,9 @@ and confirm the target PR is closed, draft-skipped, stale, or otherwise absent
 from the eligible open-head set. Retire only the exact failed head:
 
 ```bash
+neondiff_release_preflight || exit $?
 npx tsx src/cli.ts retire-failed \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
@@ -539,8 +551,9 @@ packet names the affected PR head and follow-up.
 Expired cooldown rows are actionable backlog. Run:
 
 ```bash
+neondiff_release_preflight || exit $?
 npx tsx src/cli.ts retry-provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expired-only true \
   --dry-run false \
   --zcode true
@@ -557,7 +570,8 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+neondiff_release_preflight || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin
 git checkout main
 git reset --hard <last-known-good-merge-sha>
@@ -572,7 +586,8 @@ unrelated dirty work.
 To stop the live beta worker entirely:
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+neondiff_release_preflight || exit $?
+launchctl bootout gui/$(id -u) "$NEONDIFF_LAUNCH_AGENT_PATH"
 ```
 
 ## Evidence Packet
@@ -601,7 +616,7 @@ For each beta promotion, record:
   tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
-Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+Keep raw evidence under `$NEONDIFF_EVIDENCE_ROOT`
 or session notes. Do not paste secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -98,7 +98,7 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-neondiff_release_preflight || exit $?
+set -euo pipefail; neondiff_release_preflight || exit $?
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git status --short
 git pull --ff-only
@@ -106,13 +106,13 @@ npm test
 npm run build
 npm run release:status -- \
   --config "$NEONDIFF_RUNTIME_CONFIG" \
-  --expected-head "$(git rev-parse HEAD)" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 sleep 5
 npm run release:status -- \
   --config "$NEONDIFF_RUNTIME_CONFIG" \
-  --expected-head "$(git rev-parse HEAD)" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
   --launchd-label com.electricsheephq.evaos-code-review-bot \
   --require-coverage true
 ```
@@ -570,7 +570,7 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
-neondiff_release_preflight || exit $?
+set -euo pipefail; neondiff_release_preflight || exit $?
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin
 git checkout main

--- a/docs/design/customer-journey-ux.md
+++ b/docs/design/customer-journey-ux.md
@@ -5,6 +5,12 @@ visual contract), authored for the #610 customer-journey milestone. This is the 
 #519 (onboarding), #521 (shell/Home), #522 (repos/providers), #612 (activation), and #613 (GitHub
 connect) implement together.
 
+Boundary: this blueprint describes the native GA journey and later managed
+convenience path; it is not proof that managed activation is enabled or that
+the current paid-BYO candidate is GA-ready. Use [docs/SETUP.md](../SETUP.md)
+and the [Mac GA architecture contract](../architecture/mac-ga-release-contract.md)
+for the current sealed-worker, Keychain, exact-artifact, and runtime gates.
+
 ## Product sentence
 
 A normal person installs the app and gets their first useful PR review without touching a terminal —

--- a/docs/design/customer-journey-ux.md
+++ b/docs/design/customer-journey-ux.md
@@ -5,12 +5,6 @@ visual contract), authored for the #610 customer-journey milestone. This is the 
 #519 (onboarding), #521 (shell/Home), #522 (repos/providers), #612 (activation), and #613 (GitHub
 connect) implement together.
 
-Boundary: this blueprint describes the native GA journey and later managed
-convenience path; it is not proof that managed activation is enabled or that
-the current paid-BYO candidate is GA-ready. Use [docs/SETUP.md](../SETUP.md)
-and the [Mac GA architecture contract](../architecture/mac-ga-release-contract.md)
-for the current sealed-worker, Keychain, exact-artifact, and runtime gates.
-
 ## Product sentence
 
 A normal person installs the app and gets their first useful PR review without touching a terminal —

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -95,10 +95,10 @@ re-update, immutable release assets, and live customer evidence.
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -115,7 +115,7 @@ re-update, immutable release assets, and live customer evidence.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -192,7 +192,7 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$NEONDIFF_EVIDENCE_ROOT`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -1,4 +1,4 @@
-# NeonDiff Desktop Dev MVP
+# NeonDiff Desktop architecture and local development
 
 The evaluation-first path from this development shell to a GA-quality native
 experience is specified in
@@ -6,10 +6,10 @@ experience is specified in
 and tracked by issue #514. Evaluation and layout stability land before broad
 visual redesign.
 
-NeonDiff Desktop is a SwiftPM macOS app scaffold for issue #115. It is a thin local control panel over the NeonDiff CLI and daemon contracts.
-For the 1.0 launch bar, the Mac app is intentionally a minimal launcher:
-opening the app shows local controls that can start `neondiff dashboard` or open
-the same local HTML dashboard used by the CLI.
+NeonDiff Desktop is the native macOS surface for the separate `1.1.0` candidate
+line, not the `neondiff@1.0.4` package or its release manifest. See the
+[Mac GA architecture contract](architecture/mac-ga-release-contract.md) for
+the paid-BYO/managed, sealed-worker, and GA claim boundaries.
 
 ## Boundaries
 

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -6,7 +6,7 @@ experience is specified in
 and tracked by issue #514. Evaluation and layout stability land before broad
 visual redesign.
 
-NeonDiff Desktop is the native macOS surface for the separate `1.1.0` candidate
+NeonDiff Desktop is the native macOS surface for the shared `1.1.0` GA release
 line, not the `neondiff@1.0.4` package or its release manifest. See the
 [Mac GA architecture contract](architecture/mac-ga-release-contract.md) for
 the paid-BYO/managed, sealed-worker, and GA claim boundaries.

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -4,6 +4,31 @@ This bot is a live beta agent. A live promotion is not complete until the
 source SHA is tied to an immutable Git tag, a GitHub Release, runtime evidence,
 and a rollback path.
 
+## Operator preflight
+
+Use `/Users/m1/repos` for the clean checkout and `/Users/m1/Codex` for active
+config/evidence. This block is executable; the final `exit` prevents a failed
+helper return from reaching a release command.
+
+```bash
+export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:-/Users/m1/repos/evaos-code-review-bot-neondiff}" NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:-/Users/m1/Codex/evaos-code-review-bot-neondiff/config/active-installed-live.json}"
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-/Users/m1/Codex/evidence/neondiff}" NEONDIFF_LAUNCH_AGENT_PATH="${NEONDIFF_LAUNCH_AGENT_PATH:-$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist}"
+
+neondiff_release_preflight() {
+  local path origin
+  for path in "$NEONDIFF_RELEASE_CHECKOUT" "$NEONDIFF_RUNTIME_CONFIG" "$NEONDIFF_EVIDENCE_ROOT" "$NEONDIFF_LAUNCH_AGENT_PATH"; do case "$path" in /*) ;; *) echo "release paths must be absolute" >&2; return 2;; esac; done
+  [ -d "$NEONDIFF_RELEASE_CHECKOUT" ] || { echo "release checkout is missing" >&2; return 2; }
+  git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse --show-toplevel >/dev/null 2>&1 || { echo "release checkout is not a Git repository" >&2; return 2; }
+  origin="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" remote get-url origin 2>/dev/null)" || origin=
+  case "$origin" in https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;; *) echo "release checkout origin is not NeonDiff" >&2; return 2;; esac
+  [ -f "$NEONDIFF_RUNTIME_CONFIG" ] && [ -d "$NEONDIFF_EVIDENCE_ROOT" ] && [ -f "$NEONDIFF_LAUNCH_AGENT_PATH" ] || { echo "runtime, evidence, or LaunchAgent path is missing" >&2; return 2; }
+  [ -z "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" status --porcelain)" ] || { echo "release checkout is dirty" >&2; return 2; }
+}
+
+# First executable boundary: invalid input terminates before release commands.
+neondiff_release_preflight || exit $?
+```
+
 ## Release Levels
 
 - `beta`: local launchd worker on the operator Mac, posting as the GitHub App
@@ -73,6 +98,7 @@ published through another path or the tag needs repair, the explicit cutover
 command is:
 
 ```bash
+neondiff_release_preflight || exit $?
 npm dist-tag add neondiff@<ga> latest
 ```
 
@@ -278,6 +304,7 @@ attestations. If that 30-day ceiling has expired, do not promote the package;
 produce a new replacement version and fresh protected lifecycle proof.
 
 ```bash
+neondiff_release_preflight || exit $?
 gh workflow run publish-npm.yml \
   --repo electricsheephq/evaos-code-review-bot-neondiff \
   --ref v<version> \
@@ -292,6 +319,7 @@ After that exact-tag run succeeds, verify the registry package identity and
 stable channel without mutating either one:
 
 ```bash
+neondiff_release_preflight || exit $?
 npm view neondiff@<version> version dist.integrity dist.shasum gitHead dist.attestations --json
 test "$(npm view neondiff dist-tags.latest)" = "<version>"
 ```
@@ -316,6 +344,7 @@ After the recovery change is merged to protected main, dispatch only this
 bounded command:
 
 ```bash
+neondiff_release_preflight || exit $?
 gh workflow run publish-npm.yml \
   --repo electricsheephq/evaos-code-review-bot-neondiff \
   --ref main \
@@ -342,7 +371,8 @@ unchanged and treat the package as quarantined.
 Create an annotated tag from the merged source SHA:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+neondiff_release_preflight || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
@@ -360,8 +390,9 @@ release tracker.
 Create the GitHub prerelease from the release packet:
 
 ```bash
+neondiff_release_preflight || exit $?
 gh release create vX.Y.Z-beta.N \
-  --repo electricsheephq/evaos-code-review-bot \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
   --title "vX.Y.Z-beta.N" \
   --notes-file docs/releases/vX.Y.Z-beta.N.md \
   --prerelease \
@@ -377,13 +408,14 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+neondiff_release_preflight || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
 test "$(git rev-parse HEAD)" = "<source-sha>"
-launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+launchctl bootout gui/$(id -u) "$NEONDIFF_LAUNCH_AGENT_PATH" 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "$NEONDIFF_LAUNCH_AGENT_PATH"
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 ```
 
@@ -392,10 +424,11 @@ launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 Run the status gate with App credentials set in the shell:
 
 ```bash
+neondiff_release_preflight || exit $?
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
@@ -403,10 +436,11 @@ npm run release:status -- \
 For public source-beta or public beta releases, include the public manifest gate:
 
 ```bash
+neondiff_release_preflight || exit $?
 SOURCE_SHA=replace-with-release-source-sha
 PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$SOURCE_SHA" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -423,10 +457,11 @@ that checkout; absent refs are reported as a missing rollback target.
 Also run:
 
 ```bash
+neondiff_release_preflight || exit $?
 npx tsx src/cli.ts coverage-audit \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+  --config "$NEONDIFF_RUNTIME_CONFIG"
 npx tsx src/cli.ts provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expired-only true
 ```
 
@@ -458,13 +493,14 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+neondiff_release_preflight || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin --tags
 git checkout main
 git reset --hard <previous-release-tag>
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -11,18 +11,18 @@ config/evidence. This block is executable; the final `exit` prevents a failed
 helper return from reaching a release command.
 
 ```bash
-export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:-/Users/m1/repos/evaos-code-review-bot-neondiff}" NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:-/Users/m1/Codex/evaos-code-review-bot-neondiff/config/active-installed-live.json}"
+export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:-/Users/m1/repos/evaos-code-review-bot-neondiff}" NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:-/Users/m1/Codex/evaos-code-review-bot-neondiff/config/active-installed-live.json}" NEONDIFF_EXPECTED_HEAD="${NEONDIFF_EXPECTED_HEAD:?operator-approved 40-character candidate head}" NEONDIFF_RELEASE_BRANCH="${NEONDIFF_RELEASE_BRANCH:?intended release branch (main)}"
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-/Users/m1/Codex/evidence/neondiff}" NEONDIFF_LAUNCH_AGENT_PATH="${NEONDIFF_LAUNCH_AGENT_PATH:-$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist}"
 
 neondiff_release_preflight() {
-  local path origin
+  local path origin label branch head
   for path in "$NEONDIFF_RELEASE_CHECKOUT" "$NEONDIFF_RUNTIME_CONFIG" "$NEONDIFF_EVIDENCE_ROOT" "$NEONDIFF_LAUNCH_AGENT_PATH"; do case "$path" in /*) ;; *) echo "release paths must be absolute" >&2; return 2;; esac; done
   [ -d "$NEONDIFF_RELEASE_CHECKOUT" ] || { echo "release checkout is missing" >&2; return 2; }
   git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse --show-toplevel >/dev/null 2>&1 || { echo "release checkout is not a Git repository" >&2; return 2; }
   origin="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" remote get-url origin 2>/dev/null)" || origin=
   case "$origin" in https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;; *) echo "release checkout origin is not NeonDiff" >&2; return 2;; esac
-  [ -f "$NEONDIFF_RUNTIME_CONFIG" ] && [ -d "$NEONDIFF_EVIDENCE_ROOT" ] && [ -f "$NEONDIFF_LAUNCH_AGENT_PATH" ] || { echo "runtime, evidence, or LaunchAgent path is missing" >&2; return 2; }
-  [ -z "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" status --porcelain)" ] || { echo "release checkout is dirty" >&2; return 2; }
+  [ -f "$NEONDIFF_RUNTIME_CONFIG" ] && [ -d "$NEONDIFF_EVIDENCE_ROOT" ] && [ -f "$NEONDIFF_LAUNCH_AGENT_PATH" ] || { echo "runtime, evidence, or LaunchAgent path is missing" >&2; return 2; }; label="$(/usr/bin/plutil -extract Label raw "$NEONDIFF_LAUNCH_AGENT_PATH" 2>/dev/null)" || label=; [ "$label" = "com.electricsheephq.evaos-code-review-bot" ] || { echo "LaunchAgent Label is not NeonDiff" >&2; return 2; }
+  [ -z "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" status --porcelain)" ] || { echo "release checkout is dirty" >&2; return 2; }; [[ "$NEONDIFF_EXPECTED_HEAD" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "approved head must be a 40-character SHA" >&2; return 2; }; branch="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" branch --show-current)"; [ "$NEONDIFF_RELEASE_BRANCH" = main ] && [ "$branch" = "$NEONDIFF_RELEASE_BRANCH" ] || { echo "release checkout branch is not intended main" >&2; return 2; }; head="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse HEAD)"; [ "$head" = "$NEONDIFF_EXPECTED_HEAD" ] || { echo "release checkout head is not operator-approved" >&2; return 2; }
 }
 
 # First executable boundary: invalid input terminates before release commands.
@@ -371,7 +371,7 @@ unchanged and treat the package as quarantined.
 Create an annotated tag from the merged source SHA:
 
 ```bash
-neondiff_release_preflight || exit $?
+set -euo pipefail; neondiff_release_preflight || exit $?
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
@@ -408,7 +408,7 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-neondiff_release_preflight || exit $?
+set -euo pipefail; neondiff_release_preflight || exit $?
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
@@ -493,7 +493,7 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-neondiff_release_preflight || exit $?
+set -euo pipefail; neondiff_release_preflight || exit $?
 cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin --tags
 git checkout main


### PR DESCRIPTION
## Summary

Successor to blocked PR #809, limited to the seven architecture/runbook docs. The branch starts at exact base `ce3662e99dcc16d131a573cb03adab773d6dac1b` and adds the current Mac GA lane contract while preserving the sealed-worker, Keychain, exact-head, no-downtime, rollback, BYO/managed separation, and Codex boundaries.

## Three runbook findings fixed from #809

1. The operator preflight now validates absolute paths, NeonDiff repository identity, clean checkout state, runtime config, evidence root, and the LaunchAgent plist.
2. The preflight is shell fail-fast: every release/navigation/sync/test/build/tag/promotion/launchctl command block is preceded by `neondiff_release_preflight || exit $?`, so invalid input cannot fall through from a helper return into later commands.
3. Obsolete `/Volumes/LEXAR` and hard-coded `/Users/lume` operational paths are removed from the owned docs and replaced by `/Users/m1/repos` checkout and `/Users/m1/Codex` evidence/config defaults or operator variables.

The two schema/test findings from #809 (exclusive contract validation, state-dependent evidence validation, and Ajv-backed manifest testing) are fixed in the sibling Slice A PR.

## Validation

- `npm run check:public-claims` — pass
- `npm run check:secrets` — pass
- `npm run check:design-source` — pass
- canonical preflight `bash -n` — pass
- invalid relative checkout exits `2` with no later-command marker; valid clean NeonDiff fixture passes — pass
- `git diff --check` — pass
- exactly seven owned docs changed, 200 non-generated lines
- CLI manifest SHA-256: `9e5aae15c24da42c7197133dfe1b3c9cbc52e9e6578fd2a662b83d55fd4c8b4a`

## Proof boundary

This is docs and focused-check evidence only. It does not prove merge, release, signed or notarized artifacts, hosted Sparkle feed, runtime safety, customer readiness, or Mac GA readiness. No runtime, customer, manifest, Keychain, launchctl, release, tag, or signing mutation was performed.

Related: #809 #103 #610 #116 #524 #738 #806
