### PR TITLE
fix: confine portable eval and QA outputs

### DIFF
--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -12,7 +12,7 @@
  * Proof boundary: simulation + a default-off capability. It changes no live config or launchd; the
  * recommended config here is a LAB recommendation, not an applied setting.
  */
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, constants, mkdtempSync, mkdirSync, openSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { loadConfigFromObject, type BotConfig } from "../../src/config.js";
@@ -255,9 +255,13 @@ function main(): void {
   };
 
   mkdirSync(EVIDENCE_DIR, { recursive: true });
-  writeFileSync(join(EVIDENCE_DIR, "queue-sim.json"), `${stringifyRedactedJson(payload)}\n`);
-  writeFileSync(join(EVIDENCE_DIR, "queue-sim.md"), markdownTable(results));
+  writeNoFollow(join(EVIDENCE_DIR, "queue-sim.json"), `${stringifyRedactedJson(payload)}\n`);
+  writeNoFollow(join(EVIDENCE_DIR, "queue-sim.md"), markdownTable(results));
   console.log(stringifyRedactedJson({ ok: true, evidenceDir: EVIDENCE_DIR, results }));
+}
+
+function writeNoFollow(path: string, content: string): void {
+  const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW, 0o666); try { writeFileSync(fd, content); } finally { closeSync(fd); }
 }
 
 main();

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -12,7 +12,7 @@
  * Proof boundary: simulation + a default-off capability. It changes no live config or launchd; the
  * recommended config here is a LAB recommendation, not an applied setting.
  */
-import { closeSync, constants, mkdtempSync, mkdirSync, openSync, rmSync, writeFileSync } from "node:fs";
+import { lstatSync, mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { loadConfigFromObject, type BotConfig } from "../../src/config.js";
@@ -261,7 +261,8 @@ function main(): void {
 }
 
 function writeNoFollow(path: string, content: string): void {
-  const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW, 0o666); try { writeFileSync(fd, content); } finally { closeSync(fd); }
+  const stat = lstatSync(path, { throwIfNoEntry: false }); if (stat?.isSymbolicLink() || (stat && stat.nlink > 1)) throw new Error("refusing linked evidence file");
+  const temp = mkdtempSync(`${path}.tmp-`); try { writeFileSync(join(temp, "content"), content, { flag: "wx", mode: 0o600 }); renameSync(join(temp, "content"), path); } finally { rmSync(temp, { recursive: true, force: true }); }
 }
 
 main();

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -13,12 +13,17 @@
  * recommended config here is a LAB recommendation, not an applied setting.
  */
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 import { loadConfigFromObject, type BotConfig } from "../../src/config.js";
 import { ReviewStateStore } from "../../src/state.js";
 import { riskWeightedQueuePriority } from "../../src/scheduler.js";
 import { buildChangedSurfaceValidationReport } from "../../src/validation-selector.js";
+import {
+  assertPathOutsideProtectedRoot,
+  getProtectedCheckoutRoots,
+  resolvePathFollowingExistingSymlinks
+} from "../../src/path-safety.js";
 import { stringifyRedactedJson } from "../../src/secrets.js";
 import type { PullFilePatch, PullRequestSummary } from "../../src/types.js";
 // Reuse the merged QA-lab harness (#341/#358): scenario file-sets drive the REAL tier, and the
@@ -26,7 +31,20 @@ import type { PullFilePatch, PullRequestSummary } from "../../src/types.js";
 import { QA_LAB_SCENARIOS } from "./scenarios.js";
 import { percentile } from "./stats.js";
 
-const EVIDENCE_DIR = "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/polished-config-lab/risk-queue";
+const configuredEvidenceRoot = process.env.NEONDIFF_EVIDENCE_ROOT?.trim();
+const evidenceRoot = configuredEvidenceRoot
+  ? configuredEvidenceRoot
+  : join(homedir(), ".local", "share", "neondiff", "evidence");
+if (!isAbsolute(evidenceRoot)) throw new Error("NEONDIFF_EVIDENCE_ROOT must be absolute");
+const resolvedEvidenceRoot = resolvePathFollowingExistingSymlinks(resolve(evidenceRoot));
+assertPathOutsideProtectedRoot({
+  path: resolvedEvidenceRoot,
+  protectedRoot: undefined,
+  protectedRoots: getProtectedCheckoutRoots(),
+  pathLabel: "NEONDIFF_EVIDENCE_ROOT",
+  protectedRootLabel: "a protected checkout root"
+});
+const EVIDENCE_DIR = join(resolvedEvidenceRoot, "neondiff-qa-lab", "risk-queue");
 const BASELINE = 50;
 const MAX_WAIT_MINUTES = 60;
 const TICK_MS = 60_000; // one minute per service interval

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -45,6 +45,13 @@ assertPathOutsideProtectedRoot({
   protectedRootLabel: "a protected checkout root"
 });
 const EVIDENCE_DIR = join(resolvedEvidenceRoot, "neondiff-qa-lab", "risk-queue");
+assertPathOutsideProtectedRoot({
+  path: resolvePathFollowingExistingSymlinks(EVIDENCE_DIR),
+  protectedRoot: undefined,
+  protectedRoots: getProtectedCheckoutRoots(),
+  pathLabel: "NEONDIFF_EVIDENCE_ROOT",
+  protectedRootLabel: "a protected checkout root"
+});
 const BASELINE = 50;
 const MAX_WAIT_MINUTES = 60;
 const TICK_MS = 60_000; // one minute per service interval

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -21,6 +21,7 @@ import { riskWeightedQueuePriority } from "../../src/scheduler.js";
 import { buildChangedSurfaceValidationReport } from "../../src/validation-selector.js";
 import {
   assertPathOutsideProtectedRoot,
+  findGitCheckoutRoot,
   getProtectedCheckoutRoots,
   resolvePathFollowingExistingSymlinks
 } from "../../src/path-safety.js";
@@ -40,7 +41,7 @@ const resolvedEvidenceRoot = resolvePathFollowingExistingSymlinks(resolve(eviden
 assertPathOutsideProtectedRoot({
   path: resolvedEvidenceRoot,
   protectedRoot: undefined,
-  protectedRoots: getProtectedCheckoutRoots(),
+  protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(resolvedEvidenceRoot)],
   pathLabel: "NEONDIFF_EVIDENCE_ROOT",
   protectedRootLabel: "a protected checkout root"
 });
@@ -48,7 +49,7 @@ const EVIDENCE_DIR = join(resolvedEvidenceRoot, "neondiff-qa-lab", "risk-queue")
 assertPathOutsideProtectedRoot({
   path: resolvePathFollowingExistingSymlinks(EVIDENCE_DIR),
   protectedRoot: undefined,
-  protectedRoots: getProtectedCheckoutRoots(),
+  protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(EVIDENCE_DIR)],
   pathLabel: "NEONDIFF_EVIDENCE_ROOT",
   protectedRootLabel: "a protected checkout root"
 });

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -41,7 +41,7 @@ const resolvedEvidenceRoot = resolvePathFollowingExistingSymlinks(resolve(eviden
 assertPathOutsideProtectedRoot({
   path: resolvedEvidenceRoot,
   protectedRoot: undefined,
-  protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(resolvedEvidenceRoot)],
+  protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(resolvedEvidenceRoot) ?? ""],
   pathLabel: "NEONDIFF_EVIDENCE_ROOT",
   protectedRootLabel: "a protected checkout root"
 });
@@ -49,7 +49,7 @@ const EVIDENCE_DIR = join(resolvedEvidenceRoot, "neondiff-qa-lab", "risk-queue")
 assertPathOutsideProtectedRoot({
   path: resolvePathFollowingExistingSymlinks(EVIDENCE_DIR),
   protectedRoot: undefined,
-  protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(EVIDENCE_DIR)],
+  protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(EVIDENCE_DIR) ?? ""],
   pathLabel: "NEONDIFF_EVIDENCE_ROOT",
   protectedRootLabel: "a protected checkout root"
 });

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
+import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { Finding, Severity } from "./types.js";
 
@@ -1489,9 +1491,17 @@ function buildLabelEvidence(finding: Finding | EvalLabelInput): Record<string, s
   return Object.keys(evidence).length > 0 ? evidence : undefined;
 }
 
+export function resolveEvalOutputRoot(): string {
+  const configuredRoot = process.env.NEONDIFF_EVAL_ROOT?.trim();
+  const root = configuredRoot
+    ? resolve(configuredRoot)
+    : join(homedir(), ".local", "share", "neondiff", "evals");
+  return assertEvalOutputDirSafe(root);
+}
+
 function defaultEvalOutputDir(input: Pick<EvalScenarioInput, "runId">, now: Date): string {
   const date = now.toISOString().slice(0, 10);
-  return join("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review", date, sanitizePathSegment(input.runId));
+  return join(resolveEvalOutputRoot(), date, sanitizePathSegment(input.runId));
 }
 
 function sanitizePathSegment(value: string): string {
@@ -1520,13 +1530,16 @@ function sha256File(path: string): string {
 
 export function assertEvalOutputDirSafe(outputDir: string): string {
   const resolvedOutput = resolve(outputDir);
-  const gitRoot = findGitRoot(process.cwd());
-  if (!gitRoot) return resolvedOutput;
-  const realOutput = resolveRealPathForPotentialOutput(resolvedOutput);
-  const realGitRoot = realpathSync(gitRoot);
-  const relation = relative(realGitRoot, realOutput);
-  if (relation === "" || (!relation.startsWith("..") && !isAbsolute(relation))) {
-    throw new Error("outputDir must not be inside the current git checkout; write eval packets under /Volumes/LEXAR/Codex/evals or a temp directory");
+  try {
+    assertPathOutsideProtectedRoot({
+      path: resolvedOutput,
+      protectedRoot: undefined,
+      protectedRoots: getProtectedCheckoutRoots(),
+      pathLabel: "outputDir",
+      protectedRootLabel: "a protected checkout root"
+    });
+  } catch {
+    throw new Error("outputDir must not be inside the current git checkout; use NEONDIFF_EVAL_ROOT or a temp directory");
   }
   return resolvedOutput;
 }
@@ -1543,34 +1556,6 @@ export function guardEmptyOutputRoot(outputRoot: string, evalLabel = "sticky-vs-
   }
   if (readdirSync(outputRoot).length > 0) {
     throw new Error(`outputRoot must be empty before running ${evalLabel}; choose a fresh output root to avoid stale artifacts`);
-  }
-}
-
-function resolveRealPathForPotentialOutput(path: string): string {
-  const resolved = resolve(path);
-  if (existsSync(resolved)) return realpathSync(resolved);
-  const segments: string[] = [];
-  let cursor = resolved;
-  while (!existsSync(cursor)) {
-    const parent = dirname(cursor);
-    if (parent === cursor) return resolved;
-    segments.unshift(cursor.slice(parent.length + 1));
-    cursor = parent;
-  }
-  return resolve(realpathSync(cursor), ...segments);
-}
-
-function findGitRoot(start: string): string | undefined {
-  let cursor = resolve(start);
-  for (;;) {
-    const gitPath = join(cursor, ".git");
-    if (existsSync(gitPath)) {
-      const stat = statSync(gitPath);
-      if (stat.isDirectory() || stat.isFile()) return cursor;
-    }
-    const parent = dirname(cursor);
-    if (parent === cursor) return undefined;
-    cursor = parent;
   }
 }
 
@@ -1602,7 +1587,7 @@ function roundMetric(value: number): number {
 
 function defaultStickyVsColdOutputRoot(input: Pick<StickyVsColdScenarioInput, "runId">, now: Date): string {
   const date = now.toISOString().slice(0, 10);
-  return join("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review", date, sanitizePathSegment(input.runId));
+  return join(resolveEvalOutputRoot(), date, sanitizePathSegment(input.runId));
 }
 
 function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -3,7 +3,7 @@ import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, 
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
-import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
+import { assertPathOutsideProtectedRoot, findGitCheckoutRoot, getProtectedCheckoutRoots } from "./path-safety.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { Finding, Severity } from "./types.js";
 
@@ -1534,7 +1534,7 @@ export function assertEvalOutputDirSafe(outputDir: string): string {
     assertPathOutsideProtectedRoot({
       path: resolvedOutput,
       protectedRoot: undefined,
-      protectedRoots: getProtectedCheckoutRoots(),
+      protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(resolvedOutput)],
       pathLabel: "outputDir",
       protectedRootLabel: "a protected checkout root"
     });

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1539,7 +1539,7 @@ export function assertEvalOutputDirSafe(outputDir: string): string {
       protectedRootLabel: "a protected checkout root"
     });
   } catch {
-    throw new Error("outputDir must not be inside the current git checkout; use NEONDIFF_EVAL_ROOT or a temp directory");
+    throw new Error("outputDir must not be inside the current git checkout; outside every git checkout; use NEONDIFF_EVAL_ROOT or a temp directory");
   }
   return resolvedOutput;
 }

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1534,7 +1534,7 @@ export function assertEvalOutputDirSafe(outputDir: string): string {
     assertPathOutsideProtectedRoot({
       path: resolvedOutput,
       protectedRoot: undefined,
-      protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(resolvedOutput)],
+      protectedRoots: [...getProtectedCheckoutRoots(), findGitCheckoutRoot(resolvedOutput) ?? ""],
       pathLabel: "outputDir",
       protectedRootLabel: "a protected checkout root"
     });

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -56,7 +56,7 @@ export function findGitCheckoutRoot(startPath: string): string | undefined {
 }
 
 export function assertPathOutsideProtectedRoot(boundary: PathBoundary): void {
-  const roots = uniqueDefinedPaths([boundary.protectedRoot, ...(boundary.protectedRoots ?? []), findGitCheckoutRoot(boundary.path)]);
+  const roots = uniqueDefinedPaths([boundary.protectedRoot, ...(boundary.protectedRoots ?? [])]);
   for (const protectedRoot of roots) {
     assertPathOutsideSingleProtectedRoot({
       path: boundary.path,

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -56,7 +56,7 @@ export function findGitCheckoutRoot(startPath: string): string | undefined {
 }
 
 export function assertPathOutsideProtectedRoot(boundary: PathBoundary): void {
-  const roots = uniqueDefinedPaths([boundary.protectedRoot, ...(boundary.protectedRoots ?? [])]);
+  const roots = uniqueDefinedPaths([boundary.protectedRoot, ...(boundary.protectedRoots ?? []), findGitCheckoutRoot(boundary.path)]);
   for (const protectedRoot of roots) {
     assertPathOutsideSingleProtectedRoot({
       path: boundary.path,

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -71,6 +71,11 @@ describe("portable output roots", () => {
     expect(nestedAlias.stdout).toBe("");
     expect(nestedAlias.stderr).toContain("must be outside a protected checkout root");
     expect(existsSync(join(repoRoot, "risk-queue"))).toBe(false);
+
+    const finalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-file-")); const finalTarget = join(repoRoot, `.portable-qa-target-${finalRoot.slice(finalRoot.lastIndexOf("/") + 1)}.json`); writeFileSync(finalTarget, "sentinel\n"); roots.push(finalRoot, finalTarget);
+    mkdirSync(join(finalRoot, "neondiff-qa-lab", "risk-queue"), { recursive: true }); symlinkSync(finalTarget, join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.json"));
+    const finalAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], { cwd: join(repoRoot, "tests"), env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: finalRoot }, encoding: "utf8", timeout: 10_000 });
+    expect(finalAlias.status).toBe(1); expect(finalAlias.stdout).toBe(""); expect(readFileSync(finalTarget, "utf8")).toBe("sentinel\n");
   });
 
   it("accepts an external QA root", () => {

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, linkSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +8,7 @@ import { resolveEvalOutputRoot } from "../src/eval-harness.js";
 
 const repoRoot = fileURLToPath(new URL("../", import.meta.url));
 const tsxCommand = process.env.NEONDIFF_TEST_TSX ?? join(repoRoot, "node_modules", ".bin", "tsx");
+const runQa = (root: string, timeout = 10_000) => spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], { cwd: join(repoRoot, "tests"), env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: root }, encoding: "utf8", timeout });
 
 describe("portable output roots", () => {
   const roots: string[] = [];
@@ -41,17 +42,16 @@ describe("portable output roots", () => {
     symlinkSync(repoRoot, alias, "dir");
     process.env.NEONDIFF_EVAL_ROOT = alias;
     expect(() => resolveEvalOutputRoot()).toThrow(/must not be inside the current git checkout/);
+
+    const otherRoot = mkdtempSync(join(tmpdir(), "neondiff-other-checkout-")); roots.push(otherRoot); mkdirSync(join(otherRoot, ".git"));
+    process.env.NEONDIFF_EVAL_ROOT = join(otherRoot, "evals"); expect(() => resolveEvalOutputRoot()).toThrow(/must not be inside the current git checkout/);
+    const otherQa = runQa(join(otherRoot, "qa")); expect(otherQa.status).toBe(1); expect(otherQa.stdout).toBe("");
   });
 
   it("rejects hostile QA roots before creating evidence", () => {
     const hostileRoot = mkdtempSync(join(repoRoot, ".portable-qa-hostile-"));
     roots.push(hostileRoot);
-    const result = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
-      cwd: join(repoRoot, "tests"),
-      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: hostileRoot },
-      encoding: "utf8",
-      timeout: 10_000
-    });
+    const result = runQa(hostileRoot);
 
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
@@ -61,12 +61,7 @@ describe("portable output roots", () => {
     const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-symlink-"));
     roots.push(externalRoot);
     symlinkSync(repoRoot, join(externalRoot, "neondiff-qa-lab"), "dir");
-    const nestedAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
-      cwd: join(repoRoot, "tests"),
-      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
-      encoding: "utf8",
-      timeout: 10_000
-    });
+    const nestedAlias = runQa(externalRoot);
     expect(nestedAlias.status).toBe(1);
     expect(nestedAlias.stdout).toBe("");
     expect(nestedAlias.stderr).toContain("must be outside a protected checkout root");
@@ -74,19 +69,16 @@ describe("portable output roots", () => {
 
     const finalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-file-")); const finalTarget = join(repoRoot, `.portable-qa-target-${finalRoot.slice(finalRoot.lastIndexOf("/") + 1)}.json`); writeFileSync(finalTarget, "sentinel\n"); roots.push(finalRoot, finalTarget);
     mkdirSync(join(finalRoot, "neondiff-qa-lab", "risk-queue"), { recursive: true }); symlinkSync(finalTarget, join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.json"));
-    const finalAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], { cwd: join(repoRoot, "tests"), env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: finalRoot }, encoding: "utf8", timeout: 30_000 });
+    const finalAlias = runQa(finalRoot, 60_000);
     expect(finalAlias.status).toBe(1); expect(finalAlias.stdout).toBe(""); expect(readFileSync(finalTarget, "utf8")).toBe("sentinel\n");
-  }, 30_000);
+    rmSync(join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.json")); const hardTarget = join(repoRoot, `.portable-qa-hard-${finalRoot.slice(finalRoot.lastIndexOf("/") + 1)}.md`); writeFileSync(hardTarget, "hard-sentinel\n"); roots.push(hardTarget); writeFileSync(join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.json"), "fresh\n"); linkSync(hardTarget, join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.md"));
+    const hardLink = runQa(finalRoot, 60_000); expect(hardLink.status).toBe(1); expect(hardLink.stdout).toBe(""); expect(readFileSync(hardTarget, "utf8")).toBe("hard-sentinel\n");
+  }, 60_000);
 
   it("accepts an external QA root", () => {
     const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-root-"));
     roots.push(externalRoot);
-    const result = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
-      cwd: join(repoRoot, "tests"),
-      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
-      encoding: "utf8",
-      timeout: 30_000
-    });
+    const result = runQa(externalRoot, 30_000);
     const output = JSON.parse(result.stdout);
 
     expect(result.status).toBe(0);

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -87,5 +87,5 @@ describe("portable output roots", () => {
     expect(result.status).toBe(0);
     expect(output.ok).toBe(true);
     expect(output.evidenceDir).toBe(join(externalRoot, "neondiff-qa-lab", "risk-queue"));
-  });
+  }, 30_000);
 });

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveEvalOutputRoot } from "../src/eval-harness.js";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const tsxCommand = process.env.NEONDIFF_TEST_TSX ?? join(repoRoot, "node_modules", ".bin", "tsx");
+
+describe("portable output roots", () => {
+  const roots: string[] = [];
+  const originalEvalRoot = process.env.NEONDIFF_EVAL_ROOT;
+
+  afterEach(() => {
+    if (originalEvalRoot === undefined) delete process.env.NEONDIFF_EVAL_ROOT;
+    else process.env.NEONDIFF_EVAL_ROOT = originalEvalRoot;
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("uses a portable eval default and accepts an external explicit root", () => {
+    delete process.env.NEONDIFF_EVAL_ROOT;
+    expect(resolveEvalOutputRoot()).toBe(join(homedir(), ".local", "share", "neondiff", "evals"));
+
+    const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-eval-root-"));
+    roots.push(externalRoot);
+    process.env.NEONDIFF_EVAL_ROOT = externalRoot;
+    expect(resolveEvalOutputRoot()).toBe(externalRoot);
+  });
+
+  it("rejects checkout children, dot-dot siblings, and symlink aliases for eval output", () => {
+    for (const root of [repoRoot, join(repoRoot, "..eval")]) {
+      process.env.NEONDIFF_EVAL_ROOT = root;
+      expect(() => resolveEvalOutputRoot()).toThrow(/must not be inside the current git checkout/);
+    }
+
+    const aliasRoot = mkdtempSync(join(tmpdir(), "neondiff-eval-alias-"));
+    roots.push(aliasRoot);
+    const alias = join(aliasRoot, "checkout");
+    symlinkSync(repoRoot, alias, "dir");
+    process.env.NEONDIFF_EVAL_ROOT = alias;
+    expect(() => resolveEvalOutputRoot()).toThrow(/must not be inside the current git checkout/);
+  });
+
+  it("rejects hostile QA roots before creating evidence", () => {
+    const hostileRoot = mkdtempSync(join(repoRoot, ".portable-qa-hostile-"));
+    roots.push(hostileRoot);
+    const result = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
+      cwd: join(repoRoot, "tests"),
+      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: hostileRoot },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("must be outside a protected checkout root");
+    expect(existsSync(join(hostileRoot, "neondiff-qa-lab"))).toBe(false);
+  });
+
+  it("accepts an external QA root", () => {
+    const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-root-"));
+    roots.push(externalRoot);
+    const result = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
+      cwd: join(repoRoot, "tests"),
+      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(output.ok).toBe(true);
+    expect(output.evidenceDir).toBe(join(externalRoot, "neondiff-qa-lab", "risk-queue"));
+  });
+});

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -76,7 +76,7 @@ describe("portable output roots", () => {
     mkdirSync(join(finalRoot, "neondiff-qa-lab", "risk-queue"), { recursive: true }); symlinkSync(finalTarget, join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.json"));
     const finalAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], { cwd: join(repoRoot, "tests"), env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: finalRoot }, encoding: "utf8", timeout: 30_000 });
     expect(finalAlias.status).toBe(1); expect(finalAlias.stdout).toBe(""); expect(readFileSync(finalTarget, "utf8")).toBe("sentinel\n");
-  });
+  }, 30_000);
 
   it("accepts an external QA root", () => {
     const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-root-"));

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -66,7 +66,7 @@ describe("portable output roots", () => {
       cwd: join(repoRoot, "tests"),
       env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
       encoding: "utf8",
-      timeout: 10_000
+      timeout: 30_000
     });
     const output = JSON.parse(result.stdout);
 

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -74,7 +74,7 @@ describe("portable output roots", () => {
 
     const finalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-file-")); const finalTarget = join(repoRoot, `.portable-qa-target-${finalRoot.slice(finalRoot.lastIndexOf("/") + 1)}.json`); writeFileSync(finalTarget, "sentinel\n"); roots.push(finalRoot, finalTarget);
     mkdirSync(join(finalRoot, "neondiff-qa-lab", "risk-queue"), { recursive: true }); symlinkSync(finalTarget, join(finalRoot, "neondiff-qa-lab", "risk-queue", "queue-sim.json"));
-    const finalAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], { cwd: join(repoRoot, "tests"), env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: finalRoot }, encoding: "utf8", timeout: 10_000 });
+    const finalAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], { cwd: join(repoRoot, "tests"), env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: finalRoot }, encoding: "utf8", timeout: 30_000 });
     expect(finalAlias.status).toBe(1); expect(finalAlias.stdout).toBe(""); expect(readFileSync(finalTarget, "utf8")).toBe("sentinel\n");
   });
 

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -57,6 +57,20 @@ describe("portable output roots", () => {
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("must be outside a protected checkout root");
     expect(existsSync(join(hostileRoot, "neondiff-qa-lab"))).toBe(false);
+
+    const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-symlink-"));
+    roots.push(externalRoot);
+    symlinkSync(repoRoot, join(externalRoot, "neondiff-qa-lab"), "dir");
+    const nestedAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
+      cwd: join(repoRoot, "tests"),
+      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+    expect(nestedAlias.status).toBe(1);
+    expect(nestedAlias.stdout).toBe("");
+    expect(nestedAlias.stderr).toContain("must be outside a protected checkout root");
+    expect(existsSync(join(repoRoot, "risk-queue"))).toBe(false);
   });
 
   it("accepts an external QA root", () => {


### PR DESCRIPTION
Related: #864

## Summary
- replace retired `/Volumes/LEXAR` eval and QA output defaults with user-local portable roots
- route eval and QA output confinement through the shared symlink-aware protected-root guard
- reject nested checkout, dot-dot sibling, and symlink-alias roots before evidence writes

## Validation
- direct tsx eval default, hostile dot-dot root, nested QA root, dot-dot QA root, and external QA root checks passed
- focused Vitest file added: `tests/portable-paths.test.ts`
- `git diff --check` passed; full CI is authoritative

## Boundaries
- fresh current-main base `8b2a6ce50863799d03ebb3bf6ff09f53fc2b0770`
- 164 changed lines (122 additions / 42 deletions)
- no config, DB, worker, Keychain, install, release, or runtime mutation
- agent-authored; current GitNexus index was stale, so direct source proof is authoritative