### PR TITLE
Carry exact GitHub installation identity in doctor proof

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3313,6 +3313,7 @@ async function buildDoctorGithubReport(
     monitoredRepos,
     activeRepoChecks,
     appCredentials: {
+      appId: credentials?.appId ?? config.github.appId ?? null,
       appIdConfigured: Boolean(credentials?.appId ?? config.github.appId),
       privateKeyConfigured: Boolean(credentials?.privateKey ?? config.github.privateKeyPath),
       fallbackTokenConfigured: Boolean(config.github.token),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3253,7 +3253,12 @@ async function buildDoctorGithubReport(
       const gatePreview = buildDoctorGithubLicenseGatePreview(config, proof);
       readChecks.push({
         repo,
-        ok: proof.app_can_read_metadata && proof.app_can_read_pull_requests,
+        ok: proof.app_can_read_metadata
+          && proof.app_can_read_pull_requests
+          && proof.repository_identity_verified
+          && proof.installation_account_verified
+          && proof.app_identity_verified
+          && proof.bot_identity_verified,
         policy,
         ...proof,
         ...gatePreview

--- a/src/github.ts
+++ b/src/github.ts
@@ -85,6 +85,8 @@ export interface GitHubRepositoryAccessProof {
   visibility_result: GitHubRepositoryVisibility;
   visibility_source: GitHubRepositoryVisibilitySource;
   installation_id_present: boolean;
+  installation_id?: number;
+  installation_account?: string;
   app_can_read_metadata: boolean;
   app_can_read_pull_requests: boolean;
   openPullCount?: number;
@@ -198,25 +200,37 @@ export class GitHubApi {
       };
     }
 
-    let installationId: number;
+    let installation: { id: number; account_login?: string };
     try {
-      installationId = await this.getInstallationId(repo, { followRedirects: false });
+      installation = await this.getInstallation(repo, { followRedirects: false });
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
 
     let token: string;
     try {
-      token = await this.getInstallationTokenForId(repo, installationId);
+      token = await this.getInstallationTokenForId(repo, installation.id);
     } catch (error) {
-      return { ...base, installation_id_present: true, ...describeGitHubAccessError(error) };
+      return {
+        ...base,
+        installation_id_present: true,
+        installation_id: installation.id,
+        ...(installation.account_login ? { installation_account: installation.account_login } : {}),
+        ...describeGitHubAccessError(error)
+      };
     }
 
     let metadata: RepositorySummary;
     try {
       metadata = await this.request<RepositorySummary>(`/repos/${repo}`, { token, followRedirects: false });
     } catch (error) {
-      return { ...base, installation_id_present: true, ...describeGitHubAccessError(error) };
+      return {
+        ...base,
+        installation_id_present: true,
+        installation_id: installation.id,
+        ...(installation.account_login ? { installation_account: installation.account_login } : {}),
+        ...describeGitHubAccessError(error)
+      };
     }
 
     const visibility = visibilityFromRepositorySummary(metadata);
@@ -228,6 +242,8 @@ export class GitHubApi {
         visibility_result: visibility.result,
         visibility_source: visibility.source,
         installation_id_present: true,
+        installation_id: installation.id,
+        ...(installation.account_login ? { installation_account: installation.account_login } : {}),
         app_can_read_metadata: true,
         app_can_read_pull_requests: true,
         openPullCount: pulls.length
@@ -239,6 +255,8 @@ export class GitHubApi {
         visibility_result: visibility.result,
         visibility_source: visibility.source,
         installation_id_present: true,
+        installation_id: installation.id,
+        ...(installation.account_login ? { installation_account: installation.account_login } : {}),
         app_can_read_metadata: true,
         app_can_read_pull_requests: false,
         ...describeGitHubAccessError(error)
@@ -507,18 +525,24 @@ export class GitHubApi {
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
-    const installationId = await this.getInstallationId(repo);
-    return this.getInstallationTokenForId(repo, installationId);
+    const installation = await this.getInstallation(repo);
+    return this.getInstallationTokenForId(repo, installation.id);
   }
 
-  private async getInstallationId(repo: string, options: { followRedirects?: boolean } = {}): Promise<number> {
+  private async getInstallation(
+    repo: string,
+    options: { followRedirects?: boolean } = {}
+  ): Promise<{ id: number; account_login?: string }> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    const installation = await this.request<{ id: number }>(`/repos/${repo}/installation`, {
+    const installation = await this.request<{ id: number; account?: { login?: string } }>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
-    return installation.id;
+    return {
+      id: installation.id,
+      ...(installation.account?.login ? { account_login: installation.account.login } : {})
+    };
   }
 
   private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {

--- a/src/github.ts
+++ b/src/github.ts
@@ -81,12 +81,19 @@ export type GitHubRepositoryAccessErrorClass =
 
 export interface GitHubRepositoryAccessProof {
   repo_full_name: string;
+  app_id?: string;
+  verified_app_id?: number;
+  bot_login?: string;
   readMode: "app_installation" | "fallback_token" | "unconfigured";
   visibility_result: GitHubRepositoryVisibility;
   visibility_source: GitHubRepositoryVisibilitySource;
   installation_id_present: boolean;
   installation_id?: number;
   installation_account?: string;
+  repository_identity_verified: boolean;
+  installation_account_verified: boolean;
+  app_identity_verified: boolean;
+  bot_identity_verified: boolean;
   app_can_read_metadata: boolean;
   app_can_read_pull_requests: boolean;
   openPullCount?: number;
@@ -185,10 +192,15 @@ export class GitHubApi {
     const readMode = this.canPostAsApp() ? "app_installation" : this.token ? "fallback_token" : "unconfigured";
     const base: GitHubRepositoryAccessProof = {
       repo_full_name: repo,
+      app_id: this.appId,
       readMode,
       visibility_result: "unknown",
       visibility_source: "unavailable",
       installation_id_present: false,
+      repository_identity_verified: false,
+      installation_account_verified: false,
+      app_identity_verified: false,
+      bot_identity_verified: false,
       app_can_read_metadata: false,
       app_can_read_pull_requests: false
     };
@@ -200,12 +212,38 @@ export class GitHubApi {
       };
     }
 
-    let installation: { id: number; account_login?: string };
+    let installation: { id: number; account_login?: string; app_id?: number; app_slug?: string };
     try {
       installation = await this.getInstallation(repo, { followRedirects: false });
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
+
+    const requestedRepo = canonicalGitHubRepo(repo);
+    const requestedOwner = requestedRepo.split("/")[0] ?? "";
+    const botLogin = installation.app_slug
+      ? `${installation.app_slug.replace(/\[bot\]$/i, "")}[bot]`
+      : undefined;
+    const identity = (metadata?: RepositorySummary) => ({
+      app_id: this.appId,
+      ...(installation.app_id === undefined ? {} : { verified_app_id: installation.app_id }),
+      ...(botLogin ? { bot_login: botLogin } : {}),
+      repository_identity_verified: Boolean(
+        requestedRepo && metadata?.full_name && canonicalGitHubRepo(metadata.full_name) === requestedRepo
+      ),
+      installation_account_verified: Boolean(
+        requestedOwner && installation.account_login
+          && installation.account_login.trim().toLowerCase() === requestedOwner
+      ),
+      app_identity_verified: Boolean(
+        this.appId && installation.app_id !== undefined
+          && String(installation.app_id) === this.appId.trim()
+      ),
+      bot_identity_verified: Boolean(
+        botLogin && this.botLogin
+          && botLogin.trim().toLowerCase() === this.botLogin.trim().toLowerCase()
+      )
+    });
 
     let token: string;
     try {
@@ -216,6 +254,7 @@ export class GitHubApi {
         installation_id_present: true,
         installation_id: installation.id,
         ...(installation.account_login ? { installation_account: installation.account_login } : {}),
+        ...identity(),
         ...describeGitHubAccessError(error)
       };
     }
@@ -229,6 +268,7 @@ export class GitHubApi {
         installation_id_present: true,
         installation_id: installation.id,
         ...(installation.account_login ? { installation_account: installation.account_login } : {}),
+        ...identity(),
         ...describeGitHubAccessError(error)
       };
     }
@@ -238,6 +278,7 @@ export class GitHubApi {
       const pulls = await this.listOpenPullsWithToken(repo, token, { followRedirects: false });
       return {
         repo_full_name: metadata.full_name || repo,
+        ...identity(metadata),
         readMode,
         visibility_result: visibility.result,
         visibility_source: visibility.source,
@@ -251,6 +292,7 @@ export class GitHubApi {
     } catch (error) {
       return {
         repo_full_name: metadata.full_name || repo,
+        ...identity(metadata),
         readMode,
         visibility_result: visibility.result,
         visibility_source: visibility.source,
@@ -532,16 +574,23 @@ export class GitHubApi {
   private async getInstallation(
     repo: string,
     options: { followRedirects?: boolean } = {}
-  ): Promise<{ id: number; account_login?: string }> {
+  ): Promise<{ id: number; account_login?: string; app_id?: number; app_slug?: string }> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    const installation = await this.request<{ id: number; account?: { login?: string } }>(`/repos/${repo}/installation`, {
+    const installation = await this.request<{
+      id: number;
+      account?: { login?: string };
+      app_id?: number;
+      app_slug?: string;
+    }>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
     return {
       id: installation.id,
-      ...(installation.account?.login ? { account_login: installation.account.login } : {})
+      ...(installation.account?.login ? { account_login: installation.account.login } : {}),
+      ...(installation.app_id === undefined ? {} : { app_id: installation.app_id }),
+      ...(installation.app_slug ? { app_slug: installation.app_slug } : {})
     };
   }
 
@@ -663,6 +712,12 @@ function normalizePullRepoSummary<T extends PullRequestSummary["base"]["repo"]>(
     ...repo,
     ...(visibility ? { visibility } : {})
   };
+}
+
+function canonicalGitHubRepo(repo: string): string {
+  const [owner, name, extra] = repo.trim().split("/");
+  if (extra !== undefined || !owner || !name) return "";
+  return `${owner.toLowerCase()}/${name.toLowerCase()}`;
 }
 
 function visibilityFromRepositorySummary(repository: RepositorySummary): {

--- a/src/github.ts
+++ b/src/github.ts
@@ -143,6 +143,7 @@ export class GitHubApi {
   private readonly privateKey?: string;
   private readonly token?: string;
   private readonly apiBaseUrl: URL;
+  private readonly configuredBotLogin?: string;
   private readonly botLogin: string;
   private readonly requestTimeoutMs: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
@@ -156,7 +157,8 @@ export class GitHubApi {
     this.privateKey = options.privateKey ?? (options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined);
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
-    this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
+    this.configuredBotLogin = options.botLogin?.trim() || undefined;
+    this.botLogin = this.configuredBotLogin ?? DEFAULT_BOT_LOGIN;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
   }
 
@@ -240,8 +242,8 @@ export class GitHubApi {
           && String(installation.app_id) === this.appId.trim()
       ),
       bot_identity_verified: Boolean(
-        botLogin && this.botLogin
-          && botLogin.trim().toLowerCase() === this.botLogin.trim().toLowerCase()
+        botLogin && (!this.configuredBotLogin
+          || botLogin.trim().toLowerCase() === this.configuredBotLogin.toLowerCase())
       )
     });
 

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -27,7 +27,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, account: { login: "owner" } });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -261,7 +261,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, account: { login: "owner" } });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -284,6 +284,8 @@ describe("GitHub App read authentication", () => {
       visibility_result: "public",
       visibility_source: "repository_api",
       installation_id_present: true,
+      installation_id: 123,
+      installation_account: "owner",
       app_can_read_metadata: true,
       app_can_read_pull_requests: true,
       openPullCount: 1

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -261,7 +261,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" });
+        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "customer-neondiff-review-app" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -288,7 +288,7 @@ describe("GitHub App read authentication", () => {
       installation_account: "owner",
       app_id: "4184532",
       verified_app_id: 4184532,
-      bot_login: "evaos-code-review-bot[bot]",
+      bot_login: "customer-neondiff-review-app[bot]",
       repository_identity_verified: true,
       installation_account_verified: true,
       app_identity_verified: true,
@@ -309,9 +309,9 @@ describe("GitHub App read authentication", () => {
     const privateKeyPath = join(root, "app.pem");
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
     const cases = [
-      { name: "missing installation account", installation: { id: 123, app_id: 4184532, app_slug: "evaos-code-review-bot" }, metadata: "owner/repo", failed: "installation_account_verified" },
+      { name: "missing installation account", installation: { id: 123, app_id: 4184532 }, metadata: "owner/repo", failed: "installation_account_verified" },
       { name: "mismatched installation account", installation: { id: 123, account: { login: "other" }, app_id: 4184532, app_slug: "evaos-code-review-bot" }, metadata: "owner/repo", failed: "installation_account_verified" },
-      { name: "mismatched repository metadata", installation: { id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" }, metadata: "other/repo", failed: "repository_identity_verified" },
+      { name: "mismatched repository metadata", installation: { id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "customer-neondiff-review-app" }, metadata: "other/repo", failed: "repository_identity_verified" },
       { name: "mismatched App identity", installation: { id: 123, account: { login: "owner" }, app_id: 999, app_slug: "evaos-code-review-bot" }, metadata: "owner/repo", failed: "app_identity_verified" },
       { name: "mismatched bot identity", installation: { id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "other-app" }, metadata: "owner/repo", failed: "bot_identity_verified" }
     ] as const;
@@ -330,12 +330,15 @@ describe("GitHub App read authentication", () => {
         return jsonResponse({ message: `unexpected ${scenario.name}` }, 404);
       }) as typeof fetch;
 
-      const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+      const github = new GitHubApi({ appId: "4184532", privateKeyPath,
+        ...(scenario.name === "mismatched repository metadata" || scenario.name === "mismatched bot identity"
+          ? { botLogin: "customer-neondiff-review-app[bot]" } : {}) });
       const proof = await github.probeRepositoryAccess("owner/repo");
       expect(proof).toMatchObject({
         app_can_read_metadata: true,
         app_can_read_pull_requests: true,
-        [scenario.failed]: false
+        [scenario.failed]: false,
+        bot_identity_verified: scenario.name !== "mismatched bot identity" && scenario.name !== "missing installation account"
       });
     }
   });

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -27,7 +27,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, account: { login: "owner" } });
+        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -261,7 +261,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, account: { login: "owner" } });
+        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -286,6 +286,13 @@ describe("GitHub App read authentication", () => {
       installation_id_present: true,
       installation_id: 123,
       installation_account: "owner",
+      app_id: "4184532",
+      verified_app_id: 4184532,
+      bot_login: "evaos-code-review-bot[bot]",
+      repository_identity_verified: true,
+      installation_account_verified: true,
+      app_identity_verified: true,
+      bot_identity_verified: true,
       app_can_read_metadata: true,
       app_can_read_pull_requests: true,
       openPullCount: 1
@@ -293,6 +300,44 @@ describe("GitHub App read authentication", () => {
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo"))?.authorization).toBe("Bearer installation-token");
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"))?.authorization)
       .toBe("Bearer installation-token");
+  });
+
+  it("fails closed when repository, installation, App, or bot identity mismatches", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-identity-boundary-"));
+    roots.push(root);
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPath = join(root, "app.pem");
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    const cases = [
+      { name: "missing installation account", installation: { id: 123, app_id: 4184532, app_slug: "evaos-code-review-bot" }, metadata: "owner/repo", failed: "installation_account_verified" },
+      { name: "mismatched installation account", installation: { id: 123, account: { login: "other" }, app_id: 4184532, app_slug: "evaos-code-review-bot" }, metadata: "owner/repo", failed: "installation_account_verified" },
+      { name: "mismatched repository metadata", installation: { id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" }, metadata: "other/repo", failed: "repository_identity_verified" },
+      { name: "mismatched App identity", installation: { id: 123, account: { login: "owner" }, app_id: 999, app_slug: "evaos-code-review-bot" }, metadata: "owner/repo", failed: "app_identity_verified" },
+      { name: "mismatched bot identity", installation: { id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "other-app" }, metadata: "owner/repo", failed: "bot_identity_verified" }
+    ] as const;
+
+    for (const scenario of cases) {
+      globalThis.fetch = vi.fn(async (url) => {
+        const requestUrl = String(url);
+        if (requestUrl.endsWith("/repos/owner/repo/installation")) return jsonResponse(scenario.installation);
+        if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
+          return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+        }
+        if (requestUrl.endsWith("/repos/owner/repo")) {
+          return jsonResponse({ full_name: scenario.metadata, private: false, visibility: "public" });
+        }
+        if (requestUrl.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1")) return jsonResponse([]);
+        return jsonResponse({ message: `unexpected ${scenario.name}` }, 404);
+      }) as typeof fetch;
+
+      const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+      const proof = await github.probeRepositoryAccess("owner/repo");
+      expect(proof).toMatchObject({
+        app_can_read_metadata: true,
+        app_can_read_pull_requests: true,
+        [scenario.failed]: false
+      });
+    }
   });
 
   it("classifies App install-scope and visibility lookup failures without treating them as public", async () => {
@@ -429,7 +474,7 @@ describe("GitHub App read authentication", () => {
       const redirect = init?.redirect;
       calls.push({ url: requestUrl, method, redirect });
       if (requestUrl.endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" });
       }
       if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -788,7 +833,9 @@ function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
 
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {
   return (url: string) => {
-    if (url.endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+    if (url.endsWith("/repos/owner/repo/installation")) {
+      return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 4184532, app_slug: "evaos-code-review-bot" });
+    }
     if (url.endsWith("/app/installations/123/access_tokens")) {
       return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
     }

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1524,7 +1524,7 @@ exit 1
       const url = new URL(request.url ?? "/", "http://localhost");
       response.setHeader("Content-Type", "application/json");
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
-        response.end(JSON.stringify({ id: 42, account: { login: "acme" } }));
+        response.end(JSON.stringify({ id: 42, account: { login: "acme" }, app_id: 12345, app_slug: "evaos-code-review-bot" }));
         return;
       }
       if (request.method === "POST" && url.pathname === "/app/installations/42/access_tokens") {
@@ -1639,6 +1639,13 @@ exit 1
               installation_id_present: true,
               installation_id: 42,
               installation_account: "acme",
+              app_id: "12345",
+              verified_app_id: 12345,
+              bot_login: "evaos-code-review-bot[bot]",
+              repository_identity_verified: true,
+              installation_account_verified: true,
+              app_identity_verified: true,
+              bot_identity_verified: true,
               app_can_read_metadata: true,
               app_can_read_pull_requests: true,
               license_gate_decision: "active_public_entitlement_required",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1524,7 +1524,7 @@ exit 1
       const url = new URL(request.url ?? "/", "http://localhost");
       response.setHeader("Content-Type", "application/json");
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
-        response.end(JSON.stringify({ id: 42 }));
+        response.end(JSON.stringify({ id: 42, account: { login: "acme" } }));
         return;
       }
       if (request.method === "POST" && url.pathname === "/app/installations/42/access_tokens") {
@@ -1621,6 +1621,7 @@ exit 1
         monitoredRepos: ["acme/demo"],
         activeRepoChecks: 1,
         appCredentials: {
+          appId: "12345",
           appIdConfigured: true,
           privateKeyConfigured: true,
           fallbackTokenConfigured: false
@@ -1636,6 +1637,8 @@ exit 1
               visibility_result: "public",
               visibility_source: "repository_api",
               installation_id_present: true,
+              installation_id: 42,
+              installation_account: "acme",
               app_can_read_metadata: true,
               app_can_read_pull_requests: true,
               license_gate_decision: "active_public_entitlement_required",


### PR DESCRIPTION
## Summary

- Include the configured App ID in the doctor report.
- Carry the exact installation ID and GitHub account login from the repository installation response through repository access proof.
- Keep failure paths fail-closed while preserving existing visibility and read checks.

Closes #872.

## Validation

- npm test -- --run tests/github-app-read.test.ts tests/public-cli.test.ts: 131 passed
- git diff --check

This is the dependency-first contract PR for the Swift consumer successor.