### PR TITLE
fix(release): enforce Desktop-only RC npm no-op

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -120,6 +120,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # The policy reads the exact desktop-only marker from the checked-out
+          # annotated tag before applying package/release compatibility gates.
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           RELEASE_LEVEL="$(node -p "require('./docs/public-release-manifest.json').releaseLevel")"
           SKIPPED_VERSIONS="$(node -p "JSON.stringify(require('./docs/public-release-manifest.json').packageArtifact?.skippedPublicPackageVersions ?? [])")"
@@ -137,6 +139,10 @@ jobs:
             --skipped-versions-json "$SKIPPED_VERSIONS" \
             "${RELEASE_METADATA_ARGS[@]}" \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Exit Desktop-only release without npm work
+        if: steps.package_release.outputs.release_kind == 'desktop-only'
+        run: echo "Desktop-only release; npm authentication, install, build, and publication are skipped."
 
       - name: Verify npm publish token is configured
         if: steps.package_release.outputs.should_publish == 'true'

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -13,6 +13,8 @@ const V104_PROVENANCE_RECOVERY = Object.freeze({
   commit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
   predecessor: "1.0.3"
 });
+const DESKTOP_ONLY_RC_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:[1-9]\d*)$/;
+const DESKTOP_ONLY_TAG_ANNOTATION = "NeonDiff-Release-Class: desktop-only";
 
 function fail(message) {
   console.error(message);
@@ -46,10 +48,28 @@ function git(args) {
   return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
 
+function gitRaw(args) {
+  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
 function isAncestor(ancestor, descendant) {
   try {
     execFileSync("git", ["merge-base", "--is-ancestor", ancestor, descendant], { stdio: "ignore" });
     return true;
+  } catch {
+    return false;
+  }
+}
+
+function isDesktopOnlyTag(tag) {
+  if (!DESKTOP_ONLY_RC_TAG.test(tag)) return false;
+  try {
+    if (git(["cat-file", "-t", tag]) !== "tag") return false;
+    const rawTag = gitRaw(["cat-file", "tag", tag]);
+    const messageStart = rawTag.indexOf("\n\n");
+    if (messageStart < 0) return false;
+    const annotation = rawTag.slice(messageStart + 2);
+    return annotation.split("\n").filter((line) => line === DESKTOP_ONLY_TAG_ANNOTATION).length === 1;
   } catch {
     return false;
   }
@@ -72,19 +92,13 @@ function classify(args) {
   }
 
   const npmTag = packageVersion.includes("-") ? "beta" : "latest";
-  if (eventName === "release" && releasePrerelease && npmTag === "latest") {
-    fail("stable npm packages require a non-prerelease GitHub Release");
-  }
-  if (eventName === "release" && !releasePrerelease && npmTag === "beta") {
-    fail("beta npm packages require a prerelease GitHub Release");
-  }
+  let releaseMetadata;
   if (eventName === "workflow_dispatch") {
     const releaseMetadataPath = args.get("release-metadata");
     if (!releaseMetadataPath && npmTag === "latest") {
       fail("manual stable publish requires an existing non-prerelease GitHub Release");
     }
     if (!releaseMetadataPath) fail("manual npm publish requires existing GitHub Release metadata");
-    let releaseMetadata;
     try {
       releaseMetadata = JSON.parse(readFileSync(releaseMetadataPath, "utf8"));
     } catch {
@@ -93,6 +107,26 @@ function classify(args) {
     if (releaseMetadata.tag_name !== tag || releaseMetadata.draft !== false) {
       fail("manual npm publish requires matching published GitHub Release metadata");
     }
+  }
+  const effectiveReleasePrerelease = eventName === "workflow_dispatch"
+    ? releaseMetadata?.prerelease
+    : releasePrerelease;
+  if (effectiveReleasePrerelease === true && isDesktopOnlyTag(tag)) {
+    const result = { shouldPublish: false, npmTag, releaseKind: "desktop-only" };
+    const githubOutput = args.get("github-output");
+    if (githubOutput) {
+      appendFileSync(githubOutput, `should_publish=false\nnpm_tag=${npmTag}\nrelease_kind=desktop-only\n`, { encoding: "utf8" });
+    }
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (eventName === "release" && releasePrerelease && npmTag === "latest") {
+    fail("stable npm packages require a non-prerelease GitHub Release");
+  }
+  if (eventName === "release" && !releasePrerelease && npmTag === "beta") {
+    fail("beta npm packages require a prerelease GitHub Release");
+  }
+  if (eventName === "workflow_dispatch") {
     if (npmTag === "latest" && releaseMetadata.prerelease !== false) {
       fail("manual stable publish requires an existing non-prerelease GitHub Release");
     }

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -9,10 +9,65 @@ describe("npm release policy", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
   const policyScript = join(repoRoot, "scripts", "npm-release-policy.mjs");
+  const desktopOnlyAnnotation = "NeonDiff-Release-Class: desktop-only";
   const releaseCommit = "fc66d27b6ab9f6a1eb8282d289ef63407cd96982";
 
   afterEach(() => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function taggedRepo(tag: string, annotation = desktopOnlyAnnotation, annotated = true) {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-desktop-rc-"));
+    roots.push(root);
+    execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "release-policy@example.invalid"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Release Policy Test"], { cwd: root });
+    writeFileSync(join(root, "release.txt"), "release\n");
+    execFileSync("git", ["add", "release.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "release"], { cwd: root, stdio: "ignore" });
+    if (annotated) {
+      const messagePath = join(root, "tag-message.txt");
+      writeFileSync(messagePath, annotation);
+      execFileSync("git", ["tag", "-a", "--cleanup=verbatim", "-F", messagePath, tag], { cwd: root });
+    } else execFileSync("git", ["tag", tag], { cwd: root });
+    return root;
+  }
+
+  function classifyDesktopTag(root: string, tag: string) {
+    return spawnSync(process.execPath, [
+      policyScript, "classify", "--event-name", "release", "--release-prerelease", "true",
+      "--tag", tag, "--package-version", "1.0.4", "--release-level", "stable", "--skipped-versions-json", "[]"
+    ], { cwd: root, encoding: "utf8" });
+  }
+
+  it.each([
+    ["v1.1.0-rc.1", desktopOnlyAnnotation, true], ["v0.0.0-rc.1", desktopOnlyAnnotation, true],
+    ["v1.1.0-rc.01", desktopOnlyAnnotation, false], ["v01.1.0-rc.1", desktopOnlyAnnotation, false],
+    ["v1.01.0-rc.1", desktopOnlyAnnotation, false], ["v1.1.01-rc.1", desktopOnlyAnnotation, false],
+    ["v1.1.0-rc.0", desktopOnlyAnnotation, false], ["v1.1.0-rc.1", ` ${desktopOnlyAnnotation}`, false],
+    ["v1.1.0-rc.1", `${desktopOnlyAnnotation} `, false], ["v1.1.0-rc.1", `${desktopOnlyAnnotation}\n${desktopOnlyAnnotation}`, false],
+    ["v1.1.0-rc.1", "neondiff-release-class: desktop-only", false], ["v1.1.0-rc.1", `${desktopOnlyAnnotation}-x`, false]
+  ])("classifies only exact Desktop-only RC identity: %s", (tag, annotation, desktopOnly) => {
+    const result = classifyDesktopTag(taggedRepo(tag, annotation), tag);
+    if (desktopOnly) {
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ shouldPublish: false, npmTag: "latest", releaseKind: "desktop-only" });
+    } else {
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("stable npm packages require a non-prerelease GitHub Release");
+    }
+  });
+
+  it("rejects a lightweight Desktop-only RC tag", () => {
+    const root = taggedRepo("v1.1.0-rc.1", desktopOnlyAnnotation, false);
+    const candidate = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: root });
+    const result = spawnSync(process.execPath, [
+      policyScript, "verify-git", "--tag", "v1.1.0-rc.1", "--candidate-head", candidate,
+      "--main-ref", "refs/remotes/origin/main"
+    ], { cwd: root, encoding: "utf8" });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("release tag must be annotated");
   });
 
   it("rejects a stable npm package from a prerelease GitHub Release", () => {


### PR DESCRIPTION
Supersedes #815
Related: #610

## Summary
- classify only an annotated canonical `vMAJOR.MINOR.PATCH-rc.N` tag as Desktop-only when its raw tag message contains exactly one byte-exact `NeonDiff-Release-Class: desktop-only` line
- reject leading-zero components, `rc.0`, whitespace/case/suffix/duplicate/absent markers, and lightweight tags
- preserve CLI stable/beta behavior and guard all npm auth/install/build/publish/promotion steps behind the existing publish output
- add regression coverage to the repository's executed TypeScript Vitest test file

## Validation
- direct policy matrix: canonical and zero-component RC no-ops; malformed SemVer/RC, marker variants, and lightweight tags fail closed
- direct manual workflow-dispatch metadata probe returns Desktop-only no-op
- CLI stable and beta probes retain existing publish results
- `node --check scripts/npm-release-policy.mjs`
- `git diff --check`
- changed scope: 109 lines (102 additions, 7 deletions)
- manifest SHA-256 unchanged: `9e5aae15c24da42c7197133dfe1b3c9cbc52e9e6578fd2a662b83d55fd4c8b4a`
- package SHA-256 unchanged: `1ae3ed81bafdac56f658bc8ac048f72d9310643daad07d8bdfe5483410a9c067`

The local shared Vitest install is unusable because its Rollup native binary fails Team-ID validation; no dependencies were installed. Remote CI is authoritative.

## Safety boundary
No changes to #815, package/manifest bytes, npm credentials/publication, release/tag creation, signing/notarization, deployment, runtime, customer, or secret surfaces. No merge performed.
