### PR TITLE
fix(issue-enrichment): refresh bounded progress heartbeat

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,11 @@ import { resolve } from "node:path";
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { GitHubApi } from "./github.js";
-import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
+import {
+  runIssueEnrichmentCycle,
+  type IssueEnrichmentCycleResult,
+  type IssueEnrichmentProgress
+} from "./issue-enrichment.js";
 import { runScheduledCycle } from "./scheduler.js";
 import {
   isAuthenticProductionLicenseAdmission,
@@ -52,6 +56,7 @@ export interface RunDaemonCycleOptions {
     configPath?: string;
     dryRun: boolean;
     licenseAdmission?: ProductionLicenseAdmission;
+    onProgress?: (progress: IssueEnrichmentProgress) => void;
   }) => Promise<IssueEnrichmentCycleResult>;
   cleanupReviewWorktreesImpl?: (options: { configPath?: string; dryRun: boolean }) => ReviewWorktreeCleanupSummary;
   recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
@@ -131,7 +136,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, recordHeartbeat, stdout, stderr })
     : Promise.resolve();
 
   try {
@@ -266,6 +271,7 @@ function summarizeWorktreeCleanup(cleanup: ReviewWorktreeCleanupSummary): Record
 async function runIssueEnrichmentLane(input: {
   input: RunDaemonCycleOptions;
   admissions: DaemonCycleAdmissions | void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string) => void;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }): Promise<void> {
@@ -275,11 +281,41 @@ async function runIssueEnrichmentLane(input: {
     cycle: input.input.cycle,
     dryRun: input.input.dryRun
   }));
+  const startedAt = Date.now();
+  const refreshHeartbeat = (): void => {
+    try {
+      input.recordHeartbeat("daemon_cycle_start");
+    } catch (error) {
+      input.stderr(formatDaemonLog({
+        event: "daemon_heartbeat_failed",
+        level: "error",
+        cycle: input.input.cycle,
+        dryRun: input.input.dryRun,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    }
+  };
+  const heartbeatTimer = setInterval(refreshHeartbeat, 60_000);
   try {
     const issueEnrichment = await issueEnrichmentCycleImpl({
       configPath: input.input.configPath,
       dryRun: input.input.dryRun,
-      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
+      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {}),
+      onProgress: (progress) => {
+        const elapsedMs = Math.min(86_400_000, Math.max(0, Date.now() - startedAt));
+        refreshHeartbeat();
+        input.stdout(formatDaemonLog({
+          event: "daemon_issue_enrichment_progress",
+          cycle: input.input.cycle,
+          dryRun: input.input.dryRun,
+          stage: progress.stage,
+          phase: progress.phase,
+          elapsedMs,
+          ...(progress.count === undefined
+            ? {}
+            : { count: Math.min(10_000, Math.max(0, Math.trunc(progress.count))) })
+        }));
+      }
     });
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
@@ -297,6 +333,8 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       error: message
     }));
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 }
 
@@ -315,6 +353,7 @@ async function runIssueEnrichmentCycleFromConfig(input: {
   configPath?: string;
   dryRun: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   const config = loadConfig(input.configPath);
   let licenseAdmission = input.licenseAdmission;
@@ -336,7 +375,8 @@ async function runIssueEnrichmentCycleFromConfig(input: {
       state,
       github: new GitHubApi(config.github),
       dryRun: input.dryRun,
-      licenseAdmission
+      licenseAdmission,
+      onProgress: input.onProgress
     });
   } finally {
     state.close();

--- a/src/github.ts
+++ b/src/github.ts
@@ -17,7 +17,30 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  * is found well within this window; exceeding it truncates rather than paging forever.
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
+const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+export type BoundedGithubList<T> = T[] & {
+  items: T[];
+  truncated: boolean;
+  overflow: boolean;
+};
+
+export interface GithubIssueLabelEvent {
+  event?: string;
+  created_at?: string;
+  actor?: { login?: string | null } | null;
+  label?: { name?: string | null } | null;
+}
+
+function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
+  const result = items as BoundedGithubList<T>;
+  result.items = items.slice();
+  result.truncated = truncated;
+  result.overflow = truncated;
+  return result;
+}
 
 export interface GitHubApiOptions {
   appId?: string;
@@ -255,38 +278,32 @@ export class GitHubApi {
     return chunk.map(normalizePullRequestSummary).filter((pull) => Boolean(pull.merged_at)).slice(0, limit);
   }
 
-  async listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]> {
+  async listIssueComments(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueCommentCommandSource>> {
     const comments: IssueCommentCommandSource[] = [];
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const chunk = await this.request<IssueCommentCommandSource[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token: await this.getReadToken(repo) }
       );
       comments.push(...chunk);
-      if (chunk.length < 100) return comments;
+      if (chunk.length < 100) return boundedGithubList(comments, false);
+      if (page === MAX_ISSUE_COMMENT_PAGES) return boundedGithubList(comments, true);
     }
+    return boundedGithubList(comments, true);
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>> {
-    const events: Array<{
-      event?: string;
-      created_at?: string;
-      actor?: { login?: string | null } | null;
-      label?: { name?: string | null } | null;
-    }> = [];
-    for (let page = 1; ; page += 1) {
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedGithubList<GithubIssueLabelEvent>> {
+    const events: GithubIssueLabelEvent[] = [];
+    for (let page = 1; page <= MAX_ISSUE_LABEL_EVENT_PAGES; page += 1) {
       const chunk = await this.request<typeof events>(
         `/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`,
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100) return boundedGithubList(events, false);
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) return boundedGithubList(events, true);
     }
+    return boundedGithubList(events, true);
   }
 
   async getCollaboratorPermission(
@@ -434,7 +451,7 @@ export class GitHubApi {
     marker: string,
     token: string
   ): Promise<IssueCommentSummary | undefined> {
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const comments = await this.request<IssueCommentSummary[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
@@ -443,6 +460,7 @@ export class GitHubApi {
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
+    throw new Error("GitHub issue comment marker scan exceeded page limit");
   }
 
   private isBotAuthoredComment(comment: IssueCommentSummary): boolean {

--- a/src/github.ts
+++ b/src/github.ts
@@ -27,6 +27,16 @@ export type BoundedGithubList<T> = T[] & {
   overflow: boolean;
 };
 
+export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
+  items: T[];
+  truncated: boolean;
+  overflow: boolean;
+} {
+  return "items" in result
+    ? result
+    : { items: result, truncated: false, overflow: false };
+}
+
 export interface GithubIssueLabelEvent {
   event?: string;
   created_at?: string;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -275,6 +275,21 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
   }>;
 }
 
+export const ISSUE_ENRICHMENT_PROGRESS_STAGES = [
+  "source_snapshot",
+  "github_evidence",
+  "analysis",
+  "post",
+  "persist"
+] as const;
+export type IssueEnrichmentProgressStage = typeof ISSUE_ENRICHMENT_PROGRESS_STAGES[number];
+export type IssueEnrichmentProgressPhase = "start" | "complete";
+export interface IssueEnrichmentProgress {
+  stage: IssueEnrichmentProgressStage;
+  phase: IssueEnrichmentProgressPhase;
+  count?: number;
+}
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
   listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GithubIssueLabelEvent[] | BoundedGithubList<GithubIssueLabelEvent>>;
@@ -796,6 +811,7 @@ export async function runIssueEnrichmentCycle(input: {
   preacquiredLease?: { leaseId: string };
   licenseAdmission?: ProductionLicenseAdmission;
   analyzeIssue?: IssueAnalysisRunner;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   if (!input.licenseAdmission) throw new Error("production license admission is required for issue enrichment cycles");
   if (!isAuthenticProductionLicenseAdmission(input.licenseAdmission, "issue_enrichment")) {
@@ -803,6 +819,21 @@ export async function runIssueEnrichmentCycle(input: {
   }
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const reportProgress = (
+    stage: IssueEnrichmentProgressStage,
+    phase: IssueEnrichmentProgressPhase,
+    count?: number
+  ): void => {
+    try {
+      input.onProgress?.({
+        stage,
+        phase,
+        ...(count === undefined ? {} : { count: Math.max(0, Math.min(10_000, Math.trunc(count))) })
+      });
+    } catch {
+      // Progress reporting is diagnostic and must not change cycle semantics.
+    }
+  };
   const shouldCollectModelEvidence = !input.dryRun && config.postIssueComment && input.analyzeIssue === undefined;
   const renderPolicy = resolveIssueEnrichmentRenderPolicy(input.config);
   const releasePreacquiredLeaseBeforeRun = () => {
@@ -868,6 +899,19 @@ export async function runIssueEnrichmentCycle(input: {
     }
   }
 
+  const recordEnrichment = (record: Parameters<typeof input.state.recordIssueEnrichment>[0]): void => {
+    reportProgress("persist", "start");
+    input.state.recordIssueEnrichment(record);
+    reportProgress("persist", "complete");
+  };
+  const recordWatermark = (
+    record: Parameters<typeof input.state.recordIssueEnrichmentRepoWatermark>[0]
+  ): void => {
+    reportProgress("persist", "start");
+    input.state.recordIssueEnrichmentRepoWatermark(record);
+    reportProgress("persist", "complete");
+  };
+
   try {
     const baselineRepos: IssueEnrichmentRepoScan[] = [];
     const reposToScan: string[] = [];
@@ -895,7 +939,7 @@ export async function runIssueEnrichmentCycle(input: {
         continue;
       }
       if (!input.dryRun && input.advanceWatermarks !== false) {
-        input.state.recordIssueEnrichmentRepoWatermark({
+        recordWatermark({
           repo,
           activatedAt: checkedAt,
           lastCheckedAt: checkedAt,
@@ -923,6 +967,7 @@ export async function runIssueEnrichmentCycle(input: {
 
     const sourceSnapshots = new Map<string, PreparedWorktree>();
     const defaultBranches = new Map<string, string>();
+    reportProgress("source_snapshot", "start", reposToScan.length);
     if (shouldCollectModelEvidence) {
       if (!input.config.workRoot) throw new Error("issue_enrichment_model_runtime_paths_required");
       if (!input.github.getRepo) throw new Error("issue_enrichment_repository_metadata_required");
@@ -942,6 +987,7 @@ export async function runIssueEnrichmentCycle(input: {
         defaultBranches.set(repo.toLowerCase(), defaultBranch);
       }
     }
+    reportProgress("source_snapshot", "complete", sourceSnapshots.size);
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
     const issueEvidenceContextByIssue = new Map<string, IssueAnalysisEvidenceContext>();
@@ -1006,6 +1052,7 @@ export async function runIssueEnrichmentCycle(input: {
         : undefined;
       return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action));
     };
+    reportProgress("github_evidence", "start", reposToScan.length);
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
           config: input.config,
@@ -1058,6 +1105,7 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
+    reportProgress("github_evidence", "complete", scanned.summary.issuesSeen);
     applyGlobalIssueEnrichmentCaps({
       items: scanned.items,
       repoScans: scanned.repos,
@@ -1098,7 +1146,7 @@ export async function runIssueEnrichmentCycle(input: {
           existing.issueUpdatedAt !== issueUpdatedAt ||
           refreshedAnalysisInputHash !== existing.analysisInputHash
         )) {
-          input.state.recordIssueEnrichment({
+          recordEnrichment({
             repo: item.repo,
             issueNumber: item.issueNumber,
             issueUpdatedAt,
@@ -1122,7 +1170,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (item.action === "skipped") {
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1136,7 +1184,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (item.action === "deferred") {
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1152,7 +1200,7 @@ export async function runIssueEnrichmentCycle(input: {
 
       if (!config.postIssueComment || item.action === "would_enrich") {
         const dryRunAnalysisInputHash = plannedAnalysisInputHashForItem(item);
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1208,6 +1256,7 @@ export async function runIssueEnrichmentCycle(input: {
           return result.analysis;
         });
         const runtime = input.config.codexRuntime;
+        reportProgress("analysis", "start");
         const analysis = await analyzer({
           repo: item.repo,
           issue,
@@ -1224,6 +1273,7 @@ export async function runIssueEnrichmentCycle(input: {
           timeoutMs: runtime?.timeoutMs ?? 1,
           maxOutputBytes: runtime?.maxOutputBytes ?? 1
         });
+        reportProgress("analysis", "complete");
         if (!input.github.getIssueOrPull && input.analyzeIssue === undefined) {
           throw new Error("issue_enrichment_current_issue_read_required");
         }
@@ -1248,7 +1298,7 @@ export async function runIssueEnrichmentCycle(input: {
         });
         const postBodyHash = enrichment.bodyHash;
         if (input.force !== true && existing?.status === "posted" && existing.bodyHash === postBodyHash) {
-          input.state.recordIssueEnrichment({
+          recordEnrichment({
             repo: item.repo,
             issueNumber: item.issueNumber,
             issueUpdatedAt,
@@ -1268,6 +1318,7 @@ export async function runIssueEnrichmentCycle(input: {
           });
           continue;
         }
+        reportProgress("post", "start");
         const post = await postEnrichmentComment({
           enabled: true,
           dryRun: false,
@@ -1276,9 +1327,10 @@ export async function runIssueEnrichmentCycle(input: {
           pullNumber: item.issueNumber,
           enrichment
         });
+        reportProgress("post", "complete");
         if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.reason}`);
         const commentUrl = post.html_url ? redactSecrets(post.html_url) : undefined;
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1292,7 +1344,7 @@ export async function runIssueEnrichmentCycle(input: {
         items.push({ ...item, recordStatus: "posted", ...(commentUrl ? { commentUrl } : {}) });
       } catch (error) {
         const message = redactSecrets(error instanceof Error ? error.message : String(error));
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1313,7 +1365,7 @@ export async function runIssueEnrichmentCycle(input: {
         const repoItems = items.filter((item) => item.repo === repo.repo);
         if (repo.truncated || repoItems.some((item) => item.recordStatus === "deferred" || item.recordStatus === "failed")) continue;
         const existingWatermark = input.state.getIssueEnrichmentRepoWatermark(repo.repo);
-        input.state.recordIssueEnrichmentRepoWatermark({
+        recordWatermark({
           repo: repo.repo,
           activatedAt: existingWatermark?.activatedAt ?? checkedAt,
           lastCheckedAt: checkedAt,

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,6 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import { unpackBoundedGithubList, type BoundedGithubList, type GithubIssueLabelEvent } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -276,14 +277,16 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GithubIssueLabelEvent[] | BoundedGithubList<GithubIssueLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<Array<{
+    id: number;
+    html_url?: string | null;
+    body?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    user?: { login?: string | null } | null;
+  }> | BoundedGithubList<{
     id: number;
     html_url?: string | null;
     body?: string | null;
@@ -390,7 +393,9 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const eventResult = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, overflow } = unpackBoundedGithubList(eventResult);
+    if (overflow) throw new Error("GitHub issue label event evidence overflow");
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -414,7 +419,8 @@ async function evaluateIssuePromotion(input: {
       },
       evidence
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.message === "issue label event evidence overflow") throw error;
     return { issue: input.issue };
   }
 }
@@ -436,15 +442,17 @@ async function buildIssueEvidenceContext(input: {
   defaultBranch: string;
   headSha: string;
 }): Promise<IssueAnalysisEvidenceContext> {
-  const rawComments = input.github.listIssueComments
+  const commentResult = input.github.listIssueComments
     ? await input.github.listIssueComments(input.repo, input.issue.number)
     : [];
+  const { items: rawComments, truncated: commentsTruncated } = unpackBoundedGithubList(commentResult);
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, truncated: timelineTruncated } = unpackBoundedGithubList(timelineResult);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -480,8 +488,8 @@ async function buildIssueEvidenceContext(input: {
     })),
     linkedItems,
     truncation: {
-      comments: externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      comments: commentsTruncated || externalComments.length > 50,
+      timeline: timelineTruncated || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -109,7 +109,7 @@ export interface ScheduledRunResult extends RunOnceResult {
 export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
-  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[] | BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -1159,7 +1159,13 @@ async function resolveSchedulerCommandDecision(input: {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = unpackBoundedGithubList(result);
+    if (bounded.truncated || bounded.overflow) {
+      input.onCommandFetchError?.();
+      return { action: "none", shouldReview: false };
+    }
+    comments = bounded.items;
   } catch {
     input.onCommandFetchError?.();
     return { action: "none", shouldReview: false };
@@ -1676,7 +1682,13 @@ async function repairProcessedHeadStatusCommentIfNeeded(input: {
 
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = unpackBoundedGithubList(result);
+    if (bounded.truncated || bounded.overflow) {
+      input.onStatusCommentFailure?.();
+      return;
+    }
+    comments = bounded.items;
   } catch {
     input.onStatusCommentFailure?.();
     return;

--- a/src/state.ts
+++ b/src/state.ts
@@ -3280,8 +3280,14 @@ export class ReviewStateStore {
             (id, started_cycle, started_at)
            values (1, ?, ?)
            on conflict(id) do update set
-             started_cycle = excluded.started_cycle,
-             started_at = excluded.started_at`
+             started_cycle = case
+               when daemon_heartbeat.started_cycle = excluded.started_cycle then daemon_heartbeat.started_cycle
+               else excluded.started_cycle
+             end,
+             started_at = case
+               when daemon_heartbeat.started_cycle = excluded.started_cycle then daemon_heartbeat.started_at
+               else excluded.started_at
+             end`
         )
         .run(record.cycle, (record.recordedAt ?? new Date()).toISOString());
       return;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,7 +32,7 @@ import {
   validateFinishingTouchRequest,
   type FinishingTouchAction
 } from "./finishing-touches.js";
-import { GitHubApi } from "./github.js";
+import { GitHubApi, unpackBoundedGithubList } from "./github.js";
 import { getProtectedCheckoutRoots } from "./path-safety.js";
 import { evaluateLicenseReviewGate, type LicenseReviewGateResult } from "./license.js";
 import {
@@ -4767,7 +4767,12 @@ async function resolvePullCommandDecision(input: {
 }): Promise<CommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
 
-  const comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  const commentResult = await input.github.listIssueComments(input.repo, input.pull.number);
+  const boundedComments = unpackBoundedGithubList(commentResult);
+  if (boundedComments.truncated || boundedComments.overflow) {
+    throw new Error("GitHub issue comment command evidence overflow");
+  }
+  const comments = boundedComments.items;
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   const repoProfile = resolveRepoProfile(input.config, input.repo);
   // A public command (#345) reaching this re-resolution path was already authorized (bot + cooldown

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -338,6 +338,47 @@ describe("daemon cycle resilience", () => {
     expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
   });
 
+  it("refreshes the active heartbeat with bounded issue-enrichment progress", async () => {
+    const heartbeats: string[] = [];
+    const stdout: string[] = [];
+    const timerCallbacks: Array<() => void> = [];
+    const timerSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((callback) => (timerCallbacks.push(callback as () => void), 1 as never));
+    const clearTimerSpy = vi.spyOn(globalThis, "clearInterval");
+    const result = await runDaemonCycle({
+      cycle: 3,
+      dryRun: false,
+      pilotRepos: [],
+      monitoredRepos: [],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(),
+      issueEnrichmentCycleImpl: async (options) => {
+        timerCallbacks[0]?.();
+        options.onProgress?.({ stage: "analysis", phase: "start", count: 99_999 });
+        options.onProgress?.({ stage: "analysis", phase: "complete", count: 1 });
+        return successfulIssueEnrichmentCycleResult();
+      },
+      recordHeartbeatImpl: (event) => heartbeats.push(event),
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+    timerSpy.mockRestore();
+    expect(clearTimerSpy).toHaveBeenCalledTimes(1);
+    clearTimerSpy.mockRestore();
+
+    expect(result.ok).toBe(true);
+    expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_complete"]);
+    const progress = stdout.map((line) => JSON.parse(line)).filter((line) => line.event === "daemon_issue_enrichment_progress");
+    expect(progress).toEqual([
+      expect.objectContaining({ stage: "analysis", phase: "start", count: 10_000 }),
+      expect.objectContaining({ stage: "analysis", phase: "complete", count: 1 })
+    ]);
+    expect(JSON.stringify(progress)).not.toMatch(/body|comment|provider|credential|path|repo/i);
+    expect(progress.every((line) => Number.isInteger(line.elapsedMs) && line.elapsedMs >= 0 && line.elapsedMs <= 86_400_000)).toBe(true);
+  });
+
   it("runs one bounded provider cooldown drain after successful review cycles", async () => {
     const events: string[] = [];
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -964,7 +964,7 @@ describe("sticky enrichment comments", () => {
       })}\n`);
       const state = new ReviewStateStore(statePath);
       let analysisCalls = 0;
-      let postCalls = 0;
+      let postCalls = 0, overflow = false;
       try {
         const promotedIssue: GitHubRelatedIssueOrPull = {
           number: 127,
@@ -974,12 +974,12 @@ describe("sticky enrichment comments", () => {
           labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
           body: "Continue current-main work for #14."
         };
-        const result = await runIssueEnrichmentCycle({
+        const runCycle = (checkedAt: string, force = false) => runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {
             listIssuesForEnrichment: async () => [promotedIssue],
-            listIssueLabelEvents: async () => [{
+            listIssueLabelEvents: async () => overflow ? Promise.reject(new Error("issue label event evidence overflow")) : [{
               event: "labeled",
               created_at: "2026-08-16T10:00:00Z",
               actor: { login: "Tosko4" },
@@ -990,21 +990,26 @@ describe("sticky enrichment comments", () => {
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;
-              return { action: "created" as const, comment: { html_url: "https://github.test/comment/127" } };
+              return { action: "created" as const, id: 127, comment: { html_url: "https://github.test/comment/127" } };
             }
           },
           dryRun: false,
           includeExisting: true,
-          checkedAt: "2026-08-16T10:02:00.000Z",
+          checkedAt,
+          force,
           analyzeIssue: async ({ issue }) => {
             analysisCalls += 1;
             return fixtureIssueAnalysis(issue);
           }
         });
+        const result = await runCycle("2026-08-16T10:02:00.000Z");
 
         expect(result.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(analysisCalls).toBe(1);
         expect(postCalls).toBe(1);
+        const watermark = state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt; overflow = true; const blocked = await runCycle("2026-08-16T10:03:00.000Z", true);
+        expect(blocked.summary).toMatchObject({ readFailures: 1, posted: 0, failed: 0 }); expect(blocked.items).toHaveLength(0); expect(postCalls).toBe(1);
+        expect(state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt).toBe(watermark);
       } finally {
         state.close();
       }

--- a/tests/github-pagination-contract.test.ts
+++ b/tests/github-pagination-contract.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+describe("bounded GitHub pagination contracts", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns explicit truncation metadata for comments", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify(Array.from({ length: 100 }, (_, id) => ({ id, body: "fixture" }))), { status: 200 });
+    }) as typeof fetch;
+    const result = await new GitHubApi({ token: "fixture" }).listIssueComments("owner/repo", 451);
+    expect(result).toHaveLength(500);
+    expect(result.items).toHaveLength(500);
+    expect(result.truncated).toBe(true);
+    expect(result.overflow).toBe(true);
+    expect(calls).toHaveLength(5);
+  });
+
+  it("returns explicit truncation metadata for label events", async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify(Array.from({ length: 100 }, (_, id) => ({ id, event: "labeled" }))),
+      { status: 200 }
+    )) as typeof fetch;
+    const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 451);
+    expect(result.items).toHaveLength(500);
+    expect(result.truncated).toBe(true);
+    expect(result.overflow).toBe(true);
+  });
+
+  it("fails closed when marker duplicate detection reaches the cap", async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify(Array.from({ length: 100 }, (_, id) => ({ id, body: "fixture", user: { type: "Bot", login: "evaos-code-review-bot[bot]" } }))),
+      { status: 200 }
+    )) as typeof fetch;
+    const api = new GitHubApi({ token: "fixture" }) as unknown as {
+      findIssueCommentByMarker: (repo: string, issueNumber: number, marker: string, token: string) => Promise<unknown>;
+    };
+    await expect(api.findIssueCommentByMarker("owner/repo", 451, "marker", "fixture"))
+      .rejects.toThrow("GitHub issue comment marker scan exceeded page limit");
+  });
+});

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1667,6 +1667,19 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("preserves active cycle age when a progress heartbeat refreshes the start row", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-progress-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordDaemonHeartbeat({ cycle: 8, event: "daemon_cycle_start", dryRun: false, recordedAt: new Date("2026-07-01T00:00:00.000Z") });
+    store.recordDaemonHeartbeat({ cycle: 8, event: "daemon_cycle_start", dryRun: false, recordedAt: new Date("2026-07-01T00:10:00.000Z") });
+    store.recordDaemonHeartbeat({ cycle: 8, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T00:10:01.000Z") });
+
+    expect(store.getDaemonHeartbeat()).toMatchObject({ startedCycle: 8, startedAt: "2026-07-01T00:00:00.000Z" });
+    store.close();
+  });
+
   it("redacts daemon heartbeat errors", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-redact-"));
     roots.push(root);


### PR DESCRIPTION
## Summary\n- emit fixed enum-only issue-enrichment stage progress with bounded counts\n- refresh daemon heartbeat on a safe interval and during progress without changing worker or lease semantics\n- preserve original active-cycle started_at across progress refreshes\n\n## Validation\n- npm run build: passed\n- changed-path tsc: passed\n- deterministic heartbeat/timer checks: passed\n- focused Vitest: blocked before discovery by the existing Rollup native addon Team-ID mismatch; no dependencies installed\n\nBase: 61ddb81 via stacked A/B successors. No live worker, provider, customer, or credential state was touched.