### PR TITLE
feat: add strict severe verifier v2 contract

### DIFF
--- a/src/severe-verification-contract.ts
+++ b/src/severe-verification-contract.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+
+export const SEVERE_EVIDENCE_SCHEMA = "severe-evidence/v2" as const;
+export const SEVERE_RECEIPT_SCHEMA = "severe-verifier-receipt/v2" as const;
+export const MAX_SEVERE_FILE_BYTES = 64 * 1024;
+export const MAX_SEVERE_TOTAL_BYTES = 256 * 1024;
+export const MAX_SEVERE_ENTRIES = 64;
+
+export type SevereState = "confirmed" | "refuted" | "failed" | "malformed" | "timeout" | "unavailable" | "stale_head" | "incomplete";
+export type SevereDisposition = "retain" | "suppress";
+export type SevereEvidenceKind = "whole_file" | "module";
+export type SevereFailureCode = "not_read" | "refuted" | "malformed" | "timeout" | "unavailable" | "stale_head" | "incomplete" | "schema_invalid" | "identity_mismatch" | "evidence_incomplete" | "provider_unavailable" | "cap_exceeded" | "receipt_invalid";
+
+export interface SevereHostSubject {
+  repo: string; pull: number; base: string; head: string; fingerprint: string;
+  path: string; line: number; side: "RIGHT"; lineSha256: string; hunkSha256: string;
+}
+export interface SevereEvidenceFile {
+  path: string; kind: SevereEvidenceKind; sha256: string; bytes: number; complete: boolean;
+  lineStart?: number; lineEnd?: number;
+}
+export interface SevereEvidenceOmission { path: string; code: SevereFailureCode; }
+export interface SevereEvidence {
+  schema: typeof SEVERE_EVIDENCE_SCHEMA; files: SevereEvidenceFile[]; omissions: SevereEvidenceOmission[]; complete: boolean;
+}
+export interface SevereVerificationReceipt {
+  schema: typeof SEVERE_RECEIPT_SCHEMA; subject: SevereHostSubject; state: SevereState; disposition: SevereDisposition;
+  confidence?: number; reasonCode?: SevereFailureCode; evidence: SevereEvidence;
+}
+export type SevereValidation = { ok: true; value: SevereVerificationReceipt } | { ok: false; errors: string[] };
+
+const STATES = new Set<SevereState>(["confirmed", "refuted", "failed", "malformed", "timeout", "unavailable", "stale_head", "incomplete"]);
+const CODES = new Set<SevereFailureCode>(["not_read", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete", "schema_invalid", "identity_mismatch", "evidence_incomplete", "provider_unavailable", "cap_exceeded", "receipt_invalid"]);
+const SHA1 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const SUBJECT_KEYS = ["repo", "pull", "base", "head", "fingerprint", "path", "line", "side", "lineSha256", "hunkSha256"];
+
+export function validateSevereHostSubject(value: unknown): string[] {
+  const errors: string[] = [];
+  if (!direct(value) || !exact(value, SUBJECT_KEYS)) return ["subject must be a direct object with exact keys"];
+  if (!repo(value.repo)) errors.push("subject.repo is not canonical");
+  if (!integer(value.pull) || value.pull < 1) errors.push("subject.pull is invalid");
+  if (!sha1(value.base) || !sha1(value.head)) errors.push("subject revision is invalid");
+  if (!fingerprint(value.fingerprint)) errors.push("subject.fingerprint is invalid");
+  if (!path(value.path)) errors.push("subject.path is not canonical");
+  if (!integer(value.line) || value.line < 1) errors.push("subject.line is invalid");
+  if (value.side !== "RIGHT") errors.push("subject.side is invalid");
+  if (!sha256(value.lineSha256) || !sha256(value.hunkSha256)) errors.push("subject line/hunk digest is invalid");
+  return errors;
+}
+
+export function parseSevereHostSubject(value: unknown): SevereHostSubject {
+  const errors = validateSevereHostSubject(value);
+  if (errors.length) throw new Error("severe_subject_invalid: " + errors.join(","));
+  return value as SevereHostSubject;
+}
+
+export function validateSevereVerificationReceipt(value: unknown, expectedSubject: SevereHostSubject): SevereValidation {
+  const errors: string[] = [];
+  const expectedErrors = validateSevereHostSubject(expectedSubject);
+  if (expectedErrors.length) return { ok: false, errors: ["host subject is invalid", ...expectedErrors] };
+  if (!direct(value) || !exact(value, ["schema", "subject", "state", "disposition", "evidence"], ["confidence", "reasonCode"])) return { ok: false, errors: ["receipt must be a direct object with exact keys"] };
+  if (value.schema !== SEVERE_RECEIPT_SCHEMA) errors.push("receipt.schema is invalid");
+  const subjectErrors = validateSevereHostSubject(value.subject);
+  errors.push(...subjectErrors.map((error) => "receipt." + error));
+  if (!subjectErrors.length && !sameSubject(value.subject as SevereHostSubject, expectedSubject)) errors.push("receipt subject identity mismatch");
+  if (!string(value.state) || !STATES.has(value.state as SevereState)) errors.push("receipt.state is invalid");
+  if (value.disposition !== "retain" && value.disposition !== "suppress") errors.push("receipt.disposition is invalid");
+  if (Object.hasOwn(value, "confidence") && (!number(value.confidence) || value.confidence < 0 || value.confidence > 1)) errors.push("receipt.confidence is invalid");
+  if (Object.hasOwn(value, "reasonCode") && (!string(value.reasonCode) || !CODES.has(value.reasonCode as SevereFailureCode))) errors.push("receipt.reasonCode is invalid");
+  const state = value.state as SevereState;
+  const reason = value.reasonCode as SevereFailureCode | undefined;
+  if (state === "confirmed" && value.disposition !== "retain") errors.push("confirmed receipts must retain");
+  if (state !== "confirmed" && value.disposition === "retain") errors.push("only confirmed receipts may retain");
+  if (!stateReason(state, reason)) errors.push("receipt state and reasonCode are incompatible");
+  if (!subjectErrors.length && direct(value.evidence)) errors.push(...validateEvidence(value.evidence, value.subject as SevereHostSubject, state, reason).map((error) => "receipt." + error));
+  else errors.push("receipt.evidence is invalid");
+  return errors.length ? { ok: false, errors } : { ok: true, value: value as unknown as SevereVerificationReceipt };
+}
+
+export function parseSevereVerificationReceipt(value: unknown, expectedSubject: SevereHostSubject): SevereVerificationReceipt {
+  const result = validateSevereVerificationReceipt(value, expectedSubject);
+  if (!result.ok) throw new Error("severe_receipt_invalid: " + result.errors.join(","));
+  return result.value;
+}
+
+export function isSevereVerificationReceipt(value: unknown, expectedSubject: SevereHostSubject): value is SevereVerificationReceipt {
+  return validateSevereVerificationReceipt(value, expectedSubject).ok;
+}
+
+export function validateSevereEvidence(value: unknown, subject: SevereHostSubject, state: SevereState = "confirmed", reason?: SevereFailureCode): string[] {
+  if (!direct(value)) return ["evidence must be a direct object"];
+  return validateEvidence(value, subject, state, reason);
+}
+
+export function parseSevereEvidence(value: unknown, subject: SevereHostSubject, state: SevereState = "confirmed", reason?: SevereFailureCode): SevereEvidence {
+  const errors = validateSevereEvidence(value, subject, state, reason);
+  if (errors.length) throw new Error("severe_evidence_invalid: " + errors.join(","));
+  return value as SevereEvidence;
+}
+
+export const parseSevereReceipt = parseSevereVerificationReceipt;
+export const validateSevereReceipt = validateSevereVerificationReceipt;
+
+export function canonicalizeSevereVerificationReceipt(value: unknown, expectedSubject: SevereHostSubject): string {
+  return canonical(parseSevereVerificationReceipt(value, expectedSubject));
+}
+export function severeVerificationDigest(value: unknown, expectedSubject: SevereHostSubject): string {
+  return createHash("sha256").update(canonicalizeSevereVerificationReceipt(value, expectedSubject), "utf8").digest("hex");
+}
+export function idempotencyKey(value: unknown, expectedSubject: SevereHostSubject): string {
+  return "severe-verifier/v2:" + severeVerificationDigest(value, expectedSubject);
+}
+
+function validateEvidence(value: Record<string, unknown>, subject: SevereHostSubject, state: SevereState, reason: SevereFailureCode | undefined): string[] {
+  const errors: string[] = [];
+  if (!exact(value, ["schema", "files", "omissions", "complete"]) || value.schema !== SEVERE_EVIDENCE_SCHEMA || !Array.isArray(value.files) || !Array.isArray(value.omissions) || typeof value.complete !== "boolean") return ["evidence shape is invalid"];
+  const files: SevereEvidenceFile[] = [];
+  const seen = new Set<string>();
+  let totalBytes = 0;
+  for (const item of value.files) {
+    if (!direct(item) || !exact(item, ["path", "kind", "sha256", "bytes", "complete"], ["lineStart", "lineEnd"])) { errors.push("evidence file has unknown or missing keys"); continue; }
+    if (!path(item.path) || !string(item.kind) || (item.kind !== "whole_file" && item.kind !== "module") || !sha256(item.sha256) || !integer(item.bytes) || item.bytes < 1 || item.bytes > MAX_SEVERE_FILE_BYTES || typeof item.complete !== "boolean") { errors.push("evidence file is invalid"); continue; }
+    if (seen.has(item.path)) errors.push("duplicate or conflicting evidence path");
+    seen.add(item.path); totalBytes += item.bytes;
+    if (item.kind === "module") {
+      if (!integer(item.lineStart) || !integer(item.lineEnd) || item.lineStart < 1 || item.lineEnd < item.lineStart || item.lineEnd > 1_000_000_000) errors.push("module line range is invalid");
+      else if (item.path === subject.path && (subject.line < item.lineStart || subject.line > item.lineEnd)) errors.push("module evidence does not contain finding line");
+    } else if (Object.hasOwn(item, "lineStart") || Object.hasOwn(item, "lineEnd")) errors.push("whole-file evidence cannot have a module range");
+    if ((state === "confirmed" || state === "refuted") && item.complete !== true) errors.push("completed receipt has incomplete evidence");
+    files.push(item as unknown as SevereEvidenceFile);
+  }
+  const omissions: SevereEvidenceOmission[] = [];
+  for (const item of value.omissions) {
+    if (!direct(item) || !exact(item, ["path", "code"]) || !path(item.path) || !string(item.code) || !CODES.has(item.code as SevereFailureCode)) { errors.push("evidence omission is invalid"); continue; }
+    if (seen.has(item.path)) errors.push("file and omission evidence overlap");
+    seen.add(item.path); omissions.push(item as unknown as SevereEvidenceOmission);
+    if (!omissionAllowed(state, item.code as SevereFailureCode, reason)) errors.push("omission code is incompatible with receipt state");
+  }
+  if (files.length + omissions.length === 0 || files.length + omissions.length > MAX_SEVERE_ENTRIES) errors.push("evidence entry count is invalid");
+  if (totalBytes > MAX_SEVERE_TOTAL_BYTES) errors.push("evidence byte cap exceeded");
+  if (!seen.has(subject.path)) errors.push("evidence does not cover host finding path");
+  const complete = files.length > 0 && omissions.length === 0 && files.every((item) => item.complete);
+  if (value.complete !== complete) errors.push("evidence completeness is contradictory");
+  if (state === "confirmed" || state === "refuted") { if (!complete) errors.push("completed state requires complete evidence"); }
+  else if (complete) errors.push("failure state requires incomplete or omitted evidence");
+  return errors;
+}
+
+function stateReason(state: SevereState, reason: SevereFailureCode | undefined): boolean {
+  if (state === "confirmed") return reason === undefined;
+  if (state === "refuted") return reason === undefined || reason === "refuted";
+  const allowed: Record<string, SevereFailureCode[]> = { failed: ["provider_unavailable", "receipt_invalid"], malformed: ["malformed", "schema_invalid", "receipt_invalid"], timeout: ["timeout"], unavailable: ["unavailable", "provider_unavailable"], stale_head: ["stale_head", "identity_mismatch"], incomplete: ["incomplete", "not_read", "evidence_incomplete", "cap_exceeded"] };
+  return reason !== undefined && (allowed[state]?.includes(reason) ?? false);
+}
+function omissionAllowed(state: SevereState, code: SevereFailureCode, reason: SevereFailureCode | undefined): boolean {
+  return (state === "confirmed" || state === "refuted") ? false : stateReason(state, code) && (reason === undefined || reason === code);
+}
+function sameSubject(a: SevereHostSubject, b: SevereHostSubject): boolean { return SUBJECT_KEYS.every((key) => a[key as keyof SevereHostSubject] === b[key as keyof SevereHostSubject]); }
+function repo(value: unknown): value is string { if (!string(value) || !unicode(value)) return false; const parts = value.split("/"); return parts.length === 2 && parts.every((part) => /^[a-z0-9][a-z0-9._-]{0,99}$/.test(part) && part !== "." && part !== ".." && byteLength(part) <= 100); }
+function path(value: unknown): value is string { if (!string(value) || !unicode(value) || value.length === 0 || value.length > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n\u0000-\u001f\u007f]/.test(value)) return false; return value.split("/").every((part) => part !== "." && part !== ".." && part.length > 0 && byteLength(part) <= 255); }
+function unicode(value: string): boolean { for (let i = 0; i < value.length; i += 1) { const code = value.charCodeAt(i); if (code >= 0xd800 && code <= 0xdbff) { const next = value.charCodeAt(i + 1); if (next < 0xdc00 || next > 0xdfff) return false; i += 1; } else if (code >= 0xdc00 && code <= 0xdfff) return false; } return value.normalize("NFC") === value; }
+function sha1(value: unknown): value is string { return string(value) && SHA1.test(value); }
+function sha256(value: unknown): value is string { return string(value) && SHA256.test(value); }
+function fingerprint(value: unknown): value is string { return string(value) && /^finding:[a-f0-9]{64}$/.test(value); }
+function integer(value: unknown): value is number { return typeof value === "number" && Number.isSafeInteger(value); }
+function number(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value); }
+function string(value: unknown): value is string { return typeof value === "string"; }
+function byteLength(value: string): number { return Buffer.byteLength(value, "utf8"); }
+function direct(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype; }
+function exact(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean { const keys = Reflect.ownKeys(value); const allowed = new Set([...required, ...optional]); return required.every((key) => Object.hasOwn(value, key) && value[key] !== undefined) && keys.every((key) => typeof key === "string" && allowed.has(key)); }
+function canonical(value: unknown): string { if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]"; if (value && typeof value === "object") { const entries = Object.entries(value).filter(([, item]) => item !== undefined).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0); return "{" + entries.map(([key, item]) => JSON.stringify(key) + ":" + canonical(item)).join(",") + "}"; } return JSON.stringify(value); }

--- a/src/severe-verification-contract.ts
+++ b/src/severe-verification-contract.ts
@@ -115,6 +115,7 @@ export function idempotencyKey(value: unknown, expectedSubject: SevereHostSubjec
 function validateEvidence(value: Record<string, unknown>, subject: SevereHostSubject, state: SevereState, reason: SevereFailureCode | undefined): string[] {
   const errors: string[] = [];
   if (!exact(value, ["schema", "files", "omissions", "complete"]) || value.schema !== SEVERE_EVIDENCE_SCHEMA || !Array.isArray(value.files) || !Array.isArray(value.omissions) || typeof value.complete !== "boolean") return ["evidence shape is invalid"];
+  if (value.files.length > MAX_SEVERE_ENTRIES || value.omissions.length > MAX_SEVERE_ENTRIES || value.files.length + value.omissions.length > MAX_SEVERE_ENTRIES) return ["evidence entry count is invalid"];
   const files: SevereEvidenceFile[] = [];
   const seen = new Set<string>();
   let totalBytes = 0;
@@ -158,7 +159,7 @@ function omissionAllowed(state: SevereState, code: SevereFailureCode, reason: Se
 }
 function sameSubject(a: SevereHostSubject, b: SevereHostSubject): boolean { return SUBJECT_KEYS.every((key) => a[key as keyof SevereHostSubject] === b[key as keyof SevereHostSubject]); }
 function repo(value: unknown): value is string { if (!string(value) || !unicode(value)) return false; const parts = value.split("/"); return parts.length === 2 && parts.every((part) => /^[a-z0-9][a-z0-9._-]{0,99}$/.test(part) && part !== "." && part !== ".." && byteLength(part) <= 100); }
-function path(value: unknown): value is string { if (!string(value) || !unicode(value) || value.length === 0 || value.length > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n\u0000-\u001f\u007f]/.test(value)) return false; return value.split("/").every((part) => part !== "." && part !== ".." && part.length > 0 && byteLength(part) <= 255); }
+function path(value: unknown): value is string { if (!string(value) || !unicode(value) || value.length === 0 || byteLength(value) > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n\u0000-\u001f\u007f\u2028\u2029]/.test(value)) return false; return value.split("/").every((part) => part !== "." && part !== ".." && part.length > 0 && byteLength(part) <= 255); }
 function unicode(value: string): boolean { for (let i = 0; i < value.length; i += 1) { const code = value.charCodeAt(i); if (code >= 0xd800 && code <= 0xdbff) { const next = value.charCodeAt(i + 1); if (next < 0xdc00 || next > 0xdfff) return false; i += 1; } else if (code >= 0xdc00 && code <= 0xdfff) return false; } return value.normalize("NFC") === value; }
 function sha1(value: unknown): value is string { return string(value) && SHA1.test(value); }
 function sha256(value: unknown): value is string { return string(value) && SHA256.test(value); }

--- a/src/severe-verification-contract.ts
+++ b/src/severe-verification-contract.ts
@@ -167,6 +167,9 @@ function integer(value: unknown): value is number { return typeof value === "num
 function number(value: unknown): value is number { return typeof value === "number" && Number.isFinite(value); }
 function string(value: unknown): value is string { return typeof value === "string"; }
 function byteLength(value: string): number { return Buffer.byteLength(value, "utf8"); }
-function direct(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype; }
+function direct(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
+  return Reflect.ownKeys(value).every((key) => typeof key === "string" && Object.getOwnPropertyDescriptor(value, key)?.enumerable === true && Object.hasOwn(Object.getOwnPropertyDescriptor(value, key)!, "value"));
+}
 function exact(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean { const keys = Reflect.ownKeys(value); const allowed = new Set([...required, ...optional]); return required.every((key) => Object.hasOwn(value, key) && value[key] !== undefined) && keys.every((key) => typeof key === "string" && allowed.has(key)); }
-function canonical(value: unknown): string { if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]"; if (value && typeof value === "object") { const entries = Object.entries(value).filter(([, item]) => item !== undefined).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0); return "{" + entries.map(([key, item]) => JSON.stringify(key) + ":" + canonical(item)).join(",") + "}"; } return JSON.stringify(value); }
+function canonical(value: unknown): string { if (Array.isArray(value)) return "[" + value.map(canonical).sort().join(",") + "]"; if (value && typeof value === "object") { const entries = Object.entries(value).filter(([, item]) => item !== undefined).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0); return "{" + entries.map(([key, item]) => JSON.stringify(key) + ":" + canonical(item)).join(",") + "}"; } return JSON.stringify(value); }

--- a/src/severe-verification-contract.ts
+++ b/src/severe-verification-contract.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { isProxy } from "node:util/types";
 
 export const SEVERE_EVIDENCE_SCHEMA = "severe-evidence/v2" as const;
 export const SEVERE_RECEIPT_SCHEMA = "severe-verifier-receipt/v2" as const;
@@ -114,12 +115,13 @@ export function idempotencyKey(value: unknown, expectedSubject: SevereHostSubjec
 
 function validateEvidence(value: Record<string, unknown>, subject: SevereHostSubject, state: SevereState, reason: SevereFailureCode | undefined): string[] {
   const errors: string[] = [];
-  if (!exact(value, ["schema", "files", "omissions", "complete"]) || value.schema !== SEVERE_EVIDENCE_SCHEMA || !Array.isArray(value.files) || !Array.isArray(value.omissions) || typeof value.complete !== "boolean") return ["evidence shape is invalid"];
-  if (value.files.length > MAX_SEVERE_ENTRIES || value.omissions.length > MAX_SEVERE_ENTRIES || value.files.length + value.omissions.length > MAX_SEVERE_ENTRIES) return ["evidence entry count is invalid"];
+  const fileItems = entries(value.files), omissionItems = entries(value.omissions);
+  if (!exact(value, ["schema", "files", "omissions", "complete"]) || value.schema !== SEVERE_EVIDENCE_SCHEMA || !fileItems || !omissionItems || typeof value.complete !== "boolean") return ["evidence shape is invalid"];
+  if (fileItems.length > MAX_SEVERE_ENTRIES || omissionItems.length > MAX_SEVERE_ENTRIES || fileItems.length + omissionItems.length > MAX_SEVERE_ENTRIES) return ["evidence entry count is invalid"];
   const files: SevereEvidenceFile[] = [];
   const seen = new Set<string>();
   let totalBytes = 0;
-  for (const item of value.files) {
+  for (const item of fileItems) {
     if (!direct(item) || !exact(item, ["path", "kind", "sha256", "bytes", "complete"], ["lineStart", "lineEnd"])) { errors.push("evidence file has unknown or missing keys"); continue; }
     if (!path(item.path) || !string(item.kind) || (item.kind !== "whole_file" && item.kind !== "module") || !sha256(item.sha256) || !integer(item.bytes) || item.bytes < 1 || item.bytes > MAX_SEVERE_FILE_BYTES || typeof item.complete !== "boolean") { errors.push("evidence file is invalid"); continue; }
     if (seen.has(item.path)) errors.push("duplicate or conflicting evidence path");
@@ -132,7 +134,7 @@ function validateEvidence(value: Record<string, unknown>, subject: SevereHostSub
     files.push(item as unknown as SevereEvidenceFile);
   }
   const omissions: SevereEvidenceOmission[] = [];
-  for (const item of value.omissions) {
+  for (const item of omissionItems) {
     if (!direct(item) || !exact(item, ["path", "code"]) || !path(item.path) || !string(item.code) || !CODES.has(item.code as SevereFailureCode)) { errors.push("evidence omission is invalid"); continue; }
     if (seen.has(item.path)) errors.push("file and omission evidence overlap");
     seen.add(item.path); omissions.push(item as unknown as SevereEvidenceOmission);
@@ -159,7 +161,7 @@ function omissionAllowed(state: SevereState, code: SevereFailureCode, reason: Se
 }
 function sameSubject(a: SevereHostSubject, b: SevereHostSubject): boolean { return SUBJECT_KEYS.every((key) => a[key as keyof SevereHostSubject] === b[key as keyof SevereHostSubject]); }
 function repo(value: unknown): value is string { if (!string(value) || !unicode(value)) return false; const parts = value.split("/"); return parts.length === 2 && parts.every((part) => /^[a-z0-9][a-z0-9._-]{0,99}$/.test(part) && part !== "." && part !== ".." && byteLength(part) <= 100); }
-function path(value: unknown): value is string { if (!string(value) || !unicode(value) || value.length === 0 || byteLength(value) > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n\u0000-\u001f\u007f\u2028\u2029]/.test(value)) return false; return value.split("/").every((part) => part !== "." && part !== ".." && part.length > 0 && byteLength(part) <= 255); }
+function path(value: unknown): value is string { if (!string(value) || value.length === 0 || value.length > 4096 || !unicode(value) || byteLength(value) > 4096 || value.startsWith("/") || /^[A-Za-z]:/.test(value) || /[\\\0\r\n\u0000-\u001f\u007f\u0085\u2028\u2029]/.test(value)) return false; return value.split("/").every((part) => part !== "." && part !== ".." && part.length > 0 && byteLength(part) <= 255); }
 function unicode(value: string): boolean { for (let i = 0; i < value.length; i += 1) { const code = value.charCodeAt(i); if (code >= 0xd800 && code <= 0xdbff) { const next = value.charCodeAt(i + 1); if (next < 0xdc00 || next > 0xdfff) return false; i += 1; } else if (code >= 0xdc00 && code <= 0xdfff) return false; } return value.normalize("NFC") === value; }
 function sha1(value: unknown): value is string { return string(value) && SHA1.test(value); }
 function sha256(value: unknown): value is string { return string(value) && SHA256.test(value); }
@@ -169,8 +171,9 @@ function number(value: unknown): value is number { return typeof value === "numb
 function string(value: unknown): value is string { return typeof value === "string"; }
 function byteLength(value: string): number { return Buffer.byteLength(value, "utf8"); }
 function direct(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
+  if (typeof value !== "object" || value === null || isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
   return Reflect.ownKeys(value).every((key) => typeof key === "string" && Object.getOwnPropertyDescriptor(value, key)?.enumerable === true && Object.hasOwn(Object.getOwnPropertyDescriptor(value, key)!, "value"));
 }
 function exact(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean { const keys = Reflect.ownKeys(value); const allowed = new Set([...required, ...optional]); return required.every((key) => Object.hasOwn(value, key) && value[key] !== undefined) && keys.every((key) => typeof key === "string" && allowed.has(key)); }
-function canonical(value: unknown): string { if (Array.isArray(value)) return "[" + value.map(canonical).sort().join(",") + "]"; if (value && typeof value === "object") { const entries = Object.entries(value).filter(([, item]) => item !== undefined).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0); return "{" + entries.map(([key, item]) => JSON.stringify(key) + ":" + canonical(item)).join(",") + "}"; } return JSON.stringify(value); }
+function entries(value: unknown): unknown[] | undefined { if (!Array.isArray(value) || isProxy(value) || value.length > MAX_SEVERE_ENTRIES) return; const keys = Reflect.ownKeys(value); if (keys.length !== value.length + 1 || !keys.includes("length")) return; for (let i = 0; i < value.length; i += 1) { const descriptor = Object.getOwnPropertyDescriptor(value, String(i)); if (!descriptor || !descriptor.enumerable || !Object.hasOwn(descriptor, "value")) return; } return Array.from({ length: value.length }, (_, i) => Object.getOwnPropertyDescriptor(value, String(i))!.value); }
+function canonical(value: unknown): string { if (Array.isArray(value)) { const items = entries(value); if (!items) throw new Error("severe canonical array invalid"); return "[" + items.map(canonical).sort().join(",") + "]"; } if (value && typeof value === "object") { const object = value as Record<string, unknown>; const entries = Object.entries(object).filter(([, item]) => item !== undefined).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0); return "{" + entries.map(([key, item]) => JSON.stringify(key) + ":" + canonical(item)).join(",") + "}"; } return JSON.stringify(value); }

--- a/tests/severe-verification-contract.test.ts
+++ b/tests/severe-verification-contract.test.ts
@@ -153,7 +153,7 @@ describe("severe verifier v2 contract", () => {
   });
 
   it("rejects Unicode line separators and paths over the UTF-8 byte cap", () => {
-    for (const separator of ["\u2028", "\u2029"]) {
+    for (const separator of ["\u0085", "\u2028", "\u2029"]) {
       const badPath = "src/" + separator + "record.ts";
       const badSubject = { ...subject, path: badPath };
       expect(isSevereVerificationReceipt(receipt({ subject: badSubject, evidence: evidence({ files: [file({ path: badPath })] }) }), badSubject)).toBe(false);
@@ -169,6 +169,33 @@ describe("severe verifier v2 contract", () => {
     const files = new Array(65) as Array<unknown>;
     Object.defineProperty(files, 0, { enumerable: true, get: () => { throw new Error("entry traversed"); } });
     expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files }) }), subject)).toBe(false);
+  });
+
+  it("rejects hostile array own keys and revoked or mutable proxies without throwing", () => {
+    const hiddenDuplicate = [file(), file({ sha256: "0".repeat(64) })];
+    Object.defineProperty(hiddenDuplicate, Symbol.iterator, { value: function* () { yield hiddenDuplicate[0]; } });
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: hiddenDuplicate }) }), subject)).toBe(false);
+
+    const overriddenMap = [file()];
+    Object.defineProperty(overriddenMap, "map", { value: () => [] });
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: overriddenMap }) }), subject)).toBe(false);
+
+    const sparse = new Array(1);
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: sparse }) }), subject)).toBe(false);
+    const accessor = [file()];
+    Object.defineProperty(accessor, "0", { enumerable: true, get: () => file() });
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: accessor }) }), subject)).toBe(false);
+
+    const revoked = Proxy.revocable(receipt(), {});
+    revoked.revoke();
+    expect(() => isSevereVerificationReceipt(revoked.proxy, subject)).not.toThrow();
+    expect(isSevereVerificationReceipt(revoked.proxy, subject)).toBe(false);
+
+    const mutable = new Proxy(receipt(), { get: (target, key, receiver) => {
+      if (key === "state") target.state = "refuted";
+      return Reflect.get(target, key, receiver);
+    } });
+    expect(isSevereVerificationReceipt(mutable, subject)).toBe(false);
   });
 
   it("binds the original finding fingerprint and every host coordinate", () => {

--- a/tests/severe-verification-contract.test.ts
+++ b/tests/severe-verification-contract.test.ts
@@ -118,6 +118,40 @@ describe("severe verifier v2 contract", () => {
     expect(severeVerificationDigest(receipt({ confidence: 0.8 }), subject)).not.toBe(severeVerificationDigest(a, subject));
   });
 
+  it("is order-independent for the validated evidence set", () => {
+    const other = file({ path: "src/other.ts", sha256: "1".repeat(64), lineStart: 1, lineEnd: 20 });
+    const omitted = { path: "src/omitted.ts", code: "incomplete" };
+    const omittedAgain = { path: "src/omitted-again.ts", code: "incomplete" };
+    const a = receipt({
+      state: "incomplete",
+      disposition: "suppress",
+      reasonCode: "incomplete",
+      evidence: evidence({ files: [file({ complete: false }), other], omissions: [omitted, omittedAgain], complete: false })
+    });
+    const b = receipt({
+      state: "incomplete",
+      disposition: "suppress",
+      reasonCode: "incomplete",
+      evidence: evidence({ files: [other, file({ complete: false })], omissions: [omittedAgain, omitted], complete: false })
+    });
+    expect(severeVerificationDigest(a, subject)).toBe(severeVerificationDigest(b, subject));
+    expect(idempotencyKey(a, subject)).toBe(idempotencyKey(b, subject));
+  });
+
+  it("rejects non-enumerable and accessor fields before canonicalization", () => {
+    const hidden = { ...subject } as Record<string, unknown>;
+    Object.defineProperty(hidden, "lineSha256", { value: subject.lineSha256, enumerable: false });
+    expect(isSevereVerificationReceipt(receipt({ subject: hidden }), subject)).toBe(false);
+
+    const accessor = { ...subject } as Record<string, unknown>;
+    Object.defineProperty(accessor, "repo", { enumerable: true, get: () => subject.repo });
+    expect(isSevereVerificationReceipt(receipt({ subject: accessor }), subject)).toBe(false);
+
+    const hiddenConfidence = receipt();
+    Object.defineProperty(hiddenConfidence, "confidence", { value: 0.9, enumerable: false });
+    expect(isSevereVerificationReceipt(hiddenConfidence, subject)).toBe(false);
+  });
+
   it("binds the original finding fingerprint and every host coordinate", () => {
     for (const key of ["repo", "pull", "base", "head", "fingerprint", "path", "line", "side", "lineSha256", "hunkSha256"] as const) {
       const altered = { ...subject, [key]: key === "pull" || key === "line" ? (subject[key] as number) + 1 : `${subject[key]}x` } as SevereHostSubject;

--- a/tests/severe-verification-contract.test.ts
+++ b/tests/severe-verification-contract.test.ts
@@ -152,6 +152,25 @@ describe("severe verifier v2 contract", () => {
     expect(isSevereVerificationReceipt(hiddenConfidence, subject)).toBe(false);
   });
 
+  it("rejects Unicode line separators and paths over the UTF-8 byte cap", () => {
+    for (const separator of ["\u2028", "\u2029"]) {
+      const badPath = "src/" + separator + "record.ts";
+      const badSubject = { ...subject, path: badPath };
+      expect(isSevereVerificationReceipt(receipt({ subject: badSubject, evidence: evidence({ files: [file({ path: badPath })] }) }), badSubject)).toBe(false);
+    }
+    const oversizedPath = Array.from({ length: 17 }, () => "é".repeat(127)).join("/");
+    expect(oversizedPath.length).toBeLessThan(4096);
+    expect(Buffer.byteLength(oversizedPath, "utf8")).toBeGreaterThan(4096);
+    const badSubject = { ...subject, path: oversizedPath };
+    expect(isSevereVerificationReceipt(receipt({ subject: badSubject, evidence: evidence({ files: [file({ path: oversizedPath })] }) }), badSubject)).toBe(false);
+  });
+
+  it("rejects oversized evidence arrays before traversing their entries", () => {
+    const files = new Array(65) as Array<unknown>;
+    Object.defineProperty(files, 0, { enumerable: true, get: () => { throw new Error("entry traversed"); } });
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files }) }), subject)).toBe(false);
+  });
+
   it("binds the original finding fingerprint and every host coordinate", () => {
     for (const key of ["repo", "pull", "base", "head", "fingerprint", "path", "line", "side", "lineSha256", "hunkSha256"] as const) {
       const altered = { ...subject, [key]: key === "pull" || key === "line" ? (subject[key] as number) + 1 : `${subject[key]}x` } as SevereHostSubject;

--- a/tests/severe-verification-contract.test.ts
+++ b/tests/severe-verification-contract.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeSevereVerificationReceipt,
+  idempotencyKey,
+  isSevereVerificationReceipt,
+  parseSevereVerificationReceipt,
+  severeVerificationDigest,
+  type SevereHostSubject
+} from "../src/severe-verification-contract.js";
+
+const subject: SevereHostSubject = {
+  repo: "owner/repo",
+  pull: 7,
+  base: "b".repeat(40),
+  head: "a".repeat(40),
+  fingerprint: `finding:${"f".repeat(64)}`,
+  path: "src/Δ file.ts",
+  line: 12,
+  side: "RIGHT",
+  lineSha256: "d".repeat(64),
+  hunkSha256: "e".repeat(64)
+};
+
+const file = (overrides: Record<string, unknown> = {}) => ({
+  path: subject.path,
+  kind: "module",
+  sha256: "c".repeat(64),
+  bytes: 42,
+  complete: true,
+  lineStart: 10,
+  lineEnd: 14,
+  ...overrides
+});
+
+const evidence = (overrides: Record<string, unknown> = {}) => ({
+  schema: "severe-evidence/v2",
+  files: [file()],
+  omissions: [],
+  complete: true,
+  ...overrides
+});
+
+const receipt = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  schema: "severe-verifier-receipt/v2",
+  subject,
+  state: "confirmed",
+  disposition: "retain",
+  confidence: 0.9,
+  evidence: evidence(),
+  ...overrides
+});
+
+describe("severe verifier v2 contract", () => {
+  it("accepts a completed host-bound module receipt", () => {
+    const parsed = parseSevereVerificationReceipt(receipt(), subject);
+    expect(parsed.subject).toEqual(subject);
+    expect(parsed.evidence.complete).toBe(true);
+  });
+
+  it("rejects spoofing, coercion, arrays, unknown keys, and invalid canonical identity", () => {
+    expect(isSevereVerificationReceipt(receipt({ subject: { ...subject, fingerprint: `finding:${"0".repeat(64)}` } }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ subject: { ...subject, pull: "7" } }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt([] as unknown, subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ extra: true }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ subject: new String("spoof") }), subject)).toBe(false);
+    for (const badPath of ["../x.ts", "src/./x.ts", "/tmp/x.ts", "C:/x.ts", "src\\x.ts", "src/\0x.ts", "src/\nx.ts", `src/${"é".repeat(130)}.ts`, "src/\ud800.ts", "src/e\u0301.ts"]) {
+      expect(isSevereVerificationReceipt(receipt({ subject: { ...subject, path: badPath }, evidence: evidence({ files: [file({ path: badPath })] }) }), { ...subject, path: badPath })).toBe(false);
+    }
+    for (const badRepo of ["../repo", "owner/../repo", "Owner/repo", "own er/repo", "owner\\repo", "é/repo", "owner/"]) {
+      expect(isSevereVerificationReceipt(receipt({ subject: { ...subject, repo: badRepo } }), { ...subject, repo: badRepo })).toBe(false);
+    }
+  });
+
+  it("rejects duplicate/conflicting paths and file/omission overlap", () => {
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: [file(), file({ sha256: "0".repeat(64) })] }) }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", reasonCode: "incomplete", evidence: evidence({ files: [file({ complete: false })], omissions: [{ path: subject.path, code: "incomplete" }], complete: false }) }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "suppress", reasonCode: "incomplete", evidence: evidence({ files: [], omissions: [{ path: subject.path, code: "incomplete" }, { path: subject.path, code: "not_read" }], complete: false }) }), subject)).toBe(false);
+  });
+
+  it("rejects zero-byte, incomplete, oversized, out-of-range, and non-covering modules", () => {
+    for (const bad of [
+      { bytes: 0 },
+      { bytes: 64 * 1024 + 1 },
+      { complete: false },
+      { lineStart: 13, lineEnd: 11 },
+      { lineStart: 13, lineEnd: 20 },
+      { lineStart: 1, lineEnd: 11 }
+    ]) {
+      expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: [file(bad)] }) }), subject)).toBe(false);
+    }
+    expect(isSevereVerificationReceipt(receipt({ evidence: evidence({ files: [file({ kind: "whole_file", lineStart: 10, lineEnd: 14 })] }) }), subject)).toBe(false);
+  });
+
+  it("requires explicit state, disposition, reason, and omission compatibility", () => {
+    const failures: Array<[string, string, string]> = [
+      ["failed", "provider_unavailable", "provider_unavailable"],
+      ["malformed", "schema_invalid", "schema_invalid"],
+      ["timeout", "timeout", "timeout"],
+      ["unavailable", "unavailable", "unavailable"],
+      ["stale_head", "identity_mismatch", "identity_mismatch"],
+      ["incomplete", "cap_exceeded", "cap_exceeded"]
+    ];
+    for (const [state, reasonCode, omissionCode] of failures) {
+      const value = receipt({ state, disposition: "suppress", reasonCode, evidence: evidence({ files: [], omissions: [{ path: subject.path, code: omissionCode }], complete: false }) });
+      expect(parseSevereVerificationReceipt(value, subject).state).toBe(state);
+    }
+    expect(isSevereVerificationReceipt(receipt({ state: "confirmed", disposition: "suppress" }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "failed", disposition: "suppress", reasonCode: "timeout", evidence: evidence({ files: [], omissions: [{ path: subject.path, code: "timeout" }], complete: false }) }), subject)).toBe(false);
+    expect(isSevereVerificationReceipt(receipt({ state: "incomplete", disposition: "retain", reasonCode: "incomplete", evidence: evidence({ files: [], omissions: [{ path: subject.path, code: "incomplete" }], complete: false }) }), subject)).toBe(false);
+  });
+
+  it("uses a stable canonical digest and idempotency key", () => {
+    const a = receipt();
+    const b = { evidence: a.evidence, confidence: a.confidence, disposition: a.disposition, state: a.state, subject: a.subject, schema: a.schema };
+    expect(canonicalizeSevereVerificationReceipt(a, subject)).toBe(canonicalizeSevereVerificationReceipt(b, subject));
+    expect(severeVerificationDigest(a, subject)).toBe(severeVerificationDigest(b, subject));
+    expect(idempotencyKey(a, subject)).toBe(idempotencyKey(b, subject));
+    expect(severeVerificationDigest(receipt({ confidence: 0.8 }), subject)).not.toBe(severeVerificationDigest(a, subject));
+  });
+
+  it("binds the original finding fingerprint and every host coordinate", () => {
+    for (const key of ["repo", "pull", "base", "head", "fingerprint", "path", "line", "side", "lineSha256", "hunkSha256"] as const) {
+      const altered = { ...subject, [key]: key === "pull" || key === "line" ? (subject[key] as number) + 1 : `${subject[key]}x` } as SevereHostSubject;
+      expect(isSevereVerificationReceipt(receipt({ subject: altered }), subject)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a fresh host-bound `severe-verifier-receipt/v2` and `severe-evidence/v2` contract
- enforce exact direct-object parsing, canonical repo/path/SHA/fingerprint/Unicode identity, strict module ranges, and contradiction checks
- expose deterministic canonical JSON, SHA-256 digest, and idempotency helpers

Related: #807

## Validation

- `/Users/m1/.local/bin/bun test /Users/m1/repos/worktrees/neondiff-severe-v2-contract/tests/severe-verification-contract.test.ts` — 7 pass / 57 assertions
- direct TypeScript compilation of `src/severe-verification-contract.ts` — pass
- `git diff --check` — pass
- source-only production delta: 172 lines; zero production call sites

## Safety boundary

This PR does not wire providers, file readers, transport, worker publication, databases, config, runtime, release, or customer actions. It does not prove integration, release, runtime, or customer readiness. GitNexus detect_changes was run against the registered alias; its index is stale and points at the separate clone, so direct staged diff and call-site checks are authoritative.