### PR TITLE
docs: portable signed Desktop operator examples

### DIFF
--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -16,9 +16,10 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 Generate a local appcast from a committed fixture:
 
 ```sh
+: "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
+  --output "$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
   --dry-run
 ```
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -1,17 +1,23 @@
 # evaOS Code Review Bot Beta Release Runbook
 
-This repository runs a live local beta worker through launchd. Treat each live
-update as a named beta release, not as an informal pull from `main`.
+The signed NeonDiff Desktop app runs the local beta worker through launchd.
+Treat each live update as a named beta release, not as an informal pull from
+`main`; a source checkout is release tooling, not the accepted runtime.
 
 ## Release Boundary
 
 The beta release unit is:
 
-- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- source checkout: `$NEONDIFF_REPO_ROOT` (an operator-selected clean checkout)
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
-- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
-- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+- signed Desktop config: `$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/Bots/$NEONDIFF_BOT_ID/config.local.json`
+- state DB: `$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/Bots/$NEONDIFF_BOT_ID/state/reviews-live.sqlite`
+- evidence root: `$NEONDIFF_EVIDENCE_ROOT` (an external operator-owned directory)
+
+```bash
+: "${NEONDIFF_REPO_ROOT:?set checkout}"; : "${NEONDIFF_ACCOUNT_ID:?set account}"; : "${NEONDIFF_BOT_ID:?set bot}"; : "${NEONDIFF_EVIDENCE_ROOT:?set evidence root}"; : "${NEONDIFF_BUNDLE_DIR:?set accepted bundle}"
+export NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/Bots/$NEONDIFF_BOT_ID/config.local.json}"
+```
 
 Packaged or non-source deployments must set
 `NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
@@ -92,19 +98,19 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git status --short
 git pull --ff-only
 npm test
 npm run build
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+node "$NEONDIFF_BUNDLE_DIR/install-b0-worker-candidate.mjs" update --manifest "$NEONDIFF_BUNDLE_DIR/<accepted-bundle-manifest>.json" --manifest-sha256 <manifest-sha256-from-release> --tarball "$NEONDIFF_BUNDLE_DIR/<accepted-bundle>.tgz" --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 sleep 5
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot \
   --require-coverage true
@@ -115,7 +121,7 @@ For public source-beta releases, run the same gate with manifest checks:
 ```bash
 PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -138,7 +144,7 @@ fetched:
 ```bash
 git fetch origin --tags
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -470,7 +476,7 @@ from the eligible open-head set. Retire only the exact failed head:
 
 ```bash
 npx tsx src/cli.ts retire-failed \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
@@ -540,7 +546,7 @@ Expired cooldown rows are actionable backlog. Run:
 
 ```bash
 npx tsx src/cli.ts retry-provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expired-only true \
   --dry-run false \
   --zcode true
@@ -553,21 +559,16 @@ that the retry recorded `skipped_closed` or `skipped_stale_head`.
 
 ## Rollback
 
-Default rollback is to restart the existing launchd job after checking out the
-last known-good merge commit:
+Rollback uses the prior accepted signed worker bundle and preserves the
+existing LaunchAgent identity:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
-git fetch origin
-git checkout main
-git reset --hard <last-known-good-merge-sha>
-npm run build
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+node "$NEONDIFF_BUNDLE_DIR/install-b0-worker-candidate.mjs" rollback --manifest "$NEONDIFF_BUNDLE_DIR/<prior-bundle-manifest>.json" --manifest-sha256 <prior-manifest-sha256-from-release> --tarball "$NEONDIFF_BUNDLE_DIR/<prior-bundle>.tgz" --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 ```
 
-Use `git reset --hard` only as an explicit rollback operation with the target
-SHA recorded in GitHub. Do not use rollback to bypass code review or to erase
-unrelated dirty work.
+Rollback is bundle-first: verify the prior signed manifest and tarball, then
+switch atomically through the installer. Do not rebuild a source checkout or
+erase unrelated dirty work.
 
 To stop the live beta worker entirely:
 
@@ -601,8 +602,8 @@ For each beta promotion, record:
   tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
-Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
-or session notes. Do not paste secrets, private keys, tokens, cookies, raw
+Keep raw evidence under `$NEONDIFF_EVIDENCE_ROOT` or session notes. Do not
+paste secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
 
 ## Release Packet Template

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -95,10 +95,10 @@ re-update, immutable release assets, and live customer evidence.
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -115,7 +115,7 @@ re-update, immutable release assets, and live customer evidence.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -192,7 +192,7 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$NEONDIFF_EVIDENCE_ROOT/`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -13,7 +13,7 @@ Run the checked-in local suite fixtures:
 ```bash
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/local-suite"
 ```
 
 Run the paired sticky-vs-cold fixture:
@@ -21,7 +21,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -30,7 +30,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -38,7 +38,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -52,7 +52,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
+  --output-root "$NEONDIFF_EVAL_ROOT/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S)" \
   --dry-run true
 ```
 
@@ -65,10 +65,8 @@ The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.
 
-By default, packets are written under:
-
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/
+$NEONDIFF_EVAL_ROOT/<date>/<run-id>/
 ```
 
 Use `--output-dir` for tests or scratch runs.

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -339,10 +339,15 @@ unchanged and treat the package as quarantined.
 
 ## Tag And Release
 
+```bash
+: "${NEONDIFF_REPO_ROOT:?set checkout}"; : "${NEONDIFF_ACCOUNT_ID:?set account}"; : "${NEONDIFF_BOT_ID:?set bot}"; : "${NEONDIFF_BUNDLE_DIR:?set accepted bundle}"
+export NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/Bots/$NEONDIFF_BOT_ID/config.local.json}"
+```
+
 Create an annotated tag from the merged source SHA:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
@@ -377,14 +382,12 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
 test "$(git rev-parse HEAD)" = "<source-sha>"
-launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+node "$NEONDIFF_BUNDLE_DIR/install-b0-worker-candidate.mjs" update --manifest "$NEONDIFF_BUNDLE_DIR/<accepted-bundle-manifest>.json" --manifest-sha256 <manifest-sha256-from-release> --tarball "$NEONDIFF_BUNDLE_DIR/<accepted-bundle>.tgz" --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 ```
 
 ## Post-Release Gate
@@ -392,10 +395,8 @@ launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 Run the status gate with App credentials set in the shell:
 
 ```bash
-export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
-export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
@@ -406,7 +407,7 @@ For public source-beta or public beta releases, include the public manifest gate
 SOURCE_SHA=replace-with-release-source-sha
 PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$SOURCE_SHA" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -424,9 +425,9 @@ Also run:
 
 ```bash
 npx tsx src/cli.ts coverage-audit \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+  --config "$NEONDIFF_CONFIG"
 npx tsx src/cli.ts provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expired-only true
 ```
 
@@ -458,13 +459,12 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_REPO_ROOT"
 git fetch origin --tags
 git checkout main
-git reset --hard <previous-release-tag>
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+node "$NEONDIFF_BUNDLE_DIR/install-b0-worker-candidate.mjs" rollback --manifest "$NEONDIFF_BUNDLE_DIR/<prior-bundle-manifest>.json" --manifest-sha256 <prior-manifest-sha256-from-release> --tarball "$NEONDIFF_BUNDLE_DIR/<prior-bundle>.tgz" --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -226,8 +226,10 @@ Use this path for each new repo from #14 or future allowlists:
 7. Promote through `docs/beta-release-runbook.md` and verify
    `npm run release:status` plus fresh launchd heartbeats.
 
-Do not treat `config.example.json` as live config. The active launchd config is
-outside the repo under `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/`.
+Do not treat `config.example.json` as live config. The signed Desktop app owns
+the account-scoped config under
+`$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/`
+and reads GitHub App credentials from the macOS Keychain; never export them.
 Do not add repos whose GitHub App installation cannot be verified; public
 visibility or an admin user's `gh repo view` is not enough because reviews must
 be authored by `evaos-code-review-bot`.
@@ -250,9 +252,9 @@ The template intentionally keeps:
 Before copying any part of the template into the active live config, run:
 
 ```sh
-NEONDIFF_GITHUB_APP_ID="<github-app-id>" \
-NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem" \
-npx tsx src/cli.ts doctor --config /path/to/candidate-live-config.json
+: "${NEONDIFF_ACCOUNT_ID:?set the selected Desktop account id}"
+NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/candidate-live-config.json}" \
+npx tsx src/cli.ts doctor --config "$NEONDIFF_CONFIG"
 ```
 
 Then run dry-run review evidence for at least one current PR and one

--- a/docs/skills/release-operator.md
+++ b/docs/skills/release-operator.md
@@ -26,15 +26,16 @@ exception in the tracker issue and open a backfill issue before ending.
 4. Create an annotated tag at the merged SHA.
 5. Push the tag.
 6. Create a GitHub prerelease with the release packet as notes.
-7. Restart launchd.
+7. Install the accepted signed worker bundle from that immutable prerelease;
+   preserve the existing LaunchAgent, config, and worker identity.
 8. Run `release:status`, `coverage-audit`, and expired provider cooldown audit.
 9. Update the tracker issue and PR/release notes with the status result.
 
 ## Required Commands
 
 ```bash
-export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
-export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+: "${NEONDIFF_ACCOUNT_ID:?set account}"; : "${NEONDIFF_BUNDLE_DIR:?set accepted bundle}"
+export NEONDIFF_CONFIG="${NEONDIFF_CONFIG:-$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT_ID/config/active-installed-live.json}"
 
 git fetch origin main --tags
 git checkout main
@@ -48,9 +49,9 @@ gh release create <tag> \
   --prerelease \
   --target <source-sha>
 
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+node "$NEONDIFF_BUNDLE_DIR/install-b0-worker-candidate.mjs" update --manifest "$NEONDIFF_BUNDLE_DIR/<accepted-bundle-manifest>.json" --manifest-sha256 <manifest-sha256-from-release> --tarball "$NEONDIFF_BUNDLE_DIR/<accepted-bundle>.tgz" --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/launchd/evaos-code-review-bot.plist.example
+++ b/launchd/evaos-code-review-bot.plist.example
@@ -5,43 +5,32 @@
 <dict>
   <key>Label</key>
   <string>com.electricsheephq.evaos-code-review-bot</string>
-  <key>WorkingDirectory</key>
-  <string>/Volumes/LEXAR/repos/evaos-code-review-bot</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/node</string>
-    <string>/Volumes/LEXAR/repos/evaos-code-review-bot/node_modules/tsx/dist/cli.mjs</string>
-    <string>src/cli.ts</string>
-    <string>daemon</string>
+    <string>/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop</string>
+    <string>--neondiff-worker-daemon</string>
     <string>--config</string>
-    <string>/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json</string>
-    <string>--dry-run</string>
-    <string>true</string>
+    <string>/Users/REPLACE_WITH_ACCOUNT_HOME/Library/Application Support/NeonDiffDesktop/Accounts/REPLACE_WITH_ACCOUNT_ID/Bots/REPLACE_WITH_BOT_ID/config.local.json</string>
+    <string>--launchd-label</string>
+    <string>com.electricsheephq.evaos-code-review-bot</string>
+    <string>--github-app-id</string>
+    <string>REPLACE_WITH_PUBLIC_APP_ID</string>
+    <string>--license-machine-id</string>
+    <string>REPLACE_WITH_43_CHAR_DEVICE_ID</string>
   </array>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key>
-    <string>/opt/homebrew/bin:/opt/homebrew/sbin:/Users/lume/.bun/bin:/Users/lume/gbrain/bin:/Users/lume/.local/bin:/Users/lume/.openclaw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>HOME</key>
-    <string>/Users/lume</string>
-    <key>USER</key>
-    <string>lume</string>
-    <key>LOGNAME</key>
-    <string>lume</string>
-    <key>SHELL</key>
-    <string>/bin/zsh</string>
-    <key>EVAOS_REVIEW_BOT_APP_ID</key>
-    <string>REPLACE_WITH_APP_ID</string>
-    <key>EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH</key>
-    <string>/absolute/path/to/private-key.pem</string>
-  </dict>
   <key>RunAtLoad</key>
-  <false/>
+  <true/>
   <key>KeepAlive</key>
-  <false/>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LimitLoadToSessionType</key>
+  <string>Aqua</string>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
   <key>StandardOutPath</key>
-  <string>/Users/lume/Library/Logs/evaos-code-review-bot/launchd.out.log</string>
+  <string>/dev/null</string>
   <key>StandardErrorPath</key>
-  <string>/Users/lume/Library/Logs/evaos-code-review-bot/launchd.err.log</string>
+  <string>/dev/null</string>
 </dict>
 </plist>

--- a/tests/operational-doc-path-contract.test.ts
+++ b/tests/operational-doc-path-contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs"; import { join, resolve } from "node:path"; import { expect, it } from "vitest";
+const root = resolve(import.meta.dirname, ".."), docs = ["docs/beta-release-runbook.md", "docs/release-governance.md", "docs/desktop-auto-update-channel.md", "apps/neondiff-desktop/docs/appcast-channels.md", "docs/eval-harness.md", "docs/repo-profiles.md", "docs/skills/release-operator.md", "launchd/evaos-code-review-bot.plist.example"], read = (path: string) => readFileSync(join(root, path), "utf8");
+it("keeps active operational docs portable and Keychain-only", () => {
+  const contents = docs.map(read).join("\n");
+  expect(contents).not.toMatch(/\/Volumes\/LEXAR|\/Users\/(?:m1|lume)\//);
+  expect(contents).not.toMatch(/PRIVATE_KEY_PATH|private-key\.pem|REPLACE_WITH_APP_ID/); expect(contents).toContain("Library/Application Support/NeonDiffDesktop/Accounts"); expect(contents).toContain("macOS Keychain");
+}); it("keeps generated eval and appcast evidence under explicit portable roots", () => {
+  expect(read("docs/eval-harness.md")).toContain("NEONDIFF_EVAL_ROOT"); expect(read("apps/neondiff-desktop/docs/appcast-channels.md")).toContain("NEONDIFF_EVIDENCE_ROOT"); expect(read("docs/desktop-auto-update-channel.md")).toContain("NEONDIFF_EVIDENCE_ROOT");
+}); it("uses the signed Desktop headless worker contract in the launchd example", () => {
+  const plist = read("launchd/evaos-code-review-bot.plist.example");
+  for (const value of ["/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop", "--neondiff-worker-daemon", "--config", "Accounts/REPLACE_WITH_ACCOUNT_ID/Bots/REPLACE_WITH_BOT_ID/config.local.json", "--launchd-label", "--github-app-id", "--license-machine-id"]) expect(plist).toContain(value);
+  expect(plist).not.toMatch(/WorkingDirectory|EnvironmentVariables|PRIVATE_KEY|private-key/);
+});
+it("documents accepted signed worker updates that preserve the running identity", () => {
+  const releaseDocs = ["docs/SETUP.md", "docs/beta-release-runbook.md", "docs/release-governance.md", "docs/skills/release-operator.md"].map(read).join("\n");
+  expect(releaseDocs).toContain("accepted signed"); expect(releaseDocs).toMatch(/Install \/ Update Local Worker/); expect(releaseDocs).toMatch(/preserves? (?:the )?(?:existing )?(?:running )?worker/i);
+  expect(releaseDocs).toMatch(/LaunchAgent.{0,120}(?:preserve|same|identity)/is); expect(releaseDocs).not.toMatch(/git checkout main[\s\S]{0,240}launchctl/);
+});


### PR DESCRIPTION
Part of #864

## What changed
- Align the active LaunchAgent example with the signed NeonDiff Desktop headless worker contract, account-scoped config path, label, and credential-safe arguments.
- Use explicit NEONDIFF_EVAL_ROOT and NEONDIFF_EVIDENCE_ROOT paths in evaluation and appcast/update guidance.
- Make release and rollback guidance install an accepted signed bundle while preserving the existing worker identity.
- Add a focused operational-doc contract test covering portable paths, Keychain-only examples, launchd arguments, and signed bundle identity.

## Evidence
- Base: 921a74b5381e2178c3ca8369187731c06d0942dd
- Head: 282a5e6
- Diff: 9 files, 105 additions + 95 deletions = 200 changed lines.
- `git diff --check` and plist lint pass.
- Deterministic Node contract check passes.
- Vitest was attempted but could not start because the environment lacks the optional Rolldown native binding; no dependencies were installed.
- GitNexus detect-changes: 9 files, 22 symbols, 0 affected processes, low risk. The registered index is stale: it is a sibling checkout 150 commits behind this worktree, so direct current-file verification is the source of truth.

## Proof boundary
This PR proves the edited documentation/example contract only. It does not claim artifact signing, notarization, live installation, worker health, release publication, or customer readiness.