### PR TITLE
fix(scheduler): quarantine incomplete required evidence

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, type BoundedGithubList } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -49,6 +49,7 @@ import {
   type ReviewReadinessState,
   type ReviewerSessionJobState,
   type ReviewQueueJobRecord,
+  type ReviewEvidenceQuarantine,
   type ReviewQueueJobState,
   type ReviewQueueJobSource
 } from "./state.js";
@@ -110,6 +111,7 @@ export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -172,6 +174,7 @@ export async function runScheduledCycleWithDeps(input: {
   const result = emptyScheduledRunResult();
   const now = input.now ?? new Date();
   const eventClock = input.clock ?? (() => input.now ?? new Date());
+  const evidenceQuarantines: ReviewEvidenceQuarantine[] = [];
   const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
   const providerId = config.zcode.providerId ?? config.zcode.model ?? "zcode";
   if (config.reviewerSessions?.enabled) {
@@ -242,6 +245,10 @@ export async function runScheduledCycleWithDeps(input: {
         },
         onCommandFetchError: () => {
           result.commandFetchErrors += 1;
+        },
+        onEvidenceQuarantine: (quarantine, failedQueueJobs) => {
+          evidenceQuarantines.push(quarantine);
+          result.queue.failedQueueJobs += failedQueueJobs;
         }
       });
       applyEnqueueStatus(result, enqueueStatus);
@@ -287,6 +294,7 @@ export async function runScheduledCycleWithDeps(input: {
     manualCommandReserve: Math.min(scheduler.manualCommandReserve, effectiveSlots),
     limit: effectiveSlots,
     leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
+    quarantines: evidenceQuarantines,
     ...(config.riskWeightedQueue?.aging ? { aging: config.riskWeightedQueue.aging } : {}),
     now: eventClock()
   });
@@ -503,6 +511,7 @@ async function collectSubsequentMergedPulls(input: {
 type EnqueueStatus =
   | "enqueued"
   | "already_queued"
+  | "required_evidence_incomplete"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_processed"
@@ -526,6 +535,7 @@ async function enqueuePullIfEligible(input: {
   allowActivationBaselineCommandLookup?: boolean;
   onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
+  onEvidenceQuarantine?: (quarantine: ReviewEvidenceQuarantine, failedQueueJobs: number) => void;
   automaticPriorityOverride?: number;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) {
@@ -579,6 +589,26 @@ async function enqueuePullIfEligible(input: {
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
+  if ("blocked" in commandDecision) {
+    if (processed || input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) {
+      backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
+      await repairProcessedHeadStatusCommentIfNeeded({ ...input, processed });
+      return "skipped_processed";
+    }
+    const quarantine = {
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      reason: commandDecision.blocked
+    };
+    const applied = input.state.quarantineIncompleteReviewEvidence({
+      ...quarantine,
+      leaseTtlMs: input.config.reviewConcurrency.leaseTtlMs,
+      now: input.now
+    });
+    input.onEvidenceQuarantine?.(quarantine, applied.failedQueueJobs);
+    return "required_evidence_incomplete";
+  }
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
       await retireSupersededQueueJobsForPull(input);
@@ -1148,6 +1178,12 @@ async function retireQueuedJobsForClosedPull(input: {
   }
 }
 
+type SchedulerCommandDecision = CommandDecision | {
+  action: "none";
+  shouldReview: false;
+  blocked: "required_evidence_incomplete";
+};
+
 async function resolveSchedulerCommandDecision(input: {
   config: BotConfig;
   github: SchedulerGitHubApi;
@@ -1155,15 +1191,30 @@ async function resolveSchedulerCommandDecision(input: {
   repo: string;
   pull: PullRequestSummary;
   onCommandFetchError?: () => void;
-}): Promise<CommandDecision> {
-  if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
+}): Promise<SchedulerCommandDecision> {
+  let bounded: BoundedGithubList<IssueCommentCommandSource> | undefined;
+  let boundedReadFailed = false;
+  if (input.github.listIssueCommentsForEnrichment) {
+    try {
+      bounded = await input.github.listIssueCommentsForEnrichment(input.repo, input.pull.number);
+    } catch {
+      boundedReadFailed = true;
+    }
+  }
+  const needsCompletenessProof = boundedReadFailed || Boolean(bounded?.truncated || bounded?.overflow);
+  if (!input.config.commands.enabled && !needsCompletenessProof) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
     comments = await input.github.listIssueComments(input.repo, input.pull.number);
   } catch {
     input.onCommandFetchError?.();
-    return { action: "none", shouldReview: false };
+    return needsCompletenessProof
+      ? { action: "none", shouldReview: false, blocked: "required_evidence_incomplete" }
+      : { action: "none", shouldReview: false };
   }
+  const evidenceIncomplete = boundedReadFailed || Boolean(
+    bounded && (bounded.truncated || bounded.overflow) && comments.length > bounded.rawCount
+  );
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   const authorizationRequests = collectReviewEventAuthorizationAttempts(comments, input.config.commands, {
     repo: input.repo,
@@ -1217,7 +1268,7 @@ async function resolveSchedulerCommandDecision(input: {
       author: requestChanges.author
     });
   }
-  return decideCommandAction({
+  const decision = decideCommandAction({
     commands: authorizedCommands.filter((command) =>
       !isFinishingTouchCommandAction(command.action) ||
       (repoProfile.allowed && isFinishingTouchActionEnabled(command.action, repoProfile.profile.finishingTouches))
@@ -1228,6 +1279,14 @@ async function resolveSchedulerCommandDecision(input: {
     hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
       input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
   });
+  if (
+    evidenceIncomplete &&
+    (decision.action === "none" || isFinishingTouchCommandAction(decision.action))
+  ) {
+    input.onCommandFetchError?.();
+    return { action: "none", shouldReview: false, blocked: "required_evidence_incomplete" };
+  }
+  return decision;
 }
 
 function latestPendingRequestChanges(input: {
@@ -2592,6 +2651,9 @@ function nextLicenseGateRetryAt(now = new Date()): string {
 
 function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {
   switch (status) {
+    case "required_evidence_incomplete":
+      result.failed += 1;
+      break;
     case "enqueued":
       result.queue.enqueued += 1;
       break;

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3517,6 +3517,109 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("quarantines incomplete evidence transactionally while unrelated pulls keep running", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-incomplete-evidence-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const old = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "old-head" }).job;
+    state.recordReviewReadiness({ repo: "org/repo-a", pullNumber: 1, headSha: "old-head", state: "queued" });
+    const pulls = new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A), pull("org/repo-a", 2, HEAD_B)]]]);
+    const statusCalls: StatusCommentCall[] = [];
+    const github = {
+      ...githubFromMap(pulls, new Map(), statusCalls),
+      listIssueCommentsForEnrichment: async (_repo: string, issueNumber: number) => Object.assign([], {
+        items: [], rawCount: issueNumber === 1 ? 500 : 0, truncated: issueNumber === 1, overflow: issueNumber === 1
+      }),
+      listIssueComments: async (_repo: string, issueNumber: number) => issueNumber === 1
+        ? Array.from({ length: 501 }, (_, index) => comment(index + 1, "outside", "ordinary discussion"))
+        : []
+    };
+    const reviewed: number[] = [];
+    const run = () => runScheduledCycleWithDeps({
+      config, github, state, options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(reviewPull.number);
+        reviewState.recordProcessed({ repo, pullNumber: reviewPull.number, headSha: reviewPull.head.sha, status: "posted", event: "COMMENT" });
+        return "reviewed";
+      }
+    });
+
+    expect(await run()).toMatchObject({ failed: 1, reviewed: 1, commandFetchErrors: 1 });
+    const readiness = state.getReviewReadiness("org/repo-a", 1, HEAD_A);
+    expect(readiness).toMatchObject({ state: "failed", reason: "required_evidence_incomplete" });
+    expect(state.getReviewQueueJob(old.jobId)).toMatchObject({ state: "stale_retired" });
+    expect(statusCalls.filter((call) => call.issueNumber === 1)).toEqual([]);
+    expect(reviewed).toEqual([2]);
+    expect(await run()).toMatchObject({ failed: 1, reviewed: 0, skippedProcessed: 1 });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toEqual(readiness);
+    state.close();
+  });
+
+  it.each([
+    { name: "review", body: "@neondiff review", event: "COMMENT" as const },
+    { name: "request changes", body: `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`, event: "REQUEST_CHANGES" as const },
+    { name: "complete page five", body: undefined, event: "COMMENT" as const }
+  ])("admits $name without inferred review from incomplete evidence", async ({ body, event }) => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-page-six-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = { enabled: body !== undefined, botMentions: ["@neondiff"], trustedAuthors: ["maintainer"], acknowledge: false };
+    const state = new ReviewStateStore(config.statePath);
+    const comments = Array.from({ length: 500 }, (_, index) => comment(index + 1, "outside", "ordinary discussion"));
+    if (body) comments.push(comment(501, "maintainer", body));
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]])),
+        listIssueCommentsForEnrichment: async () => Object.assign(comments.slice(0, 500), { items: comments.slice(0, 500), rawCount: 500, truncated: true, overflow: true }),
+        listIssueComments: async () => comments
+      },
+      state, options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({ repo, pullNumber: reviewPull.number, headSha: reviewPull.head.sha, status: "posted", event });
+        return body ? "reviewed_command" : "reviewed";
+      }
+    });
+    expect(result).toMatchObject({ reviewed: 1, failed: 0, commandFetchErrors: 0 });
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({ status: "posted", event });
+    state.close();
+  });
+
+  it.each([
+    { name: "trusted stop", body: "@neondiff stop", author: "maintainer", state: "skipped", field: "skippedCommandStop", outcome: "skipped_command_stop", calls: 1, processed: false },
+    { name: "trusted explain", body: "@neondiff explain", author: "maintainer", state: "command_recorded", field: "skippedCommandExplain", outcome: "skipped_command_explain", calls: 1, processed: false },
+    { name: "untrusted review", body: "@neondiff review", author: "outside", state: "failed", field: "failed", outcome: "reviewed", calls: 0, processed: false },
+    { name: "failed uncapped read", body: undefined, author: "outside", state: "failed", field: "failed", outcome: "reviewed", calls: 0, processed: false },
+    { name: "terminal processed head", body: "ordinary discussion", author: "outside", state: "ready_for_human", field: "skippedProcessed", outcome: "reviewed", calls: 0, processed: true }
+  ] as const)("keeps $name fail-closed beyond bounded evidence", async ({ body, author, state: expectedState, field, outcome, calls, processed }) => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-incomplete-command-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = { enabled: true, botMentions: ["@neondiff"], trustedAuthors: ["maintainer"], acknowledge: false };
+    const state = new ReviewStateStore(config.statePath);
+    if (processed) state.recordProcessed({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, status: "posted", event: "COMMENT" });
+    const comments = Array.from({ length: 500 }, (_, index) => comment(index + 1, "outside", "ordinary discussion"));
+    if (body) comments.push(comment(501, author, body));
+    let reviewCalls = 0;
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]])),
+        listIssueCommentsForEnrichment: async () => Object.assign(comments.slice(0, 500), { items: comments.slice(0, 500), rawCount: 500, truncated: true, overflow: true }),
+        listIssueComments: async () => { if (!body) throw new Error("GitHub read failed"); return comments; }
+      },
+      state, options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => { reviewCalls += 1; return outcome; }
+    });
+    expect(result[field]).toBe(1);
+    expect(result.reviewed).toBe(0);
+    expect(reviewCalls).toBe(calls);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)?.state).toBe(expectedState);
+    state.close();
+  });
+
   it("assigns scheduler jobs to reusable repo-sticky reviewer sessions when enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-"));
     roots.push(root);


### PR DESCRIPTION
Related: #882
Stacked on #884; merge #884 first.

Scheduler integration for the transactional state primitive:
- reads bounded completeness independently of command enablement;
- uses the uncapped command reader to admit trusted review/request-changes beyond page 5;
- treats an exactly full 500-comment boundary as complete;
- preserves safe stop/explain handling while no-command, untrusted, finishing-touch, and failed-read inference fails closed;
- bypasses quarantine for already-terminal processed heads;
- retires superseded state and records current-head readiness before returning, with no quarantine status/comment/review write;
- reapplies quarantine inside leasing so an expiry race cannot leak queued/active work while unrelated pulls remain leasable.

Focused proof on the full stack:
- npm test -- --run tests/state.test.ts tests/scheduler.test.ts tests/github-app-read.test.ts (209/209 pass)
- npm run build (pass)
- git diff --check (pass)
- PR-local envelope: 175 non-generated changed lines

Agent-authored. No merge, release, install, runtime, config, DB migration, Keychain, provider, customer, or production GitHub mutation was performed. Closed #874 and held #848/#849 were evidence only and were not used as bases.