### PR TITLE
feat: add strict severe verification receipt parser

### DIFF
--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -57,7 +57,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
   if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
   if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
-  if (!Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
+  if (typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
   if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
   if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
   if (!string(receipt.findingFingerprint) || !/^finding:[a-f0-9]{64}$/.test(receipt.findingFingerprint)) errors.push("findingFingerprint is invalid");
@@ -68,7 +68,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
   validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
-  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as SevereVerificationReceipt };
+  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as unknown as SevereVerificationReceipt };
 }
 
 export function parseSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereVerificationReceipt {
@@ -87,7 +87,7 @@ function validateEvidence(value: unknown, state: unknown, expectedPath: string |
   if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
   for (const item of value.files) {
     const file = record(item) ? item : undefined;
-    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
   }
   for (const item of value.omitted) {
     const omission = record(item) ? item : undefined;

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -96,7 +96,7 @@ function validateEvidence(value: unknown, state: unknown, expectedPath: string |
   const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
   if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
   if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
-  if (expectedPath !== undefined && (!safePath(expectedPath) || (value.files.length > 0 && !value.files.some((file) => record(file) && file.path === expectedPath)))) errors.push("evidence does not cover expected path");
+  if (expectedPath !== undefined && (!safePath(expectedPath) || ![...value.files, ...value.omitted].some((entry) => record(entry) && entry.path === expectedPath))) errors.push("evidence does not cover expected path");
   if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
 }
 

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -1,0 +1,114 @@
+export const SEVERE_VERIFICATION_STATES = [
+  "confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+] as const;
+export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
+export type SevereVerificationDisposition = "retain" | "suppress";
+export type SevereEvidenceKind = "whole_file" | "module";
+export type SevereVerificationCode =
+  | "not_read" | "refuted" | "malformed" | "timeout" | "unavailable" | "stale_head"
+  | "incomplete" | "schema_invalid" | "identity_mismatch" | "evidence_incomplete"
+  | "provider_unavailable" | "cap_exceeded" | "receipt_invalid";
+
+export interface SevereVerificationEvidenceFile {
+  path: string;
+  kind: SevereEvidenceKind;
+  sha256: string;
+  bytes: number;
+  complete: boolean;
+}
+export interface SevereVerificationEvidenceOmission { path: string; code: SevereVerificationCode; }
+export interface SevereVerificationEvidence {
+  files: SevereVerificationEvidenceFile[];
+  omitted: SevereVerificationEvidenceOmission[];
+  complete: boolean;
+}
+export interface SevereVerificationReceipt {
+  schemaVersion: "severe-verifier-v1";
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  findingFingerprint: string;
+  headSha: string;
+  state: SevereVerificationState;
+  disposition: SevereVerificationDisposition;
+  confidence?: number;
+  reasonCode?: SevereVerificationCode;
+  evidence: SevereVerificationEvidence;
+}
+export interface SevereReceiptValidationOptions { expectedPath?: string; }
+export type SevereReceiptValidation =
+  | { ok: true; value: SevereVerificationReceipt }
+  | { ok: false; errors: string[] };
+
+const CODES = new Set<string>([
+  "not_read", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete",
+  "schema_invalid", "identity_mismatch", "evidence_incomplete", "provider_unavailable",
+  "cap_exceeded", "receipt_invalid"
+]);
+const KINDS = new Set(["whole_file", "module"]);
+const STATES = new Set<string>(SEVERE_VERIFICATION_STATES);
+const SHA40 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+export function validateSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereReceiptValidation {
+  const errors: string[] = [];
+  if (!record(value)) return { ok: false, errors: ["receipt must be an object"] };
+  const receipt = value;
+  if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
+  if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
+  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
+  if (!Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
+  if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
+  if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
+  if (!string(receipt.findingFingerprint) || !/^finding:[a-f0-9]{64}$/.test(receipt.findingFingerprint)) errors.push("findingFingerprint is invalid");
+  if (!string(receipt.state) || !STATES.has(receipt.state)) errors.push("state is invalid");
+  if (receipt.disposition !== "retain" && receipt.disposition !== "suppress") errors.push("disposition is invalid");
+  if (receipt.confidence !== undefined && (!number(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) errors.push("confidence is invalid");
+  if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
+  if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
+  if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
+  validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
+  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as SevereVerificationReceipt };
+}
+
+export function parseSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereVerificationReceipt {
+  const result = validateSevereVerificationReceipt(value, options);
+  if (!result.ok) throw new Error(`severe_verification_receipt_invalid: ${result.errors.join(",")}`);
+  return result.value;
+}
+
+export function isSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): value is SevereVerificationReceipt {
+  return validateSevereVerificationReceipt(value, options).ok;
+}
+
+function validateEvidence(value: unknown, state: unknown, expectedPath: string | undefined, errors: string[]): void {
+  if (!record(value) || !exact(value, ["files", "omitted", "complete"])) { errors.push("evidence shape is invalid"); return; }
+  if (!Array.isArray(value.files) || !Array.isArray(value.omitted) || typeof value.complete !== "boolean") { errors.push("evidence types are invalid"); return; }
+  if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
+  for (const item of value.files) {
+    const file = record(item) ? item : undefined;
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+  }
+  for (const item of value.omitted) {
+    const omission = record(item) ? item : undefined;
+    if (!omission || !exact(omission, ["path", "code"]) || !safePath(omission.path) || !string(omission.code) || !CODES.has(omission.code)) errors.push("evidence omission is invalid");
+  }
+  const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
+  if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
+  if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
+  if (expectedPath !== undefined && (!safePath(expectedPath) || (value.files.length > 0 && !value.files.some((file) => record(file) && file.path === expectedPath)))) errors.push("evidence does not cover expected path");
+  if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
+}
+
+function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function exact(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return required.every((key) => Object.hasOwn(value, key)) && Reflect.ownKeys(value).every((key) => typeof key === "string" && allowed.has(key));
+}
+function string(value: unknown): value is string { return typeof value === "string"; }
+function number(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value); }
+function byteLength(value: string): number { return Buffer.byteLength(value, "utf8"); }
+function safePath(value: unknown): value is string {
+  if (!string(value) || value.length === 0 || byteLength(value) > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n]/.test(value)) return false;
+  return value.split("/").every((part) => part.length > 0 && part !== "." && part !== "..");
+}

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -1,5 +1,5 @@
 export const SEVERE_VERIFICATION_STATES = [
-  "confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+  "confirmed", "refuted", "failed", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
 ] as const;
 export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
 export type SevereVerificationDisposition = "retain" | "suppress";
@@ -49,6 +49,10 @@ const KINDS = new Set(["whole_file", "module"]);
 const STATES = new Set<string>(SEVERE_VERIFICATION_STATES);
 const SHA40 = /^[a-f0-9]{40}$/;
 const SHA256 = /^[a-f0-9]{64}$/;
+export const MAX_SEVERE_EVIDENCE_FILE_BYTES = 64 * 1024;
+const MAX_SEVERE_EVIDENCE_ENTRIES = 64;
+const MAX_SEVERE_EVIDENCE_TOTAL_BYTES = 256 * 1024;
+const MAX_SEVERE_EVIDENCE_PATH_BYTES = 64 * 1024;
 
 export function validateSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereReceiptValidation {
   const errors: string[] = [];
@@ -67,6 +71,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
+  if (!validStateReason(receipt.state, receipt.reasonCode)) errors.push("state and reasonCode are inconsistent");
   validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
   return errors.length ? { ok: false, errors } : { ok: true, value: receipt as unknown as SevereVerificationReceipt };
 }
@@ -84,20 +89,32 @@ export function isSevereVerificationReceipt(value: unknown, options: SevereRecei
 function validateEvidence(value: unknown, state: unknown, expectedPath: string | undefined, errors: string[]): void {
   if (!record(value) || !exact(value, ["files", "omitted", "complete"])) { errors.push("evidence shape is invalid"); return; }
   if (!Array.isArray(value.files) || !Array.isArray(value.omitted) || typeof value.complete !== "boolean") { errors.push("evidence types are invalid"); return; }
+  if (value.files.length + value.omitted.length > MAX_SEVERE_EVIDENCE_ENTRIES) { errors.push("evidence has too many entries"); return; }
   if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
   for (const item of value.files) {
     const file = record(item) ? item : undefined;
-    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > MAX_SEVERE_EVIDENCE_FILE_BYTES || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
   }
   for (const item of value.omitted) {
     const omission = record(item) ? item : undefined;
     if (!omission || !exact(omission, ["path", "code"]) || !safePath(omission.path) || !string(omission.code) || !CODES.has(omission.code)) errors.push("evidence omission is invalid");
   }
   const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
+  const totalBytes = value.files.reduce((sum, file) => sum + (record(file) && typeof file.bytes === "number" && Number.isSafeInteger(file.bytes) && file.bytes >= 0 ? file.bytes : 0), 0);
+  const pathBytes = [...value.files, ...value.omitted].reduce((sum, entry) => sum + (record(entry) && string(entry.path) ? byteLength(entry.path) : 0), 0);
+  if (totalBytes > MAX_SEVERE_EVIDENCE_TOTAL_BYTES || pathBytes > MAX_SEVERE_EVIDENCE_PATH_BYTES) errors.push("evidence exceeds aggregate limits");
   if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
   if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
   if (expectedPath !== undefined && (!safePath(expectedPath) || ![...value.files, ...value.omitted].some((entry) => record(entry) && entry.path === expectedPath))) errors.push("evidence does not cover expected path");
   if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
+}
+
+function validStateReason(state: unknown, reason: unknown): boolean {
+  if (!string(state) || !STATES.has(state) || (reason !== undefined && !string(reason))) return false;
+  if (state === "confirmed") return reason === undefined;
+  if (state === "refuted") return reason === undefined || reason === "refuted";
+  const allowed: Record<string, string[]> = { failed: ["provider_unavailable", "receipt_invalid"], malformed: ["malformed", "schema_invalid", "receipt_invalid"], timeout: ["timeout"], unavailable: ["unavailable", "provider_unavailable"], stale_head: ["stale_head", "identity_mismatch"], incomplete: ["incomplete", "not_read", "evidence_incomplete", "cap_exceeded"] };
+  return reason !== undefined && (allowed[state]?.includes(reason) ?? false);
 }
 
 function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -35,7 +35,7 @@ export interface SevereVerificationReceipt {
   reasonCode?: SevereVerificationCode;
   evidence: SevereVerificationEvidence;
 }
-export interface SevereReceiptValidationOptions { expectedPath?: string; }
+export interface SevereReceiptValidationOptions { expectedRepo?: string; expectedPullNumber?: number; expectedBaseSha?: string; expectedHeadSha?: string; expectedFindingFingerprint?: string; expectedPath?: string; }
 export type SevereReceiptValidation =
   | { ok: true; value: SevereVerificationReceipt }
   | { ok: false; errors: string[] };
@@ -60,7 +60,8 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   const receipt = value;
   if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
   if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
-  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
+  const repoParts = string(receipt.repo) ? receipt.repo.split("/") : [];
+  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || repoParts.some((part) => part === "." || part === "..") || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
   if (typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
   if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
   if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
@@ -69,6 +70,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.disposition !== "retain" && receipt.disposition !== "suppress") errors.push("disposition is invalid");
   if (receipt.confidence !== undefined && (!number(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) errors.push("confidence is invalid");
   if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
+  if ((options.expectedRepo !== undefined && receipt.repo !== options.expectedRepo) || (options.expectedPullNumber !== undefined && receipt.pullNumber !== options.expectedPullNumber) || (options.expectedBaseSha !== undefined && receipt.baseSha !== options.expectedBaseSha) || (options.expectedHeadSha !== undefined && receipt.headSha !== options.expectedHeadSha) || (options.expectedFindingFingerprint !== undefined && receipt.findingFingerprint !== options.expectedFindingFingerprint)) errors.push("receipt identity mismatch");
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
   if (!validStateReason(receipt.state, receipt.reasonCode)) errors.push("state and reasonCode are inconsistent");

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -39,8 +39,16 @@ describe("severe verification receipt parser", () => {
     const states = ["refuted", "timeout", "unavailable", "malformed", "stale_head", "incomplete"] as const;
     for (const state of states) {
       const evidence = state === "incomplete" ? { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } : base().evidence;
-      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", evidence }));
+      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", reasonCode: state === "refuted" ? "refuted" : state, evidence }));
       expect(parsed.state).toBe(state);
     }
+    expect(parseSevereVerificationReceipt(receipt({ state: "failed", disposition: "suppress", reasonCode: "provider_unavailable" })).state).toBe("failed");
+    expect(isSevereVerificationReceipt(receipt({ reasonCode: "timeout" }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress", reasonCode: "provider_unavailable" }))).toBe(false);
+  });
+
+  it("bounds evidence cardinality and proof sizes", () => {
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", reasonCode: "incomplete", evidence: { files: [], omitted: Array.from({ length: 10_000 }, () => ({ path, code: "incomplete" })), complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ ...base().evidence.files[0], bytes: 2 ** 32 }], omitted: [], complete: true } }))).toBe(false);
   });
 });

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -31,6 +31,7 @@ describe("severe verification receipt parser", () => {
     expect(isSevereVerificationReceipt(receipt({ evidence: { files: [], omitted: [], complete: false } }))).toBe(false);
     expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress" }), { expectedPath: path })).toBe(true);
     expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", evidence: { files: [], omitted: [{ path: "other.ts", code: "incomplete" }], complete: false } }), { expectedPath: path })).toBe(false);
     expect(isSevereVerificationReceipt(receipt({ reasonCode: "free-form prose" }))).toBe(false);
   });
 

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isSevereVerificationReceipt, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+import { isSevereVerificationReceipt, parseSevereVerificationReceipt, validateSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
 
 const path = "src/safe file+Δ.ts";
 const base = () => ({ schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`, headSha: "a".repeat(40), state: "confirmed", disposition: "retain", confidence: 0.9, evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true } });
@@ -25,6 +25,11 @@ describe("severe verification receipt parser", () => {
       expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path: unsafe, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } }))).toBe(false);
     }
     expect(isSevereVerificationReceipt(receipt(), { expectedPath: "src/other.ts" })).toBe(false);
+  });
+
+  it("rejects dot repositories and mismatched review identities", () => {
+    for (const repo of ["./repo", "owner/.."]) expect(isSevereVerificationReceipt(receipt({ repo }))).toBe(false);
+    for (const [key, value] of [["expectedRepo", "other/repo"], ["expectedPullNumber", 8], ["expectedBaseSha", "c".repeat(40)], ["expectedHeadSha", "d".repeat(40)], ["expectedFindingFingerprint", `finding:${"e".repeat(64)}`]]) expect(validateSevereVerificationReceipt(receipt(), { [key]: value } as never)).toEqual({ ok: false, errors: ["receipt identity mismatch"] });
   });
 
   it("requires nonempty, complete, relevant evidence for confirmed/refuted states", () => {

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isSevereVerificationReceipt, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+
+const path = "src/safe file+Δ.ts";
+const base = () => ({ schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`, headSha: "a".repeat(40), state: "confirmed", disposition: "retain", confidence: 0.9, evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true } });
+const receipt = (changes: Record<string, unknown> = {}) => ({ ...base(), ...changes });
+
+describe("severe verification receipt parser", () => {
+  it("accepts strict identity, bounded metadata, safe Unicode paths, and expected coverage", () => {
+    const longPath = `${"a".repeat(4070)} + safe λ.ts`;
+    const value = receipt({ evidence: { files: [{ path: longPath, kind: "whole_file", sha256: "d".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } });
+    expect(parseSevereVerificationReceipt(value, { expectedPath: longPath }).evidence.files[0]?.path).toBe(longPath);
+  });
+
+  it("rejects malformed, extra-field, coercion, and array values", () => {
+    expect(isSevereVerificationReceipt([])).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ extra: true }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ pullNumber: "7" }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ headSha: new String("a".repeat(40)) }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { ...base().evidence, files: [base().evidence.files[0], "not an object"] } }))).toBe(false);
+  });
+
+  it("rejects absolute, traversal, backslash, NUL, and unrelated evidence paths", () => {
+    for (const unsafe of ["/tmp/x.ts", "../x.ts", "src/../x.ts", "src\\x.ts", `src/${String.fromCharCode(0)}x.ts`]) {
+      expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path: unsafe, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } }))).toBe(false);
+    }
+    expect(isSevereVerificationReceipt(receipt(), { expectedPath: "src/other.ts" })).toBe(false);
+  });
+
+  it("requires nonempty, complete, relevant evidence for confirmed/refuted states", () => {
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [], omitted: [], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress" }), { expectedPath: path })).toBe(true);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ reasonCode: "free-form prose" }))).toBe(false);
+  });
+
+  it("keeps refuted distinct from timeout, unavailable, malformed, stale-head, and incomplete", () => {
+    const states = ["refuted", "timeout", "unavailable", "malformed", "stale_head", "incomplete"] as const;
+    for (const state of states) {
+      const evidence = state === "incomplete" ? { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } : base().evidence;
+      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", evidence }));
+      expect(parsed.state).toBe(state);
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n\n- add an unwired strict parser, validator, and types for severe-verification receipts\n- bound metadata to enum codes, digests, counts, and safe repository-relative paths\n- add focused malformed, coercion, path, evidence, and state-taxonomy tests\n\nRelated: #807\n\n## Validation\n\n- git diff --check passed\n- focused test command npx vitest run tests/severe-verification-receipt.test.ts --reporter=dot was attempted but could not collect because the temporary npx Vitest/Rolldown install is missing its native binding; dependencies were not installed per task authority\n- 159 non-generated added lines across two new files\n- no production worker, self-consistency, provider, DB, config, or runtime wiring changed\n\nAgent-authored Slice A split from held PR #818; this PR is source/test-only and does not prove integration, merge, release, runtime, or customer readiness.