### PR TITLE
fix(desktop): migrate BYO activation copy

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -227,6 +227,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
     }
 
+    private var managedPublicFreeDistribution: Bool {
+        dependencies.productionBoundary.managedGitHubBrokerOrigin != nil
+            && !dependencies.productionBoundary.byoGitHubEnabled
+    }
+
     package var customerRuntimeBoundaryMessage: String {
         if byoGitHubCredentialOnboardingAvailable,
            repos.filter(\.enabled).count > 1,
@@ -846,7 +851,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         // touching the Keychain on the launch path (v1.0.3 startup-stability rule).
         if let rawActivationState = dependencies.preferences.string(forKey: activationStateKey),
            let restored = ActivationState(rawValue: rawActivationState) {
-            self.activationState = restored
+            let migrated = restored == .publicFreeSkip && !managedPublicFreeDistribution
+                ? .purchaseRequired
+                : restored
+            self.activationState = migrated
+            if migrated != restored {
+                dependencies.preferences.set(migrated.rawValue, forKey: activationStateKey)
+            }
         } else {
             self.activationState = ActivationStateMachine.initialState
         }
@@ -4714,7 +4725,12 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package var activationPresentation: ActivationStatePresentation {
-        ActivationStateMachine.presentation(for: activationState, redactedKeyPrefix: activationKeyRedactedPrefix)
+        ActivationStateMachine.presentation(
+            for: activationState,
+            redactedKeyPrefix: activationKeyRedactedPrefix,
+            publicBYO: onboardingFlow.mode == .publicReposOnly
+                && dependencies.productionBoundary.byoGitHubEnabled
+        )
     }
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
@@ -4781,10 +4797,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.preferences.set(next.rawValue, forKey: activationStateKey)
     }
 
-    /// Enter the activation branch from the chosen onboarding path. The public
-    /// path skips straight to a free, license-free state.
+    /// Enter the activation branch from the chosen onboarding path. Only the
+    /// managed broker path may skip activation for public repositories.
     package func enterActivation(for mode: OnboardingMode) {
-        applyActivationEvent(mode == .publicReposOnly ? .choosePublicPath : .choosePrivatePath)
+        let publicFree = mode == .publicReposOnly && managedPublicFreeDistribution
+        applyActivationEvent(publicFree ? .choosePublicPath : .choosePrivatePath)
     }
 
     /// Align the activation entry state with the onboarding mode when the flow
@@ -4794,7 +4811,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func syncActivationEntryFromOnboardingMode() {
         switch activationState {
         case .purchaseRequired where onboardingFlow.mode == .publicReposOnly:
-            applyActivationEvent(.choosePublicPath)
+            enterActivation(for: .publicReposOnly)
+        case .publicFreeSkip where !managedPublicFreeDistribution:
+            enterActivation(for: onboardingFlow.mode)
         case .publicFreeSkip where onboardingFlow.mode == .privateRepos:
             applyActivationEvent(.choosePrivatePath)
         default:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -180,7 +180,8 @@ public enum ActivationStateMachine {
 
     public static func presentation(
         for state: ActivationState,
-        redactedKeyPrefix: String? = nil
+        redactedKeyPrefix: String? = nil,
+        publicBYO: Bool = false
     ) -> ActivationStatePresentation {
         let keyTerm = ActivationTerminology.activationKey
         switch state {
@@ -199,14 +200,18 @@ public enum ActivationStateMachine {
         case .purchaseRequired:
             return ActivationStatePresentation(
                 state: state,
-                title: "Private repositories need activation",
-                cause: "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
+                title: publicBYO ? "Every repository requires activation" : "Private repositories need activation",
+                cause: publicBYO
+                    ? "Every BYO repository requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued."
+                    : "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
                 recovery: ActivationRecovery(
                     label: "Continue with this key",
                     event: .provideExistingKey,
                     accessibilityLabel: "Store the existing \(keyTerm) securely and continue"
                 ),
-                accessibilityLabel: "Private repositories require an active \(keyTerm).",
+                accessibilityLabel: publicBYO
+                    ? "Every BYO repository requires an active \(keyTerm)."
+                    : "Private repositories require an active \(keyTerm).",
                 isSuccess: false,
                 requiresKeyEntry: true,
                 showsNotifyOption: false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -254,13 +254,17 @@ public enum ActivationStateMachine {
             return ActivationStatePresentation(
                 state: state,
                 title: "Activate your \(keyTerm)",
-                cause: "Your \(keyTerm)\(prefixNote) is ready. Activate it to unlock private repository review.",
+                cause: publicBYO
+                    ? "Your \(keyTerm)\(prefixNote) is ready. Activate it to review every BYO repository."
+                    : "Your \(keyTerm)\(prefixNote) is ready. Activate it to unlock private repository review.",
                 recovery: ActivationRecovery(
                     label: "Activate",
                     event: .submitActivation,
                     accessibilityLabel: "Activate the \(keyTerm)"
                 ),
-                accessibilityLabel: "\(keyTerm)\(prefixNote) is ready to activate.",
+                accessibilityLabel: publicBYO
+                    ? "\(keyTerm)\(prefixNote) is ready to activate for every BYO repository."
+                    : "\(keyTerm)\(prefixNote) is ready to activate.",
                 isSuccess: false,
                 requiresKeyEntry: true,
                 showsNotifyOption: false
@@ -286,9 +290,13 @@ public enum ActivationStateMachine {
             return ActivationStatePresentation(
                 state: state,
                 title: "Activated",
-                cause: "Your \(keyTerm) is active. Private repository review is unlocked.",
+                cause: publicBYO
+                    ? "Your \(keyTerm) is active. Every BYO repository is unlocked."
+                    : "Your \(keyTerm) is active. Private repository review is unlocked.",
                 recovery: nil,
-                accessibilityLabel: "\(keyTerm) is active. Private repositories unlocked.",
+                accessibilityLabel: publicBYO
+                    ? "\(keyTerm) is active. Every BYO repository is unlocked."
+                    : "\(keyTerm) is active. Private repositories unlocked.",
                 isSuccess: true,
                 requiresKeyEntry: false,
                 showsNotifyOption: false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -255,7 +255,7 @@ public enum ActivationStateMachine {
                 state: state,
                 title: "Activate your \(keyTerm)",
                 cause: publicBYO
-                    ? "Your \(keyTerm)\(prefixNote) is ready. Activate it to review every BYO repository."
+                    ? "Your \(keyTerm)\(prefixNote) is ready. Activate it to review this BYO repository."
                     : "Your \(keyTerm)\(prefixNote) is ready. Activate it to unlock private repository review.",
                 recovery: ActivationRecovery(
                     label: "Activate",
@@ -263,7 +263,7 @@ public enum ActivationStateMachine {
                     accessibilityLabel: "Activate the \(keyTerm)"
                 ),
                 accessibilityLabel: publicBYO
-                    ? "\(keyTerm)\(prefixNote) is ready to activate for every BYO repository."
+                    ? "\(keyTerm)\(prefixNote) is ready to activate for this BYO repository."
                     : "\(keyTerm)\(prefixNote) is ready to activate.",
                 isSuccess: false,
                 requiresKeyEntry: true,
@@ -291,11 +291,11 @@ public enum ActivationStateMachine {
                 state: state,
                 title: "Activated",
                 cause: publicBYO
-                    ? "Your \(keyTerm) is active. Every BYO repository is unlocked."
+                    ? "Your \(keyTerm) is active. This BYO repository is unlocked."
                     : "Your \(keyTerm) is active. Private repository review is unlocked.",
                 recovery: nil,
                 accessibilityLabel: publicBYO
-                    ? "\(keyTerm) is active. Every BYO repository is unlocked."
+                    ? "\(keyTerm) is active. This BYO repository is unlocked."
                     : "\(keyTerm) is active. Private repositories unlocked.",
                 isSuccess: true,
                 requiresKeyEntry: false,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -128,12 +128,44 @@ import NeonDiffDesktopCore
         #expect(model.activationState == .keyReady)
     }
 
+    @Test func legacyPublicFreeSkipMigratesToPaidBYOEntry() {
+        let prefs = MemoryPreferences()
+        prefs.set(ActivationState.publicFreeSkip.rawValue, forKey: activationStateKey)
+        let model = makeModel(
+            preferences: prefs,
+            productionBoundary: .testAccountLink
+        )
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(prefs.string(forKey: activationStateKey) == ActivationState.purchaseRequired.rawValue)
+    }
+
     @Test func publicPathSkipsWithoutLicenseUI() {
-        let model = makeModel()
+        let model = makeModel(productionBoundary: .testManaged)
         model.enterActivation(for: .publicReposOnly)
         #expect(model.activationState == .publicFreeSkip)
         #expect(model.activationPresentation.requiresKeyEntry == false)
         #expect(model.activationPresentation.recovery == nil)
+    }
+
+    @Test func publicBYOPathRequiresActivationAndExplainsEveryRepository() {
+        let model = makeModel(productionBoundary: .testAccountLink)
+        model.onboardingFlow.mode = .publicReposOnly
+        model.enterActivation(for: .publicReposOnly)
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(model.activationPresentation.title == "Every repository requires activation")
+        #expect(model.activationPresentation.cause.contains("Every BYO repository"))
+    }
+
+    @Test func legacyPublicFreeSkipSyncReturnsToPaidBYOEntry() {
+        let model = makeModel(productionBoundary: .testAccountLink)
+        model.activationState = .publicFreeSkip
+        model.onboardingFlow.mode = .publicReposOnly
+        model.syncActivationEntryFromOnboardingMode()
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(model.activationPresentation.requiresKeyEntry)
     }
 
     @Test func privatePathBeginsCheckoutPausedWhenCheckoutDisabled() {
@@ -357,7 +389,7 @@ import NeonDiffDesktopCore
     /// Thread 2: choosing Public Repos must skip the license wall, not sit at
     /// purchase_required.
     @Test func publicModeSyncSkipsLicenseWall() {
-        let model = makeModel()
+        let model = makeModel(productionBoundary: .testManaged)
         model.onboardingFlow.mode = .publicReposOnly
         #expect(model.activationState == .purchaseRequired)
         model.syncActivationEntryFromOnboardingMode()

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -158,9 +158,9 @@ import NeonDiffDesktopCore
         #expect(model.activationPresentation.cause.contains("Every BYO repository"))
 
         model.activationState = .keyReady
-        #expect(model.activationPresentation.cause.contains("every BYO repository"))
+        #expect(model.activationPresentation.cause.contains("this BYO repository"))
         model.activationState = .active
-        #expect(model.activationPresentation.cause.contains("Every BYO repository"))
+        #expect(model.activationPresentation.cause.contains("This BYO repository"))
     }
 
     @Test func legacyPublicFreeSkipSyncReturnsToPaidBYOEntry() {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -156,6 +156,11 @@ import NeonDiffDesktopCore
         #expect(model.activationState == .purchaseRequired)
         #expect(model.activationPresentation.title == "Every repository requires activation")
         #expect(model.activationPresentation.cause.contains("Every BYO repository"))
+
+        model.activationState = .keyReady
+        #expect(model.activationPresentation.cause.contains("every BYO repository"))
+        model.activationState = .active
+        #expect(model.activationPresentation.cause.contains("Every BYO repository"))
     }
 
     @Test func legacyPublicFreeSkipSyncReturnsToPaidBYOEntry() {


### PR DESCRIPTION
## Summary

- Migrate restored legacy public_free_skip state to paid activation outside the managed broker path.
- Keep the future managed public-free seam explicit for public activation and exact restore.
- Tell current public BYO users that every repository requires activation.

## Validation

- Failing-first legacy migration and public-copy tests.
- swift test: 438 tests in 42 suites passed.
- git diff --check: clean.

## Scope

- Base 921a74b5381e2178c3ca8369187731c06d0942dd; 80 changed lines.
- No runtime, Keychain, release, or held PR #859 changes.

Refs #872