### PR TITLE
chore: classify Ajv as runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
+        "ajv": "^8.20.0",
         "validate-npm-package-license": "^3.0.4"
       },
       "bin": {
@@ -17,7 +18,6 @@
       "devDependencies": {
         "@types/node": "^24.0.15",
         "@types/validate-npm-package-license": "^3.0.3",
-        "ajv": "^8.20.0",
         "esbuild": "0.28.1",
         "jose": "^6.2.3",
         "sigstore": "^5.0.0",
@@ -1194,7 +1194,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1400,14 +1399,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1570,7 +1567,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -1923,7 +1919,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@types/node": "^24.0.15",
     "@types/validate-npm-package-license": "^3.0.3",
-    "ajv": "^8.20.0",
     "esbuild": "0.28.1",
     "jose": "^6.2.3",
     "sigstore": "^5.0.0",
@@ -77,6 +76,7 @@
     "yaml": "^2.9.0"
   },
   "dependencies": {
+    "ajv": "^8.20.0",
     "validate-npm-package-license": "^3.0.4"
   }
 }

--- a/scripts/build-b0-cli-candidate.mjs
+++ b/scripts/build-b0-cli-candidate.mjs
@@ -22,6 +22,10 @@ const CLEAN_STATUS_COMMAND = "git status --porcelain";
 const CANDIDATE_VERSION_PATTERN = /^1\.1\.0-beta\.[1-9][0-9]{0,3}$/;
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const PRIVATE_BUCKET_TARGET = "neondiff-beta-canary";
+const B0_BUNDLED_PRODUCTION_DEPENDENCIES = [
+  { name: "ajv", version: "8.20.0" },
+  { name: "validate-npm-package-license", version: "3.0.4" }
+];
 
 function fail(message) {
   throw new Error(message);
@@ -183,21 +187,18 @@ function main() {
       stdio: ["ignore", "pipe", "pipe"]
     });
 
-    const productionDependencyPath = join(
-      repoRoot,
-      "node_modules",
-      "validate-npm-package-license",
-      "package.json"
-    );
-    if (!existsSync(productionDependencyPath)) {
-      fail("exact production dependency is missing from the reviewed install");
-    }
-    const productionDependency = JSON.parse(readFileSync(productionDependencyPath, "utf8"));
-    if (productionDependency.name !== "validate-npm-package-license" || productionDependency.version !== "3.0.4") {
-      fail("reviewed production dependency version is not validate-npm-package-license@3.0.4");
+    for (const dependency of B0_BUNDLED_PRODUCTION_DEPENDENCIES) {
+      const dependencyPath = join(repoRoot, "node_modules", dependency.name, "package.json");
+      if (!existsSync(dependencyPath)) {
+        fail(`exact production dependency is missing from the reviewed install: ${dependency.name}`);
+      }
+      const productionDependency = JSON.parse(readFileSync(dependencyPath, "utf8"));
+      if (productionDependency.name !== dependency.name || productionDependency.version !== dependency.version) {
+        fail(`reviewed production dependency version is not ${dependency.name}@${dependency.version}`);
+      }
     }
     const candidatePackage = JSON.parse(readFileSync(packagePath, "utf8"));
-    candidatePackage.bundledDependencies = ["validate-npm-package-license"];
+    candidatePackage.bundledDependencies = B0_BUNDLED_PRODUCTION_DEPENDENCIES.map(({ name }) => name);
     writeFileSync(packagePath, `${JSON.stringify(candidatePackage, null, 2)}\n`);
 
     const packOutput = execFileSync("npm", [
@@ -215,10 +216,10 @@ function main() {
     if (!pack || parsedPack.length !== 1 || pack.name !== "neondiff" || pack.version !== packageVersion) {
       fail("npm pack did not emit the exact requested neondiff candidate");
     }
-    if (!Array.isArray(pack.files) || !pack.files.some(
-      (entry) => entry?.path === "node_modules/validate-npm-package-license/package.json"
+    if (!Array.isArray(pack.files) || B0_BUNDLED_PRODUCTION_DEPENDENCIES.some(
+      ({ name }) => !pack.files.some((entry) => entry?.path === `node_modules/${name}/package.json`)
     )) {
-      fail("npm pack did not bundle the exact production dependency closure");
+      fail("npm pack did not bundle the exact direct production dependency closure");
     }
 
     packJsonPath = join(outputDirectory, "pack.json");
@@ -311,7 +312,9 @@ function main() {
         reviewFlags,
         isolatedInstallPassed: true,
         offlineInstallPassed: true,
-        bundledProductionDependencies: ["validate-npm-package-license@3.0.4"]
+        bundledProductionDependencies: B0_BUNDLED_PRODUCTION_DEPENDENCIES.map(
+          ({ name, version }) => `${name}@${version}`
+        )
       },
       distribution: {
         privateBucketTarget: PRIVATE_BUCKET_TARGET,

--- a/scripts/check-packlist.mjs
+++ b/scripts/check-packlist.mjs
@@ -7,6 +7,11 @@ const allowB0BundledProductionClosure = process.argv.includes(
   "--allow-b0-bundled-production-closure"
 );
 const allowedBundledProductionRoots = [
+  "node_modules/ajv/",
+  "node_modules/fast-deep-equal/",
+  "node_modules/fast-uri/",
+  "node_modules/json-schema-traverse/",
+  "node_modules/require-from-string/",
   "node_modules/spdx-correct/",
   "node_modules/spdx-exceptions/",
   "node_modules/spdx-expression-parse/",

--- a/scripts/lib/b0-worker-installer.mjs
+++ b/scripts/lib/b0-worker-installer.mjs
@@ -11,6 +11,7 @@ const STABLE_NODE_PATHS = new Set([
   "/usr/local/bin/node"
 ]);
 const REQUIRED_REVIEW_FLAGS = ["--expected-config-revision", "--zcode"];
+const B0_BUNDLED_PRODUCTION_DEPENDENCIES = ["ajv@8.20.0", "validate-npm-package-license@3.0.4"];
 const APP_ID_KEYS = ["NEONDIFF_GITHUB_APP_ID", "EVAOS_REVIEW_BOT_APP_ID"];
 const PRIVATE_KEY_KEYS = [
   "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
@@ -157,7 +158,7 @@ export function validateWorkerCandidate({
     || manifest?.installedCompatibility?.isolatedInstallPassed !== true
     || manifest?.installedCompatibility?.offlineInstallPassed !== true
     || JSON.stringify(manifest?.installedCompatibility?.bundledProductionDependencies)
-      !== JSON.stringify(["validate-npm-package-license@3.0.4"])
+      !== JSON.stringify(B0_BUNDLED_PRODUCTION_DEPENDENCIES)
   ) {
     fail("candidate manifest package identity is invalid");
   }

--- a/tests/b0-cli-candidate.test.ts
+++ b/tests/b0-cli-candidate.test.ts
@@ -83,6 +83,8 @@ describe("B0 access-controlled CLI candidate", () => {
     expect(script).toContain("empty-npm-cache");
     expect(script).toMatch(/execFileSync\("npm", \[\s*"ci",\s*"--ignore-scripts"/);
     expect(script).toContain("--allow-b0-bundled-production-closure");
+    expect(script).toContain('name: "ajv", version: "8.20.0"');
+    expect(script).toContain('name: "validate-npm-package-license", version: "3.0.4"');
     expect(script).toContain("git status --porcelain");
     expect(script).toContain("must not be a symbolic link");
     expect(script).toContain("must be private to the current user (0700)");
@@ -118,6 +120,11 @@ describe("B0 access-controlled CLI candidate", () => {
       "docker-compose.example.yml"
     ];
     const allowedClosure = [
+      "node_modules/ajv/package.json",
+      "node_modules/fast-deep-equal/package.json",
+      "node_modules/fast-uri/package.json",
+      "node_modules/json-schema-traverse/package.json",
+      "node_modules/require-from-string/package.json",
       "node_modules/spdx-correct/package.json",
       "node_modules/spdx-exceptions/package.json",
       "node_modules/spdx-expression-parse/package.json",

--- a/tests/b0-worker-installer.test.ts
+++ b/tests/b0-worker-installer.test.ts
@@ -53,7 +53,7 @@ function candidateManifest() {
       reviewFlags: ["--expected-config-revision", "--zcode"],
       isolatedInstallPassed: true,
       offlineInstallPassed: true,
-      bundledProductionDependencies: ["validate-npm-package-license@3.0.4"]
+      bundledProductionDependencies: ["ajv@8.20.0", "validate-npm-package-license@3.0.4"]
     },
     distribution: {
       privateBucketTarget: "neondiff-beta-canary",


### PR DESCRIPTION
Closes #865. Moves the existing Ajv ^8.20.0 entry from devDependencies to runtime dependencies and updates only the corresponding lock metadata; version, resolved tarball, and integrity are unchanged. This is the dependency prerequisite for held parser PR #869 (head 4c76233). No parser source or call sites are changed.