### PR TITLE
feat(issue-enrichment): report bounded progress stages

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,11 @@ import { resolve } from "node:path";
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { GitHubApi } from "./github.js";
-import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
+import {
+  runIssueEnrichmentCycle,
+  type IssueEnrichmentCycleResult,
+  type IssueEnrichmentProgress
+} from "./issue-enrichment.js";
 import { runScheduledCycle } from "./scheduler.js";
 import {
   isAuthenticProductionLicenseAdmission,
@@ -52,6 +56,7 @@ export interface RunDaemonCycleOptions {
     configPath?: string;
     dryRun: boolean;
     licenseAdmission?: ProductionLicenseAdmission;
+    onProgress?: (progress: IssueEnrichmentProgress) => void;
   }) => Promise<IssueEnrichmentCycleResult>;
   cleanupReviewWorktreesImpl?: (options: { configPath?: string; dryRun: boolean }) => ReviewWorktreeCleanupSummary;
   recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
@@ -131,7 +136,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, recordHeartbeat, stdout, stderr })
     : Promise.resolve();
 
   try {
@@ -266,6 +271,7 @@ function summarizeWorktreeCleanup(cleanup: ReviewWorktreeCleanupSummary): Record
 async function runIssueEnrichmentLane(input: {
   input: RunDaemonCycleOptions;
   admissions: DaemonCycleAdmissions | void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string) => void;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }): Promise<void> {
@@ -275,11 +281,41 @@ async function runIssueEnrichmentLane(input: {
     cycle: input.input.cycle,
     dryRun: input.input.dryRun
   }));
+  const startedAt = Date.now();
+  const refreshHeartbeat = (): void => {
+    try {
+      input.recordHeartbeat("daemon_cycle_start");
+    } catch (error) {
+      input.stderr(formatDaemonLog({
+        event: "daemon_heartbeat_failed",
+        level: "error",
+        cycle: input.input.cycle,
+        dryRun: input.input.dryRun,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    }
+  };
+  const heartbeatTimer = setInterval(refreshHeartbeat, 60_000);
   try {
     const issueEnrichment = await issueEnrichmentCycleImpl({
       configPath: input.input.configPath,
       dryRun: input.input.dryRun,
-      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
+      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {}),
+      onProgress: (progress) => {
+        const elapsedMs = Math.min(86_400_000, Math.max(0, Date.now() - startedAt));
+        refreshHeartbeat();
+        input.stdout(formatDaemonLog({
+          event: "daemon_issue_enrichment_progress",
+          cycle: input.input.cycle,
+          dryRun: input.input.dryRun,
+          stage: progress.stage,
+          phase: progress.phase,
+          elapsedMs,
+          ...(progress.count === undefined
+            ? {}
+            : { count: Math.min(10_000, Math.max(0, Math.trunc(progress.count))) })
+        }));
+      }
     });
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
@@ -297,6 +333,8 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       error: message
     }));
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 }
 
@@ -315,6 +353,7 @@ async function runIssueEnrichmentCycleFromConfig(input: {
   configPath?: string;
   dryRun: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   const config = loadConfig(input.configPath);
   let licenseAdmission = input.licenseAdmission;
@@ -336,7 +375,8 @@ async function runIssueEnrichmentCycleFromConfig(input: {
       state,
       github: new GitHubApi(config.github),
       dryRun: input.dryRun,
-      licenseAdmission
+      licenseAdmission,
+      onProgress: input.onProgress
     });
   } finally {
     state.close();

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -280,6 +280,21 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
   }>;
 }
 
+export const ISSUE_ENRICHMENT_PROGRESS_STAGES = [
+  "source_snapshot",
+  "github_evidence",
+  "analysis",
+  "post",
+  "persist"
+] as const;
+export type IssueEnrichmentProgressStage = typeof ISSUE_ENRICHMENT_PROGRESS_STAGES[number];
+export type IssueEnrichmentProgressPhase = "start" | "complete";
+export interface IssueEnrichmentProgress {
+  stage: IssueEnrichmentProgressStage;
+  phase: IssueEnrichmentProgressPhase;
+  count?: number;
+}
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
   listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GithubIssueLabelEvent[] | BoundedGithubList<GithubIssueLabelEvent>>;
@@ -801,6 +816,7 @@ export async function runIssueEnrichmentCycle(input: {
   preacquiredLease?: { leaseId: string };
   licenseAdmission?: ProductionLicenseAdmission;
   analyzeIssue?: IssueAnalysisRunner;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   if (!input.licenseAdmission) throw new Error("production license admission is required for issue enrichment cycles");
   if (!isAuthenticProductionLicenseAdmission(input.licenseAdmission, "issue_enrichment")) {
@@ -808,6 +824,21 @@ export async function runIssueEnrichmentCycle(input: {
   }
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const reportProgress = (
+    stage: IssueEnrichmentProgressStage,
+    phase: IssueEnrichmentProgressPhase,
+    count?: number
+  ): void => {
+    try {
+      input.onProgress?.({
+        stage,
+        phase,
+        ...(count === undefined ? {} : { count: Math.max(0, Math.min(10_000, Math.trunc(count))) })
+      });
+    } catch {
+      // Progress reporting is diagnostic and must not change cycle semantics.
+    }
+  };
   const shouldCollectModelEvidence = !input.dryRun && config.postIssueComment && input.analyzeIssue === undefined;
   const renderPolicy = resolveIssueEnrichmentRenderPolicy(input.config);
   const releasePreacquiredLeaseBeforeRun = () => {
@@ -873,6 +904,19 @@ export async function runIssueEnrichmentCycle(input: {
     }
   }
 
+  const recordEnrichment = (record: Parameters<typeof input.state.recordIssueEnrichment>[0]): void => {
+    reportProgress("persist", "start");
+    input.state.recordIssueEnrichment(record);
+    reportProgress("persist", "complete");
+  };
+  const recordWatermark = (
+    record: Parameters<typeof input.state.recordIssueEnrichmentRepoWatermark>[0]
+  ): void => {
+    reportProgress("persist", "start");
+    input.state.recordIssueEnrichmentRepoWatermark(record);
+    reportProgress("persist", "complete");
+  };
+
   try {
     const baselineRepos: IssueEnrichmentRepoScan[] = [];
     const reposToScan: string[] = [];
@@ -900,7 +944,7 @@ export async function runIssueEnrichmentCycle(input: {
         continue;
       }
       if (!input.dryRun && input.advanceWatermarks !== false) {
-        input.state.recordIssueEnrichmentRepoWatermark({
+        recordWatermark({
           repo,
           activatedAt: checkedAt,
           lastCheckedAt: checkedAt,
@@ -928,6 +972,7 @@ export async function runIssueEnrichmentCycle(input: {
 
     const sourceSnapshots = new Map<string, PreparedWorktree>();
     const defaultBranches = new Map<string, string>();
+    reportProgress("source_snapshot", "start", reposToScan.length);
     if (shouldCollectModelEvidence) {
       if (!input.config.workRoot) throw new Error("issue_enrichment_model_runtime_paths_required");
       if (!input.github.getRepo) throw new Error("issue_enrichment_repository_metadata_required");
@@ -947,6 +992,7 @@ export async function runIssueEnrichmentCycle(input: {
         defaultBranches.set(repo.toLowerCase(), defaultBranch);
       }
     }
+    reportProgress("source_snapshot", "complete", sourceSnapshots.size);
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
     const issueEvidenceContextByIssue = new Map<string, IssueAnalysisEvidenceContext>();
@@ -1011,6 +1057,7 @@ export async function runIssueEnrichmentCycle(input: {
         : undefined;
       return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action));
     };
+    reportProgress("github_evidence", "start", reposToScan.length);
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
           config: input.config,
@@ -1063,6 +1110,7 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
+    reportProgress("github_evidence", "complete", scanned.summary.issuesSeen);
     applyGlobalIssueEnrichmentCaps({
       items: scanned.items,
       repoScans: scanned.repos,
@@ -1103,7 +1151,7 @@ export async function runIssueEnrichmentCycle(input: {
           existing.issueUpdatedAt !== issueUpdatedAt ||
           refreshedAnalysisInputHash !== existing.analysisInputHash
         )) {
-          input.state.recordIssueEnrichment({
+          recordEnrichment({
             repo: item.repo,
             issueNumber: item.issueNumber,
             issueUpdatedAt,
@@ -1127,7 +1175,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (item.action === "skipped") {
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1141,7 +1189,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (item.action === "deferred") {
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1157,7 +1205,7 @@ export async function runIssueEnrichmentCycle(input: {
 
       if (!config.postIssueComment || item.action === "would_enrich") {
         const dryRunAnalysisInputHash = plannedAnalysisInputHashForItem(item);
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1213,6 +1261,7 @@ export async function runIssueEnrichmentCycle(input: {
           return result.analysis;
         });
         const runtime = input.config.codexRuntime;
+        reportProgress("analysis", "start");
         const analysis = await analyzer({
           repo: item.repo,
           issue,
@@ -1229,6 +1278,7 @@ export async function runIssueEnrichmentCycle(input: {
           timeoutMs: runtime?.timeoutMs ?? 1,
           maxOutputBytes: runtime?.maxOutputBytes ?? 1
         });
+        reportProgress("analysis", "complete");
         if (!input.github.getIssueOrPull && input.analyzeIssue === undefined) {
           throw new Error("issue_enrichment_current_issue_read_required");
         }
@@ -1253,7 +1303,7 @@ export async function runIssueEnrichmentCycle(input: {
         });
         const postBodyHash = enrichment.bodyHash;
         if (input.force !== true && existing?.status === "posted" && existing.bodyHash === postBodyHash) {
-          input.state.recordIssueEnrichment({
+          recordEnrichment({
             repo: item.repo,
             issueNumber: item.issueNumber,
             issueUpdatedAt,
@@ -1273,6 +1323,7 @@ export async function runIssueEnrichmentCycle(input: {
           });
           continue;
         }
+        reportProgress("post", "start");
         const post = await postEnrichmentComment({
           enabled: true,
           dryRun: false,
@@ -1281,9 +1332,10 @@ export async function runIssueEnrichmentCycle(input: {
           pullNumber: item.issueNumber,
           enrichment
         });
+        reportProgress("post", "complete");
         if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.reason}`);
         const commentUrl = post.html_url ? redactSecrets(post.html_url) : undefined;
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1297,7 +1349,7 @@ export async function runIssueEnrichmentCycle(input: {
         items.push({ ...item, recordStatus: "posted", ...(commentUrl ? { commentUrl } : {}) });
       } catch (error) {
         const message = redactSecrets(error instanceof Error ? error.message : String(error));
-        input.state.recordIssueEnrichment({
+        recordEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
@@ -1318,7 +1370,7 @@ export async function runIssueEnrichmentCycle(input: {
         const repoItems = items.filter((item) => item.repo === repo.repo);
         if (repo.truncated || repoItems.some((item) => item.recordStatus === "deferred" || item.recordStatus === "failed")) continue;
         const existingWatermark = input.state.getIssueEnrichmentRepoWatermark(repo.repo);
-        input.state.recordIssueEnrichmentRepoWatermark({
+        recordWatermark({
           repo: repo.repo,
           activatedAt: existingWatermark?.activatedAt ?? checkedAt,
           lastCheckedAt: checkedAt,

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -338,6 +338,47 @@ describe("daemon cycle resilience", () => {
     expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
   });
 
+  it("refreshes the active heartbeat with bounded issue-enrichment progress", async () => {
+    const heartbeats: string[] = [];
+    const stdout: string[] = [];
+    const timerCallbacks: Array<() => void> = [];
+    const timerSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((callback) => (timerCallbacks.push(callback as () => void), 1 as never));
+    const clearTimerSpy = vi.spyOn(globalThis, "clearInterval");
+    const result = await runDaemonCycle({
+      cycle: 3,
+      dryRun: false,
+      pilotRepos: [],
+      monitoredRepos: [],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(),
+      issueEnrichmentCycleImpl: async (options) => {
+        timerCallbacks[0]?.();
+        options.onProgress?.({ stage: "analysis", phase: "start", count: 99_999 });
+        options.onProgress?.({ stage: "analysis", phase: "complete", count: 1 });
+        return successfulIssueEnrichmentCycleResult();
+      },
+      recordHeartbeatImpl: (event) => heartbeats.push(event),
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+    timerSpy.mockRestore();
+    expect(clearTimerSpy).toHaveBeenCalledTimes(1);
+    clearTimerSpy.mockRestore();
+
+    expect(result.ok).toBe(true);
+    expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_complete"]);
+    const progress = stdout.map((line) => JSON.parse(line)).filter((line) => line.event === "daemon_issue_enrichment_progress");
+    expect(progress).toEqual([
+      expect.objectContaining({ stage: "analysis", phase: "start", count: 10_000 }),
+      expect.objectContaining({ stage: "analysis", phase: "complete", count: 1 })
+    ]);
+    expect(JSON.stringify(progress)).not.toMatch(/body|comment|provider|credential|path|repo/i);
+    expect(progress.every((line) => Number.isInteger(line.elapsedMs) && line.elapsedMs >= 0 && line.elapsedMs <= 86_400_000)).toBe(true);
+  });
+
   it("runs one bounded provider cooldown drain after successful review cycles", async () => {
     const events: string[] = [];
 


### PR DESCRIPTION
## Summary\n- expose fixed enum-only stages: source_snapshot, github_evidence, analysis, post, persist\n- emit bounded count metadata and redacted daemon progress logs\n- refresh heartbeat during enrichment and on a 60s timer with cleanup\n\n## Validation\n- build and changed-path TypeScript checks: passed\n- deterministic stage/timer/redaction check: passed\n- focused Vitest: blocked before discovery by existing Rollup native-addon Team-ID mismatch; no dependencies installed\n\nStacked on corrected #835 head c0b65d1. Process-aware started_at preservation is isolated in the next successor. No live state touched.