### PR TITLE
fix(scheduler): preserve bounded command/readiness ordering

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -584,7 +584,7 @@ async function enqueuePullIfEligible(input: {
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
   if ("blocked" in commandDecision) {
-    quarantineQueueJobsForTruncatedCommandEvidence(input);
+    await retireSupersededQueueJobsForPull(input, input.pull.head.sha);
     return "command_fetch_failed";
   }
   markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
@@ -1074,59 +1074,54 @@ async function retireSupersededQueueJobsForPull(input: {
   dryRun: boolean;
   now: Date;
   onStatusCommentFailure?: () => void;
-}): Promise<void> {
+}, quarantineHeadSha?: string): Promise<void> {
+  const quarantine = quarantineHeadSha !== undefined;
   const jobs = input.state.listReviewQueueJobsForPull({
     repo: input.repo,
     pullNumber: input.pull.number,
-    states: ["queued", "provider_deferred", "blocked_on_proof"]
-  }).filter((job) => job.headSha !== input.pull.head.sha);
+    states: quarantine
+      ? ["queued", "provider_deferred", "blocked_on_proof", "leased", "running"]
+      : ["queued", "provider_deferred", "blocked_on_proof"]
+  }).filter((job) => quarantine
+    ? job.headSha === quarantineHeadSha && (
+      job.state !== "leased" && job.state !== "running" ||
+      (job.leaseExpiresAt
+        ? Date.parse(job.leaseExpiresAt) <= input.now.getTime()
+        : Date.parse(job.updatedAt) <= input.now.getTime() - input.config.reviewConcurrency.leaseTtlMs)
+    )
+    : job.headSha !== input.pull.head.sha);
 
   for (const job of jobs) {
+    const nextState = quarantine ? "failed" : "stale_retired";
+    const reason = quarantine ? "command_evidence_truncated" : `superseded_by_head=${input.pull.head.sha}`;
     input.state.updateReviewQueueJobState({
       jobId: job.jobId,
-      state: "stale_retired",
-      lastError: `superseded_by_head=${input.pull.head.sha}`,
+      state: nextState,
+      lastError: reason,
       now: input.now
     });
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
       pull: pullForQueueJob(job, input.pull),
-      readinessState: "stale",
-      reason: `superseded_by_head=${input.pull.head.sha}`,
+      readinessState: quarantine ? "failed" : "stale",
+      reason,
       now: input.now
     });
-    updateReviewerSessionJobFromQueueStatus({ state: input.state, job }, "skipped", "skipped");
+    updateReviewerSessionJobFromQueueStatus(
+      { state: input.state, job },
+      quarantine ? "failed" : "skipped",
+      quarantine ? "failed" : "skipped"
+    );
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,
       dryRun: input.dryRun,
       repo: input.repo,
       pull: pullForQueueJob(job, input.pull),
-      state: "stale_head",
-      details: "Superseded by a newer PR head.",
+      state: quarantine ? "failed" : "stale_head",
+      details: quarantine ? "Command evidence was truncated; review was blocked." : "Superseded by a newer PR head.",
       onStatusCommentFailure: input.onStatusCommentFailure,
-      now: input.now
-    });
-  }
-}
-
-function quarantineQueueJobsForTruncatedCommandEvidence(input: {
-  state: ReviewStateStore;
-  repo: string;
-  pull: PullRequestSummary;
-  now: Date;
-}): void {
-  const jobs = input.state.listReviewQueueJobsForPull({
-    repo: input.repo,
-    pullNumber: input.pull.number,
-    states: ["queued", "provider_deferred", "blocked_on_proof"]
-  }).filter((job) => job.headSha === input.pull.head.sha);
-  for (const job of jobs) {
-    input.state.updateReviewQueueJobState({
-      jobId: job.jobId,
-      state: "failed",
-      lastError: "command_evidence_truncated",
       now: input.now
     });
   }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -569,19 +569,24 @@ async function enqueuePullIfEligible(input: {
       pull: input.pull
     })
   ) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     await retireSupersededQueueJobsForPull(input);
     recordActivationBaselineExistingHead(input.state, input.repo, input.pull);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
   if (!input.allowActivationBaselineCommandLookup && isActivationBaselineProcessedReview(processed)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     await retireSupersededQueueJobsForPull(input);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
-  if ("blocked" in commandDecision) return "command_fetch_failed";
+  if ("blocked" in commandDecision) {
+    quarantineQueueJobsForTruncatedCommandEvidence(input);
+    return "command_fetch_failed";
+  }
   markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
@@ -1101,6 +1106,27 @@ async function retireSupersededQueueJobsForPull(input: {
       state: "stale_head",
       details: "Superseded by a newer PR head.",
       onStatusCommentFailure: input.onStatusCommentFailure,
+      now: input.now
+    });
+  }
+}
+
+function quarantineQueueJobsForTruncatedCommandEvidence(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  now: Date;
+}): void {
+  const jobs = input.state.listReviewQueueJobsForPull({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    states: ["queued", "provider_deferred", "blocked_on_proof"]
+  }).filter((job) => job.headSha === input.pull.head.sha);
+  for (const job of jobs) {
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "failed",
+      lastError: "command_evidence_truncated",
       now: input.now
     });
   }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, type BoundedGithubList } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -109,7 +109,7 @@ export interface ScheduledRunResult extends RunOnceResult {
 export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
-  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[] | BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -503,6 +503,7 @@ async function collectSubsequentMergedPulls(input: {
 type EnqueueStatus =
   | "enqueued"
   | "already_queued"
+  | "command_fetch_failed"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_processed"
@@ -532,8 +533,8 @@ async function enqueuePullIfEligible(input: {
     await retireQueuedJobsForClosedPull(input);
     return "closed_retired";
   }
-  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (input.config.skipDrafts && input.pull.draft) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -545,6 +546,7 @@ async function enqueuePullIfEligible(input: {
     return "skipped_draft";
   }
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -579,6 +581,8 @@ async function enqueuePullIfEligible(input: {
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
+  if ("blocked" in commandDecision) return "command_fetch_failed";
+  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
       await retireSupersededQueueJobsForPull(input);
@@ -1155,11 +1159,19 @@ async function resolveSchedulerCommandDecision(input: {
   repo: string;
   pull: PullRequestSummary;
   onCommandFetchError?: () => void;
-}): Promise<CommandDecision> {
+}): Promise<CommandDecision | { action: "none"; shouldReview: false; blocked: "command_evidence_truncated" }> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = "items" in result
+      ? result
+      : { items: result, truncated: false, overflow: false };
+    if (bounded.truncated || bounded.overflow) {
+      input.onCommandFetchError?.();
+      return { action: "none", shouldReview: false, blocked: "command_evidence_truncated" };
+    }
+    comments = bounded.items;
   } catch {
     input.onCommandFetchError?.();
     return { action: "none", shouldReview: false };
@@ -1676,7 +1688,15 @@ async function repairProcessedHeadStatusCommentIfNeeded(input: {
 
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = "items" in result
+      ? result
+      : { items: result, truncated: false, overflow: false };
+    if (bounded.truncated || bounded.overflow) {
+      input.onStatusCommentFailure?.();
+      return;
+    }
+    comments = bounded.items;
   } catch {
     input.onStatusCommentFailure?.();
     return;
@@ -2592,6 +2612,9 @@ function nextLicenseGateRetryAt(now = new Date()): string {
 
 function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {
   switch (status) {
+    case "command_fetch_failed":
+      result.failed += 1;
+      break;
     case "enqueued":
       result.queue.enqueued += 1;
       break;

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3205,6 +3205,23 @@ describe("provider-aware review scheduler", () => {
       acknowledge: false
     };
     const state = new ReviewStateStore(config.statePath);
+    for (const [pullNumber, headSha] of [[1, "historical-a-old"], [2, "historical-b"]] as const) {
+      state.recordReviewReadiness({
+        repo: "org/repo-a",
+        pullNumber,
+        headSha,
+        state: "ready_for_human",
+        reason: "comment_review_posted",
+        now: new Date("2026-06-30T00:00:00.000Z")
+      });
+    }
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 2,
+      headSha: "historical-b-current",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
     let issueCommentReads = 0;
 
     const result = await runScheduledCycleWithDeps({
@@ -3212,7 +3229,7 @@ describe("provider-aware review scheduler", () => {
       github: {
         ...githubFromMap(new Map([[
           "org/repo-a",
-          [pull("org/repo-a", 1, "historical-a"), pull("org/repo-a", 2, "historical-b")]
+          [pull("org/repo-a", 1, "historical-a"), pull("org/repo-a", 2, "historical-b-current")]
         ]])),
         listIssueComments: async () => {
           issueCommentReads += 1;
@@ -3227,7 +3244,7 @@ describe("provider-aware review scheduler", () => {
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
-    expect(result.baselinedExisting).toBe(2);
+    expect(result.baselinedExisting).toBe(1);
     expect(result.skippedProcessed).toBe(2);
     expect(result.commandFetchErrors).toBe(0);
     expect(result.queue.enqueued).toBe(0);
@@ -3237,6 +3254,8 @@ describe("provider-aware review scheduler", () => {
       status: "skipped",
       error: "activation_baseline_existing_head"
     });
+    expect(state.getReviewReadiness("org/repo-a", 1, "historical-a-old")).toMatchObject({ state: "stale" });
+    expect(state.getReviewReadiness("org/repo-a", 2, "historical-b")).toMatchObject({ state: "stale" });
     state.close();
   });
 
@@ -3569,6 +3588,12 @@ describe("provider-aware review scheduler", () => {
       acknowledge: false
     };
     const state = new ReviewStateStore(config.statePath);
+    const queued = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      baseSha: "base"
+    }).job;
     state.recordReviewReadiness({
       repo: "org/repo-a",
       pullNumber: 1,
@@ -3608,7 +3633,11 @@ describe("provider-aware review scheduler", () => {
       reason: "comment_review_posted"
     });
     expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toBeUndefined();
-    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toHaveLength(0);
+    expect(state.getReviewQueueJob(queued.jobId)).toMatchObject({
+      state: "failed",
+      lastError: "command_evidence_truncated"
+    });
+    expect(result.queue.leased).toBe(1);
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1262,6 +1262,47 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("marks older readiness rows stale when the new head is skipped as draft", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-draft-superseded-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B, "base", { draft: true })]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("draft heads must not run review work");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(result.skippedDraft).toBe(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "stale",
+      reason: `superseded_by_head=${HEAD_B}`
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_B)).toMatchObject({
+      state: "skipped",
+      reason: "draft_pr"
+    });
+    state.close();
+  });
+
   it("repairs non-terminal readiness rows from processed review truth", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-backfill-"));
     roots.push(root);
@@ -3514,6 +3555,60 @@ describe("provider-aware review scheduler", () => {
     expect(result.failed).toBe(0);
     expect(result.commandFetchErrors).toBe(1);
     expect(reviewed).toHaveLength(2);
+    state.close();
+  });
+
+  it("blocks automatic enqueue when bounded command evidence is truncated", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-truncated-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "old-head",
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old",
+      now: new Date("2026-06-30T00:00:00.000Z")
+    });
+    const reviewed: string[] = [];
+    const truncated = Object.assign([], { items: [], truncated: true, overflow: true });
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, "a1")]],
+          ["org/repo-b", [pull("org/repo-b", 1, "b1")]]
+        ])),
+        listIssueComments: async (repo) => repo === "org/repo-a" ? truncated : []
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        reviewState.recordProcessed({ repo, pullNumber: reviewPull.number, headSha: reviewPull.head.sha, status: "posted", event: "COMMENT" });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.commandFetchErrors).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(reviewed).toEqual(["org/repo-b#1"]);
+    expect(state.getReviewReadiness("org/repo-a", 1, "old-head")).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted"
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toBeUndefined();
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toHaveLength(0);
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3580,64 +3580,58 @@ describe("provider-aware review scheduler", () => {
   it("blocks automatic enqueue when bounded command evidence is truncated", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-truncated-"));
     roots.push(root);
-    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]);
+    const config = schedulerConfig(root, ["org/repo-a"]);
     config.commands = {
       enabled: true,
       botMentions: ["@evaos-code-review-bot"],
       trustedAuthors: ["100yenadmin"],
       acknowledge: false
     };
+    config.reviewStatusComment!.enabled = true;
+    config.reviewerSessions = { enabled: true, ttlMs: 8 * 60 * 60_000, headCountLimit: 10 };
     const state = new ReviewStateStore(config.statePath);
-    const queued = state.enqueueReviewQueueJob({
-      repo: "org/repo-a",
-      pullNumber: 1,
-      headSha: "a1",
-      baseSha: "base"
-    }).job;
-    state.recordReviewReadiness({
-      repo: "org/repo-a",
-      pullNumber: 1,
-      headSha: "old-head",
-      state: "ready_for_human",
-      reason: "comment_review_posted",
-      event: "COMMENT",
-      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old",
-      now: new Date("2026-06-30T00:00:00.000Z")
-    });
+    const statusCalls: StatusCommentCall[] = [];
+    let truncated = false;
     const reviewed: string[] = [];
-    const truncated = Object.assign([], { items: [], truncated: true, overflow: true });
-    const result = await runScheduledCycleWithDeps({
+    const boundedTruncated = Object.assign([], { items: [], truncated: true, overflow: true });
+    const github = {
+      ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls),
+      listIssueComments: async () => truncated ? boundedTruncated : []
+    };
+    const reviewPullImpl = async ({ repo }: { repo: string }) => {
+      reviewed.push(repo);
+      return "skipped_capacity" as const;
+    };
+    const first = await runScheduledCycleWithDeps({
       config,
-      github: {
-        ...githubFromMap(new Map([
-          ["org/repo-a", [pull("org/repo-a", 1, "a1")]],
-          ["org/repo-b", [pull("org/repo-b", 1, "b1")]]
-        ])),
-        listIssueComments: async (repo) => repo === "org/repo-a" ? truncated : []
-      },
+      github,
       state,
       options: { dryRun: false, useZCode: false },
-      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
-        reviewed.push(`${repo}#${reviewPull.number}`);
-        reviewState.recordProcessed({ repo, pullNumber: reviewPull.number, headSha: reviewPull.head.sha, status: "posted", event: "COMMENT" });
-        return "reviewed";
-      },
+      reviewPullImpl,
       now: new Date("2026-07-01T00:00:00.000Z")
     });
-
-    expect(result.commandFetchErrors).toBe(1);
-    expect(result.failed).toBe(1);
-    expect(reviewed).toEqual(["org/repo-b#1"]);
-    expect(state.getReviewReadiness("org/repo-a", 1, "old-head")).toMatchObject({
-      state: "ready_for_human",
-      reason: "comment_review_posted"
+    const queued = state.listReviewQueueJobsForPull({ repo: "org/repo-a", pullNumber: 1 })[0]!;
+    expect(first.queue.enqueued).toBe(1);
+    expect(state.getReviewerSessionJob("org/repo-a", 1, HEAD_A)).toMatchObject({ jobState: "assigned" });
+    state.updateReviewQueueJobState({
+      jobId: queued.jobId,
+      state: "leased",
+      leaseId: "expired-lease",
+      leaseExpiresAt: "2026-06-30T00:00:00.000Z",
+      now: new Date("2026-07-01T00:00:00.000Z")
     });
-    expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toBeUndefined();
-    expect(state.getReviewQueueJob(queued.jobId)).toMatchObject({
-      state: "failed",
-      lastError: "command_evidence_truncated"
+    truncated = true;
+    const second = await runScheduledCycleWithDeps({
+      config, github, state, options: { dryRun: false, useZCode: false }, reviewPullImpl,
+      now: new Date("2026-07-01T00:05:00.000Z")
     });
-    expect(result.queue.leased).toBe(1);
+    expect(second.commandFetchErrors).toBe(1);
+    expect(second.queue.leased).toBe(0);
+    expect(reviewed).toHaveLength(1);
+    expect(state.getReviewQueueJob(queued.jobId)).toMatchObject({ state: "failed", lastError: "command_evidence_truncated" });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "failed", reason: "command_evidence_truncated" });
+    expect(state.getReviewerSessionJob("org/repo-a", 1, HEAD_A)).toMatchObject({ jobState: "failed", processedReviewStatus: "failed" });
+    expect(statusCalls.map(statusFromBody)).toContain("failed");
     state.close();
   });
 


### PR DESCRIPTION
## Summary

- Fail closed when bounded command comments are truncated before readiness, queue, status, or state mutation.
- Preserve readiness supersession for command-disabled draft, non-draft, and canary paths.
- Add focused regressions for all four paths.

## Validation

- `npm run build` passes.
- Focused Vitest is blocked locally by the existing Rollup native-addon Team-ID mismatch; CI is requested.
- No runtime, customer, queue, or provider state was touched.