### PR TITLE
fix(desktop): bind BYO proof to current target

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -880,6 +880,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var currentAccountBindingVerified: Bool {
         selectedAccountWorkspace != nil
             && selectedBotInstallation != nil
+            && selectedBotInstallation?.status == .verified
             && DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
                 verifiedAt: accountWorkspaceCatalogVerifiedAt,
                 now: dependencies.clock.now
@@ -4209,6 +4210,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
+        guard let expectedAppID = Int64(expectedContext.appId),
+              selectedBotInstallation == nil || selectedBotInstallation?.appID == expectedAppID else {
+            invalidateBYOGitHubVerificationContext()
+            return
+        }
+
         let selectedTarget = selectedReviewRepository
         let selectedReadCheck = selectedTarget.flatMap { target in
             report.github.readChecks.first(where: {
@@ -4225,7 +4232,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             byoGitHubRepositoryProof = BYOGitHubRepositoryProof(
                 accountID: account.id,
                 botID: bot.id,
-                appID: bot.appID,
+                appID: expectedAppID,
                 repository: selectedTarget,
                 visibility: visibility,
                 credentialRevision: expectedContext.credentialRevision,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -152,6 +152,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var pendingBYOGitHubAppPrivateKey = ""
     @Published package private(set) var byoGitHubPrivateKeyStored = false
     @Published package private(set) var byoGitHubCredentialsVerified = false
+    @Published package private(set) var byoGitHubRepositoryVisibility: GitHubBrokerRepositoryVisibility?
     @Published package private(set) var isBYOGitHubVerificationInProgress = false
     @Published package private(set) var byoGitHubCredentialStatus = "Customer-owned GitHub App credentials are not stored."
     @Published package var pendingReviewPullNumber = "" {
@@ -218,6 +219,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var activationUpdateAuthorityVerifiedAt: Date?
     private var activationUpdateAuthorityValidUntil: Date?
     private var accountWorkspaceCatalogVerifiedAt: Date?
+    private var byoGitHubRepositoryProof: BYOGitHubRepositoryProof?
     private var activationVerifiedRepositoryThisLaunch: String?
     private var appliedRepoSelection: AppliedRepoSelection?
     private var scopedReviewTask: Task<Void, Never>?
@@ -383,6 +385,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return false
         }
         if dependencies.productionBoundary.byoGitHubEnabled {
+            guard let proof = byoGitHubRepositoryProof,
+                  currentAccountBindingVerified,
+                  proof.accountID == accountWorkspaceSelection.accountID,
+                  proof.botID == accountWorkspaceSelection.botID,
+                  proof.appID == selectedBotInstallation?.appID,
+                  proof.repository.caseInsensitiveCompare(selectedReviewRepository ?? "") == .orderedSame,
+                  proof.credentialRevision == byoGitHubCredentialRevision,
+                  proof.workspaceGeneration == workspaceContextGeneration,
+                  proof.visibility != .unknown
+            else {
+                return false
+            }
             if existingLocalBotReconciliationMode {
                 guard selectedAccountEntitlementSupportsCurrentPath else {
                     return false
@@ -861,6 +875,15 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package var selectedBotInstallation: DesktopBotInstallation? {
         guard let botID = accountWorkspaceSelection.botID else { return nil }
         return selectedAccountWorkspace?.bots.first { $0.id == botID }
+    }
+
+    private var currentAccountBindingVerified: Bool {
+        selectedAccountWorkspace != nil
+            && selectedBotInstallation != nil
+            && DesktopUpdateAccessPolicy.accountCatalogIsCurrent(
+                verifiedAt: accountWorkspaceCatalogVerifiedAt,
+                now: dependencies.clock.now
+            )
     }
 
     /// Setup truth for an existing worker is distinct from current-launch
@@ -1929,6 +1952,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         managedGitHubRecovery = nil
         managedGitHubConnectionState = managedGitHubAvailable ? .disconnected : .quarantined
         byoGitHubCredentialsVerified = false
+        byoGitHubRepositoryVisibility = nil
+        byoGitHubRepositoryProof = nil
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
@@ -3211,6 +3236,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         else {
             return
         }
+        invalidateBYOGitHubVerificationContext()
         invalidateScopedReviewApproval()
         invalidateActivationForRepositoryChange(fullReset: true)
         selectedBYOReviewRepository = repository.name
@@ -4183,6 +4209,32 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
 
+        let selectedTarget = selectedReviewRepository
+        let selectedReadCheck = selectedTarget.flatMap { target in
+            report.github.readChecks.first(where: {
+                $0.repo.caseInsensitiveCompare(target) == .orderedSame
+            })
+        }
+        let visibility = selectedReadCheck?.visibilityResult
+            .flatMap { GitHubBrokerRepositoryVisibility(rawValue: $0.lowercased()) }
+            ?? .unknown
+        byoGitHubRepositoryVisibility = visibility
+        if let selectedTarget,
+           let account = selectedAccountWorkspace,
+           let bot = selectedBotInstallation {
+            byoGitHubRepositoryProof = BYOGitHubRepositoryProof(
+                accountID: account.id,
+                botID: bot.id,
+                appID: bot.appID,
+                repository: selectedTarget,
+                visibility: visibility,
+                credentialRevision: expectedContext.credentialRevision,
+                workspaceGeneration: expectedContext.workspaceGeneration
+            )
+        } else {
+            byoGitHubRepositoryProof = nil
+        }
+
         let repositories = report.github.readChecks.map(\.repo).sorted {
             $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
         }.joined(separator: ", ")
@@ -4211,7 +4263,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 expectedContext.source == .keychainStdinExistingBot
                     && existingLocalAgentAccessAvailable
             ),
-           let readCheck = report.github.readChecks.first {
+           let target = selectedReviewRepository,
+           let readCheck = report.github.readChecks.first(where: {
+               $0.repo.caseInsensitiveCompare(target) == .orderedSame
+           }) {
             verifyExistingLocalAgentEntitlement(
                 expectedContext: expectedContext,
                 visibility: readCheck.visibilityResult
@@ -4479,6 +4534,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func invalidateBYOGitHubVerificationContext() {
         invalidateScopedReviewApproval()
+        byoGitHubCredentialRevision &+= 1
+        byoGitHubRepositoryVisibility = nil
+        byoGitHubRepositoryProof = nil
         guard byoGitHubCredentialOnboardingAvailable else { return }
         byoGitHubCredentialsVerified = false
         guard !isBYOGitHubVerificationInProgress else { return }
@@ -6870,6 +6928,16 @@ private struct BYOGitHubVerificationContext: Equatable, Sendable {
     let cliPath: String
     let configPath: String
     let repositories: [String]
+    let workspaceGeneration: UInt64
+}
+
+private struct BYOGitHubRepositoryProof: Equatable, Sendable {
+    let accountID: String
+    let botID: String
+    let appID: Int64
+    let repository: String
+    let visibility: GitHubBrokerRepositoryVisibility
+    let credentialRevision: UInt64
     let workspaceGeneration: UInt64
 }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -581,6 +581,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
             now: clock.now,
             cliOutcomes: [
                 .success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo"))),
+                .success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo"))),
                 .success(CLIRunResult(
                     exitCode: 0,
                     stdout: byoRepoPatchJSON(repository: "acme/demo"),
@@ -602,6 +603,12 @@ struct BYOGitHubAppCredentialOnboardingTests {
         fixture.model.storeBYOGitHubAppCredentials()
         fixture.model.verifyBYOGitHubAppCredentials()
         await waitForBYOVerification(fixture)
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        fixture.model.pendingBYOGitHubAppId = "654321"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
         fixture.model.applyRepoAllowlistPatch()
         await fixture.waitForConfigPatchToFinish()
         fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
@@ -609,6 +616,9 @@ struct BYOGitHubAppCredentialOnboardingTests {
         await fixture.model.submitActivation()
 
         #expect(fixture.model.productionUsefulWorkAvailable)
+        fixture.model.accountWorkspaceCatalog = .loaded([workspaceWithBot(id: "account-a", configPath: nil, status: .pending)])
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+        fixture.model.accountWorkspaceCatalog = .loaded([workspaceWithBot(id: "account-a", configPath: nil)])
         fixture.clock.advance(by: 301)
         #expect(!fixture.model.productionUsefulWorkAvailable)
     }
@@ -824,7 +834,7 @@ private func fixtureWorkspace(id: String) -> DesktopAccountWorkspace {
     )
 }
 
-private func workspaceWithBot(id: String, configPath: String?) -> DesktopAccountWorkspace {
+private func workspaceWithBot(id: String, configPath: String?, status: DesktopBotStatus = .verified) -> DesktopAccountWorkspace {
     DesktopAccountWorkspace(
         id: id,
         kind: .organization,
@@ -833,12 +843,12 @@ private func workspaceWithBot(id: String, configPath: String?) -> DesktopAccount
         entitlement: .internalAdmin,
         bots: [DesktopBotInstallation(
             id: "bot-\(id)",
-            appID: 123456,
+            appID: 654321,
             appSlug: "neondiff-byo",
             mode: .byo,
             githubInstallationID: 42,
             githubAccountLogin: "acme",
-            status: .verified,
+            status: status,
             localConfigPath: configPath
         )]
     )

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -527,7 +527,90 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.selectedAccountWorkspace == nil)
         #expect(fixture.model.selectedBotInstallation == nil)
         #expect(fixture.model.currentRepositoryActivationReady)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @Test func changingBYOReviewTargetClearsVisibilityProof() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: byoRepoPatchJSON(repositories: ["acme/api", "acme/demo"]),
+                    stderr: ""
+                )),
+                .success(doctorResult(readChecks: [
+                    doctorReadCheck(repo: "acme/api", visibility: "public"),
+                    doctorReadCheck(repo: "acme/demo", visibility: "unknown")
+                ].joined(separator: ","))),
+                .success(doctorResult(readChecks: [
+                    doctorReadCheck(repo: "acme/api", visibility: "public"),
+                    doctorReadCheck(repo: "acme/demo", visibility: "unknown")
+                ].joined(separator: ",")))
+            ],
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [
+            RepoMonitor(name: "acme/api", enabled: true),
+            RepoMonitor(name: "acme/demo", enabled: true)
+        ]
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+        fixture.model.selectBYOReviewRepository(fullName: "acme/api")
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        fixture.model.selectBYOReviewRepository(fullName: "acme/demo")
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.byoGitHubRepositoryVisibility == .unknown)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
+    }
+
+    @Test func accountProofExpiresAtFinalUsefulWorkBoundary() async {
+        let clock = TestClock(now: Date(timeIntervalSince1970: 10_000))
+        let fixture = ModelDependencyFixture(
+            now: clock.now,
+            cliOutcomes: [
+                .success(doctorResult(readChecks: doctorReadCheck(repo: "acme/demo"))),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: byoRepoPatchJSON(repository: "acme/demo"),
+                    stderr: ""
+                ))
+            ],
+            activationLicenseClient: ActiveBYOActivationClient(),
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.applyAccountWorkspaceCatalog(DesktopAccountWorkspaceCatalog.loaded([
+            workspaceWithBot(id: "account-a", configPath: nil)
+        ]))
+        fixture.model.selectBotInstallation("bot-account-a")
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.selectBYOReviewRepository(fullName: "acme/demo")
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+        fixture.model.applyRepoAllowlistPatch()
+        await fixture.waitForConfigPatchToFinish()
+        fixture.model.pendingActivationKey = "NDL-FIXTURE-0123456789"
+        fixture.model.provideExistingActivationKey()
+        await fixture.model.submitActivation()
+
         #expect(fixture.model.productionUsefulWorkAvailable)
+        fixture.clock.advance(by: 301)
+        #expect(!fixture.model.productionUsefulWorkAvailable)
     }
 
     @Test func verificationFailsClosedUnlessDoctorChecksExactlyMatchEnabledRepositories() async throws {
@@ -741,6 +824,26 @@ private func fixtureWorkspace(id: String) -> DesktopAccountWorkspace {
     )
 }
 
+private func workspaceWithBot(id: String, configPath: String?) -> DesktopAccountWorkspace {
+    DesktopAccountWorkspace(
+        id: id,
+        kind: .organization,
+        name: id,
+        role: .admin,
+        entitlement: .internalAdmin,
+        bots: [DesktopBotInstallation(
+            id: "bot-\(id)",
+            appID: 123456,
+            appSlug: "neondiff-byo",
+            mode: .byo,
+            githubInstallationID: 42,
+            githubAccountLogin: "acme",
+            status: .verified,
+            localConfigPath: configPath
+        )]
+    )
+}
+
 private let availableCLIPreference = [
     "neondiff.cliPath": "/usr/bin/true"
 ]
@@ -772,12 +875,18 @@ private func doctorResult(
 private func doctorReadCheck(
     repo: String,
     skippedByPolicy: String? = nil,
-    ok: Bool = true
+    ok: Bool = true,
+    visibility: String = "public"
 ) -> String {
     let skippedField = skippedByPolicy.map {
         #","skippedByPolicy":"\#($0)""#
     } ?? ""
-    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
+    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"\#(visibility)","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
+}
+
+private func byoRepoPatchJSON(repositories: [String]) -> String {
+    let repos = repositories.map { "\"\($0)\"" }.joined(separator: ",")
+    return #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","revisionAfter":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","config":{"pilotRepos":[\#(repos)]}}"#
 }
 
 private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: [


### PR DESCRIPTION
## Summary

- Bind BYO GitHub visibility proof to the selected account, bot, repository, credential revision, and workspace generation.
- Invalidate target proof on BYO target/config/account changes and fail closed for unknown visibility.
- Recheck current account catalog freshness at the final useful-work boundary.

## Validation

- Failing-first target-switch and account-expiry tests.
- swift test: 437 tests in 42 suites passed.
- git diff --check: clean.

## Scope

- Base 921a74b5381e2178c3ca8369187731c06d0942dd; 183 changed lines.
- No runtime, Keychain, release, or held PR #859 changes.

Refs #872