### PR TITLE
ci: validate immutable desktop release identity

### DIFF
--- a/scripts/validate-desktop-release-identity.mjs
+++ b/scripts/validate-desktop-release-identity.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from "node:fs";
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const values = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  const key = process.argv[index];
+  const value = process.argv[index + 1];
+  if (!key?.startsWith("--") || value === undefined) fail(`invalid argument near ${key ?? "(missing)"}`);
+  values.set(key.slice(2), value);
+}
+const required = (name) => {
+  const value = values.get(name);
+  if (!value) fail(`--${name} is required`);
+  return value;
+};
+const readJSON = (name) => {
+  try {
+    return JSON.parse(readFileSync(required(name), "utf8"));
+  } catch {
+    fail(`--${name} must point to valid JSON`);
+  }
+};
+const tag = required("release-tag");
+const artifact = required("artifact-name");
+const digest = required("artifact-sha256");
+const sourceSHA = required("reviewed-source-sha");
+const tagMatch = tag.match(/^v1\.1\.0-(beta\.([0-9]+)|rc\.([1-9][0-9]*))$/);
+if (!tagMatch) fail("release tag must be canonical beta.N or rc.[1-9][0-9]*");
+const releaseIdentity = tagMatch[1];
+const releaseChannel = releaseIdentity.split(".")[0];
+const releaseNumber = releaseIdentity.split(".")[1];
+const artifactMatch = artifact.match(/^NeonDiff-1\.1\.0-(beta\.([0-9]+)|rc\.([1-9][0-9]*))-build([0-9]+)-macOS\.zip$/);
+if (!artifactMatch) fail("artifact name is not build-named for the supported release");
+const artifactIdentity = artifactMatch[1];
+if (artifactIdentity !== releaseIdentity) fail("tag and artifact channel/number disagree");
+if (!/^[a-f0-9]{64}$/.test(digest)) fail("artifact SHA-256 must be lowercase 64-hex");
+if (!/^[0-9a-f]{40}$/.test(sourceSHA)) fail("reviewed source SHA must be exactly 40 lowercase hex");
+
+const tagMetadata = readJSON("tag-metadata");
+const annotatedTag = readJSON("annotated-tag-metadata");
+const release = readJSON("release-metadata");
+if (tagMetadata.ref !== `refs/tags/${tag}` || tagMetadata.object?.type !== "tag" || !/^[0-9a-f]{40}$/.test(tagMetadata.object?.sha ?? "")) {
+  fail("release tag must resolve to an annotated tag object");
+}
+if (annotatedTag.object?.type !== "commit" || annotatedTag.object.sha !== sourceSHA) {
+  fail("annotated tag does not peel to the explicitly reviewed source SHA");
+}
+if (release.tag_name !== tag || release.draft !== false || release.prerelease !== true || release.immutable !== true) {
+  fail("GitHub release must match the tag and be immutable published prerelease");
+}
+const assets = Array.isArray(release.assets) ? release.assets.filter((item) => item?.name === artifact) : [];
+if (assets.length !== 1 || assets[0].digest !== `sha256:${digest}`) fail("exact release asset and digest are required");
+const expectedURL = `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${tag}/${artifact}`;
+if (assets[0].browser_download_url !== expectedURL) fail("release asset URL is not canonical");
+
+const output = values.get("github-output");
+if (output) {
+  appendFileSync(output, [
+    `release_channel=${releaseChannel}`,
+    `release_version=1.1.0-${releaseIdentity}`,
+    `artifact_build=${artifactMatch[4]}`,
+    `url=${expectedURL}`,
+    `reviewed_source_sha=${sourceSHA}`
+  ].join("\n") + "\n");
+}

--- a/scripts/validate-desktop-release-identity.mjs
+++ b/scripts/validate-desktop-release-identity.mjs
@@ -30,12 +30,12 @@ const tag = required("release-tag");
 const artifact = required("artifact-name");
 const digest = required("artifact-sha256");
 const sourceSHA = required("reviewed-source-sha");
-const tagMatch = tag.match(/^v1\.1\.0-(beta\.([0-9]+)|rc\.([1-9][0-9]*))$/);
+const tagMatch = tag.match(/^v1\.1\.0-(beta\.([1-9][0-9]{0,3})|rc\.([1-9][0-9]*))$/);
 if (!tagMatch) fail("release tag must be canonical beta.N or rc.[1-9][0-9]*");
 const releaseIdentity = tagMatch[1];
 const releaseChannel = releaseIdentity.split(".")[0];
 const releaseNumber = releaseIdentity.split(".")[1];
-const artifactMatch = artifact.match(/^NeonDiff-1\.1\.0-(beta\.([0-9]+)|rc\.([1-9][0-9]*))-build([0-9]+)-macOS\.zip$/);
+const artifactMatch = artifact.match(/^NeonDiff-1\.1\.0-(beta\.([1-9][0-9]{0,3})|rc\.([1-9][0-9]*))-build([0-9]+)-macOS\.zip$/);
 if (!artifactMatch) fail("artifact name is not build-named for the supported release");
 const artifactIdentity = artifactMatch[1];
 if (artifactIdentity !== releaseIdentity) fail("tag and artifact channel/number disagree");
@@ -45,8 +45,12 @@ if (!/^[0-9a-f]{40}$/.test(sourceSHA)) fail("reviewed source SHA must be exactly
 const tagMetadata = readJSON("tag-metadata");
 const annotatedTag = readJSON("annotated-tag-metadata");
 const release = readJSON("release-metadata");
-if (tagMetadata.ref !== `refs/tags/${tag}` || tagMetadata.object?.type !== "tag" || !/^[0-9a-f]{40}$/.test(tagMetadata.object?.sha ?? "")) {
+const tagObjectSHA = tagMetadata.object?.sha;
+if (tagMetadata.ref !== `refs/tags/${tag}` || tagMetadata.object?.type !== "tag" || !/^[0-9a-f]{40}$/.test(tagObjectSHA ?? "")) {
   fail("release tag must resolve to an annotated tag object");
+}
+if (annotatedTag.sha !== tagObjectSHA || annotatedTag.tag !== tag) {
+  fail("annotated tag identity does not match the requested tag object");
 }
 if (annotatedTag.object?.type !== "commit" || annotatedTag.object.sha !== sourceSHA) {
   fail("annotated tag does not peel to the explicitly reviewed source SHA");

--- a/tests/desktop-release-identity.test.ts
+++ b/tests/desktop-release-identity.test.ts
@@ -15,7 +15,7 @@ function fixture(tag = "v1.1.0-beta.7") {
     tag,
     artifact,
     tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: "abcdef0123456789abcdef0123456789abcdef01" } },
-    annotatedTag: { object: { type: "commit", sha: source } },
+    annotatedTag: { sha: "abcdef0123456789abcdef0123456789abcdef01", tag, object: { type: "commit", sha: source } },
     release: { tag_name: tag, draft: false, prerelease: true, immutable: true, assets: [{ name: artifact, digest: `sha256:${digest}`, browser_download_url: url }] }
   };
 }
@@ -35,7 +35,7 @@ function run(input: ReturnType<typeof fixture>, extra: string[] = []) {
 
 describe("desktop release identity validator", () => {
   it("accepts canonical beta/RC identities and emits bound outputs", () => {
-    for (const tag of ["v1.1.0-beta.7", "v1.1.0-rc.1", "v1.1.0-rc.12"]) {
+    for (const tag of ["v1.1.0-beta.87", "v1.1.0-rc.1", "v1.1.0-rc.12"]) {
       const result = run(fixture(tag));
       expect(result.result.status, result.result.stderr).toBe(0);
       expect(result.outputText).toContain(`release_version=${tag.slice(1)}`);
@@ -45,9 +45,14 @@ describe("desktop release identity validator", () => {
 
   it("rejects mutable, lightweight, wrong-source, and asset-drift metadata", () => {
     const cases = [
+      fixture("v1.1.0-beta.0"),
+      fixture("v1.1.0-beta.01"),
+      fixture("v1.1.0-beta.10000"),
       fixture("v1.1.0-rc.0"),
       fixture("v1.1.0-rc.01"),
       { ...fixture(), tagMetadata: { ...fixture().tagMetadata, object: { type: "commit", sha: source } } },
+      { ...fixture(), annotatedTag: { ...fixture().annotatedTag, sha: "fedcba9876543210fedcba9876543210fedcba98" } },
+      { ...fixture(), annotatedTag: { ...fixture().annotatedTag, tag: "v1.1.0-beta.6" } },
       { ...fixture(), annotatedTag: { object: { type: "commit", sha: "fedcba9876543210fedcba9876543210fedcba98" } } },
       { ...fixture(), release: { ...fixture().release, immutable: false } },
       { ...fixture(), release: { ...fixture().release, assets: [{ ...fixture().release.assets[0], digest: `sha256:${"b".repeat(64)}` }] } }

--- a/tests/desktop-release-identity.test.ts
+++ b/tests/desktop-release-identity.test.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/validate-desktop-release-identity.mjs";
+const source = "0123456789abcdef0123456789abcdef01234567";
+const digest = "a".repeat(64);
+
+function fixture(tag = "v1.1.0-beta.7") {
+  const artifact = `NeonDiff-${tag.slice(1)}-build42-macOS.zip`;
+  const url = `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${tag}/${artifact}`;
+  return {
+    tag,
+    artifact,
+    tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: "abcdef0123456789abcdef0123456789abcdef01" } },
+    annotatedTag: { object: { type: "commit", sha: source } },
+    release: { tag_name: tag, draft: false, prerelease: true, immutable: true, assets: [{ name: artifact, digest: `sha256:${digest}`, browser_download_url: url }] }
+  };
+}
+
+function run(input: ReturnType<typeof fixture>, extra: string[] = []) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-identity-"));
+  const output = join(root, "github-output");
+  for (const [name, value] of [["tag", input.tagMetadata], ["annotated", input.annotatedTag], ["release", input.release]] as const) {
+    writeFileSync(join(root, `${name}.json`), JSON.stringify(value));
+  }
+  const args = [script, "--release-tag", input.tag, "--artifact-name", input.artifact, "--artifact-sha256", digest, "--reviewed-source-sha", source, "--tag-metadata", join(root, "tag.json"), "--annotated-tag-metadata", join(root, "annotated.json"), "--release-metadata", join(root, "release.json"), "--github-output", output, ...extra];
+  const result = spawnSync(process.execPath, args, { encoding: "utf8" });
+  const outputText = existsSync(output) ? readFileSync(output, "utf8") : "";
+  rmSync(root, { recursive: true, force: true });
+  return { result, outputText };
+}
+
+describe("desktop release identity validator", () => {
+  it("accepts canonical beta/RC identities and emits bound outputs", () => {
+    for (const tag of ["v1.1.0-beta.7", "v1.1.0-rc.1", "v1.1.0-rc.12"]) {
+      const result = run(fixture(tag));
+      expect(result.result.status, result.result.stderr).toBe(0);
+      expect(result.outputText).toContain(`release_version=${tag.slice(1)}`);
+      expect(result.outputText).toContain(`reviewed_source_sha=${source}`);
+    }
+  });
+
+  it("rejects mutable, lightweight, wrong-source, and asset-drift metadata", () => {
+    const cases = [
+      fixture("v1.1.0-rc.0"),
+      fixture("v1.1.0-rc.01"),
+      { ...fixture(), tagMetadata: { ...fixture().tagMetadata, object: { type: "commit", sha: source } } },
+      { ...fixture(), annotatedTag: { object: { type: "commit", sha: "fedcba9876543210fedcba9876543210fedcba98" } } },
+      { ...fixture(), release: { ...fixture().release, immutable: false } },
+      { ...fixture(), release: { ...fixture().release, assets: [{ ...fixture().release.assets[0], digest: `sha256:${"b".repeat(64)}` }] } }
+    ];
+    for (const input of cases) expect(run(input).result.status).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Deterministic release identity/provenance validator for the public Mac canary stack.

- accepts exact beta.N and rc.[1-9][0-9]* identities and matching build-named ZIPs
- requires annotated tag metadata and peels it to the explicitly reviewed 40-hex source SHA
- requires GitHub Release draft=false, prerelease=true, immutable=true
- requires exactly one canonical asset name, browser URL, and sha256 digest

## Validation

- focused identity tests pass, including RC zero/leading-zero, lightweight tag, wrong peeled source, mutable release, and digest drift failures
- public claims scan passed
- git diff --check passed
- 128 added lines

This PR is the identity half of a two-PR read-only canary stack; it performs no release, tag, feed, or customer mutation.