### PR TITLE
docs(mac): document native Desktop customer adoption

### DIFF
--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -16,9 +16,10 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 Generate a local appcast from a committed fixture:
 
 ```sh
+: "${NEONDIFF_EVIDENCE_ROOT:?set an absolute evidence root outside the checkout}"
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
+  --output "$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
   --dry-run
 ```
 

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -17,9 +17,14 @@ Generate a local appcast from a committed fixture:
 
 ```sh
 : "${NEONDIFF_EVIDENCE_ROOT:?set an absolute evidence root outside the checkout}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "evidence root must be absolute" >&2; exit 1;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "evidence root must already exist" >&2; exit 1; }
+EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"
+CHECKOUT_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$EVIDENCE_ROOT/" in "$CHECKOUT_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 1;; esac
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output "$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
+  --output "$EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
   --dry-run
 ```
 

--- a/apps/neondiff-desktop/docs/customer-adoption.md
+++ b/apps/neondiff-desktop/docs/customer-adoption.md
@@ -18,10 +18,13 @@ cover the legacy CLI worker installer or source-checkout operation.
 4. Use **Check for Updates**. Adopt an update only when the downloaded bytes
    match the accepted release packet and the installed codesign, notary,
    Gatekeeper, manifest, feed, and worker-identity receipts all agree.
-5. Roll back only through the verified signed last-known-good feed. The receipt
-   must prove the same account, bot, config, database, allowlist, Keychain
-   identity, selected label, and one wrapper/helper worker pair survived, then
-   prove a re-update. Without that feed and receipt, rollback is unavailable.
+5. The current Sparkle appcast cannot downgrade an installed build. Rollback is
+   unavailable until the release owner supplies a separate proven recovery path
+   using an accepted immutable signed/notarized last-known-good artifact. Its
+   receipt must prove the same account, bot, config, database, allowlist,
+   Keychain identity, selected label, and one wrapper/helper worker pair
+   survived, then prove a re-update. Do not use **Check for Updates** to roll
+   back.
 
 Preview, start, status, update, and rollback fail closed on a missing account,
 bot, config, Keychain item, accepted artifact identity, or safe rollback target.

--- a/apps/neondiff-desktop/docs/customer-adoption.md
+++ b/apps/neondiff-desktop/docs/customer-adoption.md
@@ -1,0 +1,27 @@
+# Native Desktop customer adoption
+
+This is the customer path for an accepted NeonDiff Desktop release. It does not
+cover the legacy CLI worker installer or source-checkout operation.
+
+1. Install only the immutable app bytes named by the release. The acceptance
+   packet must bind the source SHA and signed tag to the archive and bundle-tree
+   digests, Team ID, bundle/version/build identities, codesign and hardened
+   runtime results, notarization and staple results, Gatekeeper assessment,
+   manifest digest, feed digest, and Sparkle EdDSA signature.
+2. Link the account and select the bot. The app-owned config is
+   `~/Library/Application Support/NeonDiffDesktop/Accounts/<account>/Bots/<bot>/config.local.json`;
+   its review database is `state/reviews.sqlite`. Never copy either to a
+   release checkout.
+3. In Overview, use **Preview Start**, then **Install & Start** (or
+   **Start/Restart**), and verify the displayed status. The signed app owns the
+   selected launchd label and sealed helper; secrets remain in Keychain.
+4. Use **Check for Updates**. Adopt an update only when the downloaded bytes
+   match the accepted release packet and the installed codesign, notary,
+   Gatekeeper, manifest, feed, and worker-identity receipts all agree.
+5. Roll back only through the verified signed last-known-good feed. The receipt
+   must prove the same account, bot, config, database, allowlist, Keychain
+   identity, selected label, and one wrapper/helper worker pair survived, then
+   prove a re-update. Without that feed and receipt, rollback is unavailable.
+
+Preview, start, status, update, and rollback fail closed on a missing account,
+bot, config, Keychain item, accepted artifact identity, or safe rollback target.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -421,7 +421,7 @@ A local config path, launchd label, App ID, or repository name by itself is not
 authority. Suspended, revoked, pending, mismatched, or server-unrecognized bots
 remain in setup/recovery and fail closed.
 
-### Operate and update the native Desktop worker
+### Update an existing local worker
 
 Customers use only NeonDiff Desktop for the signed native worker path. In
 Overview, use **Preview Start**, then **Install & Start** (or **Start/Restart**),
@@ -429,11 +429,13 @@ and read the resulting status there. Use **Check for Updates** for an accepted
 signed/notarized Desktop release. Do not substitute the legacy CLI worker
 installer, a source checkout, or a hand-written LaunchAgent.
 
-Rollback is available only when the release owner has published and verified a
-signed last-known-good rollback feed. It must preserve the selected account,
-bot, config, `state/reviews.sqlite`, Keychain items, and exactly one worker pair.
-If that feed and its installed rollback receipt do not exist, stop; manual
-rollback is not a supported customer action. See
+The current Sparkle appcast cannot downgrade an installed build. Native rollback
+therefore remains unavailable until the release owner provides a separate,
+proven recovery path using an accepted immutable signed/notarized
+last-known-good artifact. That path must preserve the selected account, bot,
+config, `state/reviews.sqlite`, Keychain items, and exactly one worker pair.
+Do not use **Check for Updates**, a source reset, or a manually edited appcast as
+rollback. See
 [Native Desktop customer adoption](../apps/neondiff-desktop/docs/customer-adoption.md).
 
 Legacy CLI worker updates remain an operator path. Use only the outer worker

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -421,81 +421,20 @@ A local config path, launchd label, App ID, or repository name by itself is not
 authority. Suspended, revoked, pending, mismatched, or server-unrecognized bots
 remain in setup/recovery and fail closed.
 
-### Update an existing local worker
+### Operate and update the native Desktop worker
 
-The Mac app checks the exact discovered worker's `review-pr` help contract
-before enabling **Run Dry Review**. A package version alone is not sufficient:
-older and compatible technical-beta workers may both report `1.0.4`.
+Customers use only NeonDiff Desktop for the signed native worker path. In
+Overview, use **Preview Start**, then **Install & Start** (or **Start/Restart**),
+and read the resulting status there. Use **Check for Updates** for an accepted
+signed/notarized Desktop release. Do not substitute the legacy CLI worker
+installer, a source checkout, or a hand-written LaunchAgent.
 
-If Overview shows **Worker update required**:
-
-1. Do not run or retry a live review from another terminal. The dry-to-live
-   approval contract is not proven for that worker.
-2. Choose **Install / Update Local Worker**. Use only the outer worker bundle
-   ZIP named in the same immutable GitHub prerelease and release manifest as the
-   installed app. Before extracting it, compare the bundle ZIP SHA-256 with the
-   prerelease notes. After extraction, compare the release manifest SHA-256 with
-   the prerelease notes, then compare the inner `.tgz` tarball SHA-256 with both
-   the release manifest and the prerelease notes. Do not use an unpinned `main`
-   checkout or trust the ambiguous `1.0.4` version string.
-3. Confirm `node --version` reports Node.js 26 or newer. From the extracted
-   directory, preview the checksum-bound migration using the exact LaunchAgent
-   label shown in NeonDiff Settings. The installer requires absolute artifact
-   paths:
-
-   ```bash
-   BUNDLE_DIR="$(pwd -P)"
-   node install-b0-worker-candidate.mjs update \
-     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-     --manifest-sha256 <manifest-sha256-from-release> \
-     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
-     --launchd-label <existing-label> \
-     --dry-run true
-   ```
-
-4. Inspect the public-safe preview, then repeat it with
-   `--dry-run false --confirm true`. The installer verifies the tarball before
-   mutation, freshly reinstalls an unreferenced leftover from that exact
-   artifact instead of executing it, and installs into a versioned user-owned
-   Application Support prefix,
-   preserves the existing config, LaunchAgent label/environment, GitHub App key
-   file, Keychain entries, provider state, and repository allowlist, and
-   restarts the same LaunchAgent only when it was already loaded. It never reads
-   or copies private-key bytes. Each LaunchAgent label has an isolated worker
-   version, rollback state, and install lock. A lock owned by a process that no
-   longer exists is recovered automatically; a lock with missing or invalid
-   owner metadata fails closed and must be handled with NeonDiff support. When
-   `/opt/homebrew/bin/node` or `/usr/local/bin/node` resolves to the Node runtime
-   executing the installer, that stable command is retained in the LaunchAgent
-   rather than its versioned package-manager target.
-5. Return to Overview and choose **Retry Worker Check**. Dry review stays
-   disabled until the exact installed worker advertises both config-revision
-   approval and the matching ZCode provider path.
-
-The first checksum-managed migration has no trusted prior candidate, so it
-fails closed instead of restoring the unbound original LaunchAgent invocation.
-Retain every verified worker bundle. After installing a later candidate,
-preview rollback from the complete prior bundle:
-
-```bash
-BUNDLE_DIR="$(pwd -P)"
-node install-b0-worker-candidate.mjs rollback \
-  --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.PRIOR-b0-candidate-manifest.json" \
-  --manifest-sha256 <prior-manifest-sha256-from-release> \
-  --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.PRIOR.tgz" \
-  --launchd-label <existing-label> \
-  --dry-run true
-```
-
-Rollback also requires `--dry-run false --confirm true`. It verifies that the
-supplied prior artifacts match the recorded prior candidate, installs them
-through fresh staging, and then switches atomically without executing or
-overwriting either pre-existing candidate tree or touching customer secrets.
-
-Until an immutable GitHub prerelease and release manifest name a compatible
-worker artifact, this state is a release blocker rather than a prompt to repair
-source files manually.
-The app's own Sparkle update does not update an external local worker.
+Rollback is available only when the release owner has published and verified a
+signed last-known-good rollback feed. It must preserve the selected account,
+bot, config, `state/reviews.sqlite`, Keychain items, and exactly one worker pair.
+If that feed and its installed rollback receipt do not exist, stop; manual
+rollback is not a supported customer action. See
+[Native Desktop customer adoption](../apps/neondiff-desktop/docs/customer-adoption.md).
 
 ## 4. Check Readiness
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -436,6 +436,11 @@ If that feed and its installed rollback receipt do not exist, stop; manual
 rollback is not a supported customer action. See
 [Native Desktop customer adoption](../apps/neondiff-desktop/docs/customer-adoption.md).
 
+Legacy CLI worker updates remain an operator path. Use only the outer worker
+bundle ZIP whose inner `.tgz` tarball, prerelease notes, and release manifest
+agree on immutable digests; follow `docs/beta-release-runbook.md` rather than
+the native Desktop controls above.
+
 ## 4. Check Readiness
 
 Run the GitHub-only doctor first. It verifies App installation visibility and

--- a/tests/operational-doc-path-contract.test.ts
+++ b/tests/operational-doc-path-contract.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string): string => readFileSync(path, "utf8");
+
+describe("operational documentation path contract", () => {
+  it("keeps native customer adoption on the signed Desktop path", () => {
+    const guide = read("apps/neondiff-desktop/docs/customer-adoption.md");
+    expect(guide).toContain("Accounts/<account>/Bots/<bot>/config.local.json");
+    expect(guide).toContain("state/reviews.sqlite");
+    expect(guide).toContain("**Preview Start**");
+    expect(guide).toContain("**Check for Updates**");
+    expect(guide).toContain("signed last-known-good feed");
+    expect(guide).toContain("one wrapper/helper worker pair");
+    expect(guide).not.toContain("install-b0-worker-candidate.mjs");
+    expect(guide).not.toContain("/Volumes/LEXAR");
+  });
+
+  it("guards the appcast evidence root", () => {
+    const guide = read("apps/neondiff-desktop/docs/appcast-channels.md");
+    expect(guide).toContain("${NEONDIFF_EVIDENCE_ROOT:?");
+    expect(guide).not.toContain("/Volumes/LEXAR");
+  });
+});

--- a/tests/operational-doc-path-contract.test.ts
+++ b/tests/operational-doc-path-contract.test.ts
@@ -10,7 +10,8 @@ describe("operational documentation path contract", () => {
     expect(guide).toContain("state/reviews.sqlite");
     expect(guide).toContain("**Preview Start**");
     expect(guide).toContain("**Check for Updates**");
-    expect(guide).toContain("signed last-known-good feed");
+    expect(guide).toContain("appcast cannot downgrade");
+    expect(guide).toContain("accepted immutable signed/notarized");
     expect(guide).toContain("one wrapper/helper worker pair");
     expect(guide).not.toContain("install-b0-worker-candidate.mjs");
     expect(guide).not.toContain("/Volumes/LEXAR");
@@ -19,6 +20,8 @@ describe("operational documentation path contract", () => {
   it("guards the appcast evidence root", () => {
     const guide = read("apps/neondiff-desktop/docs/appcast-channels.md");
     expect(guide).toContain("${NEONDIFF_EVIDENCE_ROOT:?");
+    expect(guide).toContain("case \"$NEONDIFF_EVIDENCE_ROOT\" in /*)");
+    expect(guide).toContain('in "$CHECKOUT_ROOT/"*)');
     expect(guide).not.toContain("/Volumes/LEXAR");
   });
 });


### PR DESCRIPTION
Part of #873

Separates the signed native Desktop customer path from legacy CLI worker operations. Documents the exact account/bot config and review DB locations, immutable artifact receipts, native preview/start/status/update controls, and fail-closed signed rollback boundary.

Checks:
- deterministic Node documentation contract: pass
- git diff --check: pass
- focused Vitest: locally blocked by missing optional Rolldown native binding; remote CI is authoritative

Proof boundary: documentation/source-contract only; no install, signing, release, runtime, config, DB, or Keychain mutation.