### PR TITLE
fix(daemon): preserve heartbeat age across restarts

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -59,7 +59,7 @@ export interface RunDaemonCycleOptions {
     onProgress?: (progress: IssueEnrichmentProgress) => void;
   }) => Promise<IssueEnrichmentCycleResult>;
   cleanupReviewWorktreesImpl?: (options: { configPath?: string; dryRun: boolean }) => ReviewWorktreeCleanupSummary;
-  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
+  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string, recordedAt?: Date) => void;
   admitDaemonCycleImpl?: (configPath?: string) => Promise<DaemonCycleAdmissions | void>;
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
@@ -90,13 +90,14 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   const schedulerEnabled = input.reviewSchedulerEnabled === true;
   const runOnceImpl = input.runOnceImpl ?? (schedulerEnabled ? runScheduledCycle : runOnce);
   const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
-  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
+  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string, recordedAt?: Date) => {
     recordDaemonHeartbeatFromConfig({
       configPath: input.configPath,
       cycle: input.cycle,
       dryRun: input.dryRun,
       event,
       error,
+      recordedAt,
       stderr
     });
   });
@@ -124,7 +125,8 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     }
   }
 
-  recordHeartbeat("daemon_cycle_start");
+  const runStartedAt = new Date();
+  recordHeartbeat("daemon_cycle_start", undefined, runStartedAt);
   stdout(formatDaemonLog({
     event: "daemon_cycle_start",
     cycle: input.cycle,
@@ -136,7 +138,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, recordHeartbeat, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, recordHeartbeat, runStartedAt, stdout, stderr })
     : Promise.resolve();
 
   try {
@@ -271,7 +273,8 @@ function summarizeWorktreeCleanup(cleanup: ReviewWorktreeCleanupSummary): Record
 async function runIssueEnrichmentLane(input: {
   input: RunDaemonCycleOptions;
   admissions: DaemonCycleAdmissions | void;
-  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string) => void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string, recordedAt?: Date) => void;
+  runStartedAt: Date;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }): Promise<void> {
@@ -281,10 +284,10 @@ async function runIssueEnrichmentLane(input: {
     cycle: input.input.cycle,
     dryRun: input.input.dryRun
   }));
-  const startedAt = Date.now();
+  const progressStartedAt = Date.now();
   const refreshHeartbeat = (): void => {
     try {
-      input.recordHeartbeat("daemon_cycle_start");
+      input.recordHeartbeat("daemon_cycle_start", undefined, input.runStartedAt);
     } catch (error) {
       input.stderr(formatDaemonLog({
         event: "daemon_heartbeat_failed",
@@ -302,7 +305,7 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {}),
       onProgress: (progress) => {
-        const elapsedMs = Math.min(86_400_000, Math.max(0, Date.now() - startedAt));
+        const elapsedMs = Math.min(86_400_000, Math.max(0, Date.now() - progressStartedAt));
         refreshHeartbeat();
         input.stdout(formatDaemonLog({
           event: "daemon_issue_enrichment_progress",
@@ -389,6 +392,7 @@ function recordDaemonHeartbeatFromConfig(input: {
   dryRun: boolean;
   event: DaemonHeartbeatEvent;
   error?: string;
+  recordedAt?: Date;
   stderr: (line: string) => void;
 }): void {
   try {
@@ -399,6 +403,7 @@ function recordDaemonHeartbeatFromConfig(input: {
         cycle: input.cycle,
         dryRun: input.dryRun,
         event: input.event,
+        ...(input.recordedAt ? { recordedAt: input.recordedAt } : {}),
         ...(input.error ? { error: input.error } : {})
       });
     } finally {

--- a/src/state.ts
+++ b/src/state.ts
@@ -3283,7 +3283,12 @@ export class ReviewStateStore {
            values (1, ?, ?)
            on conflict(id) do update set
              started_cycle = excluded.started_cycle,
-             started_at = excluded.started_at`
+             started_at = case
+               when daemon_heartbeat.started_cycle = excluded.started_cycle
+                 and daemon_heartbeat.started_at = excluded.started_at
+               then daemon_heartbeat.started_at
+               else excluded.started_at
+             end`
         )
         .run(record.cycle, (record.recordedAt ?? new Date()).toISOString());
       return;

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -340,6 +340,7 @@ describe("daemon cycle resilience", () => {
 
   it("refreshes the active heartbeat with bounded issue-enrichment progress", async () => {
     const heartbeats: string[] = [];
+    const heartbeatStarts: string[] = [];
     const stdout: string[] = [];
     const timerCallbacks: Array<() => void> = [];
     const timerSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((callback) => (timerCallbacks.push(callback as () => void), 1 as never));
@@ -360,7 +361,10 @@ describe("daemon cycle resilience", () => {
         options.onProgress?.({ stage: "analysis", phase: "complete", count: 1 });
         return successfulIssueEnrichmentCycleResult();
       },
-      recordHeartbeatImpl: (event) => heartbeats.push(event),
+      recordHeartbeatImpl: (event, _error, recordedAt) => {
+        heartbeats.push(event);
+        if (event === "daemon_cycle_start" && recordedAt) heartbeatStarts.push(recordedAt.toISOString());
+      },
       stdout: (line) => stdout.push(line),
       stderr: () => undefined
     });
@@ -370,6 +374,7 @@ describe("daemon cycle resilience", () => {
 
     expect(result.ok).toBe(true);
     expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_start", "daemon_cycle_complete"]);
+    expect(new Set(heartbeatStarts).size).toBe(1);
     const progress = stdout.map((line) => JSON.parse(line)).filter((line) => line.event === "daemon_issue_enrichment_progress");
     expect(progress).toEqual([
       expect.objectContaining({ stage: "analysis", phase: "start", count: 10_000 }),

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1670,6 +1670,24 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("preserves same-run progress age but starts a restarted cycle fresh", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-run-identity-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const firstRun = new Date("2026-07-01T00:00:00.000Z");
+
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: firstRun });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: firstRun });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T00:10:00.000Z") });
+    expect(store.getDaemonHeartbeat()).toMatchObject({ startedCycle: 1, startedAt: firstRun.toISOString() });
+
+    const restarted = new Date("2026-07-01T01:00:00.000Z");
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: restarted });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T01:10:00.000Z") });
+    expect(store.getDaemonHeartbeat()).toMatchObject({ startedCycle: 1, startedAt: restarted.toISOString() });
+    store.close();
+  });
+
   it("redacts daemon heartbeat errors", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-redact-"));
     roots.push(root);


### PR DESCRIPTION
## Summary\n- carry one run-start timestamp through cycle-start and enrichment progress heartbeats\n- preserve started_at only for the same cycle and run timestamp\n- give a restarted daemon cycle 1 a fresh active start while retaining release-status active-age semantics\n\n## Validation\n- npm run build: passed\n- daemon/state changed-path TypeScript checks: passed\n- deterministic same-run/restart/timer identity checks: passed\n- focused Vitest: blocked before discovery by existing Rollup native-addon Team-ID mismatch; no dependencies installed\n\nStacked on C1 #843 and corrected #835. No schema migration, live worker, DB, provider, customer, or credential mutation.