### PR TITLE
feat: add inert severe verdict transport

### DIFF
--- a/src/severe-verification-transport.ts
+++ b/src/severe-verification-transport.ts
@@ -2,6 +2,7 @@ import type { SevereVerificationEvidenceRead, SevereVerificationEvidenceSubject 
 import { parseSevereVerificationReceipt, type SevereVerificationCode, type SevereVerificationReceipt } from "./severe-verification-receipt.js";
 
 export interface SevereVerificationFinding { path: string; line: number; severity: "P0" | "P1"; title: string; body: string; fingerprint: string; }
+export type SevereVerificationFailureCode = Exclude<SevereVerificationCode, "refuted">;
 const PROMPT_TEXT_BYTES = 8 * 1024;
 const PROMPT_HUNK_BYTES = 32 * 1024;
 
@@ -27,7 +28,7 @@ export function parseSevereVerificationVerdict(rawResponse: string, evidence: Se
   } catch { throw new Error("severe_verifier_receipt_invalid"); }
 }
 
-export function buildSevereFailureReceipt(subject: SevereVerificationEvidenceSubject, finding: SevereVerificationFinding, code: SevereVerificationCode, suppliedEvidence?: SevereVerificationEvidenceRead): SevereVerificationReceipt {
+export function buildSevereFailureReceipt(subject: SevereVerificationEvidenceSubject, finding: SevereVerificationFinding, code: SevereVerificationFailureCode, suppliedEvidence?: SevereVerificationEvidenceRead): SevereVerificationReceipt {
   assertBinding(finding, subject);
   if (suppliedEvidence) assertEvidenceBinding(suppliedEvidence, subject);
   const state = failureState(code);
@@ -51,7 +52,7 @@ export function severeVerificationFailureCode(error: unknown): SevereVerificatio
   return "provider_unavailable";
 }
 
-function failureState(code: SevereVerificationCode): SevereVerificationReceipt["state"] {
+function failureState(code: SevereVerificationFailureCode): SevereVerificationReceipt["state"] {
   if (code === "identity_mismatch" || code === "stale_head") return "stale_head";
   if (code === "timeout") return "timeout";
   if (code === "provider_unavailable" || code === "receipt_invalid") return "failed";

--- a/src/severe-verification-transport.ts
+++ b/src/severe-verification-transport.ts
@@ -1,0 +1,68 @@
+import type { SevereVerificationEvidenceRead, SevereVerificationEvidenceSubject } from "./severe-verification-evidence.js";
+import { parseSevereVerificationReceipt, type SevereVerificationCode, type SevereVerificationReceipt } from "./severe-verification-receipt.js";
+
+export interface SevereVerificationFinding { path: string; line: number; severity: "P0" | "P1"; title: string; body: string; fingerprint: string; }
+const PROMPT_TEXT_BYTES = 8 * 1024;
+const PROMPT_HUNK_BYTES = 32 * 1024;
+
+export function buildSevereVerificationPrompt(finding: SevereVerificationFinding, hunk: string, evidence: SevereVerificationEvidenceRead): string {
+  assertBinding(finding, evidence.subject);
+  if (!bounded(finding.title) || !bounded(finding.body) || !bounded(hunk, PROMPT_HUNK_BYTES) || !Number.isSafeInteger(finding.line) || finding.line < 1) throw new Error("severe_verifier_prompt_invalid");
+  return [
+    "Review one finding using only the supplied exact-head evidence. Return direct JSON only: {\"verdict\":\"confirm\"|\"refute\",\"confidence\":0.0}.",
+    `Identity repo=${evidence.subject.repo} pull=${evidence.subject.pullNumber} base=${evidence.subject.baseSha} head=${evidence.subject.headSha}`,
+    `Finding fingerprint=${evidence.subject.findingFingerprint} path=${evidence.subject.path} line=${finding.line} severity=${finding.severity}`,
+    `Title=${finding.title}\nDetail=${finding.body}`, `Hunk:\n${hunk}`, `Exact-head evidence metadata=${JSON.stringify(evidence.evidence)}`, `Exact-head file content:\n${evidence.content}`
+  ].join("\n");
+}
+
+export function parseSevereVerificationVerdict(rawResponse: string, evidence: SevereVerificationEvidenceRead, finding: SevereVerificationFinding): SevereVerificationReceipt {
+  assertBinding(finding, evidence.subject);
+  let value: unknown;
+  try { value = typeof rawResponse === "string" ? JSON.parse(rawResponse) : undefined; } catch { throw new Error("severe_verifier_malformed"); }
+  if (!record(value) || !exactKeys(value, ["verdict", "confidence"]) || (value.verdict !== "confirm" && value.verdict !== "refute") || typeof value.confidence !== "number" || !Number.isFinite(value.confidence) || value.confidence < 0 || value.confidence > 1) throw new Error("severe_verifier_malformed");
+  const subject = evidence.subject;
+  try {
+    return parseSevereVerificationReceipt({ schemaVersion: "severe-verifier-v1", ...identity(subject), state: value.verdict === "confirm" ? "confirmed" : "refuted", disposition: value.verdict === "confirm" ? "retain" : "suppress", confidence: value.confidence, evidence: evidence.evidence }, expected(subject));
+  } catch { throw new Error("severe_verifier_receipt_invalid"); }
+}
+
+export function buildSevereFailureReceipt(subject: SevereVerificationEvidenceSubject, finding: SevereVerificationFinding, code: SevereVerificationCode, suppliedEvidence?: SevereVerificationEvidenceRead): SevereVerificationReceipt {
+  assertBinding(finding, subject);
+  if (suppliedEvidence) assertEvidenceBinding(suppliedEvidence, subject);
+  const state = failureState(code);
+  const proof = state === "incomplete" ? { files: [], omitted: [{ path: subject.path, code }], complete: false } : suppliedEvidence?.evidence ?? { files: [], omitted: [{ path: subject.path, code }], complete: false };
+  try { return parseSevereVerificationReceipt({ schemaVersion: "severe-verifier-v1", ...identity(subject), state, disposition: "suppress", reasonCode: code, evidence: proof }, expected(subject)); } catch { throw new Error("severe_verifier_receipt_invalid"); }
+}
+
+export function severeVerificationFailureCode(error: unknown): SevereVerificationCode {
+  const value = error && typeof error === "object" ? error as { code?: unknown; name?: unknown } : {};
+  const text = [error instanceof Error ? error.message : typeof error === "string" ? error : "", value.code, value.name].join(" ").toLowerCase();
+  if (/\b(?:time[- _]?out|timed[- _]?out|etimedout)\b/.test(text)) return "timeout";
+  if (text.includes("identity_mismatch") || text.includes("identity mismatch") || text.includes("stale_head") || text.includes("stale head")) return "identity_mismatch";
+  if (text.includes("provider_unavailable") || text.includes("provider unavailable")) return "provider_unavailable";
+  if (text.includes("receipt_invalid") || text.includes("receipt invalid")) return "receipt_invalid";
+  if (text.includes("schema_invalid") || text.includes("schema invalid") || text.includes("malformed")) return "malformed";
+  if (text.includes("cap_exceeded") || text.includes("cap exceeded")) return "cap_exceeded";
+  if (text.includes("evidence_incomplete") || text.includes("evidence incomplete")) return "evidence_incomplete";
+  if (text.includes("not_read") || text.includes("not read")) return "not_read";
+  if (text.includes("incomplete")) return "incomplete";
+  if (text.includes("unavailable")) return "unavailable";
+  return "provider_unavailable";
+}
+
+function failureState(code: SevereVerificationCode): SevereVerificationReceipt["state"] {
+  if (code === "identity_mismatch" || code === "stale_head") return "stale_head";
+  if (code === "timeout") return "timeout";
+  if (code === "provider_unavailable" || code === "receipt_invalid") return "failed";
+  if (code === "malformed" || code === "schema_invalid") return "malformed";
+  if (code === "unavailable") return "unavailable";
+  return "incomplete";
+}
+function expected(subject: SevereVerificationEvidenceSubject) { return { expectedRepo: subject.repo, expectedPullNumber: subject.pullNumber, expectedBaseSha: subject.baseSha, expectedHeadSha: subject.headSha, expectedFindingFingerprint: subject.findingFingerprint, expectedPath: subject.path }; }
+function identity(subject: SevereVerificationEvidenceSubject) { return { repo: subject.repo, pullNumber: subject.pullNumber, baseSha: subject.baseSha, headSha: subject.headSha, findingFingerprint: subject.findingFingerprint }; }
+function assertBinding(finding: SevereVerificationFinding, subject: SevereVerificationEvidenceSubject): void { if (finding.path !== subject.path || finding.fingerprint !== subject.findingFingerprint) throw new Error("severe_verifier_identity_mismatch"); }
+function assertEvidenceBinding(evidence: SevereVerificationEvidenceRead, subject: SevereVerificationEvidenceSubject): void { const actual = evidence.subject; if (actual.repo !== subject.repo || actual.pullNumber !== subject.pullNumber || actual.baseSha !== subject.baseSha || actual.headSha !== subject.headSha || actual.findingFingerprint !== subject.findingFingerprint || actual.path !== subject.path) throw new Error("severe_verifier_identity_mismatch"); }
+function bounded(value: unknown, max = PROMPT_TEXT_BYTES): value is string { return typeof value === "string" && value.length > 0 && Buffer.byteLength(value, "utf8") <= max; }
+function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function exactKeys(value: Record<string, unknown>, keys: string[]): boolean { return Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key)); }

--- a/tests/severe-verification-transport.test.ts
+++ b/tests/severe-verification-transport.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { SevereVerificationEvidenceRead, SevereVerificationEvidenceSubject } from "../src/severe-verification-evidence.js";
+import { buildSevereFailureReceipt, buildSevereVerificationPrompt, parseSevereVerificationVerdict, severeVerificationFailureCode, type SevereVerificationFinding } from "../src/severe-verification-transport.js";
+
+const subject: SevereVerificationEvidenceSubject = { repo: "owner/repo", pullNumber: 7, baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: "finding:" + "f".repeat(64), path: "src/safe file+λ.ts" };
+const finding: SevereVerificationFinding = { path: subject.path, line: 3, severity: "P1", title: "Import context", body: "The import context is wrong.", fingerprint: subject.findingFingerprint };
+const evidence: SevereVerificationEvidenceRead = { subject, content: "const π = 1;\n", evidence: { files: [{ path: subject.path, kind: "whole_file", sha256: "c".repeat(64), bytes: 15, complete: true }], omitted: [], complete: true } };
+const raw = (value: unknown) => JSON.stringify(value);
+
+describe("severe verification transport", () => {
+  it("binds the atomic exact evidence and bounded finding/hunk in the prompt", () => {
+    const prompt = buildSevereVerificationPrompt(finding, "+added();", evidence);
+    for (const value of [subject.repo, String(subject.pullNumber), subject.baseSha, subject.headSha, subject.findingFingerprint, subject.path, evidence.content, "+added();", finding.title]) expect(prompt).toContain(value);
+  });
+
+  it("accepts only direct strict confirm/refute JSON and binds every parser coordinate", () => {
+    expect(parseSevereVerificationVerdict(raw({ verdict: "confirm", confidence: 0.8 }), evidence, finding)).toMatchObject({ repo: subject.repo, pullNumber: 7, baseSha: subject.baseSha, headSha: subject.headSha, findingFingerprint: subject.findingFingerprint, state: "confirmed", disposition: "retain" });
+    expect(parseSevereVerificationVerdict(raw({ verdict: "refute", confidence: 0.2 }), evidence, finding).state).toBe("refuted");
+    for (const value of [{ response: { verdict: "confirm", confidence: 1 } }, [], { verdict: "maybe", confidence: 1 }, { verdict: "confirm", confidence: "1" }, { verdict: "confirm", confidence: 1, extra: true }, "confirm prose"]) expect(() => parseSevereVerificationVerdict(raw(value), evidence, finding)).toThrow("severe_verifier_malformed");
+  });
+
+  it("maps fixed failure codes to parser states and binds expected path", () => {
+    const expected: Record<string, string> = { identity_mismatch: "stale_head", timeout: "timeout", provider_unavailable: "failed", receipt_invalid: "failed", malformed: "malformed", schema_invalid: "malformed", unavailable: "unavailable", incomplete: "incomplete", cap_exceeded: "incomplete", not_read: "incomplete", evidence_incomplete: "incomplete" };
+    for (const [code, state] of Object.entries(expected)) { const receipt = buildSevereFailureReceipt(subject, finding, code as never); expect(receipt.state).toBe(state); expect(receipt.reasonCode).toBe(code); expect(receipt.evidence.omitted[0]?.path).toBe(subject.path); expect(JSON.stringify(receipt)).not.toContain("provider prose"); }
+    expect(buildSevereFailureReceipt(subject, finding, "timeout" as never, evidence).evidence.files[0]?.path).toBe(subject.path);
+  });
+
+  it("rejects every mismatched supplied evidence identity", () => {
+    for (const change of [{ repo: "other/repo" }, { pullNumber: 8 }, { baseSha: "c".repeat(40) }, { headSha: "d".repeat(40) }, { findingFingerprint: "finding:" + "e".repeat(64) }, { path: "other.ts" }]) expect(() => buildSevereFailureReceipt(subject, finding, "timeout" as never, { ...evidence, subject: { ...subject, ...change } })).toThrow("severe_verifier_identity_mismatch");
+  });
+
+  it("classifies timeout spellings and current provider timeout shapes", () => {
+    for (const message of ["timeout", "timed out", "TIME-OUT", "spawn node ETIMEDOUT", "request Timed_Out"]) expect(severeVerificationFailureCode(new Error(message))).toBe("timeout");
+    expect(severeVerificationFailureCode({ code: "ETIMEDOUT" })).toBe("timeout");
+    expect(severeVerificationFailureCode(new Error("provider unavailable"))).toBe("provider_unavailable");
+    expect(severeVerificationFailureCode(new Error("receipt identity mismatch"))).toBe("identity_mismatch");
+  });
+});


### PR DESCRIPTION
Adds a dedicated, unwired severe-verification transport module and focused tests. It consumes one atomic exact-evidence read, binds all review identity coordinates, parses direct strict verdict JSON only, maps fixed failure codes to parser states, and classifies timeout/provider errors without retaining raw prose. Validation: 5 focused tests / 76 assertions, Bun bundle check, diff check, 106 added lines. GitNexus orientation used the stale registered index; direct scope proof confirms zero production call sites.