### PR TITLE
fix(issue-enrichment): preserve bounded comment completeness

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1444,6 +1444,7 @@ async function main(): Promise<void> {
         listIssueLabelEvents: (requestedRepo, issueNumber) => github.listIssueLabelEvents(requestedRepo, issueNumber),
         getCollaboratorPermission: (requestedRepo, login) => github.getCollaboratorPermission(requestedRepo, login),
         listIssueComments: (requestedRepo, issueNumber) => github.listIssueComments(requestedRepo, issueNumber),
+        listIssueCommentsForEnrichment: (requestedRepo, issueNumber) => github.listIssueCommentsForEnrichment(requestedRepo, issueNumber),
         getIssueOrPull: (requestedRepo, issueNumber) =>
           github.getIssueOrPull(requestedRepo, issueNumber, { tolerateUnreadable: true }),
         canPostAsApp: () => github.canPostAsApp(),

--- a/src/github.ts
+++ b/src/github.ts
@@ -17,7 +17,43 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  * is found well within this window; exceeding it truncates rather than paging forever.
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
+const MAX_ISSUE_COMMENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
+export type BoundedGithubList<T> = T[] & {
+  items: T[];
+  rawCount: number;
+  truncated: boolean;
+  overflow: boolean;
+};
+
+function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
+  const result = items as BoundedGithubList<T>;
+  result.items = items.slice();
+  result.rawCount = items.length;
+  result.truncated = truncated;
+  result.overflow = truncated;
+  return result;
+}
+
+export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
+  items: T[];
+  rawCount: number;
+  truncated: boolean;
+  overflow: boolean;
+} {
+  const bounded = result as Partial<BoundedGithubList<T>>;
+  if (Array.isArray(bounded.items) && typeof bounded.truncated === "boolean") {
+    return {
+      items: bounded.items,
+      rawCount: bounded.rawCount ?? bounded.items.length,
+      truncated: bounded.truncated,
+      overflow: bounded.overflow ?? bounded.truncated
+    };
+  }
+  return { items: result, rawCount: result.length, truncated: false, overflow: false };
+}
 
 export interface GitHubApiOptions {
   appId?: string;
@@ -255,16 +291,18 @@ export class GitHubApi {
     return chunk.map(normalizePullRequestSummary).filter((pull) => Boolean(pull.merged_at)).slice(0, limit);
   }
 
-  async listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]> {
+  async listIssueComments(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueCommentCommandSource>> {
     const comments: IssueCommentCommandSource[] = [];
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const chunk = await this.request<IssueCommentCommandSource[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token: await this.getReadToken(repo) }
       );
       comments.push(...chunk);
-      if (chunk.length < 100) return comments;
+      if (chunk.length < 100) return boundedGithubList(comments, false);
+      if (page === MAX_ISSUE_COMMENT_PAGES) return boundedGithubList(comments, true);
     }
+    return boundedGithubList(comments, true);
   }
 
   async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{

--- a/src/github.ts
+++ b/src/github.ts
@@ -291,7 +291,22 @@ export class GitHubApi {
     return chunk.map(normalizePullRequestSummary).filter((pull) => Boolean(pull.merged_at)).slice(0, limit);
   }
 
-  async listIssueComments(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueCommentCommandSource>> {
+  async listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]> {
+    const comments: IssueCommentCommandSource[] = [];
+    for (let page = 1; ; page += 1) {
+      const chunk = await this.request<IssueCommentCommandSource[]>(
+        `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+        { token: await this.getReadToken(repo) }
+      );
+      comments.push(...chunk);
+      if (chunk.length < 100) return comments;
+    }
+  }
+
+  async listIssueCommentsForEnrichment(
+    repo: string,
+    issueNumber: number
+  ): Promise<BoundedGithubList<IssueCommentCommandSource>> {
     const comments: IssueCommentCommandSource[] = [];
     for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const chunk = await this.request<IssueCommentCommandSource[]>(

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -275,6 +275,15 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
   }>;
 }
 
+type IssueEnrichmentComment = {
+  id: number;
+  html_url?: string | null;
+  body?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  user?: { login?: string | null } | null;
+};
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
   listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
@@ -284,21 +293,8 @@ export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentComme
     label?: { name?: string | null } | null;
   }>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
-  listIssueComments?(repo: string, issueNumber: number): Promise<Array<{
-    id: number;
-    html_url?: string | null;
-    body?: string | null;
-    created_at?: string | null;
-    updated_at?: string | null;
-    user?: { login?: string | null } | null;
-  }> | BoundedGithubList<{
-    id: number;
-    html_url?: string | null;
-    body?: string | null;
-    created_at?: string | null;
-    updated_at?: string | null;
-    user?: { login?: string | null } | null;
-  }>>;
+  listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
+  listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
   getIssueOrPull?(repo: string, issueNumber: number): Promise<GitHubRelatedIssueOrPull | undefined>;
 };
 
@@ -444,9 +440,11 @@ export async function buildIssueEvidenceContext(input: {
   defaultBranch: string;
   headSha: string;
 }): Promise<IssueAnalysisEvidenceContext> {
-  const commentResult = input.github.listIssueComments
-    ? await input.github.listIssueComments(input.repo, input.issue.number)
-    : [];
+  const commentResult = input.github.listIssueCommentsForEnrichment
+    ? await input.github.listIssueCommentsForEnrichment(input.repo, input.issue.number)
+    : input.github.listIssueComments
+      ? await input.github.listIssueComments(input.repo, input.issue.number)
+      : [];
   const { items: rawComments, rawCount: rawCommentCount, truncated: commentsTruncated } = unpackBoundedGithubList(commentResult);
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,6 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import { unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -290,6 +291,13 @@ export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentComme
     created_at?: string | null;
     updated_at?: string | null;
     user?: { login?: string | null } | null;
+  }> | BoundedGithubList<{
+    id: number;
+    html_url?: string | null;
+    body?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    user?: { login?: string | null } | null;
   }>>;
   getIssueOrPull?(repo: string, issueNumber: number): Promise<GitHubRelatedIssueOrPull | undefined>;
 };
@@ -429,16 +437,17 @@ function emptyIssueEvidenceContext(headSha: string): IssueAnalysisEvidenceContex
   };
 }
 
-async function buildIssueEvidenceContext(input: {
+export async function buildIssueEvidenceContext(input: {
   repo: string;
   issue: GitHubRelatedIssueOrPull;
   github: IssueEnrichmentCycleGithub;
   defaultBranch: string;
   headSha: string;
 }): Promise<IssueAnalysisEvidenceContext> {
-  const rawComments = input.github.listIssueComments
+  const commentResult = input.github.listIssueComments
     ? await input.github.listIssueComments(input.repo, input.issue.number)
     : [];
+  const { items: rawComments, rawCount: rawCommentCount, truncated: commentsTruncated } = unpackBoundedGithubList(commentResult);
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
@@ -480,7 +489,7 @@ async function buildIssueEvidenceContext(input: {
     })),
     linkedItems,
     truncation: {
-      comments: externalComments.length > 50,
+      comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
       timeline: rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -731,6 +731,26 @@ describe("GitHub App read authentication", () => {
     expect(pagesRequested).toEqual([1, 2, 3, 4, 5]);
     expect(comments).toHaveLength(500);
   });
+
+  it("listIssueComments returns raw-count metadata when its bounded read truncates", async () => {
+    const pagesRequested: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const match = /\/repos\/owner\/repo\/issues\/853\/comments\?per_page=100&page=(\d+)$/.exec(String(url));
+      if (match) {
+        pagesRequested.push(Number(match[1]));
+        return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: Number(match[1]) * 1000 + index })));
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueComments("owner/repo", 853);
+
+    expect(result).toHaveLength(500);
+    expect(result.items).toHaveLength(500);
+    expect(result.rawCount).toBe(500);
+    expect(result.truncated).toBe(true);
+    expect(pagesRequested).toEqual([1, 2, 3, 4, 5]);
+  });
 });
 
 function jsonResponse(body: unknown, status = 200, statusText = ""): Response {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -732,12 +732,19 @@ describe("GitHub App read authentication", () => {
     expect(comments).toHaveLength(500);
   });
 
-  it("listIssueComments returns raw-count metadata when its bounded read truncates", async () => {
+  it("listIssueComments keeps command reads complete beyond the evidence cap", async () => {
     const pagesRequested: number[] = [];
     globalThis.fetch = vi.fn(async (url) => {
       const match = /\/repos\/owner\/repo\/issues\/853\/comments\?per_page=100&page=(\d+)$/.exec(String(url));
       if (match) {
         pagesRequested.push(Number(match[1]));
+        if (Number(match[1]) === 6) {
+          return jsonResponse([{
+            id: 6001,
+            body: "@evaos-code-review-bot stop",
+            user: { login: "100yenadmin" }
+          }]);
+        }
         return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: Number(match[1]) * 1000 + index })));
       }
       return jsonResponse({ message: "unexpected" }, 404);
@@ -745,11 +752,27 @@ describe("GitHub App read authentication", () => {
 
     const result = await new GitHubApi({ token: "fixture" }).listIssueComments("owner/repo", 853);
 
+    expect(result).toHaveLength(501);
+    expect(result.find((comment) => comment.id === 6001)).toMatchObject({
+      body: "@evaos-code-review-bot stop"
+    });
+    expect(pagesRequested).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("listIssueCommentsForEnrichment returns raw-count metadata when its bounded read truncates", async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const match = /\/repos\/owner\/repo\/issues\/853\/comments\?per_page=100&page=(\d+)$/.exec(String(url));
+      if (match) return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: Number(match[1]) * 1000 + index })));
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueCommentsForEnrichment("owner/repo", 853);
+
     expect(result).toHaveLength(500);
     expect(result.items).toHaveLength(500);
     expect(result.rawCount).toBe(500);
     expect(result.truncated).toBe(true);
-    expect(pagesRequested).toEqual([1, 2, 3, 4, 5]);
+    expect(result.overflow).toBe(true);
   });
 });
 

--- a/tests/issue-enrichment-evidence.test.ts
+++ b/tests/issue-enrichment-evidence.test.ts
@@ -1,84 +1,31 @@
 import { describe, expect, it } from "vitest";
 import { ENRICHMENT_MARKER_PREFIX } from "../src/enrichment.js";
-import {
-  buildIssueEvidenceContext,
-  type IssueEnrichmentCycleGithub
-} from "../src/issue-enrichment.js";
+import { buildIssueEvidenceContext, type IssueEnrichmentCycleGithub } from "../src/issue-enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
 import type { BoundedGithubList } from "../src/github.js";
 
-const issue: GitHubRelatedIssueOrPull = {
-  number: 853,
-  title: "Preserve issue evidence completeness",
-  state: "open",
-  updated_at: "2026-08-23T00:00:00Z",
-  body: "Acceptance criteria are recorded."
-};
-
+const issue: GitHubRelatedIssueOrPull = { number: 853, title: "Preserve issue evidence completeness", state: "open", updated_at: "2026-08-23T00:00:00Z", body: "Acceptance criteria are recorded." };
 function comment(id: number, body: string) {
-  return {
-    id,
-    body,
-    html_url: `https://github.test/issues/853#issuecomment-${id}`,
-    user: { login: id === 1 ? "evaos-code-review-bot[bot]" : `author-${id}` }
-  };
+  return { id, body, html_url: `https://github.test/issues/853#issuecomment-${id}`, user: { login: id === 1 ? "evaos-code-review-bot[bot]" : `author-${id}` } };
 }
-
-function boundedComments(
-  comments: ReturnType<typeof comment>[],
-  rawCount: number,
-  truncated: boolean
-): BoundedGithubList<ReturnType<typeof comment>> {
-  return Object.assign(comments, {
-    items: comments.slice(),
-    rawCount,
-    truncated,
-    overflow: truncated
-  });
+function boundedComments(comments: ReturnType<typeof comment>[], rawCount: number, truncated: boolean): BoundedGithubList<ReturnType<typeof comment>> {
+  return Object.assign(comments, { items: comments.slice(), rawCount, truncated, overflow: truncated });
 }
-
 async function buildEvidence(comments: ReturnType<typeof boundedComments>) {
-  const github = {
-    listIssueComments: async () => comments
-  } as unknown as IssueEnrichmentCycleGithub;
-  return buildIssueEvidenceContext({
-    repo: "owner/issue-repo",
-    issue,
-    github,
-    defaultBranch: "main",
-    headSha: "a".repeat(40)
-  });
+  const github = { listIssueCommentsForEnrichment: async () => comments } as unknown as IssueEnrichmentCycleGithub;
+  return buildIssueEvidenceContext({ repo: "owner/issue-repo", issue, github, defaultBranch: "main", headSha: "a".repeat(40) });
 }
 
 describe("issue-enrichment evidence completeness", () => {
   it("preserves bounded-reader truncation after filtering enrichment comments", async () => {
-    const comments = boundedComments(
-      [
-        comment(1, `${ENRICHMENT_MARKER_PREFIX} generated comment`),
-        ...Array.from({ length: 49 }, (_unused, index) => comment(index + 2, `human comment ${index + 1}`))
-      ],
-      500,
-      true
-    );
-
+    const comments = boundedComments([comment(1, `${ENRICHMENT_MARKER_PREFIX} generated comment`), ...Array.from({ length: 49 }, (_unused, index) => comment(index + 2, `human comment ${index + 1}`))], 500, true);
     const evidence = await buildEvidence(comments);
-
     expect(evidence.comments).toHaveLength(49);
     expect(evidence.truncation.comments).toBe(true);
   });
-
   it("keeps a fully read bounded comment list complete when filtering stays below the cap", async () => {
-    const comments = boundedComments(
-      [
-        comment(1, `${ENRICHMENT_MARKER_PREFIX} generated comment`),
-        ...Array.from({ length: 49 }, (_unused, index) => comment(index + 2, `human comment ${index + 1}`))
-      ],
-      50,
-      false
-    );
-
+    const comments = boundedComments([comment(1, `${ENRICHMENT_MARKER_PREFIX} generated comment`), ...Array.from({ length: 49 }, (_unused, index) => comment(index + 2, `human comment ${index + 1}`))], 50, false);
     const evidence = await buildEvidence(comments);
-
     expect(evidence.comments).toHaveLength(49);
     expect(evidence.truncation.comments).toBe(false);
   });

--- a/tests/issue-enrichment-evidence.test.ts
+++ b/tests/issue-enrichment-evidence.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { ENRICHMENT_MARKER_PREFIX } from "../src/enrichment.js";
+import {
+  buildIssueEvidenceContext,
+  type IssueEnrichmentCycleGithub
+} from "../src/issue-enrichment.js";
+import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
+
+const issue: GitHubRelatedIssueOrPull = {
+  number: 853,
+  title: "Preserve issue evidence completeness",
+  state: "open",
+  updated_at: "2026-08-23T00:00:00Z",
+  body: "Acceptance criteria are recorded."
+};
+
+function comment(id: number, body: string) {
+  return {
+    id,
+    body,
+    html_url: `https://github.test/issues/853#issuecomment-${id}`,
+    user: { login: id === 1 ? "evaos-code-review-bot[bot]" : `author-${id}` }
+  };
+}
+
+function boundedComments(
+  comments: ReturnType<typeof comment>[],
+  rawCount: number,
+  truncated: boolean
+): BoundedGithubList<ReturnType<typeof comment>> {
+  return Object.assign(comments, {
+    items: comments.slice(),
+    rawCount,
+    truncated,
+    overflow: truncated
+  });
+}
+
+async function buildEvidence(comments: ReturnType<typeof boundedComments>) {
+  const github = {
+    listIssueComments: async () => comments
+  } as unknown as IssueEnrichmentCycleGithub;
+  return buildIssueEvidenceContext({
+    repo: "owner/issue-repo",
+    issue,
+    github,
+    defaultBranch: "main",
+    headSha: "a".repeat(40)
+  });
+}
+
+describe("issue-enrichment evidence completeness", () => {
+  it("preserves bounded-reader truncation after filtering enrichment comments", async () => {
+    const comments = boundedComments(
+      [
+        comment(1, `${ENRICHMENT_MARKER_PREFIX} generated comment`),
+        ...Array.from({ length: 49 }, (_unused, index) => comment(index + 2, `human comment ${index + 1}`))
+      ],
+      500,
+      true
+    );
+
+    const evidence = await buildEvidence(comments);
+
+    expect(evidence.comments).toHaveLength(49);
+    expect(evidence.truncation.comments).toBe(true);
+  });
+
+  it("keeps a fully read bounded comment list complete when filtering stays below the cap", async () => {
+    const comments = boundedComments(
+      [
+        comment(1, `${ENRICHMENT_MARKER_PREFIX} generated comment`),
+        ...Array.from({ length: 49 }, (_unused, index) => comment(index + 2, `human comment ${index + 1}`))
+      ],
+      50,
+      false
+    );
+
+    const evidence = await buildEvidence(comments);
+
+    expect(evidence.comments).toHaveLength(49);
+    expect(evidence.truncation.comments).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #853

## Summary
- preserve array-compatible raw-count/truncation metadata on bounded issue-comment reads
- carry that metadata into issue evidence so filtered bot comments cannot clear truncation
- add filtered-bounded and non-truncated regressions plus reader cap evidence

## Validation
- `git diff --check` passes
- Bun source and focused-test bundling passes
- direct Bun probes pass for filtered truncated evidence and the complete control
- `npm test -- --run tests/github-app-read.test.ts tests/issue-enrichment-evidence.test.ts` is blocked in this checkout because `vitest` is not installed
- `npm run build` is blocked in this checkout because `tsc` is not installed

## Scope boundary
No merge, release, deploy, live worker, queue, DB, config, provider, credential, customer, label, assignee, project, watermark, or posting behavior was touched.