### PR TITLE
ci(desktop): preserve declaration history across revisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,19 @@ jobs:
       - name: Validate committed Desktop declaration index
         run: node scripts/validate-desktop-release-declaration.mjs --index docs/releases/desktop/index.json
 
+      - name: Validate committed Desktop declaration history
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags origin "$BASE_SHA" --depth=1
+          base="$RUNNER_TEMP/desktop-base"
+          mkdir -p "$base"
+          git archive "$BASE_SHA" docs/releases/desktop | tar -x -C "$base"
+          node scripts/validate-desktop-release-declaration.mjs \
+            --index docs/releases/desktop/index.json \
+            --base-index "$base/docs/releases/desktop/index.json"
+
       - name: Enforce Review Bench public-corpus admission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/validate-desktop-release-declaration.mjs
+++ b/scripts/validate-desktop-release-declaration.mjs
@@ -39,7 +39,7 @@ function rejectDuplicateKeys(raw) {
     const keys = objects.at(-1); if (keys.has(key)) fail(`duplicate object key: ${key}`); keys.add(key);
   }
 }
-function readRegular(path) {
+function readRawRegular(path) {
   let fd;
   try {
     fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
@@ -47,10 +47,11 @@ function readRegular(path) {
     const raw = readFileSync(fd, "utf8");
     if (/(?:"build"|"sequence")\s*:\s*(?!"[0-9]+")/.test(raw)) fail("identity fields must be quoted decimal text");
     rejectDuplicateKeys(raw);
-    return JSON.parse(raw);
+    return raw;
   } catch (error) { if (error?.code === "ELOOP") fail(`symlink or non-regular file: ${path}`); throw error; }
   finally { if (fd !== undefined) closeSync(fd); }
 }
+function readRegular(path) { return JSON.parse(readRawRegular(path)); }
 function openDirectory(path) {
   let fd;
   try {
@@ -69,10 +70,24 @@ function pathIn(directory, name) {
 }
 function check(value, valid, label) { if (!valid(value)) fail(`${label} schema invalid: ${ajv.errorsText(valid.errors)}`); }
 function buildCompare(a, b) { const left = BigInt(a), right = BigInt(b); return left < right ? -1 : left > right ? 1 : 0; }
+function validateTransition(index, directory, baseIndexPath) {
+  const base = readRegular(baseIndexPath);
+  check(base, validateIndex, "base index");
+  if (base.status !== "retained") return;
+  if (index.status !== "retained") fail("retained history cannot regress to empty");
+  if (base.declarationPaths.some((name, i) => index.declarationPaths[i] !== name)) fail("retained declaration history must be an exact prefix");
+  const baseDirectory = resolve(dirname(baseIndexPath), base.declarationDirectory), baseHandle = openDirectory(baseDirectory);
+  try {
+    for (const name of base.declarationPaths) {
+      if (readRawRegular(pathIn(directory, name)) !== readRawRegular(pathIn(baseDirectory, name))) fail(`retained declaration rewritten: ${name}`);
+    }
+    if (!sameDirectory(baseDirectory, baseHandle.stat)) fail("base declaration directory changed during validation");
+  } finally { closeSync(baseHandle.fd); }
+}
 
 function main() {
-  if (process.argv.length !== 4 || process.argv[2] !== "--index") fail("usage: validate-desktop-release-declaration.mjs --index PATH");
-  const indexPath = resolve(process.argv[3]), index = readRegular(indexPath);
+  if (![4, 6].includes(process.argv.length) || process.argv[2] !== "--index" || (process.argv.length === 6 && process.argv[4] !== "--base-index")) fail("usage: validate-desktop-release-declaration.mjs --index PATH [--base-index PATH]");
+  const indexPath = resolve(process.argv[3]), baseIndexPath = process.argv.length === 6 ? resolve(process.argv[5]) : null, index = readRegular(indexPath);
   check(index, validateIndex, "index");
   const directory = resolve(dirname(indexPath), index.declarationDirectory), handle = openDirectory(directory);
   try {
@@ -83,7 +98,7 @@ function main() {
       if (entry.name === ".gitkeep") { if (!entry.isFile()) fail("empty convention must be a regular file"); convention = true; continue; }
       if (!entry.isFile() || !listed.has(entry.name)) fail(`unindexed declaration entry: ${entry.name}`);
     }
-    if (index.status === "empty") { if (!convention || entries.length !== 1) fail("empty index requires only tracked .gitkeep convention"); return "empty"; }
+    if (index.status === "empty") { if (!convention || entries.length !== 1) fail("empty index requires only tracked .gitkeep convention"); if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during validation"); if (baseIndexPath) { validateTransition(index, directory, baseIndexPath); if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during transition"); } return "empty"; }
     if (convention) fail(".gitkeep is only valid for an empty index");
     const declarations = index.declarationPaths.map((name) => [name, readRegular(pathIn(directory, name))]);
     for (const [name, declaration] of declarations) {
@@ -106,6 +121,7 @@ function main() {
     ordered.forEach(([name, declaration], i) => { if (declaration.predecessor !== (i ? ordered[i - 1][0] : null)) fail(`predecessor mismatch: ${name}`); });
     if (index.currentPath !== ordered.at(-1)[0]) fail("currentPath must be newest compatible declaration");
     if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during validation");
+    if (baseIndexPath) { validateTransition(index, directory, baseIndexPath); if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during transition"); }
     return `${index.declarationPaths.length} declarations; currentPath=${index.currentPath}`;
   } finally { closeSync(handle.fd); }
 }

--- a/tests/desktop-release-declaration.test.ts
+++ b/tests/desktop-release-declaration.test.ts
@@ -6,11 +6,17 @@ import { describe, expect, it } from "vitest";
 
 const script = "scripts/validate-desktop-release-declaration.mjs", feed = "https://www.neondiff.com/updates/beta/appcast.xml", bundle = "com.electricsheephq.NeonDiffDesktop";
 type Item = { channel?: string; seq?: string; build?: string; feed?: string; predecessor?: string | null; bundle?: string };
-function run(items: Item[], alter: (root: string, paths: string[]) => void = () => {}) {
-  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-")), directory = join(root, "declarations"); mkdirSync(directory);
+function writeFixture(root: string, items: Item[]) {
+  const directory = join(root, "declarations"); mkdirSync(directory, { recursive: true });
   const paths = items.map((item, index) => { const channel = item.channel ?? "beta", seq = item.seq ?? String(index + 1), build = item.build ?? String(index + 100), version = `1.1.0-${channel}.${seq}`, path = `v${version}.json`, predecessor = item.predecessor === undefined ? (index ? `v1.1.0-${items[index - 1].channel ?? "beta"}.${items[index - 1].seq ?? String(index)}.json` : null) : item.predecessor; writeFileSync(join(directory, path), JSON.stringify({ schemaVersion: 1, product: "neondiff-desktop", version, tag: `v${version}`, channel, sequence: seq, build, predecessor, contract: "paid-mac-beta-byo-v1", distribution: { bundleId: item.bundle ?? bundle, appPath: "NeonDiff.app", artifactName: `NeonDiff-${version}-build${build}-macOS.zip`, releaseClass: "paid-beta", origins: { github: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff", site: "https://www.neondiff.com", feed: item.feed ?? feed } } })); return path; });
   if (!items.length) writeFileSync(join(directory, ".gitkeep"), "");
-  const index = join(root, "index.json"); writeFileSync(index, JSON.stringify({ schemaVersion: 1, status: items.length ? "retained" : "empty", declarationDirectory: "declarations", declarationPaths: paths, currentPath: paths.at(-1) ?? null })); alter(root, paths); const result = spawnSync(process.execPath, [script, "--index", index], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
+  const index = join(root, "index.json"); writeFileSync(index, JSON.stringify({ schemaVersion: 1, status: items.length ? "retained" : "empty", declarationDirectory: "declarations", declarationPaths: paths, currentPath: paths.at(-1) ?? null })); return { index, paths };
+}
+function run(items: Item[], alter: (root: string, paths: string[]) => void = () => {}) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-")), fixture = writeFixture(root, items); alter(root, fixture.paths); const result = spawnSync(process.execPath, [script, "--index", fixture.index], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
+}
+function runTransition(baseItems: Item[], currentItems: Item[], alter: (root: string) => void = () => {}) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-transition-")), base = writeFixture(join(root, "base"), baseItems), current = writeFixture(join(root, "current"), currentItems); alter(root); const result = spawnSync(process.execPath, [script, "--index", current.index, "--base-index", base.index], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
 }
 
 describe("versioned desktop declaration index", () => {
@@ -22,5 +28,12 @@ describe("versioned desktop declaration index", () => {
     expect(run([{ build: "100" }], (root) => { const path = join(root, "declarations", "v1.1.0-beta.1.json"), raw = readFileSync(path, "utf8").replace('"build":"100"', '"build":"100","build":"101"'); writeFileSync(path, raw); }).status).not.toBe(0);
     expect(run([{ build: "100" }], (root) => { const path = join(root, "declarations", "v1.1.0-beta.1.json"), raw = readFileSync(path, "utf8").replace('"site":"https://www.neondiff.com"', '"site":"https://www.neondiff.com","site":"https://www.neondiff.com"'); writeFileSync(path, raw); }).status).not.toBe(0);
     expect(run([{ build: "100" }], (root, paths) => symlinkSync(join(root, "declarations", paths[0]), join(root, "declarations", "alias.json"))).status).not.toBe(0);
+  });
+  it("preserves retained history across base transitions", () => {
+    const base = [{ build: "100" }], appended = [{ build: "100" }, { build: "101" }];
+    expect(runTransition(base, appended).status).toBe(0);
+    expect(runTransition(base, []).status).not.toBe(0);
+    expect(runTransition(base, [{ build: "101" }]).status).not.toBe(0);
+    expect(runTransition(base, base, (root) => { renameSync(join(root, "current", "declarations"), join(root, "current", "declarations-real")); symlinkSync(join(root, "current", "declarations-real"), join(root, "current", "declarations")); }).status).not.toBe(0);
   });
 });


### PR DESCRIPTION
Closes the retained-history gaps for #875 on top of #889. This stacked PR adds a base-index comparison that rejects retained-to-empty regressions, deletion/reordering, and rewritten retained declaration bytes, and adds the required pull-request CI invocation. It preserves the lossless numeric, canonical artifact, channel/feed, filename, bundle, predecessor, O_NOFOLLOW, and directory-identity checks from #889. Validate #889 first, then this PR; do not merge this PR independently of its base.