### PR TITLE
docs: bounded Mac GA release successor

### DIFF
--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -1,0 +1,27 @@
+# NeonDiff Mac GA architecture and release contract
+Status: current native Mac GA architecture, not release evidence; this docs successor is `pr_ready` and proves no release, runtime, customer, signing, or GA readiness.
+## Delivery lanes and identity
+CLI/dashboard `neondiff@1.0.4` owns npm, dashboard, API activation, and local worker;
+it must not claim signed Desktop/Sparkle maturity. Native Desktop `1.1.0` owns signed
+onboarding, sealed worker, paid BYO (managed later), and Sparkle; GA uses shared
+repository tag/release `v1.1.0`, not npm, and npm stays `1.0.4` unless CLI bytes
+change. Pre-GA fixtures may use `v1.1.0-beta.N`, never a second tag.
+## Sealed worker, activation, and proof boundary
+
+The signed app has one sealed worker; credential operations pass secrets once through bounded
+stdin and keys never enter argv, environment, config, logs, or evidence. Paid BYO and managed
+markers are mutually exclusive; Keychain, GitHub visibility, server entitlement, and signed-app
+checks remain authoritative. `codexRuntime` uses `config inspect` for exact CLI path/model/reasoning
+and never stores OAuth material. Keep `pending`, `blocked`, and `proven` state separate for
+source, bytes, signing, feed, site, billing, customer, runtime, and rollback.
+
+## No-downtime and operator contract
+
+Stage/hash, validate source/contract/signature/manifest, take a read-only snapshot, switch only
+the same named worker slot, retain last-known-good, and re-read status. Failed preflight,
+rollback target, pre-launch validation, or post-switch status stops replacement; never alter
+customer config/Keychain/DB, widen an App allowlist, or restart another worker. Runbooks use
+`/Users/m1/repos` and `/Users/m1/Codex`; two-phase preflight validates account config, exact
+sealed-worker `Program`/`ProgramArguments`, plist label, clean `main`, and approved head.
+Rollback source/tag/reset/build/status failures stop before `launchctl`; post-launch status is a
+verification/rollback trigger.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -5,13 +5,18 @@ update as a named beta release, not as an informal pull from `main`.
 
 ## Release Boundary
 
-The beta release unit is:
+The beta release unit uses operator-owned paths:
 
-- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- source checkout: `$NEONDIFF_RELEASE_CHECKOUT` (normally under `/Users/m1/repos`)
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
-- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
-- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+- launchd config: `$NEONDIFF_RUNTIME_CONFIG` (operator-approved account path)
+- state DB: adjacent to the operator's runtime config/state root
+- evidence root: `$NEONDIFF_EVIDENCE_ROOT` (normally under `/Users/m1/Codex`)
+
+Run the executable `prepare` preflight in [release governance](release-governance.md)
+in the same shell before navigation, sync, test, build, tag, promotion, or
+`launchctl`; run its `exact` phase after sync. It validates the sealed worker,
+plist label, exact `--config`/`--launchd-label`, main branch, and approved head.
 
 Packaged or non-source deployments must set
 `NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
@@ -92,34 +97,50 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+set -euo pipefail
+neondiff_release_preflight prepare || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git status --short
 git pull --ff-only
+neondiff_release_preflight exact || exit $?
 npm test
 npm run build
-npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+status_file="$NEONDIFF_EVIDENCE_ROOT/pre-restart-status.json"
+if npx tsx src/cli.ts release-status \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
+  --launchd-label "$NEONDIFF_LAUNCHD_LABEL" > "$status_file"; then
+  :
+elif /usr/bin/env node -e 'const j=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));const f=(j.gates??[]).filter(g=>!g.ok).map(g=>g.name);process.exit(f.length===1&&f[0]==="launchd_config"?0:1)' "$status_file"; then
+  echo "pre-restart status records only the allowed previous-worker launchd_config mismatch"
+else
+  echo "pre-restart release-status failed outside the allowed stale-runtime condition; do not launch" >&2
+  exit 1
+fi
+launchctl kickstart -k "gui/$(id -u)/$NEONDIFF_LAUNCHD_LABEL"
 sleep 5
-npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot \
-  --require-coverage true
+post_status_file="$NEONDIFF_EVIDENCE_ROOT/post-restart-status.json"
+if ! npx tsx src/cli.ts release-status \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
+  --launchd-label "$NEONDIFF_LAUNCHD_LABEL" \
+  --require-coverage true > "$post_status_file"; then
+  echo "post-restart status failed; stop and execute the reviewed rollback trigger" >&2
+  exit 1
+fi
 ```
 
 For public source-beta releases, run the same gate with manifest checks:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --launchd-label "$NEONDIFF_LAUNCHD_LABEL" \
   --require-coverage true
 ```
 
@@ -136,14 +157,16 @@ Public promotion evidence should include the strict variant after tags are
 fetched:
 
 ```bash
+neondiff_release_preflight prepare || exit $?
 git fetch origin --tags
+neondiff_release_preflight exact || exit $?
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
   --verify-public-rollback-refs true \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+  --launchd-label "$NEONDIFF_LAUNCHD_LABEL"
 ```
 
 If the first `release:status` fails only because launchd is still on the
@@ -469,8 +492,9 @@ and confirm the target PR is closed, draft-skipped, stale, or otherwise absent
 from the eligible open-head set. Retire only the exact failed head:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 npx tsx src/cli.ts retire-failed \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
@@ -539,8 +563,9 @@ packet names the affected PR head and follow-up.
 Expired cooldown rows are actionable backlog. Run:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 npx tsx src/cli.ts retry-provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expired-only true \
   --dry-run false \
   --zcode true
@@ -557,12 +582,14 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
-git fetch origin
-git checkout main
-git reset --hard <last-known-good-merge-sha>
-npm run build
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+set -euo pipefail
+NEONDIFF_ROLLBACK_REF="${NEONDIFF_ROLLBACK_REF:?operator-supplied previous tag or merge ref}" NEONDIFF_ROLLBACK_HEAD="${NEONDIFF_ROLLBACK_HEAD:?operator-supplied 40-character rollback head}"
+neondiff_release_preflight prepare || exit $?; cd "$NEONDIFF_RELEASE_CHECKOUT"
+git fetch origin --tags; git rev-parse --verify "$NEONDIFF_ROLLBACK_REF^{commit}" >/dev/null; git checkout main; git reset --hard "$NEONDIFF_ROLLBACK_REF"
+neondiff_release_preflight exact "$NEONDIFF_ROLLBACK_HEAD" || exit $?; npm run build
+npx tsx src/cli.ts release-status --config "$NEONDIFF_RUNTIME_CONFIG" --expected-head "$NEONDIFF_ROLLBACK_HEAD" --launchd-label "$NEONDIFF_LAUNCHD_LABEL" >/dev/null
+launchctl kickstart -k "gui/$(id -u)/$NEONDIFF_LAUNCHD_LABEL"; sleep 5
+npx tsx src/cli.ts release-status --config "$NEONDIFF_RUNTIME_CONFIG" --expected-head "$NEONDIFF_ROLLBACK_HEAD" --launchd-label "$NEONDIFF_LAUNCHD_LABEL" >/dev/null || { echo "post-rollback status failed; stop and review rollback trigger" >&2; exit 1; }
 ```
 
 Use `git reset --hard` only as an explicit rollback operation with the target
@@ -572,7 +599,8 @@ unrelated dirty work.
 To stop the live beta worker entirely:
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+neondiff_release_preflight prepare || exit $?
+launchctl bootout gui/$(id -u) "$NEONDIFF_LAUNCH_AGENT_PATH"
 ```
 
 ## Evidence Packet
@@ -601,7 +629,7 @@ For each beta promotion, record:
   tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
-Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+Keep raw evidence under `$NEONDIFF_EVIDENCE_ROOT`
 or session notes. Do not paste secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
 

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -4,6 +4,30 @@ This bot is a live beta agent. A live promotion is not complete until the
 source SHA is tied to an immutable Git tag, a GitHub Release, runtime evidence,
 and a rollback path.
 
+## Operator preflight
+
+Use `/Users/m1/repos` for clean checkouts and `/Users/m1/Codex` for evidence.
+Run `prepare` before sync and `exact` after sync before test/build/tag/promotion/
+`launchctl`; keep all commands in one shell with `set -euo pipefail`.
+
+```bash
+export NEONDIFF_RELEASE_CHECKOUT="${NEONDIFF_RELEASE_CHECKOUT:-/Users/m1/repos/evaos-code-review-bot-neondiff}" NEONDIFF_RUNTIME_CONFIG="${NEONDIFF_RUNTIME_CONFIG:?operator-approved account-scoped config path}" NEONDIFF_EXPECTED_HEAD="${NEONDIFF_EXPECTED_HEAD:?operator-approved 40-character main head}" NEONDIFF_RELEASE_BRANCH="${NEONDIFF_RELEASE_BRANCH:?intended release branch (main)}"
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-/Users/m1/Codex/evidence/neondiff}" NEONDIFF_LAUNCH_AGENT_PATH="${NEONDIFF_LAUNCH_AGENT_PATH:-$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist}" NEONDIFF_LAUNCHD_LABEL=com.electricsheephq.evaos-code-review-bot NEONDIFF_WORKER_EXECUTABLE=/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop
+plist_arg() { /usr/bin/plutil -extract "ProgramArguments.$1" raw "$NEONDIFF_LAUNCH_AGENT_PATH" 2>/dev/null; }
+neondiff_release_preflight() {
+  local phase="${1:-prepare}" approved="${2:-$NEONDIFF_EXPECTED_HEAD}" head program
+  case "$NEONDIFF_RUNTIME_CONFIG" in /Users/*/Library/Application\ Support/NeonDiffDesktop/Accounts/*/Bots/*/config.local.json) ;; *) echo "runtime config is not an account-scoped NeonDiff path" >&2; return 2;; esac
+  for path in "$NEONDIFF_RELEASE_CHECKOUT" "$NEONDIFF_RUNTIME_CONFIG" "$NEONDIFF_EVIDENCE_ROOT" "$NEONDIFF_LAUNCH_AGENT_PATH"; do case "$path" in /*) ;; *) echo "release paths must be absolute" >&2; return 2;; esac; done
+  [ -d "$NEONDIFF_RELEASE_CHECKOUT" ] && [ -f "$NEONDIFF_RUNTIME_CONFIG" ] && [ -d "$NEONDIFF_EVIDENCE_ROOT" ] && [ -f "$NEONDIFF_LAUNCH_AGENT_PATH" ] || { echo "release, config, evidence, or LaunchAgent path is missing" >&2; return 2; }; git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse --show-toplevel >/dev/null 2>&1 || { echo "release checkout is not Git" >&2; return 2; }
+  case "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" remote get-url origin 2>/dev/null)" in https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;; *) echo "release checkout origin is not NeonDiff" >&2; return 2;; esac; [ "$(/usr/bin/plutil -extract Label raw "$NEONDIFF_LAUNCH_AGENT_PATH" 2>/dev/null)" = "$NEONDIFF_LAUNCHD_LABEL" ] || { echo "LaunchAgent Label is not NeonDiff" >&2; return 2; }
+  program="$(/usr/bin/plutil -extract Program raw "$NEONDIFF_LAUNCH_AGENT_PATH" 2>/dev/null)" || program=; [ -z "$program" ] || [ "$program" = "$NEONDIFF_WORKER_EXECUTABLE" ] || { echo "LaunchAgent Program is not sealed NeonDiff" >&2; return 2; }; [ "$(plist_arg 0)" = "$NEONDIFF_WORKER_EXECUTABLE" ] && [ "$(plist_arg 1)" = "--neondiff-worker-daemon" ] && [ "$(plist_arg 2)" = "--config" ] && [ "$(plist_arg 3)" = "$NEONDIFF_RUNTIME_CONFIG" ] && [ "$(plist_arg 4)" = "--launchd-label" ] && [ "$(plist_arg 5)" = "$NEONDIFF_LAUNCHD_LABEL" ] || { echo "LaunchAgent worker/config identity is not exact" >&2; return 2; }
+  [ "$NEONDIFF_RELEASE_BRANCH" = main ] && [ "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" branch --show-current)" = main ] || { echo "release checkout is not intended main" >&2; return 2; }; [ -z "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" status --porcelain)" ] || { echo "release checkout is dirty" >&2; return 2; }
+  [[ "$approved" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "approved head must be a 40-character SHA" >&2; return 2; }; if [ "$phase" = exact ]; then head="$(git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse HEAD)"; [ "$head" = "$approved" ] || { echo "release checkout head is not operator-approved" >&2; return 2; }; fi
+  [ "$phase" = prepare ] || [ "$phase" = exact ] || { echo "unknown preflight phase" >&2; return 2; }
+}
+neondiff_release_preflight prepare || exit $?
+```
+
 ## Release Levels
 
 - `beta`: local launchd worker on the operator Mac, posting as the GitHub App
@@ -73,6 +97,7 @@ published through another path or the tag needs repair, the explicit cutover
 command is:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 npm dist-tag add neondiff@<ga> latest
 ```
 
@@ -342,10 +367,13 @@ unchanged and treat the package as quarantined.
 Create an annotated tag from the merged source SHA:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+set -euo pipefail
+neondiff_release_preflight prepare || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
+neondiff_release_preflight exact || exit $?
 git tag -a vX.Y.Z-beta.N <source-sha> -m "vX.Y.Z-beta.N"
 git push origin vX.Y.Z-beta.N
 ```
@@ -360,8 +388,9 @@ release tracker.
 Create the GitHub prerelease from the release packet:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 gh release create vX.Y.Z-beta.N \
-  --repo electricsheephq/evaos-code-review-bot \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
   --title "vX.Y.Z-beta.N" \
   --notes-file docs/releases/vX.Y.Z-beta.N.md \
   --prerelease \
@@ -377,14 +406,16 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+set -euo pipefail
+neondiff_release_preflight prepare || exit $?
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
-test "$(git rev-parse HEAD)" = "<source-sha>"
-launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+neondiff_release_preflight exact || exit $?
+launchctl bootout gui/$(id -u) "$NEONDIFF_LAUNCH_AGENT_PATH" 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "$NEONDIFF_LAUNCH_AGENT_PATH"
+launchctl kickstart -k "gui/$(id -u)/$NEONDIFF_LAUNCHD_LABEL"
 ```
 
 ## Post-Release Gate
@@ -392,25 +423,27 @@ launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 Run the status gate with App credentials set in the shell:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head <source-sha> \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
+  --launchd-label "$NEONDIFF_LAUNCHD_LABEL"
 ```
 
 For public source-beta or public beta releases, include the public manifest gate:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 SOURCE_SHA=replace-with-release-source-sha
 PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$SOURCE_SHA" \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
+  --expected-head "$NEONDIFF_EXPECTED_HEAD" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+  --launchd-label "$NEONDIFF_LAUNCHD_LABEL"
 ```
 
 Set `SOURCE_SHA` and `PUBLIC_BETA_TAG` before running the command.
@@ -423,10 +456,11 @@ that checkout; absent refs are reported as a missing rollback target.
 Also run:
 
 ```bash
+neondiff_release_preflight exact || exit $?
 npx tsx src/cli.ts coverage-audit \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+  --config "$NEONDIFF_RUNTIME_CONFIG"
 npx tsx src/cli.ts provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_RUNTIME_CONFIG" \
   --expired-only true
 ```
 
@@ -458,15 +492,14 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
-git fetch origin --tags
-git checkout main
-git reset --hard <previous-release-tag>
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
-npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+set -euo pipefail
+NEONDIFF_ROLLBACK_REF="${NEONDIFF_ROLLBACK_REF:?operator-supplied previous tag or merge ref}" NEONDIFF_ROLLBACK_HEAD="${NEONDIFF_ROLLBACK_HEAD:?operator-supplied 40-character rollback head}"
+neondiff_release_preflight prepare || exit $?; cd "$NEONDIFF_RELEASE_CHECKOUT"
+git fetch origin --tags; git rev-parse --verify "$NEONDIFF_ROLLBACK_REF^{commit}" >/dev/null; git checkout main; git reset --hard "$NEONDIFF_ROLLBACK_REF"
+neondiff_release_preflight exact "$NEONDIFF_ROLLBACK_HEAD" || exit $?; npm run build
+npx tsx src/cli.ts release-status --config "$NEONDIFF_RUNTIME_CONFIG" --expected-head "$NEONDIFF_ROLLBACK_HEAD" --launchd-label "$NEONDIFF_LAUNCHD_LABEL" >/dev/null
+launchctl kickstart -k "gui/$(id -u)/$NEONDIFF_LAUNCHD_LABEL"; sleep 5
+npx tsx src/cli.ts release-status --config "$NEONDIFF_RUNTIME_CONFIG" --expected-head "$NEONDIFF_ROLLBACK_HEAD" --launchd-label "$NEONDIFF_LAUNCHD_LABEL" >/dev/null || { echo "post-rollback status failed; stop and review rollback trigger" >&2; exit 1; }
 ```
 
 Record the rollback in the GitHub Release, the tracker issue, and any active


### PR DESCRIPTION
Successor to held PR #817; do not merge #817.

This fresh candidate starts at current main `6ff923768fd3efd784e3730371e00fd4c45f1bcb` and is limited to 200 changed lines across three docs.

Fixes the final release-safety blockers:
- Two-phase executable preflight validates operator-approved account-scoped config, plist Label, optional Program, sealed ProgramArguments worker-daemon mode, exact `--config`, exact `--launchd-label`, clean `main`, and approved head.
- Promotion syncs only after prepare preflight, exact-validates after pull, fails closed on git/test/build/status errors, and allows only the documented stale-runtime `launchd_config` pre-restart failure. Post-launch status is an explicit rollback trigger.
- Rollback requires an operator ref and rollback SHA, validates source/tag/reset/build/status before launchctl, and stops on every failure.
- Desktop `v1.1.0` is the shared repository GA identity; npm remains `1.0.4` unless CLI bytes change.
- No obsolete `/Volumes/LEXAR` or `/Users/lume` operational paths remain.

Focused evidence: preflight syntax/valid-label fixture passed; invalid-label and invalid-input markers absent; git/test/build/status promotion markers absent; stale-runtime exception reached launchctl only after the allowed gate; beta and governance rollback ref/reset/build/status markers absent; public-claims, secrets, design-source, diff, and scope checks passed.

This PR proves docs/source readiness only; it does not authorize merge, release, signing, notarization, runtime/customer mutation, or GA readiness.