### PR TITLE
feat: add severe verifier evidence transport helpers

### DIFF
--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -57,7 +57,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
   if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
   if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
-  if (!Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
+  if (typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
   if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
   if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
   if (!string(receipt.findingFingerprint) || !/^finding:[a-f0-9]{64}$/.test(receipt.findingFingerprint)) errors.push("findingFingerprint is invalid");
@@ -68,7 +68,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
   validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
-  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as SevereVerificationReceipt };
+  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as unknown as SevereVerificationReceipt };
 }
 
 export function parseSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereVerificationReceipt {
@@ -87,7 +87,7 @@ function validateEvidence(value: unknown, state: unknown, expectedPath: string |
   if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
   for (const item of value.files) {
     const file = record(item) ? item : undefined;
-    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
   }
   for (const item of value.omitted) {
     const omission = record(item) ? item : undefined;

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -96,7 +96,7 @@ function validateEvidence(value: unknown, state: unknown, expectedPath: string |
   const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
   if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
   if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
-  if (expectedPath !== undefined && (!safePath(expectedPath) || (value.files.length > 0 && !value.files.some((file) => record(file) && file.path === expectedPath)))) errors.push("evidence does not cover expected path");
+  if (expectedPath !== undefined && (!safePath(expectedPath) || ![...value.files, ...value.omitted].some((entry) => record(entry) && entry.path === expectedPath))) errors.push("evidence does not cover expected path");
   if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
 }
 

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -1,0 +1,114 @@
+export const SEVERE_VERIFICATION_STATES = [
+  "confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+] as const;
+export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
+export type SevereVerificationDisposition = "retain" | "suppress";
+export type SevereEvidenceKind = "whole_file" | "module";
+export type SevereVerificationCode =
+  | "not_read" | "refuted" | "malformed" | "timeout" | "unavailable" | "stale_head"
+  | "incomplete" | "schema_invalid" | "identity_mismatch" | "evidence_incomplete"
+  | "provider_unavailable" | "cap_exceeded" | "receipt_invalid";
+
+export interface SevereVerificationEvidenceFile {
+  path: string;
+  kind: SevereEvidenceKind;
+  sha256: string;
+  bytes: number;
+  complete: boolean;
+}
+export interface SevereVerificationEvidenceOmission { path: string; code: SevereVerificationCode; }
+export interface SevereVerificationEvidence {
+  files: SevereVerificationEvidenceFile[];
+  omitted: SevereVerificationEvidenceOmission[];
+  complete: boolean;
+}
+export interface SevereVerificationReceipt {
+  schemaVersion: "severe-verifier-v1";
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  findingFingerprint: string;
+  headSha: string;
+  state: SevereVerificationState;
+  disposition: SevereVerificationDisposition;
+  confidence?: number;
+  reasonCode?: SevereVerificationCode;
+  evidence: SevereVerificationEvidence;
+}
+export interface SevereReceiptValidationOptions { expectedPath?: string; }
+export type SevereReceiptValidation =
+  | { ok: true; value: SevereVerificationReceipt }
+  | { ok: false; errors: string[] };
+
+const CODES = new Set<string>([
+  "not_read", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete",
+  "schema_invalid", "identity_mismatch", "evidence_incomplete", "provider_unavailable",
+  "cap_exceeded", "receipt_invalid"
+]);
+const KINDS = new Set(["whole_file", "module"]);
+const STATES = new Set<string>(SEVERE_VERIFICATION_STATES);
+const SHA40 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+export function validateSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereReceiptValidation {
+  const errors: string[] = [];
+  if (!record(value)) return { ok: false, errors: ["receipt must be an object"] };
+  const receipt = value;
+  if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
+  if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
+  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
+  if (!Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
+  if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
+  if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
+  if (!string(receipt.findingFingerprint) || !/^finding:[a-f0-9]{64}$/.test(receipt.findingFingerprint)) errors.push("findingFingerprint is invalid");
+  if (!string(receipt.state) || !STATES.has(receipt.state)) errors.push("state is invalid");
+  if (receipt.disposition !== "retain" && receipt.disposition !== "suppress") errors.push("disposition is invalid");
+  if (receipt.confidence !== undefined && (!number(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) errors.push("confidence is invalid");
+  if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
+  if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
+  if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
+  validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
+  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as SevereVerificationReceipt };
+}
+
+export function parseSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereVerificationReceipt {
+  const result = validateSevereVerificationReceipt(value, options);
+  if (!result.ok) throw new Error(`severe_verification_receipt_invalid: ${result.errors.join(",")}`);
+  return result.value;
+}
+
+export function isSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): value is SevereVerificationReceipt {
+  return validateSevereVerificationReceipt(value, options).ok;
+}
+
+function validateEvidence(value: unknown, state: unknown, expectedPath: string | undefined, errors: string[]): void {
+  if (!record(value) || !exact(value, ["files", "omitted", "complete"])) { errors.push("evidence shape is invalid"); return; }
+  if (!Array.isArray(value.files) || !Array.isArray(value.omitted) || typeof value.complete !== "boolean") { errors.push("evidence types are invalid"); return; }
+  if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
+  for (const item of value.files) {
+    const file = record(item) ? item : undefined;
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+  }
+  for (const item of value.omitted) {
+    const omission = record(item) ? item : undefined;
+    if (!omission || !exact(omission, ["path", "code"]) || !safePath(omission.path) || !string(omission.code) || !CODES.has(omission.code)) errors.push("evidence omission is invalid");
+  }
+  const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
+  if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
+  if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
+  if (expectedPath !== undefined && (!safePath(expectedPath) || (value.files.length > 0 && !value.files.some((file) => record(file) && file.path === expectedPath)))) errors.push("evidence does not cover expected path");
+  if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
+}
+
+function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function exact(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return required.every((key) => Object.hasOwn(value, key)) && Reflect.ownKeys(value).every((key) => typeof key === "string" && allowed.has(key));
+}
+function string(value: unknown): value is string { return typeof value === "string"; }
+function number(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value); }
+function byteLength(value: string): number { return Buffer.byteLength(value, "utf8"); }
+function safePath(value: unknown): value is string {
+  if (!string(value) || value.length === 0 || byteLength(value) > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n]/.test(value)) return false;
+  return value.split("/").every((part) => part.length > 0 && part !== "." && part !== "..");
+}

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -1,5 +1,5 @@
 export const SEVERE_VERIFICATION_STATES = [
-  "confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+  "confirmed", "refuted", "failed", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
 ] as const;
 export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
 export type SevereVerificationDisposition = "retain" | "suppress";
@@ -49,6 +49,10 @@ const KINDS = new Set(["whole_file", "module"]);
 const STATES = new Set<string>(SEVERE_VERIFICATION_STATES);
 const SHA40 = /^[a-f0-9]{40}$/;
 const SHA256 = /^[a-f0-9]{64}$/;
+export const MAX_SEVERE_EVIDENCE_FILE_BYTES = 64 * 1024;
+const MAX_SEVERE_EVIDENCE_ENTRIES = 64;
+const MAX_SEVERE_EVIDENCE_TOTAL_BYTES = 256 * 1024;
+const MAX_SEVERE_EVIDENCE_PATH_BYTES = 64 * 1024;
 
 export function validateSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereReceiptValidation {
   const errors: string[] = [];
@@ -67,6 +71,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
+  if (!validStateReason(receipt.state, receipt.reasonCode)) errors.push("state and reasonCode are inconsistent");
   validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
   return errors.length ? { ok: false, errors } : { ok: true, value: receipt as unknown as SevereVerificationReceipt };
 }
@@ -84,20 +89,32 @@ export function isSevereVerificationReceipt(value: unknown, options: SevereRecei
 function validateEvidence(value: unknown, state: unknown, expectedPath: string | undefined, errors: string[]): void {
   if (!record(value) || !exact(value, ["files", "omitted", "complete"])) { errors.push("evidence shape is invalid"); return; }
   if (!Array.isArray(value.files) || !Array.isArray(value.omitted) || typeof value.complete !== "boolean") { errors.push("evidence types are invalid"); return; }
+  if (value.files.length + value.omitted.length > MAX_SEVERE_EVIDENCE_ENTRIES) { errors.push("evidence has too many entries"); return; }
   if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
   for (const item of value.files) {
     const file = record(item) ? item : undefined;
-    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > MAX_SEVERE_EVIDENCE_FILE_BYTES || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
   }
   for (const item of value.omitted) {
     const omission = record(item) ? item : undefined;
     if (!omission || !exact(omission, ["path", "code"]) || !safePath(omission.path) || !string(omission.code) || !CODES.has(omission.code)) errors.push("evidence omission is invalid");
   }
   const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
+  const totalBytes = value.files.reduce((sum, file) => sum + (record(file) && typeof file.bytes === "number" && Number.isSafeInteger(file.bytes) && file.bytes >= 0 ? file.bytes : 0), 0);
+  const pathBytes = [...value.files, ...value.omitted].reduce((sum, entry) => sum + (record(entry) && string(entry.path) ? byteLength(entry.path) : 0), 0);
+  if (totalBytes > MAX_SEVERE_EVIDENCE_TOTAL_BYTES || pathBytes > MAX_SEVERE_EVIDENCE_PATH_BYTES) errors.push("evidence exceeds aggregate limits");
   if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
   if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
   if (expectedPath !== undefined && (!safePath(expectedPath) || ![...value.files, ...value.omitted].some((entry) => record(entry) && entry.path === expectedPath))) errors.push("evidence does not cover expected path");
   if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
+}
+
+function validStateReason(state: unknown, reason: unknown): boolean {
+  if (!string(state) || !STATES.has(state) || (reason !== undefined && !string(reason))) return false;
+  if (state === "confirmed") return reason === undefined;
+  if (state === "refuted") return reason === undefined || reason === "refuted";
+  const allowed: Record<string, string[]> = { failed: ["provider_unavailable", "receipt_invalid"], malformed: ["malformed", "schema_invalid", "receipt_invalid"], timeout: ["timeout"], unavailable: ["unavailable", "provider_unavailable"], stale_head: ["stale_head", "identity_mismatch"], incomplete: ["incomplete", "not_read", "evidence_incomplete", "cap_exceeded"] };
+  return reason !== undefined && (allowed[state]?.includes(reason) ?? false);
 }
 
 function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
 import {
   buildCommandStatusBody,
@@ -33,7 +33,7 @@ import {
   type FinishingTouchAction
 } from "./finishing-touches.js";
 import { GitHubApi } from "./github.js";
-import { getProtectedCheckoutRoots } from "./path-safety.js";
+import { getProtectedCheckoutRoots, resolvePathFollowingExistingSymlinks } from "./path-safety.js";
 import { evaluateLicenseReviewGate, type LicenseReviewGateResult } from "./license.js";
 import {
   authorizeAdmissionForVisibility,
@@ -133,6 +133,12 @@ import {
 import { runCodexReview } from "./codex-runtime.js";
 import { runSelfConsistencyRecheck, type SelfConsistencySecondDrawResult } from "./self-consistency.js";
 import type { DeterministicReviewGateResult } from "./review-gate.js";
+import {
+  MAX_SEVERE_EVIDENCE_FILE_BYTES,
+  parseSevereVerificationReceipt,
+  type SevereVerificationCode,
+  type SevereVerificationReceipt
+} from "./severe-verification-receipt.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
 import type { DroppedFinding, Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
 import { applyRuntimeGitHubCredentials } from "./runtime-github-credentials.js";
@@ -3990,6 +3996,76 @@ export function resolveSelfConsistencyBackend(
     useCodex,
     providerId: useCodex ? "codex-cli-oauth" : (selfConsistencyConfig.provider ?? config.zcode.providerId)
   };
+}
+
+export interface SevereVerificationReviewContext { repo: string; pullNumber: number; baseSha: string; headSha: string; }
+export type SevereVerificationEvidenceInput = { content: string; receipt: SevereVerificationReceipt["evidence"]; };
+export const MAX_SEVERE_CONTEXT_BYTES = MAX_SEVERE_EVIDENCE_FILE_BYTES;
+
+export function readSevereVerificationEvidence(worktreePath: string, requestedPath: string): SevereVerificationEvidenceInput {
+  if (!safeSevereRelativePath(requestedPath)) throw new Error("severe_verifier_incomplete");
+  const root = resolvePathFollowingExistingSymlinks(worktreePath);
+  const realPath = resolvePathFollowingExistingSymlinks(resolve(worktreePath, requestedPath));
+  const relativePath = relative(root, realPath);
+  const info = existsSync(realPath) ? statSync(realPath) : undefined;
+  if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath) || !info?.isFile()) throw new Error("severe_verifier_incomplete");
+  if (info.size > MAX_SEVERE_CONTEXT_BYTES) throw new Error("severe_verifier_cap_exceeded");
+  const bytes = readFileSync(realPath);
+  return {
+    content: bytes.toString("utf8"),
+    receipt: { files: [{ path: requestedPath, kind: "whole_file", sha256: createHash("sha256").update(bytes).digest("hex"), bytes: bytes.byteLength, complete: true }], omitted: [], complete: true }
+  };
+}
+
+export function buildSevereVerificationPrompt(comment: DeterministicReviewGateResult["comments"][number], hunk: string, content: string, context: SevereVerificationReviewContext): string {
+  const fence = String.fromCharCode(96).repeat(3);
+  return [
+    "You are re-checking a SINGLE prior code-review finding for self-consistency.",
+    "Do not modify files, run commands, or inspect anything beyond the finding, diff hunk, and exact-head file below.",
+    "Decide independently whether the finding is a genuine, actionable issue on the current diff.",
+    "Return JSON ONLY: {\"verdict\":\"confirm\"|\"refute\",\"confidence\":0.0}. No prose, no code fences.",
+    "confirm means you AGREE the finding is real; refute means you REFUTE it.",
+    "", "Review identity: " + context.repo + "#" + context.pullNumber + " base=" + context.baseSha + " head=" + context.headSha,
+    "Finding fingerprint: " + comment.fingerprint, "Finding severity: " + comment.severity,
+    "Finding file: " + comment.path + " (line " + comment.line + ")", "Finding title: " + comment.title, "Finding detail: " + comment.body,
+    "", "Relevant diff hunk:", fence + "diff", hunk, fence, "", "Exact-head whole-file context (" + comment.path + "):", fence + "text", content, fence
+  ].join("\n");
+}
+
+export function parseSevereVerificationVerdict(rawResponse: string, context: SevereVerificationReviewContext, comment: DeterministicReviewGateResult["comments"][number], evidence: SevereVerificationReceipt["evidence"]): SevereVerificationReceipt {
+  let parsed: unknown;
+  try { parsed = JSON.parse(extractZCodeResponse(rawResponse).trim()); } catch { throw new Error("severe_verifier_malformed"); }
+  if (!recordSevereValue(parsed) || Object.keys(parsed).length !== 2 || (parsed.verdict !== "confirm" && parsed.verdict !== "refute") || typeof parsed.confidence !== "number" || !Number.isFinite(parsed.confidence) || parsed.confidence < 0 || parsed.confidence > 1) throw new Error("severe_verifier_malformed");
+  return parseSevereVerificationReceipt({
+    schemaVersion: "severe-verifier-v1", ...context, findingFingerprint: comment.fingerprint,
+    state: parsed.verdict === "confirm" ? "confirmed" : "refuted", disposition: parsed.verdict === "confirm" ? "retain" : "suppress", confidence: parsed.confidence, evidence
+  }, { expectedPath: comment.path });
+}
+
+export function buildSevereFailureReceipt(context: SevereVerificationReviewContext, comment: DeterministicReviewGateResult["comments"][number], evidence: SevereVerificationReceipt["evidence"] | undefined, code: SevereVerificationCode): SevereVerificationReceipt {
+  const state = code === "timeout" ? "timeout" : code === "stale_head" ? "stale_head" : code === "unavailable" ? "unavailable" : code === "provider_unavailable" || code === "receipt_invalid" ? "failed" : code === "refuted" ? "refuted" : code === "malformed" || code === "schema_invalid" ? "malformed" : "incomplete";
+  const path = safeSevereRelativePath(comment.path) ? comment.path : "unknown.ts";
+  return parseSevereVerificationReceipt({
+    schemaVersion: "severe-verifier-v1", ...context, findingFingerprint: comment.fingerprint, state, disposition: "suppress", reasonCode: code,
+    evidence: evidence ?? { files: [], omitted: [{ path, code }], complete: false }
+  });
+}
+
+export function severeVerificationFailureCode(error: unknown): SevereVerificationCode {
+  const message = error instanceof Error ? error.message : "";
+  if (message.includes("timeout")) return "timeout";
+  if (message.startsWith("severe_verifier_malformed")) return "malformed";
+  if (message.includes("stale")) return "stale_head";
+  if (message.includes("cap_exceeded")) return "cap_exceeded";
+  if (message.includes("incomplete")) return "incomplete";
+  return "provider_unavailable";
+}
+
+function safeSevereRelativePath(value: string): boolean {
+  return value.length > 0 && !value.startsWith("/") && !/^[A-Za-z]:/.test(value) && !/[\\\0\r\n]/.test(value) && value.split("/").every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+function recordSevereValue(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function buildSelfConsistencyPrompt(comment: DeterministicReviewGateResult["comments"][number], hunk: string): string {

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -39,8 +39,16 @@ describe("severe verification receipt parser", () => {
     const states = ["refuted", "timeout", "unavailable", "malformed", "stale_head", "incomplete"] as const;
     for (const state of states) {
       const evidence = state === "incomplete" ? { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } : base().evidence;
-      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", evidence }));
+      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", reasonCode: state === "refuted" ? "refuted" : state, evidence }));
       expect(parsed.state).toBe(state);
     }
+    expect(parseSevereVerificationReceipt(receipt({ state: "failed", disposition: "suppress", reasonCode: "provider_unavailable" })).state).toBe("failed");
+    expect(isSevereVerificationReceipt(receipt({ reasonCode: "timeout" }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress", reasonCode: "provider_unavailable" }))).toBe(false);
+  });
+
+  it("bounds evidence cardinality and proof sizes", () => {
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", reasonCode: "incomplete", evidence: { files: [], omitted: Array.from({ length: 10_000 }, () => ({ path, code: "incomplete" })), complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ ...base().evidence.files[0], bytes: 2 ** 32 }], omitted: [], complete: true } }))).toBe(false);
   });
 });

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -31,6 +31,7 @@ describe("severe verification receipt parser", () => {
     expect(isSevereVerificationReceipt(receipt({ evidence: { files: [], omitted: [], complete: false } }))).toBe(false);
     expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress" }), { expectedPath: path })).toBe(true);
     expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", evidence: { files: [], omitted: [{ path: "other.ts", code: "incomplete" }], complete: false } }), { expectedPath: path })).toBe(false);
     expect(isSevereVerificationReceipt(receipt({ reasonCode: "free-form prose" }))).toBe(false);
   });
 

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isSevereVerificationReceipt, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+
+const path = "src/safe file+Δ.ts";
+const base = () => ({ schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`, headSha: "a".repeat(40), state: "confirmed", disposition: "retain", confidence: 0.9, evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true } });
+const receipt = (changes: Record<string, unknown> = {}) => ({ ...base(), ...changes });
+
+describe("severe verification receipt parser", () => {
+  it("accepts strict identity, bounded metadata, safe Unicode paths, and expected coverage", () => {
+    const longPath = `${"a".repeat(4070)} + safe λ.ts`;
+    const value = receipt({ evidence: { files: [{ path: longPath, kind: "whole_file", sha256: "d".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } });
+    expect(parseSevereVerificationReceipt(value, { expectedPath: longPath }).evidence.files[0]?.path).toBe(longPath);
+  });
+
+  it("rejects malformed, extra-field, coercion, and array values", () => {
+    expect(isSevereVerificationReceipt([])).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ extra: true }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ pullNumber: "7" }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ headSha: new String("a".repeat(40)) }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { ...base().evidence, files: [base().evidence.files[0], "not an object"] } }))).toBe(false);
+  });
+
+  it("rejects absolute, traversal, backslash, NUL, and unrelated evidence paths", () => {
+    for (const unsafe of ["/tmp/x.ts", "../x.ts", "src/../x.ts", "src\\x.ts", `src/${String.fromCharCode(0)}x.ts`]) {
+      expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path: unsafe, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } }))).toBe(false);
+    }
+    expect(isSevereVerificationReceipt(receipt(), { expectedPath: "src/other.ts" })).toBe(false);
+  });
+
+  it("requires nonempty, complete, relevant evidence for confirmed/refuted states", () => {
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [], omitted: [], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress" }), { expectedPath: path })).toBe(true);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ reasonCode: "free-form prose" }))).toBe(false);
+  });
+
+  it("keeps refuted distinct from timeout, unavailable, malformed, stale-head, and incomplete", () => {
+    const states = ["refuted", "timeout", "unavailable", "malformed", "stale_head", "incomplete"] as const;
+    for (const state of states) {
+      const evidence = state === "incomplete" ? { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } : base().evidence;
+      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", evidence }));
+      expect(parsed.state).toBe(state);
+    }
+  });
+});

--- a/tests/severe-verifier-worker.test.ts
+++ b/tests/severe-verifier-worker.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildSevereFailureReceipt,
+  buildSevereVerificationPrompt,
+  MAX_SEVERE_CONTEXT_BYTES,
+  parseSevereVerificationVerdict,
+  readSevereVerificationEvidence,
+  severeVerificationFailureCode
+} from "../src/worker.js";
+import type { SevereVerificationReviewContext } from "../src/worker.js";
+import type { ReviewComment } from "../src/types.js";
+
+const context: SevereVerificationReviewContext = { repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), headSha: "a".repeat(40) };
+const comment: ReviewComment = { path: "nested dir/plus+λ/file.ts", line: 3, side: "RIGHT", body: "Import context is wrong.", severity: "P1", category: "runtime_correctness", confidence: 0.9, title: "Import context", fingerprint: "finding:" + "f".repeat(64) };
+
+describe("inert severe verifier transport helpers", () => {
+  it("reads safe Unicode/space/plus paths and rejects traversal, symlink escape, and caps", () => {
+    const root = mkdtempSync(join("/tmp", "severe-helper-")), outside = mkdtempSync(join("/tmp", "severe-outside-"));
+    try {
+      mkdirSync(join(root, "nested dir/plus+λ"), { recursive: true });
+      writeFileSync(join(root, comment.path), "const value = 1;\n");
+      writeFileSync(join(outside, "secret.ts"), "secret");
+      symlinkSync(outside, join(root, "link"));
+      const evidence = readSevereVerificationEvidence(root, comment.path);
+      expect(evidence.content).toContain("value");
+      expect(evidence.receipt.files[0]?.complete).toBe(true);
+      for (const path of ["../secret.ts", "/tmp/secret.ts", "link/secret.ts", "missing.ts", "nested dir"]) expect(() => readSevereVerificationEvidence(root, path)).toThrow("severe_verifier_incomplete");
+      writeFileSync(join(root, "big.ts"), "x".repeat(MAX_SEVERE_CONTEXT_BYTES + 1));
+      expect(() => readSevereVerificationEvidence(root, "big.ts")).toThrow("severe_verifier_cap_exceeded");
+    } finally { rmSync(root, { recursive: true, force: true }); rmSync(outside, { recursive: true, force: true }); }
+  });
+
+  it("binds exact review identity/fingerprint and accepts only strict confirm/refute JSON", () => {
+    const prompt = buildSevereVerificationPrompt(comment, "+added();", "const value = 1;", context);
+    expect(prompt).toContain("owner/repo#7 base=" + context.baseSha + " head=" + context.headSha);
+    expect(prompt).toContain(comment.fingerprint);
+    expect(prompt).toContain(comment.path);
+    const evidence = { files: [{ path: comment.path, kind: "whole_file" as const, sha256: "c".repeat(64), bytes: 16, complete: true }], omitted: [], complete: true };
+    const raw = (value: unknown) => JSON.stringify({ response: JSON.stringify(value) });
+    expect(parseSevereVerificationVerdict(raw({ verdict: "confirm", confidence: 0.8 }), context, comment, evidence).state).toBe("confirmed");
+    expect(parseSevereVerificationVerdict(raw({ verdict: "refute", confidence: 0.2 }), context, comment, evidence).disposition).toBe("suppress");
+    for (const value of [{ verified: true, confidence: 1 }, { verdict: "maybe", confidence: 1 }, { verdict: "confirm", confidence: 2 }, { verdict: "confirm", confidence: 1, extra: true }]) expect(() => parseSevereVerificationVerdict(raw(value), context, comment, evidence)).toThrow("severe_verifier_malformed");
+  });
+
+  it("emits parser-accepted bounded failure states with fixed codes", () => {
+    for (const code of ["timeout", "unavailable", "malformed", "stale_head", "incomplete", "cap_exceeded", "provider_unavailable", "receipt_invalid"] as const) {
+      const receipt = buildSevereFailureReceipt(context, comment, undefined, code);
+      expect(receipt.reasonCode).toBe(code);
+      expect(receipt.disposition).toBe("suppress");
+      expect(["timeout", "unavailable", "malformed", "stale_head", "incomplete", "failed"]).toContain(receipt.state);
+    }
+    expect(severeVerificationFailureCode(new Error("timed out"))).toBe("timeout");
+    expect(severeVerificationFailureCode(new Error("severe_verifier_incomplete"))).toBe("incomplete");
+    expect(severeVerificationFailureCode(new Error("provider unavailable"))).toBe("provider_unavailable");
+  });
+});


### PR DESCRIPTION
Stacked on Slice A PR #823 at exact base 218c031cb6b2cc7483f7005464471473dac2e3e0.

This behavior-neutral B1 adds inert exported helpers only; there are zero production call sites and no self-consistency runtime change. It provides safe exact-head whole-file evidence, parser-bounded SHA-256 receipts, exact review identity/fingerprint prompt context, strict confirm/refute conversion, and fixed-code failure receipts including explicit failed/provider-unavailable states.

Changed lines: 140 total (137 additions, 3 deletions), non-generated, within the 200-line envelope.

Proof: git diff --check passed; Bun worker/test transpilation passed; existing severe receipt parser tests pass 6/6. The focused worker test is blocked before execution by missing node:sqlite in the available Bun runtime, and npm build is blocked because tsc is unavailable. GitNexus detect_changes ran against a stale index and is recorded as non-authoritative.

No merge, live provider, runtime, customer, or release mutation was performed. B2 will wire these helpers into publication.