### PR TITLE
fix(issue-enrichment): fail closed on label-event overflow

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -27,6 +27,26 @@ export type BoundedGithubList<T> = T[] & {
   overflow: boolean;
 };
 
+export const GITHUB_ISSUE_LABEL_EVENT_EVIDENCE_OVERFLOW = "GitHub issue label event evidence overflow";
+export class GithubIssueLabelEventOverflowError extends Error {
+  readonly code = "github_issue_label_event_evidence_overflow" as const;
+
+  constructor() {
+    super(GITHUB_ISSUE_LABEL_EVENT_EVIDENCE_OVERFLOW);
+    this.name = "GithubIssueLabelEventOverflowError";
+  }
+}
+
+export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
+  items: T[];
+  truncated: boolean;
+  overflow: boolean;
+} {
+  return "items" in result
+    ? result
+    : { items: result, truncated: false, overflow: false };
+}
+
 export interface GithubIssueLabelEvent {
   event?: string;
   created_at?: string;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -13,6 +13,12 @@ import {
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import {
+  GithubIssueLabelEventOverflowError,
+  unpackBoundedGithubList,
+  type BoundedGithubList,
+  type GithubIssueLabelEvent
+} from "./github.js";
+import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
   type IssueAnalysis,
@@ -276,12 +282,7 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GithubIssueLabelEvent[] | BoundedGithubList<GithubIssueLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<Array<{
     id: number;
@@ -390,7 +391,9 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const eventResult = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, overflow } = unpackBoundedGithubList(eventResult);
+    if (overflow) throw new GithubIssueLabelEventOverflowError();
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -414,7 +417,8 @@ async function evaluateIssuePromotion(input: {
       },
       evidence
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof GithubIssueLabelEventOverflowError) throw error;
     return { issue: input.issue };
   }
 }

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -883,8 +883,7 @@ describe("sticky enrichment comments", () => {
       let analysisCalls = 0;
       let postCalls = 0;
       try {
-        let overflow = false;
-        const runCycle = (checkedAt: string, force = false) => runIssueEnrichmentCycle({
+        const result = await runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {
@@ -967,6 +966,7 @@ describe("sticky enrichment comments", () => {
       let analysisCalls = 0;
       let postCalls = 0;
       try {
+        let overflow = false;
         const promotedIssue: GitHubRelatedIssueOrPull = {
           number: 127,
           title: "Continue the imported replay fix",
@@ -975,7 +975,7 @@ describe("sticky enrichment comments", () => {
           labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
           body: "Continue current-main work for #14."
         };
-        const result = await runIssueEnrichmentCycle({
+        const runCycle = (checkedAt: string, force = false) => runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -883,7 +883,8 @@ describe("sticky enrichment comments", () => {
       let analysisCalls = 0;
       let postCalls = 0;
       try {
-        const result = await runIssueEnrichmentCycle({
+        let overflow = false;
+        const runCycle = (checkedAt: string, force = false) => runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {
@@ -979,12 +980,14 @@ describe("sticky enrichment comments", () => {
           state,
           github: {
             listIssuesForEnrichment: async () => [promotedIssue],
-            listIssueLabelEvents: async () => [{
-              event: "labeled",
-              created_at: "2026-08-16T10:00:00Z",
-              actor: { login: "Tosko4" },
-              label: { name: "active-continuation" }
-            }],
+            listIssueLabelEvents: async () => overflow
+              ? Object.assign([], { items: [], truncated: true, overflow: true })
+              : [{
+                event: "labeled",
+                created_at: "2026-08-16T10:00:00Z",
+                actor: { login: "Tosko4" },
+                label: { name: "active-continuation" }
+              }],
             getCollaboratorPermission: async () => "maintain",
             getIssueOrPull: async () => promotedIssue,
             canPostAsApp: () => true,
@@ -995,16 +998,25 @@ describe("sticky enrichment comments", () => {
           },
           dryRun: false,
           includeExisting: true,
-          checkedAt: "2026-08-16T10:02:00.000Z",
+          checkedAt,
+          force,
           analyzeIssue: async ({ issue }) => {
             analysisCalls += 1;
             return fixtureIssueAnalysis(issue);
           }
         });
+        const result = await runCycle("2026-08-16T10:02:00.000Z");
 
         expect(result.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(analysisCalls).toBe(1);
         expect(postCalls).toBe(1);
+        const watermark = state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt;
+        overflow = true;
+        const blocked = await runCycle("2026-08-16T10:03:00.000Z", true);
+        expect(blocked.summary).toMatchObject({ readFailures: 1, posted: 0, failed: 0 });
+        expect(blocked.items).toHaveLength(0);
+        expect(postCalls).toBe(1);
+        expect(state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")?.lastCheckedAt).toBe(watermark);
       } finally {
         state.close();
       }


### PR DESCRIPTION
## Summary

- Add a shared typed GitHub label-event overflow sentinel.
- Refuse authenticated promotion when bounded label history is truncated.
- Verify no analysis/post, record, label, or watermark advancement follows overflow.

## Validation

- `npm run build` passes.
- Focused scheduler/enrichment Vitest is blocked locally by the existing Rollup native-addon Team-ID mismatch; CI is requested.
- No runtime, customer, queue, or provider state was touched.