### PR TITLE
fix: scope paid BYO activation by verified repository visibility

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4745,6 +4745,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var selectedBYOActivationContext: Bool {
         dependencies.productionBoundary.byoGitHubEnabled
             && onboardingFlow.mode == .publicReposOnly
+            && !existingLocalBotReconciliationMode
             && selectedReviewRepository != nil
     }
 
@@ -5001,17 +5002,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 lastError = "Apply and read back the selected Review Target before activating."
                 return
             }
-            guard byoGitHubCredentialsVerified,
-                  let verifiedBYORepository,
-                  verifiedBYORepository.caseInsensitiveCompare(activationRepository)
-                      == .orderedSame,
-                  let visibility = verifiedBYORepositoryVisibility,
-                  ["public", "private", "internal"].contains(visibility)
-            else {
-                applyActivationEvent(.activationServiceError)
-                lastError = "Verify the exact GitHub visibility for this Review Target before activating."
-                return
-            }
             if let activatedRepository,
                activatedRepository.caseInsensitiveCompare(activationRepository)
                    != .orderedSame {
@@ -5076,16 +5066,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard dependencies.productionBoundary.byoGitHubEnabled else {
             return summary.coversPrivateRepos ? outcome : .scopeConflict
         }
-        guard byoGitHubCredentialsVerified,
-              let repository = selectedReviewRepository,
-              let verifiedBYORepository,
-              verifiedBYORepository.caseInsensitiveCompare(repository) == .orderedSame,
-              let visibility = verifiedBYORepositoryVisibility?.lowercased()
-        else {
-            return .scopeConflict
+        if summary.repoVisibilityScope.lowercased() == "public" {
+            guard byoGitHubCredentialsVerified,
+                  let repository = selectedReviewRepository,
+                  let verifiedBYORepository,
+                  verifiedBYORepository.caseInsensitiveCompare(repository) == .orderedSame,
+                  let visibility = verifiedBYORepositoryVisibility?.lowercased()
+            else {
+                return .scopeConflict
+            }
+            guard summary.covers(repositoryVisibility: visibility) else { return .scopeConflict }
         }
-        guard summary.covers(repositoryVisibility: visibility) else { return .scopeConflict }
-        return outcome
+        return summary.coversPrivateRepos || summary.repoVisibilityScope.lowercased() == "public"
+            ? outcome
+            : .scopeConflict
     }
 
     private func applyActivationOutcomeSideEffects(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -219,12 +219,19 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var activationUpdateAuthorityValidUntil: Date?
     private var accountWorkspaceCatalogVerifiedAt: Date?
     private var activationVerifiedRepositoryThisLaunch: String?
+    private var verifiedBYORepository: String?
+    private var verifiedBYORepositoryVisibility: String?
     private var appliedRepoSelection: AppliedRepoSelection?
     private var scopedReviewTask: Task<Void, Never>?
     private var scopedDryRunApproval: ScopedReviewApproval?
 
     package var productionActivationBoundaryMessage: String {
         "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
+    }
+
+    private var managedPublicFreeDistribution: Bool {
+        dependencies.productionBoundary.managedGitHubBrokerOrigin != nil
+            && !dependencies.productionBoundary.byoGitHubEnabled
     }
 
     package var customerRuntimeBoundaryMessage: String {
@@ -846,7 +853,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         // touching the Keychain on the launch path (v1.0.3 startup-stability rule).
         if let rawActivationState = dependencies.preferences.string(forKey: activationStateKey),
            let restored = ActivationState(rawValue: rawActivationState) {
-            self.activationState = restored
+            let migrated = restored == .publicFreeSkip && !managedPublicFreeDistribution
+                ? .purchaseRequired
+                : restored
+            self.activationState = migrated
+            if migrated != restored {
+                dependencies.preferences.set(migrated.rawValue, forKey: activationStateKey)
+            }
         } else {
             self.activationState = ActivationStateMachine.initialState
         }
@@ -1932,6 +1945,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         providerVerificationStatus = "Verify the selected account's provider credential when ready."
         activationVerifiedThisLaunch = false
         activationVerifiedRepositoryThisLaunch = nil
+        verifiedBYORepository = nil
+        verifiedBYORepositoryVisibility = nil
         if !preservingActivationJourney {
             dependencies.preferences.set("", forKey: activationRepositoryKey)
         }
@@ -3891,6 +3906,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let cli = dependencies.cli
         isBYOGitHubVerificationInProgress = true
         byoGitHubCredentialsVerified = false
+        verifiedBYORepository = nil
+        verifiedBYORepositoryVisibility = nil
         lastError = nil
         lastCommandLine = safeCommand
         byoGitHubCredentialStatus = repositoryScope == nil
@@ -4187,6 +4204,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
             $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
         }.joined(separator: ", ")
         byoGitHubCredentialsVerified = true
+        if let selectedReviewRepository,
+           let readCheck = report.github.readChecks.first(where: {
+               $0.repo.caseInsensitiveCompare(selectedReviewRepository) == .orderedSame
+           }) {
+            verifiedBYORepository = selectedReviewRepository
+            verifiedBYORepositoryVisibility = readCheck.visibilityResult?.lowercased()
+        } else {
+            verifiedBYORepository = nil
+            verifiedBYORepositoryVisibility = nil
+        }
         lastError = nil
         switch expectedContext.source {
         case .existingLocalAgent:
@@ -4479,6 +4506,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func invalidateBYOGitHubVerificationContext() {
         invalidateScopedReviewApproval()
+        verifiedBYORepository = nil
+        verifiedBYORepositoryVisibility = nil
         guard byoGitHubCredentialOnboardingAvailable else { return }
         byoGitHubCredentialsVerified = false
         guard !isBYOGitHubVerificationInProgress else { return }
@@ -4713,8 +4742,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
             || dependencies.preferences.bool(forKey: activationCheckoutEnabledKey)
     }
 
+    private var selectedBYOActivationContext: Bool {
+        dependencies.productionBoundary.byoGitHubEnabled
+            && onboardingFlow.mode == .publicReposOnly
+            && selectedReviewRepository != nil
+    }
+
     package var activationPresentation: ActivationStatePresentation {
-        ActivationStateMachine.presentation(for: activationState, redactedKeyPrefix: activationKeyRedactedPrefix)
+        ActivationStateMachine.presentation(
+            for: activationState,
+            redactedKeyPrefix: activationKeyRedactedPrefix,
+            publicBYO: selectedBYOActivationContext
+        )
     }
 
     private var activationLicenseClient: (any ActivationLicenseClienting)? {
@@ -4781,10 +4820,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         dependencies.preferences.set(next.rawValue, forKey: activationStateKey)
     }
 
-    /// Enter the activation branch from the chosen onboarding path. The public
-    /// path skips straight to a free, license-free state.
+    /// Enter the activation branch from the chosen onboarding path. Only the
+    /// managed broker path may skip activation for public repositories.
     package func enterActivation(for mode: OnboardingMode) {
-        applyActivationEvent(mode == .publicReposOnly ? .choosePublicPath : .choosePrivatePath)
+        let publicFree = mode == .publicReposOnly && managedPublicFreeDistribution
+        applyActivationEvent(publicFree ? .choosePublicPath : .choosePrivatePath)
     }
 
     /// Align the activation entry state with the onboarding mode when the flow
@@ -4794,7 +4834,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package func syncActivationEntryFromOnboardingMode() {
         switch activationState {
         case .purchaseRequired where onboardingFlow.mode == .publicReposOnly:
-            applyActivationEvent(.choosePublicPath)
+            enterActivation(for: .publicReposOnly)
+        case .publicFreeSkip where !managedPublicFreeDistribution:
+            enterActivation(for: onboardingFlow.mode)
         case .publicFreeSkip where onboardingFlow.mode == .privateRepos:
             applyActivationEvent(.choosePrivatePath)
         default:
@@ -4959,6 +5001,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 lastError = "Apply and read back the selected Review Target before activating."
                 return
             }
+            guard byoGitHubCredentialsVerified,
+                  let verifiedBYORepository,
+                  verifiedBYORepository.caseInsensitiveCompare(activationRepository)
+                      == .orderedSame,
+                  let visibility = verifiedBYORepositoryVisibility,
+                  ["public", "private", "internal"].contains(visibility)
+            else {
+                applyActivationEvent(.activationServiceError)
+                lastError = "Verify the exact GitHub visibility for this Review Target before activating."
+                return
+            }
             if let activatedRepository,
                activatedRepository.caseInsensitiveCompare(activationRepository)
                    != .orderedSame {
@@ -5014,14 +5067,24 @@ package final class NeonDiffDesktopModel: ObservableObject {
         )
     }
 
-    /// A 200-`active` response can still be public-only or `privateRepoAllowed=false`,
-    /// which the server review gate rejects for private repos. Downgrade such a
-    /// scope-insufficient success to a scope conflict so the pane never reports
-    /// private review as unlocked when it is not.
+    /// A 200-`active` response is accepted only when its entitlement covers the
+    /// exact GitHub-verified visibility of the selected BYO repository. Unknown,
+    /// stale, mismatched, or scope-insufficient proof becomes a scope conflict so
+    /// the pane never reports access beyond that repository.
     private func resolveActivationOutcome(_ outcome: ActivationClientOutcome) -> ActivationClientOutcome {
-        if case let .active(summary) = outcome, !summary.coversPrivateRepos {
+        guard case let .active(summary) = outcome else { return outcome }
+        guard dependencies.productionBoundary.byoGitHubEnabled else {
+            return summary.coversPrivateRepos ? outcome : .scopeConflict
+        }
+        guard byoGitHubCredentialsVerified,
+              let repository = selectedReviewRepository,
+              let verifiedBYORepository,
+              verifiedBYORepository.caseInsensitiveCompare(repository) == .orderedSame,
+              let visibility = verifiedBYORepositoryVisibility?.lowercased()
+        else {
             return .scopeConflict
         }
+        guard summary.covers(repositoryVisibility: visibility) else { return .scopeConflict }
         return outcome
     }
 
@@ -5049,7 +5112,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             let plan = summary.plan.map { " · \($0)" } ?? ""
             license.entitlement = "active (\(scope)\(plan))"
             logText = activeLogMessage
-                ?? "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked."
+                ?? (selectedBYOActivationContext
+                    ? "\(ActivationTerminology.activationKey) is active for this BYO repository."
+                    : "\(ActivationTerminology.activationKey) is active. Private repository review is unlocked.")
             activationVerifiedRepositoryThisLaunch = repository
             if let repository {
                 dependencies.preferences.set(repository, forKey: activationRepositoryKey)
@@ -5059,7 +5124,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         case .scopeConflict:
             activationVerifiedThisLaunch = false
             activationVerifiedRepositoryThisLaunch = nil
-            lastError = "This \(ActivationTerminology.activationKey) does not cover private repositories. Use a key with a private-repo entitlement."
+            lastError = selectedBYOActivationContext
+                ? "This \(ActivationTerminology.activationKey) does not cover this BYO repository. Verify its exact GitHub visibility and use a matching entitlement."
+                : "This \(ActivationTerminology.activationKey) does not cover private repositories. Use a key with a private-repo entitlement."
         case .expired, .revoked, .invalid:
             activationVerifiedThisLaunch = false
             activationVerifiedRepositoryThisLaunch = nil

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/ActivationStateMachine.swift
@@ -180,7 +180,8 @@ public enum ActivationStateMachine {
 
     public static func presentation(
         for state: ActivationState,
-        redactedKeyPrefix: String? = nil
+        redactedKeyPrefix: String? = nil,
+        publicBYO: Bool = false
     ) -> ActivationStatePresentation {
         let keyTerm = ActivationTerminology.activationKey
         switch state {
@@ -199,14 +200,18 @@ public enum ActivationStateMachine {
         case .purchaseRequired:
             return ActivationStatePresentation(
                 state: state,
-                title: "Private repositories need activation",
-                cause: "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
+                title: publicBYO ? "This BYO repository requires activation" : "Private repositories need activation",
+                cause: publicBYO
+                    ? "This BYO repository requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued."
+                    : "Private repository review requires an active \(keyTerm). Buy one through checkout, or paste the key checkout already issued.",
                 recovery: ActivationRecovery(
                     label: "Continue with this key",
                     event: .provideExistingKey,
                     accessibilityLabel: "Store the existing \(keyTerm) securely and continue"
                 ),
-                accessibilityLabel: "Private repositories require an active \(keyTerm).",
+                accessibilityLabel: publicBYO
+                    ? "This BYO repository requires an active \(keyTerm)."
+                    : "Private repositories require an active \(keyTerm).",
                 isSuccess: false,
                 requiresKeyEntry: true,
                 showsNotifyOption: false
@@ -249,13 +254,17 @@ public enum ActivationStateMachine {
             return ActivationStatePresentation(
                 state: state,
                 title: "Activate your \(keyTerm)",
-                cause: "Your \(keyTerm)\(prefixNote) is ready. Activate it to unlock private repository review.",
+                cause: publicBYO
+                    ? "Your \(keyTerm)\(prefixNote) is ready. Activate it to review this BYO repository."
+                    : "Your \(keyTerm)\(prefixNote) is ready. Activate it to unlock private repository review.",
                 recovery: ActivationRecovery(
                     label: "Activate",
                     event: .submitActivation,
                     accessibilityLabel: "Activate the \(keyTerm)"
                 ),
-                accessibilityLabel: "\(keyTerm)\(prefixNote) is ready to activate.",
+                accessibilityLabel: publicBYO
+                    ? "\(keyTerm)\(prefixNote) is ready to activate for this BYO repository."
+                    : "\(keyTerm)\(prefixNote) is ready to activate.",
                 isSuccess: false,
                 requiresKeyEntry: true,
                 showsNotifyOption: false
@@ -281,9 +290,13 @@ public enum ActivationStateMachine {
             return ActivationStatePresentation(
                 state: state,
                 title: "Activated",
-                cause: "Your \(keyTerm) is active. Private repository review is unlocked.",
+                cause: publicBYO
+                    ? "Your \(keyTerm) is active. This BYO repository is unlocked."
+                    : "Your \(keyTerm) is active. Private repository review is unlocked.",
                 recovery: nil,
-                accessibilityLabel: "\(keyTerm) is active. Private repositories unlocked.",
+                accessibilityLabel: publicBYO
+                    ? "\(keyTerm) is active. This BYO repository is unlocked."
+                    : "\(keyTerm) is active. Private repositories unlocked.",
                 isSuccess: true,
                 requiresKeyEntry: false,
                 showsNotifyOption: false
@@ -309,13 +322,17 @@ public enum ActivationStateMachine {
             return ActivationStatePresentation(
                 state: state,
                 title: "Your entitlement expired",
-                cause: "This \(keyTerm) has expired. Renew to keep reviewing private repositories, or paste a renewed key.",
+                cause: publicBYO
+                    ? "This \(keyTerm) has expired. Renew to keep reviewing this BYO repository, or paste a renewed key."
+                    : "This \(keyTerm) has expired. Renew to keep reviewing private repositories, or paste a renewed key.",
                 recovery: ActivationRecovery(
                     label: "Renew",
                     event: .renew,
                     accessibilityLabel: "Renew your entitlement"
                 ),
-                accessibilityLabel: "The \(keyTerm) has expired.",
+                accessibilityLabel: publicBYO
+                    ? "The \(keyTerm) has expired for this BYO repository."
+                    : "The \(keyTerm) has expired.",
                 isSuccess: false,
                 requiresKeyEntry: false,
                 showsNotifyOption: false

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ActivationLicenseClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ActivationLicenseClient.swift
@@ -96,6 +96,17 @@ public struct ActivationEntitlementSummary: Sendable, Equatable {
         if privateRepoAllowed == false { return false }
         return repoVisibilityScope == "all" || repoVisibilityScope == "private"
     }
+
+    public func covers(repositoryVisibility: String) -> Bool {
+        switch repositoryVisibility.lowercased() {
+        case "public":
+            return ["all", "public", "private"].contains(repoVisibilityScope.lowercased())
+        case "private", "internal":
+            return coversPrivateRepos
+        default:
+            return false
+        }
+    }
 }
 
 /// The classified outcome of an activation/validation call.

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -128,12 +128,38 @@ import NeonDiffDesktopCore
         #expect(model.activationState == .keyReady)
     }
 
+    @Test func legacyPublicFreeSkipMigratesToPaidBYOEntry() {
+        let prefs = MemoryPreferences()
+        prefs.set(ActivationState.publicFreeSkip.rawValue, forKey: activationStateKey)
+        let model = makeModel(
+            preferences: prefs,
+            productionBoundary: .testAccountLink
+        )
+
+        #expect(model.activationState == .purchaseRequired)
+        #expect(prefs.string(forKey: activationStateKey) == ActivationState.purchaseRequired.rawValue)
+    }
+
     @Test func publicPathSkipsWithoutLicenseUI() {
-        let model = makeModel()
+        let model = makeModel(productionBoundary: .testManaged)
         model.enterActivation(for: .publicReposOnly)
         #expect(model.activationState == .publicFreeSkip)
         #expect(model.activationPresentation.requiresKeyEntry == false)
         #expect(model.activationPresentation.recovery == nil)
+    }
+
+    @Test func selectedBYOStatesUseExactRepositoryCopy() {
+        let model = makeModel(productionBoundary: .testAccountLink)
+        model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        model.enterActivation(for: .publicReposOnly)
+
+        for state in [ActivationState.purchaseRequired, .keyReady, .active, .expired] {
+            model.activationState = state
+            let copy = "\(model.activationPresentation.title) \(model.activationPresentation.cause)"
+            #expect(copy.localizedCaseInsensitiveContains("this byo repository"))
+            #expect(!copy.localizedCaseInsensitiveContains("private repository"))
+            #expect(!copy.localizedCaseInsensitiveContains("every repository"))
+        }
     }
 
     @Test func privatePathBeginsCheckoutPausedWhenCheckoutDisabled() {
@@ -357,7 +383,7 @@ import NeonDiffDesktopCore
     /// Thread 2: choosing Public Repos must skip the license wall, not sit at
     /// purchase_required.
     @Test func publicModeSyncSkipsLicenseWall() {
-        let model = makeModel()
+        let model = makeModel(productionBoundary: .testManaged)
         model.onboardingFlow.mode = .publicReposOnly
         #expect(model.activationState == .purchaseRequired)
         model.syncActivationEntryFromOnboardingMode()

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ActivationHandoffModelTests.swift
@@ -148,20 +148,6 @@ import NeonDiffDesktopCore
         #expect(model.activationPresentation.recovery == nil)
     }
 
-    @Test func selectedBYOStatesUseExactRepositoryCopy() {
-        let model = makeModel(productionBoundary: .testAccountLink)
-        model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
-        model.enterActivation(for: .publicReposOnly)
-
-        for state in [ActivationState.purchaseRequired, .keyReady, .active, .expired] {
-            model.activationState = state
-            let copy = "\(model.activationPresentation.title) \(model.activationPresentation.cause)"
-            #expect(copy.localizedCaseInsensitiveContains("this byo repository"))
-            #expect(!copy.localizedCaseInsensitiveContains("private repository"))
-            #expect(!copy.localizedCaseInsensitiveContains("every repository"))
-        }
-    }
-
     @Test func privatePathBeginsCheckoutPausedWhenCheckoutDisabled() {
         let model = makeModel()
         model.enterActivation(for: .privateRepos)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -506,7 +506,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
                     stderr: ""
                 ))
             ],
-            activationLicenseClient: ActiveBYOActivationClient(),
+            activationLicenseClient: ActiveBYOActivationClient(scope: "public"),
             preferenceStrings: availableCLIPreference,
             productionBoundary: exactB0Boundary
         )
@@ -528,6 +528,8 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(fixture.model.selectedBotInstallation == nil)
         #expect(fixture.model.currentRepositoryActivationReady)
         #expect(fixture.model.productionUsefulWorkAvailable)
+        #expect(fixture.model.logText == "NeonDiff Activation Key is active for this BYO repository.")
+        #expect(!fixture.model.logText.contains("Private repository"))
     }
 
     @Test func verificationFailsClosedUnlessDoctorChecksExactlyMatchEnabledRepositories() async throws {
@@ -786,10 +788,16 @@ private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: 
 ])
 
 private struct ActiveBYOActivationClient: ActivationLicenseClienting {
+    let scope: String
+
+    init(scope: String = "private") {
+        self.scope = scope
+    }
+
     func activate(key _: ActivationKeyMaterial) async throws -> ActivationClientOutcome {
         .active(ActivationEntitlementSummary(
             status: .active,
-            repoVisibilityScope: "private",
+            repoVisibilityScope: scope,
             privateRepoAllowed: true,
             updateEntitlement: true,
             expiresAt: nil,

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationLicenseClientTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationLicenseClientTests.swift
@@ -201,6 +201,9 @@ import Testing
         #expect(!summary(scope: "public", privateAllowed: nil).coversPrivateRepos)
         #expect(!summary(scope: "all", privateAllowed: false).coversPrivateRepos)
         #expect(!summary(scope: "private", privateAllowed: false).coversPrivateRepos)
+        #expect(summary(scope: "public", privateAllowed: nil).covers(repositoryVisibility: "public"))
+        #expect(!summary(scope: "public", privateAllowed: nil).covers(repositoryVisibility: "private"))
+        #expect(!summary(scope: "public", privateAllowed: nil).covers(repositoryVisibility: "unknown"))
     }
 
     @Test func keyMaterialNeverExposesRawSecret() {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationStateMachineTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/ActivationStateMachineTests.swift
@@ -180,4 +180,18 @@ import Testing
         #expect(!p.requiresKeyEntry, "public_free_skip must never ask for an activation key")
         #expect(p.recovery == nil, "public_free_skip is a clean skip, not a gated wall")
     }
+
+    @Test func selectedBYOPresentationNeverOverclaimsScope() {
+        let scopedStates: [ActivationState] = [.purchaseRequired, .keyReady, .active, .expired]
+        for state in scopedStates {
+            let presentation = ActivationStateMachine.presentation(
+                for: state,
+                publicBYO: true
+            )
+            let copy = "\(presentation.title) \(presentation.cause) \(presentation.accessibilityLabel)"
+            #expect(copy.localizedCaseInsensitiveContains("this byo repository"))
+            #expect(!copy.localizedCaseInsensitiveContains("private repository"))
+            #expect(!copy.localizedCaseInsensitiveContains("every repository"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Keep the public-free activation skip limited to managed distribution.
- Retain exact selected BYO repository visibility from the successful GitHub doctor proof and fail closed for missing, stale, mismatched, or unknown proof.
- Accept public-scoped entitlements only for verified public targets; require private coverage for private/internal targets.
- Use selected-BYO wording across purchase, key-ready, active, expired, scope-conflict, and activation log surfaces.

Closes #891

## Evidence

- `swift build` (apps/neondiff-desktop): PASS
- `swift test --filter NeonDiffDesktopCoreTests.ActivationLicenseClientTests` with Xcode Testing.framework: 16/16 PASS
- `swift test --filter NeonDiffDesktopCoreTests.ActivationStateMachineTests` with Xcode Testing.framework: 12/12 PASS
- `swift test --filter NeonDiffDesktopAppCoreTests.ActivationHandoffModelTests` with Xcode Testing.framework: 27/27 PASS
- `swift test --filter NeonDiffDesktopAppCoreTests.BYOGitHubAppCredentialOnboardingTests` with Xcode Testing.framework: 25/25 PASS
- `git diff --check`: PASS
- 200 changed lines against current `origin/main` 8b2a6ce50863799d03ebb3bf6ff09f53fc2b0770

The repository's wrapper selected the Command Line Tools Testing.framework, which produced undefined Testing linker symbols; the matching Xcode framework completed the same focused suites successfully.
