### PR TITLE
fix(operator): present active health without recovery commands

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -22,10 +22,7 @@ evaos-review-bot status --config config.local.json
 
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
-  durable queue counts, and recommended actions. JSON is the default; use
-  `--human` for a compact explanation. Active blockers and recent unrecovered
-  failures (within the 24-hour health window) gate `ok`; retained historical
-  counts remain visible and recovered failures do not create retry actions.
+  durable queue counts, and recommended actions.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
   budget status, leases, heartbeat, and bot-owned process rows. It can classify

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -22,7 +22,10 @@ evaos-review-bot status --config config.local.json
 
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
-  durable queue counts, and recommended actions.
+  durable queue counts, and recommended actions. JSON is the default; use
+  `--human` for a compact explanation. Active blockers and recent unrecovered
+  failures (within the 24-hour health window) gate `ok`; retained historical
+  counts remain visible and recovered failures do not create retry actions.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
   budget status, leases, heartbeat, and bot-owned process rows. It can classify

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,6 +98,7 @@ import {
   collectOperatorReviewQueue,
   explainPullStatus,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorDurableQueueSnapshot,
@@ -724,7 +725,7 @@ async function main(): Promise<void> {
       }),
       issueEnrichmentRuntime
     });
-    console.log(stringifyRedactedJson(status));
+    console.log(args.human === "true" ? formatOperatorStatusHuman(status) : stringifyRedactedJson(status));
     if (!status.ok) process.exitCode = 1;
     return;
   }
@@ -3613,7 +3614,8 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--limit", description: "Cap the number of provider-cooldown/durable-queue rows returned." },
       { name: "--expected-head", description: "Expected release head SHA to verify against." },
       { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
-      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." }
+      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." },
+      { name: "--human", description: "Print a compact operator summary instead of JSON; the exit code still follows the combined operator gate." }
     ]
   },
   "release-status": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -714,6 +714,7 @@ async function main(): Promise<void> {
     const github = new GitHubApi(config.github);
     const status = buildOperatorStatus({
       release,
+      ...(args.repo ? { repo: args.repo } : {}),
       coverage,
       agents,
       providerCooldowns,

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -47,12 +47,14 @@ export interface OperatorStatus {
     staleHeads: number;
     readFailures: number;
     failedRows: number;
+    recentUnrecoveredReviewErrors: number;
     expiredProviderCooldowns: number;
     activeProviderCooldowns: number;
     queuedJobs: number;
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    activeFailedQueueJobs: number;
     zcodeTimeoutFailedQueueJobs: number;
     retryableZCodeTimeoutFailedQueueJobs: number;
     exhaustedZCodeTimeoutFailedQueueJobs: number;
@@ -403,6 +405,7 @@ export function buildOperatorStatus(input: {
   issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
   checkedAt?: string;
 }): OperatorStatus {
+  const safeRelease = sanitizeOperatorRelease(input.release);
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
   const providerCooldowns = input.providerCooldowns ?? [];
   const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
@@ -413,7 +416,10 @@ export function buildOperatorStatus(input: {
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
-  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const queueFailures = operatorQueueFailureCounts(input.release, durableQueue);
+  const failedQueueJobs = queueFailures.total;
+  const activeFailedQueueJobs = queueFailures.active;
+  const recentUnrecoveredReviewErrors = input.release.database.recentUnrecoveredErrorCount ?? failedRows;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
@@ -430,7 +436,7 @@ export function buildOperatorStatus(input: {
     describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
 
   const gates = [
-    ...input.release.gates,
+    ...safeRelease.gates,
     {
       name: "queue_no_pending_heads",
       ok: pendingHeads === 0,
@@ -455,15 +461,20 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "durable_queue_no_failed_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
-      detail:
-        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+      ok: zcodeTimeoutQueue.activeTotal === 0,
+      detail: zcodeTimeoutQueue.activeTotal === zcodeTimeoutQueue.total
+        ? `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+        : `${zcodeTimeoutQueue.activeTotal} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutQueue.total}; retryable=${zcodeTimeoutQueue.retryable} ` +
+          `exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "durable_queue_no_retryable_provider_deferred_jobs",
@@ -499,13 +510,13 @@ export function buildOperatorStatus(input: {
   ];
 
   const recommendedActions = uniqueStrings([
-    ...input.release.recommendedActions,
+    ...safeRelease.recommendedActions,
     ...(pendingHeads > 0 ? ["wait for daemon cycle or run scoped run-once"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(zcodeTimeoutQueue.activeTotal > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -528,12 +539,14 @@ export function buildOperatorStatus(input: {
       staleHeads,
       readFailures,
       failedRows,
+      recentUnrecoveredReviewErrors,
       expiredProviderCooldowns,
       activeProviderCooldowns,
       queuedJobs: durableQueue?.summary.queued ?? 0,
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
       failedQueueJobs,
+      activeFailedQueueJobs,
       zcodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.total,
       retryableZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.retryable,
       exhaustedZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.exhausted,
@@ -545,7 +558,7 @@ export function buildOperatorStatus(input: {
     gates,
     failedGates: gates.filter((gate) => !gate.ok),
     recommendedActions,
-    release: input.release,
+    release: safeRelease,
     ...(budget ? { budget } : {}),
     ...(queue ? { coverage: queue } : {}),
     agents: input.agents,
@@ -554,6 +567,29 @@ export function buildOperatorStatus(input: {
     ...(issueEnrichment ? { issueEnrichment } : {}),
     ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {})
   };
+}
+
+export function formatOperatorStatusHuman(status: OperatorStatus): string {
+  const health = status.release.health;
+  const failedGates = status.gates.filter((gate) => !gate.ok);
+  const reason = status.ok
+    ? health?.reason ?? "current operator gates pass"
+    : failedGates.length > 0
+      ? failedGates.map((gate) => `${gate.name}: ${sanitizeOperatorAction(gate.detail)}`).join("; ")
+      : health?.reason ?? "current operator gates failed";
+  const lines = [
+    `status: ${status.ok ? "ok" : "blocked"} (operator) - ${reason}`,
+    `releaseHealth: ${health?.state ?? "unknown"}` + (health?.reason ? ` - ${health.reason}` : ""),
+    `current: activeFailedQueueJobs=${status.summary.activeFailedQueueJobs} ` +
+      `recentUnrecoveredReviewErrors=${status.summary.recentUnrecoveredReviewErrors} ` +
+      `staleLeases=${status.summary.staleLeases}`,
+    `history: reviewErrors=${status.summary.failedRows} failedQueueJobs=${status.summary.failedQueueJobs}`,
+    ...(failedGates.length > 0
+      ? failedGates.map((gate) => `actionable: ${gate.name} - ${sanitizeOperatorAction(gate.detail)}`)
+      : ["actionable: none"]),
+    ...status.recommendedActions.map((action) => `next: ${sanitizeOperatorAction(action)}`)
+  ];
+  return redactSecrets(lines.join("\n"));
 }
 
 export function buildRuntimeInventory(input: {
@@ -1735,28 +1771,65 @@ function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
 
+function sanitizeOperatorRelease(release: ReleaseStatus): ReleaseStatus {
+  return {
+    ...release,
+    recommendedActions: release.recommendedActions.map(sanitizeOperatorAction),
+    gates: release.gates.map((gate) => ({ ...gate, detail: sanitizeOperatorAction(gate.detail) }))
+  };
+}
+
+function sanitizeOperatorAction(action: string): string {
+  return /\b(?:retry-failed|retry-provider-cooldowns)\b|--dry-run false/i.test(action)
+    ? "inspect operator recovery rows before any action"
+    : action;
+}
+
+function operatorQueueFailureCounts(
+  release: ReleaseStatus,
+  durableQueue?: OperatorDurableQueueSnapshot
+): { total: number; active: number } {
+  const total = durableQueue?.summary.failed ?? release.database.failedReviewQueueJobCount ?? 0;
+  const active = release.database.activeFailedReviewQueueJobCount ?? total;
+  return { total, active: durableQueue ? Math.min(active, total) : active };
+}
+
 function zcodeTimeoutQueueCounts(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
-): { total: number; retryable: number; exhausted: number } {
+): { total: number; activeTotal: number; retryable: number; exhausted: number } {
+  const failedJobs = durableQueue?.jobs.filter((job) => job.state === "failed") ?? [];
+  if (durableQueue && (durableQueue.summary.failed === 0 || failedJobs.length === durableQueue.summary.failed)) {
+    const counts = summarizeZCodeTimeoutErrors(failedJobs.map((job) => job.lastError));
+    const activeTotal = Math.min(
+      release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? counts.total,
+      counts.total
+    );
+    return { ...counts, activeTotal };
+  }
   if (release.database.zcodeTimeoutFailedReviewQueueJobCount !== undefined) {
+    const total = release.database.zcodeTimeoutFailedReviewQueueJobCount;
     return {
-      total: release.database.zcodeTimeoutFailedReviewQueueJobCount,
+      total,
+      activeTotal: durableQueue
+        ? Math.min(release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? total, total)
+        : release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? total,
       retryable: release.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0,
       exhausted: release.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0
     };
   }
-  return summarizeZCodeTimeoutErrors(
-    (durableQueue?.jobs ?? [])
-      .filter((job) => job.state === "failed")
-      .map((job) => job.lastError)
-  );
+  const counts = summarizeZCodeTimeoutErrors(failedJobs.map((job) => job.lastError));
+  return { ...counts, activeTotal: counts.total };
 }
 
 function zcodeTimeoutRecommendedActions(
   release: ReleaseStatus,
   durableQueue?: OperatorDurableQueueSnapshot
 ): string[] {
+  const counts = zcodeTimeoutQueueCounts(release, durableQueue);
+  if (counts.activeTotal !== counts.total) {
+    return [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
+  }
   const retryCommands = buildZCodeTimeoutRetryCommandsForJobs({
     configPath: release.releaseUnit.configPath,
     jobs: durableQueue?.jobs ?? []

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -398,6 +398,7 @@ export interface PullStatusExplanation {
 export function buildOperatorStatus(input: {
   release: ReleaseStatus;
   coverage?: CoverageAuditReport;
+  repo?: string;
   agents: OperatorAgentInventory;
   providerCooldowns?: ProviderCooldownReviewRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
@@ -416,12 +417,14 @@ export function buildOperatorStatus(input: {
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
-  const queueFailures = operatorQueueFailureCounts(input.release, durableQueue);
+  const recoveredQueueFailures = recoveredQueueFailureTimes(input.coverage);
+  const queueFailures = operatorQueueFailureCounts(input.release, durableQueue, Boolean(input.repo), recoveredQueueFailures);
   const failedQueueJobs = queueFailures.total;
   const activeFailedQueueJobs = queueFailures.active;
   const recentUnrecoveredReviewErrors = input.release.database.recentUnrecoveredErrorCount ?? failedRows;
-  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
-  const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
+  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue, Boolean(input.repo), recoveredQueueFailures);
+  const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue)
+    .map(sanitizeOperatorAction);
   const budget = input.release.budget;
   const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
     budget,
@@ -1711,7 +1714,7 @@ function providerDeferredQueueEntry(entry: CoverageProviderDeferredEntry): Opera
     url: entry.url,
     status: entry.status,
     reason: entry.reason ?? entry.error ?? "provider cooldown",
-    nextAction: "wait for cooldown expiry or run retry-provider-cooldowns when expired"
+    nextAction: "inspect provider-deferred recovery rows before any action"
   };
 }
 
@@ -1775,7 +1778,8 @@ function sanitizeOperatorRelease(release: ReleaseStatus): ReleaseStatus {
   return {
     ...release,
     recommendedActions: release.recommendedActions.map(sanitizeOperatorAction),
-    gates: release.gates.map((gate) => ({ ...gate, detail: sanitizeOperatorAction(gate.detail) }))
+    gates: release.gates.map((gate) => ({ ...gate, detail: sanitizeOperatorAction(gate.detail) })),
+    rollback: { restartCommand: "inspect operator recovery rows before any action", unloadCommand: "inspect operator recovery rows before any action" }
   };
 }
 
@@ -1785,22 +1789,39 @@ function sanitizeOperatorAction(action: string): string {
     : action;
 }
 
+function recoveredQueueFailureTimes(report?: CoverageAuditReport): Map<string, string> {
+  return new Map((report?.processed ?? []).filter((entry) => entry.status === "posted").map((entry) => [`${entry.repo}\u0000${entry.pullNumber}`, entry.createdAt]));
+}
+
+function isRecoveredQueueFailure(job: ReviewQueueJobRecord, postedAtByPull: Map<string, string>): boolean {
+  const postedAt = Date.parse(postedAtByPull.get(`${job.repo}\u0000${job.pullNumber}`) ?? ""), failedAt = Date.parse(job.updatedAt);
+  return Number.isFinite(postedAt) && Number.isFinite(failedAt) && postedAt > failedAt;
+}
+
 function operatorQueueFailureCounts(
   release: ReleaseStatus,
-  durableQueue?: OperatorDurableQueueSnapshot
+  durableQueue?: OperatorDurableQueueSnapshot,
+  repoScoped = false,
+  postedAtByPull = new Map<string, string>()
 ): { total: number; active: number } {
   const total = durableQueue?.summary.failed ?? release.database.failedReviewQueueJobCount ?? 0;
+  if (repoScoped && durableQueue) {
+    return { total, active: durableQueue.jobs.filter((job) => job.state === "failed" && !isRecoveredQueueFailure(job, postedAtByPull)).length };
+  }
   const active = release.database.activeFailedReviewQueueJobCount ?? total;
   return { total, active: durableQueue ? Math.min(active, total) : active };
 }
 
 function zcodeTimeoutQueueCounts(
   release: ReleaseStatus,
-  durableQueue?: OperatorDurableQueueSnapshot
+  durableQueue?: OperatorDurableQueueSnapshot,
+  repoScoped = false,
+  postedAtByPull = new Map<string, string>()
 ): { total: number; activeTotal: number; retryable: number; exhausted: number } {
   const failedJobs = durableQueue?.jobs.filter((job) => job.state === "failed") ?? [];
   if (durableQueue && (durableQueue.summary.failed === 0 || failedJobs.length === durableQueue.summary.failed)) {
     const counts = summarizeZCodeTimeoutErrors(failedJobs.map((job) => job.lastError));
+    if (repoScoped) return { ...counts, activeTotal: summarizeZCodeTimeoutErrors(failedJobs.filter((job) => !isRecoveredQueueFailure(job, postedAtByPull)).map((job) => job.lastError)).total };
     const activeTotal = Math.min(
       release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? counts.total,
       counts.total

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -127,12 +127,20 @@ describe("operator CLI summaries", () => {
         ok: false,
         recommendedActions: ["inspect ghp_fake_token", "npx tsx src/cli.ts retry-provider-cooldowns --dry-run false"]
       }),
-      coverage: coverageReport({ ok: true }),
+      coverage: coverageReport({ ok: true, providerDeferred: [providerDeferredEntry(2, "deferred")] }),
       agents: agentInventory({}),
       durableQueue: durableQueueSnapshot({ summary: cleanDurableQueueSummary() })
     });
     expect(formatOperatorStatusHuman(status)).not.toContain("ghp_fake_token");
-    expect(JSON.stringify(status)).not.toMatch(/retry-provider-cooldowns|retry-failed|--dry-run false/);
+    expect(JSON.stringify(status)).not.toMatch(/retry-provider-cooldowns|retry-failed|kickstart|bootout|--dry-run false/);
+  });
+
+  it("scopes status active failures and sanitizes generated timeout recovery", () => {
+    const release = releaseStatus({ ok: true, database: { activeFailedReviewQueueJobCount: 2, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: 1 } });
+    const job = durableJob({ repo: "owner/repo", pullNumber: 1, headSha: "failed", state: "failed", lastError: "zcode_timeout_retryable", updatedAt: "2026-07-01T00:00:00.000Z" });
+    const status = buildOperatorStatus({ release, repo: "owner/repo", coverage: coverageReport({ ok: true, processed: [{ ...processedEntry(1, "failed", "posted"), createdAt: "2026-07-01T00:30:00.000Z" }] }), agents: agentInventory({ ok: true }), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 1 }, jobs: [job] }) });
+    expect(status).toMatchObject({ ok: true, summary: { activeFailedQueueJobs: 0 } });
+    expect(JSON.stringify(status)).not.toMatch(/retry-failed|retry-provider-cooldowns|--dry-run false/);
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {
@@ -1462,9 +1470,7 @@ describe("operator CLI summaries", () => {
       ok: false,
       detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
     });
-    expect(status.recommendedActions).toContain(
-      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 216 --head-sha head-timeout --dry-run false --zcode true"
-    );
+    expect(status.recommendedActions).toContain("inspect operator recovery rows before any action");
   });
 
   it("surfaces exhausted ZCode timeout failed queue jobs through durable queue fallback counts", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -19,6 +19,7 @@ import {
   explainPullStatus,
   filterBotProcessRows,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorAgentInventory,
@@ -98,6 +99,40 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("uses active failures for gates while retaining history and separating coverage headlines", () => {
+    const release = releaseStatus({ ok: true, database: {
+      errorCount: 2, recentUnrecoveredErrorCount: 0, failedReviewQueueJobCount: 2,
+      activeFailedReviewQueueJobCount: 0, zcodeTimeoutFailedReviewQueueJobCount: 1,
+      activeZCodeTimeoutFailedReviewQueueJobCount: 0
+    } });
+    release.health = { state: "amber", reason: "current gates pass; retained history has 2 review error(s) and 2 failed queue job(s)", active: { failedQueueJobs: 0, staleReviewLeases: 0 }, recent: { unrecoveredReviewErrors: 0 }, history: { reviewErrors: 2, failedQueueJobs: 2 } };
+    const recovered = buildOperatorStatus({ release, coverage: coverageReport({ ok: true }), agents: agentInventory({}), durableQueue: durableQueueSnapshot({ ok: false, summary: { ...cleanDurableQueueSummary(), failed: 2 }, jobs: [] }) });
+    expect(recovered.ok).toBe(true);
+    expect(recovered.summary.failedQueueJobs).toBe(2);
+    expect(recovered.gates).toContainEqual(expect.objectContaining({ name: "durable_queue_no_failed_jobs", ok: true }));
+    expect(formatOperatorStatusHuman(recovered)).toContain("status: ok (operator)");
+
+    const coverageBlocked = buildOperatorStatus({ release, coverage: coverageReport({ unprocessed: [pullEntry(9, "pending-head")] }), agents: agentInventory({}), durableQueue: durableQueueSnapshot({ summary: cleanDurableQueueSummary() }) });
+    const human = formatOperatorStatusHuman(coverageBlocked);
+    expect(human).toContain("status: blocked (operator) - queue_no_pending_heads");
+    expect(human).toContain("releaseHealth: amber - current gates pass");
+    expect(human).not.toContain("blocked (operator) - current gates pass");
+  });
+
+  it("redacts dynamic human status values", () => {
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        recommendedActions: ["inspect ghp_fake_token", "npx tsx src/cli.ts retry-provider-cooldowns --dry-run false"]
+      }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({ summary: cleanDurableQueueSummary() })
+    });
+    expect(formatOperatorStatusHuman(status)).not.toContain("ghp_fake_token");
+    expect(JSON.stringify(status)).not.toMatch(/retry-provider-cooldowns|retry-failed|--dry-run false/);
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {


### PR DESCRIPTION
Related: #741

## Summary
- present operator status with active/recent/history counts without contradictory headlines
- add a compact human status view with secret redaction
- keep status presentation read-only and suppress live recovery commands from its JSON/human projection

## Validation
- focused Vitest: tests/operator-cli.test.ts and tests/release-status.test.ts (165 passed)
- npm run build
- git diff --check

This is O1 of the focused successors replacing held PR #846. O2 will add repo-scoped runtime inventory and strict row-level recovery projection. No worker, database, queue, provider, credential, customer, release, or runtime state was changed.
