### PR TITLE
docs(release): make legacy CLI operator paths portable

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -5,17 +5,51 @@ update as a named beta release, not as an informal pull from `main`.
 
 ## Release Boundary
 
-The beta release unit is:
+Set the operator-owned coordinates once, before any command in this runbook:
 
-- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+```bash
+: "${HOME:?HOME is required}"
+: "${NEONDIFF_ACCOUNT:?NEONDIFF_ACCOUNT is required}"
+: "${NEONDIFF_BOT:?NEONDIFF_BOT is required}"
+: "${NEONDIFF_RELEASE_CHECKOUT:?set an absolute release checkout}"
+: "${NEONDIFF_EVIDENCE_ROOT:?set an absolute evidence root outside the checkout}"
+NEONDIFF_BOT_ROOT="$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT/Bots/$NEONDIFF_BOT"
+NEONDIFF_CONFIG_PATH="$NEONDIFF_BOT_ROOT/config.local.json"
+NEONDIFF_STATE_DB="$NEONDIFF_BOT_ROOT/state/reviews.sqlite"
+export NEONDIFF_BOT_ROOT NEONDIFF_CONFIG_PATH NEONDIFF_STATE_DB
+```
+
+All named paths must be absolute. The evidence root must be outside the release
+checkout. The beta release unit is:
+
+- source checkout: `$NEONDIFF_RELEASE_CHECKOUT`
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
-- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
-- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+- launchd config: `$NEONDIFF_CONFIG_PATH`
+- state DB: `$NEONDIFF_STATE_DB`
+- evidence root: `$NEONDIFF_EVIDENCE_ROOT`
 
 Packaged or non-source deployments must set
 `NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
 review mirrors and worktrees cannot be planned inside or above that checkout.
+
+### Legacy CLI worker candidate
+
+This operator-only path is separate from native Desktop adoption. Before an
+update or rollback, verify the immutable candidate manifest digest and tarball
+digest from the GitHub prerelease. The existing LaunchAgent must have its exact
+label, an absolute `WorkingDirectory`, non-empty `ProgramArguments` containing
+exactly one absolute `--config "$NEONDIFF_CONFIG_PATH"`, and
+`EnvironmentVariables` with the App ID plus an absolute private-key file path.
+The private-key file remains the legacy credential contract; never copy its
+bytes into the manifest, plist, logs, or evidence.
+
+Use `install-b0-worker-candidate.mjs update` or `rollback` first with
+`--dry-run true`, then with `--dry-run false --confirm true`, supplying the
+absolute manifest and tarball paths, manifest SHA-256, and existing launchd
+label. The installer must preserve the original label, config,
+`WorkingDirectory`, environment, worker loaded/stopped state, account/bot state,
+`state/reviews.sqlite`, allowlist, and exactly one installed worker. Rollback
+uses the recorded prior candidate; it never substitutes source checkout bytes.
 
 The beta release unit does not include expanding monitored repos, GitHub App
 permissions, ZCode tools, auto-merge, approvals, or repair behavior. Those need
@@ -92,19 +126,19 @@ tagged version.
 Run from a clean release checkout on `main`:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git status --short
 git pull --ff-only
 npm test
 npm run build
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 sleep 5
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot \
   --require-coverage true
@@ -115,7 +149,7 @@ For public source-beta releases, run the same gate with manifest checks:
 ```bash
 PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -138,7 +172,7 @@ fetched:
 ```bash
 git fetch origin --tags
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -470,7 +504,7 @@ from the eligible open-head set. Retire only the exact failed head:
 
 ```bash
 npx tsx src/cli.ts retire-failed \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
@@ -540,7 +574,7 @@ Expired cooldown rows are actionable backlog. Run:
 
 ```bash
 npx tsx src/cli.ts retry-provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expired-only true \
   --dry-run false \
   --zcode true
@@ -557,7 +591,7 @@ Default rollback is to restart the existing launchd job after checking out the
 last known-good merge commit:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin
 git checkout main
 git reset --hard <last-known-good-merge-sha>
@@ -601,7 +635,7 @@ For each beta promotion, record:
   tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
-Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+Keep raw evidence under `$NEONDIFF_EVIDENCE_ROOT`
 or session notes. Do not paste secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -9,18 +9,27 @@ Set the operator-owned coordinates once, before any command in this runbook:
 
 ```bash
 : "${HOME:?HOME is required}"
-: "${NEONDIFF_ACCOUNT:?NEONDIFF_ACCOUNT is required}"
-: "${NEONDIFF_BOT:?NEONDIFF_BOT is required}"
 : "${NEONDIFF_RELEASE_CHECKOUT:?set an absolute release checkout}"
 : "${NEONDIFF_EVIDENCE_ROOT:?set an absolute evidence root outside the checkout}"
-NEONDIFF_BOT_ROOT="$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT/Bots/$NEONDIFF_BOT"
-NEONDIFF_CONFIG_PATH="$NEONDIFF_BOT_ROOT/config.local.json"
-NEONDIFF_STATE_DB="$NEONDIFF_BOT_ROOT/state/reviews.sqlite"
-export NEONDIFF_BOT_ROOT NEONDIFF_CONFIG_PATH NEONDIFF_STATE_DB
+: "${NEONDIFF_CONFIG_PATH:?copy the absolute --config operand from the verified plist}"
+: "${NEONDIFF_STATE_DB:?copy the absolute statePath from that config}"
+for path in "$NEONDIFF_RELEASE_CHECKOUT" "$NEONDIFF_EVIDENCE_ROOT" "$NEONDIFF_CONFIG_PATH" "$NEONDIFF_STATE_DB"; do
+  case "$path" in /*) ;; *) echo "operator paths must be absolute" >&2; exit 1;; esac
+done
+test -d "$NEONDIFF_RELEASE_CHECKOUT" && test -d "$NEONDIFF_EVIDENCE_ROOT"
+NEONDIFF_RELEASE_CHECKOUT="$(cd "$NEONDIFF_RELEASE_CHECKOUT" && pwd -P)"
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"
+CHECKOUT_TOP="$(cd "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" rev-parse --show-toplevel)" && pwd -P)"
+test "$CHECKOUT_TOP" = "$NEONDIFF_RELEASE_CHECKOUT" || { echo "release checkout root mismatch" >&2; exit 1; }
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$NEONDIFF_RELEASE_CHECKOUT/"*) echo "evidence root must be outside the checkout" >&2; exit 1;; esac
+case "$(git -C "$NEONDIFF_RELEASE_CHECKOUT" remote get-url origin)" in https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;; *) echo "release checkout origin mismatch" >&2; exit 1;; esac
+export NEONDIFF_RELEASE_CHECKOUT NEONDIFF_EVIDENCE_ROOT NEONDIFF_CONFIG_PATH NEONDIFF_STATE_DB
 ```
 
-All named paths must be absolute. The evidence root must be outside the release
-checkout. The beta release unit is:
+The config coordinate is the legacy LaunchAgent's verified absolute `--config`
+operand; it need not be under Desktop's account/bot tree. The native path is
+documented separately in `apps/neondiff-desktop/docs/customer-adoption.md`.
+The beta release unit is:
 
 - source checkout: `$NEONDIFF_RELEASE_CHECKOUT`
 - launchd job: `com.electricsheephq.evaos-code-review-bot`
@@ -47,8 +56,8 @@ Use `install-b0-worker-candidate.mjs update` or `rollback` first with
 `--dry-run true`, then with `--dry-run false --confirm true`, supplying the
 absolute manifest and tarball paths, manifest SHA-256, and existing launchd
 label. The installer must preserve the original label, config,
-`WorkingDirectory`, environment, worker loaded/stopped state, account/bot state,
-`state/reviews.sqlite`, allowlist, and exactly one installed worker. Rollback
+`WorkingDirectory`, environment, worker loaded/stopped state, config `statePath`,
+allowlist, and exactly one installed worker. Rollback
 uses the recorded prior candidate; it never substitutes source checkout bytes.
 
 The beta release unit does not include expanding monitored repos, GitHub App
@@ -587,8 +596,10 @@ that the retry recorded `skipped_closed` or `skipped_stale_head`.
 
 ## Rollback
 
-Default rollback is to restart the existing launchd job after checking out the
-last known-good merge commit:
+For a managed candidate whose plist executes `Workers/.../current`, use the
+candidate installer's recorded-prior `rollback` flow above; a source reset does
+not change that worker. Only a source-managed plist may use the source rollback
+below to restart after checking out the last known-good merge commit:
 
 ```bash
 cd "$NEONDIFF_RELEASE_CHECKOUT"

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -459,7 +459,10 @@ before calling the release green.
 
 ## Rollback
 
-Rollback is tag-first:
+For a managed candidate whose plist executes `Workers/.../current`, use
+`install-b0-worker-candidate.mjs rollback` with its recorded prior candidate;
+the source reset below cannot roll it back. Only a source-managed plist uses
+this tag-first flow:
 
 ```bash
 cd "$NEONDIFF_RELEASE_CHECKOUT"

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -339,10 +339,14 @@ unchanged and treat the package as quarantined.
 
 ## Tag And Release
 
+Before any command below, run the guarded coordinate block in
+`docs/beta-release-runbook.md`. It defines the absolute
+`NEONDIFF_RELEASE_CHECKOUT` and account/bot-scoped `NEONDIFF_CONFIG_PATH`.
+
 Create an annotated tag from the merged source SHA:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
@@ -377,13 +381,13 @@ pass that file as `--notes-file` and include the tag name at the top.
 After the GitHub Release exists:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin main --tags
 git checkout main
 git pull --ff-only origin main
 test "$(git rev-parse HEAD)" = "<source-sha>"
-launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+launchctl bootout gui/$(id -u) "$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist" 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "$HOME/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist"
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 ```
 
@@ -395,7 +399,7 @@ Run the status gate with App credentials set in the shell:
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
@@ -406,7 +410,7 @@ For public source-beta or public beta releases, include the public manifest gate
 SOURCE_SHA=replace-with-release-source-sha
 PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head "$SOURCE_SHA" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
@@ -424,9 +428,9 @@ Also run:
 
 ```bash
 npx tsx src/cli.ts coverage-audit \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+  --config "$NEONDIFF_CONFIG_PATH"
 npx tsx src/cli.ts provider-cooldowns \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expired-only true
 ```
 
@@ -458,13 +462,13 @@ before calling the release green.
 Rollback is tag-first:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd "$NEONDIFF_RELEASE_CHECKOUT"
 git fetch origin --tags
 git checkout main
 git reset --hard <previous-release-tag>
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -227,7 +227,9 @@ Use this path for each new repo from #14 or future allowlists:
    `npm run release:status` plus fresh launchd heartbeats.
 
 Do not treat `config.example.json` as live config. The active launchd config is
-outside the repo under `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/`.
+the account/bot-scoped
+`~/Library/Application Support/NeonDiffDesktop/Accounts/<account>/Bots/<bot>/config.local.json`;
+operators must guard `HOME`, account, and bot before deriving that path.
 Do not add repos whose GitHub App installation cannot be verified; public
 visibility or an admin user's `gh repo view` is not enough because reviews must
 be authored by `evaos-code-review-bot`.

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -226,10 +226,10 @@ Use this path for each new repo from #14 or future allowlists:
 7. Promote through `docs/beta-release-runbook.md` and verify
    `npm run release:status` plus fresh launchd heartbeats.
 
-Do not treat `config.example.json` as live config. The active launchd config is
-the account/bot-scoped
-`~/Library/Application Support/NeonDiffDesktop/Accounts/<account>/Bots/<bot>/config.local.json`;
-operators must guard `HOME`, account, and bot before deriving that path.
+Do not treat `config.example.json` as live config. A legacy LaunchAgent may keep
+any verified absolute `--config` path, and release operations must reuse that
+exact plist operand. Native Desktop instead owns the account/bot-scoped
+`~/Library/Application Support/NeonDiffDesktop/Accounts/<account>/Bots/<bot>/config.local.json`.
 Do not add repos whose GitHub App installation cannot be verified; public
 visibility or an admin user's `gh repo view` is not enough because reviews must
 be authored by `evaos-code-review-bot`.

--- a/docs/skills/release-operator.md
+++ b/docs/skills/release-operator.md
@@ -34,11 +34,13 @@ exception in the tracker issue and open a backfill issue before ending.
 
 ```bash
 : "${HOME:?HOME is required}"
-: "${NEONDIFF_ACCOUNT:?NEONDIFF_ACCOUNT is required}"
-: "${NEONDIFF_BOT:?NEONDIFF_BOT is required}"
 : "${NEONDIFF_RELEASE_CHECKOUT:?set an absolute release checkout}"
-NEONDIFF_CONFIG_PATH="$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT/Bots/$NEONDIFF_BOT/config.local.json"
-export NEONDIFF_CONFIG_PATH
+: "${NEONDIFF_CONFIG_PATH:?copy the absolute --config operand from the verified plist}"
+case "$NEONDIFF_RELEASE_CHECKOUT" in /*) ;; *) echo "release checkout must be absolute" >&2; exit 1;; esac
+NEONDIFF_RELEASE_CHECKOUT="$(cd "$NEONDIFF_RELEASE_CHECKOUT" && pwd -P)"
+cd "$NEONDIFF_RELEASE_CHECKOUT"
+test "$(cd "$(git rev-parse --show-toplevel)" && pwd -P)" = "$NEONDIFF_RELEASE_CHECKOUT" || exit 1
+case "$(git remote get-url origin)" in https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git|git@github.com:electricsheephq/evaos-code-review-bot-neondiff.git) ;; *) echo "release checkout origin mismatch" >&2; exit 1;; esac
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 

--- a/docs/skills/release-operator.md
+++ b/docs/skills/release-operator.md
@@ -33,6 +33,12 @@ exception in the tracker issue and open a backfill issue before ending.
 ## Required Commands
 
 ```bash
+: "${HOME:?HOME is required}"
+: "${NEONDIFF_ACCOUNT:?NEONDIFF_ACCOUNT is required}"
+: "${NEONDIFF_BOT:?NEONDIFF_BOT is required}"
+: "${NEONDIFF_RELEASE_CHECKOUT:?set an absolute release checkout}"
+NEONDIFF_CONFIG_PATH="$HOME/Library/Application Support/NeonDiffDesktop/Accounts/$NEONDIFF_ACCOUNT/Bots/$NEONDIFF_BOT/config.local.json"
+export NEONDIFF_CONFIG_PATH
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 
@@ -50,7 +56,7 @@ gh release create <tag> \
 
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$NEONDIFF_CONFIG_PATH" \
   --expected-head <source-sha> \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/tests/operational-doc-path-contract.test.ts
+++ b/tests/operational-doc-path-contract.test.ts
@@ -24,4 +24,21 @@ describe("operational documentation path contract", () => {
     expect(guide).toContain('in "$CHECKOUT_ROOT/"*)');
     expect(guide).not.toContain("/Volumes/LEXAR");
   });
+
+  it("keeps legacy release operation portable and credential-file based", () => {
+    const runbook = read("docs/beta-release-runbook.md");
+    const governance = read("docs/release-governance.md");
+    const operator = read("docs/skills/release-operator.md");
+    const profiles = read("docs/repo-profiles.md");
+    const legacy = [runbook, governance, operator, profiles].join("\n");
+
+    expect(runbook).toContain("Accounts/$NEONDIFF_ACCOUNT/Bots/$NEONDIFF_BOT");
+    expect(runbook).toContain("state/reviews.sqlite");
+    expect(runbook).toContain("absolute `WorkingDirectory`");
+    expect(runbook).toContain("`EnvironmentVariables`");
+    expect(runbook).toContain("absolute private-key file path");
+    expect(runbook).toContain("exactly one installed worker");
+    expect(operator).toContain("${HOME:?HOME is required}");
+    expect(legacy).not.toContain("/Volumes/LEXAR");
+  });
 });

--- a/tests/operational-doc-path-contract.test.ts
+++ b/tests/operational-doc-path-contract.test.ts
@@ -32,13 +32,17 @@ describe("operational documentation path contract", () => {
     const profiles = read("docs/repo-profiles.md");
     const legacy = [runbook, governance, operator, profiles].join("\n");
 
-    expect(runbook).toContain("Accounts/$NEONDIFF_ACCOUNT/Bots/$NEONDIFF_BOT");
-    expect(runbook).toContain("state/reviews.sqlite");
+    expect(runbook).toContain("copy the absolute --config operand from the verified plist");
+    expect(runbook).toContain("copy the absolute statePath from that config");
+    expect(runbook).toContain('in "$NEONDIFF_RELEASE_CHECKOUT/"*)');
+    expect(runbook).toContain("release checkout origin mismatch");
     expect(runbook).toContain("absolute `WorkingDirectory`");
     expect(runbook).toContain("`EnvironmentVariables`");
     expect(runbook).toContain("absolute private-key file path");
     expect(runbook).toContain("exactly one installed worker");
     expect(operator).toContain("${HOME:?HOME is required}");
+    expect(operator).toContain('cd "$NEONDIFF_RELEASE_CHECKOUT"');
+    expect(governance).toContain("source reset below cannot roll it back");
     expect(legacy).not.toContain("/Volumes/LEXAR");
   });
 });


### PR DESCRIPTION
Part of #873

Stacked on #876. Keeps the legacy CLI/operator release path separate from native Desktop adoption and aligns it with the current installer contract: guarded absolute operator coordinates, account/bot config, reviews.sqlite, absolute WorkingDirectory/argv/private-key file coordinates, immutable candidate digests, and identity-preserving update/rollback.

Checks:
- deterministic Node legacy documentation contract: pass
- git diff --check: pass
- focused Vitest: locally blocked by missing optional Rolldown native binding; remote CI is authoritative

Proof boundary: documentation/source-contract only; no install, release, runtime, config, DB, credential, or Keychain mutation.