### PR TITLE
ci(release): validate every desktop manifest from index

### DIFF
--- a/.github/workflows/desktop-manifest-contract.yml
+++ b/.github/workflows/desktop-manifest-contract.yml
@@ -1,0 +1,26 @@
+name: Desktop manifest contract
+on:
+  pull_request:
+    paths:
+      - "docs/release-candidates/**"
+      - "docs/schema/desktop-release-manifest-v1.schema.json"
+      - "scripts/validate-desktop-candidate-manifest.mjs"
+      - "tests/desktop-candidate-manifest.test.ts"
+      - ".github/workflows/desktop-manifest-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/release-candidates/**"
+      - "docs/schema/desktop-release-manifest-v1.schema.json"
+      - "scripts/validate-desktop-candidate-manifest.mjs"
+      - ".github/workflows/desktop-manifest-contract.yml"
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 26, cache: npm }
+      - run: npm ci --ignore-scripts
+      - run: node scripts/validate-desktop-candidate-manifest.mjs --index docs/release-candidates/desktop-manifests.index.json
+      - run: npx vitest run tests/desktop-candidate-manifest.test.ts --pool=forks --maxWorkers=1

--- a/docs/release-candidates/desktop-manifests.index.json
+++ b/docs/release-candidates/desktop-manifests.index.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": "desktop-release-manifest-index.v1",
+  "status": "no-versioned-manifest",
+  "manifestPaths": [],
+  "reason": "The versioned Desktop candidate is deferred until the frozen accepted source and artifact are available; this index is not a release candidate."
+}

--- a/scripts/validate-desktop-candidate-manifest.mjs
+++ b/scripts/validate-desktop-candidate-manifest.mjs
@@ -91,6 +91,7 @@ export function validateDesktopReleaseManifest(manifest, options = {}) {
 export function validateManifestIndex(indexPath, options = {}) {
   const Ajv = Object.prototype.hasOwnProperty.call(options, "ajv") ? options.ajv : ImportedAjv;
   if (!Ajv) return fail(SCHEMA_UNAVAILABLE);
+  try { (typeof Ajv === "function" ? new Ajv({ allErrors: true, strict: true, allowUnionTypes: true }) : Ajv).compile(schema); } catch { return fail(SCHEMA_UNAVAILABLE); }
   let index;
   try { index = JSON.parse(readFileSync(resolve(indexPath), "utf8")); } catch { return fail("manifest index unreadable or invalid"); }
   if (!index || typeof index !== "object" || Array.isArray(index)) return fail("manifest index shape invalid");

--- a/scripts/validate-desktop-candidate-manifest.mjs
+++ b/scripts/validate-desktop-candidate-manifest.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 const here = fileURLToPath(new URL(".", import.meta.url));
@@ -88,8 +88,29 @@ export function validateDesktopReleaseManifest(manifest, options = {}) {
   }
   return errors.length ? fail(...errors) : { valid: true, errors: [] };
 }
+export function validateManifestIndex(indexPath, options = {}) {
+  const Ajv = Object.prototype.hasOwnProperty.call(options, "ajv") ? options.ajv : ImportedAjv;
+  if (!Ajv) return fail(SCHEMA_UNAVAILABLE);
+  let index;
+  try { index = JSON.parse(readFileSync(resolve(indexPath), "utf8")); } catch { return fail("manifest index unreadable or invalid"); }
+  if (!index || typeof index !== "object" || Array.isArray(index)) return fail("manifest index shape invalid");
+  const errors = [], expectedKeys = ["manifestPaths", "reason", "schemaVersion", "status"];
+  if (JSON.stringify(Object.keys(index).sort()) !== JSON.stringify(expectedKeys)) errors.push("index: unexpected or missing fields");
+  if (index.schemaVersion !== "desktop-release-manifest-index.v1" || !["no-versioned-manifest", "current"].includes(index.status) || !Array.isArray(index.manifestPaths) || index.manifestPaths.some((path) => typeof path !== "string" || !/^v\d+\.\d+\.\d+(?:-[^/]+)?-desktop-[^/]+\.json$/.test(path))) errors.push("index: strict versioned manifest index shape required");
+  if (!nonblank(index.reason)) errors.push("index: reason is required");
+  let discovered = [];
+  try { discovered = readdirSync(resolve(indexPath, ".."), { withFileTypes: true }).filter((entry) => entry.isFile() && /^v\d+\.\d+\.\d+(?:-[^/]+)?-desktop-[^/]+\.json$/.test(entry.name)).map((entry) => entry.name).sort(); } catch { errors.push("index: candidate directory unreadable"); }
+  const listed = Array.isArray(index.manifestPaths) ? [...index.manifestPaths].sort() : [];
+  if (JSON.stringify(discovered) !== JSON.stringify(listed)) errors.push("index: does not enumerate every versioned Desktop manifest");
+  if (index.status === "no-versioned-manifest" && (listed.length || !/defer|frozen|not a release candidate/i.test(index.reason ?? ""))) errors.push("index: pending status must explain deferred non-candidate state");
+  if (index.status === "current" && !listed.length) errors.push("index: current status requires a manifest");
+  for (const path of listed) {
+    try { const result = validateDesktopReleaseManifest(JSON.parse(readFileSync(resolve(indexPath, "..", path), "utf8")), options); if (!result.valid) errors.push(`${path}: ${result.errors.join("; ")}`); } catch { errors.push(`${path}: manifest unreadable or invalid`); }
+  }
+  return errors.length ? fail(...errors) : { valid: true, errors: [] };
+}
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
-  const path = process.argv[2];
-  if (!path || path === "--index") { console.error("usage: node scripts/validate-desktop-candidate-manifest.mjs <manifest.json>"); process.exitCode = 64; }
-  else { try { const result = validateDesktopReleaseManifest(JSON.parse(readFileSync(resolve(path), "utf8"))); if (!result.valid) { for (const error of result.errors) console.error(error); process.exitCode = 1; } } catch { console.error("manifest input unreadable or invalid"); process.exitCode = 1; } }
+  const mode = process.argv[2], path = mode === "--index" ? process.argv[3] : mode;
+  if (!path) { console.error("usage: node scripts/validate-desktop-candidate-manifest.mjs [--index] <path>"); process.exitCode = 64; }
+  else { const result = mode === "--index" ? validateManifestIndex(path) : (() => { try { return validateDesktopReleaseManifest(JSON.parse(readFileSync(resolve(path), "utf8"))); } catch { return fail("manifest input unreadable or invalid"); } })(); if (!result.valid) { for (const error of result.errors) console.error(error); process.exitCode = 1; } }
 }

--- a/tests/desktop-candidate-manifest.test.ts
+++ b/tests/desktop-candidate-manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
-import { compareSemver, validateDesktopReleaseManifest } from "../scripts/validate-desktop-candidate-manifest.mjs";
+import { compareSemver, validateDesktopReleaseManifest, validateManifestIndex } from "../scripts/validate-desktop-candidate-manifest.mjs";
 const commit = "a".repeat(40);
 const artifactSha = "a".repeat(64);
 const rollbackSha = "b".repeat(64);
@@ -69,5 +69,9 @@ describe("Desktop release manifest contract", () => {
     const rollback = stable(); rollback.rollback.targetVersion = "1.1.0";
     expect(validateDesktopReleaseManifest(rollback, { ajv: AcceptingAjv }).valid).toBe(false);
     const boundary = stable(); boundary.proofBoundary.excludes = ["This is not a release candidate."]; expect(validateDesktopReleaseManifest(boundary, { ajv: AcceptingAjv }).valid).toBe(false);
+  });
+  it("requires the explicit index and fails closed without Ajv", () => {
+    expect(validateManifestIndex("docs/release-candidates/desktop-manifests.index.json", { ajv: Ajv2020 })).toEqual({ valid: true, errors: [] });
+    expect(validateManifestIndex("docs/release-candidates/desktop-manifests.index.json", { ajv: null })).toEqual({ valid: false, errors: ["schema validator unavailable"] });
   });
 });


### PR DESCRIPTION
## Summary
- add a strict explicit `desktop-manifests.index.json` for the current no-candidate state
- enumerate every versioned Desktop manifest and validate each listed manifest through the v1 contract
- compile the schema before even an empty index can pass
- add Node 26 CI coverage for the index and focused contract tests

## Exact stack
- base: `c19853cbe0126cec7d77f30865cb95eb5552ba77` (#838 head)
- head: `cada560552f90dc17c68f03ce4ae914092132073`
- changed lines: 63 additions and 5 deletions relative to #838
- main ancestor: `cb71205dde46bb2a2b4101694c7ae86141b54f87`

## Proof boundary
The index deliberately contains no versioned candidate. It states that a candidate is deferred until frozen accepted source and artifact evidence exist and is not a release candidate. This PR does not sign, notarize, staple, publish, install, release, or prove deployment.

## Checks
- indexed no-versioned-manifest CLI validation: pass
- strict Ajv schema compilation: pass
- focused Desktop manifest contract workflow: pass
- fresh full CI is running after the mechanical rebase
