### PR TITLE
fix(scheduler): quarantine truncated command heads

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, type BoundedGithubList } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -109,7 +109,7 @@ export interface ScheduledRunResult extends RunOnceResult {
 export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
-  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[] | BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -172,6 +172,7 @@ export async function runScheduledCycleWithDeps(input: {
   const result = emptyScheduledRunResult();
   const now = input.now ?? new Date();
   const eventClock = input.clock ?? (() => input.now ?? new Date());
+  const excludedJobIds = new Set<string>();
   const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
   const providerId = config.zcode.providerId ?? config.zcode.model ?? "zcode";
   if (config.reviewerSessions?.enabled) {
@@ -242,6 +243,11 @@ export async function runScheduledCycleWithDeps(input: {
         },
         onCommandFetchError: () => {
           result.commandFetchErrors += 1;
+        },
+        clock: eventClock,
+        onQueueJobsQuarantined: ({ jobIds, count }) => {
+          for (const jobId of jobIds) excludedJobIds.add(jobId);
+          result.queue.failedQueueJobs += count;
         }
       });
       applyEnqueueStatus(result, enqueueStatus);
@@ -287,6 +293,7 @@ export async function runScheduledCycleWithDeps(input: {
     manualCommandReserve: Math.min(scheduler.manualCommandReserve, effectiveSlots),
     limit: effectiveSlots,
     leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
+    excludeJobIds: excludedJobIds,
     ...(config.riskWeightedQueue?.aging ? { aging: config.riskWeightedQueue.aging } : {}),
     now: eventClock()
   });
@@ -503,6 +510,7 @@ async function collectSubsequentMergedPulls(input: {
 type EnqueueStatus =
   | "enqueued"
   | "already_queued"
+  | "command_fetch_failed"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_processed"
@@ -526,14 +534,16 @@ async function enqueuePullIfEligible(input: {
   allowActivationBaselineCommandLookup?: boolean;
   onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
+  clock?: () => Date;
+  onQueueJobsQuarantined?: (input: { jobIds: string[]; count: number }) => void;
   automaticPriorityOverride?: number;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) {
     await retireQueuedJobsForClosedPull(input);
     return "closed_retired";
   }
-  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (input.config.skipDrafts && input.pull.draft) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -545,6 +555,7 @@ async function enqueuePullIfEligible(input: {
     return "skipped_draft";
   }
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -567,18 +578,29 @@ async function enqueuePullIfEligible(input: {
       pull: input.pull
     })
   ) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     await retireSupersededQueueJobsForPull(input);
     recordActivationBaselineExistingHead(input.state, input.repo, input.pull);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
   if (!input.allowActivationBaselineCommandLookup && isActivationBaselineProcessedReview(processed)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     await retireSupersededQueueJobsForPull(input);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
+  if ("blocked" in commandDecision) {
+    const quarantine = await quarantineQueueJobsForTruncatedCommandEvidence({
+      ...input,
+      now: input.clock?.() ?? input.now
+    });
+    input.onQueueJobsQuarantined?.(quarantine);
+    return "command_fetch_failed";
+  }
+  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
       await retireSupersededQueueJobsForPull(input);
@@ -1102,6 +1124,73 @@ async function retireSupersededQueueJobsForPull(input: {
   }
 }
 
+async function quarantineQueueJobsForTruncatedCommandEvidence(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  dryRun: boolean;
+  now: Date;
+  onStatusCommentFailure?: () => void;
+}): Promise<{ jobIds: string[]; count: number }> {
+  const jobs = input.state.listReviewQueueJobsForPull({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    states: ["queued", "provider_deferred", "blocked_on_proof", "leased", "running"]
+  });
+  const jobIds = jobs.map((job) => job.jobId);
+  let count = 0;
+  for (const job of jobs) {
+    const eligible = job.state === "queued" || job.state === "provider_deferred" || job.state === "blocked_on_proof";
+    const expired = (job.state === "leased" || job.state === "running") && isQueueJobLeaseExpired({
+      job,
+      now: input.now,
+      leaseTtlMs: input.config.reviewConcurrency.leaseTtlMs
+    });
+    if (!eligible && !expired) continue;
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "failed",
+      lastError: "command_evidence_truncated",
+      now: input.now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      readinessState: "failed",
+      reason: "command_evidence_truncated",
+      now: input.now
+    });
+    updateReviewerSessionJobFromQueueStatus({ state: input.state, job, now: input.now }, "failed", "failed");
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      state: "failed",
+      details: "Command evidence was truncated; review was blocked.",
+      onStatusCommentFailure: input.onStatusCommentFailure,
+      now: input.now
+    });
+    count += 1;
+  }
+  return { jobIds, count };
+}
+
+function isQueueJobLeaseExpired(input: {
+  job: ReviewQueueJobRecord;
+  now: Date;
+  leaseTtlMs: number;
+}): boolean {
+  const leaseExpiryMs = input.job.leaseExpiresAt
+    ? Date.parse(input.job.leaseExpiresAt)
+    : Date.parse(input.job.updatedAt) + input.leaseTtlMs;
+  return Number.isFinite(leaseExpiryMs) && leaseExpiryMs <= input.now.getTime();
+}
+
 async function retireQueuedJobsForClosedPull(input: {
   config: BotConfig;
   github: SchedulerGitHubApi;
@@ -1155,11 +1244,19 @@ async function resolveSchedulerCommandDecision(input: {
   repo: string;
   pull: PullRequestSummary;
   onCommandFetchError?: () => void;
-}): Promise<CommandDecision> {
+}): Promise<CommandDecision | { action: "none"; shouldReview: false; blocked: "command_evidence_truncated" }> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = await input.github.listIssueComments(input.repo, input.pull.number);
+    const bounded = "items" in result
+      ? result
+      : { items: result, truncated: false, overflow: false };
+    if (bounded.truncated || bounded.overflow) {
+      input.onCommandFetchError?.();
+      return { action: "none", shouldReview: false, blocked: "command_evidence_truncated" };
+    }
+    comments = bounded.items;
   } catch {
     input.onCommandFetchError?.();
     return { action: "none", shouldReview: false };
@@ -2592,6 +2689,9 @@ function nextLicenseGateRetryAt(now = new Date()): string {
 
 function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {
   switch (status) {
+    case "command_fetch_failed":
+      result.failed += 1;
+      break;
     case "enqueued":
       result.queue.enqueued += 1;
       break;

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3517,6 +3517,84 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not mutate a truncated command head before quarantine is needed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-command-truncated-noop-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = { enabled: true, botMentions: ["@evaos-code-review-bot"], trustedAuthors: ["100yenadmin"], acknowledge: false };
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const now = new Date("2026-07-01T00:05:00.000Z");
+    state.recordReviewReadiness({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, state: "ready_for_human", reason: "comment_review_posted", now });
+    const statusCalls: StatusCommentCall[] = [];
+    const truncated = truncatedComments();
+    let reviewCalls = 0;
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: { ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]]]), new Map(), statusCalls), listIssueComments: async () => truncated },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => { reviewCalls += 1; return "reviewed"; },
+      now
+    });
+    expect(result).toMatchObject({ failed: 1, commandFetchErrors: 1 });
+    expect(result.queue).toMatchObject({ enqueued: 0, leased: 0, failedQueueJobs: 0 });
+    expect(reviewCalls).toBe(0);
+    expect(statusCalls).toEqual([]);
+    expect(state.listReviewQueueJobs()).toEqual([]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "ready_for_human", reason: "comment_review_posted" });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_B)).toBeUndefined();
+    state.close();
+  });
+
+  it("quarantines every same-head attempt and excludes an expiry crossing into leasing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-command-truncated-quarantine-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = { enabled: true, botMentions: ["@evaos-code-review-bot"], trustedAuthors: ["100yenadmin"], acknowledge: false };
+    config.reviewStatusComment!.enabled = true;
+    config.reviewerSessions = { enabled: true, ttlMs: 8 * 60 * 60_000, headCountLimit: 10 };
+    config.reviewConcurrency.maxActiveRuns = 2;
+    config.reviewScheduler!.maxProviderActive = 2;
+    const state = new ReviewStateStore(config.statePath);
+    const discoveryNow = new Date("2026-07-01T00:00:00.000Z");
+    const leaseExpiry = new Date("2026-07-01T00:00:30.000Z");
+    const leasingNow = new Date("2026-07-01T00:01:00.000Z");
+    const automatic = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base", now: discoveryNow }).job;
+    const manual = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base", source: "manual_command", commentId: 501, now: discoveryNow }).job;
+    const assignment = state.assignReviewerSessionJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, ttlMs: config.reviewerSessions.ttlMs, headCountLimit: config.reviewerSessions.headCountLimit, now: discoveryNow });
+    if (!assignment.assigned) throw new Error("expected reviewer session assignment");
+    for (const job of [automatic, manual]) {
+      state.updateReviewQueueJobState({ jobId: job.jobId, state: "queued", sessionId: assignment.session.sessionId, now: discoveryNow });
+    }
+    state.recordReviewReadiness({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, state: "queued", reason: "automatic_enqueue", now: discoveryNow });
+    state.updateReviewQueueJobState({ jobId: manual.jobId, state: "leased", leaseId: "lease-crossing-discovery", leaseExpiresAt: leaseExpiry.toISOString(), now: discoveryNow });
+    const statusCalls: StatusCommentCall[] = [];
+    const github = { ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls), listIssueComments: async () => truncatedComments() };
+    let reviewCalls = 0;
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => { reviewCalls += 1; return "reviewed"; },
+      now: discoveryNow,
+      clock: () => leasingNow
+    });
+    expect(result).toMatchObject({ failed: 1, commandFetchErrors: 1 });
+    expect(result.queue).toMatchObject({ leased: 0, failedQueueJobs: 2, remainingQueued: 0 });
+    expect(reviewCalls).toBe(0);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(2);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ jobId: automatic.jobId, lastError: "command_evidence_truncated" }),
+      expect.objectContaining({ jobId: manual.jobId, lastError: "command_evidence_truncated" })
+    ]));
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "failed", reason: "command_evidence_truncated" });
+    expect(state.getReviewerSessionJob("org/repo-a", 1, HEAD_A)).toMatchObject({ jobState: "failed", processedReviewStatus: "failed" });
+    expect(statusCalls.map(statusFromBody)).toEqual(["failed", "failed"]);
+    state.close();
+  });
+
   it("assigns scheduler jobs to reusable repo-sticky reviewer sessions when enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-"));
     roots.push(root);
@@ -5292,4 +5370,8 @@ function comment(id: number, login: string, body: string) {
       type: login.endsWith("bot") ? "Bot" : "User"
     }
   };
+}
+
+function truncatedComments() {
+  return Object.assign([], { items: [], truncated: true, overflow: true });
 }


### PR DESCRIPTION
Closes #862

## Summary
- Fail closed when bounded command comments are truncated, without mutating readiness or queue state for a new head.
- Quarantine all same-head eligible and expired queue attempts before leasing, synchronizing readiness, reviewer-session, and public status state.
- Exclude every observed same-head attempt from the leasing batch and count every quarantined failure.
- Preserve readiness supersession for draft, canary, activation-baseline, and normal paths.

## Validation
- `npx tsc --noEmit -p tsconfig.build.json`
- `/tmp/neondiff-node node_modules/vitest/vitest.mjs run tests/scheduler.test.ts -t 'truncated command'` (2 focused tests)\n- `/tmp/neondiff-node node_modules/vitest/vitest.mjs run tests/scheduler.test.ts` (105/105)\n- 187 changed lines (105 source additions, 5 deletions, 82 test additions)\n\nBase is exact #832 head `3483941d9cbf70a888da89ffd045442b6be2266b`; held #848/#849 were not used as merge bases.