### PR TITLE
fix(issue-enrichment): refresh daemon heartbeat during stages

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,11 @@ import { resolve } from "node:path";
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { GitHubApi } from "./github.js";
-import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
+import {
+  runIssueEnrichmentCycle,
+  type IssueEnrichmentCycleResult,
+  type IssueEnrichmentProgress
+} from "./issue-enrichment.js";
 import { runScheduledCycle } from "./scheduler.js";
 import {
   isAuthenticProductionLicenseAdmission,
@@ -52,6 +56,7 @@ export interface RunDaemonCycleOptions {
     configPath?: string;
     dryRun: boolean;
     licenseAdmission?: ProductionLicenseAdmission;
+    onProgress?: (progress: IssueEnrichmentProgress) => void;
   }) => Promise<IssueEnrichmentCycleResult>;
   cleanupReviewWorktreesImpl?: (options: { configPath?: string; dryRun: boolean }) => ReviewWorktreeCleanupSummary;
   recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
@@ -131,7 +136,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, recordHeartbeat, stdout, stderr })
     : Promise.resolve();
 
   try {
@@ -266,6 +271,7 @@ function summarizeWorktreeCleanup(cleanup: ReviewWorktreeCleanupSummary): Record
 async function runIssueEnrichmentLane(input: {
   input: RunDaemonCycleOptions;
   admissions: DaemonCycleAdmissions | void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string) => void;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }): Promise<void> {
@@ -275,11 +281,41 @@ async function runIssueEnrichmentLane(input: {
     cycle: input.input.cycle,
     dryRun: input.input.dryRun
   }));
+  const startedAt = Date.now();
+  const refreshHeartbeat = (): void => {
+    try {
+      input.recordHeartbeat("daemon_cycle_start");
+    } catch (error) {
+      input.stderr(formatDaemonLog({
+        event: "daemon_heartbeat_failed",
+        level: "error",
+        cycle: input.input.cycle,
+        dryRun: input.input.dryRun,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    }
+  };
+  const heartbeatTimer = setInterval(refreshHeartbeat, 60_000);
   try {
     const issueEnrichment = await issueEnrichmentCycleImpl({
       configPath: input.input.configPath,
       dryRun: input.input.dryRun,
-      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
+      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {}),
+      onProgress: (progress) => {
+        const elapsedMs = Math.min(86_400_000, Math.max(0, Date.now() - startedAt));
+        refreshHeartbeat();
+        input.stdout(formatDaemonLog({
+          event: "daemon_issue_enrichment_progress",
+          cycle: input.input.cycle,
+          dryRun: input.input.dryRun,
+          stage: progress.stage,
+          phase: progress.phase,
+          elapsedMs,
+          ...(progress.count === undefined
+            ? {}
+            : { count: Math.min(10_000, Math.max(0, Math.trunc(progress.count))) })
+        }));
+      }
     });
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
@@ -297,6 +333,8 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       error: message
     }));
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 }
 
@@ -315,6 +353,7 @@ async function runIssueEnrichmentCycleFromConfig(input: {
   configPath?: string;
   dryRun: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   const config = loadConfig(input.configPath);
   let licenseAdmission = input.licenseAdmission;
@@ -336,7 +375,8 @@ async function runIssueEnrichmentCycleFromConfig(input: {
       state,
       github: new GitHubApi(config.github),
       dryRun: input.dryRun,
-      licenseAdmission
+      licenseAdmission,
+      onProgress: input.onProgress
     });
   } finally {
     state.close();

--- a/src/github.ts
+++ b/src/github.ts
@@ -293,7 +293,8 @@ export class GitHubApi {
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100 || page === MAX_ISSUE_LABEL_EVENT_PAGES) return events;
+      if (chunk.length < 100) return events;
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) throw new Error("GitHub issue label event scan exceeded page limit");
     }
     return events;
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -17,6 +17,13 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  * is found well within this window; exceeding it truncates rather than paging forever.
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
+/**
+ * Bound issue comment/event reads as well. Issue enrichment retains only a small
+ * evidence prefix, and an issue with a permanently full page must not hold the
+ * worker lease (or the daemon heartbeat) forever.
+ */
+const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface GitHubApiOptions {
@@ -257,14 +264,15 @@ export class GitHubApi {
 
   async listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]> {
     const comments: IssueCommentCommandSource[] = [];
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const chunk = await this.request<IssueCommentCommandSource[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token: await this.getReadToken(repo) }
       );
       comments.push(...chunk);
-      if (chunk.length < 100) return comments;
+      if (chunk.length < 100 || page === MAX_ISSUE_COMMENT_PAGES) return comments;
     }
+    return comments;
   }
 
   async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
@@ -279,14 +287,15 @@ export class GitHubApi {
       actor?: { login?: string | null } | null;
       label?: { name?: string | null } | null;
     }> = [];
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_LABEL_EVENT_PAGES; page += 1) {
       const chunk = await this.request<typeof events>(
         `/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`,
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100 || page === MAX_ISSUE_LABEL_EVENT_PAGES) return events;
     }
+    return events;
   }
 
   async getCollaboratorPermission(
@@ -434,7 +443,7 @@ export class GitHubApi {
     marker: string,
     token: string
   ): Promise<IssueCommentSummary | undefined> {
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const comments = await this.request<IssueCommentSummary[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
@@ -443,6 +452,7 @@ export class GitHubApi {
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
+    throw new Error("GitHub issue comment marker scan exceeded page limit");
   }
 
   private isBotAuthoredComment(comment: IssueCommentSummary): boolean {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -429,7 +429,8 @@ async function evaluateIssuePromotion(input: {
       },
       evidence
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.message === "GitHub issue label event scan exceeded page limit") throw error;
     return { issue: input.issue };
   }
 }

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -274,6 +274,21 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
   }>;
 }
 
+export const ISSUE_ENRICHMENT_PROGRESS_STAGES = [
+  "source_snapshot",
+  "github_evidence",
+  "analysis",
+  "post",
+  "persist"
+] as const;
+export type IssueEnrichmentProgressStage = typeof ISSUE_ENRICHMENT_PROGRESS_STAGES[number];
+export type IssueEnrichmentProgressPhase = "start" | "complete";
+export interface IssueEnrichmentProgress {
+  stage: IssueEnrichmentProgressStage;
+  phase: IssueEnrichmentProgressPhase;
+  count?: number;
+}
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
   listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
@@ -788,6 +803,7 @@ export async function runIssueEnrichmentCycle(input: {
   preacquiredLease?: { leaseId: string };
   licenseAdmission?: ProductionLicenseAdmission;
   analyzeIssue?: IssueAnalysisRunner;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   if (!input.licenseAdmission) throw new Error("production license admission is required for issue enrichment cycles");
   if (!isAuthenticProductionLicenseAdmission(input.licenseAdmission, "issue_enrichment")) {
@@ -795,6 +811,21 @@ export async function runIssueEnrichmentCycle(input: {
   }
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const reportProgress = (
+    stage: IssueEnrichmentProgressStage,
+    phase: IssueEnrichmentProgressPhase,
+    count?: number
+  ): void => {
+    try {
+      input.onProgress?.({
+        stage,
+        phase,
+        ...(count === undefined ? {} : { count: Math.max(0, Math.min(10_000, Math.trunc(count))) })
+      });
+    } catch {
+      // Progress reporting is diagnostic and must not change cycle semantics.
+    }
+  };
   const shouldCollectModelEvidence = !input.dryRun && config.postIssueComment && input.analyzeIssue === undefined;
   const renderPolicy = resolveIssueEnrichmentRenderPolicy(input.config);
   const releasePreacquiredLeaseBeforeRun = () => {
@@ -860,6 +891,19 @@ export async function runIssueEnrichmentCycle(input: {
     }
   }
 
+  const recordEnrichment = (record: Parameters<typeof input.state.recordIssueEnrichment>[0]): void => {
+    reportProgress("persist", "start");
+    input.state.recordIssueEnrichment(record);
+    reportProgress("persist", "complete");
+  };
+  const recordWatermark = (
+    record: Parameters<typeof input.state.recordIssueEnrichmentRepoWatermark>[0]
+  ): void => {
+    reportProgress("persist", "start");
+    input.state.recordIssueEnrichmentRepoWatermark(record);
+    reportProgress("persist", "complete");
+  };
+
   try {
     const baselineRepos: IssueEnrichmentRepoScan[] = [];
     const reposToScan: string[] = [];
@@ -887,7 +931,7 @@ export async function runIssueEnrichmentCycle(input: {
         continue;
       }
       if (!input.dryRun && input.advanceWatermarks !== false) {
-        input.state.recordIssueEnrichmentRepoWatermark({
+        recordWatermark({
           repo,
           activatedAt: checkedAt,
           lastCheckedAt: checkedAt,
@@ -915,6 +959,7 @@ export async function runIssueEnrichmentCycle(input: {
 
     const sourceSnapshots = new Map<string, PreparedWorktree>();
     const defaultBranches = new Map<string, string>();
+    reportProgress("source_snapshot", "start", reposToScan.length);
     if (shouldCollectModelEvidence) {
       if (!input.config.workRoot) throw new Error("issue_enrichment_model_runtime_paths_required");
       if (!input.github.getRepo) throw new Error("issue_enrichment_repository_metadata_required");
@@ -934,6 +979,7 @@ export async function runIssueEnrichmentCycle(input: {
         defaultBranches.set(repo.toLowerCase(), defaultBranch);
       }
     }
+    reportProgress("source_snapshot", "complete", sourceSnapshots.size);
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
     const issueEvidenceContextByIssue = new Map<string, IssueAnalysisEvidenceContext>();
@@ -998,6 +1044,7 @@ export async function runIssueEnrichmentCycle(input: {
         : undefined;
       return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action));
     };
+    reportProgress("github_evidence", "start", reposToScan.length);
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
           config: input.config,
@@ -1050,6 +1097,7 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
+    reportProgress("github_evidence", "complete", scanned.summary.issuesSeen);
     applyGlobalIssueEnrichmentCaps({
       items: scanned.items,
       repoScans: scanned.repos,
@@ -1090,7 +1138,7 @@ export async function runIssueEnrichmentCycle(input: {
           existing.issueUpdatedAt !== issueUpdatedAt ||
           refreshedAnalysisInputHash !== existing.analysisInputHash
         )) {
-          input.state.recordIssueEnrichment({
+          recordEnrichment({
             repo: item.repo,
             issueNumber: item.issueNumber,
             issueUpdatedAt,
@@ -1114,7 +1162,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (item.action === "skipped") {
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1128,7 +1176,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (item.action === "deferred") {
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1144,7 +1192,7 @@ export async function runIssueEnrichmentCycle(input: {
 
       if (!config.postIssueComment || item.action === "would_enrich") {
         const dryRunAnalysisInputHash = plannedAnalysisInputHashForItem(item);
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1200,6 +1248,7 @@ export async function runIssueEnrichmentCycle(input: {
           return result.analysis;
         });
         const runtime = input.config.codexRuntime;
+        reportProgress("analysis", "start");
         const analysis = await analyzer({
           repo: item.repo,
           issue,
@@ -1216,6 +1265,7 @@ export async function runIssueEnrichmentCycle(input: {
           timeoutMs: runtime?.timeoutMs ?? 1,
           maxOutputBytes: runtime?.maxOutputBytes ?? 1
         });
+        reportProgress("analysis", "complete");
         if (!input.github.getIssueOrPull && input.analyzeIssue === undefined) {
           throw new Error("issue_enrichment_current_issue_read_required");
         }
@@ -1240,7 +1290,7 @@ export async function runIssueEnrichmentCycle(input: {
         });
         const postBodyHash = enrichment.bodyHash;
         if (input.force !== true && existing?.status === "posted" && existing.bodyHash === postBodyHash) {
-          input.state.recordIssueEnrichment({
+          recordEnrichment({
             repo: item.repo,
             issueNumber: item.issueNumber,
             issueUpdatedAt,
@@ -1260,6 +1310,7 @@ export async function runIssueEnrichmentCycle(input: {
           });
           continue;
         }
+        reportProgress("post", "start");
         const post = await postEnrichmentComment({
           enabled: true,
           dryRun: false,
@@ -1268,9 +1319,10 @@ export async function runIssueEnrichmentCycle(input: {
           pullNumber: item.issueNumber,
           enrichment
         });
+        reportProgress("post", "complete");
         if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.reason}`);
         const commentUrl = post.html_url ? redactSecrets(post.html_url) : undefined;
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1284,7 +1336,7 @@ export async function runIssueEnrichmentCycle(input: {
         items.push({ ...item, recordStatus: "posted", ...(commentUrl ? { commentUrl } : {}) });
       } catch (error) {
         const message = redactSecrets(error instanceof Error ? error.message : String(error));
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1305,7 +1357,7 @@ export async function runIssueEnrichmentCycle(input: {
         const repoItems = items.filter((item) => item.repo === repo.repo);
         if (repo.truncated || repoItems.some((item) => item.recordStatus === "deferred" || item.recordStatus === "failed")) continue;
         const existingWatermark = input.state.getIssueEnrichmentRepoWatermark(repo.repo);
-        input.state.recordIssueEnrichmentRepoWatermark({
+        recordWatermark({
           repo: repo.repo,
           activatedAt: existingWatermark?.activatedAt ?? checkedAt,
           lastCheckedAt: checkedAt,

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -338,6 +338,41 @@ describe("daemon cycle resilience", () => {
     expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
   });
 
+  it("refreshes the active heartbeat with bounded issue-enrichment progress", async () => {
+    const heartbeats: string[] = [];
+    const stdout: string[] = [];
+    const timerCallbacks: Array<() => void> = [];
+    const timerSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((callback) => (timerCallbacks.push(callback as () => void), 1 as never));
+    const result = await runDaemonCycle({
+      cycle: 3,
+      dryRun: false,
+      pilotRepos: [],
+      monitoredRepos: [],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(),
+      issueEnrichmentCycleImpl: async (options) => {
+        timerCallbacks[0]?.();
+        options.onProgress?.({ stage: "analysis", phase: "start", count: 99_999 });
+        options.onProgress?.({ stage: "analysis", phase: "complete", count: 1 });
+        return successfulIssueEnrichmentCycleResult();
+      },
+      recordHeartbeatImpl: (event) => heartbeats.push(event),
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+    timerSpy.mockRestore();
+
+    expect(result.ok).toBe(true);
+    expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_complete"]);
+    const progress = stdout.map((line) => JSON.parse(line)).filter((line) => line.event === "daemon_issue_enrichment_progress");
+    expect(progress).toEqual([expect.objectContaining({ stage: "analysis", phase: "start", count: 10_000 }), expect.objectContaining({ stage: "analysis", phase: "complete", count: 1 })]);
+    expect(JSON.stringify(progress)).not.toMatch(/body|comment|provider|credential|path|repo/i);
+    expect(progress.every((line) => Number.isInteger(line.elapsedMs) && line.elapsedMs >= 0 && line.elapsedMs <= 86_400_000)).toBe(true);
+  });
+
   it("runs one bounded provider cooldown drain after successful review cycles", async () => {
     const events: string[] = [];
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -964,7 +964,7 @@ describe("sticky enrichment comments", () => {
       })}\n`);
       const state = new ReviewStateStore(statePath);
       let analysisCalls = 0;
-      let postCalls = 0;
+      let postCalls = 0, overflow = false;
       try {
         const promotedIssue: GitHubRelatedIssueOrPull = {
           number: 127,
@@ -974,12 +974,12 @@ describe("sticky enrichment comments", () => {
           labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
           body: "Continue current-main work for #14."
         };
-        const result = await runIssueEnrichmentCycle({
+        const runCycle = (checkedAt: string, force = false) => runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {
             listIssuesForEnrichment: async () => [promotedIssue],
-            listIssueLabelEvents: async () => [{
+            listIssueLabelEvents: async () => overflow ? Promise.reject(new Error("GitHub issue label event scan exceeded page limit")) : [{
               event: "labeled",
               created_at: "2026-08-16T10:00:00Z",
               actor: { login: "Tosko4" },
@@ -990,21 +990,26 @@ describe("sticky enrichment comments", () => {
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;
-              return { action: "created" as const, comment: { html_url: "https://github.test/comment/127" } };
+              return { action: "created" as const, id: 127, comment: { html_url: "https://github.test/comment/127" } };
             }
           },
           dryRun: false,
           includeExisting: true,
-          checkedAt: "2026-08-16T10:02:00.000Z",
+          checkedAt,
+          force,
           analyzeIssue: async ({ issue }) => {
             analysisCalls += 1;
             return fixtureIssueAnalysis(issue);
           }
         });
+        const result = await runCycle("2026-08-16T10:02:00.000Z");
 
         expect(result.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(analysisCalls).toBe(1);
         expect(postCalls).toBe(1);
+        overflow = true; const blocked = await runCycle("2026-08-16T10:03:00.000Z", true);
+        expect(blocked.summary).toMatchObject({ readFailures: 1, posted: 0, failed: 0 }); expect(blocked.items).toHaveLength(0); expect(postCalls).toBe(1);
+        expect(state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt).toBe("2026-08-16T10:02:00.000Z");
       } finally {
         state.close();
       }

--- a/tests/issue-enrichment-pagination.test.ts
+++ b/tests/issue-enrichment-pagination.test.ts
@@ -4,24 +4,31 @@ import { GitHubApi } from "../src/github.js";
 describe("issue-enrichment GitHub pagination", () => {
   const originalFetch = globalThis.fetch;
 
+  async function readFullPageStream(kind: "comments" | "events") {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      if (page > 5) throw new Error("pagination probe reached page 6");
+      return new Response(JSON.stringify(Array.from({ length: 100 }, (_, index) =>
+        kind === "comments"
+          ? { id: page * 100 + index, body: "fixture" }
+          : { id: page * 100 + index, event: "labeled" }
+      )), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const rows = kind === "comments"
+      ? await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 }).listIssueComments("owner/repo", 451)
+      : await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 }).listIssueLabelEvents("owner/repo", 451);
+    return { rows, calls };
+  }
+
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
   it("bounds a permanently full issue-comment page stream", async () => {
-    const calls: string[] = [];
-    globalThis.fetch = vi.fn(async (url) => {
-      calls.push(String(url));
-      const page = Number(new URL(String(url)).searchParams.get("page"));
-      if (page > 5) throw new Error("pagination probe reached page 6");
-      return new Response(JSON.stringify(
-        Array.from({ length: 100 }, (_, index) => ({ id: page * 100 + index, body: "fixture" }))
-      ), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
-
-    const comments = await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 })
-      .listIssueComments("owner/repo", 451);
+    const { rows: comments, calls } = await readFullPageStream("comments");
 
     expect(comments).toHaveLength(500);
     expect(calls).toHaveLength(5);
@@ -29,18 +36,7 @@ describe("issue-enrichment GitHub pagination", () => {
   });
 
   it("bounds a permanently full issue-label-event page stream", async () => {
-    const calls: string[] = [];
-    globalThis.fetch = vi.fn(async (url) => {
-      calls.push(String(url));
-      const page = Number(new URL(String(url)).searchParams.get("page"));
-      if (page > 5) throw new Error("pagination probe reached page 6");
-      return new Response(JSON.stringify(
-        Array.from({ length: 100 }, (_, index) => ({ id: page * 100 + index, event: "labeled" }))
-      ), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
-
-    const events = await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 })
-      .listIssueLabelEvents("owner/repo", 451);
+    const { rows: events, calls } = await readFullPageStream("events");
 
     expect(events).toHaveLength(500);
     expect(calls).toHaveLength(5);

--- a/tests/issue-enrichment-pagination.test.ts
+++ b/tests/issue-enrichment-pagination.test.ts
@@ -9,37 +9,25 @@ describe("issue-enrichment GitHub pagination", () => {
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
       const page = Number(new URL(String(url)).searchParams.get("page"));
-      if (page > 5) throw new Error("pagination probe reached page 6");
-      return new Response(JSON.stringify(Array.from({ length: 100 }, (_, index) =>
-        kind === "comments"
-          ? { id: page * 100 + index, body: "fixture" }
-          : { id: page * 100 + index, event: "labeled" }
-      )), { status: 200, headers: { "content-type": "application/json" } });
+      if (page > 5) throw new Error("pagination probe reached omitted newer unauthorized event");
+      return new Response(JSON.stringify(Array.from({ length: 100 }, (_, index) => kind === "comments" ? { id: page * 100 + index, body: "fixture" } : page === 1 && index === 0 ? { event: "labeled", created_at: "2026-08-01T00:00:00Z", actor: { login: "older-trusted" }, label: { name: "active-continuation" } } : { event: "labeled" })), { status: 200 });
     }) as typeof fetch;
-    const rows = kind === "comments"
-      ? await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 }).listIssueComments("owner/repo", 451)
-      : await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 }).listIssueLabelEvents("owner/repo", 451);
-    return { rows, calls };
+    try {
+      const api = new GitHubApi({ token: "fixture", requestTimeoutMs: 50 });
+      const rows = kind === "comments" ? await api.listIssueComments("owner/repo", 451) : await api.listIssueLabelEvents("owner/repo", 451);
+      return { rows, calls };
+    } catch (error) {
+      return { rows: [], calls, error };
+    }
   }
 
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-    vi.restoreAllMocks();
-  });
+  afterEach(() => { globalThis.fetch = originalFetch; vi.restoreAllMocks(); });
 
   it("bounds a permanently full issue-comment page stream", async () => {
-    const { rows: comments, calls } = await readFullPageStream("comments");
-
-    expect(comments).toHaveLength(500);
-    expect(calls).toHaveLength(5);
-    expect(calls.at(-1)).toContain("page=5");
+    const { rows: comments, calls } = await readFullPageStream("comments"); expect(comments).toHaveLength(500); expect(calls).toHaveLength(5);
   });
 
-  it("bounds a permanently full issue-label-event page stream", async () => {
-    const { rows: events, calls } = await readFullPageStream("events");
-
-    expect(events).toHaveLength(500);
-    expect(calls).toHaveLength(5);
-    expect(calls.at(-1)).toContain("page=5");
+  it("fails closed on a permanently full issue-label-event page stream", async () => {
+    const { calls, error } = await readFullPageStream("events"); expect(error).toMatchObject({ message: "GitHub issue label event scan exceeded page limit" }); expect(calls).toHaveLength(5);
   });
 });

--- a/tests/issue-enrichment-pagination.test.ts
+++ b/tests/issue-enrichment-pagination.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+describe("issue-enrichment GitHub pagination", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("bounds a permanently full issue-comment page stream", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      if (page > 5) throw new Error("pagination probe reached page 6");
+      return new Response(JSON.stringify(
+        Array.from({ length: 100 }, (_, index) => ({ id: page * 100 + index, body: "fixture" }))
+      ), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const comments = await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 })
+      .listIssueComments("owner/repo", 451);
+
+    expect(comments).toHaveLength(500);
+    expect(calls).toHaveLength(5);
+    expect(calls.at(-1)).toContain("page=5");
+  });
+
+  it("bounds a permanently full issue-label-event page stream", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      if (page > 5) throw new Error("pagination probe reached page 6");
+      return new Response(JSON.stringify(
+        Array.from({ length: 100 }, (_, index) => ({ id: page * 100 + index, event: "labeled" }))
+      ), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const events = await new GitHubApi({ token: "fixture", requestTimeoutMs: 50 })
+      .listIssueLabelEvents("owner/repo", 451);
+
+    expect(events).toHaveLength(500);
+    expect(calls).toHaveLength(5);
+    expect(calls.at(-1)).toContain("page=5");
+  });
+});


### PR DESCRIPTION
## Summary
- bound issue comment and label-event pagination to five pages / 500 rows and fail closed on marker overflow
- add enum-only issue-enrichment stage progress receipts with bounded counts
- refresh the active daemon heartbeat immediately and every 60 seconds while enrichment awaits work

## Validation
- `npm run build` passes
- changed-path TypeScript checks pass; repository has unrelated pre-existing test type errors
- deterministic direct checks cover pagination caps, daemon timer refresh, bounded/redacted progress metadata, and all five enrichment stages
- Vitest focused run is blocked by the existing Rollup native addon code-signature mismatch on this machine

Base: 81255acc335d69deb72801fe8019acccb1d4be32
Candidate: 924ae2d082d1faaacfc178d563b7a11c1c9968e6 plus this commit
No live worker, queue, state, credentials, or provider/customer data was touched.