### PR TITLE
feat: add exact severe evidence reader

### DIFF
--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { closeSync, constants, fstatSync, lstatSync, openSync, readSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { MAX_SEVERE_EVIDENCE_FILE_BYTES, parseSevereVerificationReceipt, type SevereVerificationReceipt } from "./severe-verification-receipt.js";
+
+export interface SevereVerificationEvidenceSubject {
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  headSha: string;
+  findingFingerprint: string;
+  path: string;
+}
+
+export interface SevereVerificationEvidenceRead {
+  subject: SevereVerificationEvidenceSubject;
+  content: string;
+  evidence: SevereVerificationReceipt["evidence"];
+}
+
+export function readSevereVerificationEvidence(worktreePath: string, subject: SevereVerificationEvidenceSubject): SevereVerificationEvidenceRead {
+  assertSafeRelativePath(subject.path);
+  const root = resolve(worktreePath);
+  const candidate = resolve(root, subject.path);
+  assertContained(root, candidate, "lexical");
+  assertNoSymlinkComponents(root, subject.path);
+  const realRoot = realpathSync.native(root);
+  const realCandidate = realpathSync.native(candidate);
+  assertContained(realRoot, realCandidate, "real");
+  const bytes = readBoundedRegularFile(candidate);
+  let content: string;
+  try { content = new TextDecoder("utf-8", { fatal: true }).decode(bytes); } catch { throw new Error("severe_evidence_malformed"); }
+  const evidence = { files: [{ path: subject.path, kind: "whole_file" as const, sha256: createHash("sha256").update(bytes).digest("hex"), bytes: bytes.byteLength, complete: true }], omitted: [], complete: true };
+  parseSevereVerificationReceipt({
+    schemaVersion: "severe-verifier-v1", repo: subject.repo, pullNumber: subject.pullNumber, baseSha: subject.baseSha,
+    findingFingerprint: subject.findingFingerprint, headSha: subject.headSha, state: "confirmed", disposition: "retain", evidence
+  }, { expectedRepo: subject.repo, expectedPullNumber: subject.pullNumber, expectedBaseSha: subject.baseSha, expectedHeadSha: subject.headSha, expectedFindingFingerprint: subject.findingFingerprint, expectedPath: subject.path });
+  return { subject: { ...subject }, content, evidence };
+}
+
+function assertSafeRelativePath(path: string): void {
+  if (!path || Buffer.byteLength(path, "utf8") > 4096 || path.startsWith("/") || /^[A-Za-z]:/.test(path) || /[\\\0\r\n]/.test(path) || path.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error("severe_evidence_incomplete");
+  }
+}
+
+function assertContained(root: string, candidate: string, kind: string): void {
+  const rel = relative(root, candidate);
+  if (!rel || rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) throw new Error("severe_evidence_incomplete:" + kind);
+}
+
+function assertNoSymlinkComponents(root: string, requestedPath: string): void {
+  let current = root;
+  const parts = requestedPath.split("/");
+  for (const [index, part] of parts.entries()) {
+    current = join(current, part);
+    let stat;
+    try { stat = lstatSync(current); } catch { throw new Error("severe_evidence_incomplete"); }
+    if (stat.isSymbolicLink() || (index < parts.length - 1 && !stat.isDirectory())) throw new Error("severe_evidence_incomplete");
+  }
+}
+
+function readBoundedRegularFile(path: string): Uint8Array {
+  const descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const before = fstatSync(descriptor);
+    if (!before.isFile()) throw new Error("severe_evidence_incomplete");
+    if (before.size > MAX_SEVERE_EVIDENCE_FILE_BYTES) throw new Error("severe_evidence_cap_exceeded");
+    const bytes = Buffer.alloc(before.size);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const count = readSync(descriptor, bytes, offset, bytes.byteLength - offset, offset);
+      if (count === 0) throw new Error("severe_evidence_incomplete");
+      offset += count;
+    }
+    const after = fstatSync(descriptor);
+    if (after.size !== before.size || after.mtimeMs !== before.mtimeMs || after.ctimeMs !== before.ctimeMs) throw new Error("severe_evidence_incomplete");
+    return bytes;
+  } finally { closeSync(descriptor); }
+}

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { MAX_SEVERE_EVIDENCE_FILE_BYTES, parseSevereVerificationReceipt } from "../src/severe-verification-receipt.js";
+import { readSevereVerificationEvidence, type SevereVerificationEvidenceSubject } from "../src/severe-verification-evidence.js";
+
+const subject = (path: string): SevereVerificationEvidenceSubject => ({ repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: "finding:" + "f".repeat(64), path });
+
+describe("severe verification exact evidence read", () => {
+  it("binds identity, bytes, digest, completeness, and decoded content", () => {
+    const root = mkdtempSync(join("/tmp", "severe-evidence-")), path = "space dir/plus+λ/..hidden/file.ts", content = "const π = 1;\n";
+    try {
+      mkdirSync(join(root, "space dir/plus+λ/..hidden"), { recursive: true });
+      writeFileSync(join(root, path), content);
+      const result = readSevereVerificationEvidence(root, subject(path));
+      expect(result.subject).toEqual(subject(path));
+      expect(result.content).toBe(content);
+      expect(result.evidence).toEqual({ files: [{ path, kind: "whole_file", sha256: createHash("sha256").update(content).digest("hex"), bytes: Buffer.byteLength(content), complete: true }], omitted: [], complete: true });
+      const parsed = parseSevereVerificationReceipt({ schemaVersion: "severe-verifier-v1", repo: result.subject.repo, pullNumber: result.subject.pullNumber, baseSha: result.subject.baseSha, findingFingerprint: result.subject.findingFingerprint, headSha: result.subject.headSha, state: "confirmed", disposition: "retain", evidence: result.evidence }, { expectedPath: path });
+      expect(parsed.findingFingerprint).toBe(result.subject.findingFingerprint);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it("allows long contained paths but rejects lexical escapes and prefix lookalikes", () => {
+    const root = mkdtempSync(join("/tmp", "severe-evidence-")), parts = Array.from({ length: 20 }, (_, i) => "segment" + i), path = parts.join("/") + "/file.ts";
+    try {
+      mkdirSync(join(root, parts.join("/")), { recursive: true });
+      writeFileSync(join(root, path), "safe");
+      expect(readSevereVerificationEvidence(root, subject(path)).content).toBe("safe");
+      for (const unsafe of ["../" + root.split("/").pop() + "-evil/file.ts", "../file.ts", "dir/../file.ts", "./file.ts", "dir//file.ts", "/tmp/file.ts", "C:/file.ts", "dir\\file.ts", "dir/" + String.fromCharCode(0) + "x.ts", "dir/\nx.ts"]) {
+        expect(() => readSevereVerificationEvidence(root, subject(unsafe))).toThrow("severe_evidence_incomplete");
+      }
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it("rejects every symlink component, missing/non-file paths, invalid UTF-8, and oversized files", () => {
+    const root = mkdtempSync(join("/tmp", "severe-evidence-")), outside = mkdtempSync(join("/tmp", "severe-outside-"));
+    try {
+      mkdirSync(join(root, "real/dir"), { recursive: true });
+      writeFileSync(join(root, "real/file.ts"), "same");
+      writeFileSync(join(outside, "file.ts"), "same");
+      symlinkSync(join(root, "real/file.ts"), join(root, "inside-link.ts"));
+      symlinkSync(join(outside, "file.ts"), join(root, "outside-link.ts"));
+      symlinkSync(join(root, "real"), join(root, "dir-link"));
+      for (const path of ["inside-link.ts", "outside-link.ts", "dir-link/file.ts", "missing.ts", "real", "real/missing.ts"]) expect(() => readSevereVerificationEvidence(root, subject(path))).toThrow("severe_evidence_incomplete");
+      writeFileSync(join(root, "invalid.ts"), Buffer.from([0xff, 0xfe]));
+      expect(() => readSevereVerificationEvidence(root, subject("invalid.ts"))).toThrow("severe_evidence_malformed");
+      writeFileSync(join(root, "large.ts"), Buffer.alloc(MAX_SEVERE_EVIDENCE_FILE_BYTES + 1));
+      expect(() => readSevereVerificationEvidence(root, subject("large.ts"))).toThrow("severe_evidence_cap_exceeded");
+    } finally { rmSync(root, { recursive: true, force: true }); rmSync(outside, { recursive: true, force: true }); }
+  });
+});


### PR DESCRIPTION
Related: #807

Clean v4 successor to stale E1 #839, recreated byte-for-byte from the accepted evidence-reader module/tests. Stacked on rebased Slice A #823 head 4c7f1c844a1cf4c70b47da54b420720e26c503ee.

The dedicated module has zero production call sites and atomically returns the typed review subject, exact decoded content, and parser-compatible whole-file evidence with SHA-256, byte count, and completeness. It rejects traversal/absolute/drive/backslash/empty/dot/parent/NUL/newline paths, lexical and real containment escapes, every symlink component, missing/non-file paths, invalid UTF-8, and oversized files. Valid spaces, plus signs, Unicode, ..hidden names, and long contained paths remain covered.

Proof: module and test blobs match #839 exactly; focused Bun tests pass 3/3 (23 assertions); source and test transpilation pass; git diff --check passes; 133 non-generated changed lines; zero-call-site rg is clean. GitNexus detect_changes is non-authoritative because its registered index is stale.

No existing source, runtime, provider, customer, or release behavior was changed. B2 remains responsible for wiring this leaf into publication.