### PR TITLE
fix(state): transact incomplete evidence quarantine

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -2784,17 +2784,17 @@ export class ReviewStateStore {
       `update review_queue_jobs set state = 'queued', lease_id = null, lease_expires_at = null,
               last_error = 'queue_lease_expired_requeued', updated_at = ?
        where repo = ? and pull_number = ? and state in ('leased', 'running') and
-         ((lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?)) or
-          (lease_expires_at is null and datetime(updated_at) <= datetime(?)))`
+         ((lease_expires_at is not null and lease_expires_at <= ?) or
+          (lease_expires_at is null and updated_at <= ?))`
     ).run(nowIso, input.repo, input.pullNumber, nowIso, legacyLeaseCutoffIso);
     const retiredQueueJobs = Number(this.db.prepare(
-      `update review_queue_jobs set state = 'stale_retired', lease_id = null, lease_expires_at = null,
+      `update review_queue_jobs set state = 'stale_retired', lease_id = null, lease_expires_at = null, next_eligible_at = null,
               last_error = ?, updated_at = ?
        where repo = ? and pull_number = ? and head_sha <> ?
          and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
     ).run(supersededReason, nowIso, input.repo, input.pullNumber, input.headSha).changes);
     const failedQueueJobs = Number(this.db.prepare(
-      `update review_queue_jobs set state = 'failed', lease_id = null, lease_expires_at = null,
+      `update review_queue_jobs set state = 'failed', lease_id = null, lease_expires_at = null, next_eligible_at = null,
               last_error = ?, updated_at = ?
        where repo = ? and pull_number = ? and head_sha = ?
          and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
@@ -2815,22 +2815,30 @@ export class ReviewStateStore {
       `update reviewer_session_jobs set job_state = 'failed', finished_at = coalesce(finished_at, ?),
               processed_review_status = 'failed'
        where repo = ? and pull_number = ? and head_sha = ? and
-         (job_state = 'assigned' or (job_state = 'running' and exists (
+         (job_state = 'assigned' or (job_state = 'running' and not exists (
            select 1 from review_queue_jobs q where q.repo = reviewer_session_jobs.repo
              and q.pull_number = reviewer_session_jobs.pull_number
-             and q.head_sha = reviewer_session_jobs.head_sha and q.state = 'failed'
+             and q.head_sha = reviewer_session_jobs.head_sha and q.state in ('leased', 'running')
+             and ((q.lease_expires_at is not null and q.lease_expires_at > ?)
+               or (q.lease_expires_at is null and q.updated_at > ?))
          )))`
-    ).run(nowIso, input.repo, input.pullNumber, input.headSha);
+    ).run(nowIso, input.repo, input.pullNumber, input.headSha, nowIso, legacyLeaseCutoffIso);
     this.db.prepare(
       `update reviewer_session_jobs set job_state = 'skipped', finished_at = coalesce(finished_at, ?),
               processed_review_status = 'skipped'
        where repo = ? and pull_number = ? and head_sha <> ? and
-         (job_state = 'assigned' or (job_state = 'running' and exists (
+         (job_state = 'assigned' or (job_state = 'running' and not exists (
            select 1 from review_queue_jobs q where q.repo = reviewer_session_jobs.repo
              and q.pull_number = reviewer_session_jobs.pull_number
-             and q.head_sha = reviewer_session_jobs.head_sha and q.state = 'stale_retired'
+             and q.head_sha = reviewer_session_jobs.head_sha and q.state in ('leased', 'running')
+             and ((q.lease_expires_at is not null and q.lease_expires_at > ?)
+               or (q.lease_expires_at is null and q.updated_at > ?))
          )))`
-    ).run(nowIso, input.repo, input.pullNumber, input.headSha);
+    ).run(nowIso, input.repo, input.pullNumber, input.headSha, nowIso, legacyLeaseCutoffIso);
+    const sessions = this.db.prepare(
+      "select distinct session_id from reviewer_session_jobs where repo = ? and pull_number = ?"
+    ).all(input.repo, input.pullNumber) as unknown as Array<{ session_id: string }>;
+    for (const session of sessions) this.expireDrainedReviewerSessionIfComplete(session.session_id);
     return { failedQueueJobs, retiredQueueJobs };
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -44,6 +44,16 @@ export type ReviewReadinessState =
   | "command_recorded"
   | "skipped"
   | "failed";
+export interface ReviewEvidenceQuarantine {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  reason: string;
+}
+export interface ReviewEvidenceQuarantineResult {
+  failedQueueJobs: number;
+  retiredQueueJobs: number;
+}
 export type RepoMemoryNoteKind =
   | "policy_note"
   | "machine_fact"
@@ -2611,6 +2621,26 @@ export class ReviewStateStore {
     return { enqueued: true, job: this.getReviewQueueJob(jobId)! };
   }
 
+  quarantineIncompleteReviewEvidence(input: ReviewEvidenceQuarantine & {
+    leaseTtlMs?: number;
+    now?: Date;
+  }): ReviewEvidenceQuarantineResult {
+    validateReviewQueueInput(input.repo, input.pullNumber, input.headSha);
+    const leaseTtlMs = input.leaseTtlMs ?? 15 * 60_000;
+    validatePositiveQueueLimit(leaseTtlMs, "leaseTtlMs");
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      const result = this.applyIncompleteReviewEvidence(input, nowIso, legacyLeaseCutoffIso);
+      this.db.exec("commit");
+      return result;
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
   leaseNextReviewQueueJobs(input: {
     maxGlobalActive?: number;
     maxProviderActive: number;
@@ -2619,6 +2649,7 @@ export class ReviewStateStore {
     maxRepoActiveByRepo?: Record<string, number>;
     manualCommandReserve?: number;
     excludeJobIds?: Iterable<string>;
+    quarantines?: Iterable<ReviewEvidenceQuarantine>;
     reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo" | "pullNumber" | "headSha">>;
     limit?: number;
     leaseTtlMs?: number;
@@ -2650,6 +2681,10 @@ export class ReviewStateStore {
     const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
     const leaseExpiresAt = new Date(Date.parse(nowIso) + leaseTtlMs).toISOString();
     const excludeJobIds = new Set(input.excludeJobIds ?? []);
+    const quarantines = Array.from(input.quarantines ?? []);
+    for (const quarantine of quarantines) {
+      validateReviewQueueInput(quarantine.repo, quarantine.pullNumber, quarantine.headSha);
+    }
     const reservedActiveJobs = Array.from(input.reservedActiveJobs ?? []);
     const leased: ReviewQueueJobRecord[] = [];
 
@@ -2670,6 +2705,9 @@ export class ReviewStateStore {
              )`
         )
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
+      for (const quarantine of quarantines) {
+        this.applyIncompleteReviewEvidence(quarantine, nowIso, legacyLeaseCutoffIso);
+      }
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
@@ -2733,6 +2771,67 @@ export class ReviewStateStore {
     }
 
     return leased;
+  }
+
+  private applyIncompleteReviewEvidence(
+    input: ReviewEvidenceQuarantine,
+    nowIso: string,
+    legacyLeaseCutoffIso: string
+  ): ReviewEvidenceQuarantineResult {
+    const reason = redactSecrets(input.reason).trim().slice(0, 500);
+    const supersededReason = `superseded_by_head=${input.headSha}`;
+    this.db.prepare(
+      `update review_queue_jobs set state = 'queued', lease_id = null, lease_expires_at = null,
+              last_error = 'queue_lease_expired_requeued', updated_at = ?
+       where repo = ? and pull_number = ? and state in ('leased', 'running') and
+         ((lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?)) or
+          (lease_expires_at is null and datetime(updated_at) <= datetime(?)))`
+    ).run(nowIso, input.repo, input.pullNumber, nowIso, legacyLeaseCutoffIso);
+    const retiredQueueJobs = Number(this.db.prepare(
+      `update review_queue_jobs set state = 'stale_retired', lease_id = null, lease_expires_at = null,
+              last_error = ?, updated_at = ?
+       where repo = ? and pull_number = ? and head_sha <> ?
+         and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
+    ).run(supersededReason, nowIso, input.repo, input.pullNumber, input.headSha).changes);
+    const failedQueueJobs = Number(this.db.prepare(
+      `update review_queue_jobs set state = 'failed', lease_id = null, lease_expires_at = null,
+              last_error = ?, updated_at = ?
+       where repo = ? and pull_number = ? and head_sha = ?
+         and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
+    ).run(reason, nowIso, input.repo, input.pullNumber, input.headSha).changes);
+    this.db.prepare(
+      `update review_readiness set state = 'stale', reason = ?, updated_at = ?
+       where repo = ? and pull_number = ? and head_sha <> ?
+         and state in ('queued', 'reviewing', 'needs_fix', 'awaiting_re_review', 'ready_for_human', 'provider_deferred', 'command_recorded')`
+    ).run(supersededReason, nowIso, input.repo, input.pullNumber, input.headSha);
+    this.db.prepare(
+      `insert into review_readiness (repo, pull_number, head_sha, state, reason, created_at, updated_at)
+       values (?, ?, ?, 'failed', ?, ?, ?)
+       on conflict(repo, pull_number, head_sha) do update set
+         state = 'failed', reason = excluded.reason, updated_at = excluded.updated_at
+       where review_readiness.state <> 'failed' or coalesce(review_readiness.reason, '') <> excluded.reason`
+    ).run(input.repo, input.pullNumber, input.headSha, reason, nowIso, nowIso);
+    this.db.prepare(
+      `update reviewer_session_jobs set job_state = 'failed', finished_at = coalesce(finished_at, ?),
+              processed_review_status = 'failed'
+       where repo = ? and pull_number = ? and head_sha = ? and
+         (job_state = 'assigned' or (job_state = 'running' and exists (
+           select 1 from review_queue_jobs q where q.repo = reviewer_session_jobs.repo
+             and q.pull_number = reviewer_session_jobs.pull_number
+             and q.head_sha = reviewer_session_jobs.head_sha and q.state = 'failed'
+         )))`
+    ).run(nowIso, input.repo, input.pullNumber, input.headSha);
+    this.db.prepare(
+      `update reviewer_session_jobs set job_state = 'skipped', finished_at = coalesce(finished_at, ?),
+              processed_review_status = 'skipped'
+       where repo = ? and pull_number = ? and head_sha <> ? and
+         (job_state = 'assigned' or (job_state = 'running' and exists (
+           select 1 from review_queue_jobs q where q.repo = reviewer_session_jobs.repo
+             and q.pull_number = reviewer_session_jobs.pull_number
+             and q.head_sha = reviewer_session_jobs.head_sha and q.state = 'stale_retired'
+         )))`
+    ).run(nowIso, input.repo, input.pullNumber, input.headSha);
+    return { failedQueueJobs, retiredQueueJobs };
   }
 
   updateReviewQueueJobState(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -2700,8 +2700,8 @@ export class ReviewStateStore {
                updated_at = ?
            where state in ('leased', 'running')
              and (
-               (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
-               or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
+               (lease_expires_at is not null and lease_expires_at <= ?)
+               or (lease_expires_at is null and updated_at <= ?)
              )`
         )
         .run(nowIso, nowIso, legacyLeaseCutoffIso);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1290,6 +1290,7 @@ describe("review state store", () => {
     expect(store.getReviewQueueJob(expired.jobId)).not.toHaveProperty("leaseId");
     expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "leased", leaseId: "race" });
     expect(store.quarantineIncompleteReviewEvidence({ ...quarantine, now: new Date("2026-07-01T00:00:04.100Z") })).toEqual({ failedQueueJobs: 0, retiredQueueJobs: 0 });
+    expect(store.leaseNextReviewQueueJobs({ maxProviderActive: 2, maxOrgActive: 2, maxRepoActive: 2, quarantines: [quarantine], now: new Date("2026-07-01T00:00:04.100Z") }).map((job) => job.jobId)).toEqual([unrelated.jobId]);
     expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "leased", leaseId: "race" });
     expect(store.getReviewQueueJob(superseded.jobId)).toMatchObject({ state: "stale_retired", lastError: "superseded_by_head=head-b" });
     expect(store.getReviewReadiness(repo, 1, "head-a")).toMatchObject({ state: "stale", reason: "superseded_by_head=head-b" });
@@ -1312,7 +1313,7 @@ describe("review state store", () => {
       maxRepoActive: 2,
       quarantines: [quarantine],
       now: new Date("2026-07-01T00:00:05Z")
-    }).map((job) => job.jobId)).toEqual([unrelated.jobId]);
+    })).toEqual([]);
     expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "failed" });
     expect(store.getReviewQueueJob(expiryRace.jobId)).not.toHaveProperty("leaseId");
     expect(store.listReviewQueueJobsForPull({ repo, pullNumber: 1 }).some((job) => job.state === "queued" || job.state === "leased" || job.state === "running")).toBe(false);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1270,6 +1270,7 @@ describe("review state store", () => {
     const expiryRace = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", source: "manual_command", commentId: 3, now: new Date("2026-07-01T00:00:00Z") }).job;
     const superseded = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-a", now: new Date("2026-07-01T00:00:00Z") }).job;
     const unrelated = store.enqueueReviewQueueJob({ repo, pullNumber: 2, headSha: "head-c", now: new Date("2026-07-01T00:00:00Z") }).job;
+    store.updateReviewQueueJobState({ jobId: current.jobId, state: "provider_deferred", nextEligibleAt: "2026-07-01T00:10:00Z" });
     store.updateReviewQueueJobState({ jobId: expired.jobId, state: "leased", leaseId: "expired", leaseExpiresAt: "2026-07-01T00:00:01Z" });
     store.updateReviewQueueJobState({ jobId: expiryRace.jobId, state: "leased", leaseId: "race", leaseExpiresAt: "2026-07-01T00:00:04.500Z" });
     store.recordReviewReadiness({ repo, pullNumber: 1, headSha: "head-a", state: "queued", reason: "automatic_enqueue" });
@@ -1284,21 +1285,26 @@ describe("review state store", () => {
       retiredQueueJobs: 0
     });
     expect(store.getReviewQueueJob(current.jobId)).toMatchObject({ state: "failed", lastError: expect.not.stringContaining("ghp_fake_token") });
+    expect(store.getReviewQueueJob(current.jobId)).not.toHaveProperty("nextEligibleAt");
     expect(store.getReviewQueueJob(expired.jobId)).toMatchObject({ state: "failed" });
     expect(store.getReviewQueueJob(expired.jobId)).not.toHaveProperty("leaseId");
+    expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "leased", leaseId: "race" });
+    expect(store.quarantineIncompleteReviewEvidence({ ...quarantine, now: new Date("2026-07-01T00:00:04.100Z") })).toEqual({ failedQueueJobs: 0, retiredQueueJobs: 0 });
     expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "leased", leaseId: "race" });
     expect(store.getReviewQueueJob(superseded.jobId)).toMatchObject({ state: "stale_retired", lastError: "superseded_by_head=head-b" });
     expect(store.getReviewReadiness(repo, 1, "head-a")).toMatchObject({ state: "stale", reason: "superseded_by_head=head-b" });
     expect(store.getReviewReadiness(repo, 1, "head-b")).toMatchObject({ state: "failed", reason: expect.not.stringContaining("ghp_fake_token") });
 
     const noJob = { repo, pullNumber: 3, headSha: "head-no-job", reason: "required_evidence_incomplete" };
-    store.assignReviewerSessionJob({ ...noJob, ttlMs: 60_000, headCountLimit: 2, now: new Date("2026-07-01T00:00:03Z") });
+    const assignment = store.assignReviewerSessionJob({ ...noJob, ttlMs: 60_000, headCountLimit: 1, now: new Date("2026-07-01T00:00:03Z") });
+    store.updateReviewerSessionJobState({ ...noJob, jobState: "running", now: new Date("2026-07-01T00:00:03Z") });
     expect(store.quarantineIncompleteReviewEvidence({ ...noJob, now: new Date("2026-07-01T00:00:03Z") })).toEqual({
       failedQueueJobs: 0,
       retiredQueueJobs: 0
     });
     expect(store.getReviewReadiness(repo, 3, "head-no-job")).toMatchObject({ state: "failed", reason: "required_evidence_incomplete" });
     expect(store.getReviewerSessionJob(repo, 3, "head-no-job")).toMatchObject({ jobState: "failed", processedReviewStatus: "failed" });
+    expect(store.getReviewerSession(assignment.session!.sessionId)).toMatchObject({ state: "expired" });
 
     expect(store.leaseNextReviewQueueJobs({
       maxProviderActive: 2,

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1260,6 +1260,59 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("atomically quarantines incomplete evidence without leaking expired or unrelated jobs", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-evidence-quarantine-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const repo = "org/repo-a";
+    const current = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", now: new Date("2026-07-01T00:00:00Z") }).job;
+    const expired = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", source: "manual_command", commentId: 2, now: new Date("2026-07-01T00:00:00Z") }).job;
+    const expiryRace = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", source: "manual_command", commentId: 3, now: new Date("2026-07-01T00:00:00Z") }).job;
+    const superseded = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-a", now: new Date("2026-07-01T00:00:00Z") }).job;
+    const unrelated = store.enqueueReviewQueueJob({ repo, pullNumber: 2, headSha: "head-c", now: new Date("2026-07-01T00:00:00Z") }).job;
+    store.updateReviewQueueJobState({ jobId: expired.jobId, state: "leased", leaseId: "expired", leaseExpiresAt: "2026-07-01T00:00:01Z" });
+    store.updateReviewQueueJobState({ jobId: expiryRace.jobId, state: "leased", leaseId: "race", leaseExpiresAt: "2026-07-01T00:00:04.500Z" });
+    store.recordReviewReadiness({ repo, pullNumber: 1, headSha: "head-a", state: "queued", reason: "automatic_enqueue" });
+
+    const quarantine = { repo, pullNumber: 1, headSha: "head-b", reason: "required_evidence_incomplete token=ghp_fake_token" };
+    expect(store.quarantineIncompleteReviewEvidence({ ...quarantine, now: new Date("2026-07-01T00:00:02Z") })).toEqual({
+      failedQueueJobs: 2,
+      retiredQueueJobs: 1
+    });
+    expect(store.quarantineIncompleteReviewEvidence({ ...quarantine, now: new Date("2026-07-01T00:00:03Z") })).toEqual({
+      failedQueueJobs: 0,
+      retiredQueueJobs: 0
+    });
+    expect(store.getReviewQueueJob(current.jobId)).toMatchObject({ state: "failed", lastError: expect.not.stringContaining("ghp_fake_token") });
+    expect(store.getReviewQueueJob(expired.jobId)).toMatchObject({ state: "failed" });
+    expect(store.getReviewQueueJob(expired.jobId)).not.toHaveProperty("leaseId");
+    expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "leased", leaseId: "race" });
+    expect(store.getReviewQueueJob(superseded.jobId)).toMatchObject({ state: "stale_retired", lastError: "superseded_by_head=head-b" });
+    expect(store.getReviewReadiness(repo, 1, "head-a")).toMatchObject({ state: "stale", reason: "superseded_by_head=head-b" });
+    expect(store.getReviewReadiness(repo, 1, "head-b")).toMatchObject({ state: "failed", reason: expect.not.stringContaining("ghp_fake_token") });
+
+    const noJob = { repo, pullNumber: 3, headSha: "head-no-job", reason: "required_evidence_incomplete" };
+    store.assignReviewerSessionJob({ ...noJob, ttlMs: 60_000, headCountLimit: 2, now: new Date("2026-07-01T00:00:03Z") });
+    expect(store.quarantineIncompleteReviewEvidence({ ...noJob, now: new Date("2026-07-01T00:00:03Z") })).toEqual({
+      failedQueueJobs: 0,
+      retiredQueueJobs: 0
+    });
+    expect(store.getReviewReadiness(repo, 3, "head-no-job")).toMatchObject({ state: "failed", reason: "required_evidence_incomplete" });
+    expect(store.getReviewerSessionJob(repo, 3, "head-no-job")).toMatchObject({ jobState: "failed", processedReviewStatus: "failed" });
+
+    expect(store.leaseNextReviewQueueJobs({
+      maxProviderActive: 2,
+      maxOrgActive: 2,
+      maxRepoActive: 2,
+      quarantines: [quarantine],
+      now: new Date("2026-07-01T00:00:05Z")
+    }).map((job) => job.jobId)).toEqual([unrelated.jobId]);
+    expect(store.getReviewQueueJob(expiryRace.jobId)).toMatchObject({ state: "failed" });
+    expect(store.getReviewQueueJob(expiryRace.jobId)).not.toHaveProperty("leaseId");
+    expect(store.listReviewQueueJobsForPull({ repo, pullNumber: 1 }).some((job) => job.state === "queued" || job.state === "leased" || job.state === "running")).toBe(false);
+    store.close();
+  });
+
   it("dry-runs and clears expired review queue leases without manual SQL", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-clear-"));
     roots.push(root);


### PR DESCRIPTION
Related: #882

State-only foundation for the issue #882 stack.

This adds one exact-pull/head transaction that:
- requeues expired target-pull leases before disposition;
- fails only the incomplete current head and retires superseded queue/readiness rows;
- records idempotent redacted readiness and reviewer-session truth even when no queue job exists;
- lets the lease transaction reapply quarantine after expiry requeue so excluded jobs cannot leak back into eligibility;
- preserves non-expired lease ownership and unrelated pulls.

Focused proof:
- PATH=/opt/homebrew/bin:/Users/m1/.local/bin:/Users/m1/.codex/tmp/arg0/codex-arg0T7mR5p:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm test -- --run tests/state.test.ts (72/72 pass)
- git diff --check (pass)
- 152 non-generated changed lines

Local build reached TypeScript but the shared local dependency tree lacks stripe; authoritative full build/test/package is left to exact-head GitHub CI.

Agent-authored. No runtime, config, DB migration, Keychain, provider, customer, release, or merge mutation was performed. PR #874/#848/#849 were evidence only and were not used as bases.