### PR TITLE
fix(scheduler): quarantine incomplete evidence heads

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1246,6 +1246,7 @@ async function resolveSchedulerCommandDecision(input: {
 }): Promise<SchedulerCommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
+  let boundedEvidenceIncomplete = false;
   try {
     let boundedEvidence: BoundedGithubList<IssueCommentCommandSource> | undefined;
     if (input.github.listIssueCommentsForEnrichment) {
@@ -1255,13 +1256,11 @@ async function resolveSchedulerCommandDecision(input: {
         // Keep the uncapped command reader as the source of truth when the optional evidence read is unavailable.
       }
     }
-    if (boundedEvidence?.truncated || boundedEvidence?.overflow) {
-      input.onCommandFetchError?.();
-      return { action: "none", shouldReview: false, blocked: "required_evidence_incomplete" };
-    }
+    boundedEvidenceIncomplete = Boolean(boundedEvidence?.truncated || boundedEvidence?.overflow);
     comments = await input.github.listIssueComments(input.repo, input.pull.number);
   } catch {
     input.onCommandFetchError?.();
+    if (boundedEvidenceIncomplete) return { action: "none", shouldReview: false, blocked: "required_evidence_incomplete" };
     return { action: "none", shouldReview: false };
   }
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
@@ -1317,7 +1316,7 @@ async function resolveSchedulerCommandDecision(input: {
       author: requestChanges.author
     });
   }
-  return decideCommandAction({
+  const commandDecision = decideCommandAction({
     commands: authorizedCommands.filter((command) =>
       !isFinishingTouchCommandAction(command.action) ||
       (repoProfile.allowed && isFinishingTouchActionEnabled(command.action, repoProfile.profile.finishingTouches))
@@ -1328,6 +1327,11 @@ async function resolveSchedulerCommandDecision(input: {
     hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
       input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
   });
+  if (boundedEvidenceIncomplete && !commandDecision.shouldReview) {
+    input.onCommandFetchError?.();
+    return { action: "none", shouldReview: false, blocked: "required_evidence_incomplete" };
+  }
+  return commandDecision;
 }
 
 function latestPendingRequestChanges(input: {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, type BoundedGithubList } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -110,6 +110,8 @@ export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  // Bounded evidence is separate from the uncapped command reader (#857).
+  listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -172,6 +174,7 @@ export async function runScheduledCycleWithDeps(input: {
   const result = emptyScheduledRunResult();
   const now = input.now ?? new Date();
   const eventClock = input.clock ?? (() => input.now ?? new Date());
+  const excludedHeadKeys = new Set<string>();
   const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
   const providerId = config.zcode.providerId ?? config.zcode.model ?? "zcode";
   if (config.reviewerSessions?.enabled) {
@@ -242,6 +245,11 @@ export async function runScheduledCycleWithDeps(input: {
         },
         onCommandFetchError: () => {
           result.commandFetchErrors += 1;
+        },
+        clock: eventClock,
+        onQueueJobsQuarantined: ({ headKey, count }) => {
+          excludedHeadKeys.add(headKey);
+          result.queue.failedQueueJobs += count;
         }
       });
       applyEnqueueStatus(result, enqueueStatus);
@@ -287,6 +295,7 @@ export async function runScheduledCycleWithDeps(input: {
     manualCommandReserve: Math.min(scheduler.manualCommandReserve, effectiveSlots),
     limit: effectiveSlots,
     leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
+    excludeHeadKeys: excludedHeadKeys,
     ...(config.riskWeightedQueue?.aging ? { aging: config.riskWeightedQueue.aging } : {}),
     now: eventClock()
   });
@@ -503,6 +512,7 @@ async function collectSubsequentMergedPulls(input: {
 type EnqueueStatus =
   | "enqueued"
   | "already_queued"
+  | "command_fetch_failed"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_processed"
@@ -526,14 +536,16 @@ async function enqueuePullIfEligible(input: {
   allowActivationBaselineCommandLookup?: boolean;
   onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
+  clock?: () => Date;
+  onQueueJobsQuarantined?: (input: { headKey: string; count: number }) => void;
   automaticPriorityOverride?: number;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) {
     await retireQueuedJobsForClosedPull(input);
     return "closed_retired";
   }
-  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (input.config.skipDrafts && input.pull.draft) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -545,6 +557,7 @@ async function enqueuePullIfEligible(input: {
     return "skipped_draft";
   }
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -567,18 +580,32 @@ async function enqueuePullIfEligible(input: {
       pull: input.pull
     })
   ) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     await retireSupersededQueueJobsForPull(input);
     recordActivationBaselineExistingHead(input.state, input.repo, input.pull);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
   if (!input.allowActivationBaselineCommandLookup && isActivationBaselineProcessedReview(processed)) {
+    markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
     await retireSupersededQueueJobsForPull(input);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
+  if ("blocked" in commandDecision) {
+    const quarantine = quarantineQueueJobsForIncompleteEvidence({
+      config: input.config,
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      now: input.clock?.() ?? input.now
+    });
+    input.onQueueJobsQuarantined?.(quarantine);
+    return "command_fetch_failed";
+  }
+  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
       await retireSupersededQueueJobsForPull(input);
@@ -1102,6 +1129,61 @@ async function retireSupersededQueueJobsForPull(input: {
   }
 }
 
+function quarantineQueueJobsForIncompleteEvidence(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  now: Date;
+}): { headKey: string; count: number } {
+  const jobs = input.state.listReviewQueueJobsForPull({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    states: ["queued", "provider_deferred", "blocked_on_proof", "leased", "running"]
+  }).filter((job) => job.headSha === input.pull.head.sha);
+  let count = 0;
+  for (const job of jobs) {
+    const eligible = job.state === "queued" || job.state === "provider_deferred" || job.state === "blocked_on_proof";
+    const expired = (job.state === "leased" || job.state === "running") && isQueueJobLeaseExpired({
+      job,
+      now: input.now,
+      leaseTtlMs: input.config.reviewConcurrency.leaseTtlMs
+    });
+    if (!eligible && !expired) continue;
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "failed",
+      lastError: "required_evidence_incomplete",
+      now: input.now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      readinessState: "failed",
+      reason: "required_evidence_incomplete",
+      now: input.now
+    });
+    updateReviewerSessionJobFromQueueStatus({ state: input.state, job, now: input.now }, "failed", "failed");
+    count += 1;
+  }
+  return {
+    headKey: `${input.repo.toLowerCase()}#${input.pull.number}@${input.pull.head.sha.toLowerCase()}`,
+    count
+  };
+}
+
+function isQueueJobLeaseExpired(input: {
+  job: ReviewQueueJobRecord;
+  now: Date;
+  leaseTtlMs: number;
+}): boolean {
+  const leaseExpiryMs = input.job.leaseExpiresAt
+    ? Date.parse(input.job.leaseExpiresAt)
+    : Date.parse(input.job.updatedAt) + input.leaseTtlMs;
+  return Number.isFinite(leaseExpiryMs) && leaseExpiryMs <= input.now.getTime();
+}
+
 async function retireQueuedJobsForClosedPull(input: {
   config: BotConfig;
   github: SchedulerGitHubApi;
@@ -1148,6 +1230,12 @@ async function retireQueuedJobsForClosedPull(input: {
   }
 }
 
+type SchedulerCommandDecision = CommandDecision | {
+  action: "none";
+  shouldReview: false;
+  blocked: "required_evidence_incomplete";
+};
+
 async function resolveSchedulerCommandDecision(input: {
   config: BotConfig;
   github: SchedulerGitHubApi;
@@ -1155,10 +1243,22 @@ async function resolveSchedulerCommandDecision(input: {
   repo: string;
   pull: PullRequestSummary;
   onCommandFetchError?: () => void;
-}): Promise<CommandDecision> {
+}): Promise<SchedulerCommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
+    let boundedEvidence: BoundedGithubList<IssueCommentCommandSource> | undefined;
+    if (input.github.listIssueCommentsForEnrichment) {
+      try {
+        boundedEvidence = await input.github.listIssueCommentsForEnrichment(input.repo, input.pull.number);
+      } catch {
+        // Keep the uncapped command reader as the source of truth when the optional evidence read is unavailable.
+      }
+    }
+    if (boundedEvidence?.truncated || boundedEvidence?.overflow) {
+      input.onCommandFetchError?.();
+      return { action: "none", shouldReview: false, blocked: "required_evidence_incomplete" };
+    }
     comments = await input.github.listIssueComments(input.repo, input.pull.number);
   } catch {
     input.onCommandFetchError?.();
@@ -2592,6 +2692,9 @@ function nextLicenseGateRetryAt(now = new Date()): string {
 
 function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {
   switch (status) {
+    case "command_fetch_failed":
+      result.failed += 1;
+      break;
     case "enqueued":
       result.queue.enqueued += 1;
       break;

--- a/src/state.ts
+++ b/src/state.ts
@@ -2624,6 +2624,7 @@ export class ReviewStateStore {
     leaseTtlMs?: number;
     aging?: { enabled: boolean; maxWaitMinutes: number };
     now?: Date;
+    excludeHeadKeys?: Iterable<string>;
   }): ReviewQueueJobRecord[] {
     validatePositiveQueueLimit(input.maxProviderActive, "maxProviderActive");
     const maxGlobalActive = input.maxGlobalActive ?? input.maxProviderActive;
@@ -2650,6 +2651,7 @@ export class ReviewStateStore {
     const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
     const leaseExpiresAt = new Date(Date.parse(nowIso) + leaseTtlMs).toISOString();
     const excludeJobIds = new Set(input.excludeJobIds ?? []);
+    const excludeHeadKeys = new Set(input.excludeHeadKeys ?? []);
     const reservedActiveJobs = Array.from(input.reservedActiveJobs ?? []);
     const leased: ReviewQueueJobRecord[] = [];
 
@@ -2672,7 +2674,7 @@ export class ReviewStateStore {
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
-        .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
+        .filter((job) => !excludeJobIds.has(job.jobId) && !excludeHeadKeys.has(reviewQueueHeadKey(job)) && isQueueJobEligible(job, nowIso))
         .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
       const active = [

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3246,7 +3246,7 @@ describe("provider-aware review scheduler", () => {
     });
     const github = {
       ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls),
-      listIssueComments: async () => { throw new Error("uncapped reader must not run"); },
+      listIssueComments: async () => [],
       listIssueCommentsForEnrichment: async () => truncatedEvidence
     };
     let reviewCalls = 0;
@@ -3275,6 +3275,9 @@ describe("provider-aware review scheduler", () => {
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_B)).toMatchObject({ state: "ready_for_human", reason: "comment_review_posted" });
     state.close();
   });
+
+  it("admits an explicit review command found beyond bounded evidence pages", async () => { const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-page-six-command-")); roots.push(root); const config = schedulerConfig(root, ["org/repo-a"]); config.commands = { enabled: true, botMentions: ["@evaos-code-review-bot"], trustedAuthors: ["100yenadmin"], acknowledge: false }; const state = new ReviewStateStore(config.statePath); const comments = [...Array.from({ length: 500 }, (_unused, index) => comment(index + 1, "other", "ordinary discussion")), comment(501, "100yenadmin", "@evaos-code-review-bot review")]; const bounded = Object.assign(comments.slice(0, 500), { items: comments.slice(0, 500), rawCount: 500, truncated: true, overflow: true }); let reads = "", reviewCalls = 0;
+    const result = await runScheduledCycleWithDeps({ config, state, github: { ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]])), listIssueCommentsForEnrichment: async () => { reads += "b"; return bounded; }, listIssueComments: async () => { reads += "u"; return comments; } }, options: { dryRun: false, useZCode: false }, reviewPullImpl: async ({ state: s, repo, pull: p }) => { reviewCalls += 1; s.recordProcessed({ repo, pullNumber: p.number, headSha: p.head.sha, status: "posted", event: "COMMENT" }); return "reviewed_command"; } }); expect(reads).toBe("bu"); expect(result).toMatchObject({ reviewed: 1, commandReviewRequested: 1, commandFetchErrors: 0 }); expect(result.queue).toMatchObject({ enqueued: 1, leased: 1, failedQueueJobs: 0, remainingQueued: 0 }); expect(reviewCalls).toBe(1); state.close(); });
 
   it("allows scoped trusted commands for activation-baselined heads", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-baseline-scoped-"));

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3199,6 +3199,83 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("quarantines only the incomplete head without public status writes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-evidence-quarantine-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = { enabled: true, botMentions: ["@evaos-code-review-bot"], trustedAuthors: ["100yenadmin"], acknowledge: false };
+    config.reviewStatusComment!.enabled = true;
+    config.reviewerSessions = { enabled: true, ttlMs: 8 * 60 * 60_000, headCountLimit: 10 };
+    const state = new ReviewStateStore(config.statePath);
+    const now = new Date("2026-07-01T00:01:00.000Z");
+    const assignment = state.assignReviewerSessionJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, ttlMs: config.reviewerSessions.ttlMs, headCountLimit: config.reviewerSessions.headCountLimit, now });
+    if (!assignment.assigned || !assignment.session) throw new Error("expected reviewer session assignment");
+    const queue = (headSha: string, source: "automatic" | "manual_command" = "automatic", commentId?: number) => state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha, baseSha: "base", source, ...(commentId ? { commentId } : {}), sessionId: assignment.session!.sessionId, now }).job;
+    const sameHeadAutomatic = queue(HEAD_A);
+    const sameHeadDeferred = queue(HEAD_A, "manual_command", 501);
+    state.updateReviewQueueJobState({
+      jobId: sameHeadDeferred.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:00:30.000Z",
+      now
+    });
+    const sameHeadExpired = queue(HEAD_A, "manual_command", 502);
+    state.updateReviewQueueJobState({
+      jobId: sameHeadExpired.jobId,
+      state: "leased",
+      leaseId: "expired",
+      leaseExpiresAt: "2026-07-01T00:00:30.000Z",
+      now
+    });
+    const otherHead = queue(HEAD_B);
+    state.updateReviewQueueJobState({
+      jobId: otherHead.jobId,
+      state: "leased",
+      leaseId: "other-live",
+      leaseExpiresAt: "2026-07-01T00:10:00.000Z",
+      now
+    });
+    state.recordReviewReadiness({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, state: "queued", reason: "automatic_enqueue", now });
+    state.recordReviewReadiness({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_B, state: "ready_for_human", reason: "comment_review_posted", now });
+    const statusCalls: StatusCommentCall[] = [];
+    const truncatedEvidence = Object.assign([], {
+      items: [],
+      rawCount: 500,
+      truncated: true,
+      overflow: true
+    });
+    const github = {
+      ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls),
+      listIssueComments: async () => { throw new Error("uncapped reader must not run"); },
+      listIssueCommentsForEnrichment: async () => truncatedEvidence
+    };
+    let reviewCalls = 0;
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => { reviewCalls += 1; return "reviewed"; },
+      now,
+      clock: () => now
+    });
+
+    expect(result).toMatchObject({ failed: 1, commandFetchErrors: 1 });
+    expect(result.queue).toMatchObject({ leased: 0, failedQueueJobs: 3, remainingQueued: 0 });
+    expect(reviewCalls).toBe(0);
+    expect(statusCalls).toEqual([]);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ jobId: sameHeadAutomatic.jobId, lastError: "required_evidence_incomplete" }),
+      expect.objectContaining({ jobId: sameHeadDeferred.jobId, lastError: "required_evidence_incomplete" }),
+      expect.objectContaining({ jobId: sameHeadExpired.jobId, lastError: "required_evidence_incomplete" })
+    ]));
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "failed", reason: "required_evidence_incomplete" });
+    expect(state.getReviewerSessionJob("org/repo-a", 1, HEAD_A)).toMatchObject({ jobState: "failed", processedReviewStatus: "failed" });
+    expect(state.getReviewQueueJob(otherHead.jobId)).toMatchObject({ state: "leased" });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_B)).toMatchObject({ state: "ready_for_human", reason: "comment_review_posted" });
+    state.close();
+  });
+
   it("allows scoped trusted commands for activation-baselined heads", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-baseline-scoped-"));
     roots.push(root);


### PR DESCRIPTION
Closes #862

## Summary
- consume the accepted #857 bounded evidence contract without changing the uncapped command reader
- fail closed on explicit truncation/overflow for the exact current head
- quarantine queued/provider-deferred/blocked and expired same-head attempts, synchronizing queue/readiness/session state
- exclude the incomplete head from the leasing batch and suppress public status writes for this failure

## Validation
- `/tmp/neondiff-node node_modules/vitest/vitest.mjs run tests/scheduler.test.ts -t "quarantines only the incomplete head"`
- `/tmp/neondiff-node node_modules/vitest/vitest.mjs run tests/scheduler.test.ts` (104/104)
- `/tmp/neondiff-node node_modules/.bin/tsc --noEmit -p tsconfig.build.json`
- `npm run build`
- `git diff --check`
- 190 changed non-generated lines

Base is current main #857 head `921a74b5381e2178c3ca8369187731c06d0942dd`; #832 and #866 were not used as merge bases.