### PR TITLE
fix(issue-enrichment): make bounded reads safety aware

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -27,6 +27,16 @@ export type BoundedGithubList<T> = T[] & {
   overflow: boolean;
 };
 
+export const GITHUB_ISSUE_LABEL_EVENT_EVIDENCE_OVERFLOW = "GitHub issue label event evidence overflow";
+export class GithubIssueLabelEventOverflowError extends Error {
+  readonly code = "github_issue_label_event_evidence_overflow" as const;
+
+  constructor() {
+    super(GITHUB_ISSUE_LABEL_EVENT_EVIDENCE_OVERFLOW);
+    this.name = "GithubIssueLabelEventOverflowError";
+  }
+}
+
 export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
   items: T[];
   truncated: boolean;

--- a/src/github.ts
+++ b/src/github.ts
@@ -27,6 +27,16 @@ export type BoundedGithubList<T> = T[] & {
   overflow: boolean;
 };
 
+export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
+  items: T[];
+  truncated: boolean;
+  overflow: boolean;
+} {
+  return "items" in result
+    ? result
+    : { items: result, truncated: false, overflow: false };
+}
+
 export interface GithubIssueLabelEvent {
   event?: string;
   created_at?: string;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,6 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import { unpackBoundedGithubList, type BoundedGithubList, type GithubIssueLabelEvent } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -276,14 +277,16 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GithubIssueLabelEvent[] | BoundedGithubList<GithubIssueLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<Array<{
+    id: number;
+    html_url?: string | null;
+    body?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    user?: { login?: string | null } | null;
+  }> | BoundedGithubList<{
     id: number;
     html_url?: string | null;
     body?: string | null;
@@ -390,7 +393,9 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const eventResult = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, overflow } = unpackBoundedGithubList(eventResult);
+    if (overflow) throw new Error("GitHub issue label event evidence overflow");
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -414,7 +419,8 @@ async function evaluateIssuePromotion(input: {
       },
       evidence
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.message === "issue label event evidence overflow") throw error;
     return { issue: input.issue };
   }
 }
@@ -436,15 +442,17 @@ async function buildIssueEvidenceContext(input: {
   defaultBranch: string;
   headSha: string;
 }): Promise<IssueAnalysisEvidenceContext> {
-  const rawComments = input.github.listIssueComments
+  const commentResult = input.github.listIssueComments
     ? await input.github.listIssueComments(input.repo, input.issue.number)
     : [];
+  const { items: rawComments, truncated: commentsTruncated } = unpackBoundedGithubList(commentResult);
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, truncated: timelineTruncated } = unpackBoundedGithubList(timelineResult);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -480,8 +488,8 @@ async function buildIssueEvidenceContext(input: {
     })),
     linkedItems,
     truncation: {
-      comments: externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      comments: commentsTruncated || externalComments.length > 50,
+      timeline: timelineTruncated || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,7 +12,12 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
-import { unpackBoundedGithubList, type BoundedGithubList, type GithubIssueLabelEvent } from "./github.js";
+import {
+  GithubIssueLabelEventOverflowError,
+  unpackBoundedGithubList,
+  type BoundedGithubList,
+  type GithubIssueLabelEvent
+} from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -395,7 +400,7 @@ async function evaluateIssuePromotion(input: {
   try {
     const eventResult = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
     const { items: events, overflow } = unpackBoundedGithubList(eventResult);
-    if (overflow) throw new Error("GitHub issue label event evidence overflow");
+    if (overflow) throw new GithubIssueLabelEventOverflowError();
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -420,7 +425,7 @@ async function evaluateIssuePromotion(input: {
       evidence
     };
   } catch (error) {
-    if (error instanceof Error && error.message === "issue label event evidence overflow") throw error;
+    if (error instanceof GithubIssueLabelEventOverflowError) throw error;
     return { issue: input.issue };
   }
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -545,6 +545,7 @@ async function enqueuePullIfEligible(input: {
     return "skipped_draft";
   }
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -109,7 +109,7 @@ export interface ScheduledRunResult extends RunOnceResult {
 export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
-  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[] | BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -1159,7 +1159,13 @@ async function resolveSchedulerCommandDecision(input: {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = unpackBoundedGithubList(result);
+    if (bounded.truncated || bounded.overflow) {
+      input.onCommandFetchError?.();
+      return { action: "none", shouldReview: false };
+    }
+    comments = bounded.items;
   } catch {
     input.onCommandFetchError?.();
     return { action: "none", shouldReview: false };
@@ -1676,7 +1682,13 @@ async function repairProcessedHeadStatusCommentIfNeeded(input: {
 
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = unpackBoundedGithubList(result);
+    if (bounded.truncated || bounded.overflow) {
+      input.onStatusCommentFailure?.();
+      return;
+    }
+    comments = bounded.items;
   } catch {
     input.onStatusCommentFailure?.();
     return;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -503,6 +503,7 @@ async function collectSubsequentMergedPulls(input: {
 type EnqueueStatus =
   | "enqueued"
   | "already_queued"
+  | "command_fetch_failed"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_processed"
@@ -532,7 +533,6 @@ async function enqueuePullIfEligible(input: {
     await retireQueuedJobsForClosedPull(input);
     return "closed_retired";
   }
-  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (input.config.skipDrafts && input.pull.draft) {
     recordReadinessTransition({
       state: input.state,
@@ -579,6 +579,8 @@ async function enqueuePullIfEligible(input: {
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
+  if ("blocked" in commandDecision) return "command_fetch_failed";
+  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
       await retireSupersededQueueJobsForPull(input);
@@ -1155,7 +1157,7 @@ async function resolveSchedulerCommandDecision(input: {
   repo: string;
   pull: PullRequestSummary;
   onCommandFetchError?: () => void;
-}): Promise<CommandDecision> {
+}): Promise<CommandDecision | { action: "none"; shouldReview: false; blocked: "command_evidence_truncated" }> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
@@ -1163,7 +1165,7 @@ async function resolveSchedulerCommandDecision(input: {
     const bounded = unpackBoundedGithubList(result);
     if (bounded.truncated || bounded.overflow) {
       input.onCommandFetchError?.();
-      return { action: "none", shouldReview: false };
+      return { action: "none", shouldReview: false, blocked: "command_evidence_truncated" };
     }
     comments = bounded.items;
   } catch {
@@ -2604,6 +2606,9 @@ function nextLicenseGateRetryAt(now = new Date()): string {
 
 function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {
   switch (status) {
+    case "command_fetch_failed":
+      result.failed += 1;
+      break;
     case "enqueued":
       result.queue.enqueued += 1;
       break;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,7 +32,7 @@ import {
   validateFinishingTouchRequest,
   type FinishingTouchAction
 } from "./finishing-touches.js";
-import { GitHubApi } from "./github.js";
+import { GitHubApi, unpackBoundedGithubList } from "./github.js";
 import { getProtectedCheckoutRoots } from "./path-safety.js";
 import { evaluateLicenseReviewGate, type LicenseReviewGateResult } from "./license.js";
 import {
@@ -4767,7 +4767,12 @@ async function resolvePullCommandDecision(input: {
 }): Promise<CommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
 
-  const comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  const commentResult = await input.github.listIssueComments(input.repo, input.pull.number);
+  const boundedComments = unpackBoundedGithubList(commentResult);
+  if (boundedComments.truncated || boundedComments.overflow) {
+    throw new Error("GitHub issue comment command evidence overflow");
+  }
+  const comments = boundedComments.items;
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   const repoProfile = resolveRepoProfile(input.config, input.repo);
   // A public command (#345) reaching this re-resolution path was already authorized (bot + cooldown

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -964,7 +964,7 @@ describe("sticky enrichment comments", () => {
       })}\n`);
       const state = new ReviewStateStore(statePath);
       let analysisCalls = 0;
-      let postCalls = 0;
+      let postCalls = 0, overflow = false;
       try {
         const promotedIssue: GitHubRelatedIssueOrPull = {
           number: 127,
@@ -974,12 +974,12 @@ describe("sticky enrichment comments", () => {
           labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
           body: "Continue current-main work for #14."
         };
-        const result = await runIssueEnrichmentCycle({
+        const runCycle = (checkedAt: string, force = false) => runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {
             listIssuesForEnrichment: async () => [promotedIssue],
-            listIssueLabelEvents: async () => [{
+            listIssueLabelEvents: async () => overflow ? Promise.reject(new Error("issue label event evidence overflow")) : [{
               event: "labeled",
               created_at: "2026-08-16T10:00:00Z",
               actor: { login: "Tosko4" },
@@ -990,21 +990,26 @@ describe("sticky enrichment comments", () => {
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;
-              return { action: "created" as const, comment: { html_url: "https://github.test/comment/127" } };
+              return { action: "created" as const, id: 127, comment: { html_url: "https://github.test/comment/127" } };
             }
           },
           dryRun: false,
           includeExisting: true,
-          checkedAt: "2026-08-16T10:02:00.000Z",
+          checkedAt,
+          force,
           analyzeIssue: async ({ issue }) => {
             analysisCalls += 1;
             return fixtureIssueAnalysis(issue);
           }
         });
+        const result = await runCycle("2026-08-16T10:02:00.000Z");
 
         expect(result.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(analysisCalls).toBe(1);
         expect(postCalls).toBe(1);
+        const watermark = state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt; overflow = true; const blocked = await runCycle("2026-08-16T10:03:00.000Z", true);
+        expect(blocked.summary).toMatchObject({ readFailures: 1, posted: 0, failed: 0 }); expect(blocked.items).toHaveLength(0); expect(postCalls).toBe(1);
+        expect(state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt).toBe(watermark);
       } finally {
         state.close();
       }

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -979,7 +979,7 @@ describe("sticky enrichment comments", () => {
           state,
           github: {
             listIssuesForEnrichment: async () => [promotedIssue],
-            listIssueLabelEvents: async () => overflow ? Promise.reject(new Error("issue label event evidence overflow")) : [{
+            listIssueLabelEvents: async () => overflow ? Object.assign([], { items: [], truncated: true, overflow: true }) : [{
               event: "labeled",
               created_at: "2026-08-16T10:00:00Z",
               actor: { login: "Tosko4" },

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3517,6 +3517,46 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("blocks automatic enqueue when bounded command evidence is truncated", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-truncated-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const reviewed: string[] = [];
+    const truncated = Object.assign([], { items: [], truncated: true, overflow: true });
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, "a1")]],
+          ["org/repo-b", [pull("org/repo-b", 1, "b1")]]
+        ])),
+        listIssueComments: async (repo) => repo === "org/repo-a" ? truncated : []
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        reviewState.recordProcessed({ repo, pullNumber: reviewPull.number, headSha: reviewPull.head.sha, status: "posted", event: "COMMENT" });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.commandFetchErrors).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(reviewed).toEqual(["org/repo-b#1"]);
+    expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toBeUndefined();
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toHaveLength(0);
+    state.close();
+  });
+
   it("assigns scheduler jobs to reusable repo-sticky reviewer sessions when enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3528,6 +3528,16 @@ describe("provider-aware review scheduler", () => {
       acknowledge: false
     };
     const state = new ReviewStateStore(config.statePath);
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "old-head",
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old",
+      now: new Date("2026-06-30T00:00:00.000Z")
+    });
     const reviewed: string[] = [];
     const truncated = Object.assign([], { items: [], truncated: true, overflow: true });
     const result = await runScheduledCycleWithDeps({
@@ -3552,6 +3562,10 @@ describe("provider-aware review scheduler", () => {
     expect(result.commandFetchErrors).toBe(1);
     expect(result.failed).toBe(1);
     expect(reviewed).toEqual(["org/repo-b#1"]);
+    expect(state.getReviewReadiness("org/repo-a", 1, "old-head")).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted"
+    });
     expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toBeUndefined();
     expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toHaveLength(0);
     state.close();


### PR DESCRIPTION
## Summary
- safety-sensitive scheduler and worker command reads stop on truncated comment results
- trusted issue promotion fails closed on truncated label-event results
- ordinary model evidence consumes bounded rows and records explicit truncation flags
- promotion overflow blocks posting, label removal, records, and watermark advancement

## Validation
- `npm run build` passes with the existing dependency tree
- changed-path TypeScript checks pass after fixing the existing test fixture type omission
- deterministic overflow cycle check confirms no POST and unchanged watermark
- focused Vitest is blocked locally by the existing Rollup native-addon code-signature mismatch

Stacked on PR A / `codex/issue-enrichment-pagination-contracts`.
No live worker, state, queue, provider, customer, or credential mutation.