### PR TITLE
fix: separate active health and recover authorized posts

### DIFF
--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2381,7 +2381,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
         : "none";
     const failureHealth = readProcessedFailureHealth(db, now);
     const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
-    const reviewQueue = readReviewQueueCounts(db, now, failureHealth.latestPostedAtByPull);
+    const reviewQueue = readReviewQueueCounts(db, now);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
@@ -2425,66 +2425,38 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
   }
 }
 
-type ProcessedFailureRow = { repo: string; pull_number: number; status: string; error: string | null; created_at: string };
-type FailedQueueRow = { repo: string; pull_number: number; last_error: string | null; updated_at: string };
+type FailedQueueRow = { last_error: string | null; active: number };
 
 function readProcessedFailureHealth(db: DatabaseSync, now: Date): {
   recentUnrecoveredErrorCount: number;
   lastErrorAt?: string;
-  latestPostedAtByPull: Map<string, number>;
 } {
-  const rows = db.prepare(
-    `select repo, pull_number, status, error, created_at
-       from processed_reviews
-      where status = 'posted'
-         or status = 'failed'
-         or (status != 'skipped' and error is not null and error != '')`
-  ).all() as unknown as ProcessedFailureRow[];
-  const latestPostedAtByPull = new Map<string, number>();
-  for (const row of rows) {
-    if (row.status !== "posted") continue;
-    const postedAt = parseDatabaseTimestamp(row.created_at);
-    if (!Number.isFinite(postedAt)) continue;
-    const key = `${row.repo}\u0000${row.pull_number}`;
-    if (postedAt > (latestPostedAtByPull.get(key) ?? Number.NEGATIVE_INFINITY)) {
-      latestPostedAtByPull.set(key, postedAt);
-    }
-  }
-  const cutoff = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
-  let recentUnrecoveredErrorCount = 0;
-  let lastErrorAt: { value: string; timestamp: number } | undefined;
-  for (const row of rows) {
-    const isError = row.status === "failed" || (row.status !== "skipped" && Boolean(row.error));
-    if (!isError) continue;
-    const timestamp = parseDatabaseTimestamp(row.created_at);
-    const key = `${row.repo}\u0000${row.pull_number}`;
-    const recoveredAt = latestPostedAtByPull.get(key);
-    if (!(recoveredAt !== undefined && Number.isFinite(timestamp) && recoveredAt > timestamp) &&
-        (!Number.isFinite(timestamp) || timestamp >= cutoff)) {
-      recentUnrecoveredErrorCount += 1;
-    }
-    if (Number.isFinite(timestamp) && (!lastErrorAt || timestamp > lastErrorAt.timestamp)) {
-      lastErrorAt = { value: row.created_at, timestamp };
-    }
-  }
+  const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
+  const cutoff = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
+  const recent = db.prepare(
+    `select count(*) as count from processed_reviews failed
+      where (${errorWhere})
+        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))
+        and not exists (
+          select 1 from processed_reviews posted
+           where posted.repo = failed.repo and posted.pull_number = failed.pull_number
+             and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.created_at)
+        )`
+  ).get(cutoff) as { count: number };
+  const last = db.prepare(
+    `select created_at from processed_reviews failed
+      where ${errorWhere}
+      order by datetime(created_at) desc limit 1`
+  ).get() as { created_at?: string } | undefined;
   return {
-    recentUnrecoveredErrorCount,
-    ...(lastErrorAt ? { lastErrorAt: lastErrorAt.value } : {}),
-    latestPostedAtByPull
+    recentUnrecoveredErrorCount: recent.count ?? 0,
+    ...(last?.created_at ? { lastErrorAt: last.created_at } : {})
   };
-}
-
-function parseDatabaseTimestamp(value: string | null | undefined): number {
-  const text = value?.trim();
-  if (!text) return Number.NaN;
-  return Date.parse(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(text)
-    ? `${text.replace(" ", "T")}Z` : text);
 }
 
 function readReviewQueueCounts(
   db: DatabaseSync,
-  now: Date,
-  latestPostedAtByPull: Map<string, number>
+  now: Date
 ): {
   total: number;
   queued: number;
@@ -2551,15 +2523,16 @@ function readReviewQueueCounts(
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
   const failedRows = db.prepare(
-    `select repo, pull_number, last_error, updated_at
-       from review_queue_jobs
-      where state = 'failed'`
+    `select failed.last_error,
+            not exists (
+              select 1 from processed_reviews posted
+               where posted.repo = failed.repo and posted.pull_number = failed.pull_number
+                 and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.updated_at)
+            ) as active
+       from review_queue_jobs failed
+      where failed.state = 'failed'`
   ).all() as unknown as FailedQueueRow[];
-  const activeFailedRows = failedRows.filter((row) => {
-    const recoveredAt = latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
-    const failedAt = parseDatabaseTimestamp(row.updated_at);
-    return recoveredAt === undefined || !Number.isFinite(failedAt) || recoveredAt <= failedAt;
-  });
+  const activeFailedRows = failedRows.filter((row) => row.active === 1);
   const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
   const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2379,9 +2379,10 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       : retryableExpiredProviderCooldownCount > 0
         ? "expired_retryable"
         : "none";
-    const failureHealth = readProcessedFailureHealth(db, now);
+    const recovery = readFailureRecoveryIndex(db);
+    const failureHealth = readProcessedFailureHealth(db, now, recovery);
     const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
-    const reviewQueue = readReviewQueueCounts(db, now);
+    const reviewQueue = readReviewQueueCounts(db, now, recovery.latestPostedAtByPull);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
@@ -2425,38 +2426,53 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
   }
 }
 
-type FailedQueueRow = { last_error: string | null; active: number };
+type FailedQueueRow = { repo: string; pull_number: number; last_error: string | null; failed_at: number | null };
+type FailureRecoveryIndex = { latestPostedAtByPull: Map<string, number>; lastErrorAt?: string };
 
-function readProcessedFailureHealth(db: DatabaseSync, now: Date): {
+function readFailureRecoveryIndex(db: DatabaseSync): FailureRecoveryIndex {
+  const rows = db.prepare(
+    `select repo, pull_number,
+            max(case when status = 'posted' then julianday(created_at) end) as posted_at,
+            max(case when (status = 'failed' or (status != 'skipped' and error is not null and error != '')) and julianday(created_at) is not null
+                     then printf('%020.10f|%s', julianday(created_at), created_at) end) as error_marker
+       from processed_reviews group by repo, pull_number`
+  ).all() as unknown as Array<{ repo: string; pull_number: number; posted_at: number | null; error_marker: string | null }>;
+  const latestPostedAtByPull = new Map<string, number>();
+  let lastErrorMarker: string | undefined;
+  for (const row of rows) {
+    if (row.posted_at !== null) latestPostedAtByPull.set(`${row.repo}\u0000${row.pull_number}`, row.posted_at);
+    if (row.error_marker && (!lastErrorMarker || row.error_marker > lastErrorMarker)) lastErrorMarker = row.error_marker;
+  }
+  return {
+    latestPostedAtByPull,
+    ...(lastErrorMarker ? { lastErrorAt: lastErrorMarker.slice(lastErrorMarker.indexOf("|") + 1) } : {})
+  };
+}
+
+function readProcessedFailureHealth(db: DatabaseSync, now: Date, recovery: FailureRecoveryIndex): {
   recentUnrecoveredErrorCount: number;
   lastErrorAt?: string;
 } {
   const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
   const cutoff = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
   const recent = db.prepare(
-    `select count(*) as count from processed_reviews failed
+    `select repo, pull_number, julianday(created_at) as failed_at from processed_reviews failed
       where (${errorWhere})
-        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))
-        and not exists (
-          select 1 from processed_reviews posted
-           where posted.repo = failed.repo and posted.pull_number = failed.pull_number
-             and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.created_at)
-        )`
-  ).get(cutoff) as { count: number };
-  const last = db.prepare(
-    `select created_at from processed_reviews failed
-      where ${errorWhere}
-      order by datetime(created_at) desc limit 1`
-  ).get() as { created_at?: string } | undefined;
+        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))`
+  ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; failed_at: number | null }>;
   return {
-    recentUnrecoveredErrorCount: recent.count ?? 0,
-    ...(last?.created_at ? { lastErrorAt: last.created_at } : {})
+    recentUnrecoveredErrorCount: recent.filter((row) => {
+      const postedAt = recovery.latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
+      return row.failed_at === null || postedAt === undefined || postedAt <= row.failed_at;
+    }).length,
+    ...(recovery.lastErrorAt ? { lastErrorAt: recovery.lastErrorAt } : {})
   };
 }
 
 function readReviewQueueCounts(
   db: DatabaseSync,
-  now: Date
+  now: Date,
+  latestPostedAtByPull: Map<string, number>
 ): {
   total: number;
   queued: number;
@@ -2523,16 +2539,14 @@ function readReviewQueueCounts(
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
   const failedRows = db.prepare(
-    `select failed.last_error,
-            not exists (
-              select 1 from processed_reviews posted
-               where posted.repo = failed.repo and posted.pull_number = failed.pull_number
-                 and posted.status = 'posted' and datetime(posted.created_at) > datetime(failed.updated_at)
-            ) as active
+    `select repo, pull_number, last_error, julianday(updated_at) as failed_at
        from review_queue_jobs failed
       where failed.state = 'failed'`
   ).all() as unknown as FailedQueueRow[];
-  const activeFailedRows = failedRows.filter((row) => row.active === 1);
+  const activeFailedRows = failedRows.filter((row) => {
+    const postedAt = latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
+    return row.failed_at === null || postedAt === undefined || postedAt <= row.failed_at;
+  });
   const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
   const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { containsSecretLikeText } from "./secrets.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
-import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
+import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
 import type { ReviewQueueJobRecord } from "./state.js";
 
@@ -32,6 +32,8 @@ export interface ReleaseLaunchdStatus {
 export interface ReleaseDatabaseStatus {
   rowCount: number;
   errorCount: number;
+  recentUnrecoveredErrorCount?: number;
+  lastErrorAt?: string;
   skippedCount?: number;
   reviewerSessionCount?: number;
   activeReviewerSessionCount?: number;
@@ -53,7 +55,9 @@ export interface ReleaseDatabaseStatus {
   providerDeferredReviewQueueJobCount?: number;
   retryableProviderDeferredReviewQueueJobCount?: number;
   failedReviewQueueJobCount?: number;
+  activeFailedReviewQueueJobCount?: number;
   zcodeTimeoutFailedReviewQueueJobCount?: number;
+  activeZCodeTimeoutFailedReviewQueueJobCount?: number;
   retryableZCodeTimeoutFailedReviewQueueJobCount?: number;
   exhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
   reviewRunLeaseCount?: number;
@@ -61,6 +65,8 @@ export interface ReleaseDatabaseStatus {
   staleActiveReviewQueueJobCount?: number;
   reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
 }
+
+export interface ReleaseHealthStatus { state: "green" | "amber" | "red"; reason: string; active: { failedQueueJobs: number; staleReviewLeases: number }; recent: { unrecoveredReviewErrors: number }; history: { reviewErrors: number; failedQueueJobs: number }; }
 
 export interface ReviewerSessionRepoStatus {
   repo: string;
@@ -166,6 +172,7 @@ export interface PublicReleaseChannelStatus {
 export interface ReleaseStatus {
   ok: boolean;
   checkedAt: string;
+  health?: ReleaseHealthStatus;
   summary: {
     blockingErrorRows: number;
     failedQueueJobs: number;
@@ -246,6 +253,8 @@ const OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATE_OVERRIDES = new Map([
   ["website", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "pending-site-sync"])],
   ["desktop", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "post_1_0"])]
 ]);
+const FAILURE_HEALTH_WINDOW_HOURS = 24;
+const FAILURE_HEALTH_WINDOW_MS = FAILURE_HEALTH_WINDOW_HOURS * 60 * 60 * 1_000;
 
 export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const expectedHeadOk = !input.expectedHead || input.repo.head === input.expectedHead;
@@ -255,7 +264,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const launchdSystemCaOk =
     input.launchd.sealedDesktopWorker === true || input.launchd.usesSystemCa === true;
-  const dbOk = input.database.errorCount === 0;
+  const failureWindowHours = FAILURE_HEALTH_WINDOW_HOURS;
+  const recentUnrecoveredErrorCount = input.database.recentUnrecoveredErrorCount ?? input.database.errorCount;
+  const dbOk = recentUnrecoveredErrorCount === 0;
   const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
   const retryableExpiredProviderCooldownCount =
     input.database.retryableExpiredProviderCooldownCount ??
@@ -264,11 +275,15 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       (input.database.expiredProviderCooldownCount ?? 0) - (input.database.coveredExpiredProviderCooldownCount ?? 0)
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
-  const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const failedQueueJobs = input.database.failedReviewQueueJobCount ?? 0;
+  const activeFailedQueueJobs = input.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
+  const failedQueueJobsOk = activeFailedQueueJobs === 0;
   const zcodeTimeoutFailedQueueJobCount = input.database.zcodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const activeZCodeTimeoutFailedQueueJobCount =
+    input.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? zcodeTimeoutFailedQueueJobCount;
   const retryableZCodeTimeoutFailedQueueJobCount = input.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0;
   const exhaustedZCodeTimeoutFailedQueueJobCount = input.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0;
-  const zcodeTimeoutFailedQueueJobsOk = zcodeTimeoutFailedQueueJobCount === 0;
+  const zcodeTimeoutFailedQueueJobsOk = activeZCodeTimeoutFailedQueueJobCount === 0;
   const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
     (input.database.staleActiveReviewQueueJobCount ?? 0);
   const staleReviewLeasesOk = staleReviewLeaseCount === 0;
@@ -322,7 +337,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "live_db_no_errors",
       ok: dbOk,
       detail:
-        `${input.database.errorCount} blocking error row(s)` +
+        (input.database.recentUnrecoveredErrorCount === undefined
+          ? `${input.database.errorCount} blocking error row(s)`
+          : `${recentUnrecoveredErrorCount} recent unrecovered blocking error row(s) in ${failureWindowHours}h; ` +
+            `${input.database.errorCount} retained history; last failure ${input.database.lastErrorAt ?? "unknown"}`) +
         describeProviderCooldownCounts(input.database)
     },
     {
@@ -335,14 +353,19 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "queue_no_failed_jobs",
       ok: failedQueueJobsOk,
-      detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "queue_no_zcode_timeout_failed_jobs",
       ok: zcodeTimeoutFailedQueueJobsOk,
-      detail:
-        `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+      detail: activeZCodeTimeoutFailedQueueJobCount === zcodeTimeoutFailedQueueJobCount
+        ? `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+        : `${activeZCodeTimeoutFailedQueueJobCount} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutFailedQueueJobCount}; retryable=${retryableZCodeTimeoutFailedQueueJobCount} ` +
+          `exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
     },
     {
       name: "queue_no_stale_review_leases",
@@ -390,13 +413,21 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     ...runtimeGates,
     ...publicReleaseGates
   ];
+  const health = classifyReleaseHealth({
+    gates,
+    database: input.database,
+    recentUnrecoveredErrorCount,
+    activeFailedQueueJobs,
+    staleReviewLeaseCount
+  });
 
   return {
     ok: gates.every((gate) => gate.ok),
     checkedAt: (input.now ?? new Date()).toISOString(),
+    health,
     summary: {
       blockingErrorRows: input.database.errorCount,
-      failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0,
+      failedQueueJobs,
       staleReviewLeases: staleReviewLeaseCount,
       providerDeferredQueueJobs: input.database.providerDeferredReviewQueueJobCount ?? 0,
       retryableProviderDeferredQueueJobs: input.database.retryableProviderDeferredReviewQueueJobCount ?? 0,
@@ -444,6 +475,18 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
       unloadCommand: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${input.launchd.label}.plist`
     }
+  };
+}
+
+function classifyReleaseHealth(input: { gates: Array<{ name: string; ok: boolean }>; database: ReleaseDatabaseStatus; recentUnrecoveredErrorCount: number; activeFailedQueueJobs: number; staleReviewLeaseCount: number }): ReleaseHealthStatus {
+  const failedGates = input.gates.filter((gate) => !gate.ok).map((gate) => gate.name);
+  const state: ReleaseHealthStatus["state"] = failedGates.length ? "red" : input.database.errorCount || input.database.failedReviewQueueJobCount ? "amber" : "green";
+  return {
+    state,
+    reason: state === "red" ? `current or recent actionable gate(s) failed: ${failedGates.join(", ")}` : state === "amber" ? `current gates pass; retained history has ${input.database.errorCount} review error(s) and ${input.database.failedReviewQueueJobCount ?? 0} failed queue job(s)` : "current gates pass with no recorded review or queue failure history",
+    active: { failedQueueJobs: input.activeFailedQueueJobs, staleReviewLeases: input.staleReviewLeaseCount },
+    recent: { unrecoveredReviewErrors: input.recentUnrecoveredErrorCount },
+    history: { reviewErrors: input.database.errorCount, failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0 }
   };
 }
 
@@ -2336,8 +2379,9 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       : retryableExpiredProviderCooldownCount > 0
         ? "expired_retryable"
         : "none";
+    const failureHealth = readProcessedFailureHealth(db, now);
     const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
-    const reviewQueue = readReviewQueueCounts(db, now);
+    const reviewQueue = readReviewQueueCounts(db, now, failureHealth.latestPostedAtByPull);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
@@ -2363,23 +2407,84 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
       retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
       failedReviewQueueJobCount: reviewQueue.failed,
+      activeFailedReviewQueueJobCount: reviewQueue.activeFailed,
       zcodeTimeoutFailedReviewQueueJobCount: reviewQueue.zcodeTimeoutFailed,
+      activeZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.activeZCodeTimeoutFailed,
       retryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.retryableZCodeTimeoutFailed,
       exhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.exhaustedZCodeTimeoutFailed,
       reviewRunLeaseCount: reviewRunLeases.total,
       staleReviewRunLeaseCount: reviewRunLeases.stale,
       staleActiveReviewQueueJobCount,
       reviewQueueJobsByRepo: reviewQueue.byRepo,
-      errorCount: row.errorCount ?? 0
+      errorCount: row.errorCount ?? 0,
+      recentUnrecoveredErrorCount: failureHealth.recentUnrecoveredErrorCount,
+      ...(failureHealth.lastErrorAt ? { lastErrorAt: failureHealth.lastErrorAt } : {})
     };
   } finally {
     db.close();
   }
 }
 
+type ProcessedFailureRow = { repo: string; pull_number: number; status: string; error: string | null; created_at: string };
+type FailedQueueRow = { repo: string; pull_number: number; last_error: string | null; updated_at: string };
+
+function readProcessedFailureHealth(db: DatabaseSync, now: Date): {
+  recentUnrecoveredErrorCount: number;
+  lastErrorAt?: string;
+  latestPostedAtByPull: Map<string, number>;
+} {
+  const rows = db.prepare(
+    `select repo, pull_number, status, error, created_at
+       from processed_reviews
+      where status = 'posted'
+         or status = 'failed'
+         or (status != 'skipped' and error is not null and error != '')`
+  ).all() as unknown as ProcessedFailureRow[];
+  const latestPostedAtByPull = new Map<string, number>();
+  for (const row of rows) {
+    if (row.status !== "posted") continue;
+    const postedAt = parseDatabaseTimestamp(row.created_at);
+    if (!Number.isFinite(postedAt)) continue;
+    const key = `${row.repo}\u0000${row.pull_number}`;
+    if (postedAt > (latestPostedAtByPull.get(key) ?? Number.NEGATIVE_INFINITY)) {
+      latestPostedAtByPull.set(key, postedAt);
+    }
+  }
+  const cutoff = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
+  let recentUnrecoveredErrorCount = 0;
+  let lastErrorAt: { value: string; timestamp: number } | undefined;
+  for (const row of rows) {
+    const isError = row.status === "failed" || (row.status !== "skipped" && Boolean(row.error));
+    if (!isError) continue;
+    const timestamp = parseDatabaseTimestamp(row.created_at);
+    const key = `${row.repo}\u0000${row.pull_number}`;
+    const recoveredAt = latestPostedAtByPull.get(key);
+    if (!(recoveredAt !== undefined && Number.isFinite(timestamp) && recoveredAt > timestamp) &&
+        (!Number.isFinite(timestamp) || timestamp >= cutoff)) {
+      recentUnrecoveredErrorCount += 1;
+    }
+    if (Number.isFinite(timestamp) && (!lastErrorAt || timestamp > lastErrorAt.timestamp)) {
+      lastErrorAt = { value: row.created_at, timestamp };
+    }
+  }
+  return {
+    recentUnrecoveredErrorCount,
+    ...(lastErrorAt ? { lastErrorAt: lastErrorAt.value } : {}),
+    latestPostedAtByPull
+  };
+}
+
+function parseDatabaseTimestamp(value: string | null | undefined): number {
+  const text = value?.trim();
+  if (!text) return Number.NaN;
+  return Date.parse(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(text)
+    ? `${text.replace(" ", "T")}Z` : text);
+}
+
 function readReviewQueueCounts(
   db: DatabaseSync,
-  now: Date
+  now: Date,
+  latestPostedAtByPull: Map<string, number>
 ): {
   total: number;
   queued: number;
@@ -2388,7 +2493,9 @@ function readReviewQueueCounts(
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  activeFailed: number;
   zcodeTimeoutFailed: number;
+  activeZCodeTimeoutFailed: number;
   retryableZCodeTimeoutFailed: number;
   exhaustedZCodeTimeoutFailed: number;
   byRepo: ReviewQueueRepoStatus[];
@@ -2405,7 +2512,9 @@ function readReviewQueueCounts(
       providerDeferred: 0,
       retryableProviderDeferred: 0,
       failed: 0,
+      activeFailed: 0,
       zcodeTimeoutFailed: 0,
+      activeZCodeTimeoutFailed: 0,
       retryableZCodeTimeoutFailed: 0,
       exhaustedZCodeTimeoutFailed: 0,
       byRepo: []
@@ -2441,14 +2550,18 @@ function readReviewQueueCounts(
        order by repo`
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
-  const timeoutRows = db
-    .prepare(
-      `select last_error
+  const failedRows = db.prepare(
+    `select repo, pull_number, last_error, updated_at
        from review_queue_jobs
-       where state = 'failed' and last_error like ?`
-    )
-    .all(`${ZCODE_TIMEOUT_ERROR_PREFIX}%`) as unknown as Array<{ last_error: string | null }>;
-  const timeoutCounts = summarizeZCodeTimeoutErrors(timeoutRows.map((timeoutRow) => timeoutRow.last_error));
+      where state = 'failed'`
+  ).all() as unknown as FailedQueueRow[];
+  const activeFailedRows = failedRows.filter((row) => {
+    const recoveredAt = latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
+    const failedAt = parseDatabaseTimestamp(row.updated_at);
+    return recoveredAt === undefined || !Number.isFinite(failedAt) || recoveredAt <= failedAt;
+  });
+  const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
+  const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -2457,7 +2570,9 @@ function readReviewQueueCounts(
     providerDeferred: row.providerDeferred ?? 0,
     retryableProviderDeferred: row.retryableProviderDeferred ?? 0,
     failed: row.failed ?? 0,
+    activeFailed: activeFailedRows.length,
     zcodeTimeoutFailed: timeoutCounts.total,
+    activeZCodeTimeoutFailed: activeTimeoutCounts.total,
     retryableZCodeTimeoutFailed: timeoutCounts.retryable,
     exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,
     byRepo: byRepoRows.map((repoRow) => ({

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2443,6 +2443,22 @@ function readFailureRecoveryIndex(db: DatabaseSync): FailureRecoveryIndex {
     if (row.posted_at !== null) latestPostedAtByPull.set(`${row.repo}\u0000${row.pull_number}`, row.posted_at);
     if (row.error_marker && (!lastErrorMarker || row.error_marker > lastErrorMarker)) lastErrorMarker = row.error_marker;
   }
+  const hasAuthorizedPostedAt = db
+    .prepare("select 1 from pragma_table_info('review_event_authorization_consumptions') where name = 'posted_at'")
+    .get();
+  const authorizedRows = hasAuthorizedPostedAt
+    ? db.prepare(
+        `select repo, pull_number, max(julianday(posted_at)) as posted_at
+           from review_event_authorization_consumptions
+          where posted_at is not null group by repo, pull_number`
+      ).all() as unknown as Array<{ repo: string; pull_number: number; posted_at: number | null }>
+    : [];
+  for (const row of authorizedRows) {
+    const key = `${row.repo}\u0000${row.pull_number}`;
+    if (row.posted_at !== null && row.posted_at > (latestPostedAtByPull.get(key) ?? -Infinity)) {
+      latestPostedAtByPull.set(key, row.posted_at);
+    }
+  }
   return {
     latestPostedAtByPull,
     ...(lastErrorMarker ? { lastErrorAt: lastErrorMarker.slice(lastErrorMarker.indexOf("|") + 1) } : {})

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2454,16 +2454,20 @@ function readProcessedFailureHealth(db: DatabaseSync, now: Date, recovery: Failu
   lastErrorAt?: string;
 } {
   const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
-  const cutoff = new Date(now.getTime() - FAILURE_HEALTH_WINDOW_MS).toISOString();
+  const cutoffMs = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
+  const cutoff = new Date(cutoffMs).toISOString();
   const recent = db.prepare(
-    `select repo, pull_number, julianday(created_at) as failed_at from processed_reviews failed
+    `select repo, pull_number, created_at from processed_reviews failed
       where (${errorWhere})
-        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?))`
-  ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; failed_at: number | null }>;
+        and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?, '-1 second'))`
+  ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; created_at: string }>;
   return {
     recentUnrecoveredErrorCount: recent.filter((row) => {
+      const normalized = row.created_at.replace(" ", "T");
+      const failedAt = Date.parse(/[zZ]|[+-]\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`);
+      if (Number.isFinite(failedAt) && failedAt < cutoffMs) return false;
       const postedAt = recovery.latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
-      return row.failed_at === null || postedAt === undefined || postedAt <= row.failed_at;
+      return !Number.isFinite(failedAt) || postedAt === undefined || postedAt <= failedAt / 86_400_000 + 2440587.5;
     }).length,
     ...(recovery.lastErrorAt ? { lastErrorAt: recovery.lastErrorAt } : {})
   };

--- a/src/state.ts
+++ b/src/state.ts
@@ -920,13 +920,14 @@ export class ReviewStateStore {
   }
 
   recordProcessed(record: ProcessedReviewRecord): void {
+    const recordedAt = new Date().toISOString();
     this.db.exec("begin immediate");
     try {
       this.db
         .prepare(
           `insert or replace into processed_reviews
             (repo, pull_number, head_sha, status, config_revision, event, review_url, error, created_at)
-           values (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+           values (?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           record.repo,
@@ -936,7 +937,8 @@ export class ReviewStateStore {
           record.configRevision ?? null,
           record.event ?? null,
           record.reviewUrl ?? null,
-          record.error ?? null
+          record.error ?? null,
+          recordedAt
         );
       // Completion and claim retirement are one transaction. A later ordinary claimant must see
       // either the live claim or the durable processed row, never a gap between the two.
@@ -1888,9 +1890,9 @@ export class ReviewStateStore {
           .prepare(
             `insert or replace into processed_reviews
               (repo, pull_number, head_sha, status, event, review_url, error, created_at)
-             values (?, ?, ?, 'posted', ?, ?, null, datetime('now'))`
+             values (?, ?, ?, 'posted', ?, ?, null, ?)`
           )
-          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl);
+          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl, postedAt);
       }
       const readinessEvent = preserveExistingBlocking ? "REQUEST_CHANGES" : input.event;
       const readinessUrl = preserveExistingBlocking ? existingProcessed?.reviewUrl : input.reviewUrl;

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -220,6 +220,49 @@ describe("beta release status", () => {
     expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
   });
 
+  it("separates recovered history from recent UTC failures and active queue work", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-active-health-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`create table processed_reviews (repo text, pull_number integer, head_sha text, status text, error text, created_at text, primary key (repo, pull_number, head_sha));
+      create table review_queue_jobs (job_id text primary key, attempt_id text, source text, lane text, repo text, org text, pull_number integer, head_sha text, priority integer, state text, next_eligible_at text, lease_expires_at text, last_error text, created_at text, updated_at text);`);
+    const processed = db.prepare("insert into processed_reviews (repo,pull_number,head_sha,status,error,created_at) values (?,?,?,?,?,?)");
+    processed.run("owner/repo", 7, "old-failure", "failed", "provider timeout", "2026-08-21T23:30:00+07:00");
+    processed.run("owner/repo", 7, "old-posted", "posted", null, "2026-08-22T12:00:00Z");
+    processed.run("owner/repo", 8, "recent-failure", "failed", "provider timeout", "2026-08-22 23:30:00");
+    processed.run("owner/repo", 8, "recent-posted-before", "posted", null, "2026-08-22T22:00:00Z");
+    const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
+    queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
+    queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
+    db.close();
+    const status = collectReleaseStatus({
+      cwd: repoRoot,
+      statePath: dbPath,
+      configPath: join(root, "missing-config.json"),
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-08-23T00:00:00Z")
+    });
+
+    expect(status.database).toMatchObject({
+      errorCount: 2,
+      recentUnrecoveredErrorCount: 1,
+      lastErrorAt: "2026-08-22 23:30:00",
+      failedReviewQueueJobCount: 2,
+      activeFailedReviewQueueJobCount: 1,
+      zcodeTimeoutFailedReviewQueueJobCount: 1,
+      activeZCodeTimeoutFailedReviewQueueJobCount: 0
+    });
+    expect(status.gates).toContainEqual(expect.objectContaining({ name: "live_db_no_errors", ok: false }));
+    expect(status.gates).toContainEqual(expect.objectContaining({ name: "queue_no_failed_jobs", ok: false }));
+  });
+
+  it("keeps recovered historical failures amber rather than red", () => {
+    const status = buildReleaseStatus({ repo: { branch: "main", head: "head", dirtyFiles: [] }, expectedHead: "head", configPath: "/config/live.json", launchd: { label: "worker", state: "running", configPath: "/config/live.json", usesSystemCa: true }, database: { rowCount: 2, errorCount: 1, recentUnrecoveredErrorCount: 0, lastErrorAt: "2026-08-21T00:00:00Z", failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: 0, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: 0 }, heartbeat: freshHeartbeat(), now: new Date("2026-08-23T00:00:00Z") });
+    expect(status.ok).toBe(true);
+    expect(status.health).toMatchObject({ state: "amber", active: { failedQueueJobs: 0 }, recent: { unrecoveredReviewErrors: 0 }, history: { reviewErrors: 1, failedQueueJobs: 1 } });
+  });
+
   it("adds public release manifest gates while allowing an explicit source beta license API deferral", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-green-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -232,9 +232,14 @@ describe("beta release status", () => {
     processed.run("owner/repo", 7, "old-posted", "posted", null, "2026-08-22T12:00:00Z");
     processed.run("owner/repo", 8, "recent-failure", "failed", "provider timeout", "2026-08-22 23:30:00");
     processed.run("owner/repo", 8, "recent-posted-before", "posted", null, "2026-08-22T22:00:00Z");
+    processed.run("owner/repo", 9, "millisecond-failure", "failed", "provider timeout", "2026-08-22T23:45:00.100Z");
+    processed.run("owner/repo", 9, "millisecond-posted", "posted", null, "2026-08-22T23:45:00.900Z");
+    db.exec(`with recursive n(x) as (values(1) union all select x+1 from n where x<10000) insert into processed_reviews select 'history/repo',x,'history-'||x,'posted',null,'2026-01-01T00:00:00Z' from n;
+      with recursive n(x) as (values(1) union all select x+1 from n where x<100) insert into processed_reviews select 'error/repo',x,'error-'||x,'failed','provider timeout','2026-08-22T23:00:00Z' from n;`);
     const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
     queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
     queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
+    queue.run("millisecond", "millisecond", "automatic", "background", "owner/repo", "owner", 9, "millisecond-failure", 1, "failed", "ordinary failure", "2026-08-22T23:45:00.100Z", "2026-08-22T23:45:00.100Z");
     db.close();
     const status = collectReleaseStatus({
       cwd: repoRoot,
@@ -245,10 +250,10 @@ describe("beta release status", () => {
     });
 
     expect(status.database).toMatchObject({
-      errorCount: 2,
-      recentUnrecoveredErrorCount: 1,
-      lastErrorAt: "2026-08-22 23:30:00",
-      failedReviewQueueJobCount: 2,
+      errorCount: 103,
+      recentUnrecoveredErrorCount: 101,
+      lastErrorAt: "2026-08-22T23:45:00.100Z",
+      failedReviewQueueJobCount: 3,
       activeFailedReviewQueueJobCount: 1,
       zcodeTimeoutFailedReviewQueueJobCount: 1,
       activeZCodeTimeoutFailedReviewQueueJobCount: 0

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -236,6 +236,7 @@ describe("beta release status", () => {
     processed.run("owner/repo", 9, "millisecond-posted", "posted", null, "2026-08-22T23:45:00.900Z");
     db.exec(`with recursive n(x) as (values(1) union all select x+1 from n where x<10000) insert into processed_reviews select 'history/repo',x,'history-'||x,'posted',null,'2026-01-01T00:00:00Z' from n;
       with recursive n(x) as (values(1) union all select x+1 from n where x<100) insert into processed_reviews select 'error/repo',x,'error-'||x,'failed','provider timeout','2026-08-22T23:00:00Z' from n;`);
+    db.exec("insert into processed_reviews values ('owner/repo',10,'outside-cutoff','failed','provider timeout','2026-08-22T00:00:00.100Z'),('owner/repo',11,'exact-cutoff','failed','provider timeout','2026-08-22T07:00:00.500+07:00'),('owner/repo',12,'inside-cutoff','failed','provider timeout','2026-08-22T00:00:00.900Z')");
     const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
     queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
     queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
@@ -246,12 +247,12 @@ describe("beta release status", () => {
       statePath: dbPath,
       configPath: join(root, "missing-config.json"),
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
-      now: new Date("2026-08-23T00:00:00Z")
+      now: new Date("2026-08-23T00:00:00.500Z")
     });
 
     expect(status.database).toMatchObject({
-      errorCount: 103,
-      recentUnrecoveredErrorCount: 101,
+      errorCount: 106,
+      recentUnrecoveredErrorCount: 103,
       lastErrorAt: "2026-08-22T23:45:00.100Z",
       failedReviewQueueJobCount: 3,
       activeFailedReviewQueueJobCount: 1,

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -220,13 +220,14 @@ describe("beta release status", () => {
     expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
   });
 
-  it("separates recovered history from recent UTC failures and active queue work", () => {
+  it("separates recovered history including preserved authorized posts from active work", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-active-health-"));
     roots.push(root);
     const dbPath = join(root, "state.sqlite");
     const db = new DatabaseSync(dbPath);
-    db.exec(`create table processed_reviews (repo text, pull_number integer, head_sha text, status text, error text, created_at text, primary key (repo, pull_number, head_sha));
-      create table review_queue_jobs (job_id text primary key, attempt_id text, source text, lane text, repo text, org text, pull_number integer, head_sha text, priority integer, state text, next_eligible_at text, lease_expires_at text, last_error text, created_at text, updated_at text);`);
+    db.exec(`create table processed_reviews (repo text, pull_number integer, head_sha text, status text, event text, error text, created_at text, primary key (repo, pull_number, head_sha));
+      create table review_queue_jobs (job_id text primary key, attempt_id text, source text, lane text, repo text, org text, pull_number integer, head_sha text, priority integer, state text, next_eligible_at text, lease_expires_at text, last_error text, created_at text, updated_at text);
+      create table review_event_authorization_consumptions (repo text, pull_number integer, posted_event text, posted_at text);`);
     const processed = db.prepare("insert into processed_reviews (repo,pull_number,head_sha,status,error,created_at) values (?,?,?,?,?,?)");
     processed.run("owner/repo", 7, "old-failure", "failed", "provider timeout", "2026-08-21T23:30:00+07:00");
     processed.run("owner/repo", 7, "old-posted", "posted", null, "2026-08-22T12:00:00Z");
@@ -234,13 +235,21 @@ describe("beta release status", () => {
     processed.run("owner/repo", 8, "recent-posted-before", "posted", null, "2026-08-22T22:00:00Z");
     processed.run("owner/repo", 9, "millisecond-failure", "failed", "provider timeout", "2026-08-22T23:45:00.100Z");
     processed.run("owner/repo", 9, "millisecond-posted", "posted", null, "2026-08-22T23:45:00.900Z");
-    db.exec(`with recursive n(x) as (values(1) union all select x+1 from n where x<10000) insert into processed_reviews select 'history/repo',x,'history-'||x,'posted',null,'2026-01-01T00:00:00Z' from n;
-      with recursive n(x) as (values(1) union all select x+1 from n where x<100) insert into processed_reviews select 'error/repo',x,'error-'||x,'failed','provider timeout','2026-08-22T23:00:00Z' from n;`);
-    db.exec("insert into processed_reviews values ('owner/repo',10,'outside-cutoff','failed','provider timeout','2026-08-22T00:00:00.100Z'),('owner/repo',11,'exact-cutoff','failed','provider timeout','2026-08-22T07:00:00.500+07:00'),('owner/repo',12,'inside-cutoff','failed','provider timeout','2026-08-22T00:00:00.900Z')");
+    processed.run("owner/repo", 13, "preserved-failure", "failed", "provider timeout", "2026-08-22T23:30:00.100Z");
+    processed.run("owner/repo", 13, "preserved-blocking", "posted", null, "2026-08-22T23:00:00Z");
+    processed.run("owner/repo", 14, "receipt-before-failure", "failed", "provider timeout", "2026-08-22T23:30:00.900Z");
+    processed.run("owner/repo", 14, "prior-blocking", "posted", null, "2026-08-22T23:00:00Z");
+    db.exec(`update processed_reviews set event = 'REQUEST_CHANGES' where pull_number in (13,14) and status = 'posted';
+      insert into review_event_authorization_consumptions values ('owner/repo',13,'COMMENT','2026-08-22T23:30:00.900Z'),('owner/repo',14,'COMMENT','2026-08-22T23:30:00.100Z');`);
+    db.exec(`with recursive n(x) as (values(1) union all select x+1 from n where x<10000) insert into processed_reviews (repo,pull_number,head_sha,status,error,created_at) select 'history/repo',x,'history-'||x,'posted',null,'2026-01-01T00:00:00Z' from n;
+      with recursive n(x) as (values(1) union all select x+1 from n where x<100) insert into processed_reviews (repo,pull_number,head_sha,status,error,created_at) select 'error/repo',x,'error-'||x,'failed','provider timeout','2026-08-22T23:00:00Z' from n;`);
+    db.exec("insert into processed_reviews (repo,pull_number,head_sha,status,error,created_at) values ('owner/repo',10,'outside-cutoff','failed','provider timeout','2026-08-22T00:00:00.100Z'),('owner/repo',11,'exact-cutoff','failed','provider timeout','2026-08-22T07:00:00.500+07:00'),('owner/repo',12,'inside-cutoff','failed','provider timeout','2026-08-22T00:00:00.900Z')");
     const queue = db.prepare("insert into review_queue_jobs (job_id,attempt_id,source,lane,repo,org,pull_number,head_sha,priority,state,last_error,created_at,updated_at) values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
     queue.run("zcode", "zcode", "automatic", "background", "owner/repo", "owner", 7, "old-failure", 1, "failed", "zcode_timeout_retryable; retry_attempt=1; reason=timeout", "2026-08-21T23:30:00+07:00", "2026-08-21T23:30:00+07:00");
     queue.run("recent", "recent", "automatic", "background", "owner/repo", "owner", 8, "recent-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
     queue.run("millisecond", "millisecond", "automatic", "background", "owner/repo", "owner", 9, "millisecond-failure", 1, "failed", "ordinary failure", "2026-08-22T23:45:00.100Z", "2026-08-22T23:45:00.100Z");
+    queue.run("preserved", "preserved", "automatic", "background", "owner/repo", "owner", 13, "preserved-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00.100Z", "2026-08-22T23:30:00.100Z");
+    queue.run("prior-receipt", "prior-receipt", "automatic", "background", "owner/repo", "owner", 14, "receipt-before-failure", 1, "failed", "ordinary failure", "2026-08-22T23:30:00.900Z", "2026-08-22T23:30:00.900Z");
     db.close();
     const status = collectReleaseStatus({
       cwd: repoRoot,
@@ -251,11 +260,11 @@ describe("beta release status", () => {
     });
 
     expect(status.database).toMatchObject({
-      errorCount: 106,
-      recentUnrecoveredErrorCount: 103,
+      errorCount: 108,
+      recentUnrecoveredErrorCount: 104,
       lastErrorAt: "2026-08-22T23:45:00.100Z",
-      failedReviewQueueJobCount: 3,
-      activeFailedReviewQueueJobCount: 1,
+      failedReviewQueueJobCount: 5,
+      activeFailedReviewQueueJobCount: 2,
       zcodeTimeoutFailedReviewQueueJobCount: 1,
       activeZCodeTimeoutFailedReviewQueueJobCount: 0
     });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2,17 +2,19 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseProviderCooldownError, ReviewStateStore } from "../src/state.js";
 
 describe("review state store", () => {
   const roots: string[] = [];
 
   afterEach(() => {
+    vi.useRealTimers();
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
   it("deduplicates one review per repo, PR, and head SHA", () => {
+    vi.useFakeTimers({ now: new Date("2026-08-23T00:00:00.900Z") });
     const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
@@ -22,11 +24,12 @@ describe("review state store", () => {
       repo: "electricsheephq/WorldOS",
       pullNumber: 1205,
       headSha: "abc123",
-      status: "dry_run",
+      status: "posted",
       event: "COMMENT"
     });
 
     expect(store.hasProcessed("electricsheephq/WorldOS", 1205, "abc123")).toBe(true);
+    expect(store.getProcessedReview("electricsheephq/WorldOS", 1205, "abc123")?.createdAt).toBe("2026-08-23T00:00:00.900Z");
     expect(store.hasProcessed("electricsheephq/WorldOS", 1205, "def456")).toBe(false);
     store.close();
   });
@@ -1801,7 +1804,7 @@ describe("review state store", () => {
       ...authorization,
       event: "REQUEST_CHANGES",
       reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
-      now: new Date("2026-07-13T00:01:00.000Z")
+      now: new Date("2026-07-13T00:01:00.900Z")
     });
     expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "A".repeat(40))).toEqual({
       repo: "owner/repo",
@@ -1812,12 +1815,13 @@ describe("review state store", () => {
       consumedAt: "2026-07-13T00:00:00.000Z",
       postedEvent: "REQUEST_CHANGES",
       reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
-      postedAt: "2026-07-13T00:01:00.000Z"
+      postedAt: "2026-07-13T00:01:00.900Z"
     });
     expect(store.getProcessedReview("owner/repo", 7, "A".repeat(40))).toMatchObject({
       status: "posted",
       event: "REQUEST_CHANGES",
-      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1"
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+      createdAt: "2026-07-13T00:01:00.900Z"
     });
     expect(store.recordReviewEventAuthorizationIncident({
       repo: "owner/repo",


### PR DESCRIPTION
Related: #741
Supersedes the unmerged parent candidate #821 and the held operator presentation #822 for the core active-health surface.

## Summary

- separate active/recent failure truth from retained historical audit debt;
- aggregate recovery timestamps with bounded grouped SQL rather than history-wide or per-row scans;
- fold successful authorized-review `posted_at` receipts into the recovery index;
- preserve exact millisecond and UTC ordering in production review timestamps;
- keep raw `lastErrorAt` and historical totals visible without making old debt automatically current-red.

## Regression proof

- later posts/authorization receipts recover the same repository/PR failure; earlier or equal receipts do not;
- same-second `.100Z` failure followed by `.900Z` post recovers, reverse order does not;
- legacy receipt tables without `posted_at` remain read-only compatible;
- query plans use one grouped scan per source and no correlated subquery;
- combined state/release-status tests: 188/188 passed;
- exact-head CI passed on the rebased parent and child trees;
- parent and child accepted patch hashes remained unchanged after rebase.

## Review envelope

The implementation was deliberately reviewed as two bounded slices: #821 (197 changed lines) plus the #833 recovery/timestamp delta (69 changed lines). This PR now targets `main` so the known parent timestamp gap is never merged without its accepted fix.

Base: `61ddb81f2ce7e3523c3af4e9bc582cafff62cb71`
Head: `440eb5f21293eefe0debe95e285a4d05e20f34e6`

Agent-authored. No schema migration, live database/config/queue/worker/customer mutation, release, or installation occurred.
