### PR TITLE
fix(desktop): make BYO versus managed policy explicit

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -9,6 +9,13 @@ package struct DesktopProductionBoundary: Sendable {
     package let accountLinkBrokerOrigin: URL?
     package let accountConnectURL: URL?
 
+    package var distributionPolicy: DesktopDistributionPolicy {
+        DesktopDistributionPolicyBoundary.resolve(
+            byoEnabled: byoGitHubEnabled,
+            managedBrokerConfigured: managedGitHubBrokerOrigin != nil
+        )
+    }
+
     package static let quarantined = DesktopProductionBoundary(
         nativeActivationBrokerVerified: false,
         byoGitHubEnabled: false,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DistributionPolicy.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DistributionPolicy.swift
@@ -1,34 +1,20 @@
 import NeonDiffDesktopCore
 
-// Mac GA is BYO. Managed public-free remains milestone-20-owned.
-package enum DesktopDistributionPolicy: String, Equatable, Sendable {
-    case byo, managed, mixed, unavailable
-}
-
+package enum DesktopDistributionPolicy: String, Equatable, Sendable { case byo, managed, mixed, unavailable }
 package struct DesktopBYOActivationProof: Equatable, Sendable {
-    package let currentAccountBound: Bool
-    package let githubAppVerified: Bool
-    package let repositoryBound: Bool
-    package let apiEntitlementActive: Bool
+    package let currentAccountBound, githubAppVerified, repositoryBound, apiEntitlementActive: Bool
     package init(currentAccountBound: Bool, githubAppVerified: Bool, repositoryBound: Bool, apiEntitlementActive: Bool) {
-        self.currentAccountBound = currentAccountBound
-        self.githubAppVerified = githubAppVerified
-        self.repositoryBound = repositoryBound
-        self.apiEntitlementActive = apiEntitlementActive
+        self.currentAccountBound = currentAccountBound; self.githubAppVerified = githubAppVerified
+        self.repositoryBound = repositoryBound; self.apiEntitlementActive = apiEntitlementActive
     }
     package var isComplete: Bool { currentAccountBound && githubAppVerified && repositoryBound && apiEntitlementActive }
 }
-
 package enum DesktopDistributionBlockReason: Equatable, Sendable {
-    case distributionMarkerInvalid, visibilityUnavailable
-    case activeExactEntitlementRequired, managedPublicFreeUnavailable
+    case distributionMarkerInvalid, visibilityUnavailable, activeExactEntitlementRequired, managedPublicFreeUnavailable
 }
-
 package enum DesktopDistributionAccess: Equatable, Sendable {
-    case allowed
-    case blocked(reason: DesktopDistributionBlockReason)
+    case allowed, blocked(reason: DesktopDistributionBlockReason)
 }
-
 package enum DesktopDistributionPolicyBoundary {
     package static func resolve(byoEnabled: Bool, managedBrokerConfigured: Bool) -> DesktopDistributionPolicy {
         switch (byoEnabled, managedBrokerConfigured) {
@@ -38,17 +24,10 @@ package enum DesktopDistributionPolicyBoundary {
         case (false, false): .unavailable
         }
     }
-
     package static func evaluate(policy: DesktopDistributionPolicy, proof: DesktopBYOActivationProof) -> DesktopDistributionAccess {
-        guard policy == .byo else { return .blocked(reason: .distributionMarkerInvalid) }
-        return proof.isComplete ? .allowed : .blocked(reason: .activeExactEntitlementRequired)
+        guard policy == .byo else { return .blocked(reason: .distributionMarkerInvalid) }; return proof.isComplete ? .allowed : .blocked(reason: .activeExactEntitlementRequired)
     }
-
-    package static func migrateRestoredActivationState(_ state: ActivationState, policy: DesktopDistributionPolicy) -> ActivationState {
-        state == .publicFreeSkip && policy != .managed ? .purchaseRequired : state
-    }
-
-    // Visibility must be broker-authoritative; managed public-free is not in GA.
+    package static func migrateRestoredActivationState(_ state: ActivationState, policy: DesktopDistributionPolicy) -> ActivationState { state == .publicFreeSkip && policy != .managed ? .purchaseRequired : state }
     package static func evaluate(policy: DesktopDistributionPolicy, visibility: GitHubBrokerRepositoryVisibility?, proof: DesktopBYOActivationProof) -> DesktopDistributionAccess {
         guard let visibility, visibility != .unknown else { return .blocked(reason: .visibilityUnavailable) }
         switch policy {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DistributionPolicy.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DistributionPolicy.swift
@@ -44,6 +44,10 @@ package enum DesktopDistributionPolicyBoundary {
         return proof.isComplete ? .allowed : .blocked(reason: .activeExactEntitlementRequired)
     }
 
+    package static func migrateRestoredActivationState(_ state: ActivationState, policy: DesktopDistributionPolicy) -> ActivationState {
+        state == .publicFreeSkip && policy != .managed ? .purchaseRequired : state
+    }
+
     // Visibility must be broker-authoritative; managed public-free is not in GA.
     package static func evaluate(policy: DesktopDistributionPolicy, visibility: GitHubBrokerRepositoryVisibility?, proof: DesktopBYOActivationProof) -> DesktopDistributionAccess {
         guard let visibility, visibility != .unknown else { return .blocked(reason: .visibilityUnavailable) }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DistributionPolicy.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DistributionPolicy.swift
@@ -1,0 +1,57 @@
+import NeonDiffDesktopCore
+
+// Mac GA is BYO. Managed public-free remains milestone-20-owned.
+package enum DesktopDistributionPolicy: String, Equatable, Sendable {
+    case byo, managed, mixed, unavailable
+}
+
+package struct DesktopBYOActivationProof: Equatable, Sendable {
+    package let currentAccountBound: Bool
+    package let githubAppVerified: Bool
+    package let repositoryBound: Bool
+    package let apiEntitlementActive: Bool
+    package init(currentAccountBound: Bool, githubAppVerified: Bool, repositoryBound: Bool, apiEntitlementActive: Bool) {
+        self.currentAccountBound = currentAccountBound
+        self.githubAppVerified = githubAppVerified
+        self.repositoryBound = repositoryBound
+        self.apiEntitlementActive = apiEntitlementActive
+    }
+    package var isComplete: Bool { currentAccountBound && githubAppVerified && repositoryBound && apiEntitlementActive }
+}
+
+package enum DesktopDistributionBlockReason: Equatable, Sendable {
+    case distributionMarkerInvalid, visibilityUnavailable
+    case activeExactEntitlementRequired, managedPublicFreeUnavailable
+}
+
+package enum DesktopDistributionAccess: Equatable, Sendable {
+    case allowed
+    case blocked(reason: DesktopDistributionBlockReason)
+}
+
+package enum DesktopDistributionPolicyBoundary {
+    package static func resolve(byoEnabled: Bool, managedBrokerConfigured: Bool) -> DesktopDistributionPolicy {
+        switch (byoEnabled, managedBrokerConfigured) {
+        case (true, false): .byo
+        case (false, true): .managed
+        case (true, true): .mixed
+        case (false, false): .unavailable
+        }
+    }
+
+    package static func evaluate(policy: DesktopDistributionPolicy, proof: DesktopBYOActivationProof) -> DesktopDistributionAccess {
+        guard policy == .byo else { return .blocked(reason: .distributionMarkerInvalid) }
+        return proof.isComplete ? .allowed : .blocked(reason: .activeExactEntitlementRequired)
+    }
+
+    // Visibility must be broker-authoritative; managed public-free is not in GA.
+    package static func evaluate(policy: DesktopDistributionPolicy, visibility: GitHubBrokerRepositoryVisibility?, proof: DesktopBYOActivationProof) -> DesktopDistributionAccess {
+        guard let visibility, visibility != .unknown else { return .blocked(reason: .visibilityUnavailable) }
+        switch policy {
+        case .byo: return evaluate(policy: policy, proof: proof)
+        case .managed where visibility == .public: return .blocked(reason: .managedPublicFreeUnavailable)
+        case .managed: return proof.isComplete ? .allowed : .blocked(reason: .activeExactEntitlementRequired)
+        case .mixed, .unavailable: return .blocked(reason: .distributionMarkerInvalid)
+        }
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -383,6 +383,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
+            let byoProof = DesktopBYOActivationProof(
+                currentAccountBound: dependencies.productionBoundary.nativeActivationBrokerVerified,
+                githubAppVerified: byoGitHubCredentialsVerified,
+                repositoryBound: repositoryConfigurationReady && scopedReviewTargetReady,
+                apiEntitlementActive: currentRepositoryActivationReady
+            )
+            guard dependencies.productionBoundary.distributionPolicy == .byo,
+                  DesktopDistributionPolicyBoundary.evaluate(
+                      policy: .byo,
+                      proof: byoProof
+                  ) == .allowed
+            else {
+                return false
+            }
             if existingLocalBotReconciliationMode {
                 guard selectedAccountEntitlementSupportsCurrentPath else {
                     return false
@@ -4781,10 +4795,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.preferences.set(next.rawValue, forKey: activationStateKey)
     }
 
-    /// Enter the activation branch from the chosen onboarding path. The public
-    /// path skips straight to a free, license-free state.
+    /// Only the managed broker policy may enter the future public-free state.
     package func enterActivation(for mode: OnboardingMode) {
-        applyActivationEvent(mode == .publicReposOnly ? .choosePublicPath : .choosePrivatePath)
+        let publicFree = mode == .publicReposOnly
+            && dependencies.productionBoundary.distributionPolicy == .managed
+        applyActivationEvent(publicFree ? .choosePublicPath : .choosePrivatePath)
     }
 
     /// Align the activation entry state with the onboarding mode when the flow
@@ -4794,7 +4809,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func syncActivationEntryFromOnboardingMode() {
         switch activationState {
         case .purchaseRequired where onboardingFlow.mode == .publicReposOnly:
-            applyActivationEvent(.choosePublicPath)
+            enterActivation(for: .publicReposOnly)
         case .publicFreeSkip where onboardingFlow.mode == .privateRepos:
             applyActivationEvent(.choosePrivatePath)
         default:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -152,6 +152,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var pendingBYOGitHubAppPrivateKey = ""
     @Published package private(set) var byoGitHubPrivateKeyStored = false
     @Published package private(set) var byoGitHubCredentialsVerified = false
+    @Published package private(set) var byoGitHubRepositoryVisibility: GitHubBrokerRepositoryVisibility?
     @Published package private(set) var isBYOGitHubVerificationInProgress = false
     @Published package private(set) var byoGitHubCredentialStatus = "Customer-owned GitHub App credentials are not stored."
     @Published package var pendingReviewPullNumber = "" {
@@ -384,7 +385,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
             let byoProof = DesktopBYOActivationProof(
-                currentAccountBound: dependencies.productionBoundary.nativeActivationBrokerVerified,
+                currentAccountBound: currentAccountBindingVerified,
                 githubAppVerified: byoGitHubCredentialsVerified,
                 repositoryBound: repositoryConfigurationReady && scopedReviewTargetReady,
                 apiEntitlementActive: currentRepositoryActivationReady
@@ -392,6 +393,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             guard dependencies.productionBoundary.distributionPolicy == .byo,
                   DesktopDistributionPolicyBoundary.evaluate(
                       policy: .byo,
+                      visibility: byoGitHubRepositoryVisibility,
                       proof: byoProof
                   ) == .allowed
             else {
@@ -877,6 +879,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var selectedAccountWorkspace: DesktopAccountWorkspace? {
         guard let accountID = accountWorkspaceSelection.accountID else { return nil }
         return accountWorkspaceCatalog.accounts.first { $0.id == accountID }
+    }
+
+    private var currentAccountBindingVerified: Bool {
+        selectedAccountWorkspace != nil
+            && DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+                verifiedAt: accountWorkspaceCatalogVerifiedAt,
+                now: dependencies.clock.now
+            )
     }
 
     package var selectedBotInstallation: DesktopBotInstallation? {
@@ -1950,6 +1960,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubRecovery = nil
         managedGitHubConnectionState = managedGitHubAvailable ? .disconnected : .quarantined
         byoGitHubCredentialsVerified = false
+        byoGitHubRepositoryVisibility = nil
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
@@ -3912,6 +3923,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let cli = dependencies.cli
         isBYOGitHubVerificationInProgress = true
         byoGitHubCredentialsVerified = false
+        byoGitHubRepositoryVisibility = nil
         lastError = nil
         lastCommandLine = safeCommand
         byoGitHubCredentialStatus = repositoryScope == nil
@@ -4020,6 +4032,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let cli = dependencies.cli
         isBYOGitHubVerificationInProgress = true
         byoGitHubCredentialsVerified = false
+        byoGitHubRepositoryVisibility = nil
         lastError = nil
         lastCommandLine =
             "\(shellQuote(cliPath)) doctor github --config \(shellQuote(configPath)) --repo \(shellQuote(targetRepository)) --json"
@@ -4207,6 +4220,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let repositories = report.github.readChecks.map(\.repo).sorted {
             $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
         }.joined(separator: ", ")
+        let selectedReadCheck = report.github.readChecks.first { check in
+            guard let selectedReviewRepository else { return false }
+            return check.repo.caseInsensitiveCompare(selectedReviewRepository)
+                == .orderedSame
+        } ?? report.github.readChecks.first
+        if let visibility = selectedReadCheck?.visibilityResult?.lowercased(),
+           let resolvedVisibility = GitHubBrokerRepositoryVisibility(rawValue: visibility) {
+            byoGitHubRepositoryVisibility = resolvedVisibility
+        } else {
+            byoGitHubRepositoryVisibility = .unknown
+        }
         byoGitHubCredentialsVerified = true
         lastError = nil
         switch expectedContext.source {
@@ -4500,6 +4524,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func invalidateBYOGitHubVerificationContext() {
         invalidateScopedReviewApproval()
+        byoGitHubRepositoryVisibility = nil
         guard byoGitHubCredentialOnboardingAvailable else { return }
         byoGitHubCredentialsVerified = false
         guard !isBYOGitHubVerificationInProgress else { return }
@@ -4735,7 +4760,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var activationPresentation: ActivationStatePresentation {
-        ActivationStateMachine.presentation(for: activationState, redactedKeyPrefix: activationKeyRedactedPrefix)
+        ActivationStateMachine.presentation(
+            for: activationState,
+            redactedKeyPrefix: activationKeyRedactedPrefix,
+            publicBYO: onboardingFlow.mode == .publicReposOnly
+                && dependencies.productionBoundary.distributionPolicy == .byo
+        )
     }
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
@@ -4817,6 +4847,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         switch activationState {
         case .purchaseRequired where onboardingFlow.mode == .publicReposOnly:
             enterActivation(for: .publicReposOnly)
+        case .publicFreeSkip
+            where dependencies.productionBoundary.distributionPolicy != .managed:
+            enterActivation(for: onboardingFlow.mode)
         case .publicFreeSkip where onboardingFlow.mode == .privateRepos:
             applyActivationEvent(.choosePrivatePath)
         default:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -860,7 +860,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
         // touching the Keychain on the launch path (v1.0.3 startup-stability rule).
         if let rawActivationState = dependencies.preferences.string(forKey: activationStateKey),
            let restored = ActivationState(rawValue: rawActivationState) {
-            self.activationState = restored
+            let migrated = DesktopDistributionPolicyBoundary.migrateRestoredActivationState(
+                restored,
+                policy: dependencies.productionBoundary.distributionPolicy
+            )
+            self.activationState = migrated
+            if migrated != restored {
+                dependencies.preferences.set(migrated.rawValue, forKey: activationStateKey)
+            }
         } else {
             self.activationState = ActivationStateMachine.initialState
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -385,17 +385,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
             let byoProof = DesktopBYOActivationProof(
-                currentAccountBound: currentAccountBindingVerified,
-                githubAppVerified: byoGitHubCredentialsVerified,
+                currentAccountBound: currentAccountBindingVerified, githubAppVerified: byoGitHubCredentialsVerified,
                 repositoryBound: repositoryConfigurationReady && scopedReviewTargetReady,
                 apiEntitlementActive: currentRepositoryActivationReady
             )
             guard dependencies.productionBoundary.distributionPolicy == .byo,
-                  DesktopDistributionPolicyBoundary.evaluate(
-                      policy: .byo,
-                      visibility: byoGitHubRepositoryVisibility,
-                      proof: byoProof
-                  ) == .allowed
+                  DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: byoGitHubRepositoryVisibility, proof: byoProof) == .allowed
             else {
                 return false
             }
@@ -862,10 +857,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         // touching the Keychain on the launch path (v1.0.3 startup-stability rule).
         if let rawActivationState = dependencies.preferences.string(forKey: activationStateKey),
            let restored = ActivationState(rawValue: rawActivationState) {
-            let migrated = DesktopDistributionPolicyBoundary.migrateRestoredActivationState(
-                restored,
-                policy: dependencies.productionBoundary.distributionPolicy
-            )
+            let migrated = DesktopDistributionPolicyBoundary.migrateRestoredActivationState(restored, policy: dependencies.productionBoundary.distributionPolicy)
             self.activationState = migrated
             if migrated != restored {
                 dependencies.preferences.set(migrated.rawValue, forKey: activationStateKey)
@@ -881,13 +873,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         return accountWorkspaceCatalog.accounts.first { $0.id == accountID }
     }
 
-    private var currentAccountBindingVerified: Bool {
-        selectedAccountWorkspace != nil
-            && DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
-                verifiedAt: accountWorkspaceCatalogVerifiedAt,
-                now: dependencies.clock.now
-            )
-    }
+    private var currentAccountBindingVerified: Bool { selectedAccountWorkspace != nil && DesktopUpdateAccessPolicy.accountCatalogIsCurrent(verifiedAt: accountWorkspaceCatalogVerifiedAt, now: dependencies.clock.now) }
 
     package var selectedBotInstallation: DesktopBotInstallation? {
         guard let botID = accountWorkspaceSelection.botID else { return nil }
@@ -4221,16 +4207,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
         }.joined(separator: ", ")
         let selectedReadCheck = report.github.readChecks.first { check in
-            guard let selectedReviewRepository else { return false }
-            return check.repo.caseInsensitiveCompare(selectedReviewRepository)
-                == .orderedSame
+            selectedReviewRepository.map { check.repo.caseInsensitiveCompare($0) == .orderedSame } ?? false
         } ?? report.github.readChecks.first
-        if let visibility = selectedReadCheck?.visibilityResult?.lowercased(),
-           let resolvedVisibility = GitHubBrokerRepositoryVisibility(rawValue: visibility) {
-            byoGitHubRepositoryVisibility = resolvedVisibility
-        } else {
-            byoGitHubRepositoryVisibility = .unknown
-        }
+        byoGitHubRepositoryVisibility = selectedReadCheck?.visibilityResult
+            .flatMap { GitHubBrokerRepositoryVisibility(rawValue: $0.lowercased()) } ?? .unknown
         byoGitHubCredentialsVerified = true
         lastError = nil
         switch expectedContext.source {
@@ -4760,12 +4740,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var activationPresentation: ActivationStatePresentation {
-        ActivationStateMachine.presentation(
-            for: activationState,
-            redactedKeyPrefix: activationKeyRedactedPrefix,
-            publicBYO: onboardingFlow.mode == .publicReposOnly
-                && dependencies.productionBoundary.distributionPolicy == .byo
-        )
+        ActivationStateMachine.presentation(for: activationState, redactedKeyPrefix: activationKeyRedactedPrefix, publicBYO: onboardingFlow.mode == .publicReposOnly && dependencies.productionBoundary.distributionPolicy == .byo)
     }
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
@@ -4847,9 +4822,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         switch activationState {
         case .purchaseRequired where onboardingFlow.mode == .publicReposOnly:
             enterActivation(for: .publicReposOnly)
-        case .publicFreeSkip
-            where dependencies.productionBoundary.distributionPolicy != .managed:
-            enterActivation(for: onboardingFlow.mode)
+        case .publicFreeSkip where dependencies.productionBoundary.distributionPolicy != .managed: enterActivation(for: onboardingFlow.mode)
         case .publicFreeSkip where onboardingFlow.mode == .privateRepos:
             applyActivationEvent(.choosePrivatePath)
         default:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -180,7 +180,8 @@ public enum ActivationStateMachine {
 
     public static func presentation(
         for state: ActivationState,
-        redactedKeyPrefix: String? = nil
+        redactedKeyPrefix: String? = nil,
+        publicBYO: Bool = false
     ) -> ActivationStatePresentation {
         let keyTerm = ActivationTerminology.activationKey
         switch state {
@@ -197,16 +198,25 @@ public enum ActivationStateMachine {
             )
 
         case .purchaseRequired:
+            let title = publicBYO
+                ? "Every repository requires activation"
+                : "Private repositories need activation"
+            let cause = publicBYO
+                ? "Every BYO repository requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued."
+                : "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued."
+            let accessibilityLabel = publicBYO
+                ? "Every BYO repository requires an active \(keyTerm)."
+                : "Private repositories require an active \(keyTerm)."
             return ActivationStatePresentation(
                 state: state,
-                title: "Private repositories need activation",
-                cause: "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
+                title: title,
+                cause: cause,
                 recovery: ActivationRecovery(
                     label: "Continue with this key",
                     event: .provideExistingKey,
                     accessibilityLabel: "Store the existing \(keyTerm) securely and continue"
                 ),
-                accessibilityLabel: "Private repositories require an active \(keyTerm).",
+                accessibilityLabel: accessibilityLabel,
                 isSuccess: false,
                 requiresKeyEntry: true,
                 showsNotifyOption: false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -198,25 +198,16 @@ public enum ActivationStateMachine {
             )
 
         case .purchaseRequired:
-            let title = publicBYO
-                ? "Every repository requires activation"
-                : "Private repositories need activation"
-            let cause = publicBYO
-                ? "Every BYO repository requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued."
-                : "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued."
-            let accessibilityLabel = publicBYO
-                ? "Every BYO repository requires an active \(keyTerm)."
-                : "Private repositories require an active \(keyTerm)."
             return ActivationStatePresentation(
                 state: state,
-                title: title,
-                cause: cause,
+                title: publicBYO ? "Every repository requires activation" : "Private repositories need activation",
+                cause: publicBYO ? "Every BYO repository requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued." : "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
                 recovery: ActivationRecovery(
                     label: "Continue with this key",
                     event: .provideExistingKey,
                     accessibilityLabel: "Store the existing \(keyTerm) securely and continue"
                 ),
-                accessibilityLabel: accessibilityLabel,
+                accessibilityLabel: publicBYO ? "Every BYO repository requires an active \(keyTerm)." : "Private repositories require an active \(keyTerm).",
                 isSuccess: false,
                 requiresKeyEntry: true,
                 showsNotifyOption: false

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -128,6 +128,16 @@ import NeonDiffDesktopCore
         #expect(model.activationState == .keyReady)
     }
 
+    @Test func legacyPublicFreeSkipRestoresAsPaidBYOEntry() {
+        let prefs = MemoryPreferences()
+        prefs.set(ActivationState.publicFreeSkip.rawValue, forKey: activationStateKey)
+        let model = makeModel(preferences: prefs, productionBoundary: .testAccountLink)
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(prefs.string(forKey: activationStateKey) == ActivationState.purchaseRequired.rawValue)
+        #expect(model.activationPresentation.requiresKeyEntry)
+    }
+
     @Test func publicPathSkipsWithoutLicenseUI() {
         let model = makeModel(productionBoundary: .testManaged)
         model.enterActivation(for: .publicReposOnly)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -132,10 +132,7 @@ import NeonDiffDesktopCore
         let prefs = MemoryPreferences()
         prefs.set(ActivationState.publicFreeSkip.rawValue, forKey: activationStateKey)
         let model = makeModel(preferences: prefs, productionBoundary: .testAccountLink)
-
-        #expect(model.activationState == .purchaseRequired)
-        #expect(prefs.string(forKey: activationStateKey) == ActivationState.purchaseRequired.rawValue)
-        #expect(model.activationPresentation.requiresKeyEntry)
+        #expect(model.activationState == .purchaseRequired && prefs.string(forKey: activationStateKey) == ActivationState.purchaseRequired.rawValue)
     }
 
     @Test func publicPathSkipsWithoutLicenseUI() {
@@ -150,19 +147,15 @@ import NeonDiffDesktopCore
         let model = makeModel(productionBoundary: .testAccountLink)
         model.onboardingFlow.mode = .publicReposOnly
         model.enterActivation(for: .publicReposOnly)
-
         #expect(model.activationState == .purchaseRequired)
         #expect(model.activationPresentation.title == "Every repository requires activation")
         #expect(model.activationPresentation.cause.contains("Every BYO repository"))
     }
-
     @Test func publicBYOLegacyStateSyncReturnsToPaidEntry() {
         let model = makeModel(productionBoundary: .testAccountLink)
         model.activationState = .publicFreeSkip
         model.onboardingFlow.mode = .publicReposOnly
-
         model.syncActivationEntryFromOnboardingMode()
-
         #expect(model.activationState == .purchaseRequired)
         #expect(model.activationPresentation.requiresKeyEntry)
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -146,6 +146,27 @@ import NeonDiffDesktopCore
         #expect(model.activationPresentation.recovery == nil)
     }
 
+    @Test func publicBYOPathRequiresActivationAndSaysSo() {
+        let model = makeModel(productionBoundary: .testAccountLink)
+        model.onboardingFlow.mode = .publicReposOnly
+        model.enterActivation(for: .publicReposOnly)
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(model.activationPresentation.title == "Every repository requires activation")
+        #expect(model.activationPresentation.cause.contains("Every BYO repository"))
+    }
+
+    @Test func publicBYOLegacyStateSyncReturnsToPaidEntry() {
+        let model = makeModel(productionBoundary: .testAccountLink)
+        model.activationState = .publicFreeSkip
+        model.onboardingFlow.mode = .publicReposOnly
+
+        model.syncActivationEntryFromOnboardingMode()
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(model.activationPresentation.requiresKeyEntry)
+    }
+
     @Test func privatePathBeginsCheckoutPausedWhenCheckoutDisabled() {
         let model = makeModel()
         model.enterActivation(for: .privateRepos)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -129,7 +129,7 @@ import NeonDiffDesktopCore
     }
 
     @Test func publicPathSkipsWithoutLicenseUI() {
-        let model = makeModel()
+        let model = makeModel(productionBoundary: .testManaged)
         model.enterActivation(for: .publicReposOnly)
         #expect(model.activationState == .publicFreeSkip)
         #expect(model.activationPresentation.requiresKeyEntry == false)
@@ -357,7 +357,7 @@ import NeonDiffDesktopCore
     /// Thread 2: choosing Public Repos must skip the license wall, not sit at
     /// purchase_required.
     @Test func publicModeSyncSkipsLicenseWall() {
-        let model = makeModel()
+        let model = makeModel(productionBoundary: .testManaged)
         model.onboardingFlow.mode = .publicReposOnly
         #expect(model.activationState == .purchaseRequired)
         model.syncActivationEntryFromOnboardingMode()

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -527,7 +527,43 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.selectedAccountWorkspace == nil)
         #expect(fixture.model.selectedBotInstallation == nil)
         #expect(fixture.model.currentRepositoryActivationReady)
-        #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @Test func unknownRepositoryVisibilityCannotUnlockBYOUsefulWork() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(doctorResult(
+                    readChecks: doctorReadCheck(repo: "acme/demo", visibility: "unknown")
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: byoRepoPatchJSON(repository: "acme/demo"),
+                    stderr: ""
+                ))
+            ],
+            activationLicenseClient: ActiveBYOActivationClient(),
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.applyAccountWorkspaceCatalog(.loaded([fixtureWorkspace(id: "account-a")]))
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.selectBYOReviewRepository(fullName: "acme/demo")
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
     @Test func verificationFailsClosedUnlessDoctorChecksExactlyMatchEnabledRepositories() async throws {
@@ -772,12 +808,13 @@ private func doctorResult(
 private func doctorReadCheck(
     repo: String,
     skippedByPolicy: String? = nil,
-    ok: Bool = true
+    ok: Bool = true,
+    visibility: String = "public"
 ) -> String {
     let skippedField = skippedByPolicy.map {
         #","skippedByPolicy":"\#($0)""#
     } ?? ""
-    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
+    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"\#(visibility)","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
 }
 
 private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: [

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -531,36 +531,15 @@ struct BYOGitHubAppCredentialOnboardingTests {
     }
 
     @Test func unknownRepositoryVisibilityCannotUnlockBYOUsefulWork() async {
-        let fixture = ModelDependencyFixture(
-            cliOutcomes: [
-                .success(doctorResult(
-                    readChecks: doctorReadCheck(repo: "acme/demo", visibility: "unknown")
-                )),
-                .success(CLIRunResult(
-                    exitCode: 0,
-                    stdout: byoRepoPatchJSON(repository: "acme/demo"),
-                    stderr: ""
-                ))
-            ],
-            activationLicenseClient: ActiveBYOActivationClient(),
-            preferenceStrings: availableCLIPreference,
-            productionBoundary: exactB0Boundary
-        )
+        let fixture = ModelDependencyFixture(cliOutcomes: [.success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo", visibility: "unknown"))), .success(CLIRunResult(exitCode: 0, stdout: byoRepoPatchJSON(repository: "acme/demo"), stderr: ""))], activationLicenseClient: ActiveBYOActivationClient(), preferenceStrings: availableCLIPreference, productionBoundary: exactB0Boundary)
         fixture.model.applyAccountWorkspaceCatalog(.loaded([fixtureWorkspace(id: "account-a")]))
-        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
-        fixture.model.selectBYOReviewRepository(fullName: "acme/demo")
-        fixture.model.pendingBYOGitHubAppId = "123456"
-        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
-        fixture.model.storeBYOGitHubAppCredentials()
-        fixture.model.verifyBYOGitHubAppCredentials()
-        await waitForBYOVerification(fixture)
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]; fixture.model.selectBYOReviewRepository(fullName: "acme/demo")
+        fixture.model.pendingBYOGitHubAppId = "123456"; fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials(); fixture.model.verifyBYOGitHubAppCredentials(); await waitForBYOVerification(fixture)
         fixture.model.applyRepoAllowlistPatch()
         await fixture.waitForConfigPatchToFinish()
-
-        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
-        fixture.model.provideExistingActivationKey()
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"; fixture.model.provideExistingActivationKey()
         await fixture.model.submitActivation()
-
         #expect(fixture.model.byoGitHubCredentialsVerified)
         #expect(fixture.model.currentRepositoryActivationReady)
         #expect(!fixture.model.productionUsefulWorkAvailable)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import NeonDiffDesktopAppCore
+import NeonDiffDesktopCore
+
+@Suite struct DistributionPolicyTests {
+    private let completeProof = DesktopBYOActivationProof(
+        currentAccountBound: true, githubAppVerified: true,
+        repositoryBound: true, apiEntitlementActive: true
+    )
+
+    @Test func distributionMarkersResolveToOneExplicitPolicy() {
+        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: true, managedBrokerConfigured: false) == .byo)
+        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: false, managedBrokerConfigured: true) == .managed)
+        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: true, managedBrokerConfigured: true) == .mixed)
+        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: false, managedBrokerConfigured: false) == .unavailable)
+    }
+
+    @Test func byoPublicAndPrivateRequireExactActiveEntitlement() {
+        let missingEntitlement = DesktopBYOActivationProof(
+            currentAccountBound: true, githubAppVerified: true,
+            repositoryBound: true, apiEntitlementActive: false
+        )
+        for visibility in [GitHubBrokerRepositoryVisibility.public, .private, .internal] {
+            #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: visibility, proof: completeProof) == .allowed)
+            #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: visibility, proof: missingEntitlement) == .blocked(reason: .activeExactEntitlementRequired))
+        }
+    }
+
+    @Test func missingUnknownAndMixedMarkersFailClosed() {
+        #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: nil, proof: completeProof) == .blocked(reason: .visibilityUnavailable))
+        #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: .unknown, proof: completeProof) == .blocked(reason: .visibilityUnavailable))
+        for policy in [DesktopDistributionPolicy.mixed, .unavailable] {
+            #expect(DesktopDistributionPolicyBoundary.evaluate(policy: policy, visibility: .private, proof: completeProof) == .blocked(reason: .distributionMarkerInvalid))
+        }
+    }
+
+    @Test func managedPublicFreeIsUnavailableUntilManagedMilestone() {
+        #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .managed, visibility: .public, proof: completeProof) == .blocked(reason: .managedPublicFreeUnavailable))
+    }
+}

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
@@ -7,43 +7,32 @@ import NeonDiffDesktopCore
         currentAccountBound: true, githubAppVerified: true,
         repositoryBound: true, apiEntitlementActive: true
     )
-
     @Test func distributionMarkersResolveToOneExplicitPolicy() {
-        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: true, managedBrokerConfigured: false) == .byo)
-        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: false, managedBrokerConfigured: true) == .managed)
-        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: true, managedBrokerConfigured: true) == .mixed)
-        #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: false, managedBrokerConfigured: false) == .unavailable)
+        for (flags, policy) in [
+            ((true, false), DesktopDistributionPolicy.byo),
+            ((false, true), .managed), ((true, true), .mixed), ((false, false), .unavailable)
+        ] {
+            #expect(DesktopDistributionPolicyBoundary.resolve(byoEnabled: flags.0, managedBrokerConfigured: flags.1) == policy)
+        }
     }
-
     @Test func byoPublicAndPrivateRequireExactActiveEntitlement() {
-        let missingEntitlement = DesktopBYOActivationProof(
-            currentAccountBound: true, githubAppVerified: true,
-            repositoryBound: true, apiEntitlementActive: false
-        )
+        let missingEntitlement = DesktopBYOActivationProof(currentAccountBound: true, githubAppVerified: true, repositoryBound: true, apiEntitlementActive: false)
         for visibility in [GitHubBrokerRepositoryVisibility.public, .private, .internal] {
             #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: visibility, proof: completeProof) == .allowed)
             #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: visibility, proof: missingEntitlement) == .blocked(reason: .activeExactEntitlementRequired))
         }
     }
-
     @Test func missingUnknownAndMixedMarkersFailClosed() {
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: nil, proof: completeProof) == .blocked(reason: .visibilityUnavailable))
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: .unknown, proof: completeProof) == .blocked(reason: .visibilityUnavailable))
-        let missingAccount = DesktopBYOActivationProof(
-            currentAccountBound: false, githubAppVerified: true,
-            repositoryBound: true, apiEntitlementActive: true
-        )
+        let missingAccount = DesktopBYOActivationProof(currentAccountBound: false, githubAppVerified: true, repositoryBound: true, apiEntitlementActive: true)
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: .private, proof: missingAccount) == .blocked(reason: .activeExactEntitlementRequired))
         for policy in [DesktopDistributionPolicy.mixed, .unavailable] {
             #expect(DesktopDistributionPolicyBoundary.evaluate(policy: policy, visibility: .private, proof: completeProof) == .blocked(reason: .distributionMarkerInvalid))
         }
     }
-
-    @Test func managedPublicFreeIsUnavailableUntilManagedMilestone() {
+    @Test func managedPublicFreeAndLegacyRestoreStayPolicyBound() {
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .managed, visibility: .public, proof: completeProof) == .blocked(reason: .managedPublicFreeUnavailable))
-    }
-
-    @Test func legacyPublicFreeRestoreIsOnlyPreservedForManagedPolicy() {
         #expect(DesktopDistributionPolicyBoundary.migrateRestoredActivationState(.publicFreeSkip, policy: .managed) == .publicFreeSkip)
         for policy in [DesktopDistributionPolicy.byo, .mixed, .unavailable] {
             #expect(DesktopDistributionPolicyBoundary.migrateRestoredActivationState(.publicFreeSkip, policy: policy) == .purchaseRequired)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
@@ -37,4 +37,11 @@ import NeonDiffDesktopCore
     @Test func managedPublicFreeIsUnavailableUntilManagedMilestone() {
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .managed, visibility: .public, proof: completeProof) == .blocked(reason: .managedPublicFreeUnavailable))
     }
+
+    @Test func legacyPublicFreeRestoreIsOnlyPreservedForManagedPolicy() {
+        #expect(DesktopDistributionPolicyBoundary.migrateRestoredActivationState(.publicFreeSkip, policy: .managed) == .publicFreeSkip)
+        for policy in [DesktopDistributionPolicy.byo, .mixed, .unavailable] {
+            #expect(DesktopDistributionPolicyBoundary.migrateRestoredActivationState(.publicFreeSkip, policy: policy) == .purchaseRequired)
+        }
+    }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DistributionPolicyTests.swift
@@ -29,6 +29,11 @@ import NeonDiffDesktopCore
     @Test func missingUnknownAndMixedMarkersFailClosed() {
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: nil, proof: completeProof) == .blocked(reason: .visibilityUnavailable))
         #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: .unknown, proof: completeProof) == .blocked(reason: .visibilityUnavailable))
+        let missingAccount = DesktopBYOActivationProof(
+            currentAccountBound: false, githubAppVerified: true,
+            repositoryBound: true, apiEntitlementActive: true
+        )
+        #expect(DesktopDistributionPolicyBoundary.evaluate(policy: .byo, visibility: .private, proof: missingAccount) == .blocked(reason: .activeExactEntitlementRequired))
         for policy in [DesktopDistributionPolicy.mixed, .unavailable] {
             #expect(DesktopDistributionPolicyBoundary.evaluate(policy: policy, visibility: .private, proof: completeProof) == .blocked(reason: .distributionMarkerInvalid))
         }


### PR DESCRIPTION
Closes #854

## Summary
- add an explicit BYO/managed distribution-policy boundary with mixed/unavailable fail-closed states
- require current account, GitHub App, repository, and API entitlement proof for BYO public/private/internal paths
- keep managed public-free unwired in the current GA path; only the managed policy may enter the future public-free activation state
- preserve existing managed broker behavior and add focused regressions

## Proof
- exact base: 58196ad8feaeea3c6611788ac0d83c462fe0c216
- focused: `swift test --filter DistributionPolicyTests`
- affected: `swift test --filter ActivationHandoffModelTests`
- affected: `swift test --filter ExistingLocalBotReconciliationTests`
- affected: `swift test --filter ManagedGitHubOnboardingTests`
- `git diff --cached --check` clean; 125 added / 6 removed lines

Proof boundary: this PR proves the source policy boundary and focused regressions only. It does not prove managed-App readiness, release, deployment, or customer/runtime state.