### PR TITLE
feat: add fail-closed severe verifier receipts

### DIFF
--- a/src/self-consistency.ts
+++ b/src/self-consistency.ts
@@ -34,9 +34,7 @@ export interface SevereVerificationReceipt {
   };
 }
 
-export type SelfConsistencySecondDrawResult =
-  | { receipt: SevereVerificationReceipt }
-  | { verified: boolean; confidence: number };
+export type SelfConsistencySecondDrawResult = unknown;
 
 export interface SelfConsistencyVerdict {
   path: string;
@@ -80,22 +78,20 @@ function exactKeys(value: object, expected: string[], optional: string[] = []): 
   return expected.every((key) => keys.includes(key)) && keys.every((key) => expected.includes(key) || optional.includes(key));
 }
 
-function metadataString(value: unknown, max = 256): value is string {
-  return typeof value === "string" && value.length > 0 && value.length <= max && !/[\r\n]/.test(value);
-}
+const SEVERE_REASON_CODES = new Set(["not_read", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete", "schema_invalid", "identity_mismatch", "evidence_incomplete", "provider_unavailable", "cap_exceeded", "receipt_invalid"]);
 
 export function isSevereVerificationReceipt(value: unknown): value is SevereVerificationReceipt {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   const receipt = value as Record<string, unknown>;
   if (!exactKeys(receipt, ["baseSha", "disposition", "evidence", "findingFingerprint", "headSha", "pullNumber", "repo", "schemaVersion", "state"], ["confidence", "reasonCode"])) return false;
-  if (receipt.schemaVersion !== "severe-verifier-v1" || !metadataString(receipt.repo) ||
+  if (receipt.schemaVersion !== "severe-verifier-v1" || typeof receipt.repo !== "string" || receipt.repo.length === 0 || receipt.repo.length > 256 || /[\r\n]/.test(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) ||
       typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1 ||
       !/^[a-f0-9]{40}$/.test(String(receipt.baseSha)) || !/^[a-f0-9]{40}$/.test(String(receipt.headSha)) ||
       !/^finding:[a-f0-9]{64}$/.test(String(receipt.findingFingerprint)) ||
       !["confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"].includes(String(receipt.state)) ||
       !["retain", "suppress"].includes(String(receipt.disposition))) return false;
   if (receipt.confidence !== undefined && (typeof receipt.confidence !== "number" || !Number.isFinite(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) return false;
-  if (receipt.reasonCode !== undefined && (!metadataString(receipt.reasonCode, 64) || !/^[a-z0-9_.-]+$/.test(receipt.reasonCode))) return false;
+  if (receipt.reasonCode !== undefined && (typeof receipt.reasonCode !== "string" || !SEVERE_REASON_CODES.has(receipt.reasonCode))) return false;
   const evidence = receipt.evidence;
   if (typeof evidence !== "object" || evidence === null || Array.isArray(evidence)) return false;
   const evidenceRecord = evidence as Record<string, unknown>;
@@ -104,23 +100,23 @@ export function isSevereVerificationReceipt(value: unknown): value is SevereVeri
   if (!evidenceRecord.files.every((file) => {
     if (typeof file !== "object" || file === null || Array.isArray(file)) return false;
     const entry = file as Record<string, unknown>;
-    return exactKeys(entry, ["bytes", "complete", "kind", "path", "sha256"]) && metadataString(entry.path) &&
+    return exactKeys(entry, ["bytes", "complete", "kind", "path", "sha256"]) && typeof entry.path === "string" && entry.path.length > 0 && entry.path.length <= 256 && !/[\r\n]/.test(entry.path) && !/[^A-Za-z0-9_./@~-]/.test(entry.path) &&
       ["whole_file", "module"].includes(String(entry.kind)) && /^[a-f0-9]{64}$/.test(String(entry.sha256)) &&
       typeof entry.bytes === "number" && Number.isSafeInteger(entry.bytes) && entry.bytes >= 0 && typeof entry.complete === "boolean";
   })) return false;
   return evidenceRecord.omitted.every((entry) => {
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return false;
     const omitted = entry as Record<string, unknown>;
-    return exactKeys(omitted, ["path", "reason"]) && metadataString(omitted.path) && metadataString(omitted.reason, 64) && /^[a-z0-9_.-]+$/.test(omitted.reason);
+    return exactKeys(omitted, ["path", "reason"]) && typeof omitted.path === "string" && omitted.path.length > 0 && omitted.path.length <= 256 && !/[\r\n]/.test(omitted.path) && !/[^A-Za-z0-9_./@~-]/.test(omitted.path) && typeof omitted.reason === "string" && SEVERE_REASON_CODES.has(omitted.reason);
   });
 }
 
-function hasCompleteEvidence(receipt: SevereVerificationReceipt): boolean {
-  return receipt.evidence.complete && receipt.evidence.omitted.length === 0 && receipt.evidence.files.every((file) => file.complete);
+function hasCompleteEvidence(receipt: SevereVerificationReceipt, path: string): boolean {
+  return receipt.evidence.complete && receipt.evidence.omitted.length === 0 && receipt.evidence.files.length > 0 && receipt.evidence.files.every((file) => file.complete) && receipt.evidence.files.some((file) => file.path === path && file.complete);
 }
 
-function retainsSevereFinding(receipt: SevereVerificationReceipt): boolean {
-  return receipt.state === "confirmed" && receipt.disposition === "retain" && hasCompleteEvidence(receipt) && receipt.confidence !== undefined;
+function retainsSevereFinding(receipt: SevereVerificationReceipt, comment: ReviewComment, context: { repo: string; pullNumber: number; baseSha: string; headSha: string; findingFingerprint: string } | undefined): boolean {
+  return context !== undefined && receipt.state === "confirmed" && receipt.disposition === "retain" && hasCompleteEvidence(receipt, comment.path) && receipt.confidence !== undefined && receipt.findingFingerprint === comment.fingerprint && receipt.findingFingerprint === context.findingFingerprint && receipt.repo === context.repo && receipt.pullNumber === context.pullNumber && receipt.baseSha === context.baseSha && receipt.headSha === context.headSha;
 }
 
 /**
@@ -133,6 +129,7 @@ export async function runSelfConsistencyRecheck(input: {
   comments: ReviewComment[];
   files: PullFilePatch[];
   config: SelfConsistencyRecheckConfig;
+  reviewContext?: { repo: string; pullNumber: number; baseSha: string; headSha: string; findingFingerprint: string };
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
   categoryPrecisionFloors?: CategoryPrecisionFloors;
   secondDraw: (input: SelfConsistencySecondDrawInput) => SelfConsistencySecondDrawResult | Promise<SelfConsistencySecondDrawResult>;
@@ -176,7 +173,7 @@ export async function runSelfConsistencyRecheck(input: {
     try {
       draw = await input.secondDraw({ comment, hunk: extractHunk(comment, input.files) });
     } catch (error) {
-      verdicts.push({ ...base, error: error instanceof Error ? error.message : String(error) });
+      verdicts.push({ ...base, error: "severe_verifier_unavailable" });
       continue;
     }
 
@@ -185,7 +182,7 @@ export async function runSelfConsistencyRecheck(input: {
       continue;
     }
 
-    if (retainsSevereFinding(draw.receipt)) {
+    if (retainsSevereFinding(draw.receipt, comment, input.reviewContext)) {
       verdicts.push({ ...base, secondConfidence: draw.receipt.confidence, agreed: true, refuted: false, receipt: draw.receipt });
       comments.push(comment);
       continue;

--- a/src/self-consistency.ts
+++ b/src/self-consistency.ts
@@ -1,5 +1,5 @@
 import { decideReviewEvent } from "./findings.js";
-import { isRequestChangesEligible, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import type { CategoryPrecisionFloors, RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type { PullFilePatch, ReviewComment, ReviewEvent, Severity } from "./types.js";
 
 export interface SelfConsistencyRecheckConfig {
@@ -14,10 +14,29 @@ export interface SelfConsistencySecondDrawInput {
   hunk: string;
 }
 
-export interface SelfConsistencySecondDrawResult {
-  verified: boolean;
-  confidence: number;
+export type SevereVerificationState = "confirmed" | "refuted" | "malformed" | "timeout" | "unavailable" | "stale_head" | "incomplete";
+
+export interface SevereVerificationReceipt {
+  schemaVersion: "severe-verifier-v1";
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  findingFingerprint: string;
+  headSha: string;
+  state: SevereVerificationState;
+  disposition: "retain" | "suppress";
+  confidence?: number;
+  reasonCode?: string;
+  evidence: {
+    files: Array<{ path: string; kind: "whole_file" | "module"; sha256: string; bytes: number; complete: boolean }>;
+    omitted: Array<{ path: string; reason: string }>;
+    complete: boolean;
+  };
 }
+
+export type SelfConsistencySecondDrawResult =
+  | { receipt: SevereVerificationReceipt }
+  | { verified: boolean; confidence: number };
 
 export interface SelfConsistencyVerdict {
   path: string;
@@ -28,21 +47,87 @@ export interface SelfConsistencyVerdict {
   secondConfidence?: number;
   agreed?: boolean;
   refuted?: boolean;
+  receipt?: SevereVerificationReceipt;
   error?: string;
 }
 
 const DEFAULT_SEVERITIES: Array<"P0" | "P1"> = ["P0", "P1"];
 const DEFAULT_MAX_FINDINGS = 5;
 
+export const SEVERE_VERIFIER_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["verdict", "confidence"],
+  properties: {
+    verdict: { type: "string", enum: ["confirm", "refute"] },
+    confidence: { type: "number", minimum: 0, maximum: 1 }
+  }
+} as const;
+
+export function parseSevereVerifierOutput(value: unknown): { verdict: "confirm" | "refute"; confidence: number } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("severe_verifier_schema_invalid");
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.length !== 2 || keys[0] !== "confidence" || keys[1] !== "verdict") throw new Error("severe_verifier_schema_invalid");
+  if ((record.verdict !== "confirm" && record.verdict !== "refute") ||
+      typeof record.confidence !== "number" || !Number.isFinite(record.confidence) ||
+      record.confidence < 0 || record.confidence > 1) throw new Error("severe_verifier_schema_invalid");
+  return { verdict: record.verdict, confidence: record.confidence };
+}
+
+function exactKeys(value: object, expected: string[], optional: string[] = []): boolean {
+  const keys = Object.keys(value).sort();
+  return expected.every((key) => keys.includes(key)) && keys.every((key) => expected.includes(key) || optional.includes(key));
+}
+
+function metadataString(value: unknown, max = 256): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= max && !/[\r\n]/.test(value);
+}
+
+export function isSevereVerificationReceipt(value: unknown): value is SevereVerificationReceipt {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const receipt = value as Record<string, unknown>;
+  if (!exactKeys(receipt, ["baseSha", "disposition", "evidence", "findingFingerprint", "headSha", "pullNumber", "repo", "schemaVersion", "state"], ["confidence", "reasonCode"])) return false;
+  if (receipt.schemaVersion !== "severe-verifier-v1" || !metadataString(receipt.repo) ||
+      typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1 ||
+      !/^[a-f0-9]{40}$/.test(String(receipt.baseSha)) || !/^[a-f0-9]{40}$/.test(String(receipt.headSha)) ||
+      !/^finding:[a-f0-9]{64}$/.test(String(receipt.findingFingerprint)) ||
+      !["confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"].includes(String(receipt.state)) ||
+      !["retain", "suppress"].includes(String(receipt.disposition))) return false;
+  if (receipt.confidence !== undefined && (typeof receipt.confidence !== "number" || !Number.isFinite(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) return false;
+  if (receipt.reasonCode !== undefined && (!metadataString(receipt.reasonCode, 64) || !/^[a-z0-9_.-]+$/.test(receipt.reasonCode))) return false;
+  const evidence = receipt.evidence;
+  if (typeof evidence !== "object" || evidence === null || Array.isArray(evidence)) return false;
+  const evidenceRecord = evidence as Record<string, unknown>;
+  if (!exactKeys(evidenceRecord, ["complete", "files", "omitted"]) || typeof evidenceRecord.complete !== "boolean" ||
+      !Array.isArray(evidenceRecord.files) || !Array.isArray(evidenceRecord.omitted)) return false;
+  if (!evidenceRecord.files.every((file) => {
+    if (typeof file !== "object" || file === null || Array.isArray(file)) return false;
+    const entry = file as Record<string, unknown>;
+    return exactKeys(entry, ["bytes", "complete", "kind", "path", "sha256"]) && metadataString(entry.path) &&
+      ["whole_file", "module"].includes(String(entry.kind)) && /^[a-f0-9]{64}$/.test(String(entry.sha256)) &&
+      typeof entry.bytes === "number" && Number.isSafeInteger(entry.bytes) && entry.bytes >= 0 && typeof entry.complete === "boolean";
+  })) return false;
+  return evidenceRecord.omitted.every((entry) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return false;
+    const omitted = entry as Record<string, unknown>;
+    return exactKeys(omitted, ["path", "reason"]) && metadataString(omitted.path) && metadataString(omitted.reason, 64) && /^[a-z0-9_.-]+$/.test(omitted.reason);
+  });
+}
+
+function hasCompleteEvidence(receipt: SevereVerificationReceipt): boolean {
+  return receipt.evidence.complete && receipt.evidence.omitted.length === 0 && receipt.evidence.files.every((file) => file.complete);
+}
+
+function retainsSevereFinding(receipt: SevereVerificationReceipt): boolean {
+  return receipt.state === "confirmed" && receipt.disposition === "retain" && hasCompleteEvidence(receipt) && receipt.confidence !== undefined;
+}
+
 /**
  * Opt-in P0/P1 self-consistency re-check (#303). For each gate-accepted comment at a configured
- * severity (post-dedup, pre-event-decision; capped by maxFindingsPerReview in the ranked order the
- * gate already produced), issue ONE bounded second draw asking verify/refute + confidence. The merge
- * is strictly QUIETER-ONLY: agreement keeps the original confidence (never raised); refutation sets
- * confidence to min(original, second) AND strips REQUEST_CHANGES eligibility for that comment. Any
- * second-draw failure leaves the comment untouched (never blocks/drops the review). The event is then
- * re-derived from the comments that retain eligibility. Disabled ⇒ no second draw, byte-identical
- * output. The second-draw runner is injected so callers pick the provider and tests stay hermetic.
+ * severity (post-dedup, pre-event-decision; capped by maxFindingsPerReview in ranked order), issue
+ * ONE bounded second draw. Only a schema-valid confirmed receipt with complete evidence can retain a
+ * severe finding; every other outcome is suppressed. Disabled ⇒ no second draw, byte-identical output.
  */
 export async function runSelfConsistencyRecheck(input: {
   comments: ReviewComment[];
@@ -63,17 +148,15 @@ export async function runSelfConsistencyRecheck(input: {
   const severities = new Set<Severity>(input.config.severities ?? DEFAULT_SEVERITIES);
   const maxFindings = input.config.maxFindingsPerReview ?? DEFAULT_MAX_FINDINGS;
   const verdicts: SelfConsistencyVerdict[] = [];
-  const refutedKeys = new Set<string>();
   let rechecked = 0;
 
   // input.comments is already in the gate's ranked (highest-confidence-first) order.
   const comments: ReviewComment[] = [];
   for (const comment of input.comments) {
-    if (rechecked >= maxFindings || !severities.has(comment.severity)) {
+    if (!severities.has(comment.severity)) {
       comments.push(comment);
       continue;
     }
-    rechecked += 1;
 
     const base: SelfConsistencyVerdict = {
       path: comment.path,
@@ -83,40 +166,37 @@ export async function runSelfConsistencyRecheck(input: {
       originalConfidence: comment.confidence
     };
 
+    if (rechecked >= maxFindings) {
+      verdicts.push({ ...base, error: "severe_verifier_cap_exceeded" });
+      continue;
+    }
+    rechecked += 1;
+
     let draw: SelfConsistencySecondDrawResult;
     try {
       draw = await input.secondDraw({ comment, hunk: extractHunk(comment, input.files) });
     } catch (error) {
-      // Failure posture: keep the finding untouched; the re-check can only make output quieter.
       verdicts.push({ ...base, error: error instanceof Error ? error.message : String(error) });
+      continue;
+    }
+
+    if (typeof draw !== "object" || draw === null || !("receipt" in draw) || !isSevereVerificationReceipt(draw.receipt)) {
+      verdicts.push({ ...base, error: "severe_verifier_receipt_invalid" });
+      continue;
+    }
+
+    if (retainsSevereFinding(draw.receipt)) {
+      verdicts.push({ ...base, secondConfidence: draw.receipt.confidence, agreed: true, refuted: false, receipt: draw.receipt });
       comments.push(comment);
       continue;
     }
 
-    if (draw.verified) {
-      // Agreement: never raise confidence; keep the original.
-      verdicts.push({ ...base, secondConfidence: draw.confidence, agreed: true, refuted: false });
-      comments.push(comment);
-      continue;
-    }
-
-    // Refutation: quieter-only — lower confidence and strip REQUEST_CHANGES eligibility.
-    verdicts.push({ ...base, secondConfidence: draw.confidence, agreed: false, refuted: true });
-    refutedKeys.add(commentKey(comment));
-    comments.push({ ...comment, confidence: Math.min(comment.confidence, draw.confidence) });
+    verdicts.push({ ...base, ...(draw.receipt.confidence !== undefined ? { secondConfidence: draw.receipt.confidence } : {}), agreed: false, refuted: true, receipt: draw.receipt });
   }
 
-  // Re-derive the event: a refuted comment still POSTS but no longer counts toward REQUEST_CHANGES.
-  const eligibleComments = comments.filter((comment) => !refutedKeys.has(commentKey(comment)));
-  const event = eligibleComments.some((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors))
-    ? "REQUEST_CHANGES"
-    : "COMMENT";
+  const event = decideReviewEvent(comments, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors);
 
   return { comments, event, verdicts };
-}
-
-function commentKey(comment: Pick<ReviewComment, "path" | "line" | "title">): string {
-  return `${comment.path}${comment.line}${comment.title}`;
 }
 
 /**

--- a/tests/self-consistency.test.ts
+++ b/tests/self-consistency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { parseSevereVerifierOutput, runSelfConsistencyRecheck, type SevereVerificationReceipt } from "../src/self-consistency.js";
+import { parseSevereVerifierOutput, runSelfConsistencyRecheck as rawSelfConsistencyRecheck, type SevereVerificationReceipt } from "../src/self-consistency.js";
 import type { PullFilePatch, ReviewComment } from "../src/types.js";
 
 function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severity" | "line" | "title" | "confidence">): ReviewComment {
@@ -17,9 +17,10 @@ const files: PullFilePatch[] = [
   { filename: "src/save.ts", patch: "@@ -1,2 +1,3 @@\n export function save() {\n+  overwriteAllData();\n }" }
 ];
 
-function receipt(state: SevereVerificationReceipt["state"], complete = state === "confirmed", confidence = 0.8): { receipt: SevereVerificationReceipt } {
-  return { receipt: { schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 1, baseSha: "b".repeat(40), findingFingerprint: `finding:${"0".repeat(64)}`, headSha: "a".repeat(40), state,
-    disposition: state === "confirmed" && complete ? "retain" : "suppress", confidence, evidence: { files: [], omitted: complete ? [] : [{ path: "src/save.ts", reason: "not_read" }], complete } } };
+const reviewContext = { repo: "owner/repo", pullNumber: 1, baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: `finding:${"0".repeat(64)}` }; const runSelfConsistencyRecheck = (input: Parameters<typeof rawSelfConsistencyRecheck>[0]) => rawSelfConsistencyRecheck({ ...input, reviewContext: input.reviewContext ?? reviewContext });
+
+function receipt(state: SevereVerificationReceipt["state"], complete = state === "confirmed", confidence = 0.8, withFiles = complete): { receipt: SevereVerificationReceipt } {
+  return { receipt: { schemaVersion: "severe-verifier-v1", ...reviewContext, findingFingerprint: `finding:${"0".repeat(64)}`, state, disposition: state === "confirmed" && complete ? "retain" : "suppress", confidence, evidence: { files: withFiles ? [{ path: "src/save.ts", kind: "whole_file", sha256: "f".repeat(64), bytes: 1, complete: true }] : [], omitted: complete ? [] : [{ path: "src/save.ts", reason: "not_read" }], complete } } };
 }
 
 describe("self-consistency re-check (#303)", () => {
@@ -126,7 +127,7 @@ describe("self-consistency re-check (#303)", () => {
 
     expect(result.comments).toHaveLength(0);
     expect(result.event).toBe("COMMENT");
-    expect(result.verdicts).toEqual([expect.objectContaining({ error: expect.stringContaining("provider exploded") })]);
+    expect(result.verdicts).toEqual([expect.objectContaining({ error: "severe_verifier_unavailable" })]);
   });
 
   it("awaits asynchronous second draws sequentially in ranked order", async () => {
@@ -154,24 +155,19 @@ describe("self-consistency re-check (#303)", () => {
   });
 
   it("suppresses every non-confirmed receipt, including incomplete evidence", async () => {
-    const states: Array<SevereVerificationReceipt["state"]> = ["refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"]; for (const state of states) {
-      const result = await runSelfConsistencyRecheck({
-        comments: [comment({ severity: "P1", line: 2, title: state, confidence: 0.9 })],
-        files,
-        config: { enabled: true },
-        secondDraw: () => receipt(state, false)
-      });
-      expect(result.comments, state).toEqual([]); expect(result.event, state).toBe("COMMENT");
-    }
+    for (const state of ["refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"] as const) { const result = await runSelfConsistencyRecheck({ comments: [comment({ severity: "P1", line: 2, title: state, confidence: 0.9 })], files, config: { enabled: true }, secondDraw: () => receipt(state, false) }); expect(result.comments, state).toEqual([]); expect(result.event, state).toBe("COMMENT"); }
   });
   it("strictly parses the dedicated verifier result", () => {
     expect(parseSevereVerifierOutput({ verdict: "confirm", confidence: 0.7 })).toEqual({ verdict: "confirm", confidence: 0.7 });
-    for (const invalid of [
-      { verdict: "confirm" },
-      { verdict: "confirm", confidence: 0.7, extra: true },
-      { verdict: "confirm", confidence: Number.NaN },
-      { verdict: "confirm", confidence: 1.1 },
-      { verdict: "maybe", confidence: 0.7 }
-    ]) expect(() => parseSevereVerifierOutput(invalid)).toThrow("severe_verifier_schema_invalid");
+    for (const invalid of [{ verdict: "confirm" }, { verdict: "confirm", confidence: 0.7, extra: true }, { verdict: "confirm", confidence: Number.NaN }, { verdict: "confirm", confidence: 1.1 }, { verdict: "maybe", confidence: 0.7 }]) expect(() => parseSevereVerifierOutput(invalid)).toThrow("severe_verifier_schema_invalid");
+  });
+
+  it("suppresses empty evidence, identity mismatches, and free-form reason metadata", async () => {
+    const base = { comments: [comment({ severity: "P1", line: 2, title: "bound", confidence: 0.9 })], files, config: { enabled: true } };
+    const empty = await runSelfConsistencyRecheck({ ...base, secondDraw: () => receipt("confirmed", true, 0.8, false) });
+    const mismatch = await runSelfConsistencyRecheck({ ...base, reviewContext: { ...reviewContext, headSha: "c".repeat(40) }, secondDraw: () => receipt("confirmed") });
+    const prose = await runSelfConsistencyRecheck({ ...base, secondDraw: () => ({ receipt: { ...receipt("confirmed").receipt, reasonCode: "provider said keep this" } }) }); expect([empty.comments, mismatch.comments, prose.comments]).toEqual([[], [], []]);
+    const legacy = await runSelfConsistencyRecheck({ ...base, secondDraw: () => ({ verified: true, confidence: 1 }) });
+    const nil = await runSelfConsistencyRecheck({ ...base, secondDraw: () => null }); expect([legacy.comments, nil.comments]).toEqual([[], []]);
   });
 });

--- a/tests/self-consistency.test.ts
+++ b/tests/self-consistency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runSelfConsistencyRecheck } from "../src/self-consistency.js";
+import { parseSevereVerifierOutput, runSelfConsistencyRecheck, type SevereVerificationReceipt } from "../src/self-consistency.js";
 import type { PullFilePatch, ReviewComment } from "../src/types.js";
 
 function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severity" | "line" | "title" | "confidence">): ReviewComment {
@@ -16,6 +16,11 @@ function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severi
 const files: PullFilePatch[] = [
   { filename: "src/save.ts", patch: "@@ -1,2 +1,3 @@\n export function save() {\n+  overwriteAllData();\n }" }
 ];
+
+function receipt(state: SevereVerificationReceipt["state"], complete = state === "confirmed", confidence = 0.8): { receipt: SevereVerificationReceipt } {
+  return { receipt: { schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 1, baseSha: "b".repeat(40), findingFingerprint: `finding:${"0".repeat(64)}`, headSha: "a".repeat(40), state,
+    disposition: state === "confirmed" && complete ? "retain" : "suppress", confidence, evidence: { files: [], omitted: complete ? [] : [{ path: "src/save.ts", reason: "not_read" }], complete } } };
+}
 
 describe("self-consistency re-check (#303)", () => {
   it("is a no-op with zero second-draw calls when disabled (byte-identical)", async () => {
@@ -41,7 +46,7 @@ describe("self-consistency re-check (#303)", () => {
       comments,
       files,
       config: { enabled: true, severities: ["P0", "P1"], maxFindingsPerReview: 5 },
-      secondDraw: () => ({ verified: true, confidence: 0.7 })
+      secondDraw: () => receipt("confirmed", true, 0.7)
     });
 
     expect(result.comments[0]?.confidence).toBe(0.9); // never raised, kept on agreement
@@ -49,18 +54,17 @@ describe("self-consistency re-check (#303)", () => {
     expect(result.verdicts).toEqual([expect.objectContaining({ agreed: true, originalConfidence: 0.9, secondConfidence: 0.7 })]);
   });
 
-  it("downgrades confidence and removes REQUEST_CHANGES eligibility on refutation", async () => {
+  it("suppresses the severe finding on refutation", async () => {
     const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
     const result = await runSelfConsistencyRecheck({
       comments,
       files,
       config: { enabled: true, severities: ["P0", "P1"], maxFindingsPerReview: 5 },
-      secondDraw: () => ({ verified: false, confidence: 0.2 })
+      secondDraw: () => receipt("refuted", true, 0.2)
     });
 
-    expect(result.comments[0]?.confidence).toBe(0.2); // min(0.9, 0.2)
-    expect(result.comments).toHaveLength(1); // still POSTS as a comment
-    expect(result.event).toBe("COMMENT"); // lost eligibility ⇒ quieter
+    expect(result.comments).toHaveLength(0);
+    expect(result.event).toBe("COMMENT");
     expect(result.verdicts).toEqual([expect.objectContaining({ agreed: false, refuted: true })]);
   });
 
@@ -69,7 +73,7 @@ describe("self-consistency re-check (#303)", () => {
       comments: [comment({ severity: "P1", line: 2, title: "Concern", confidence: 0.4 })],
       files,
       config: { enabled: true, maxFindingsPerReview: 5 },
-      secondDraw: () => ({ verified: true, confidence: 0.99 })
+      secondDraw: () => receipt("confirmed", true, 0.99)
     });
     expect(result.comments[0]?.confidence).toBe(0.4);
   });
@@ -85,18 +89,18 @@ describe("self-consistency re-check (#303)", () => {
       config: { enabled: true, severities: ["P0"], maxFindingsPerReview: 5 },
       secondDraw: (input) => {
         seen.push(input.comment.title);
-        return { verified: true, confidence: 0.8 };
+        return receipt("confirmed");
       }
     });
 
     expect(seen).toHaveLength(5);
     // Ranked order = the comment order the gate already produced (highest-confidence first).
     expect(seen).toEqual(["Finding 0", "Finding 1", "Finding 2", "Finding 3", "Finding 4"]);
-    expect(result.verdicts).toHaveLength(5);
+    expect(result.verdicts).toHaveLength(6); expect(result.verdicts[5]?.error).toBe("severe_verifier_cap_exceeded");
   });
 
   it("only re-checks findings at configured severities (default P0/P1)", async () => {
-    const secondDraw = vi.fn(() => ({ verified: true, confidence: 0.8 }));
+    const secondDraw = vi.fn(() => receipt("confirmed"));
     await runSelfConsistencyRecheck({
       comments: [
         comment({ severity: "P0", line: 2, title: "high", confidence: 0.9 }),
@@ -109,7 +113,7 @@ describe("self-consistency re-check (#303)", () => {
     expect(secondDraw).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves a finding untouched when the second draw fails (quieter-only, never blocks)", async () => {
+  it("suppresses a severe finding when the second draw fails without failing the review", async () => {
     const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
     const result = await runSelfConsistencyRecheck({
       comments,
@@ -120,8 +124,8 @@ describe("self-consistency re-check (#303)", () => {
       }
     });
 
-    expect(result.comments[0]?.confidence).toBe(0.9);
-    expect(result.event).toBe("REQUEST_CHANGES");
+    expect(result.comments).toHaveLength(0);
+    expect(result.event).toBe("COMMENT");
     expect(result.verdicts).toEqual([expect.objectContaining({ error: expect.stringContaining("provider exploded") })]);
   });
 
@@ -140,12 +144,34 @@ describe("self-consistency re-check (#303)", () => {
         events.push(`start:${finding.title}`);
         await new Promise((resolve) => setTimeout(resolve, 5));
         events.push(`finish:${finding.title}`);
-        return { verified: true, confidence: 0.7 };
+        return receipt("confirmed", true, 0.7);
       }
     });
 
     expect(events).toEqual(["start:first", "finish:first", "start:second", "finish:second"]);
     expect(result.verdicts).toHaveLength(2);
     expect(result.event).toBe("REQUEST_CHANGES");
+  });
+
+  it("suppresses every non-confirmed receipt, including incomplete evidence", async () => {
+    const states: Array<SevereVerificationReceipt["state"]> = ["refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"]; for (const state of states) {
+      const result = await runSelfConsistencyRecheck({
+        comments: [comment({ severity: "P1", line: 2, title: state, confidence: 0.9 })],
+        files,
+        config: { enabled: true },
+        secondDraw: () => receipt(state, false)
+      });
+      expect(result.comments, state).toEqual([]); expect(result.event, state).toBe("COMMENT");
+    }
+  });
+  it("strictly parses the dedicated verifier result", () => {
+    expect(parseSevereVerifierOutput({ verdict: "confirm", confidence: 0.7 })).toEqual({ verdict: "confirm", confidence: 0.7 });
+    for (const invalid of [
+      { verdict: "confirm" },
+      { verdict: "confirm", confidence: 0.7, extra: true },
+      { verdict: "confirm", confidence: Number.NaN },
+      { verdict: "confirm", confidence: 1.1 },
+      { verdict: "maybe", confidence: 0.7 }
+    ]) expect(() => parseSevereVerifierOutput(invalid)).toThrow("severe_verifier_schema_invalid");
   });
 });


### PR DESCRIPTION
## Summary

- add a strict dedicated severe-verifier result parser
- add typed metadata-only verification receipts and complete-evidence checks
- suppress P0/P1 findings on refuted, malformed, timeout, unavailable, stale-head, incomplete, invalid, or capped outcomes
- preserve original finding severity/confidence on confirmed complete evidence

## Validation

- `npm run build` passed with the authorized existing dependency tree via a temporary symlink; symlink removed afterward
- focused `tests/self-consistency.test.ts`: 10/10 passed under Node 26
- `git diff --check` passed
- exactly two owned files changed, 200 changed lines

## Scope boundary

This slice does not wire worker/provider transport or collect evidence. Those belong to the stacked follow-up.

Related: #807