### PR TITLE
feat(operator): present scoped active health safely

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -311,6 +311,20 @@ Check whether the live bot is healthy:
 npx tsx src/cli.ts status --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
+For a nested summary intended for a person at the terminal, add `--human`:
+
+```bash
+npx tsx src/cli.ts status --human --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Human status prints the current release health, current blocking counts,
+retained history, failed gates, and read-only next guidance. JSON remains the
+default and both formats recursively redact secret-looking values and replace
+recovery commands with inspection guidance. The command exits `0` only when
+the combined operator gate passes; `--human` changes presentation only, so a
+failed gate still exits nonzero and does not authorize a restart, retry,
+requeue, or launchd mutation.
+
 Classify whether the bot is idle, healthy-active, or blocked:
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -716,6 +716,7 @@ async function main(): Promise<void> {
     const github = new GitHubApi(config.github);
     const status = buildOperatorStatus({
       release,
+      ...(args.repo ? { repo: args.repo } : {}),
       coverage,
       agents,
       providerCooldowns,
@@ -777,6 +778,7 @@ async function main(): Promise<void> {
     });
     const inventory = buildRuntimeInventory({
       release,
+      ...(args.repo ? { repo: args.repo } : {}),
       coverage,
       agents,
       processes,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,10 @@ import {
   collectOperatorReviewQueue,
   explainPullStatus,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
+  formatOperatorStatusJson,
   formatRuntimeInventoryHuman,
+  formatRuntimeInventoryJson,
   summarizeAgentInventory,
   type OperatorDurableQueueSnapshot,
   type OperatorQueueSnapshot
@@ -724,7 +727,7 @@ async function main(): Promise<void> {
       }),
       issueEnrichmentRuntime
     });
-    console.log(stringifyRedactedJson(status));
+    console.log(args.human === "true" ? formatOperatorStatusHuman(status) : formatOperatorStatusJson(status));
     if (!status.ok) process.exitCode = 1;
     return;
   }
@@ -788,7 +791,7 @@ async function main(): Promise<void> {
       issueEnrichmentRuntime,
       checkedAt: now.toISOString()
     });
-    console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : JSON.stringify(inventory, null, 2));
+    console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : formatRuntimeInventoryJson(inventory));
     if (!inventory.ok) process.exitCode = 1;
     return;
   }
@@ -3614,7 +3617,8 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--limit", description: "Cap the number of provider-cooldown/durable-queue rows returned." },
       { name: "--expected-head", description: "Expected release head SHA to verify against." },
       { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
-      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." }
+      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." },
+      { name: "--human", description: "Print a compact nested operator summary instead of JSON; exit status still follows the combined gate." }
     ]
   },
   "release-status": {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -53,6 +53,7 @@ export interface OperatorStatus {
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    activeFailedQueueJobs: number;
     zcodeTimeoutFailedQueueJobs: number;
     retryableZCodeTimeoutFailedQueueJobs: number;
     exhaustedZCodeTimeoutFailedQueueJobs: number;
@@ -395,6 +396,7 @@ export interface PullStatusExplanation {
 
 export function buildOperatorStatus(input: {
   release: ReleaseStatus;
+  repo?: string;
   coverage?: CoverageAuditReport;
   agents: OperatorAgentInventory;
   providerCooldowns?: ProviderCooldownReviewRecord[];
@@ -403,6 +405,7 @@ export function buildOperatorStatus(input: {
   issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
   checkedAt?: string;
 }): OperatorStatus {
+  const release = scopeReleaseForRepo(input.release, input.repo);
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
   const providerCooldowns = input.providerCooldowns ?? [];
   const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
@@ -412,9 +415,12 @@ export function buildOperatorStatus(input: {
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
+  const scopedQueue = input.repo ? input.release.database.reviewQueueJobsByRepo?.find((row) => row.repo === input.repo) : undefined;
   const failedRows = input.release.database.errorCount;
-  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const failedQueueJobs = scopedQueue?.failed ?? durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs = scopedQueue?.activeFailed ?? input.release.database.activeFailedReviewQueueJobCount ?? failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
+  const activeZcodeTimeouts = scopedQueue?.activeZCodeTimeoutFailed ?? input.release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? zcodeTimeoutQueue.total;
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
   const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
@@ -430,7 +436,7 @@ export function buildOperatorStatus(input: {
     describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
 
   const gates = [
-    ...input.release.gates,
+    ...release.gates,
     {
       name: "queue_no_pending_heads",
       ok: pendingHeads === 0,
@@ -455,12 +461,12 @@ export function buildOperatorStatus(input: {
     },
     {
       name: "durable_queue_no_failed_jobs",
-      ok: failedQueueJobs === 0,
-      detail: `${failedQueueJobs} failed durable queue job(s)`
+      ok: activeFailedQueueJobs === 0,
+      detail: `${activeFailedQueueJobs} active failed durable queue job(s); ${failedQueueJobs} retained history`
     },
     {
       name: "durable_queue_no_zcode_timeout_failed_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
+      ok: activeZcodeTimeouts === 0,
       detail:
         `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
         `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
@@ -499,13 +505,13 @@ export function buildOperatorStatus(input: {
   ];
 
   const recommendedActions = uniqueStrings([
-    ...input.release.recommendedActions,
+    ...release.recommendedActions,
     ...(pendingHeads > 0 ? ["wait for daemon cycle or run scoped run-once"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(activeZcodeTimeouts > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -534,6 +540,7 @@ export function buildOperatorStatus(input: {
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
       failedQueueJobs,
+      activeFailedQueueJobs,
       zcodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.total,
       retryableZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.retryable,
       exhaustedZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.exhausted,
@@ -545,7 +552,7 @@ export function buildOperatorStatus(input: {
     gates,
     failedGates: gates.filter((gate) => !gate.ok),
     recommendedActions,
-    release: input.release,
+    release,
     ...(budget ? { budget } : {}),
     ...(queue ? { coverage: queue } : {}),
     agents: input.agents,
@@ -558,6 +565,7 @@ export function buildOperatorStatus(input: {
 
 export function buildRuntimeInventory(input: {
   release: ReleaseStatus;
+  repo?: string;
   coverage?: CoverageAuditReport;
   agents: OperatorAgentInventory;
   processes?: RuntimeProcessInventory;
@@ -568,21 +576,20 @@ export function buildRuntimeInventory(input: {
   issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
   checkedAt?: string;
 }): RuntimeInventory {
+  const release = scopeReleaseForRepo(input.release, input.repo);
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
   const durableQueue = input.durableQueue;
   const providerCooldowns = input.providerCooldowns ?? [];
   const repoProviderCooldowns = input.repoProviderCooldowns ?? [];
-  const activeWork = (durableQueue?.jobs ?? []).filter((job) =>
-    job.state === "queued" || job.state === "leased" || job.state === "running"
-  );
+  const checkedAtMs = Date.parse(input.checkedAt ?? input.release.checkedAt);
+  const nowMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
+  const activeWork = (durableQueue?.jobs ?? []).filter((job) => isActiveQueueJob(job, nowMs));
   const uncoveredPendingHeads = (queue?.pending ?? []).filter((pending) =>
     !activeWork.some((job) => sameHead(job, pending))
   );
   const coveredPendingHeads = (queue?.pending.length ?? 0) - uncoveredPendingHeads.length;
   const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
   const activeProviderCooldowns = providerCooldowns.length - expiredProviderCooldowns;
-  const checkedAtMs = Date.parse(input.checkedAt ?? input.release.checkedAt);
-  const nowMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const activeRepoCooldowns = repoProviderCooldowns.filter((cooldown) => {
     const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
     return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > nowMs;
@@ -593,9 +600,12 @@ export function buildRuntimeInventory(input: {
   const retryableExpiredProviderCooldowns =
     input.release.database.retryableExpiredProviderCooldownCount ??
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
-  const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
-  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const scopedQueue = input.repo ? input.release.database.reviewQueueJobsByRepo?.find((row) => row.repo === input.repo) : undefined;
+  const retryCoveredReviewerSessions = input.repo ? input.release.database.reviewerSessionsByRepo?.find((row) => row.repo === input.repo)?.retryCovered ?? 0 : input.release.database.retryCoveredReviewerSessionCount ?? 0;
+  const failedQueueJobs = scopedQueue?.failed ?? durableQueue?.summary.failed ?? 0;
+  const activeFailedQueueJobs = scopedQueue?.activeFailed ?? failedQueueJobs;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
+  const activeZcodeTimeouts = scopedQueue?.activeZCodeTimeoutFailed ?? input.release.database.activeZCodeTimeoutFailedReviewQueueJobCount ?? zcodeTimeoutQueue.total;
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
@@ -615,7 +625,7 @@ export function buildRuntimeInventory(input: {
     describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
 
   const gates = [
-    ...input.release.gates,
+    ...release.gates,
     {
       name: "runtime_no_stale_leases",
       ok: input.agents.summary.staleLeases === 0,
@@ -623,12 +633,12 @@ export function buildRuntimeInventory(input: {
     },
     {
       name: "runtime_no_failed_queue_jobs",
-      ok: failedQueueJobs === 0,
+      ok: activeFailedQueueJobs === 0,
       detail: `${failedQueueJobs} failed durable queue job(s)`
     },
     {
       name: "runtime_no_zcode_timeout_failed_queue_jobs",
-      ok: zcodeTimeoutQueue.total === 0,
+      ok: activeZcodeTimeouts === 0,
       detail:
         `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
         `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
@@ -715,13 +725,13 @@ export function buildRuntimeInventory(input: {
       : "healthy_idle";
 
   const recommendedActions = uniqueStrings([
-    ...input.release.recommendedActions,
+    ...release.recommendedActions,
     ...(activeWork.length > 0 ? ["monitor active review work; avoid restarting a healthy in-flight run"] : []),
     ...(uncoveredPendingHeads.length > 0 ? ["wait for daemon cycle or run scoped run-once for uncovered pending heads"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
-    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(zcodeTimeoutQueue.total > 0
+    ...(activeFailedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(activeZcodeTimeouts > 0
       ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
@@ -774,7 +784,7 @@ export function buildRuntimeInventory(input: {
     recommendedActions,
     activeWork,
     uncoveredPendingHeads,
-    release: input.release,
+    release,
     ...(budget ? { budget } : {}),
     agents: input.agents,
     ...(input.processes ? { processes: input.processes } : {}),
@@ -1773,6 +1783,18 @@ function staleHeadQueueEntry(entry: CoverageStaleHead): OperatorQueueEntry {
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
+}
+
+const GLOBAL_SCOPED_GATES = new Set(["live_db_no_errors", "provider_cooldown_backlog", "queue_no_failed_jobs", "queue_no_zcode_timeout_failed_jobs", "queue_no_stale_review_leases", "queue_no_retryable_provider_deferred_jobs"]);
+
+function scopeReleaseForRepo(release: ReleaseStatus, repo?: string): ReleaseStatus {
+  if (!repo) return release; const gates = release.gates.filter((gate) => !GLOBAL_SCOPED_GATES.has(gate.name));
+  return { ...release, ok: gates.every((gate) => gate.ok), gates, recommendedActions: [] };
+}
+
+function isActiveQueueJob(job: ReviewQueueJobRecord, nowMs: number): boolean {
+  if (job.state !== "queued" && job.state !== "leased" && job.state !== "running") return false;
+  const expiresAtMs = Date.parse(job.leaseExpiresAt ?? ""); return job.state === "queued" || !Number.isFinite(expiresAtMs) || expiresAtMs > nowMs;
 }
 
 function sanitizeOperatorProjection(input: unknown): unknown {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -14,7 +14,7 @@ import type {
 import type { IssueEnrichmentStatus } from "./issue-enrichment.js";
 import type { ReviewBudgetStatus } from "./review-budget.js";
 import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
-import { redactSecrets } from "./secrets.js";
+import { redactSecrets, stringifyRedactedJson } from "./secrets.js";
 import {
   parseProviderCooldownError,
   PROVIDER_COOLDOWN_ERROR_PREFIX,
@@ -881,7 +881,47 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
     lines.push("recommendedActions:");
     for (const action of inventory.recommendedActions) lines.push(`- ${action}`);
   }
-  return lines.join("\n");
+  return redactSecrets(lines.map(sanitizeOperatorAction).join("\n"));
+}
+
+export function formatOperatorStatusHuman(status: OperatorStatus): string {
+  const summary = status.summary as OperatorStatus["summary"] & {
+    activeFailedQueueJobs?: number;
+    recentUnrecoveredReviewErrors?: number;
+  };
+  const failingGates = status.gates.filter((gate) => !gate.ok);
+  const health = status.release.health;
+  const activeFailedQueueJobs = summary.activeFailedQueueJobs ?? summary.failedQueueJobs;
+  const recentUnrecoveredReviewErrors = summary.recentUnrecoveredReviewErrors ?? summary.failedRows;
+  const reason = failingGates[0]?.detail ?? health?.reason ?? "current operator gates pass";
+  const lines = [
+    `status: ${status.ok ? "ok" : "blocked"} (operator) - ${sanitizeOperatorAction(reason)}`,
+    `  releaseHealth: ${health?.state ?? (status.release.ok ? "green" : "red")}`,
+    "  current:",
+    `    failedQueueJobs: ${activeFailedQueueJobs}`,
+    `    recentUnrecoveredReviewErrors: ${recentUnrecoveredReviewErrors}`,
+    `    staleLeases: ${summary.staleLeases}`,
+    "  history:",
+    `    reviewErrors: ${summary.failedRows}`,
+    `    failedQueueJobs: ${summary.failedQueueJobs}`,
+    "  gates:",
+    ...(failingGates.length > 0
+      ? failingGates.map((gate) => `    - ${gate.name}: ${sanitizeOperatorAction(gate.detail)}`)
+      : ["    - none"]),
+    "  next:",
+    ...(status.recommendedActions.length > 0
+      ? status.recommendedActions.map((action) => `    - ${sanitizeOperatorAction(action)}`)
+      : ["    - inspect current operator status before any action"])
+  ];
+  return redactSecrets(lines.join("\n"));
+}
+
+export function formatOperatorStatusJson(status: OperatorStatus): string {
+  return stringifyRedactedJson(sanitizeOperatorProjection(status));
+}
+
+export function formatRuntimeInventoryJson(inventory: RuntimeInventory): string {
+  return stringifyRedactedJson(sanitizeOperatorProjection(inventory));
 }
 
 export function summarizeAgentInventory(input: {
@@ -1733,6 +1773,24 @@ function staleHeadQueueEntry(entry: CoverageStaleHead): OperatorQueueEntry {
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
+}
+
+function sanitizeOperatorProjection(input: unknown): unknown {
+  if (typeof input === "string") return sanitizeOperatorAction(input);
+  if (input instanceof Date) return input.toISOString();
+  if (Array.isArray(input)) return input.map((item) => sanitizeOperatorProjection(item));
+  if (input && typeof input === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) output[key] = sanitizeOperatorProjection(value);
+    return output;
+  }
+  return input;
+}
+
+function sanitizeOperatorAction(action: string): string {
+  return /\b(?:retry|requeue|restart|kickstart|bootout|clear|retire)\b|--dry-run\s+false/i.test(action)
+    ? "inspect operator recovery rows before any action"
+    : action;
 }
 
 function zcodeTimeoutQueueCounts(

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -19,7 +19,10 @@ import {
   explainPullStatus,
   filterBotProcessRows,
   formatOperatorDashboardHuman,
+  formatOperatorStatusHuman,
+  formatOperatorStatusJson,
   formatRuntimeInventoryHuman,
+  formatRuntimeInventoryJson,
   summarizeAgentInventory,
   type OperatorAgentInventory,
   type OperatorDurableQueueSnapshot
@@ -98,6 +101,31 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("presents status as nested human output with command-free JSON and gate exit semantics", () => {
+    const release = releaseStatus({ ok: false, recommendedActions: ["retry cooldowns --dry-run false"] });
+    release.releaseUnit.configPath = "/config/ghp_status_secret.json";
+    const status = buildOperatorStatus({
+      release,
+      coverage: coverageReport({
+        providerDeferred: [providerDeferredEntry(8, "head-deferred")],
+        unprocessed: [pullEntry(9, "head-pending")]
+      }),
+      agents: agentInventory({})
+    });
+
+    const human = formatOperatorStatusHuman(status);
+    expect(human).toContain("status: blocked (operator)");
+    expect(human).toContain("  gates:");
+    expect(human).toContain("  next:");
+    expect(human).toContain("inspect operator recovery rows before any action");
+    expect(human).not.toMatch(/retry-failed|retry-provider-cooldowns|restart worker|kickstart -k|bootout |--dry-run false/i);
+
+    const json = formatOperatorStatusJson(status);
+    expect(json).toContain("[redacted-secret]");
+    expect(json).not.toMatch(/retry-failed|retry-provider-cooldowns|restart worker|kickstart -k|bootout |--dry-run false/i);
+    expect(status.ok).toBe(false);
   });
 
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {
@@ -953,8 +981,10 @@ describe("operator CLI summaries", () => {
   });
 
   it("formats a concise human runtime inventory without leaking secrets", () => {
+    const release = releaseStatus({ ok: true, recommendedActions: ["restart worker --dry-run false"] });
+    release.releaseUnit.configPath = "/runtime/ghp_runtime_secret.json";
     const inventory = buildRuntimeInventory({
-      release: releaseStatus({ ok: true, budget: reviewBudgetStatus() }),
+      release: { ...release, budget: reviewBudgetStatus() },
       coverage: coverageReport({ ok: true }),
       agents: agentInventory({ ok: true }),
       durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
@@ -969,6 +999,9 @@ describe("operator CLI summaries", () => {
     expect(output).toContain("queue: active=0 queued=0 running=0 providerDeferred=0 failed=0");
     expect(output).toContain("budget: wouldLease=1 delayed=1 delayedByReason={\"manual_reserve\":1}");
     expect(output).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+    expect(output).not.toMatch(/restart worker|kickstart -k|bootout |--dry-run false/i);
+    expect(formatRuntimeInventoryJson(inventory)).toContain("[redacted-secret]");
+    expect(formatRuntimeInventoryJson(inventory)).not.toMatch(/restart worker|kickstart -k|bootout |--dry-run false/i);
   });
 
   it("builds a read-only dashboard over coverage, durable queue, readiness, and evidence links", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -865,6 +865,12 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(inventory)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
+  it("uses scoped recovered queue/session truth and excludes expired leases", () => {
+    const release = releaseStatus({ ok: false, database: { reviewQueueJobsByRepo: [{ repo: "owner/repo", total: 2, queued: 0, leased: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0, failed: 1, activeFailed: 0 }], reviewerSessionsByRepo: [{ repo: "owner/repo", total: 1, active: 1, expired: 0, retryCovered: 1 }] } });
+    const inventory = buildRuntimeInventory({ release, repo: "owner/repo", coverage: coverageReport({ ok: true }), agents: agentInventory({ ok: true }), durableQueue: durableQueueSnapshot({ summary: { ...cleanDurableQueueSummary(), total: 2, running: 1, failed: 1 }, jobs: [{ ...durableJob({ repo: "owner/repo", state: "running" }), leaseExpiresAt: "2026-07-01T00:01:00.000Z" }] }), providerCooldowns: [], repoProviderCooldowns: [], checkedAt: "2026-07-01T00:05:00.000Z" });
+    expect(inventory).toMatchObject({ summary: { activeQueueJobs: 0, retryCoveredReviewerSessions: 1 }, gates: expect.arrayContaining([expect.objectContaining({ name: "runtime_no_failed_queue_jobs", ok: true })]) }); expect(inventory.release.gates).not.toContainEqual(expect.objectContaining({ name: "live_db_no_errors" }));
+  });
+
   it("surfaces reviewer sessions covered by active queue retries in runtime inventory", () => {
     const inventory = buildRuntimeInventory({
       release: releaseStatus({


### PR DESCRIPTION
Related: #863

## Summary
- add documented `status --human` output with unchanged gate exit semantics
- recursively redact secrets and replace mutating recovery commands in status and runtime-inventory JSON/human projections
- consume complete per-repository recovery counts for active-vs-history gates
- exclude expired queue leases from active work and scope release, cooldown, and reviewer-session truth to the selected repository

## Validation
- failing-first presentation and scoped-inventory tests
- `/opt/homebrew/bin/node ./node_modules/vitest/vitest.mjs run tests/operator-cli.test.ts tests/release-status.test.ts` (166 passed)
- TypeScript build via `tsc -p tsconfig.build.json`
- `status --help` confirms `--human` and exit semantics
- `git diff --check`
- 197 changed non-generated lines against PR #870

Agent-authored. No live worker, status, health, queue, database, config, provider, credential, customer, or release mutation was performed. Held PRs #851/#852 were reference-only; no predecessor commit was reused.