### PR TITLE
fix(release): close manifest proof bypasses

### DIFF
--- a/scripts/validate-desktop-candidate-manifest.mjs
+++ b/scripts/validate-desktop-candidate-manifest.mjs
@@ -27,7 +27,7 @@ export function compareSemver(a, b) {
     if (i === left.pre.length) return -1;
     if (i === right.pre.length) return 1;
     const x = left.pre[i], y = right.pre[i], xn = /^\d+$/.test(x), yn = /^\d+$/.test(y);
-    if (xn && yn && +x !== +y) return +x - +y;
+    if (xn && yn && x !== y) return compareNumeric(x, y);
     if (xn !== yn) return xn ? -1 : 1;
     if (x !== y) return x < y ? -1 : 1;
   }
@@ -40,7 +40,9 @@ function https(value) {
 function refs(value) { return Array.isArray(value) && value.length > 0 && value.every((ref) => typeof ref === "string" && /\S/.test(ref)); }
 function nonblank(value) { return typeof value === "string" && /\S/.test(value); }
 function immutable(value, kind) { return (kind === "workflow" ? workflowUrl : artifactUrl).test(value); }
+function runId(value) { return /^https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff\/actions\/runs\/(\d+)/.exec(value ?? "")?.[1] ?? null; }
 function sameDigest(value, expected) { return typeof value === "string" && digest.test(value) && value === expected; }
+function compareNumeric(a, b) { const left = a.replace(/^0+/, "") || "0", right = b.replace(/^0+/, "") || "0"; return left.length === right.length ? (left === right ? 0 : left < right ? -1 : 1) : left.length - right.length; }
 function checkGate(manifest, name, errors) {
   const value = manifest[name];
   if (value.state === "proven" && (!refs(value.evidenceRefs) || ("artifactSha256" in value && !sameDigest(value.artifactSha256, manifest.artifact.sha256)))) errors.push(`${name}: proven gate lacks artifact and evidence proof`);
@@ -67,7 +69,10 @@ export function validateDesktopReleaseManifest(manifest, options = {}) {
   if (manifest.source.ref !== `sha:${manifest.source.commit}` && manifest.source.ref !== `refs/tags/v${manifest.version}`) errors.push("source: ref must be an exact SHA ref or version-pinned tag");
   if (manifest.artifact.version !== manifest.version || manifest.artifact.archiveName !== `NeonDiff-${manifest.version}-build${manifest.artifact.build}-macOS.zip`) errors.push("artifact: version/build/archive identity mismatch");
   for (const [value, kind] of [[manifest.source.workflowRunRef, "workflow"], [manifest.artifact.workflowRunRef, "workflow"], [manifest.source.artifactRef, "artifact"], [manifest.artifact.artifactRef, "artifact"]]) if (value !== null && !immutable(value, kind)) errors.push("provenance: supported immutable workflow/artifact URL required");
+  const released = ["beta", "stable"].includes(manifest.releaseLevel), provenance = [[manifest.source.workflowRunRef, "workflow"], [manifest.artifact.workflowRunRef, "workflow"], [manifest.source.artifactRef, "artifact"], [manifest.artifact.artifactRef, "artifact"]];
+  if (released && provenance.some(([value, kind]) => value === null || !immutable(value, kind))) errors.push("provenance: released manifest requires non-null immutable workflow and artifact refs");
   if (manifest.source.workflowRunRef !== manifest.artifact.workflowRunRef || manifest.source.artifactRef !== manifest.artifact.artifactRef) errors.push("provenance: source and artifact refs disagree");
+  const runIds = provenance.map(([value]) => runId(value)).filter(Boolean); if (new Set(runIds).size > 1) errors.push("provenance: workflow run and artifact refs identify different runs");
   for (const value of [...Object.values(manifest.references), manifest.site.productUrl, manifest.site.downloadUrl, manifest.site.releaseNotesUrl, manifest.feed.embeddedFeedUrl, manifest.feed.feedUrl, manifest.feed.artifactUrl, manifest.feed.publicKeyRef, manifest.feed.signatureRef, manifest.rollback.targetReleaseRef, manifest.rollback.targetSignatureRef, manifest.rollback.targetPublicKeyRef].filter((x) => x !== null)) if (!https(value)) errors.push("url: credential-free HTTPS URL required");
   for (const name of ["artifact", ...gates]) if (!refs(manifest[name].evidenceRefs)) errors.push(`${name}: evidence references must be nonblank`);
   for (const name of gates) checkGate(manifest, name, errors);
@@ -76,9 +81,10 @@ export function validateDesktopReleaseManifest(manifest, options = {}) {
     for (const name of gates) if (!["pending", "not-performed"].includes(manifest[name].state)) errors.push("template: every gate must remain pending or not-performed");
     if (!manifest.proofBoundary.excludes.some((item) => /not a release candidate/i.test(item))) errors.push("template: proof boundary must exclude release-candidate claims");
   }
-  if (["beta", "stable"].includes(manifest.releaseLevel)) { for (const name of gates) if (manifest[name].state !== "proven") errors.push(`${name}: released manifest requires proof`); if (manifest.proofBoundary.excludes.some((item) => /\b(?:not|no|without|pending|unproven|excluded)\b.*\b(?:candidate|signed|notarized|stapled|gatekeeper|feed|site|billing|customer|runtime|rollback)\b/i.test(item))) errors.push("proof boundary: released proof cannot be excluded"); }
+  if (released) { for (const name of gates) if (manifest[name].state !== "proven") errors.push(`${name}: released manifest requires proof`); if (manifest.proofBoundary.excludes.some((item) => /\b(?:not|no|without|pending|unproven|excluded|never|cannot|doesn?['’]?t|does not)\b/i.test(item) && /\b(?:candidate|artifact|signed|signing|notarized|notarization|stapled|stapling|gatekeeper|feed|site|billing|customer|runtime|rollback)\b/i.test(item))) errors.push("proof boundary: released proof cannot be excluded"); }
   if (manifest.artifact.state === "proven" && (!digest.test(manifest.artifact.sha256 ?? "") || !refs(manifest.artifact.evidenceRefs))) errors.push("artifact: proven artifact requires digest and evidence");
-  if (manifest.feed.state === "proven" && (manifest.feed.channel !== manifest.channel || manifest.feed.embeddedFeedUrl !== manifest.feed.feedUrl || !nonblank(manifest.feed.publicKeyIdentity) || !nonblank(manifest.feed.publicKeyRef) || !nonblank(manifest.feed.signatureRef) || !sameDigest(manifest.feed.artifactSha256, manifest.artifact.sha256))) errors.push("feed: embedded URL, key identity, signature, and artifact binding are incomplete");
+  if (manifest.gatekeeper.state === "proven" && !/^(accepted|passed|pass|success)$/i.test(manifest.gatekeeper.assessment?.trim() ?? "")) errors.push("gatekeeper: proven assessment must be successful");
+  if (manifest.feed.state === "proven" && (manifest.feed.channel !== manifest.channel || manifest.feed.embeddedFeedUrl !== manifest.feed.feedUrl || !nonblank(manifest.feed.publicKeyIdentity) || !nonblank(manifest.feed.publicKeyRef) || !nonblank(manifest.feed.signatureRef) || !https(manifest.feed.artifactUrl) || manifest.feed.artifactUrl !== manifest.site.downloadUrl || !sameDigest(manifest.feed.artifactSha256, manifest.artifact.sha256))) errors.push("feed: embedded URL, key identity, signature, and exact artifact binding are incomplete");
   if (manifest.site.state === "proven" && (!https(manifest.site.downloadUrl) || !https(manifest.site.releaseNotesUrl) || !sameDigest(manifest.site.artifactSha256, manifest.artifact.sha256))) errors.push("site: proven URL and artifact binding are incomplete");
   if (manifest.customer.state === "proven" && !nonblank(manifest.customer.canaryRef)) errors.push("customer: proven canary reference required");
   if (manifest.runtime.state === "proven" && (!nonblank(manifest.runtime.workerVersion) || !sameDigest(manifest.runtime.artifactSha256, manifest.artifact.sha256) || !digest.test(manifest.runtime.configIdentitySha256 ?? ""))) errors.push("runtime: artifact and independent config identity proof required");

--- a/tests/desktop-candidate-manifest.test.ts
+++ b/tests/desktop-candidate-manifest.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { compareSemver, validateDesktopReleaseManifest, validateManifestIndex } from "../scripts/validate-desktop-candidate-manifest.mjs";
 const commit = "a".repeat(40);
@@ -54,6 +56,7 @@ describe("Desktop release manifest contract", () => {
   });
   it("uses SemVer prerelease precedence and stable GA proof", () => {
     expect(compareSemver("1.1.0-beta.10", "1.1.0-beta.2")).toBeGreaterThan(0);
+    expect(compareSemver("1.0.0-beta.100000000000000000000", "1.0.0-beta.99999999999999999999")).toBeGreaterThan(0);
     expect(compareSemver("1.1.0", "1.1.0-rc.1")).toBeGreaterThan(0);
     expect(validateDesktopReleaseManifest(stable(), { ajv: Ajv2020 })).toEqual({ valid: true, errors: [] });
   });
@@ -69,9 +72,23 @@ describe("Desktop release manifest contract", () => {
     const rollback = stable(); rollback.rollback.targetVersion = "1.1.0";
     expect(validateDesktopReleaseManifest(rollback, { ajv: AcceptingAjv }).valid).toBe(false);
     const boundary = stable(); boundary.proofBoundary.excludes = ["This is not a release candidate."]; expect(validateDesktopReleaseManifest(boundary, { ajv: AcceptingAjv }).valid).toBe(false);
+    const bypasses = [
+      (() => { const m = stable(); Object.assign(m.source, { workflowRunRef: null, artifactRef: null }); Object.assign(m.artifact, { workflowRunRef: null, artifactRef: null }); return m; })(),
+      (() => { const m = stable(), other = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/124/artifacts/456"; Object.assign(m.source, { artifactRef: other }); Object.assign(m.artifact, { artifactRef: other }); return m; })(),
+      (() => { const m = stable(); m.gatekeeper.assessment = null; return m; })(),
+      (() => { const m = stable(); m.feed.artifactUrl = "https://downloads.neondiff.com/other.zip"; return m; })(),
+      (() => { const m = stable(); m.proofBoundary.excludes = ["Gatekeeper is not proven"]; return m; })()
+    ];
+    for (const manifest of bypasses) expect(validateDesktopReleaseManifest(manifest, { ajv: AcceptingAjv }).valid).toBe(false);
   });
   it("requires the explicit index and fails closed without Ajv", () => {
     expect(validateManifestIndex("docs/release-candidates/desktop-manifests.index.json", { ajv: Ajv2020 })).toEqual({ valid: true, errors: [] });
     expect(validateManifestIndex("docs/release-candidates/desktop-manifests.index.json", { ajv: null })).toEqual({ valid: false, errors: ["schema validator unavailable"] });
+  });
+  it("rejects an unindexed versioned manifest", () => {
+    const dir = mkdtempSync(`${tmpdir()}/desktop-manifest-`), index = `${dir}/desktop-manifests.index.json`;
+    writeFileSync(index, JSON.stringify({ schemaVersion: "desktop-release-manifest-index.v1", status: "no-versioned-manifest", manifestPaths: [], reason: "deferred until frozen source; not a release candidate" }));
+    writeFileSync(`${dir}/v1.1.0-desktop-template.json`, "{}");
+    expect(validateManifestIndex(index, { ajv: Ajv2020 }).valid).toBe(false); rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- require released beta/stable manifests to carry all four immutable workflow/artifact refs
- bind workflow-run and artifact URLs to the same Actions run
- require successful Gatekeeper assessment and feed artifact URL equality with the hosted site download
- reject proof-boundary negations in either word order
- compare arbitrarily large numeric SemVer prerelease identifiers without Number precision loss
- add deterministic unindexed-manifest and adversarial fixtures

## Exact stack
- base: `cada560552f90dc17c68f03ce4ae914092132073` (#840 head)
- head: `52094308b064c5f325b2f44cc3fbf81c0fc00a94`
- changed lines: 26 additions, 3 deletions

## Proof boundary
No versioned candidate, public/CLI manifest, package bytes, release, signing, publishing, install, runtime, or customer state is changed.

## Checks
- `node --check`: pass
- strict Ajv schema compilation: pass
- large-number comparator and no-Ajv checks: pass
- focused Desktop manifest contract workflow: pass
- fresh full CI is running after the mechanical rebase
