### PR TITLE
fix(operator): scope runtime inventory recovery projection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -777,6 +777,7 @@ async function main(): Promise<void> {
     const inventory = buildRuntimeInventory({
       release,
       coverage,
+      ...(args.repo ? { repo: args.repo } : {}),
       agents,
       processes,
       providerCooldowns,
@@ -790,7 +791,7 @@ async function main(): Promise<void> {
       issueEnrichmentRuntime,
       checkedAt: now.toISOString()
     });
-    console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : JSON.stringify(inventory, null, 2));
+    console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : stringifyRedactedJson(inventory));
     if (!inventory.ok) process.exitCode = 1;
     return;
   }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -621,14 +621,19 @@ export function buildRuntimeInventory(input: {
       ? buildDurableQueueSnapshot(input.durableQueue.jobs.filter((job) => job.repo === input.repo), now)
       : undefined
     : input.durableQueue;
+  const recoveredQueueFailures = recoveredQueueFailureTimes(input.coverage);
   const providerCooldowns = (input.providerCooldowns ?? []).filter((cooldown) =>
     !input.repo || cooldown.repo === input.repo
   );
   const repoProviderCooldowns = (input.repoProviderCooldowns ?? []).filter((cooldown) =>
     !input.repo || cooldown.repo === input.repo
   );
+  const staleQueueJobs = input.repo
+    ? (durableQueue?.jobs ?? []).filter((job) => isExpiredQueueLease(job, nowMs)).length
+    : 0;
   const activeWork = (durableQueue?.jobs ?? []).filter((job) =>
-    job.state === "queued" || job.state === "leased" || job.state === "running"
+    (job.state === "queued" || job.state === "leased" || job.state === "running") &&
+    !isExpiredQueueLease(job, nowMs)
   );
   const uncoveredPendingHeads = (queue?.pending ?? []).filter((pending) =>
     !activeWork.some((job) => sameHead(job, pending))
@@ -641,25 +646,28 @@ export function buildRuntimeInventory(input: {
     return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > nowMs;
   }).length;
   const coveredExpiredProviderCooldowns = input.repo
-    ? (activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0)
+    ? ((input.release.database.activeGlobalProviderCooldownCount ?? 0) > 0 || activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0)
     : input.release.database.coveredExpiredProviderCooldownCount ??
       (activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0);
   const retryableExpiredProviderCooldowns = input.repo
     ? Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns)
     : input.release.database.retryableExpiredProviderCooldownCount ??
       Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
-  const retryCoveredReviewerSessions = input.repo ? 0 : input.release.database.retryCoveredReviewerSessionCount ?? 0;
-  const queueFailures = operatorQueueFailureCounts(input.release, durableQueue, Boolean(input.repo));
+  const retryCoveredReviewerSessions = input.repo
+    ? input.release.database.reviewerSessionsByRepo?.find((row) => row.repo === input.repo)?.retryCovered ?? 0
+    : input.release.database.retryCoveredReviewerSessionCount ?? 0;
+  const queueFailures = operatorQueueFailureCounts(input.release, durableQueue, Boolean(input.repo), recoveredQueueFailures);
   const failedQueueJobs = queueFailures.total;
   const activeFailedQueueJobs = queueFailures.active;
-  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue, Boolean(input.repo));
+  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue, Boolean(input.repo), recoveredQueueFailures);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
+  const processedFailures = input.repo ? queue?.processed.filter((entry) => entry.status === "failed").length ?? 0 : 0;
   const budget = input.release.budget;
   const retryableProviderDeferredJobs = input.repo
-    ? durableQueue?.summary.retryableProviderDeferred ?? 0
+    ? scopedRetryableProviderDeferredJobs(budget, durableQueue, input.repo)
     : actionableProviderDeferredJobs(budget, durableQueue?.summary.retryableProviderDeferred ?? 0);
   const issueEnrichment = input.issueEnrichment;
   const issueEnrichmentRuntime = input.issueEnrichmentRuntime;
@@ -671,6 +679,8 @@ export function buildRuntimeInventory(input: {
 
   const gates = [
     ...runtimeRelease.gates,
+    ...(input.repo ? [{ name: "runtime_no_processed_failures", ok: processedFailures === 0, detail: `${processedFailures} selected-repo processed failure(s)` }] : []),
+    ...(input.repo ? [{ name: "runtime_no_stale_queue_leases", ok: staleQueueJobs === 0, detail: `${staleQueueJobs} expired selected-repo queue lease(s)` }] : []),
     {
       name: "runtime_no_stale_leases",
       ok: input.agents.summary.staleLeases === 0,
@@ -945,7 +955,7 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
     lines.push("recommendedActions:");
     for (const action of inventory.recommendedActions) lines.push(`- ${action}`);
   }
-  return lines.join("\n");
+  return redactSecrets(lines.join("\n"));
 }
 
 export function summarizeAgentInventory(input: {
@@ -1809,10 +1819,12 @@ function scopeRuntimeRelease(release: ReleaseStatus, repo?: string): ReleaseStat
     gates: safeRelease.gates.map((gate) => ({ ...gate, detail: sanitizeRuntimeAction(gate.detail) }))
   };
   if (!repo) return runtimeRelease;
+  const gates = runtimeRelease.gates.filter((gate) => !REPO_GLOBAL_RUNTIME_GATES.has(gate.name));
+  const ok = gates.every((gate) => gate.ok);
   return {
     ...runtimeRelease,
-    gates: runtimeRelease.gates.filter((gate) => !REPO_GLOBAL_RUNTIME_GATES.has(gate.name)),
-    recommendedActions: []
+    ok, gates, recommendedActions: [],
+    ...(runtimeRelease.health ? { health: { ...runtimeRelease.health, state: ok ? "green" : "red", reason: ok ? "selected repository release gates pass" : runtimeRelease.health.reason } } : {})
   };
 }
 
@@ -2005,11 +2017,20 @@ function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {
   return !Number.isFinite(nextEligibleAtMs) || nextEligibleAtMs <= now.getTime();
 }
 
+function isExpiredQueueLease(job: ReviewQueueJobRecord, nowMs: number): boolean {
+  return (job.state === "leased" || job.state === "running") && Number.isFinite(Date.parse(job.leaseExpiresAt ?? "")) && Date.parse(job.leaseExpiresAt!) <= nowMs;
+}
+
 function actionableProviderDeferredJobs(
   budget: ReviewBudgetStatus | undefined,
   fallbackRetryableProviderDeferred: number
 ): number {
   return budget?.providerDeferred.readyToRetry ?? fallbackRetryableProviderDeferred;
+}
+
+function scopedRetryableProviderDeferredJobs(budget: ReviewBudgetStatus | undefined, queue: OperatorDurableQueueSnapshot | undefined, repo: string): number {
+  if (!budget || !budget.details.included) return queue?.summary.retryableProviderDeferred ?? 0;
+  return budget.wouldLease.filter((job) => job.repo === repo && job.state === "provider_deferred").length;
 }
 
 function describeActionableProviderDeferredJobs(

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -598,6 +598,7 @@ export function formatOperatorStatusHuman(status: OperatorStatus): string {
 export function buildRuntimeInventory(input: {
   release: ReleaseStatus;
   coverage?: CoverageAuditReport;
+  repo?: string;
   agents: OperatorAgentInventory;
   processes?: RuntimeProcessInventory;
   providerCooldowns?: ProviderCooldownReviewRecord[];
@@ -607,10 +608,25 @@ export function buildRuntimeInventory(input: {
   issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
   checkedAt?: string;
 }): RuntimeInventory {
-  const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
-  const durableQueue = input.durableQueue;
-  const providerCooldowns = input.providerCooldowns ?? [];
-  const repoProviderCooldowns = input.repoProviderCooldowns ?? [];
+  const checkedAt = input.checkedAt ?? input.release.checkedAt;
+  const checkedAtMs = Date.parse(checkedAt);
+  const nowMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
+  const now = new Date(nowMs);
+  const runtimeRelease = scopeRuntimeRelease(input.release, input.repo);
+  const queue = input.coverage
+    ? buildOperatorQueue(input.repo ? scopeCoverageReport(input.coverage, input.repo) : input.coverage)
+    : undefined;
+  const durableQueue = input.repo
+    ? input.durableQueue
+      ? buildDurableQueueSnapshot(input.durableQueue.jobs.filter((job) => job.repo === input.repo), now)
+      : undefined
+    : input.durableQueue;
+  const providerCooldowns = (input.providerCooldowns ?? []).filter((cooldown) =>
+    !input.repo || cooldown.repo === input.repo
+  );
+  const repoProviderCooldowns = (input.repoProviderCooldowns ?? []).filter((cooldown) =>
+    !input.repo || cooldown.repo === input.repo
+  );
   const activeWork = (durableQueue?.jobs ?? []).filter((job) =>
     job.state === "queued" || job.state === "leased" || job.state === "running"
   );
@@ -620,31 +636,31 @@ export function buildRuntimeInventory(input: {
   const coveredPendingHeads = (queue?.pending.length ?? 0) - uncoveredPendingHeads.length;
   const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
   const activeProviderCooldowns = providerCooldowns.length - expiredProviderCooldowns;
-  const checkedAtMs = Date.parse(input.checkedAt ?? input.release.checkedAt);
-  const nowMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const activeRepoCooldowns = repoProviderCooldowns.filter((cooldown) => {
     const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
     return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > nowMs;
   }).length;
-  const coveredExpiredProviderCooldowns =
-    input.release.database.coveredExpiredProviderCooldownCount ??
-    (activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0);
-  const retryableExpiredProviderCooldowns =
-    input.release.database.retryableExpiredProviderCooldownCount ??
-    Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
-  const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
-  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
-  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
-  const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
+  const coveredExpiredProviderCooldowns = input.repo
+    ? (activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0)
+    : input.release.database.coveredExpiredProviderCooldownCount ??
+      (activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0);
+  const retryableExpiredProviderCooldowns = input.repo
+    ? Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns)
+    : input.release.database.retryableExpiredProviderCooldownCount ??
+      Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
+  const retryCoveredReviewerSessions = input.repo ? 0 : input.release.database.retryCoveredReviewerSessionCount ?? 0;
+  const queueFailures = operatorQueueFailureCounts(input.release, durableQueue, Boolean(input.repo));
+  const failedQueueJobs = queueFailures.total;
+  const activeFailedQueueJobs = queueFailures.active;
+  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue, Boolean(input.repo));
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const budget = input.release.budget;
-  const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
-    budget,
-    durableQueue?.summary.retryableProviderDeferred ?? 0
-  );
+  const retryableProviderDeferredJobs = input.repo
+    ? durableQueue?.summary.retryableProviderDeferred ?? 0
+    : actionableProviderDeferredJobs(budget, durableQueue?.summary.retryableProviderDeferred ?? 0);
   const issueEnrichment = input.issueEnrichment;
   const issueEnrichmentRuntime = input.issueEnrichmentRuntime;
   const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
@@ -654,7 +670,7 @@ export function buildRuntimeInventory(input: {
     describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
 
   const gates = [
-    ...input.release.gates,
+    ...runtimeRelease.gates,
     {
       name: "runtime_no_stale_leases",
       ok: input.agents.summary.staleLeases === 0,
@@ -662,20 +678,25 @@ export function buildRuntimeInventory(input: {
     },
     {
       name: "runtime_no_failed_queue_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: activeFailedQueueJobs === failedQueueJobs
+        ? `${failedQueueJobs} failed durable queue job(s)`
+        : `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "runtime_no_zcode_timeout_failed_queue_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
-      detail:
-        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
-        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+      ok: zcodeTimeoutQueue.activeTotal === 0,
+      detail: zcodeTimeoutQueue.activeTotal === zcodeTimeoutQueue.total
+        ? `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+          `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+        : `${zcodeTimeoutQueue.activeTotal} active ZCode timeout failed durable queue job(s); ` +
+          `retained=${zcodeTimeoutQueue.total}; retryable=${zcodeTimeoutQueue.retryable} ` +
+          `exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "runtime_no_retryable_provider_deferred_jobs",
       ok: retryableProviderDeferredJobs === 0,
-      detail: describeActionableProviderDeferredJobs(budget, retryableProviderDeferredJobs)
+      detail: input.repo ? `${retryableProviderDeferredJobs} retryable provider-deferred durable queue job(s)` : describeActionableProviderDeferredJobs(budget, retryableProviderDeferredJobs)
     },
     {
       name: "runtime_pending_heads_covered",
@@ -754,17 +775,21 @@ export function buildRuntimeInventory(input: {
       : "healthy_idle";
 
   const recommendedActions = uniqueStrings([
-    ...input.release.recommendedActions,
+    ...runtimeRelease.recommendedActions,
     ...(activeWork.length > 0 ? ["monitor active review work; avoid restarting a healthy in-flight run"] : []),
     ...(uncoveredPendingHeads.length > 0 ? ["wait for daemon cycle or run scoped run-once for uncovered pending heads"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
-      ? zcodeTimeoutRetryActions
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(zcodeTimeoutQueue.activeTotal > 0
+      ? [buildZCodeTimeoutInspectCommand(runtimeRelease.releaseUnit.configPath)]
       : []),
-    ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
-    ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : []),
+    ...(retryableProviderDeferredJobs > 0
+      ? ["inspect provider-deferred recovery rows before any action"]
+      : []),
+    ...(retryableExpiredProviderCooldowns > 0
+      ? ["inspect provider cooldown recovery rows before any action"]
+      : []),
     ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
     ...(issueEnrichmentRuntimeFailed > 0 ? ["inspect failed issue-enrichment records before promotion"] : []),
     ...(issueEnrichmentRuntimeRetryableDeferred > 0 ? ["retry or inspect deferred issue-enrichment records"] : [])
@@ -772,12 +797,12 @@ export function buildRuntimeInventory(input: {
 
   return {
     ok,
-    checkedAt: input.checkedAt ?? input.release.checkedAt,
+    checkedAt,
     runtimeState,
     classification: runtimeState,
     summary: {
-      launchdState: input.release.launchd.state,
-      heartbeatStatus: input.release.heartbeat.status,
+      launchdState: runtimeRelease.launchd.state,
+      heartbeatStatus: runtimeRelease.heartbeat.status,
       activeLeases: input.agents.summary.activeLeases,
       staleLeases: input.agents.summary.staleLeases,
       activeQueueJobs: activeWork.length,
@@ -813,7 +838,7 @@ export function buildRuntimeInventory(input: {
     recommendedActions,
     activeWork,
     uncoveredPendingHeads,
-    release: input.release,
+    release: runtimeRelease,
     ...(budget ? { budget } : {}),
     agents: input.agents,
     ...(input.processes ? { processes: input.processes } : {}),
@@ -1772,6 +1797,39 @@ function staleHeadQueueEntry(entry: CoverageStaleHead): OperatorQueueEntry {
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
+}
+
+const REPO_GLOBAL_RUNTIME_GATES = new Set(["live_db_no_errors", "provider_cooldown_backlog", "queue_no_failed_jobs", "queue_no_zcode_timeout_failed_jobs", "queue_no_stale_review_leases", "queue_no_retryable_provider_deferred_jobs"]);
+
+function scopeRuntimeRelease(release: ReleaseStatus, repo?: string): ReleaseStatus {
+  const safeRelease = sanitizeOperatorRelease(release);
+  const runtimeRelease: ReleaseStatus = {
+    ...safeRelease,
+    recommendedActions: safeRelease.recommendedActions.map(sanitizeRuntimeAction),
+    gates: safeRelease.gates.map((gate) => ({ ...gate, detail: sanitizeRuntimeAction(gate.detail) }))
+  };
+  if (!repo) return runtimeRelease;
+  return {
+    ...runtimeRelease,
+    gates: runtimeRelease.gates.filter((gate) => !REPO_GLOBAL_RUNTIME_GATES.has(gate.name)),
+    recommendedActions: []
+  };
+}
+
+function sanitizeRuntimeAction(action: string): string {
+  return /\b(?:retry|requeue|retire|restart|kickstart|bootout)\b|--dry-run false/i.test(action)
+    ? "inspect operator recovery rows before any action"
+    : action;
+}
+
+function scopeCoverageReport(report: CoverageAuditReport, repo: string): CoverageAuditReport {
+  const filter = <T extends { repo: string }>(rows: T[]): T[] => rows.filter((row) => row.repo === repo);
+  return {
+    ...report,
+    processed: filter(report.processed), providerDeferred: filter(report.providerDeferred),
+    queued: filter(report.queued), unprocessed: filter(report.unprocessed), skipped: filter(report.skipped),
+    staleHeads: filter(report.staleHeads), readFailures: filter(report.readFailures)
+  };
 }
 
 function sanitizeOperatorRelease(release: ReleaseStatus): ReleaseStatus {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -143,6 +143,14 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(status)).not.toMatch(/retry-failed|retry-provider-cooldowns|--dry-run false/);
   });
 
+  it("scopes status active failures and sanitizes generated timeout recovery", () => {
+    const release = releaseStatus({ ok: true, database: { activeFailedReviewQueueJobCount: 2, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: 1 } });
+    const job = durableJob({ repo: "owner/repo", pullNumber: 1, headSha: "failed", state: "failed", lastError: "zcode_timeout_retryable", updatedAt: "2026-07-01T00:00:00.000Z" });
+    const status = buildOperatorStatus({ release, repo: "owner/repo", coverage: coverageReport({ ok: true, processed: [{ ...processedEntry(1, "failed", "posted"), createdAt: "2026-07-01T00:30:00.000Z" }] }), agents: agentInventory({ ok: true }), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), failed: 1 }, jobs: [job] }) });
+    expect(status).toMatchObject({ ok: true, summary: { activeFailedQueueJobs: 0 } });
+    expect(JSON.stringify(status)).not.toMatch(/retry-failed|retry-provider-cooldowns|--dry-run false/);
+  });
+
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {
     const coverage = buildReleaseMonitoringCoverage({
       required: false,

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1003,6 +1003,51 @@ describe("operator CLI summaries", () => {
     expect(inventory.recommendedActions).not.toContain("retry expired provider cooldowns or inspect provider health");
   });
 
+  it("keeps repo runtime inventory on selected rows and strips global recovery actions", () => {
+    const release = releaseStatus({
+      ok: false,
+      recommendedActions: [
+        "npx tsx src/cli.ts retry-failed --dry-run false",
+        "retry expired provider cooldowns or inspect provider health"
+      ],
+      database: {
+        errorCount: 3,
+        recentUnrecoveredErrorCount: 2,
+        failedReviewQueueJobCount: 2,
+        activeFailedReviewQueueJobCount: 2,
+        zcodeTimeoutFailedReviewQueueJobCount: 1,
+        activeZCodeTimeoutFailedReviewQueueJobCount: 1,
+        retryableExpiredProviderCooldownCount: 1
+      }
+    });
+    release.gates.push(
+      { name: "live_db_no_errors", ok: false, detail: "2 recent unrecovered blocking error row(s)" },
+      { name: "queue_no_failed_jobs", ok: false, detail: "2 active failed durable queue job(s)" },
+      { name: "queue_no_zcode_timeout_failed_jobs", ok: false, detail: "1 active ZCode timeout failed durable queue job(s)" },
+      { name: "queue_no_retryable_provider_deferred_jobs", ok: false, detail: "1 ready-to-retry provider-deferred durable queue job(s)" }
+    );
+    const selected = buildRuntimeInventory({
+      release,
+      repo: "owner/selected",
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      repoProviderCooldowns: [],
+      durableQueue: durableQueueSnapshot({
+        ok: true,
+        summary: { ...cleanDurableQueueSummary(), total: 1, posted: 1 },
+        jobs: [durableJob({ repo: "owner/selected", pullNumber: 7, headSha: "recovered", state: "posted" })]
+      }),
+      checkedAt: "2026-07-01T00:30:00.000Z"
+    });
+
+    expect(selected.ok).toBe(true);
+    expect(selected.summary.failedQueueJobs).toBe(0);
+    expect(selected.gates.some((gate) => /^(live_db|provider_cooldown_backlog|queue_no_)/.test(gate.name))).toBe(false);
+    expect(`${selected.recommendedActions.join("\n")}\n${JSON.stringify(selected)}`).not.toMatch(/retry-failed|retry-provider-cooldowns|--dry-run false|retry or requeue/i);
+
+  });
+
   it("formats a concise human runtime inventory without leaking secrets", () => {
     const inventory = buildRuntimeInventory({
       release: releaseStatus({ ok: true, budget: reviewBudgetStatus() }),

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1003,54 +1003,37 @@ describe("operator CLI summaries", () => {
     expect(inventory.recommendedActions).not.toContain("retry expired provider cooldowns or inspect provider health");
   });
 
-  it("keeps repo runtime inventory on selected rows and strips global recovery actions", () => {
-    const release = releaseStatus({
-      ok: false,
-      recommendedActions: [
-        "npx tsx src/cli.ts retry-failed --dry-run false",
-        "retry expired provider cooldowns or inspect provider health"
-      ],
-      database: {
-        errorCount: 3,
-        recentUnrecoveredErrorCount: 2,
-        failedReviewQueueJobCount: 2,
-        activeFailedReviewQueueJobCount: 2,
-        zcodeTimeoutFailedReviewQueueJobCount: 1,
-        activeZCodeTimeoutFailedReviewQueueJobCount: 1,
-        retryableExpiredProviderCooldownCount: 1
-      }
-    });
-    release.gates.push(
-      { name: "live_db_no_errors", ok: false, detail: "2 recent unrecovered blocking error row(s)" },
-      { name: "queue_no_failed_jobs", ok: false, detail: "2 active failed durable queue job(s)" },
-      { name: "queue_no_zcode_timeout_failed_jobs", ok: false, detail: "1 active ZCode timeout failed durable queue job(s)" },
-      { name: "queue_no_retryable_provider_deferred_jobs", ok: false, detail: "1 ready-to-retry provider-deferred durable queue job(s)" }
-    );
-    const selected = buildRuntimeInventory({
-      release,
-      repo: "owner/selected",
-      coverage: coverageReport({ ok: true }),
-      agents: agentInventory({ ok: true }),
-      providerCooldowns: [],
-      repoProviderCooldowns: [],
-      durableQueue: durableQueueSnapshot({
-        ok: true,
-        summary: { ...cleanDurableQueueSummary(), total: 1, posted: 1 },
-        jobs: [durableJob({ repo: "owner/selected", pullNumber: 7, headSha: "recovered", state: "posted" })]
-      }),
-      checkedAt: "2026-07-01T00:30:00.000Z"
-    });
-
-    expect(selected.ok).toBe(true);
-    expect(selected.summary.failedQueueJobs).toBe(0);
-    expect(selected.gates.some((gate) => /^(live_db|provider_cooldown_backlog|queue_no_)/.test(gate.name))).toBe(false);
-    expect(`${selected.recommendedActions.join("\n")}\n${JSON.stringify(selected)}`).not.toMatch(/retry-failed|retry-provider-cooldowns|--dry-run false|retry or requeue/i);
-
+  it("scopes runtime truth and strips recovery commands", () => {
+    const release = releaseStatus({ ok: true, recommendedActions: ["retry-failed --dry-run false"], database: { activeGlobalProviderCooldownCount: 1, reviewerSessionsByRepo: [{ repo: "owner/selected", total: 1, active: 0, expired: 1, retryCovered: 1 }] } });
+    release.ok = false;
+    release.gates.push({ name: "live_db_no_errors", ok: false, detail: "global failure" });
+    release.health = { state: "red", reason: "global failure", active: { failedQueueJobs: 1, staleReviewLeases: 0 }, recent: { unrecoveredReviewErrors: 1 }, history: { reviewErrors: 1, failedQueueJobs: 1 } };
+    const budget = reviewBudgetStatus();
+    budget.wouldLease = [];
+    budget.providerDeferred = { ...budget.providerDeferred, total: 1, retryable: 1, readyToRetry: 1 };
+    release.budget = budget;
+    const inventory = buildRuntimeInventory({ release, repo: "owner/selected", coverage: coverageReport({ processed: [
+      { ...processedEntry(9, "processed-failed", "failed"), repo: "owner/selected" },
+      { ...processedEntry(8, "recovered", "posted"), repo: "owner/selected", createdAt: "2026-07-01T00:30:00.000Z" }
+    ] }), agents: agentInventory({ ok: true }), providerCooldowns: [{ ...processedRecord(7, "cooldown", "skipped"), repo: "owner/selected", expired: true, cooldownUntil: "2026-07-01T00:01:00.000Z", reason: "expired" }], repoProviderCooldowns: [],
+      durableQueue: durableQueueSnapshot({ jobs: [
+        { ...durableJob({ repo: "owner/selected", pullNumber: 6, headSha: "expired", state: "leased" }), leaseExpiresAt: "2026-07-01T00:01:00.000Z" },
+        durableJob({ repo: "owner/selected", pullNumber: 8, headSha: "recovered", state: "failed" }),
+        durableJob({ repo: "owner/selected", pullNumber: 7, headSha: "deferred", state: "provider_deferred", nextEligibleAt: "2026-07-01T00:01:00.000Z" })
+      ] }), checkedAt: "2026-07-01T00:30:00.000Z" });
+    expect(inventory.summary).toMatchObject({ activeQueueJobs: 0, failedQueueJobs: 1, retryableProviderDeferredJobs: 0, retryCoveredReviewerSessions: 1, retryableExpiredProviderCooldowns: 0, coveredExpiredProviderCooldowns: 1 });
+    expect(inventory.gates).toContainEqual(expect.objectContaining({ name: "runtime_no_processed_failures", ok: false }));
+    expect(inventory.gates).toContainEqual(expect.objectContaining({ name: "runtime_no_stale_queue_leases", ok: false }));
+    expect(inventory.gates).toContainEqual(expect.objectContaining({ name: "runtime_no_failed_queue_jobs", ok: true }));
+    expect(inventory.release).toMatchObject({ ok: true, health: { state: "green" } });
+    expect(JSON.stringify(inventory)).not.toMatch(/retry-failed|retry-provider-cooldowns|--dry-run false/);
   });
 
   it("formats a concise human runtime inventory without leaking secrets", () => {
+    const release = releaseStatus({ ok: true, budget: reviewBudgetStatus() });
+    release.releaseUnit.configPath = "/runtime/ghp_dynamic_secret.json";
     const inventory = buildRuntimeInventory({
-      release: releaseStatus({ ok: true, budget: reviewBudgetStatus() }),
+      release,
       coverage: coverageReport({ ok: true }),
       agents: agentInventory({ ok: true }),
       durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),


### PR DESCRIPTION
## Summary\n- project runtime inventory counts, coverage, durable queue, and cooldowns to --repo input\n- omit global DB/queue/cooldown gates and actions from repo-scoped output\n- retain global behavior when --repo is absent while replacing live retry output with read-only inspection\n\nThis is O2 of the clean successors replacing held #846; O1 is #851. #846 is not edited or pushed.\n\n## Validation\n- focused Vitest: 166 passed (operator-cli + release-status)\n- npm run build\n- git diff --check\n- 195 changed lines (154 additions, 41 deletions), non-generated\n- no runtime, DB, queue, config, credential, customer, or recovery mutation\n\nRelated: #741\n