### PR TITLE
fix(operator): expose scoped durable recovery truth

### DIFF
--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -64,6 +64,7 @@ export interface ReleaseDatabaseStatus {
   staleReviewRunLeaseCount?: number;
   staleActiveReviewQueueJobCount?: number;
   reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
+  reviewErrorsByRepo?: ReviewErrorRepoStatus[];
 }
 
 export interface ReleaseHealthStatus { state: "green" | "amber" | "red"; reason: string; active: { failedQueueJobs: number; staleReviewLeases: number }; recent: { unrecoveredReviewErrors: number }; history: { reviewErrors: number; failedQueueJobs: number }; }
@@ -76,6 +77,11 @@ export interface ReviewerSessionRepoStatus {
   retryCovered?: number;
 }
 
+export interface ReviewErrorRepoStatus {
+  repo: string;
+  recentUnrecovered: number;
+}
+
 export interface ReviewQueueRepoStatus {
   repo: string;
   total: number;
@@ -85,6 +91,9 @@ export interface ReviewQueueRepoStatus {
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  activeFailed?: number;
+  zcodeTimeoutFailed?: number;
+  activeZCodeTimeoutFailed?: number;
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -2417,6 +2426,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       staleReviewRunLeaseCount: reviewRunLeases.stale,
       staleActiveReviewQueueJobCount,
       reviewQueueJobsByRepo: reviewQueue.byRepo,
+      reviewErrorsByRepo: failureHealth.byRepo,
       errorCount: row.errorCount ?? 0,
       recentUnrecoveredErrorCount: failureHealth.recentUnrecoveredErrorCount,
       ...(failureHealth.lastErrorAt ? { lastErrorAt: failureHealth.lastErrorAt } : {})
@@ -2468,6 +2478,7 @@ function readFailureRecoveryIndex(db: DatabaseSync): FailureRecoveryIndex {
 function readProcessedFailureHealth(db: DatabaseSync, now: Date, recovery: FailureRecoveryIndex): {
   recentUnrecoveredErrorCount: number;
   lastErrorAt?: string;
+  byRepo: ReviewErrorRepoStatus[];
 } {
   const errorWhere = "failed.status = 'failed' or (failed.status != 'skipped' and failed.error is not null and failed.error != '')";
   const cutoffMs = now.getTime() - FAILURE_HEALTH_WINDOW_MS;
@@ -2477,14 +2488,18 @@ function readProcessedFailureHealth(db: DatabaseSync, now: Date, recovery: Failu
       where (${errorWhere})
         and (datetime(failed.created_at) is null or datetime(failed.created_at) >= datetime(?, '-1 second'))`
   ).all(cutoff) as unknown as Array<{ repo: string; pull_number: number; created_at: string }>;
-  return {
-    recentUnrecoveredErrorCount: recent.filter((row) => {
+  const unrecovered = recent.filter((row) => {
       const normalized = row.created_at.replace(" ", "T");
       const failedAt = Date.parse(/[zZ]|[+-]\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`);
       if (Number.isFinite(failedAt) && failedAt < cutoffMs) return false;
       const postedAt = recovery.latestPostedAtByPull.get(`${row.repo}\u0000${row.pull_number}`);
       return !Number.isFinite(failedAt) || postedAt === undefined || postedAt <= failedAt / 86_400_000 + 2440587.5;
-    }).length,
+    });
+  const byRepo = new Map<string, number>();
+  for (const row of unrecovered) byRepo.set(row.repo, (byRepo.get(row.repo) ?? 0) + 1);
+  return {
+    recentUnrecoveredErrorCount: unrecovered.length,
+    byRepo: [...byRepo.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([repo, count]) => ({ repo, recentUnrecovered: count })),
     ...(recovery.lastErrorAt ? { lastErrorAt: recovery.lastErrorAt } : {})
   };
 }
@@ -2569,6 +2584,12 @@ function readReviewQueueCounts(
   });
   const timeoutCounts = summarizeZCodeTimeoutErrors(failedRows.map((row) => row.last_error));
   const activeTimeoutCounts = summarizeZCodeTimeoutErrors(activeFailedRows.map((row) => row.last_error));
+  const activeFailedByRepo = new Map<string, FailedQueueRow[]>();
+  for (const row of activeFailedRows) {
+    const rows = activeFailedByRepo.get(row.repo) ?? [];
+    rows.push(row);
+    activeFailedByRepo.set(row.repo, rows);
+  }
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -2582,16 +2603,25 @@ function readReviewQueueCounts(
     activeZCodeTimeoutFailed: activeTimeoutCounts.total,
     retryableZCodeTimeoutFailed: timeoutCounts.retryable,
     exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,
-    byRepo: byRepoRows.map((repoRow) => ({
-      repo: repoRow.repo,
-      total: repoRow.total ?? 0,
-      queued: repoRow.queued ?? 0,
-      leased: repoRow.leased ?? 0,
-      running: repoRow.running ?? 0,
-      providerDeferred: repoRow.providerDeferred ?? 0,
-      retryableProviderDeferred: repoRow.retryableProviderDeferred ?? 0,
-      failed: repoRow.failed ?? 0
-    }))
+    byRepo: byRepoRows.map((repoRow) => {
+      const activeRows = activeFailedByRepo.get(repoRow.repo) ?? [];
+      const repoTimeouts = summarizeZCodeTimeoutErrors(
+        failedRows.filter((row) => row.repo === repoRow.repo).map((row) => row.last_error)
+      );
+      return {
+        repo: repoRow.repo,
+        total: repoRow.total ?? 0,
+        queued: repoRow.queued ?? 0,
+        leased: repoRow.leased ?? 0,
+        running: repoRow.running ?? 0,
+        providerDeferred: repoRow.providerDeferred ?? 0,
+        retryableProviderDeferred: repoRow.retryableProviderDeferred ?? 0,
+        failed: repoRow.failed ?? 0,
+        activeFailed: activeRows.length,
+        zcodeTimeoutFailed: repoTimeouts.total,
+        activeZCodeTimeoutFailed: summarizeZCodeTimeoutErrors(activeRows.map((row) => row.last_error)).total
+      };
+    })
   };
 }
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -272,6 +272,22 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual(expect.objectContaining({ name: "queue_no_failed_jobs", ok: false }));
   });
 
+  it("projects closed-PR recovery into complete repository queue counts", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-closed-recovery-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`create table processed_reviews (repo text, pull_number integer, head_sha text, status text, event text, error text, created_at text, primary key (repo, pull_number, head_sha));
+      create table review_event_authorization_consumptions (repo text, pull_number integer, posted_event text, posted_at text);
+      create table review_queue_jobs (job_id text primary key, attempt_id text, source text, lane text, repo text, org text, pull_number integer, head_sha text, priority integer, state text, next_eligible_at text, lease_expires_at text, last_error text, created_at text, updated_at text);`);
+    db.prepare("insert into processed_reviews values (?,?,?,?,?,?,?)").run("owner/repo", 7, "failed-head", "failed", null, "provider timeout", "2026-08-22T23:30:00Z");
+    db.prepare("insert into review_event_authorization_consumptions values (?,?,?,?)").run("owner/repo", 7, "COMMENT", "2026-08-22T23:45:00Z");
+    db.prepare("insert into review_queue_jobs values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)").run("failed", "attempt", "automatic", "background", "owner/repo", "owner", 7, "failed-head", 1, "failed", null, null, "ordinary failure", "2026-08-22T23:30:00Z", "2026-08-22T23:30:00Z");
+    db.close();
+    const status = collectReleaseStatus({ cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"), launchdLabel: "worker", now: new Date("2026-08-23T00:00:00Z") });
+    expect(status.database.reviewQueueJobsByRepo?.[0]).toMatchObject({ repo: "owner/repo", failed: 1, activeFailed: 0 });
+  });
+
   it("keeps recovered historical failures amber rather than red", () => {
     const status = buildReleaseStatus({ repo: { branch: "main", head: "head", dirtyFiles: [] }, expectedHead: "head", configPath: "/config/live.json", launchd: { label: "worker", state: "running", configPath: "/config/live.json", usesSystemCa: true }, database: { rowCount: 2, errorCount: 1, recentUnrecoveredErrorCount: 0, lastErrorAt: "2026-08-21T00:00:00Z", failedReviewQueueJobCount: 1, activeFailedReviewQueueJobCount: 0, zcodeTimeoutFailedReviewQueueJobCount: 1, activeZCodeTimeoutFailedReviewQueueJobCount: 0 }, heartbeat: freshHeartbeat(), now: new Date("2026-08-23T00:00:00Z") });
     expect(status.ok).toBe(true);
@@ -6205,7 +6221,10 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         running: 0,
         providerDeferred: 0,
         retryableProviderDeferred: 0,
-        failed: 1
+        failed: 1,
+        activeFailed: 1,
+        zcodeTimeoutFailed: 0,
+        activeZCodeTimeoutFailed: 0
       },
       {
         repo: "100yenadmin/evaOS-GUI",
@@ -6215,7 +6234,10 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         running: 0,
         providerDeferred: 2,
         retryableProviderDeferred: 1,
-        failed: 0
+        failed: 0,
+        activeFailed: 0,
+        zcodeTimeoutFailed: 0,
+        activeZCodeTimeoutFailed: 0
       },
       {
         repo: "electricsheephq/WorldOS",
@@ -6225,7 +6247,10 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         running: 1,
         providerDeferred: 0,
         retryableProviderDeferred: 0,
-        failed: 0
+        failed: 0,
+        activeFailed: 0,
+        zcodeTimeoutFailed: 0,
+        activeZCodeTimeoutFailed: 0
       }
     ]);
     expect(status.gates).toContainEqual({


### PR DESCRIPTION
Related: #863

## Summary
- extend complete per-repository queue totals with active-failure and ZCode-timeout counts
- derive recovery from durable processed reviews and authorization-consumption posts, including subsequently closed PRs
- expose scoped recent unrecovered review-error counts without changing the database schema

## Validation
- failing-first: the closed-PR authorization fixture initially failed before the collector/test correction
- `/opt/homebrew/bin/node ./node_modules/vitest/vitest.mjs run tests/release-status.test.ts` (118 passed)
- TypeScript build via `tsc -p tsconfig.build.json`
- `git diff --check`
- 87 changed non-generated lines

Agent-authored. No live worker, status, health, queue, database, config, provider, credential, customer, or release mutation was performed. Held PRs #851/#852 were reference-only; no predecessor commit was reused.