### PR TITLE
fix(status): align operator health presentation

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -10,6 +10,13 @@ Run commands from the repository checkout:
 npx tsx src/cli.ts status --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
+Add `--human` for a compact operator headline and actionable gates; the exit
+code remains nonzero when the combined status gate is blocked:
+
+```bash
+npx tsx src/cli.ts status --human --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
 After `npm run build` and `npm link`, the package exposes the `neondiff`
 binary and the `evaos-review-bot` compatibility alias (same CLI, older name):
 
@@ -22,13 +29,16 @@ evaos-review-bot status --config config.local.json
 
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
-  durable queue counts, and recommended actions.
+  durable queue counts, and recommended actions. Current gates use active and
+  recent-unrecovered health; retained error and failed-queue totals remain
+  visible as history.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
   budget status, leases, heartbeat, and bot-owned process rows. It can classify
   the worker as `healthy_active` when open PR heads are already covered by
   active queue work, even if the stricter `status` command is nonzero because
-  live PR churn exists. JSON is the default; use `--human` for a compact
+  live PR churn exists. Active failures gate this command; retained failures
+  stay visible in history. JSON is the default; use `--human` for a compact
   operator summary.
 - `agents`: launchd, heartbeat, and review-run lease inventory. This is
   read-only; it does not restart, kill, prune, or retire anything.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,6 +98,7 @@ import {
   collectOperatorReviewQueue,
   explainPullStatus,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorDurableQueueSnapshot,
@@ -724,7 +725,7 @@ async function main(): Promise<void> {
       }),
       issueEnrichmentRuntime
     });
-    console.log(stringifyRedactedJson(status));
+    console.log(args.human === "true" ? formatOperatorStatusHuman(status) : stringifyRedactedJson(status));
     if (!status.ok) process.exitCode = 1;
     return;
   }
@@ -3613,7 +3614,8 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--limit", description: "Cap the number of provider-cooldown/durable-queue rows returned." },
       { name: "--expected-head", description: "Expected release head SHA to verify against." },
       { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
-      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." }
+      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." },
+      { name: "--human", description: "Print a compact operator summary instead of JSON; the exit code still follows the combined operator gate." }
     ]
   },
   "release-status": {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -33,6 +33,8 @@ import {
   summarizeZCodeTimeoutErrors
 } from "./zcode-timeout.js";
 
+type OperatorRelease = ReleaseStatus & { database: ReleaseStatus["database"] & { recentUnrecoveredErrorCount?: number; activeFailedReviewQueueJobCount?: number; activeZCodeTimeoutFailedReviewQueueJobCount?: number }; health?: { state: string; reason: string; active: { failedQueueJobs: number; staleReviewLeases: number }; recent: { unrecoveredReviewErrors: number } } };
+
 export interface OperatorStatus {
   ok: boolean;
   checkedAt: string;
@@ -412,8 +414,13 @@ export function buildOperatorStatus(input: {
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
-  const failedRows = input.release.database.errorCount;
-  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const release = input.release as OperatorRelease;
+  const { database, health } = release;
+  const failedRows = database.errorCount;
+  const failedQueueJobs = database.failedReviewQueueJobCount ?? durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs = database.activeFailedReviewQueueJobCount ??
+    health?.active.failedQueueJobs ??
+    failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
@@ -455,15 +462,20 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "durable_queue_no_failed_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
-      detail:
-        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+      ok: zcodeTimeoutQueue.activeTotal === 0,
+      detail: zcodeTimeoutQueue.activeTotal === zcodeTimeoutQueue.total
+        ? `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+        : `${zcodeTimeoutQueue.activeTotal} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutQueue.total}; retryable=${zcodeTimeoutQueue.retryable} ` +
+          `exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "durable_queue_no_retryable_provider_deferred_jobs",
@@ -504,8 +516,8 @@ export function buildOperatorStatus(input: {
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(zcodeTimeoutQueue.activeTotal > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -556,6 +568,29 @@ export function buildOperatorStatus(input: {
   };
 }
 
+export function formatOperatorStatusHuman(status: OperatorStatus): string {
+  const release = status.release as OperatorRelease;
+  const health = release.health;
+  const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount ?? health?.active.failedQueueJobs ?? status.summary.failedQueueJobs;
+  const recentUnrecoveredReviewErrors = release.database.recentUnrecoveredErrorCount ?? health?.recent.unrecoveredReviewErrors ?? status.summary.failedRows;
+  const failedGates = status.gates.filter((gate) => !gate.ok);
+  const headline = status.ok ? "ok" : "blocked";
+  const reason = health?.reason ?? (status.ok ? "current operator gates pass" : "current operator gates failed");
+  const lines = [
+    `status: ${headline} (operator) - ${reason}`,
+    `releaseHealth: ${health?.state ?? "unknown"} (release-only context)`,
+    `current: activeFailedQueueJobs=${activeFailedQueueJobs} ` +
+      `recentUnrecoveredReviewErrors=${recentUnrecoveredReviewErrors} ` +
+      `staleLeases=${status.summary.staleLeases}`,
+    `history: reviewErrors=${status.summary.failedRows} failedQueueJobs=${status.summary.failedQueueJobs}`,
+    ...(failedGates.length > 0
+      ? failedGates.map((gate) => `actionable: ${gate.name} - ${gate.detail}`)
+      : ["actionable: none"]),
+    ...status.recommendedActions.map((action) => `next: ${action}`)
+  ];
+  return lines.join("\n");
+}
+
 export function buildRuntimeInventory(input: {
   release: ReleaseStatus;
   coverage?: CoverageAuditReport;
@@ -594,7 +629,12 @@ export function buildRuntimeInventory(input: {
     input.release.database.retryableExpiredProviderCooldownCount ??
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
-  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const release = input.release as OperatorRelease;
+  const { database, health } = release;
+  const failedQueueJobs = database.failedReviewQueueJobCount ?? durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs = database.activeFailedReviewQueueJobCount ??
+    health?.active.failedQueueJobs ??
+    failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
@@ -623,15 +663,20 @@ export function buildRuntimeInventory(input: {
     },
     {
       name: "runtime_no_failed_queue_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "runtime_no_zcode_timeout_failed_queue_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
-      detail:
-        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+      ok: zcodeTimeoutQueue.activeTotal === 0,
+      detail: zcodeTimeoutQueue.activeTotal === zcodeTimeoutQueue.total
+        ? `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+        : `${zcodeTimeoutQueue.activeTotal} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutQueue.total}; retryable=${zcodeTimeoutQueue.retryable} ` +
+          `exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "runtime_no_retryable_provider_deferred_jobs",
@@ -720,8 +765,8 @@ export function buildRuntimeInventory(input: {
     ...(uncoveredPendingHeads.length > 0 ? ["wait for daemon cycle or run scoped run-once for uncovered pending heads"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(zcodeTimeoutQueue.activeTotal > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -840,9 +885,17 @@ export function filterBotProcessRows(
 }
 
 export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string {
+  const release = inventory.release as OperatorRelease;
+  const health = release.health;
+  const activeFailedQueueJobs = release.database.activeFailedReviewQueueJobCount ?? health?.active.failedQueueJobs ?? inventory.summary.failedQueueJobs;
+  const recentUnrecoveredReviewErrors = release.database.recentUnrecoveredErrorCount ?? health?.recent.unrecoveredReviewErrors ?? inventory.release.database.errorCount;
   const lines = [
     `runtime: ${inventory.classification} (${inventory.ok ? "ok" : "blocked"})`,
     `checkedAt: ${inventory.checkedAt}`,
+    `health: activeFailedQueueJobs=${activeFailedQueueJobs}` +
+      ` recentUnrecoveredReviewErrors=${recentUnrecoveredReviewErrors}` +
+      ` failedQueueHistory=${inventory.summary.failedQueueJobs}` +
+      ` release=${health?.state ?? "unknown"}`,
     `launchd: ${inventory.summary.launchdState}` +
       (inventory.release.launchd.pid ? ` pid=${inventory.release.launchd.pid}` : "") +
       (inventory.release.launchd.configPath ? ` config=${inventory.release.launchd.configPath}` : ""),
@@ -853,7 +906,10 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
       (inventory.release.repo.dirtyFiles.length > 0 ? ` dirty=${inventory.release.repo.dirtyFiles.length}` : " clean"),
     `queue: active=${inventory.summary.activeQueueJobs} queued=${inventory.summary.queuedJobs}` +
       ` running=${inventory.summary.runningJobs} providerDeferred=${inventory.summary.providerDeferredJobs}` +
-      ` failed=${inventory.summary.failedQueueJobs}`,
+      ` failed=${activeFailedQueueJobs}` +
+      (activeFailedQueueJobs === inventory.summary.failedQueueJobs
+        ? ""
+        : ` failedHistory=${inventory.summary.failedQueueJobs}`),
     `budget: wouldLease=${inventory.summary.budgetWouldLeaseJobs}` +
       ` delayed=${inventory.summary.budgetDelayedJobs}` +
       ` delayedByReason=${JSON.stringify(inventory.budget?.delayedByReason ?? {})}`,
@@ -1738,19 +1794,22 @@ function uniqueStrings(values: string[]): string[] {
 function zcodeTimeoutQueueCounts(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
-): { total: number; retryable: number; exhausted: number } {
-  if (release.database.zcodeTimeoutFailedReviewQueueJobCount !== undefined) {
+): { total: number; activeTotal: number; retryable: number; exhausted: number } {
+  const database = (release as OperatorRelease).database;
+  if (database.zcodeTimeoutFailedReviewQueueJobCount !== undefined) {
     return {
-      total: release.database.zcodeTimeoutFailedReviewQueueJobCount,
-      retryable: release.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0,
-      exhausted: release.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0
+      total: database.zcodeTimeoutFailedReviewQueueJobCount,
+      activeTotal: database.activeZCodeTimeoutFailedReviewQueueJobCount ?? database.zcodeTimeoutFailedReviewQueueJobCount,
+      retryable: database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0,
+      exhausted: database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0
     };
   }
-  return summarizeZCodeTimeoutErrors(
+  const counts = summarizeZCodeTimeoutErrors(
     (durableQueue?.jobs ?? [])
       .filter((job) => job.state === "failed")
       .map((job) => job.lastError)
   );
+  return { ...counts, activeTotal: counts.total };
 }
 
 function zcodeTimeoutRecommendedActions(

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1816,6 +1816,8 @@ function zcodeTimeoutRecommendedActions(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
 ): string[] {
+  const counts = zcodeTimeoutQueueCounts(release, durableQueue);
+  if (counts.activeTotal !== counts.total) return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
   const retryCommands = buildZCodeTimeoutRetryCommandsForJobs({
     configPath: release.releaseUnit.configPath,
     jobs: durableQueue?.jobs ?? []

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2381,7 +2381,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
         : "none";
     const failureHealth = readProcessedFailureHealth(db, now);
     const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
-    const reviewQueue = readReviewQueueCounts(db, now, failureHealth.latestPostedAtByPull);
+    const reviewQueue = readReviewQueueCounts(db, now);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
@@ -2425,66 +2425,38 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
   }
 }
 
-type ProcessedFailureRow = { repo: string; pull_number: number; status: string; error: string | null; created_at: string };
-type FailedQueueRow = { repo: string; pull_number: number; last_error: string | null; updated_at: string };
+type FailedQueueRow = { last_error: string | null; active: number };
 
 function readProcessedFailureHealth(db: DatabaseSync, now: Date): {
   recentUnrecoveredErrorCount: number;
   lastErrorAt?: string;
-  latestPostedAtByPull: Map<string, number>;
 } {
-  const rows = db.prepare(
-    `select repo, pull_number, status, error, created_at
-       from processed_reviews
-      where status = 'posted'
-         or status = 'failed'
-         or (status != 'skipped' and error is not null and error != '')`
-  ).all() as unknown as ProcessedFailureRow[];
-  const latestPostedAtByPull = new Map<string, number>();
-  for (const row of rows) {
-    if (row.status !== "posted") continue;
-    const postedAt = parseDatabaseTimestamp(row.created_at);
-    if (!Number.isFinite(postedAt)) continue;
-    const key = `${row.repo}\u0000${row.pull_number}`;
-    if (postedAt > (latestPostedAtByPull.get(key) ?? Number.NEGATIVE_INFINITY)) {
-      latestPostedAtByPull.set(key, postedAt);
-    }
-  }
-  const cutoff = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
-  let recentUnrecoveredErrorCount = 0;
-  let lastErrorAt: { value: string; timestamp: number } | undefined;
-  for (const row of rows) {
-    const isError = row.status === "failed" || (row.status !== "skipped" && Boolean(row.error));
-    if (!isError) continue;
-    const timestamp = parseDatabaseTimestamp(row.created_at);
-    const key = `${row.repo}\u0000${row.pull_number}`;
-    const recoveredAt = latestPostedAtByPull.get(key);
-    if (!(recoveredAt !== undefined && Number.isFinite(timestamp) && recoveredAt > timestamp) &&
-        (!Number.isFinite(timestamp) || timestamp >= cutoff)) {
-      recentUnrecoveredErrorCount += 1;
-    }
-    if (Number.isFinite(timestamp) && (!lastErrorAt || timestamp > lastErrorAt.timestamp)) {
-      lastErrorAt = { value: row.created_at, timestamp };
-    }
-  }
+  const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
+  const cutoff = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
+  const recent = db.prepare(
+    `select count(*) as count from processed_reviews failed
+      where (${errorWhere})
+        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))
+        and not exists (
+          select 1 from processed_reviews posted
+           where posted.repo = failed.repo and posted.pull_number = failed.pull_number
+             and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.created_at)
+        )`
+  ).get(cutoff) as { count: number };
+  const last = db.prepare(
+    `select created_at from processed_reviews failed
+      where ${errorWhere}
+      order by datetime(created_at) desc limit 1`
+  ).get() as { created_at?: string } | undefined;
   return {
-    recentUnrecoveredErrorCount,
-    ...(lastErrorAt ? { lastErrorAt: lastErrorAt.value } : {}),
-    latestPostedAtByPull
+    recentUnrecoveredErrorCount: recent.count ?? 0,
+    ...(last?.created_at ? { lastErrorAt: last.created_at } : {})
   };
-}
-
-function parseDatabaseTimestamp(value: string | null | undefined): number {
-  const text = value?.trim();
-  if (!text) return Number.NaN;
-  return Date.parse(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(text)
-    ? `${text.replace(" ", "T")}Z` : text);
 }
 
 function readReviewQueueCounts(
   db: DatabaseSync,
-  now: Date,
-  latestPostedAtByPull: Map<string, number>
+  now: Date
 ): {
   total: number;
   queued: number;
@@ -2551,15 +2523,16 @@ function readReviewQueueCounts(
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
   const failedRows = db.prepare(
-    `select repo, pull_number, last_error, updated_at
-       from review_queue_jobs
-      where state = 'failed'`
+    `select failed.last_error,
+            not exists (
+              select 1 from processed_reviews posted
+               where posted.repo = failed.repo and posted.pull_number = failed.pull_number
+                 and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.updated_at)
+            ) as active
+       from review_queue_jobs failed
+      where failed.state = 'failed'`
   ).all() as unknown as FailedQueueRow[];
-  const activeFailedRows = failedRows.filter((row) => {
-    const recoveredAt = latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
-    const failedAt = parseDatabaseTimestamp(row.updated_at);
-    return recoveredAt === undefined || !Number.isFinite(failedAt) || recoveredAt <= failedAt;
-  });
+  const activeFailedRows = failedRows.filter((row) => row.active === 1);
   const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
   const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2379,9 +2379,10 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       : retryableExpiredProviderCooldownCount > 0
         ? "expired_retryable"
         : "none";
-    const failureHealth = readProcessedFailureHealth(db, now);
+    const recovery = readFailureRecoveryIndex(db);
+    const failureHealth = readProcessedFailureHealth(db, now, recovery);
     const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
-    const reviewQueue = readReviewQueueCounts(db, now);
+    const reviewQueue = readReviewQueueCounts(db, now, recovery.latestPostedAtByPull);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
@@ -2425,38 +2426,53 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
   }
 }
 
-type FailedQueueRow = { last_error: string | null; active: number };
+type FailedQueueRow = { repo: string; pull_number: number; last_error: string | null; failed_at: number | null };
+type FailureRecoveryIndex = { latestPostedAtByPull: Map<string, number>; lastErrorAt?: string };
 
-function readProcessedFailureHealth(db: DatabaseSync, now: Date): {
+function readFailureRecoveryIndex(db: DatabaseSync): FailureRecoveryIndex {
+  const rows = db.prepare(
+    `select repo, pull_number,
+            max(case when status = 'posted' then julianday(created_at) end) as posted_at,
+            max(case when (status = 'failed' or (status != 'skipped' and error is not null and error != '')) and julianday(created_at) is not null
+                     then printf('%020.10f|%s', julianday(created_at), created_at) end) as error_marker
+       from processed_reviews group by repo, pull_number`
+  ).all() as unknown as Array<{ repo: string; pull_number: number; posted_at: number | null; error_marker: string | null }>;
+  const latestPostedAtByPull = new Map<string, number>();
+  let lastErrorMarker: string | undefined;
+  for (const row of rows) {
+    if (row.posted_at !== null) latestPostedAtByPull.set(`${row.repo}\u0000${row.pull_number}`, row.posted_at);
+    if (row.error_marker && (!lastErrorMarker || row.error_marker > lastErrorMarker)) lastErrorMarker = row.error_marker;
+  }
+  return {
+    latestPostedAtByPull,
+    ...(lastErrorMarker ? { lastErrorAt: lastErrorMarker.slice(lastErrorMarker.indexOf("|") + 1) } : {})
+  };
+}
+
+function readProcessedFailureHealth(db: DatabaseSync, now: Date, recovery: FailureRecoveryIndex): {
   recentUnrecoveredErrorCount: number;
   lastErrorAt?: string;
 } {
   const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
   const cutoff = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
   const recent = db.prepare(
-    `select count(*) as count from processed_reviews failed
+    `select repo, pull_number, julianday(created_at) as failed_at from processed_reviews failed
       where (${errorWhere})
-        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))
-        and not exists (
-          select 1 from processed_reviews posted
-           where posted.repo = failed.repo and posted.pull_number = failed.pull_number
-             and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.created_at)
-        )`
-  ).get(cutoff) as { count: number };
-  const last = db.prepare(
-    `select created_at from processed_reviews failed
-      where ${errorWhere}
-      order by datetime(created_at) desc limit 1`
-  ).get() as { created_at?: string } | undefined;
+        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))`
+  ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; failed_at: number | null }>;
   return {
-    recentUnrecoveredErrorCount: recent.count ?? 0,
-    ...(last?.created_at ? { lastErrorAt: last.created_at } : {})
+    recentUnrecoveredErrorCount: recent.filter((row) => {
+      const postedAt = recovery.latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
+      return row.failed_at === null || postedAt === undefined || postedAt <= row.failed_at;
+    }).length,
+    ...(recovery.lastErrorAt ? { lastErrorAt: recovery.lastErrorAt } : {})
   };
 }
 
 function readReviewQueueCounts(
   db: DatabaseSync,
-  now: Date
+  now: Date,
+  latestPostedAtByPull: Map<string, number>
 ): {
   total: number;
   queued: number;
@@ -2523,16 +2539,14 @@ function readReviewQueueCounts(
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
   const failedRows = db.prepare(
-    `select failed.last_error,
-            not exists (
-              select 1 from processed_reviews posted
-               where posted.repo = failed.repo and posted.pull_number = failed.pull_number
-                 and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.updated_at)
-            ) as active
+    `select repo, pull_number, last_error, julianday(updated_at) as failed_at
        from review_queue_jobs failed
       where failed.state = 'failed'`
   ).all() as unknown as FailedQueueRow[];
-  const activeFailedRows = failedRows.filter((row) => row.active === 1);
+  const activeFailedRows = failedRows.filter((row) => {
+    const postedAt = latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
+    return row.failed_at === null || postedAt === undefined || postedAt <= row.failed_at;
+  });
   const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
   const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { containsSecretLikeText } from "./secrets.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
-import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
+import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
 import type { ReviewQueueJobRecord } from "./state.js";
 
@@ -32,6 +32,8 @@ export interface ReleaseLaunchdStatus {
 export interface ReleaseDatabaseStatus {
   rowCount: number;
   errorCount: number;
+  recentUnrecoveredErrorCount?: number;
+  lastErrorAt?: string;
   skippedCount?: number;
   reviewerSessionCount?: number;
   activeReviewerSessionCount?: number;
@@ -53,7 +55,9 @@ export interface ReleaseDatabaseStatus {
   providerDeferredReviewQueueJobCount?: number;
   retryableProviderDeferredReviewQueueJobCount?: number;
   failedReviewQueueJobCount?: number;
+  activeFailedReviewQueueJobCount?: number;
   zcodeTimeoutFailedReviewQueueJobCount?: number;
+  activeZCodeTimeoutFailedReviewQueueJobCount?: number;
   retryableZCodeTimeoutFailedReviewQueueJobCount?: number;
   exhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
   reviewRunLeaseCount?: number;
@@ -61,6 +65,8 @@ export interface ReleaseDatabaseStatus {
   staleActiveReviewQueueJobCount?: number;
   reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
 }
+
+export interface ReleaseHealthStatus { state: "green" | "amber" | "red"; reason: string; active: { failedQueueJobs: number; staleReviewLeases: number }; recent: { unrecoveredReviewErrors: number }; history: { reviewErrors: number; failedQueueJobs: number }; }
 
 export interface ReviewerSessionRepoStatus {
   repo: string;
@@ -166,6 +172,7 @@ export interface PublicReleaseChannelStatus {
 export interface ReleaseStatus {
   ok: boolean;
   checkedAt: string;
+  health?: ReleaseHealthStatus;
   summary: {
     blockingErrorRows: number;
     failedQueueJobs: number;
@@ -246,6 +253,8 @@ const OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATE_OVERRIDES = new Map([
   ["website", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "pending-site-sync"])],
   ["desktop", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "post_1_0"])]
 ]);
+const FAILURE_HEALTH_WINDOW_HOURS = 24;
+const FAILURE_HEALTH_WINDOW_MS = FAILURE_HEALTH_WINDOW_HOURS * 60 * 60 * 1_000;
 
 export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const expectedHeadOk = !input.expectedHead || input.repo.head === input.expectedHead;
@@ -255,7 +264,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const launchdSystemCaOk =
     input.launchd.sealedDesktopWorker === true || input.launchd.usesSystemCa === true;
-  const dbOk = input.database.errorCount === 0;
+  const failureWindowHours = FAILURE_HEALTH_WINDOW_HOURS;
+  const recentUnrecoveredErrorCount = input.database.recentUnrecoveredErrorCount ?? input.database.errorCount;
+  const dbOk = recentUnrecoveredErrorCount === 0;
   const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
   const retryableExpiredProviderCooldownCount =
     input.database.retryableExpiredProviderCooldownCount ??
@@ -264,11 +275,15 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       (input.database.expiredProviderCooldownCount ?? 0) - (input.database.coveredExpiredProviderCooldownCount ?? 0)
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
-  const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const failedQueueJobs = input.database.failedReviewQueueJobCount ?? 0;
+  const activeFailedQueueJobs = input.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
+  const failedQueueJobsOk = activeFailedQueueJobs === 0;
   const zcodeTimeoutFailedQueueJobCount = input.database.zcodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const activeZCodeTimeoutFailedQueueJobCount =
+    input.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? zcodeTimeoutFailedQueueJobCount;
   const retryableZCodeTimeoutFailedQueueJobCount = input.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0;
   const exhaustedZCodeTimeoutFailedQueueJobCount = input.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0;
-  const zcodeTimeoutFailedQueueJobsOk = zcodeTimeoutFailedQueueJobCount === 0;
+  const zcodeTimeoutFailedQueueJobsOk = activeZCodeTimeoutFailedQueueJobCount === 0;
   const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
     (input.database.staleActiveReviewQueueJobCount ?? 0);
   const staleReviewLeasesOk = staleReviewLeaseCount === 0;
@@ -322,7 +337,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "live_db_no_errors",
       ok: dbOk,
       detail:
-        `${input.database.errorCount} blocking error row(s)` +
+        (input.database.recentUnrecoveredErrorCount === undefined
+          ? `${input.database.errorCount} blocking error row(s)`
+          : `${recentUnrecoveredErrorCount} recent unrecovered blocking error row(s) in ${failureWindowHours}h; ` +
+            `${input.database.errorCount} retained history; last failure ${input.database.lastErrorAt ?? "unknown"}`) +
         describeProviderCooldownCounts(input.database)
     },
     {
@@ -335,14 +353,19 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "queue_no_failed_jobs",
       ok: failedQueueJobsOk,
-      detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "queue_no_zcode_timeout_failed_jobs",
       ok: zcodeTimeoutFailedQueueJobsOk,
-      detail:
-        `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+      detail: activeZCodeTimeoutFailedQueueJobCount === zcodeTimeoutFailedQueueJobCount
+        ? `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+        : `${activeZCodeTimeoutFailedQueueJobCount} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutFailedQueueJobCount}; retryable=${retryableZCodeTimeoutFailedQueueJobCount} ` +
+          `exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
     },
     {
       name: "queue_no_stale_review_leases",
@@ -390,13 +413,21 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     ...runtimeGates,
     ...publicReleaseGates
   ];
+  const health = classifyReleaseHealth({
+    gates,
+    database: input.database,
+    recentUnrecoveredErrorCount,
+    activeFailedQueueJobs,
+    staleReviewLeaseCount
+  });
 
   return {
     ok: gates.every((gate) => gate.ok),
     checkedAt: (input.now ?? new Date()).toISOString(),
+    health,
     summary: {
       blockingErrorRows: input.database.errorCount,
-      failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0,
+      failedQueueJobs,
       staleReviewLeases: staleReviewLeaseCount,
       providerDeferredQueueJobs: input.database.providerDeferredReviewQueueJobCount ?? 0,
       retryableProviderDeferredQueueJobs: input.database.retryableProviderDeferredReviewQueueJobCount ?? 0,
@@ -444,6 +475,18 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
       unloadCommand: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${input.launchd.label}.plist`
     }
+  };
+}
+
+function classifyReleaseHealth(input: { gates: Array<{ name: string; ok: boolean }>; database: ReleaseDatabaseStatus; recentUnrecoveredErrorCount: number; activeFailedQueueJobs: number; staleReviewLeaseCount: number }): ReleaseHealthStatus {
+  const failedGates = input.gates.filter((gate) => !gate.ok).map((gate) => gate.name);
+  const state: ReleaseHealthStatus["state"] = failedGates.length ? "red" : input.database.errorCount || input.database.failedReviewQueueJobCount ? "amber" : "green";
+  return {
+    state,
+    reason: state === "red" ? `current or recent actionable gate(s) failed: ${failedGates.join(", ")}` : state === "amber" ? `current gates pass; retained history has ${input.database.errorCount} review error(s) and ${input.database.failedReviewQueueJobCount ?? 0} failed queue job(s)` : "current gates pass with no recorded review or queue failure history",
+    active: { failedQueueJobs: input.activeFailedQueueJobs, staleReviewLeases: input.staleReviewLeaseCount },
+    recent: { unrecoveredReviewErrors: input.recentUnrecoveredErrorCount },
+    history: { reviewErrors: input.database.errorCount, failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0 }
   };
 }
 
@@ -2336,8 +2379,9 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       : retryableExpiredProviderCooldownCount > 0
         ? "expired_retryable"
         : "none";
+    const failureHealth = readProcessedFailureHealth(db, now);
     const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
-    const reviewQueue = readReviewQueueCounts(db, now);
+    const reviewQueue = readReviewQueueCounts(db, now, failureHealth.latestPostedAtByPull);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
@@ -2363,23 +2407,84 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
       retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
       failedReviewQueueJobCount: reviewQueue.failed,
+      activeFailedReviewQueueJobCount: reviewQueue.activeFailed,
       zcodeTimeoutFailedReviewQueueJobCount: reviewQueue.zcodeTimeoutFailed,
+      activeZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.activeZCodeTimeoutFailed,
       retryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.retryableZCodeTimeoutFailed,
       exhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.exhaustedZCodeTimeoutFailed,
       reviewRunLeaseCount: reviewRunLeases.total,
       staleReviewRunLeaseCount: reviewRunLeases.stale,
       staleActiveReviewQueueJobCount,
       reviewQueueJobsByRepo: reviewQueue.byRepo,
-      errorCount: row.errorCount ?? 0
+      errorCount: row.errorCount ?? 0,
+      recentUnrecoveredErrorCount: failureHealth.recentUnrecoveredErrorCount,
+      ...(failureHealth.lastErrorAt ? { lastErrorAt: failureHealth.lastErrorAt } : {})
     };
   } finally {
     db.close();
   }
 }
 
+type ProcessedFailureRow = { repo: string; pull_number: number; status: string; error: string | null; created_at: string };
+type FailedQueueRow = { repo: string; pull_number: number; last_error: string | null; updated_at: string };
+
+function readProcessedFailureHealth(db: DatabaseSync, now: Date): {
+  recentUnrecoveredErrorCount: number;
+  lastErrorAt?: string;
+  latestPostedAtByPull: Map<string, number>;
+} {
+  const rows = db.prepare(
+    `select repo, pull_number, status, error, created_at
+       from processed_reviews
+      where status = 'posted'
+         or status = 'failed'
+         or (status != 'skipped' and error is not null and error != '')`
+  ).all() as unknown as ProcessedFailureRow[];
+  const latestPostedAtByPull = new Map<string, number>();
+  for (const row of rows) {
+    if (row.status !== "posted") continue;
+    const postedAt = parseDatabaseTimestamp(row.created_at);
+    if (!Number.isFinite(postedAt)) continue;
+    const key = `${row.repo}\u0000${row.pull_number}`;
+    if (postedAt > (latestPostedAtByPull.get(key) ?? Number.NEGATIVE_INFINITY)) {
+      latestPostedAtByPull.set(key, postedAt);
+    }
+  }
+  const cutoff = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
+  let recentUnrecoveredErrorCount = 0;
+  let lastErrorAt: { value: string; timestamp: number } | undefined;
+  for (const row of rows) {
+    const isError = row.status === "failed" || (row.status !== "skipped" && Boolean(row.error));
+    if (!isError) continue;
+    const timestamp = parseDatabaseTimestamp(row.created_at);
+    const key = `${row.repo}\u0000${row.pull_number}`;
+    const recoveredAt = latestPostedAtByPull.get(key);
+    if (!(recoveredAt !== undefined && Number.isFinite(timestamp) && recoveredAt > timestamp) &&
+        (!Number.isFinite(timestamp) || timestamp >= cutoff)) {
+      recentUnrecoveredErrorCount += 1;
+    }
+    if (Number.isFinite(timestamp) && (!lastErrorAt || timestamp > lastErrorAt.timestamp)) {
+      lastErrorAt = { value: row.created_at, timestamp };
+    }
+  }
+  return {
+    recentUnrecoveredErrorCount,
+    ...(lastErrorAt ? { lastErrorAt: lastErrorAt.value } : {}),
+    latestPostedAtByPull
+  };
+}
+
+function parseDatabaseTimestamp(value: string | null | undefined): number {
+  const text = value?.trim();
+  if (!text) return Number.NaN;
+  return Date.parse(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(text)
+    ? `${text.replace(" ", "T")}Z` : text);
+}
+
 function readReviewQueueCounts(
   db: DatabaseSync,
-  now: Date
+  now: Date,
+  latestPostedAtByPull: Map<string, number>
 ): {
   total: number;
   queued: number;
@@ -2388,7 +2493,9 @@ function readReviewQueueCounts(
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  activeFailed: number;
   zcodeTimeoutFailed: number;
+  activeZCodeTimeoutFailed: number;
   retryableZCodeTimeoutFailed: number;
   exhaustedZCodeTimeoutFailed: number;
   byRepo: ReviewQueueRepoStatus[];
@@ -2405,7 +2512,9 @@ function readReviewQueueCounts(
       providerDeferred: 0,
       retryableProviderDeferred: 0,
       failed: 0,
+      activeFailed: 0,
       zcodeTimeoutFailed: 0,
+      activeZCodeTimeoutFailed: 0,
       retryableZCodeTimeoutFailed: 0,
       exhaustedZCodeTimeoutFailed: 0,
       byRepo: []
@@ -2441,14 +2550,18 @@ function readReviewQueueCounts(
        order by repo`
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
-  const timeoutRows = db
-    .prepare(
-      `select last_error
+  const failedRows = db.prepare(
+    `select repo, pull_number, last_error, updated_at
        from review_queue_jobs
-       where state = 'failed' and last_error like ?`
-    )
-    .all(`${ZCODE_TIMEOUT_ERROR_PREFIX}%`) as unknown as Array<{ last_error: string | null }>;
-  const timeoutCounts = summarizeZCodeTimeoutErrors(timeoutRows.map((timeoutRow) => timeoutRow.last_error));
+      where state = 'failed'`
+  ).all() as unknown as FailedQueueRow[];
+  const activeFailedRows = failedRows.filter((row) => {
+    const recoveredAt = latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
+    const failedAt = parseDatabaseTimestamp(row.updated_at);
+    return recoveredAt === undefined || !Number.isFinite(failedAt) || recoveredAt <= failedAt;
+  });
+  const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
+  const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -2457,7 +2570,9 @@ function readReviewQueueCounts(
     providerDeferred: row.providerDeferred ?? 0,
     retryableProviderDeferred: row.retryableProviderDeferred ?? 0,
     failed: row.failed ?? 0,
+    activeFailed: activeFailedRows.length,
     zcodeTimeoutFailed: timeoutCounts.total,
+    activeZCodeTimeoutFailed: activeTimeoutCounts.total,
     retryableZCodeTimeoutFailed: timeoutCounts.retryable,
     exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,
     byRepo: byRepoRows.map((repoRow) => ({

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2454,16 +2454,20 @@ function readProcessedFailureHealth(db: DatabaseSync, now: Date, recovery: Failu
   lastErrorAt?: string;
 } {
   const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
-  const cutoff = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
+  const cutoffMs = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
+  const cutoff = new Date(cutoffMs).toISOString();
   const recent = db.prepare(
-    `select repo, pull_number, julianday(created_at) as failed_at from processed_reviews failed
+    `select repo, pull_number, created_at from processed_reviews failed
       where (${errorWhere})
-        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))`
-  ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; failed_at: number | null }>;
+        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?, '-1 second'))`
+  ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; created_at: string }>;
   return {
     recentUnrecoveredErrorCount: recent.filter((row) => {
+      const normalized = row.created_at.replace(" ", "T");
+      const failedAt = Date.parse(/[zZ]|[+-]\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`);
+      if (Number.isFinite(failedAt) && failedAt < cutoffMs) return false;
       const postedAt = recovery.latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
-      return row.failed_at === null || postedAt === undefined || postedAt <= row.failed_at;
+      return !Number.isFinite(failedAt) || postedAt === undefined || postedAt <= failedAt / 86_400_000 + 2440587.5;
     }).length,
     ...(recovery.lastErrorAt ? { lastErrorAt: recovery.lastErrorAt } : {})
   };

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -996,6 +996,25 @@ describe("operator CLI summaries", () => {
     expect(formatOperatorStatusHuman(active)).toContain("status: blocked (operator)");
   });
 
+  it("does not emit retry commands when active ZCode row identity is ambiguous", () => {
+    const jobs = ["recovered-head", "active-head"].map((headSha, index) => durableJob({
+      repo: "owner/repo", pullNumber: index + 1, headSha, state: "failed",
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1"
+    }));
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: false, database: {
+        failedReviewQueueJobCount: 2, activeFailedReviewQueueJobCount: 1,
+        zcodeTimeoutFailedReviewQueueJobCount: 2, activeZCodeTimeoutFailedReviewQueueJobCount: 1
+      } }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 2 }, jobs })
+    });
+    expect(status.recommendedActions.some((action) => action.includes("retry-failed"))).toBe(false);
+    expect(status.recommendedActions).toContain("npx tsx src/cli.ts queue --config /config/live.json --state failed");
+    const runtime = buildRuntimeInventory({ release: status.release, agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 2 }, jobs }) });
+    expect(runtime.recommendedActions.some((action) => action.includes("retry-failed"))).toBe(false);
+  });
+
   it("builds a read-only dashboard over coverage, durable queue, readiness, and evidence links", () => {
     const dashboard = buildOperatorDashboard({
       coverage: coverageReport({

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -19,6 +19,7 @@ import {
   explainPullStatus,
   filterBotProcessRows,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorAgentInventory,
@@ -969,6 +970,30 @@ describe("operator CLI summaries", () => {
     expect(output).toContain("queue: active=0 queued=0 running=0 providerDeferred=0 failed=0");
     expect(output).toContain("budget: wouldLease=1 delayed=1 delayedByReason={\"manual_reserve\":1}");
     expect(output).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("uses active failures for gates and keeps recovered history visible", () => {
+    const release = (active: number, recent: number) => releaseStatus({
+      ok: true,
+      database: {
+        errorCount: 2,
+        recentUnrecoveredErrorCount: recent,
+        failedReviewQueueJobCount: 2,
+        activeFailedReviewQueueJobCount: active,
+        zcodeTimeoutFailedReviewQueueJobCount: 1,
+        activeZCodeTimeoutFailedReviewQueueJobCount: active
+      }
+    });
+    const recovered = buildOperatorStatus({ release: release(0, 0), agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 2 }, jobs: [] }) });
+    expect(recovered.ok).toBe(true);
+    expect(recovered.summary.failedQueueJobs).toBe(2);
+    expect(recovered.gates).toContainEqual(expect.objectContaining({ name: "durable_queue_no_failed_jobs", ok: true }));
+    expect(recovered.gates).toContainEqual(expect.objectContaining({ name: "durable_queue_no_zcode_timeout_failed_jobs", ok: true }));
+    expect(formatOperatorStatusHuman(recovered)).toContain("status: ok (operator)");
+    expect(buildRuntimeInventory({ release: release(0, 0), agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 2 }, jobs: [] }) }).ok).toBe(true);
+    const active = buildOperatorStatus({ release: release(1, 1), agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 2 }, jobs: [] }) });
+    expect(active.ok).toBe(false);
+    expect(formatOperatorStatusHuman(active)).toContain("status: blocked (operator)");
   });
 
   it("builds a read-only dashboard over coverage, durable queue, readiness, and evidence links", () => {
@@ -1979,10 +2004,16 @@ function createTempDatabase(tempDirs: string[]): string {
   return join(dir, "state.sqlite");
 }
 
+type ActiveHealthDatabaseFixture = Partial<ReleaseStatus["database"]> & {
+  recentUnrecoveredErrorCount?: number;
+  activeFailedReviewQueueJobCount?: number;
+  activeZCodeTimeoutFailedReviewQueueJobCount?: number;
+};
+
 function releaseStatus(input: {
   ok: boolean;
   recommendedActions?: string[];
-  database?: Partial<ReleaseStatus["database"]>;
+  database?: ActiveHealthDatabaseFixture;
   budget?: ReviewBudgetStatus;
 }): ReleaseStatus {
   const providerCooldownCount = input.database?.providerCooldownCount ?? (input.ok ? 0 : 1);
@@ -2011,14 +2042,14 @@ function releaseStatus(input: {
 	      retryableExpiredProviderCooldowns: input.database?.retryableExpiredProviderCooldownCount ?? expiredProviderCooldownCount,
 	      activeProviderCooldowns: input.database?.activeProviderCooldownCount ?? 0
 	    },
-	    database: {
+    database: {
       rowCount: 10,
       errorCount: 0,
       providerCooldownCount,
       expiredProviderCooldownCount,
       activeProviderCooldownCount: 0,
       ...input.database
-    },
+    } as ReleaseStatus["database"],
     ...(input.budget ? { budget: input.budget } : {}),
     heartbeat: {
       status: "fresh",

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -220,6 +220,49 @@ describe("beta release status", () => {
     expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
   });
 
+  it("separates recovered history from recent UTC failures and active queue work", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-active-health-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`create table processed_reviews (repo text, pull_number integer, head_sha text, status text, error text, created_at text, primary key (repo, pull_number, head_sha));
+      create table review_queue_jobs (job_id text primary key, attempt_id text, source text, lane text, repo text, org text, pull_number integer, head_sha text, priority integer, state text, next_eligible_at text, lease_expires_at text, last_error text, created_at text, updated_at text);`);
+    const processed = db.prepare("insert into processed_reviews (repo,pull_number,head_sha,status,error,created_at) values (?,?,?,?,?,?)");
+    processed.run("owner/repo", 7, "old-failure", "failed", "provider timeout", "2026-08-21T23:30:00+07:00");
+    processed.run("owner/repo", 7, "old-posted", "posted", null, "2026-08-22T12:00:00Z");
+    processed.run("owner/repo", 8, "recent-failure", "failed", "provider timeout", "2026-08-22 23:30:00");
+    processed.run("owner/repo", 8, "recent-posted-before", "posted", null, "2026-08-22T22:00:00Z");
+    const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
+    queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
+    queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
+    db.close();
+    const status = collectReleaseStatus({
+      cwd: repoRoot,
+      statePath: dbPath,
+      configPath: join(root, "missing-config.json"),
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-08-23T00:00:00Z")
+    });
+
+    expect(status.database).toMatchObject({
+      errorCount: 2,
+      recentUnrecoveredErrorCount: 1,
+      lastErrorAt: "2026-08-22 23:30:00",
+      failedReviewQueueJobCount: 2,
+      activeFailedReviewQueueJobCount: 1,
+      zcodeTimeoutFailedReviewQueueJobCount: 1,
+      activeZCodeTimeoutFailedReviewQueueJobCount: 0
+    });
+    expect(status.gates).toContainEqual(expect.objectContaining({ name: "live_db_no_errors", ok: false }));
+    expect(status.gates).toContainEqual(expect.objectContaining({ name: "queue_no_failed_jobs", ok: false }));
+  });
+
+  it("keeps recovered historical failures amber rather than red", () => {
+    const status = buildReleaseStatus({ repo: { branch: "main", head: "head", dirtyFiles: [] }, expectedHead: "head", configPath: "/config/live.json", launchd: { label: "worker", state: "running", configPath: "/config/live.json", usesSystemCa: true }, database: { rowCount: 2, errorCount: 1, recentUnrecoveredErrorCount: 0, lastErrorAt: "2026-08-21T00:00:00Z", failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: 0, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: 0 }, heartbeat: freshHeartbeat(), now: new Date("2026-08-23T00:00:00Z") });
+    expect(status.ok).toBe(true);
+    expect(status.health).toMatchObject({ state: "amber", active: { failedQueueJobs: 0 }, recent: { unrecoveredReviewErrors: 0 }, history: { reviewErrors: 1, failedQueueJobs: 1 } });
+  });
+
   it("adds public release manifest gates while allowing an explicit source beta license API deferral", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-green-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -232,9 +232,14 @@ describe("beta release status", () => {
     processed.run("owner/repo", 7, "old-posted", "posted", null, "2026-08-22T12:00:00Z");
     processed.run("owner/repo", 8, "recent-failure", "failed", "provider timeout", "2026-08-22 23:30:00");
     processed.run("owner/repo", 8, "recent-posted-before", "posted", null, "2026-08-22T22:00:00Z");
+    processed.run("owner/repo", 9, "millisecond-failure", "failed", "provider timeout", "2026-08-22T23:45:00.100Z");
+    processed.run("owner/repo", 9, "millisecond-posted", "posted", null, "2026-08-22T23:45:00.900Z");
+    db.exec(`with recursive n(x) as (values(1) union all select x+1 from n where x<10000) insert into processed_reviews select 'history/repo',x,'history-'||x,'posted',null,'2026-01-01T00:00:00Z' from n;
+      with recursive n(x) as (values(1) union all select x+1 from n where x<100) insert into processed_reviews select 'error/repo',x,'error-'||x,'failed','provider timeout','2026-08-22T23:00:00Z' from n;`);
     const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
     queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
     queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
+    queue.run("millisecond", "millisecond", "automatic", "background", "owner/repo", "owner", 9, "millisecond-failure", 1, "failed", "ordinary failure", "2026-08-22T23:45:00.100Z", "2026-08-22T23:45:00.100Z");
     db.close();
     const status = collectReleaseStatus({
       cwd: repoRoot,
@@ -245,10 +250,10 @@ describe("beta release status", () => {
     });
 
     expect(status.database).toMatchObject({
-      errorCount: 2,
-      recentUnrecoveredErrorCount: 1,
-      lastErrorAt: "2026-08-22 23:30:00",
-      failedReviewQueueJobCount: 2,
+      errorCount: 103,
+      recentUnrecoveredErrorCount: 101,
+      lastErrorAt: "2026-08-22T23:45:00.100Z",
+      failedReviewQueueJobCount: 3,
       activeFailedReviewQueueJobCount: 1,
       zcodeTimeoutFailedReviewQueueJobCount: 1,
       activeZCodeTimeoutFailedReviewQueueJobCount: 0

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -236,6 +236,7 @@ describe("beta release status", () => {
     processed.run("owner/repo", 9, "millisecond-posted", "posted", null, "2026-08-22T23:45:00.900Z");
     db.exec(`with recursive n(x) as (values(1) union all select x+1 from n where x<10000) insert into processed_reviews select 'history/repo',x,'history-'||x,'posted',null,'2026-01-01T00:00:00Z' from n;
       with recursive n(x) as (values(1) union all select x+1 from n where x<100) insert into processed_reviews select 'error/repo',x,'error-'||x,'failed','provider timeout','2026-08-22T23:00:00Z' from n;`);
+    db.exec("insert into processed_reviews values ('owner/repo',10,'outside-cutoff','failed','provider timeout','2026-08-22T00:00:00.100Z'),('owner/repo',11,'exact-cutoff','failed','provider timeout','2026-08-22T07:00:00.500+07:00'),('owner/repo',12,'inside-cutoff','failed','provider timeout','2026-08-22T00:00:00.900Z')");
     const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
     queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
     queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
@@ -246,12 +247,12 @@ describe("beta release status", () => {
       statePath: dbPath,
       configPath: join(root, "missing-config.json"),
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
-      now: new Date("2026-08-23T00:00:00Z")
+      now: new Date("2026-08-23T00:00:00.500Z")
     });
 
     expect(status.database).toMatchObject({
-      errorCount: 103,
-      recentUnrecoveredErrorCount: 101,
+      errorCount: 106,
+      recentUnrecoveredErrorCount: 103,
       lastErrorAt: "2026-08-22T23:45:00.100Z",
       failedReviewQueueJobCount: 3,
       activeFailedReviewQueueJobCount: 1,


### PR DESCRIPTION
Related: #741

## Summary
- gate operator status and runtime inventory on active/unrecovered failures while retaining all-time counts
- suppress retry-failed commands whenever active ZCode row identity is ambiguous
- make the human status headline reflect combined operator health and document status --human

## Stack
- Base PR: #821
- Base head: 8f0cb626d4ddcf90224fc942f5878e9a7a809dc8
- This head: e5fa6e3fa7ee36ae73c750cb05024178ef478624
- Merge #821 first.

## Validation
- combined focused Vitest: 165 passed across tests/release-status.test.ts and tests/operator-cli.test.ts
- mixed recovered/active ZCode fixture proves status and runtime emit no retry-failed command
- git diff --check against #821 head
- canonical GitHub CI is the authoritative full test/build/package gate

No live worker, LaunchAgent, config, database, queue, Keychain, release, or customer state was changed.