### PR TITLE
fix(state): quarantine incomplete review evidence atomically

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -44,6 +44,16 @@ export type ReviewReadinessState =
   | "command_recorded"
   | "skipped"
   | "failed";
+export interface ReviewEvidenceQuarantine {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  reason: string;
+}
+export interface ReviewEvidenceQuarantineResult {
+  failedQueueJobs: number;
+  retiredQueueJobs: number;
+}
 export type RepoMemoryNoteKind =
   | "policy_note"
   | "machine_fact"
@@ -2611,6 +2621,23 @@ export class ReviewStateStore {
     return { enqueued: true, job: this.getReviewQueueJob(jobId)! };
   }
 
+  quarantineIncompleteReviewEvidence(input: ReviewEvidenceQuarantine & { leaseTtlMs?: number; now?: Date }): ReviewEvidenceQuarantineResult {
+    validateReviewQueueInput(input.repo, input.pullNumber, input.headSha);
+    const leaseTtlMs = input.leaseTtlMs ?? 15 * 60_000;
+    validatePositiveQueueLimit(leaseTtlMs, "leaseTtlMs");
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      const result = this.applyIncompleteReviewEvidence(input, nowIso, legacyLeaseCutoffIso);
+      this.db.exec("commit");
+      return result;
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
   leaseNextReviewQueueJobs(input: {
     maxGlobalActive?: number;
     maxProviderActive: number;
@@ -2619,6 +2646,7 @@ export class ReviewStateStore {
     maxRepoActiveByRepo?: Record<string, number>;
     manualCommandReserve?: number;
     excludeJobIds?: Iterable<string>;
+    quarantines?: Iterable<ReviewEvidenceQuarantine>;
     reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo" | "pullNumber" | "headSha">>;
     limit?: number;
     leaseTtlMs?: number;
@@ -2650,6 +2678,8 @@ export class ReviewStateStore {
     const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
     const leaseExpiresAt = new Date(Date.parse(nowIso) + leaseTtlMs).toISOString();
     const excludeJobIds = new Set(input.excludeJobIds ?? []);
+    const quarantines = Array.from(input.quarantines ?? []);
+    for (const quarantine of quarantines) validateReviewQueueInput(quarantine.repo, quarantine.pullNumber, quarantine.headSha);
     const reservedActiveJobs = Array.from(input.reservedActiveJobs ?? []);
     const leased: ReviewQueueJobRecord[] = [];
 
@@ -2665,11 +2695,12 @@ export class ReviewStateStore {
                updated_at = ?
            where state in ('leased', 'running')
              and (
-               (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
-               or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
+               (lease_expires_at is not null and lease_expires_at <= ?)
+               or (lease_expires_at is null and updated_at <= ?)
              )`
         )
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
+      for (const quarantine of quarantines) this.applyIncompleteReviewEvidence(quarantine, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
@@ -2733,6 +2764,68 @@ export class ReviewStateStore {
     }
 
     return leased;
+  }
+
+  private applyIncompleteReviewEvidence(input: ReviewEvidenceQuarantine, nowIso: string, legacyLeaseCutoffIso: string): ReviewEvidenceQuarantineResult {
+    const reason = redactSecrets(input.reason).trim().slice(0, 500);
+    const supersededReason = `superseded_by_head=${input.headSha}`;
+    this.db.prepare(
+      `update review_queue_jobs set state = 'queued', lease_id = null, lease_expires_at = null,
+              last_error = 'queue_lease_expired_requeued', updated_at = ?
+       where repo = ? and pull_number = ? and state in ('leased', 'running') and
+         ((lease_expires_at is not null and lease_expires_at <= ?) or
+          (lease_expires_at is null and updated_at <= ?))`
+    ).run(nowIso, input.repo, input.pullNumber, nowIso, legacyLeaseCutoffIso);
+    const retiredQueueJobs = Number(this.db.prepare(
+      `update review_queue_jobs set state = 'stale_retired', lease_id = null, lease_expires_at = null,
+              next_eligible_at = null, finished_at = coalesce(finished_at, ?), last_error = ?, updated_at = ?
+       where repo = ? and pull_number = ? and head_sha <> ?
+         and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
+    ).run(nowIso, supersededReason, nowIso, input.repo, input.pullNumber, input.headSha).changes);
+    const failedQueueJobs = Number(this.db.prepare(
+      `update review_queue_jobs set state = 'failed', lease_id = null, lease_expires_at = null,
+              next_eligible_at = null, finished_at = coalesce(finished_at, ?), last_error = ?, updated_at = ?
+       where repo = ? and pull_number = ? and head_sha = ?
+         and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
+    ).run(nowIso, reason, nowIso, input.repo, input.pullNumber, input.headSha).changes);
+    this.db.prepare(
+      `update review_readiness set state = 'stale', reason = ?, updated_at = ?
+       where repo = ? and pull_number = ? and head_sha <> ?
+         and state in ('queued', 'reviewing', 'needs_fix', 'awaiting_re_review', 'blocked_on_checks',
+                       'blocked_on_proof', 'ready_for_human', 'provider_deferred', 'command_recorded')`
+    ).run(supersededReason, nowIso, input.repo, input.pullNumber, input.headSha);
+    this.db.prepare(
+      `insert into review_readiness (repo, pull_number, head_sha, state, reason, created_at, updated_at)
+       values (?, ?, ?, 'failed', ?, ?, ?)
+       on conflict(repo, pull_number, head_sha) do update set
+         state = excluded.state, reason = excluded.reason, updated_at = excluded.updated_at
+       where review_readiness.state <> 'failed' or coalesce(review_readiness.reason, '') <> excluded.reason`
+    ).run(input.repo, input.pullNumber, input.headSha, reason, nowIso, nowIso);
+    this.db.prepare(
+      `update reviewer_session_jobs set job_state = 'failed', finished_at = coalesce(finished_at, ?),
+              processed_review_status = 'failed'
+       where repo = ? and pull_number = ? and head_sha = ? and job_state in ('assigned', 'running')
+         and not exists (select 1 from review_queue_jobs q where q.repo = reviewer_session_jobs.repo
+           and q.pull_number = reviewer_session_jobs.pull_number and q.head_sha = reviewer_session_jobs.head_sha
+           and q.state in ('leased', 'running')
+           and ((q.lease_expires_at is not null and q.lease_expires_at > ?)
+             or (q.lease_expires_at is null and q.updated_at > ?)))`
+    ).run(nowIso, input.repo, input.pullNumber, input.headSha, nowIso, legacyLeaseCutoffIso);
+    this.db.prepare(
+      `update reviewer_session_jobs set job_state = 'skipped', finished_at = coalesce(finished_at, ?),
+              processed_review_status = 'skipped'
+       where repo = ? and pull_number = ? and head_sha <> ? and job_state in ('assigned', 'running')
+         and not exists (select 1 from review_queue_jobs q where q.repo = reviewer_session_jobs.repo
+           and q.pull_number = reviewer_session_jobs.pull_number and q.head_sha = reviewer_session_jobs.head_sha
+           and q.state in ('leased', 'running')
+           and ((q.lease_expires_at is not null and q.lease_expires_at > ?)
+             or (q.lease_expires_at is null and q.updated_at > ?)))`
+    ).run(nowIso, input.repo, input.pullNumber, input.headSha, nowIso, legacyLeaseCutoffIso);
+    const sessions = this.db.prepare(
+      "select distinct session_id from reviewer_session_jobs where repo = ? and pull_number = ?"
+    ).all(input.repo, input.pullNumber) as unknown as Array<{ session_id: string }>;
+    for (const session of sessions) this.expireDrainedReviewerSessionIfComplete(session.session_id);
+    return { failedQueueJobs, retiredQueueJobs };
   }
 
   updateReviewQueueJobState(input: {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1260,6 +1260,52 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("atomically quarantines one exact head while fencing leases and converging sessions", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-evidence-quarantine-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const repo = "org/repo-a";
+    const now = new Date("2026-07-01T00:00:02.100Z");
+    const current = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", now }).job;
+    const retry = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", source: "manual_command", commentId: 2, now }).job;
+    const active = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-b", source: "manual_command", commentId: 3, now }).job;
+    const superseded = store.enqueueReviewQueueJob({ repo, pullNumber: 1, headSha: "head-a", now }).job;
+    const unrelated = store.enqueueReviewQueueJob({ repo, pullNumber: 2, headSha: "head-c", now }).job;
+    store.updateReviewQueueJobState({ jobId: current.jobId, state: "blocked_on_proof", nextEligibleAt: "2026-07-01T00:10:00Z" });
+    store.updateReviewQueueJobState({ jobId: retry.jobId, state: "leased", leaseId: "expired", leaseExpiresAt: "2026-07-01T00:00:02.000Z" });
+    store.updateReviewQueueJobState({ jobId: active.jobId, state: "running", leaseId: "active", leaseExpiresAt: "2026-07-01T00:00:02.900Z" });
+    store.updateReviewQueueJobState({ jobId: superseded.jobId, state: "blocked_on_proof" });
+    store.recordReviewReadiness({ repo, pullNumber: 1, headSha: "head-a", state: "blocked_on_proof", reason: "proof" });
+    const activeAssignment = store.assignReviewerSessionJob({ repo, pullNumber: 1, headSha: "head-b", ttlMs: 60_000, headCountLimit: 1, now });
+    const supersededAssignment = store.assignReviewerSessionJob({ repo, pullNumber: 1, headSha: "head-a", ttlMs: 60_000, headCountLimit: 1, now });
+
+    expect(store.quarantineIncompleteReviewEvidence({ repo, pullNumber: 1, headSha: "head-b", reason: "token=ghp_fake_token", now })).toEqual({
+      failedQueueJobs: 2, retiredQueueJobs: 1
+    });
+    expect(store.getReviewQueueJob(current.jobId)).toMatchObject({ state: "failed", finishedAt: now.toISOString(), lastError: expect.not.stringContaining("ghp_fake_token") });
+    expect(store.getReviewQueueJob(current.jobId)).not.toHaveProperty("nextEligibleAt");
+    expect(store.getReviewQueueJob(retry.jobId)).toMatchObject({ state: "failed", finishedAt: now.toISOString() });
+    expect(store.getReviewQueueJob(active.jobId)).toMatchObject({ state: "running", leaseId: "active" });
+    expect(store.getReviewQueueJob(superseded.jobId)).toMatchObject({ state: "stale_retired", finishedAt: now.toISOString() });
+    expect(store.getReviewReadiness(repo, 1, "head-a")).toMatchObject({ state: "stale" });
+    expect(store.getReviewerSessionJob(repo, 1, "head-b")).toMatchObject({ jobState: "assigned" });
+    expect(store.getReviewerSessionJob(repo, 1, "head-b")).not.toHaveProperty("finishedAt");
+    expect(store.getReviewerSession(activeAssignment.session!.sessionId)).toMatchObject({ state: "draining" });
+    expect(store.getReviewerSessionJob(repo, 1, "head-a")).toMatchObject({ jobState: "skipped", finishedAt: now.toISOString() });
+    expect(store.getReviewerSession(supersededAssignment.session!.sessionId)).toMatchObject({ state: "expired" });
+    expect(store.quarantineIncompleteReviewEvidence({ repo, pullNumber: 1, headSha: "head-b", reason: "same", now })).toEqual({ failedQueueJobs: 0, retiredQueueJobs: 0 });
+    expect(store.getReviewReadiness(repo, 1, "head-b")).toMatchObject({ state: "failed", reason: expect.not.stringContaining("ghp_fake_token") });
+    expect(store.quarantineIncompleteReviewEvidence({ repo, pullNumber: 3, headSha: "head-no-job", reason: "required_evidence_incomplete", now })).toEqual({ failedQueueJobs: 0, retiredQueueJobs: 0 });
+    expect(store.getReviewReadiness(repo, 3, "head-no-job")).toMatchObject({ state: "failed", reason: "required_evidence_incomplete" });
+    const orphan = store.assignReviewerSessionJob({ repo, pullNumber: 4, headSha: "head-orphan", ttlMs: 60_000, headCountLimit: 1, now });
+    store.updateReviewerSessionJobState({ repo, pullNumber: 4, headSha: "head-orphan", jobState: "running", now });
+    store.quarantineIncompleteReviewEvidence({ repo, pullNumber: 4, headSha: "head-orphan", reason: "required_evidence_incomplete", now });
+    expect(store.getReviewerSessionJob(repo, 4, "head-orphan")).toMatchObject({ jobState: "failed", finishedAt: now.toISOString() });
+    expect(store.getReviewerSession(orphan.session!.sessionId)).toMatchObject({ state: "expired" });
+    expect(store.leaseNextReviewQueueJobs({ maxProviderActive: 2, maxOrgActive: 2, maxRepoActive: 2, now })).toEqual([expect.objectContaining({ jobId: unrelated.jobId, state: "leased" })]);
+    store.close();
+  });
+
   it("dry-runs and clears expired review queue leases without manual SQL", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-clear-"));
     roots.push(root);


### PR DESCRIPTION
Related: #882

Slice 1 of 3: state transaction primitives only.

Proof:
- exact base 8b2a6ce50863799d03ebb3bf6ff09f53fc2b0770
- 141 additions, 2 deletions
- state and scheduler focused suites: 175/175 passed with Node 26
- TypeScript build config and git diff --check passed

Safety:
- exact-head quarantine only
- preserves active leases and assigned/running session ownership
- terminal timestamps and retry deadline clearing
- superseded proof-blocked readiness becomes stale
- no runtime, live DB, config, worker, provider, customer, or review mutation