### PR TITLE
fix: preserve structured config failures

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -529,7 +529,14 @@ async function main(): Promise<void> {
       : parseBooleanArg(args["require-coverage"], "--require-coverage");
     const collectCoverage = requireCoverage ||
       (args.coverage === undefined ? false : parseBooleanArg(args.coverage, "--coverage"));
-    const config = loadConfig(args.config);
+    let config: BotConfig;
+    let configLoadError: string | undefined;
+    try {
+      config = loadConfig(args.config);
+    } catch (error) {
+      configLoadError = error instanceof Error ? error.message : "config load failed";
+      config = loadConfig();
+    }
     const status = collectReleaseStatusWithConfig({
       cwd: process.cwd(),
       configPath: args.config,
@@ -543,9 +550,10 @@ async function main(): Promise<void> {
       statePath: args["state-path"],
       budgetDetails: args["budget-details"] === "true",
       ...(budgetDetailLimit !== undefined ? { budgetDetailLimit } : {}),
-      ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {})
+      ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {}),
+      ...(configLoadError ? { configLoadError } : {})
     }, config);
-    const coverageReport = collectCoverage
+    const coverageReport = collectCoverage && !configLoadError
       ? await collectCoverageReport(args, config)
       : undefined;
     const monitoringCoverage = buildReleaseMonitoringCoverage({
@@ -598,13 +606,11 @@ async function main(): Promise<void> {
       budgetDetailLimit,
       budgetJobLimit
     });
+    const configLoadGate = status.gates.find((gate) => gate.name === "config_load");
     const readyToRetry = status.budget?.providerDeferred.readyToRetry ?? 0;
     const failed = status.database.failedReviewQueueJobCount ?? 0;
-    const ok = status.budget?.enabled === true &&
-      status.budget.details.inputJobsTruncated !== true &&
-      readyToRetry === 0 &&
-      failed === 0;
     const gates = [
+      ...(configLoadGate ? [configLoadGate] : []),
       {
         name: "budget_available",
         ok: status.budget?.enabled === true,
@@ -626,6 +632,7 @@ async function main(): Promise<void> {
         detail: `${failed} failed durable queue job(s)`
       }
     ];
+    const ok = gates.every((gate) => gate.ok);
     console.log(stringifyRedactedJson({
       ok,
       healthState: ok ? "runtime_ok" : "runtime_blocked",
@@ -639,6 +646,7 @@ async function main(): Promise<void> {
       },
       failedGates: failedGates(gates),
       recommendedActions: ok ? [] : [
+        ...(configLoadGate ? ["provide an existing config file for budget-status"] : []),
         ...(readyToRetry > 0 ? ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"] : []),
         ...(failed > 0 ? ["inspect operator queue failed jobs before promotion"] : [])
       ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isIP } from "node:net";
+import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { DEFAULT_CONTEXT_BUDGET_CONFIG, type ContextBudgetConfig } from "./context-budget.js";
 import type { EnrichmentConfig } from "./enrichment.js";
@@ -43,6 +44,13 @@ const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
 const MAX_ISSUE_POLICY_TEXT_LENGTH = 4_000;
 const MAX_ISSUE_POLICY_ITEMS = 20;
 const MAX_ISSUE_POLICY_ALIASES = 50;
+export function resolvePortableHomePath(homeDirectory: string, ...segments: string[]): string {
+  if (!isAbsolute(homeDirectory)) throw new Error("user home directory must be absolute");
+  return join(homeDirectory, ...segments);
+}
+
+const DEFAULT_SKILL_ROOT = resolvePortableHomePath(homedir(), ".config", "neondiff", "skills");
+const DEFAULT_ZCODE_APP_CONFIG_PATH = resolvePortableHomePath(homedir(), ".config", "zcode", "config.json");
 
 export interface BotConfig {
   pilotRepos: string[];
@@ -441,7 +449,7 @@ const DEFAULT_CONFIG: BotConfig = {
   skillPacks: {
     enabled: false,
     packetVersion: "skill-pack-context-packet-v0.1",
-    skillRoot: "/Volumes/LEXAR/Codex/evaos-code-review-bot/skills",
+    skillRoot: DEFAULT_SKILL_ROOT,
     allowlist: [],
     maxSkillBytes: 8_000,
     maxPacketBytes: 16_000
@@ -590,7 +598,7 @@ const DEFAULT_CONFIG: BotConfig = {
   },
   zcode: {
     cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
-    appConfigPath: "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
+    appConfigPath: DEFAULT_ZCODE_APP_CONFIG_PATH,
     model: "GLM-5.2",
     timeoutMs: 180_000,
     maxPatchBytes: 80_000,
@@ -609,7 +617,13 @@ const DEFAULT_CONFIG: BotConfig = {
 };
 
 export function loadConfig(configPath?: string): BotConfig {
-  const fromFile = configPath && existsSync(configPath) ? JSON.parse(readFileSync(configPath, "utf8")) : {};
+  let fromFile: unknown = {};
+  if (configPath !== undefined) {
+    const requestedPath = configPath.trim();
+    if (!requestedPath || requestedPath === "true") throw new Error("config path is required");
+    if (!existsSync(requestedPath)) throw new Error(`config file not found: ${requestedPath}`);
+    fromFile = JSON.parse(readFileSync(requestedPath, "utf8"));
+  }
   return loadConfigFromObject(fromFile);
 }
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -119,6 +119,7 @@ export interface ReleaseStatusInput {
   heartbeat: ReleaseHeartbeatStatus;
   budget?: ReviewBudgetStatus;
   publicRelease?: PublicReleaseStatus;
+  configLoadError?: string;
   now?: Date;
 }
 
@@ -306,6 +307,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     "--expired-only true --dry-run false --zcode true";
   const inspectZCodeTimeoutCommand = buildZCodeTimeoutInspectCommand(input.configPath);
   const runtimeGates = [
+    ...(input.configLoadError
+      ? [{ name: "config_load", ok: false, detail: input.configLoadError }]
+      : []),
     {
       name: "expected_head",
       ok: expectedHeadOk,
@@ -513,7 +517,13 @@ export function collectReleaseStatus(input: {
   budgetJobLimit?: number;
   now?: Date;
 }): ReleaseStatus {
-  const config = loadConfig(input.configPath);
+  let config: BotConfig;
+  try {
+    config = loadConfig(input.configPath);
+  } catch (error) {
+    const configLoadError = error instanceof Error ? error.message : "config load failed";
+    return collectReleaseStatusWithConfig({ ...input, configLoadError }, loadConfig());
+  }
   return collectReleaseStatusWithConfig(input, config);
 }
 
@@ -529,6 +539,7 @@ export function collectReleaseStatusWithConfig(input: {
   budgetDetails?: boolean;
   budgetDetailLimit?: number;
   budgetJobLimit?: number;
+  configLoadError?: string;
   now?: Date;
 }, config: BotConfig): ReleaseStatus {
   validatePublicReleaseManifestInputs(input);
@@ -563,6 +574,7 @@ export function collectReleaseStatusWithConfig(input: {
           })
         }
       : {}),
+    configLoadError: input.configLoadError,
     now
   });
 }

--- a/tests/config-recovery.test.ts
+++ b/tests/config-recovery.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const tsxCommand = process.env.NEONDIFF_TEST_TSX ?? join(repoRoot, "node_modules", ".bin", "tsx");
+
+describe("structured config recovery", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("keeps no-argument defaults user-local and rejects empty explicit paths", () => {
+    const config = loadConfig();
+    expect(config.skillPacks?.skillRoot).toBe(join(homedir(), ".config", "neondiff", "skills"));
+    expect(config.zcode.appConfigPath).toBe(join(homedir(), ".config", "zcode", "config.json"));
+    expect(JSON.stringify(config)).not.toContain("/Volumes/LEXAR");
+    expect(() => loadConfig("")).toThrow("config path is required");
+  });
+
+  it.each(["release-status", "budget-status"])("reports missing %s config as JSON config_load", (command) => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-config-recovery-"));
+    roots.push(root);
+    const missingConfig = join(root, "missing.json");
+    const result = spawnSync(tsxCommand, [join(repoRoot, "src/cli.ts"), command, "--config", missingConfig], {
+      cwd: repoRoot,
+      env: { ...process.env, NEONDIFF_TEST_TSX: tsxCommand },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(output.ok).toBe(false);
+    expect(output.failedGates).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "config_load", ok: false })])
+    );
+  });
+});


### PR DESCRIPTION
Related: #864\n\n## Summary\n- make explicit missing or empty config paths fail closed while preserving loadConfig() user-local defaults\n- add a structured config_load gate to release-status recovery\n- propagate that gate through budget-status instead of hiding it behind budget-only failures\n\n## Validation\n- direct tsx no-arg default, empty-path, release-status missing-config, and budget-status missing-config assertions passed\n- focused Vitest file added: tests/config-recovery.test.ts\n- git diff --check passed; full CI is authoritative\n\n## Boundaries\n- fresh current-main base 8b2a6ce50863799d03ebb3bf6ff09f53fc2b0770\n- 102 changed lines (91 additions / 11 deletions)\n- no config, DB, worker, Keychain, install, release, or runtime mutation\n- agent-authored; current GitNexus index was stale, so direct source proof is authoritative