### PR TITLE
docs: make Mac GA operational paths portable

### DIFF
--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -16,11 +16,16 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 Generate a local appcast from a committed fixture:
 
 ```sh
+: "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
+  --output "$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
   --dry-run
 ```
+
+Keep generated evidence under that external root, never in the checkout. The
+signed Desktop app owns account-scoped configuration and Keychain credentials;
+this fixture command takes no credential or private-key paths.
 
 Dry-run mode never signs, uploads, notarizes, or fabricates a real signature.
 The `sparkle:edSignature` attribute appears only when the manifest explicitly

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -1,17 +1,32 @@
 # evaOS Code Review Bot Beta Release Runbook
 
-This repository runs a live local beta worker through launchd. Treat each live
-update as a named beta release, not as an informal pull from `main`.
+The signed NeonDiff Desktop app runs the local beta worker through launchd.
+Treat each live update as a named beta release, not as an informal pull from
+`main`. A source checkout is release tooling only; it is not the installed
+runtime or accepted artifact.
 
 ## Release Boundary
 
 The beta release unit is:
 
-- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- source checkout: `$NEONDIFF_REPO_ROOT` (an operator-selected clean checkout)
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
-- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
-- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+- signed Desktop config: `$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/active-installed-live.json`
+- state DB: `$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/state/reviews-live.sqlite`
+- evidence root: `$NEONDIFF_EVIDENCE_ROOT` (an external, operator-owned directory)
+
+Before running the commands below, set the clean checkout, Desktop account,
+and external evidence root. The signed app owns account-scoped config and reads
+GitHub App credentials from the macOS Keychain; never put credentials in config,
+arguments, or environment variables:
+
+```bash
+: "${NEONDIFF_REPO_ROOT:?set the clean release checkout}"
+: "${NEONDIFF_ACCOUNT_ID:?set the selected Desktop account id}"
+: "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
+export NEONDIFF_ACCOUNT_ROOT="${NEONDIFF_ACCOUNT_ROOT:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID}"
+export NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$NEONDIFF_ACCOUNT_ROOT/config/active-installed-live.json}"
+```
 
 Packaged or non-source deployments must set
 `NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
@@ -92,19 +107,19 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git status --short
 git pull --ff-only
 npm test
 npm run build
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 sleep 5
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot \
   --require-coverage true
@@ -115,7 +130,7 @@ For public source-beta releases, run the same gate with manifest checks:
 ```bash
 PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -138,7 +153,7 @@ fetched:
 ```bash
 git fetch origin --tags
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -470,7 +485,7 @@ from the eligible open-head set. Retire only the exact failed head:
 
 ```bash
 npx tsx src/cli.ts retire-failed \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
@@ -540,7 +555,7 @@ Expired cooldown rows are actionable backlog. Run:
 
 ```bash
 npx tsx src/cli.ts retry-provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expired-only true \
   --dry-run false \
   --zcode true
@@ -557,7 +572,7 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin
 git checkout main
 git reset --hard <last-known-good-merge-sha>
@@ -601,8 +616,8 @@ For each beta promotion, record:
   tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
-Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
-or session notes. Do not paste secrets, private keys, tokens, cookies, raw
+Keep raw evidence under `$NEONDIFF_EVIDENCE_ROOT` or session notes. Do not paste
+secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
 
 ## Release Packet Template

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -43,6 +43,10 @@ re-update, immutable release assets, and live customer evidence.
 
 ## Durable Plan Contract
 
+Evidence paths in this plan are portable operator inputs. Set
+`NEONDIFF_EVIDENCE_ROOT` to an external directory outside the source checkout;
+never commit private keys, credentials, or customer data there or in the repo.
+
 - Goal: define the desktop auto-update channel contract for NeonDiff Desktop so
   future implementation can choose Sparkle, Tauri updater, or an equivalent
   signed updater without weakening release governance or license boundaries.
@@ -95,10 +99,10 @@ re-update, immutable release assets, and live customer evidence.
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -115,7 +119,7 @@ re-update, immutable release assets, and live customer evidence.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -192,7 +196,7 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$NEONDIFF_EVIDENCE_ROOT/`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -11,9 +11,10 @@ npm run eval:offline -- --input /path/to/scenario.json
 Run the checked-in local suite fixtures:
 
 ```bash
+: "${NEONDIFF_EVAL_ROOT:?set an external eval output root outside this checkout}"
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/local-suite"
 ```
 
 Run the paired sticky-vs-cold fixture:
@@ -21,7 +22,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -30,7 +31,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -38,7 +39,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -52,7 +53,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S)" \
   --dry-run true
 ```
 
@@ -65,10 +66,11 @@ The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.
 
-By default, packets are written under:
+By default, packets are written under the external root selected by
+`NEONDIFF_EVAL_ROOT`:
 
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/
+$NEONDIFF_EVAL_ROOT/<date>/<run-id>/
 ```
 
 Use `--output-dir` for tests or scratch runs.

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -339,10 +339,22 @@ unchanged and treat the package as quarantined.
 
 ## Tag And Release
 
+Use an operator-selected clean checkout and signed Desktop account; set these
+variables once for the command blocks below. The app owns account-scoped config
+under `$HOME/Library/Application Support/NeonDiffDesktop/Accounts/` and reads
+GitHub App credentials from the macOS Keychain; never export private-key paths.
+
+```bash
+: "${NEONDIFF_REPO_ROOT:?set the clean release checkout}"
+: "${NEONDIFF_ACCOUNT_ID:?set the selected Desktop account id}"
+export NEONDIFF_ACCOUNT_ROOT="${NEONDIFF_ACCOUNT_ROOT:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID}"
+export NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$NEONDIFF_ACCOUNT_ROOT/config/active-installed-live.json}"
+```
+
 Create an annotated tag from the merged source SHA:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
@@ -377,25 +389,24 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
 test "$(git rev-parse HEAD)" = "<source-sha>"
-launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+launchctl bootout gui/$(id -u) "$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist" 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist"
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 ```
 
 ## Post-Release Gate
 
-Run the status gate with App credentials set in the shell:
+Run the status gate with the signed Desktop account selected above. Credentials
+remain Keychain-only:
 
 ```bash
-export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
-export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
@@ -406,7 +417,7 @@ For public source-beta or public beta releases, include the public manifest gate
 SOURCE_SHA=replace-with-release-source-sha
 PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$SOURCE_SHA" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -424,9 +435,9 @@ Also run:
 
 ```bash
 npx tsx src/cli.ts coverage-audit \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+  --config "$NEONDIFF_CONFIG"
 npx tsx src/cli.ts provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expired-only true
 ```
 
@@ -458,13 +469,13 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin --tags
 git checkout main
 git reset --hard <previous-release-tag>
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -226,8 +226,10 @@ Use this path for each new repo from #14 or future allowlists:
 7. Promote through `docs/beta-release-runbook.md` and verify
    `npm run release:status` plus fresh launchd heartbeats.
 
-Do not treat `config.example.json` as live config. The active launchd config is
-outside the repo under `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/`.
+Do not treat `config.example.json` as live config. The signed Desktop app owns
+the account-scoped config under
+`$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/`
+and reads GitHub App credentials from the macOS Keychain; never export them.
 Do not add repos whose GitHub App installation cannot be verified; public
 visibility or an admin user's `gh repo view` is not enough because reviews must
 be authored by `evaos-code-review-bot`.
@@ -250,9 +252,9 @@ The template intentionally keeps:
 Before copying any part of the template into the active live config, run:
 
 ```sh
-NEONDIFF_GITHUB_APP_ID="<github-app-id>" \
-NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem" \
-npx tsx src/cli.ts doctor --config /path/to/candidate-live-config.json
+: "${NEONDIFF_ACCOUNT_ID:?set the selected Desktop account id}"
+NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/candidate-live-config.json}" \
+npx tsx src/cli.ts doctor --config "$NEONDIFF_CONFIG"
 ```
 
 Then run dry-run review evidence for at least one current PR and one

--- a/docs/skills/release-operator.md
+++ b/docs/skills/release-operator.md
@@ -32,9 +32,14 @@ exception in the tracker issue and open a backfill issue before ending.
 
 ## Required Commands
 
+The signed Desktop app owns account-scoped config under
+`$HOME/Library/Application Support/NeonDiffDesktop/Accounts/` and reads GitHub
+App credentials from the macOS Keychain. Set `NEONDIFF_ACCOUNT_ID`; never export
+app IDs or private-key paths.
+
 ```bash
-export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
-export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+: "${NEONDIFF_ACCOUNT_ID:?set the selected Desktop account id}"
+export NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/active-installed-live.json}"
 
 git fetch origin main --tags
 git checkout main
@@ -50,7 +55,7 @@ gh release create <tag> \
 
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/launchd/evaos-code-review-bot.plist.example
+++ b/launchd/evaos-code-review-bot.plist.example
@@ -5,43 +5,15 @@
 <dict>
   <key>Label</key>
   <string>com.electricsheephq.evaos-code-review-bot</string>
-  <key>WorkingDirectory</key>
-  <string>/Volumes/LEXAR/repos/evaos-code-review-bot</string>
+  <!-- The signed Desktop wrapper selects account-scoped config and launches
+       the sealed worker helper. It reads credentials from the macOS Keychain. -->
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/node</string>
-    <string>/Volumes/LEXAR/repos/evaos-code-review-bot/node_modules/tsx/dist/cli.mjs</string>
-    <string>src/cli.ts</string>
-    <string>daemon</string>
-    <string>--config</string>
-    <string>/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json</string>
-    <string>--dry-run</string>
-    <string>true</string>
+    <string>/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop</string>
   </array>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key>
-    <string>/opt/homebrew/bin:/opt/homebrew/sbin:/Users/lume/.bun/bin:/Users/lume/gbrain/bin:/Users/lume/.local/bin:/Users/lume/.openclaw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>HOME</key>
-    <string>/Users/lume</string>
-    <key>USER</key>
-    <string>lume</string>
-    <key>LOGNAME</key>
-    <string>lume</string>
-    <key>SHELL</key>
-    <string>/bin/zsh</string>
-    <key>EVAOS_REVIEW_BOT_APP_ID</key>
-    <string>REPLACE_WITH_APP_ID</string>
-    <key>EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH</key>
-    <string>/absolute/path/to/private-key.pem</string>
-  </dict>
   <key>RunAtLoad</key>
   <false/>
   <key>KeepAlive</key>
   <false/>
-  <key>StandardOutPath</key>
-  <string>/Users/lume/Library/Logs/evaos-code-review-bot/launchd.out.log</string>
-  <key>StandardErrorPath</key>
-  <string>/Users/lume/Library/Logs/evaos-code-review-bot/launchd.err.log</string>
 </dict>
 </plist>

--- a/tests/operational-doc-path-contract.test.ts
+++ b/tests/operational-doc-path-contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { expect, it } from "vitest";
+const repoRoot = resolve(import.meta.dirname, "..");
+const operationalDocs = ["docs/beta-release-runbook.md", "docs/release-governance.md", "docs/desktop-auto-update-channel.md", "apps/neondiff-desktop/docs/appcast-channels.md", "docs/eval-harness.md", "docs/repo-profiles.md", "docs/skills/release-operator.md", "launchd/evaos-code-review-bot.plist.example"];
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+it("keeps current operational docs portable and account-scoped", () => {
+  const contents = operationalDocs.map(read).join("\n");
+  expect(contents).not.toMatch(/\/Volumes\/LEXAR|\/Users\/(?:m1|lume)|PRIVATE_KEY_PATH|REPLACE_WITH_APP_ID/);
+  expect(contents).toContain("Library/Application Support/NeonDiffDesktop/Accounts");
+  expect(contents).toContain("macOS Keychain");
+});
+it("keeps generated eval and appcast evidence outside the checkout", () => {
+  expect(read("docs/eval-harness.md")).toContain("NEONDIFF_EVAL_ROOT");
+  expect(read("apps/neondiff-desktop/docs/appcast-channels.md")).toContain("NEONDIFF_EVIDENCE_ROOT");
+});
+it("uses the signed Desktop executable in the launchd example", () => {
+  const plist = read("launchd/evaos-code-review-bot.plist.example");
+  expect(plist).toContain("/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop");
+  expect(plist).not.toMatch(/WorkingDirectory|EnvironmentVariables/);
+});


### PR DESCRIPTION
## Summary

Related: #858

Replace obsolete machine-specific routes in the current Mac release, updater, eval, repo-profile, and release-operator docs with portable operator variables and signed Desktop account-scoped guidance. Replace the launchd source-checkout example with the installed signed Desktop executable and remove credential/private-key environment entries.

Historical release packets and test-only hostile fixtures are untouched. No source defaults, CLI manifest bytes, runtime state, customer data, signing, release, or deployment actions were changed.

## Proof

- Base: 58196ad8feaeea3c6611788ac0d83c462fe0c216 (main)
- Head: 602bf61
- Changed lines: 199 total (119 additions, 80 deletions)
- Focused deterministic path-contract assertions: pass
- plist lint: pass
- public-claims scan: pass
- secret scan: pass
- git diff --check: pass
- Focused Vitest could not run in the clean worktree because node_modules is absent; no dependencies were installed. CI should run the added tests.

## Proof boundary

This PR proves current operational documentation and example portability only. It does not prove signed artifacts, notarization, installed runtime health, live launchd state, update publication, release readiness, or customer readiness.