### PR TITLE
fix(issue-enrichment): expose bounded progress heartbeat

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,11 @@ import { resolve } from "node:path";
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { GitHubApi } from "./github.js";
-import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
+import {
+  runIssueEnrichmentCycle,
+  type IssueEnrichmentCycleResult,
+  type IssueEnrichmentProgress
+} from "./issue-enrichment.js";
 import { runScheduledCycle } from "./scheduler.js";
 import {
   isAuthenticProductionLicenseAdmission,
@@ -52,9 +56,10 @@ export interface RunDaemonCycleOptions {
     configPath?: string;
     dryRun: boolean;
     licenseAdmission?: ProductionLicenseAdmission;
+    onProgress?: (progress: IssueEnrichmentProgress) => void;
   }) => Promise<IssueEnrichmentCycleResult>;
   cleanupReviewWorktreesImpl?: (options: { configPath?: string; dryRun: boolean }) => ReviewWorktreeCleanupSummary;
-  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
+  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string, recordedAt?: Date) => void;
   admitDaemonCycleImpl?: (configPath?: string) => Promise<DaemonCycleAdmissions | void>;
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
@@ -85,13 +90,14 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   const schedulerEnabled = input.reviewSchedulerEnabled === true;
   const runOnceImpl = input.runOnceImpl ?? (schedulerEnabled ? runScheduledCycle : runOnce);
   const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
-  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
+  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string, recordedAt?: Date) => {
     recordDaemonHeartbeatFromConfig({
       configPath: input.configPath,
       cycle: input.cycle,
       dryRun: input.dryRun,
       event,
       error,
+      recordedAt,
       stderr
     });
   });
@@ -119,7 +125,8 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     }
   }
 
-  recordHeartbeat("daemon_cycle_start");
+  const runStartedAt = new Date();
+  recordHeartbeat("daemon_cycle_start", undefined, runStartedAt);
   stdout(formatDaemonLog({
     event: "daemon_cycle_start",
     cycle: input.cycle,
@@ -131,7 +138,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, recordHeartbeat, runStartedAt, stdout, stderr })
     : Promise.resolve();
 
   try {
@@ -266,6 +273,8 @@ function summarizeWorktreeCleanup(cleanup: ReviewWorktreeCleanupSummary): Record
 async function runIssueEnrichmentLane(input: {
   input: RunDaemonCycleOptions;
   admissions: DaemonCycleAdmissions | void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string, recordedAt?: Date) => void;
+  runStartedAt: Date;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }): Promise<void> {
@@ -275,11 +284,38 @@ async function runIssueEnrichmentLane(input: {
     cycle: input.input.cycle,
     dryRun: input.input.dryRun
   }));
+  const progressStartedAt = Date.now();
+  const refreshHeartbeat = (): void => {
+    try {
+      input.recordHeartbeat("daemon_cycle_start", undefined, input.runStartedAt);
+    } catch (error) {
+      input.stderr(formatDaemonLog({
+        event: "daemon_heartbeat_failed",
+        level: "error",
+        cycle: input.input.cycle,
+        dryRun: input.input.dryRun,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    }
+  };
+  const heartbeatTimer = setInterval(refreshHeartbeat, 60_000);
   try {
     const issueEnrichment = await issueEnrichmentCycleImpl({
       configPath: input.input.configPath,
       dryRun: input.input.dryRun,
-      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
+      ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {}),
+      onProgress: (progress) => {
+        refreshHeartbeat();
+        input.stdout(formatDaemonLog({
+          event: "daemon_issue_enrichment_progress",
+          cycle: input.input.cycle,
+          dryRun: input.input.dryRun,
+          stage: progress.stage,
+          phase: progress.phase,
+          elapsedMs: Math.min(86_400_000, Math.max(0, Date.now() - progressStartedAt)),
+          ...(progress.count === undefined ? {} : { count: Math.min(10_000, Math.max(0, Math.trunc(progress.count))) })
+        }));
+      }
     });
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
@@ -297,6 +333,8 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       error: message
     }));
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 }
 
@@ -315,6 +353,7 @@ async function runIssueEnrichmentCycleFromConfig(input: {
   configPath?: string;
   dryRun: boolean;
   licenseAdmission?: ProductionLicenseAdmission;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   const config = loadConfig(input.configPath);
   let licenseAdmission = input.licenseAdmission;
@@ -336,7 +375,8 @@ async function runIssueEnrichmentCycleFromConfig(input: {
       state,
       github: new GitHubApi(config.github),
       dryRun: input.dryRun,
-      licenseAdmission
+      licenseAdmission,
+      onProgress: input.onProgress
     });
   } finally {
     state.close();
@@ -349,6 +389,7 @@ function recordDaemonHeartbeatFromConfig(input: {
   dryRun: boolean;
   event: DaemonHeartbeatEvent;
   error?: string;
+  recordedAt?: Date;
   stderr: (line: string) => void;
 }): void {
   try {
@@ -359,6 +400,7 @@ function recordDaemonHeartbeatFromConfig(input: {
         cycle: input.cycle,
         dryRun: input.dryRun,
         event: input.event,
+        ...(input.recordedAt ? { recordedAt: input.recordedAt } : {}),
         ...(input.error ? { error: input.error } : {})
       });
     } finally {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -287,7 +287,7 @@ async function runIssueEnrichmentLane(input: {
   const progressStartedAt = Date.now();
   const refreshHeartbeat = (): void => {
     try {
-      input.recordHeartbeat("daemon_cycle_start", undefined, input.runStartedAt);
+      input.recordHeartbeat("daemon_cycle_progress");
     } catch (error) {
       input.stderr(formatDaemonLog({
         event: "daemon_heartbeat_failed",

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -275,6 +275,19 @@ export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResu
   }>;
 }
 
+export const ISSUE_ENRICHMENT_PROGRESS_STAGES = [
+  "source_snapshot",
+  "github_evidence",
+  "analysis",
+  "post",
+  "persist"
+] as const;
+export interface IssueEnrichmentProgress {
+  stage: typeof ISSUE_ENRICHMENT_PROGRESS_STAGES[number];
+  phase: "start" | "complete";
+  count?: number;
+}
+
 type IssueEnrichmentComment = {
   id: number;
   html_url?: string | null;
@@ -795,6 +808,7 @@ export async function runIssueEnrichmentCycle(input: {
   preacquiredLease?: { leaseId: string };
   licenseAdmission?: ProductionLicenseAdmission;
   analyzeIssue?: IssueAnalysisRunner;
+  onProgress?: (progress: IssueEnrichmentProgress) => void;
 }): Promise<IssueEnrichmentCycleResult> {
   if (!input.licenseAdmission) throw new Error("production license admission is required for issue enrichment cycles");
   if (!isAuthenticProductionLicenseAdmission(input.licenseAdmission, "issue_enrichment")) {
@@ -802,6 +816,16 @@ export async function runIssueEnrichmentCycle(input: {
   }
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const reportProgress = (progress: IssueEnrichmentProgress): void => {
+    try {
+      input.onProgress?.({
+        ...progress,
+        ...(progress.count === undefined ? {} : { count: Math.min(10_000, Math.max(0, Math.trunc(progress.count))) })
+      });
+    } catch {
+      // Diagnostic progress must never change issue-enrichment semantics.
+    }
+  };
   const shouldCollectModelEvidence = !input.dryRun && config.postIssueComment && input.analyzeIssue === undefined;
   const renderPolicy = resolveIssueEnrichmentRenderPolicy(input.config);
   const releasePreacquiredLeaseBeforeRun = () => {
@@ -922,6 +946,7 @@ export async function runIssueEnrichmentCycle(input: {
 
     const sourceSnapshots = new Map<string, PreparedWorktree>();
     const defaultBranches = new Map<string, string>();
+    reportProgress({ stage: "source_snapshot", phase: "start", count: reposToScan.length });
     if (shouldCollectModelEvidence) {
       if (!input.config.workRoot) throw new Error("issue_enrichment_model_runtime_paths_required");
       if (!input.github.getRepo) throw new Error("issue_enrichment_repository_metadata_required");
@@ -941,6 +966,7 @@ export async function runIssueEnrichmentCycle(input: {
         defaultBranches.set(repo.toLowerCase(), defaultBranch);
       }
     }
+    reportProgress({ stage: "source_snapshot", phase: "complete", count: sourceSnapshots.size });
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
     const issueEvidenceContextByIssue = new Map<string, IssueAnalysisEvidenceContext>();
@@ -1005,6 +1031,7 @@ export async function runIssueEnrichmentCycle(input: {
         : undefined;
       return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action));
     };
+    reportProgress({ stage: "github_evidence", phase: "start", count: reposToScan.length });
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
           config: input.config,
@@ -1057,6 +1084,7 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
+    reportProgress({ stage: "github_evidence", phase: "complete", count: scanned.summary.issuesSeen });
     applyGlobalIssueEnrichmentCaps({
       items: scanned.items,
       repoScans: scanned.repos,
@@ -1207,6 +1235,7 @@ export async function runIssueEnrichmentCycle(input: {
           return result.analysis;
         });
         const runtime = input.config.codexRuntime;
+        reportProgress({ stage: "analysis", phase: "start" });
         const analysis = await analyzer({
           repo: item.repo,
           issue,
@@ -1223,6 +1252,7 @@ export async function runIssueEnrichmentCycle(input: {
           timeoutMs: runtime?.timeoutMs ?? 1,
           maxOutputBytes: runtime?.maxOutputBytes ?? 1
         });
+        reportProgress({ stage: "analysis", phase: "complete" });
         if (!input.github.getIssueOrPull && input.analyzeIssue === undefined) {
           throw new Error("issue_enrichment_current_issue_read_required");
         }
@@ -1267,6 +1297,7 @@ export async function runIssueEnrichmentCycle(input: {
           });
           continue;
         }
+        reportProgress({ stage: "post", phase: "start" });
         const post = await postEnrichmentComment({
           enabled: true,
           dryRun: false,
@@ -1275,6 +1306,7 @@ export async function runIssueEnrichmentCycle(input: {
           pullNumber: item.issueNumber,
           enrichment
         });
+        reportProgress({ stage: "post", phase: "complete" });
         if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.reason}`);
         const commentUrl = post.html_url ? redactSecrets(post.html_url) : undefined;
         input.state.recordIssueEnrichment({
@@ -1306,6 +1338,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
     }
 
+    reportProgress({ stage: "persist", phase: "start" });
     if (!input.dryRun && input.advanceWatermarks !== false) {
       for (const repo of scanned.repos) {
         if (!repo.allowed || !repo.ok || repo.baselined) continue;
@@ -1320,6 +1353,7 @@ export async function runIssueEnrichmentCycle(input: {
         });
       }
     }
+    reportProgress({ stage: "persist", phase: "complete" });
 
     return {
       ...scan,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -3010,11 +3010,12 @@ function readHeartbeatStatus(
     const activeStartedTime = row.started_at ? Date.parse(row.started_at) : NaN;
     const hasActiveCycle =
       Number.isFinite(activeStartedTime) &&
-      (!Number.isFinite(latestTime) || activeStartedTime > latestTime);
+      (row.event === "daemon_cycle_progress" || !Number.isFinite(latestTime) || activeStartedTime > latestTime);
     if (hasActiveCycle) {
       const activeAgeMs = Math.max(0, now.getTime() - activeStartedTime);
+      const livenessAgeMs = Math.max(0, now.getTime() - Math.max(activeStartedTime, row.event === "daemon_cycle_progress" ? latestTime : 0));
       return {
-        status: activeAgeMs <= activeMaxAgeMs ? "active" : "stale",
+        status: livenessAgeMs <= activeMaxAgeMs ? "active" : "stale",
         maxAgeMs,
         activeMaxAgeMs,
         ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),

--- a/src/state.ts
+++ b/src/state.ts
@@ -336,7 +336,7 @@ export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecor
   expired: boolean;
 }
 
-export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_complete" | "daemon_cycle_failed";
+export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete" | "daemon_cycle_failed";
 
 export interface DaemonHeartbeatRecord {
   cycle: number;

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -566,6 +566,45 @@ describe("daemon cycle resilience", () => {
     ]));
   });
 
+  it("refreshes one bounded active heartbeat while issue enrichment progresses", async () => {
+    const heartbeats: Array<{ event: string; startedAt?: string }> = [];
+    const stdout: string[] = [];
+    const timers: Array<() => void> = [];
+    const timerSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((callback) => (timers.push(callback as () => void), 1 as never));
+    let cleared = 0;
+    const clearSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => { cleared += 1; });
+    try {
+      await runDaemonCycle({
+        cycle: 13,
+        dryRun: false,
+        pilotRepos: [],
+        monitoredRepos: [],
+        canaryPulls: [],
+        commandsEnabled: false,
+        reviewSchedulerEnabled: true,
+        issueEnrichmentEnabled: true,
+        runOnceImpl: async () => successfulRunOnceResult(),
+        issueEnrichmentCycleImpl: async (options) => {
+          timers[0]?.();
+          options.onProgress?.({ stage: "analysis", phase: "start", count: 99_999 });
+          return successfulIssueEnrichmentCycleResult();
+        },
+        recordHeartbeatImpl: (event, _error, recordedAt) => heartbeats.push({ event, startedAt: recordedAt?.toISOString() }),
+        stdout: (line) => stdout.push(line),
+        stderr: () => undefined
+      });
+    } finally {
+      timerSpy.mockRestore();
+      clearSpy.mockRestore();
+    }
+
+    expect(new Set(heartbeats.filter(({ event }) => event === "daemon_cycle_start").map(({ startedAt }) => startedAt)).size).toBe(1);
+    expect(cleared).toBe(1);
+    const progress = stdout.map((line) => JSON.parse(line)).find((line) => line.event === "daemon_issue_enrichment_progress");
+    expect(progress).toMatchObject({ stage: "analysis", phase: "start", count: 10_000 });
+    expect(JSON.stringify(progress)).not.toMatch(/body|comment|provider|credential|path|repo/i);
+  });
+
   it("waits for issue-lane cleanup before returning a review failure", async () => {
     let releaseIssue!: () => void;
     const issueBarrier = new Promise<void>((resolve) => { releaseIssue = resolve; });

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -599,6 +599,7 @@ describe("daemon cycle resilience", () => {
     }
 
     expect(new Set(heartbeats.filter(({ event }) => event === "daemon_cycle_start").map(({ startedAt }) => startedAt)).size).toBe(1);
+    expect(heartbeats.some(({ event }) => event === "daemon_cycle_progress")).toBe(true);
     expect(cleared).toBe(1);
     const progress = stdout.map((line) => JSON.parse(line)).find((line) => line.event === "daemon_issue_enrichment_progress");
     expect(progress).toMatchObject({ stage: "analysis", phase: "start", count: 10_000 });

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -965,6 +965,7 @@ describe("sticky enrichment comments", () => {
       const state = new ReviewStateStore(statePath);
       let analysisCalls = 0;
       let postCalls = 0;
+      const progressStages: string[] = [];
       try {
         const promotedIssue: GitHubRelatedIssueOrPull = {
           number: 127,
@@ -996,6 +997,7 @@ describe("sticky enrichment comments", () => {
           dryRun: false,
           includeExisting: true,
           checkedAt: "2026-08-16T10:02:00.000Z",
+          onProgress: ({ stage }) => progressStages.push(stage),
           analyzeIssue: async ({ issue }) => {
             analysisCalls += 1;
             return fixtureIssueAnalysis(issue);
@@ -1005,6 +1007,7 @@ describe("sticky enrichment comments", () => {
         expect(result.summary).toMatchObject({ posted: 1, failed: 0 });
         expect(analysisCalls).toBe(1);
         expect(postCalls).toBe(1);
+        expect(new Set(progressStages)).toEqual(new Set(["source_snapshot", "github_evidence", "analysis", "post", "persist"]));
       } finally {
         state.close();
       }

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6950,14 +6950,14 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         status: "active",
         maxAgeMs: 120_000,
         activeMaxAgeMs: 420_000,
-        latestAt: "2026-06-30T23:57:00.000Z",
-        ageMs: 180_000,
+        latestAt: "2026-06-30T23:59:30.000Z",
+        ageMs: 30_000,
         cycle: 5,
-        event: "daemon_cycle_complete",
+        event: "daemon_cycle_progress",
         dryRun: false,
         activeCycle: 6,
-        activeStartedAt: "2026-06-30T23:59:00.000Z",
-        activeAgeMs: 60_000
+        activeStartedAt: "2026-06-30T23:50:00.000Z",
+        activeAgeMs: 600_000
       },
       now: new Date("2026-07-01T00:00:00.000Z")
     });
@@ -6966,7 +6966,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     expect(status.gates).toContainEqual({
       name: "daemon_heartbeat_recent",
       ok: true,
-      detail: "active; active age 60000ms; max 420000ms; started cycle 6; last event daemon_cycle_complete; last cycle 5"
+      detail: "active; active age 600000ms; max 420000ms; started cycle 6; last event daemon_cycle_progress; last cycle 5"
     });
   });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1670,6 +1670,23 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("preserves same-run progress age but starts a restarted cycle fresh", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-run-identity-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const firstRun = new Date("2026-07-01T00:00:00.000Z");
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: firstRun });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: firstRun });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T00:10:00.000Z") });
+    expect(store.getDaemonHeartbeat()).toMatchObject({ startedCycle: 1, startedAt: firstRun.toISOString() });
+
+    const restarted = new Date("2026-07-01T01:00:00.000Z");
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: restarted });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T01:10:00.000Z") });
+    expect(store.getDaemonHeartbeat()).toMatchObject({ startedCycle: 1, startedAt: restarted.toISOString() });
+    store.close();
+  });
+
   it("redacts daemon heartbeat errors", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-redact-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1677,6 +1677,10 @@ describe("review state store", () => {
     const firstRun = new Date("2026-07-01T00:00:00.000Z");
     store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: firstRun });
     store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_start", dryRun: false, recordedAt: firstRun });
+    store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_progress", dryRun: false, recordedAt: new Date("2026-07-01T00:09:00.000Z") });
+    expect(store.getDaemonHeartbeat()).toMatchObject({
+      event: "daemon_cycle_progress", recordedAt: "2026-07-01T00:09:00.000Z", startedAt: firstRun.toISOString()
+    });
     store.recordDaemonHeartbeat({ cycle: 1, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T00:10:00.000Z") });
     expect(store.getDaemonHeartbeat()).toMatchObject({ startedCycle: 1, startedAt: firstRun.toISOString() });
 


### PR DESCRIPTION
Related: #808
Parent runtime tracker: #738
GA tracker: #610

## Outcome

Issue enrichment now refreshes the existing daemon heartbeat every 60 seconds and at bounded progress transitions. Each refresh preserves one run-start timestamp, so active age remains honest rather than resetting. Progress logs expose only fixed stage/phase enums, bounded counts, and bounded elapsed time.

The five stages are `source_snapshot`, `github_evidence`, `analysis`, `post`, and `persist`. Progress callbacks are diagnostic-only: callback failures cannot change issue-enrichment results. Existing lease, watermark, exact-head, idempotency, posting, and historical-row semantics are unchanged.

## Failing-first and validation proof

On base `8b2a6ce50863799d03ebb3bf6ff09f53fc2b0770`, focused tests first failed because no progress was emitted and the enrichment lane did not create or clear a refresh timer. The unchanged candidate then passed:

- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/daemon-loop.test.ts tests/enrichment.test.ts tests/state.test.ts` — 159 passed.
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin /opt/homebrew/bin/npm run build` — passed.
- `git diff --check` — passed.

## Change envelope

Five files, 142 insertions and 7 deletions (149 changed lines). This is a clean current-main successor, not based on or cherry-picked from held issue-enrichment PRs.

## Proof boundary

Agent-authored source and deterministic test change only. It does not merge, release, install, restart, signal, reconfigure, or inspect the live beta.87 worker; mutate live config, database, leases, queue, or watermarks; retry historical failures; or prove packaged/runtime/customer adoption. GitNexus pre-edit impact for the three daemon seams was LOW, while post-change detection was marked HIGH by an index that explicitly warned it was 152 commits stale; exact current source, focused tests, and current-head CI are the authoritative proof boundary.