### PR TITLE
docs: add packaged native Desktop setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ checksum-bound prerelease bundle.
 
 Follow [docs/SETUP.md](docs/SETUP.md) for the CLI-first setup path (the
 first-run path on non-Mac platforms and the operator/advanced path on Mac). The
-short version is:
+signed Desktop customer path starts at
+[Native Desktop adoption](docs/SETUP.md#native-desktop-adoption); the npm
+package ships this guide and the CLI, not signed Desktop app bytes or a source
+checkout. The short CLI version is:
 
 ```bash
 neondiff init --config config.local.json
@@ -164,6 +167,11 @@ surface for CLI-first and non-Mac setups, not the product UI. It shows license
 status, GitHub App status, daemon status, and provider readiness, and its
 provider card includes a `Verify API Key` control that reports redacted
 pass/fail output.
+An account can have current update access even when its server catalog reports
+`bots: []`; update access is not proof of a selected bot, GitHub installation,
+repository access, provider readiness, or useful work. Before a current launch
+can review, the native app must verify the exact account/bot, GitHub-selected
+repository, and API-backed entitlement for that repository and visibility.
 The managed native path binds activation and private-repository token issuance
 to the same Keychain-backed broker device identity and exact GitHub-selected
 repository. The raw Activation Key remains Keychain-owned: it crosses bounded

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ commands always use the sealed worker; the app never sends Keychain material to
 a global, customer-writable, or checksum-marker-only executable. A verified
 legacy LaunchAgent remains supported without migrating or exporting its
 existing credential environment.
+The app cannot promote a pending local bot client-side. After an authorized
+account operator registers the same bot/App identity in the NeonDiff account
+service, choose **REFRESH ACCOUNTS**; useful work remains blocked until the
+fresh server catalog returns that exact bot as verified.
 This
 source path does not prove customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -78,7 +78,8 @@ worker migration.
 The current Sparkle appcast does not provide a supported downgrade. Do not use
 **Check for Updates**, a source reset, or a manually edited feed as rollback;
 rollback requires a separately accepted immutable signed/notarized prior
-artifact and a tested state-preserving recovery path.
+artifact and the tested state-preserving recovery path in
+[Immutable Mac update, rollback, and re-update](mac-update-rollback.md).
 
 ## 1. Install NeonDiff
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -347,6 +347,11 @@ For a B0 customer, the native first-run path is:
    the exact configured repository through that App installation. If the local
    profile is missing or disabled, apply the repository again before retrying
    verification.
+6. A pending local bot cannot promote itself to account authority. Have an
+   authorized NeonDiff account operator register the same bot/App identity in
+   the account service, then choose **REFRESH ACCOUNTS** and reselect it. Stop
+   while the fresh server catalog still reports it as pending or absent;
+   useful work requires that exact bot to return as verified.
 
 If verification reports a missing or disabled repository policy profile,
 choose **Apply Repository** again before retrying **Verify App Access**. This is a local

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -40,6 +40,46 @@ remain honored for existing holders but are no longer sold. Provider/model costs
 remain external through your own provider key or local model; NeonDiff does not
 include hosted model credits, unlimited SaaS inference, or bundled provider tokens.
 
+## Native Desktop adoption
+
+This is the customer path for an accepted signed and notarized NeonDiff Desktop
+release. The npm package contains this guide and the CLI; it does not contain
+Desktop app bytes, and native setup must not require a source checkout. Use the
+CLI commands below only after `npm install -g neondiff` when the signed app
+explicitly hands off to the operator path.
+
+1. Download only the immutable Desktop artifact named by its release evidence.
+   Verify its archive, bundle version/build, codesign, notarization, Gatekeeper,
+   manifest, feed, and worker identities before opening it.
+2. Link the account and select a bot in the app. Native state is account-scoped:
+   `~/Library/Application Support/NeonDiffDesktop/Accounts/<account>/Bots/<bot>/config.local.json`,
+   with the review database at `state/reviews.sqlite` beside that config. Keep
+   both outside a release checkout and keep credentials in Keychain.
+3. Use **Preview Start**, then **Install & Start** (or **Start/Restart**) and
+   verify the displayed account, bot, config, launchd label, and worker status.
+   Use **Check for Updates** only for a signed release whose accepted bytes and
+   feed identity match the same evidence packet.
+4. Update access is a separate authority. A fresh account catalog can authorize
+   signed update access even when `bots: []`; that does not select a bot or prove
+   GitHub installation, repository access, provider readiness, or current work.
+   Useful current-launch work requires the exact account/bot, GitHub App and
+   selected `owner/repo`, provider readiness, and a live API entitlement covering
+   that repository visibility. Missing, stale, unknown, or revoked proof fails
+   closed.
+
+The native account-scoped path is separate from the legacy CLI/operator path.
+Legacy CLI setup accepts a caller-selected config path such as
+`config.local.json` and an operator-owned LaunchAgent coordinate; it may be an
+arbitrary absolute path and is not evidence of native account or bot authority.
+Do not copy a legacy config, DB, allowlist, Keychain item, or credential path
+into `Accounts/<account>/Bots/<bot>/`, and do not treat native state as a legacy
+worker migration.
+
+The current Sparkle appcast does not provide a supported downgrade. Do not use
+**Check for Updates**, a source reset, or a manually edited feed as rollback;
+rollback requires a separately accepted immutable signed/notarized prior
+artifact and a tested state-preserving recovery path.
+
 ## 1. Install NeonDiff
 
 Recommended package install after v1.0.4 is published and verified:

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -269,7 +269,13 @@ app, use the config created in the app's user-writable Application Support
 directory:
 
 ```bash
-NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
+: "${HOME:?HOME is required}"
+: "${NATIVE_CONFIG:?copy the exact selected bot config path shown by NeonDiff}"
+case "$NATIVE_CONFIG" in
+  "$HOME/Library/Application Support/NeonDiffDesktop/Accounts/"*/Bots/*/config.local.json) ;;
+  *) echo "native config must identify the selected account/bot" >&2; exit 1 ;;
+esac
+test -f "$NATIVE_CONFIG"
 neondiff doctor github --config "$NATIVE_CONFIG" --repo owner/repo --json
 ```
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -166,6 +166,10 @@ integration proof under #630.
    manifest/tarball and dry-run-default, confirm-required `first-install`
    command. Source support does not prove that immutable release publication,
    signing, clean-Mac execution, review, or daemon readiness has passed.
+   A pending local bot cannot become account authority client-side. After an
+   authorized account operator registers the same bot/App identity in the
+   NeonDiff account service, choose **REFRESH ACCOUNTS** and reselect it; useful
+   work stays blocked until the fresh server catalog returns it as verified.
 
 8. After App access, provider, repository, and activation are verified, use the
    native daemon step's **Preview Start** and **Install & Start** actions. The

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "docs/github-app-setup.md",
     "docs/providers.md",
     "docs/license-boundary.md",
+    "docs/mac-update-rollback.md",
     "docs/pricing.md",
     "docs/schema/neondiff-config.schema.json",
     "docs/systemd.md",

--- a/tests/package-surface.test.ts
+++ b/tests/package-surface.test.ts
@@ -20,6 +20,7 @@ describe("packaged customer setup surface", () => {
 
     const readme = read("README.md");
     const setup = read("docs/SETUP.md");
+    const githubSetup = read("docs/github-app-setup.md");
     expect(readme).toContain("docs/SETUP.md#native-desktop-adoption");
     expect(readme).toContain("docs/SETUP.md#update-an-existing-local-worker");
     expect(setup).toContain("## Native Desktop adoption");
@@ -28,6 +29,12 @@ describe("packaged customer setup surface", () => {
     expect(setup).toContain("state/reviews.sqlite");
     expect(setup).toContain("mac-update-rollback.md");
     expect(setup).toContain("Useful current-launch work requires the exact");
+    expect(setup).toContain("REFRESH ACCOUNTS");
+    expect(setup).toContain("pending local bot cannot promote itself");
+    for (const guide of [readme, setup, githubSetup]) {
+      expect(guide).toContain("REFRESH ACCOUNTS");
+      expect(guide).toContain("pending local bot");
+    }
     expect(setup).not.toContain("apps/neondiff-desktop/docs/customer-adoption.md");
   });
 });

--- a/tests/package-surface.test.ts
+++ b/tests/package-surface.test.ts
@@ -35,6 +35,8 @@ describe("packaged customer setup surface", () => {
       expect(guide).toContain("REFRESH ACCOUNTS");
       expect(guide).toContain("pending local bot");
     }
+    expect(githubSetup).toContain("NeonDiffDesktop/Accounts/");
+    expect(githubSetup).not.toContain("NeonDiffDesktop/config.local.json");
     expect(setup).not.toContain("apps/neondiff-desktop/docs/customer-adoption.md");
   });
 });

--- a/tests/package-surface.test.ts
+++ b/tests/package-surface.test.ts
@@ -13,7 +13,7 @@ describe("packaged customer setup surface", () => {
     ) as Array<{ files?: Array<{ path?: string }> }>;
     const files = new Set(pack[0]?.files?.map((entry) => entry.path));
 
-    for (const path of ["README.md", "docs/SETUP.md", "docs/github-app-setup.md"]) {
+    for (const path of ["README.md", "docs/SETUP.md", "docs/github-app-setup.md", "docs/mac-update-rollback.md"]) {
       expect(existsSync(path), `${path} exists in the repository`).toBe(true);
       expect(files.has(path), `${path} is present in npm pack`).toBe(true);
     }
@@ -26,6 +26,7 @@ describe("packaged customer setup surface", () => {
     expect(setup).toContain("### Update an existing local worker");
     expect(setup).toContain("bots: []");
     expect(setup).toContain("state/reviews.sqlite");
+    expect(setup).toContain("mac-update-rollback.md");
     expect(setup).toContain("Useful current-launch work requires the exact");
     expect(setup).not.toContain("apps/neondiff-desktop/docs/customer-adoption.md");
   });

--- a/tests/package-surface.test.ts
+++ b/tests/package-surface.test.ts
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("packaged customer setup surface", () => {
+  it("packs the README, setup guide, and native adoption anchor", () => {
+    const pack = JSON.parse(
+      execFileSync("npm", ["pack", "--dry-run", "--json"], { encoding: "utf8" })
+    ) as Array<{ files?: Array<{ path?: string }> }>;
+    const files = new Set(pack[0]?.files?.map((entry) => entry.path));
+
+    for (const path of ["README.md", "docs/SETUP.md", "docs/github-app-setup.md"]) {
+      expect(existsSync(path), `${path} exists in the repository`).toBe(true);
+      expect(files.has(path), `${path} is present in npm pack`).toBe(true);
+    }
+
+    const readme = read("README.md");
+    const setup = read("docs/SETUP.md");
+    expect(readme).toContain("docs/SETUP.md#native-desktop-adoption");
+    expect(readme).toContain("docs/SETUP.md#update-an-existing-local-worker");
+    expect(setup).toContain("## Native Desktop adoption");
+    expect(setup).toContain("### Update an existing local worker");
+    expect(setup).toContain("bots: []");
+    expect(setup).toContain("state/reviews.sqlite");
+    expect(setup).toContain("Useful current-launch work requires the exact");
+    expect(setup).not.toContain("apps/neondiff-desktop/docs/customer-adoption.md");
+  });
+});

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -84,6 +84,7 @@ describe("NeonDiff public release readiness", () => {
       "docs/github-app-setup.md",
       "docs/providers.md",
       "docs/license-boundary.md",
+      "docs/mac-update-rollback.md",
       "docs/pricing.md",
       "docs/schema/neondiff-config.schema.json",
       "docs/systemd.md",


### PR DESCRIPTION
Part of #883 and #873. Stacked on #890.

## Scope

- Keep README, SETUP, GitHub App setup, and immutable recovery links package-visible.
- Add the signed Desktop adoption path without an omitted apps guide or source-checkout assumption.
- Distinguish account update access, including bots: [], from current-launch bot/repository/API authority.
- Explain that a pending bot cannot become account authority client-side: the authorized account operator registers the same bot/App identity, then the user chooses REFRESH ACCOUNTS; useful work stays blocked until the fresh catalog returns it verified.
- Separate native account-scoped config/database from legacy arbitrary-absolute CLI/operator coordinates.
- Ship docs/mac-update-rollback.md in the npm package and test the packlist.

## Proof

- Root base: 8b2a6ce50863799d03ebb3bf6ff09f53fc2b0770
- Stack base: #890 / dc7536d20138173c73f7aa2f645bb40bdc0201ff
- Head: 66840a955b41bba53c0c1f01750a46d7c7924183
- Delta: 104 additions and 1 deletion = 105 non-generated changed lines.
- npm pack --dry-run --json --ignore-scripts: package includes README, SETUP, GitHub App setup, and immutable Mac runbook.
- public claims scan: pass.
- git diff --check: pass.
- Focused Vitest is blocked locally by the missing optional Rolldown binding; remote Build, test, and package CI is authoritative.

Website onboarding is an external-repository owner gate outside this PR. The current app has no client-side pending-bot promotion mechanism, and these docs do not claim one.

Proof boundary: source/docs/package-surface only; no install, release, runtime, customer, Keychain, config, database, account-service registration, or Desktop artifact mutation.