### PR TITLE
feat: add exact severe evidence reader

### DIFF
--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { closeSync, constants, fstatSync, lstatSync, openSync, readSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { MAX_SEVERE_EVIDENCE_FILE_BYTES, parseSevereVerificationReceipt, type SevereVerificationReceipt } from "./severe-verification-receipt.js";
+
+export interface SevereVerificationEvidenceSubject {
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  headSha: string;
+  findingFingerprint: string;
+  path: string;
+}
+
+export interface SevereVerificationEvidenceRead {
+  subject: SevereVerificationEvidenceSubject;
+  content: string;
+  evidence: SevereVerificationReceipt["evidence"];
+}
+
+export function readSevereVerificationEvidence(worktreePath: string, subject: SevereVerificationEvidenceSubject): SevereVerificationEvidenceRead {
+  assertSafeRelativePath(subject.path);
+  const root = resolve(worktreePath);
+  const candidate = resolve(root, subject.path);
+  assertContained(root, candidate, "lexical");
+  assertNoSymlinkComponents(root, subject.path);
+  const realRoot = realpathSync.native(root);
+  const realCandidate = realpathSync.native(candidate);
+  assertContained(realRoot, realCandidate, "real");
+  const bytes = readBoundedRegularFile(candidate);
+  let content: string;
+  try { content = new TextDecoder("utf-8", { fatal: true }).decode(bytes); } catch { throw new Error("severe_evidence_malformed"); }
+  const evidence = { files: [{ path: subject.path, kind: "whole_file" as const, sha256: createHash("sha256").update(bytes).digest("hex"), bytes: bytes.byteLength, complete: true }], omitted: [], complete: true };
+  parseSevereVerificationReceipt({
+    schemaVersion: "severe-verifier-v1", repo: subject.repo, pullNumber: subject.pullNumber, baseSha: subject.baseSha,
+    findingFingerprint: subject.findingFingerprint, headSha: subject.headSha, state: "confirmed", disposition: "retain", evidence
+  }, { expectedRepo: subject.repo, expectedPullNumber: subject.pullNumber, expectedBaseSha: subject.baseSha, expectedHeadSha: subject.headSha, expectedFindingFingerprint: subject.findingFingerprint, expectedPath: subject.path });
+  return { subject: { ...subject }, content, evidence };
+}
+
+function assertSafeRelativePath(path: string): void {
+  if (!path || Buffer.byteLength(path, "utf8") > 4096 || path.startsWith("/") || /^[A-Za-z]:/.test(path) || /[\\\0\r\n]/.test(path) || path.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error("severe_evidence_incomplete");
+  }
+}
+
+function assertContained(root: string, candidate: string, kind: string): void {
+  const rel = relative(root, candidate);
+  if (!rel || rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) throw new Error("severe_evidence_incomplete:" + kind);
+}
+
+function assertNoSymlinkComponents(root: string, requestedPath: string): void {
+  let current = root;
+  const parts = requestedPath.split("/");
+  for (const [index, part] of parts.entries()) {
+    current = join(current, part);
+    let stat;
+    try { stat = lstatSync(current); } catch { throw new Error("severe_evidence_incomplete"); }
+    if (stat.isSymbolicLink() || (index < parts.length - 1 && !stat.isDirectory())) throw new Error("severe_evidence_incomplete");
+  }
+}
+
+function readBoundedRegularFile(path: string): Uint8Array {
+  const descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const before = fstatSync(descriptor);
+    if (!before.isFile()) throw new Error("severe_evidence_incomplete");
+    if (before.size > MAX_SEVERE_EVIDENCE_FILE_BYTES) throw new Error("severe_evidence_cap_exceeded");
+    const bytes = Buffer.alloc(before.size);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const count = readSync(descriptor, bytes, offset, bytes.byteLength - offset, offset);
+      if (count === 0) throw new Error("severe_evidence_incomplete");
+      offset += count;
+    }
+    const after = fstatSync(descriptor);
+    if (after.size !== before.size || after.mtimeMs !== before.mtimeMs || after.ctimeMs !== before.ctimeMs) throw new Error("severe_evidence_incomplete");
+    return bytes;
+  } finally { closeSync(descriptor); }
+}

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -57,7 +57,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
   if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
   if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
-  if (!Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
+  if (typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
   if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
   if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
   if (!string(receipt.findingFingerprint) || !/^finding:[a-f0-9]{64}$/.test(receipt.findingFingerprint)) errors.push("findingFingerprint is invalid");
@@ -68,7 +68,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
   validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
-  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as SevereVerificationReceipt };
+  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as unknown as SevereVerificationReceipt };
 }
 
 export function parseSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereVerificationReceipt {
@@ -87,7 +87,7 @@ function validateEvidence(value: unknown, state: unknown, expectedPath: string |
   if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
   for (const item of value.files) {
     const file = record(item) ? item : undefined;
-    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
   }
   for (const item of value.omitted) {
     const omission = record(item) ? item : undefined;

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -96,7 +96,7 @@ function validateEvidence(value: unknown, state: unknown, expectedPath: string |
   const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
   if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
   if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
-  if (expectedPath !== undefined && (!safePath(expectedPath) || (value.files.length > 0 && !value.files.some((file) => record(file) && file.path === expectedPath)))) errors.push("evidence does not cover expected path");
+  if (expectedPath !== undefined && (!safePath(expectedPath) || ![...value.files, ...value.omitted].some((entry) => record(entry) && entry.path === expectedPath))) errors.push("evidence does not cover expected path");
   if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
 }
 

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -1,0 +1,114 @@
+export const SEVERE_VERIFICATION_STATES = [
+  "confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+] as const;
+export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
+export type SevereVerificationDisposition = "retain" | "suppress";
+export type SevereEvidenceKind = "whole_file" | "module";
+export type SevereVerificationCode =
+  | "not_read" | "refuted" | "malformed" | "timeout" | "unavailable" | "stale_head"
+  | "incomplete" | "schema_invalid" | "identity_mismatch" | "evidence_incomplete"
+  | "provider_unavailable" | "cap_exceeded" | "receipt_invalid";
+
+export interface SevereVerificationEvidenceFile {
+  path: string;
+  kind: SevereEvidenceKind;
+  sha256: string;
+  bytes: number;
+  complete: boolean;
+}
+export interface SevereVerificationEvidenceOmission { path: string; code: SevereVerificationCode; }
+export interface SevereVerificationEvidence {
+  files: SevereVerificationEvidenceFile[];
+  omitted: SevereVerificationEvidenceOmission[];
+  complete: boolean;
+}
+export interface SevereVerificationReceipt {
+  schemaVersion: "severe-verifier-v1";
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  findingFingerprint: string;
+  headSha: string;
+  state: SevereVerificationState;
+  disposition: SevereVerificationDisposition;
+  confidence?: number;
+  reasonCode?: SevereVerificationCode;
+  evidence: SevereVerificationEvidence;
+}
+export interface SevereReceiptValidationOptions { expectedPath?: string; }
+export type SevereReceiptValidation =
+  | { ok: true; value: SevereVerificationReceipt }
+  | { ok: false; errors: string[] };
+
+const CODES = new Set<string>([
+  "not_read", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete",
+  "schema_invalid", "identity_mismatch", "evidence_incomplete", "provider_unavailable",
+  "cap_exceeded", "receipt_invalid"
+]);
+const KINDS = new Set(["whole_file", "module"]);
+const STATES = new Set<string>(SEVERE_VERIFICATION_STATES);
+const SHA40 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+export function validateSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereReceiptValidation {
+  const errors: string[] = [];
+  if (!record(value)) return { ok: false, errors: ["receipt must be an object"] };
+  const receipt = value;
+  if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
+  if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
+  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
+  if (!Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
+  if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
+  if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
+  if (!string(receipt.findingFingerprint) || !/^finding:[a-f0-9]{64}$/.test(receipt.findingFingerprint)) errors.push("findingFingerprint is invalid");
+  if (!string(receipt.state) || !STATES.has(receipt.state)) errors.push("state is invalid");
+  if (receipt.disposition !== "retain" && receipt.disposition !== "suppress") errors.push("disposition is invalid");
+  if (receipt.confidence !== undefined && (!number(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) errors.push("confidence is invalid");
+  if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
+  if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
+  if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
+  validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
+  return errors.length ? { ok: false, errors } : { ok: true, value: receipt as SevereVerificationReceipt };
+}
+
+export function parseSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereVerificationReceipt {
+  const result = validateSevereVerificationReceipt(value, options);
+  if (!result.ok) throw new Error(`severe_verification_receipt_invalid: ${result.errors.join(",")}`);
+  return result.value;
+}
+
+export function isSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): value is SevereVerificationReceipt {
+  return validateSevereVerificationReceipt(value, options).ok;
+}
+
+function validateEvidence(value: unknown, state: unknown, expectedPath: string | undefined, errors: string[]): void {
+  if (!record(value) || !exact(value, ["files", "omitted", "complete"])) { errors.push("evidence shape is invalid"); return; }
+  if (!Array.isArray(value.files) || !Array.isArray(value.omitted) || typeof value.complete !== "boolean") { errors.push("evidence types are invalid"); return; }
+  if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
+  for (const item of value.files) {
+    const file = record(item) ? item : undefined;
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+  }
+  for (const item of value.omitted) {
+    const omission = record(item) ? item : undefined;
+    if (!omission || !exact(omission, ["path", "code"]) || !safePath(omission.path) || !string(omission.code) || !CODES.has(omission.code)) errors.push("evidence omission is invalid");
+  }
+  const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
+  if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
+  if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
+  if (expectedPath !== undefined && (!safePath(expectedPath) || (value.files.length > 0 && !value.files.some((file) => record(file) && file.path === expectedPath)))) errors.push("evidence does not cover expected path");
+  if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
+}
+
+function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function exact(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return required.every((key) => Object.hasOwn(value, key)) && Reflect.ownKeys(value).every((key) => typeof key === "string" && allowed.has(key));
+}
+function string(value: unknown): value is string { return typeof value === "string"; }
+function number(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value); }
+function byteLength(value: string): number { return Buffer.byteLength(value, "utf8"); }
+function safePath(value: unknown): value is string {
+  if (!string(value) || value.length === 0 || byteLength(value) > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n]/.test(value)) return false;
+  return value.split("/").every((part) => part.length > 0 && part !== "." && part !== "..");
+}

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -1,5 +1,5 @@
 export const SEVERE_VERIFICATION_STATES = [
-  "confirmed", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+  "confirmed", "refuted", "failed", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
 ] as const;
 export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
 export type SevereVerificationDisposition = "retain" | "suppress";
@@ -49,6 +49,10 @@ const KINDS = new Set(["whole_file", "module"]);
 const STATES = new Set<string>(SEVERE_VERIFICATION_STATES);
 const SHA40 = /^[a-f0-9]{40}$/;
 const SHA256 = /^[a-f0-9]{64}$/;
+export const MAX_SEVERE_EVIDENCE_FILE_BYTES = 64 * 1024;
+const MAX_SEVERE_EVIDENCE_ENTRIES = 64;
+const MAX_SEVERE_EVIDENCE_TOTAL_BYTES = 256 * 1024;
+const MAX_SEVERE_EVIDENCE_PATH_BYTES = 64 * 1024;
 
 export function validateSevereVerificationReceipt(value: unknown, options: SevereReceiptValidationOptions = {}): SevereReceiptValidation {
   const errors: string[] = [];
@@ -67,6 +71,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
+  if (!validStateReason(receipt.state, receipt.reasonCode)) errors.push("state and reasonCode are inconsistent");
   validateEvidence(receipt.evidence, receipt.state, options.expectedPath, errors);
   return errors.length ? { ok: false, errors } : { ok: true, value: receipt as unknown as SevereVerificationReceipt };
 }
@@ -84,20 +89,32 @@ export function isSevereVerificationReceipt(value: unknown, options: SevereRecei
 function validateEvidence(value: unknown, state: unknown, expectedPath: string | undefined, errors: string[]): void {
   if (!record(value) || !exact(value, ["files", "omitted", "complete"])) { errors.push("evidence shape is invalid"); return; }
   if (!Array.isArray(value.files) || !Array.isArray(value.omitted) || typeof value.complete !== "boolean") { errors.push("evidence types are invalid"); return; }
+  if (value.files.length + value.omitted.length > MAX_SEVERE_EVIDENCE_ENTRIES) { errors.push("evidence has too many entries"); return; }
   if (value.files.length + value.omitted.length === 0) errors.push("evidence must be nonempty");
   for (const item of value.files) {
     const file = record(item) ? item : undefined;
-    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > 2 ** 32 || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
+    if (!file || !exact(file, ["path", "kind", "sha256", "bytes", "complete"]) || !safePath(file.path) || !string(file.kind) || !KINDS.has(file.kind) || !string(file.sha256) || !SHA256.test(file.sha256) || typeof file.bytes !== "number" || !Number.isSafeInteger(file.bytes) || file.bytes < 0 || file.bytes > MAX_SEVERE_EVIDENCE_FILE_BYTES || typeof file.complete !== "boolean") errors.push("evidence file is invalid");
   }
   for (const item of value.omitted) {
     const omission = record(item) ? item : undefined;
     if (!omission || !exact(omission, ["path", "code"]) || !safePath(omission.path) || !string(omission.code) || !CODES.has(omission.code)) errors.push("evidence omission is invalid");
   }
   const completeFiles = value.files.length > 0 && value.omitted.length === 0 && value.files.every((file) => record(file) && file.complete === true);
+  const totalBytes = value.files.reduce((sum, file) => sum + (record(file) && typeof file.bytes === "number" && Number.isSafeInteger(file.bytes) && file.bytes >= 0 ? file.bytes : 0), 0);
+  const pathBytes = [...value.files, ...value.omitted].reduce((sum, entry) => sum + (record(entry) && string(entry.path) ? byteLength(entry.path) : 0), 0);
+  if (totalBytes > MAX_SEVERE_EVIDENCE_TOTAL_BYTES || pathBytes > MAX_SEVERE_EVIDENCE_PATH_BYTES) errors.push("evidence exceeds aggregate limits");
   if (value.complete !== completeFiles) errors.push("evidence completeness is inconsistent");
   if ((state === "confirmed" || state === "refuted") && (!value.complete || !completeFiles)) errors.push("confirmed or refuted evidence must be complete");
   if (expectedPath !== undefined && (!safePath(expectedPath) || ![...value.files, ...value.omitted].some((entry) => record(entry) && entry.path === expectedPath))) errors.push("evidence does not cover expected path");
   if (state === "incomplete" && value.complete) errors.push("incomplete state requires incomplete evidence");
+}
+
+function validStateReason(state: unknown, reason: unknown): boolean {
+  if (!string(state) || !STATES.has(state) || (reason !== undefined && !string(reason))) return false;
+  if (state === "confirmed") return reason === undefined;
+  if (state === "refuted") return reason === undefined || reason === "refuted";
+  const allowed: Record<string, string[]> = { failed: ["provider_unavailable", "receipt_invalid"], malformed: ["malformed", "schema_invalid", "receipt_invalid"], timeout: ["timeout"], unavailable: ["unavailable", "provider_unavailable"], stale_head: ["stale_head", "identity_mismatch"], incomplete: ["incomplete", "not_read", "evidence_incomplete", "cap_exceeded"] };
+  return reason !== undefined && (allowed[state]?.includes(reason) ?? false);
 }
 
 function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }

--- a/src/severe-verification-receipt.ts
+++ b/src/severe-verification-receipt.ts
@@ -35,7 +35,7 @@ export interface SevereVerificationReceipt {
   reasonCode?: SevereVerificationCode;
   evidence: SevereVerificationEvidence;
 }
-export interface SevereReceiptValidationOptions { expectedPath?: string; }
+export interface SevereReceiptValidationOptions { expectedRepo?: string; expectedPullNumber?: number; expectedBaseSha?: string; expectedHeadSha?: string; expectedFindingFingerprint?: string; expectedPath?: string; }
 export type SevereReceiptValidation =
   | { ok: true; value: SevereVerificationReceipt }
   | { ok: false; errors: string[] };
@@ -60,7 +60,8 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   const receipt = value;
   if (!exact(receipt, ["schemaVersion", "repo", "pullNumber", "baseSha", "findingFingerprint", "headSha", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) errors.push("receipt has missing or unknown fields");
   if (receipt.schemaVersion !== "severe-verifier-v1") errors.push("schemaVersion is invalid");
-  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
+  const repoParts = string(receipt.repo) ? receipt.repo.split("/") : [];
+  if (!string(receipt.repo) || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(receipt.repo) || repoParts.some((part) => part === "." || part === "..") || byteLength(receipt.repo) > 256) errors.push("repo is invalid");
   if (typeof receipt.pullNumber !== "number" || !Number.isSafeInteger(receipt.pullNumber) || receipt.pullNumber < 1) errors.push("pullNumber is invalid");
   if (!string(receipt.baseSha) || !SHA40.test(receipt.baseSha)) errors.push("baseSha is invalid");
   if (!string(receipt.headSha) || !SHA40.test(receipt.headSha)) errors.push("headSha is invalid");
@@ -69,6 +70,7 @@ export function validateSevereVerificationReceipt(value: unknown, options: Sever
   if (receipt.disposition !== "retain" && receipt.disposition !== "suppress") errors.push("disposition is invalid");
   if (receipt.confidence !== undefined && (!number(receipt.confidence) || receipt.confidence < 0 || receipt.confidence > 1)) errors.push("confidence is invalid");
   if (receipt.reasonCode !== undefined && (!string(receipt.reasonCode) || !CODES.has(receipt.reasonCode))) errors.push("reasonCode is invalid");
+  if ((options.expectedRepo !== undefined && receipt.repo !== options.expectedRepo) || (options.expectedPullNumber !== undefined && receipt.pullNumber !== options.expectedPullNumber) || (options.expectedBaseSha !== undefined && receipt.baseSha !== options.expectedBaseSha) || (options.expectedHeadSha !== undefined && receipt.headSha !== options.expectedHeadSha) || (options.expectedFindingFingerprint !== undefined && receipt.findingFingerprint !== options.expectedFindingFingerprint)) errors.push("receipt identity mismatch");
   if (receipt.state === "confirmed" && receipt.disposition !== "retain") errors.push("confirmed receipts must retain");
   if (receipt.state !== "confirmed" && receipt.disposition === "retain") errors.push("non-confirmed receipts must suppress");
   if (!validStateReason(receipt.state, receipt.reasonCode)) errors.push("state and reasonCode are inconsistent");

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { MAX_SEVERE_EVIDENCE_FILE_BYTES, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+import { readSevereVerificationEvidence, type SevereVerificationEvidenceSubject } from "../src/severe-verification-evidence.js";
+
+const subject = (path: string): SevereVerificationEvidenceSubject => ({ repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: "finding:" + "f".repeat(64), path });
+
+describe("severe verification exact evidence read", () => {
+  it("binds identity, bytes, digest, completeness, and decoded content", () => {
+    const root = mkdtempSync(join("/tmp", "severe-evidence-")), path = "space dir/plus+λ/..hidden/file.ts", content = "const π = 1;\n";
+    try {
+      mkdirSync(join(root, "space dir/plus+λ/..hidden"), { recursive: true });
+      writeFileSync(join(root, path), content);
+      const result = readSevereVerificationEvidence(root, subject(path));
+      expect(result.subject).toEqual(subject(path));
+      expect(result.content).toBe(content);
+      expect(result.evidence).toEqual({ files: [{ path, kind: "whole_file", sha256: createHash("sha256").update(content).digest("hex"), bytes: Buffer.byteLength(content), complete: true }], omitted: [], complete: true });
+      const parsed = parseSevereVerificationReceipt({ schemaVersion: "severe-verifier-v1", repo: result.subject.repo, pullNumber: result.subject.pullNumber, baseSha: result.subject.baseSha, findingFingerprint: result.subject.findingFingerprint, headSha: result.subject.headSha, state: "confirmed", disposition: "retain", evidence: result.evidence }, { expectedPath: path });
+      expect(parsed.findingFingerprint).toBe(result.subject.findingFingerprint);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it("allows long contained paths but rejects lexical escapes and prefix lookalikes", () => {
+    const root = mkdtempSync(join("/tmp", "severe-evidence-")), parts = Array.from({ length: 20 }, (_, i) => "segment" + i), path = parts.join("/") + "/file.ts";
+    try {
+      mkdirSync(join(root, parts.join("/")), { recursive: true });
+      writeFileSync(join(root, path), "safe");
+      expect(readSevereVerificationEvidence(root, subject(path)).content).toBe("safe");
+      for (const unsafe of ["../" + root.split("/").pop() + "-evil/file.ts", "../file.ts", "dir/../file.ts", "./file.ts", "dir//file.ts", "/tmp/file.ts", "C:/file.ts", "dir\\file.ts", "dir/" + String.fromCharCode(0) + "x.ts", "dir/\nx.ts"]) {
+        expect(() => readSevereVerificationEvidence(root, subject(unsafe))).toThrow("severe_evidence_incomplete");
+      }
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it("rejects every symlink component, missing/non-file paths, invalid UTF-8, and oversized files", () => {
+    const root = mkdtempSync(join("/tmp", "severe-evidence-")), outside = mkdtempSync(join("/tmp", "severe-outside-"));
+    try {
+      mkdirSync(join(root, "real/dir"), { recursive: true });
+      writeFileSync(join(root, "real/file.ts"), "same");
+      writeFileSync(join(outside, "file.ts"), "same");
+      symlinkSync(join(root, "real/file.ts"), join(root, "inside-link.ts"));
+      symlinkSync(join(outside, "file.ts"), join(root, "outside-link.ts"));
+      symlinkSync(join(root, "real"), join(root, "dir-link"));
+      for (const path of ["inside-link.ts", "outside-link.ts", "dir-link/file.ts", "missing.ts", "real", "real/missing.ts"]) expect(() => readSevereVerificationEvidence(root, subject(path))).toThrow("severe_evidence_incomplete");
+      writeFileSync(join(root, "invalid.ts"), Buffer.from([0xff, 0xfe]));
+      expect(() => readSevereVerificationEvidence(root, subject("invalid.ts"))).toThrow("severe_evidence_malformed");
+      writeFileSync(join(root, "large.ts"), Buffer.alloc(MAX_SEVERE_EVIDENCE_FILE_BYTES + 1));
+      expect(() => readSevereVerificationEvidence(root, subject("large.ts"))).toThrow("severe_evidence_cap_exceeded");
+    } finally { rmSync(root, { recursive: true, force: true }); rmSync(outside, { recursive: true, force: true }); }
+  });
+});

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -39,8 +39,16 @@ describe("severe verification receipt parser", () => {
     const states = ["refuted", "timeout", "unavailable", "malformed", "stale_head", "incomplete"] as const;
     for (const state of states) {
       const evidence = state === "incomplete" ? { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } : base().evidence;
-      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", evidence }));
+      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", reasonCode: state === "refuted" ? "refuted" : state, evidence }));
       expect(parsed.state).toBe(state);
     }
+    expect(parseSevereVerificationReceipt(receipt({ state: "failed", disposition: "suppress", reasonCode: "provider_unavailable" })).state).toBe("failed");
+    expect(isSevereVerificationReceipt(receipt({ reasonCode: "timeout" }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress", reasonCode: "provider_unavailable" }))).toBe(false);
+  });
+
+  it("bounds evidence cardinality and proof sizes", () => {
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", reasonCode: "incomplete", evidence: { files: [], omitted: Array.from({ length: 10_000 }, () => ({ path, code: "incomplete" })), complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ ...base().evidence.files[0], bytes: 2 ** 32 }], omitted: [], complete: true } }))).toBe(false);
   });
 });

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -31,6 +31,7 @@ describe("severe verification receipt parser", () => {
     expect(isSevereVerificationReceipt(receipt({ evidence: { files: [], omitted: [], complete: false } }))).toBe(false);
     expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress" }), { expectedPath: path })).toBe(true);
     expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", evidence: { files: [], omitted: [{ path: "other.ts", code: "incomplete" }], complete: false } }), { expectedPath: path })).toBe(false);
     expect(isSevereVerificationReceipt(receipt({ reasonCode: "free-form prose" }))).toBe(false);
   });
 

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isSevereVerificationReceipt, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+import { isSevereVerificationReceipt, parseSevereVerificationReceipt, validateSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
 
 const path = "src/safe file+Δ.ts";
 const base = () => ({ schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`, headSha: "a".repeat(40), state: "confirmed", disposition: "retain", confidence: 0.9, evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true } });
@@ -25,6 +25,11 @@ describe("severe verification receipt parser", () => {
       expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path: unsafe, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } }))).toBe(false);
     }
     expect(isSevereVerificationReceipt(receipt(), { expectedPath: "src/other.ts" })).toBe(false);
+  });
+
+  it("rejects dot repositories and mismatched review identities", () => {
+    for (const repo of ["./repo", "owner/.."]) expect(isSevereVerificationReceipt(receipt({ repo }))).toBe(false);
+    for (const [key, value] of [["expectedRepo", "other/repo"], ["expectedPullNumber", 8], ["expectedBaseSha", "c".repeat(40)], ["expectedHeadSha", "d".repeat(40)], ["expectedFindingFingerprint", `finding:${"e".repeat(64)}`]]) expect(validateSevereVerificationReceipt(receipt(), { [key]: value } as never)).toEqual({ ok: false, errors: ["receipt identity mismatch"] });
   });
 
   it("requires nonempty, complete, relevant evidence for confirmed/refuted states", () => {

--- a/tests/severe-verification-receipt.test.ts
+++ b/tests/severe-verification-receipt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isSevereVerificationReceipt, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+
+const path = "src/safe file+Δ.ts";
+const base = () => ({ schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`, headSha: "a".repeat(40), state: "confirmed", disposition: "retain", confidence: 0.9, evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true } });
+const receipt = (changes: Record<string, unknown> = {}) => ({ ...base(), ...changes });
+
+describe("severe verification receipt parser", () => {
+  it("accepts strict identity, bounded metadata, safe Unicode paths, and expected coverage", () => {
+    const longPath = `${"a".repeat(4070)} + safe λ.ts`;
+    const value = receipt({ evidence: { files: [{ path: longPath, kind: "whole_file", sha256: "d".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } });
+    expect(parseSevereVerificationReceipt(value, { expectedPath: longPath }).evidence.files[0]?.path).toBe(longPath);
+  });
+
+  it("rejects malformed, extra-field, coercion, and array values", () => {
+    expect(isSevereVerificationReceipt([])).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ extra: true }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ pullNumber: "7" }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ headSha: new String("a".repeat(40)) }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { ...base().evidence, files: [base().evidence.files[0], "not an object"] } }))).toBe(false);
+  });
+
+  it("rejects absolute, traversal, backslash, NUL, and unrelated evidence paths", () => {
+    for (const unsafe of ["/tmp/x.ts", "../x.ts", "src/../x.ts", "src\\x.ts", `src/${String.fromCharCode(0)}x.ts`]) {
+      expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path: unsafe, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true } }))).toBe(false);
+    }
+    expect(isSevereVerificationReceipt(receipt(), { expectedPath: "src/other.ts" })).toBe(false);
+  });
+
+  it("requires nonempty, complete, relevant evidence for confirmed/refuted states", () => {
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [], omitted: [], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "refuted", disposition: "suppress" }), { expectedPath: path })).toBe(true);
+    expect(isSevereVerificationReceipt(receipt({ evidence: { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } }))).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ reasonCode: "free-form prose" }))).toBe(false);
+  });
+
+  it("keeps refuted distinct from timeout, unavailable, malformed, stale-head, and incomplete", () => {
+    const states = ["refuted", "timeout", "unavailable", "malformed", "stale_head", "incomplete"] as const;
+    for (const state of states) {
+      const evidence = state === "incomplete" ? { files: [{ path, kind: "module", sha256: "c".repeat(64), bytes: 1, complete: false }], omitted: [{ path, code: "incomplete" }], complete: false } : base().evidence;
+      const parsed = parseSevereVerificationReceipt(receipt({ state, disposition: "suppress", evidence }));
+      expect(parsed.state).toBe(state);
+    }
+  });
+});


### PR DESCRIPTION
Related: #807

E1 supersedes the held inert helper draft #830 with a dedicated, behavior-neutral evidence leaf stacked on corrected Slice A head 5f777ccda94ab42d1ae17b3b962e1bd57a1afc5f.

The new module has zero production call sites. It atomically returns the typed review subject, exact decoded content, and parser-compatible whole-file evidence with SHA-256, byte count, and completeness. It rejects traversal/absolute/drive/backslash/empty/dot/parent/NUL/newline paths, lexical and real containment escapes, every symlink component, missing/non-file paths, invalid UTF-8, and oversized files. Valid spaces, plus signs, Unicode, ..hidden names, and long contained paths are covered.

Proof: focused Bun tests pass 3/3 (23 assertions); source and test transpilation pass; git diff --check passes; 133 non-generated changed lines. GitNexus detect_changes reports no changes because its registered index is stale and predates this checkout.

No existing source, runtime, provider, customer, or release behavior was changed. B2 remains responsible for wiring this leaf into publication.