### PR TITLE
feat: add incomplete-evidence command decision primitive

### DIFF
--- a/src/evidence-decision.ts
+++ b/src/evidence-decision.ts
@@ -1,0 +1,92 @@
+import type { CommandConfig } from "./config.js";
+import {
+  collectReviewEventAuthorizationAttempts,
+  collectTrustedReviewCommands,
+  decideCommandAction,
+  isReviewCommandAction,
+  type CommandDecision,
+  type IssueCommentCommandSource,
+  type ReviewCommand
+} from "./commands.js";
+
+export type EvidenceRead =
+  | { status: "complete" | "truncated"; comments: IssueCommentCommandSource[] }
+  | { status: "failed" };
+
+export type EvidenceDecisionReason =
+  | "bounded_complete_no_command"
+  | "bounded_complete_trusted_command"
+  | "incomplete_evidence"
+  | "incomplete_uncapped_explicit_command"
+  | "incomplete_trusted_stop"
+  | "incomplete_uncapped_read_failed";
+
+export interface EvidenceCommandDecision {
+  decision: CommandDecision;
+  /** Automatic review authority. Explicit admitted commands may still be returned when false. */
+  evidenceComplete: boolean;
+  /** Literal, public-safe reason; never contains comment text, URLs, authors, or read errors. */
+  reason: EvidenceDecisionReason;
+}
+
+export function resolveEvidenceCommandDecision(input: {
+  config: CommandConfig;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  bounded: EvidenceRead;
+  uncapped?: EvidenceRead;
+  isProcessedCommand: (command: ReviewCommand) => boolean;
+}): EvidenceCommandDecision {
+  const boundedIds = new Set(input.bounded.status === "failed" ? [] : input.bounded.comments.map((comment) => comment.id));
+  const boundedCommands = trustedCommands(input.bounded, input);
+  let commands = boundedCommands;
+  let uncappedExplicit = false;
+  if (input.bounded.status !== "complete" && input.uncapped?.status === "complete") {
+    const uncappedCommands = trustedCommands(input.uncapped, input);
+    const additions = uncappedCommands.filter((command) => !boundedIds.has(command.commentId));
+    commands = [
+      ...boundedCommands,
+      ...additions.filter((command) => isReviewCommandAction(command.action) || command.action === "stop")
+    ];
+    uncappedExplicit = additions.some((command) => isReviewCommandAction(command.action));
+  }
+
+  const decision = decideCommandAction({
+    commands: dedupeCommands(commands),
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    hasProcessedCommand: (_repo, _pullNumber, _headSha, commentId) => {
+      const command = commands.find((candidate) => candidate.commentId === commentId);
+      return command ? input.isProcessedCommand(command) : false;
+    }
+  });
+  const evidenceComplete = input.bounded.status === "complete";
+  const reason: EvidenceDecisionReason = evidenceComplete
+    ? (decision.action === "none" ? "bounded_complete_no_command" : "bounded_complete_trusted_command")
+    : uncappedExplicit && decision.shouldReview
+      ? "incomplete_uncapped_explicit_command"
+      : decision.action === "stop"
+        ? "incomplete_trusted_stop"
+        : input.uncapped?.status === "failed"
+          ? "incomplete_uncapped_read_failed"
+          : "incomplete_evidence";
+  return { decision, evidenceComplete, reason };
+}
+
+function trustedCommands(read: EvidenceRead, input: { config: CommandConfig; repo: string; pullNumber: number; headSha: string }): ReviewCommand[] {
+  if (read.status === "failed") return [];
+  const collected = collectTrustedReviewCommands(read.comments, input.config).commands;
+  const requests = collectReviewEventAuthorizationAttempts(read.comments, input.config, input).reviewRequests;
+  const commands = [
+    ...collected,
+    ...requests.map((request) => ({ action: request.action, commentId: request.commentId, author: request.author, body: "" }))
+  ];
+  return commands.map((command) => ({ action: command.action, commentId: command.commentId, author: command.author, body: "" }));
+}
+
+function dedupeCommands(commands: ReviewCommand[]): ReviewCommand[] {
+  return [...new Map(commands.map((command) => [command.commentId, command])).values()]
+    .sort((left, right) => left.commentId - right.commentId);
+}

--- a/tests/evidence-decision.test.ts
+++ b/tests/evidence-decision.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { resolveEvidenceCommandDecision, type EvidenceRead } from "../src/evidence-decision.js";
+import type { CommandConfig } from "../src/config.js";
+import type { IssueCommentCommandSource } from "../src/commands.js";
+
+const config: CommandConfig = { enabled: true, botMentions: ["@neondiff"], trustedAuthors: ["owner"], acknowledge: false };
+const target = { repo: "owner/repo", pullNumber: 7, headSha: "a".repeat(40) };
+
+function comment(id: number, body?: string, login = "owner"): IssueCommentCommandSource {
+  return { id, body, user: { login } };
+}
+function read(status: "failed"): EvidenceRead;
+function read(status: "complete" | "truncated", comments: IssueCommentCommandSource[]): EvidenceRead;
+function read(status: EvidenceRead["status"], comments: IssueCommentCommandSource[] = []): EvidenceRead {
+  return status === "failed" ? { status } : { status, comments };
+}
+function decide(bounded: EvidenceRead, uncapped?: EvidenceRead) {
+  return resolveEvidenceCommandDecision({ ...target, config, bounded, uncapped, isProcessedCommand: () => false });
+}
+
+describe("evidence command decision", () => {
+  it("preserves a trusted stop when the redundant uncapped read fails", () => {
+    const result = decide(read("complete", [comment(1, "@neondiff stop")]), read("failed"));
+    expect(result.decision).toMatchObject({ action: "stop", shouldReview: false, commandId: 1 });
+    expect(result.evidenceComplete).toBe(true);
+    expect(result.reason).toBe("bounded_complete_trusted_command");
+  });
+
+  it("admits only a trusted explicit page-6 review from successful uncapped evidence", () => {
+    const bounded = Array.from({ length: 500 }, (_unused, index) => comment(index + 1));
+    const uncapped = [...bounded, comment(501, "@neondiff review")];
+    const result = decide(read("truncated", bounded), read("complete", uncapped));
+    expect(result.decision).toMatchObject({ action: "review", shouldReview: true, commandId: 501 });
+    expect(result.evidenceComplete).toBe(false);
+    expect(result.reason).toBe("incomplete_uncapped_explicit_command");
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  it("admits an exact-head trusted request-changes command beyond page 5", () => {
+    const bounded = Array.from({ length: 500 }, (_unused, index) => comment(index + 1));
+    const body = `@neondiff request-changes --repo ${target.repo} --pr ${target.pullNumber} --head ${target.headSha}`;
+    const result = decide(read("truncated", bounded), read("complete", [...bounded, comment(501, body)]));
+    expect(result.decision).toMatchObject({ action: "request-changes", shouldReview: true, commandId: 501 });
+  });
+
+  it("fails closed for inferred, untrusted, and failed incomplete evidence", () => {
+    const bounded = Array.from({ length: 500 }, (_unused, index) => comment(index + 1));
+    expect(decide(read("truncated", bounded), read("complete", [...bounded, comment(501, "@neondiff review", "stranger")]))).toMatchObject({
+      decision: { action: "none", shouldReview: false }, evidenceComplete: false
+    });
+    expect(decide(read("truncated", bounded), read("complete", [...bounded, comment(501, "discussion")])).decision.action).toBe("none");
+    expect(decide(read("failed"), read("failed")).evidenceComplete).toBe(false);
+  });
+
+  it("treats an explicitly complete 500-comment boundary as authoritative", () => {
+    const bounded = Array.from({ length: 500 }, (_unused, index) => comment(index + 1));
+    const result = decide(read("complete", bounded), read("failed"));
+    expect(result).toMatchObject({ evidenceComplete: true, decision: { action: "none", shouldReview: false } });
+  });
+
+  it("gives processed records precedence over otherwise admissible commands", () => {
+    const result = resolveEvidenceCommandDecision({
+      ...target, config, bounded: read("complete", [comment(9, "@neondiff review")]),
+      isProcessedCommand: (command) => command.commentId === 9
+    });
+    expect(result.decision).toEqual({ action: "none", shouldReview: false });
+  });
+});


### PR DESCRIPTION
Related: #882

Slice 2 of 3, stacked on #899: scheduler-independent evidence and command decision semantics.

Proof:
- 160 additions, zero deletions relative to slice 1
- state plus decision suites: 78/78 passed with Node 26
- focused TypeScript check, direct acceptance smoke, and git diff --check passed

Safety:
- complete bounded trusted stop remains authoritative
- successful uncapped evidence admits trusted explicit review or request-changes beyond page 5
- incomplete inferred, untrusted, and failed evidence remains fail-closed
- public-safe literal reasons only
- no scheduler, runtime, live state, config, or GitHub review mutation