### PR TITLE
Bind BYO verification to current GitHub installation

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -755,6 +755,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     private var accountLinkTask: Task<Void, Never>?
     private var mostRecentAccountLinkTask: Task<Void, Never>?
     private var accountLinkGeneration: UInt64 = 0
+    private var byoGitHubVerificationGeneration: UInt64 = 0
+    private var byoGitHubVerificationTask: Task<Void, Never>?
     private var attemptedAutomaticAccountWorkspaceRefresh = false
     private var pendingManagedGitHubAuthorization: PendingManagedGitHubAuthorization?
     private var githubRepositoryRefreshGate = GitHubLatestRequestGate()
@@ -1900,6 +1902,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
         pendingBYOGitHubAppId = ""
         pendingBYOGitHubAppPrivateKey = ""
         byoGitHubCredentialRevision &+= 1
+        byoGitHubVerificationGeneration &+= 1
+        byoGitHubVerificationTask?.cancel()
         isBYOGitHubVerificationInProgress = false
         isScopedReviewInProgress = false
         pendingReviewPullNumber = ""
@@ -3212,6 +3216,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         invalidateScopedReviewApproval()
+        invalidateBYOGitHubVerificationContext()
         invalidateActivationForRepositoryChange(fullReset: true)
         selectedBYOReviewRepository = repository.name
         dependencies.preferences.set(
@@ -3752,6 +3757,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             byoGitHubCredentialStatus = lastError ?? "Account check required"
             return
         }
+        let verificationWasInProgress = isBYOGitHubVerificationInProgress
         byoGitHubCredentialRevision &+= 1
         invalidateBYOGitHubVerificationContext()
         guard byoGitHubCredentialOnboardingAvailable else {
@@ -3775,7 +3781,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             pendingBYOGitHubAppId = appId
             byoGitHubPrivateKeyStored = true
             lastError = nil
-            byoGitHubCredentialStatus = "App ID stored; private key is in Keychain. Worker verification has not run yet."
+            byoGitHubCredentialStatus = verificationWasInProgress
+                ? "Configuration changed. Verify App access again."
+                : "App ID stored; private key is in Keychain. Worker verification has not run yet."
             logText = "Customer-owned GitHub App credentials stored. The private key was not written to config or command arguments. Worker verification remains pending."
         } catch {
             byoGitHubPrivateKeyStored = dependencies.secretStore.containsSecret(
@@ -3843,6 +3851,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             byoGitHubCredentialStatus = lastError ?? "App ID missing"
             return
         }
+        byoGitHubVerificationGeneration &+= 1
+        let verificationGeneration = byoGitHubVerificationGeneration
 
         let privateKey: String
         do {
@@ -3879,12 +3889,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let verificationContext = BYOGitHubVerificationContext(
             appId: appId,
             source: source,
+            accountID: selectedAccountWorkspace?.id,
+            botID: selectedBotInstallation?.id,
+            installationID: selectedBotInstallation?.githubInstallationID,
+            installationAccount: selectedBotInstallation?.githubAccountLogin,
             credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
             repositories: repositoryScope.map { [$0] }
                 ?? repos.filter(\.enabled).map(\.name).sorted(),
-            workspaceGeneration: workspaceContextGeneration
+            workspaceGeneration: workspaceContextGeneration,
+            verificationGeneration: verificationGeneration
         )
         var standardInput = Data(privateKey.utf8)
         let executablePath = cliPath
@@ -3897,7 +3912,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             ? "Verifying the configured repositories against the customer-owned GitHub App installation…"
             : "Verifying the selected Review Target against the customer-owned GitHub App installation…"
 
-        Task.detached {
+        byoGitHubVerificationTask = Task.detached {
             defer {
                 standardInput.resetBytes(in: 0..<standardInput.count)
             }
@@ -3913,7 +3928,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 }
             } catch {
                 await MainActor.run {
-                    guard self.isCurrentWorkspace(verificationContext.workspaceGeneration) else { return }
+                    guard self.isCurrentWorkspace(verificationContext.workspaceGeneration),
+                          self.byoGitHubVerificationGeneration == verificationContext.verificationGeneration
+                    else { return }
                     self.isBYOGitHubVerificationInProgress = false
                     self.byoGitHubCredentialsVerified = false
                     self.lastError = "Customer-owned GitHub App verification failed safely."
@@ -3980,6 +3997,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
             byoGitHubCredentialStatus = lastError ?? "Review target required"
             return
         }
+        byoGitHubVerificationGeneration &+= 1
+        let verificationGeneration = byoGitHubVerificationGeneration
         let arguments = [
             "doctor", "github",
             "--config", configPath,
@@ -3989,11 +4008,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let verificationContext = BYOGitHubVerificationContext(
             appId: String(bot.appID),
             source: .existingLocalAgent,
+            accountID: selectedAccountWorkspace?.id,
+            botID: bot.id,
+            installationID: bot.githubInstallationID,
+            installationAccount: bot.githubAccountLogin,
             credentialRevision: byoGitHubCredentialRevision,
             cliPath: cliPath,
             configPath: configPath,
             repositories: [targetRepository],
-            workspaceGeneration: workspaceContextGeneration
+            workspaceGeneration: workspaceContextGeneration,
+            verificationGeneration: verificationGeneration
         )
         let executablePath = cliPath
         let cli = dependencies.cli
@@ -4005,7 +4029,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         byoGitHubCredentialStatus =
             "Verifying current App installation access through the exact existing local agent…"
 
-        Task.detached {
+        byoGitHubVerificationTask = Task.detached {
             do {
                 let result = try await cli.run(
                     executablePath: executablePath,
@@ -4027,7 +4051,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 await MainActor.run {
                     guard self.isCurrentWorkspace(
                         verificationContext.workspaceGeneration
-                    ) else { return }
+                    ), self.byoGitHubVerificationGeneration == verificationContext.verificationGeneration
+                    else { return }
                     self.isBYOGitHubVerificationInProgress = false
                     self.byoGitHubCredentialsVerified = false
                     self.lastError =
@@ -4045,7 +4070,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         _ result: CLIRunResult,
         expectedContext: BYOGitHubVerificationContext
     ) {
-        guard isCurrentWorkspace(expectedContext.workspaceGeneration) else { return }
+        guard isCurrentWorkspace(expectedContext.workspaceGeneration),
+              byoGitHubVerificationGeneration == expectedContext.verificationGeneration
+        else { return }
         isBYOGitHubVerificationInProgress = false
         let currentContext: BYOGitHubVerificationContext?
         switch expectedContext.source {
@@ -4054,11 +4081,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 BYOGitHubVerificationContext(
                     appId: appId,
                     source: .keychainStdin,
+                    accountID: selectedAccountWorkspace?.id,
+                    botID: selectedBotInstallation?.id,
+                    installationID: selectedBotInstallation?.githubInstallationID,
+                    installationAccount: selectedBotInstallation?.githubAccountLogin,
                     credentialRevision: byoGitHubCredentialRevision,
                     cliPath: cliPath,
                     configPath: configPath,
                     repositories: repos.filter(\.enabled).map(\.name).sorted(),
-                    workspaceGeneration: workspaceContextGeneration
+                    workspaceGeneration: workspaceContextGeneration,
+                    verificationGeneration: byoGitHubVerificationGeneration
                 )
             }
         case .keychainStdinExistingBot:
@@ -4079,11 +4111,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         return BYOGitHubVerificationContext(
                             appId: storedAppID,
                             source: .keychainStdinExistingBot,
+                            accountID: selectedAccountWorkspace?.id,
+                            botID: bot.id,
+                            installationID: bot.githubInstallationID,
+                            installationAccount: bot.githubAccountLogin,
                             credentialRevision: byoGitHubCredentialRevision,
                             cliPath: cliPath,
                             configPath: configPath,
                             repositories: [targetRepository],
-                            workspaceGeneration: workspaceContextGeneration
+                            workspaceGeneration: workspaceContextGeneration,
+                            verificationGeneration: byoGitHubVerificationGeneration
                         )
                     }
                 }
@@ -4095,11 +4132,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
                         BYOGitHubVerificationContext(
                             appId: String(bot.appID),
                             source: .existingLocalAgent,
+                            accountID: selectedAccountWorkspace?.id,
+                            botID: bot.id,
+                            installationID: bot.githubInstallationID,
+                            installationAccount: bot.githubAccountLogin,
                             credentialRevision: byoGitHubCredentialRevision,
                             cliPath: cliPath,
                             configPath: configPath,
                             repositories: [targetRepository],
-                            workspaceGeneration: workspaceContextGeneration
+                            workspaceGeneration: workspaceContextGeneration,
+                            verificationGeneration: byoGitHubVerificationGeneration
                         )
                     }
                 }
@@ -4162,6 +4204,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
               reportedRepositories == expectedRepositories,
               report.ok,
               report.command == "doctor github",
+              report.appCredentials.appId == expectedContext.appId,
               report.appCredentials.source == expectedCredentialSource,
               report.appCredentials.appIdConfigured,
               report.appCredentials.privateKeyConfigured,
@@ -4172,8 +4215,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
                   check.skippedByPolicy == nil
                       && check.ok
                       && check.installationIdPresent
+                      && (check.installationId ?? 0) > 0
+                      && !(check.installationAccount?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
                       && check.appCanReadMetadata
                       && check.appCanReadPullRequests
+                      && (expectedContext.installationID == nil
+                          || Int64(check.installationId ?? 0) == expectedContext.installationID)
+                      && (expectedContext.installationAccount == nil
+                          || check.installationAccount?.caseInsensitiveCompare(expectedContext.installationAccount!) == .orderedSame)
               })
         else {
             byoGitHubCredentialsVerified = false
@@ -4479,9 +4528,16 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     private func invalidateBYOGitHubVerificationContext() {
         invalidateScopedReviewApproval()
+        let verificationWasInProgress = isBYOGitHubVerificationInProgress
+        byoGitHubVerificationGeneration &+= 1
+        byoGitHubVerificationTask?.cancel()
+        isBYOGitHubVerificationInProgress = false
+        if verificationWasInProgress && activationState == .activationPending {
+            applyActivationEvent(.activationServiceError)
+            onboardingFlow.licenseActivation = .servicePending
+        }
         guard byoGitHubCredentialOnboardingAvailable else { return }
         byoGitHubCredentialsVerified = false
-        guard !isBYOGitHubVerificationInProgress else { return }
         if byoGitHubCredentialsStored {
             byoGitHubCredentialStatus = "Configuration changed. Verify App access again."
         }
@@ -6825,6 +6881,7 @@ private struct BYOGitHubDoctorReport: Decodable {
     let github: GitHub
 
     struct Credentials: Decodable {
+        let appId: String?
         let appIdConfigured: Bool
         let privateKeyConfigured: Bool
         let source: String
@@ -6842,6 +6899,8 @@ private struct BYOGitHubDoctorReport: Decodable {
         let visibilityResult: String?
         let skippedByPolicy: String?
         let installationIdPresent: Bool
+        let installationId: Int?
+        let installationAccount: String?
         let appCanReadMetadata: Bool
         let appCanReadPullRequests: Bool
 
@@ -6851,6 +6910,8 @@ private struct BYOGitHubDoctorReport: Decodable {
             case visibilityResult = "visibility_result"
             case skippedByPolicy
             case installationIdPresent = "installation_id_present"
+            case installationId = "installation_id"
+            case installationAccount = "installation_account"
             case appCanReadMetadata = "app_can_read_metadata"
             case appCanReadPullRequests = "app_can_read_pull_requests"
         }
@@ -6866,11 +6927,16 @@ private struct BYOGitHubVerificationContext: Equatable, Sendable {
 
     let appId: String
     let source: CredentialSource
+    let accountID: String?
+    let botID: String?
+    let installationID: Int64?
+    let installationAccount: String?
     let credentialRevision: UInt64
     let cliPath: String
     let configPath: String
     let repositories: [String]
     let workspaceGeneration: UInt64
+    let verificationGeneration: UInt64
 }
 
 private struct ScopedReviewApproval: Equatable, Sendable {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -287,7 +287,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
     @Test func explicitVerificationReadsKeychainAndUsesOnlyBoundedCLIStdin() async throws {
         let doctorResult = CLIRunResult(
             exitCode: 0,
-            stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"acme/demo","ok":true,"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+            stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"123456","appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"acme/demo","ok":true,"visibility_result":"public","installation_id_present":true,"installation_id":42,"installation_account":"acme","app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
             stderr: ""
         )
         let fixture = ModelDependencyFixture(
@@ -728,6 +728,27 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.productionDaemonStopAvailable)
     }
+
+    @Test func doctorProofMustMatchTheConfiguredAppIdentity() async {
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(doctorResult(
+                readChecks: doctorReadCheck(repo: "acme/demo"),
+                appId: "999999"
+            ))],
+            preferenceStrings: availableCLIPreference,
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+
+        fixture.model.verifyBYOGitHubAppCredentials()
+        await waitForBYOVerification(fixture)
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.lastError?.contains("GitHub") == true)
+    }
 }
 
 private func fixtureWorkspace(id: String) -> DesktopAccountWorkspace {
@@ -759,12 +780,13 @@ private func byoRepoPatchJSON(repository: String) -> String {
 
 private func doctorResult(
     readChecks: String,
+    appId: String = "123456",
     exitCode: Int32 = 0,
     ok: Bool = true
 ) -> CLIRunResult {
     CLIRunResult(
         exitCode: exitCode,
-        stdout: #"{"ok":\#(ok),"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
+        stdout: #"{"ok":\#(ok),"command":"doctor github","appCredentials":{"appId":"\#(appId)","appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
         stderr: ""
     )
 }
@@ -777,7 +799,7 @@ private func doctorReadCheck(
     let skippedField = skippedByPolicy.map {
         #","skippedByPolicy":"\#($0)""#
     } ?? ""
-    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
+    return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"installation_id":42,"installation_account":"acme","app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
 }
 
 private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: [

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -769,7 +769,7 @@ import NeonDiffDesktopCore
             "electricsheephq/evaos-code-review-bot-neondiff"
         let otherRepository = "electricsheephq/WorldOS"
         let readCheck =
-            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
                 .success(CLIRunResult(
@@ -782,7 +782,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
                     stderr: ""
                 ))
             ],
@@ -850,7 +850,7 @@ import NeonDiffDesktopCore
             expectedKey: activationKey
         )
         let readCheck =
-            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
                 .success(CLIRunResult(
@@ -868,7 +868,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readCheck)]}}"#,
                     stderr: ""
                 ))
             ],
@@ -1051,7 +1051,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"electricsheephq/evaos-code-review-bot-neondiff","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"electricsheephq/evaos-code-review-bot-neondiff","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
                 .success(existingAgentLicenseStatus(
@@ -1119,7 +1119,7 @@ import NeonDiffDesktopCore
             targetRepository
         ]
         let readChecks =
-            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
+            #"{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}"#
         let reviewHeadSHA = String(repeating: "a", count: 40)
         let fixture = ModelDependencyFixture(
             cliOutcomes: [
@@ -1138,7 +1138,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[\#(readChecks)]}}"#,
                     stderr: ""
                 )),
                 .success(CLIRunResult(
@@ -1338,7 +1338,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
                 .success(existingAgentLicenseStatus(
@@ -1438,7 +1438,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
                 .success(CLIRunResult(
@@ -1738,7 +1738,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"private","installation_id_present":true,"installation_id":72001,"installation_account":"electricsheephq","app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
                 .success(existingAgentLicenseStatus(
@@ -1911,6 +1911,62 @@ import NeonDiffDesktopCore
             "--zcode", "true"
         ])
         #expect(fixture.model.scopedReviewStatus.contains("posted"))
+    }
+
+    @MainActor
+    @Test func changingReviewTargetRetiresOldVerificationAndAllowsImmediateRetry() async throws {
+        let firstRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let secondRepository = "electricsheephq/WorldOS"
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            ),
+            repositories: [firstRepository, secondRepository]
+        )
+        fixture.cli.suspendFutureRuns()
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(3)
+        #expect(fixture.model.isBYOGitHubVerificationInProgress)
+
+        fixture.model.selectBYOReviewRepository(fullName: secondRepository)
+
+        #expect(fixture.model.selectedBYOReviewRepository == secondRepository)
+        #expect(!fixture.model.isBYOGitHubVerificationInProgress)
+
+        fixture.cli.resumeSuspendedRuns()
+        for _ in 0..<20 { await Task.yield() }
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(4)
+        #expect(fixture.cli.calls[3].arguments.contains(secondRepository))
+    }
+
+    @MainActor
+    @Test func selectedBotRequiresExactInstallationAndAccountProof() async throws {
+        let targetRepository = "electricsheephq/evaos-code-review-bot-neondiff"
+        let fixture = await preparedExistingAgentVerificationFixture(
+            visibility: "private",
+            licenseResult: existingAgentLicenseStatus(
+                scope: "private",
+                privateRepoAllowed: true
+            ),
+            doctorInstallationID: 72002,
+            doctorInstallationAccount: "another-account"
+        )
+
+        fixture.model.verifyExistingLocalBotGitHubAccess()
+        await fixture.cli.waitUntilCallCount(3)
+        for _ in 0..<20 where fixture.model.isBYOGitHubVerificationInProgress {
+            await Task.yield()
+        }
+
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.lastError?.contains("GitHub") == true)
+        #expect(fixture.cli.calls.last?.arguments.contains(targetRepository) == true)
     }
 
     @MainActor
@@ -2202,7 +2258,9 @@ import NeonDiffDesktopCore
         visibility: String,
         licenseResult: CLIRunResult,
         activationLicenseClient: (any ActivationLicenseClienting)? = nil,
-        repositories: [String]? = nil
+        repositories: [String]? = nil,
+        doctorInstallationID: Int64 = 72001,
+        doctorInstallationAccount: String = "electricsheephq"
     ) async -> ModelDependencyFixture {
         let targetRepository =
             "electricsheephq/evaos-code-review-bot-neondiff"
@@ -2224,7 +2282,7 @@ import NeonDiffDesktopCore
                 )),
                 .success(CLIRunResult(
                     exitCode: 0,
-                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"\#(visibility)","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+                    stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appId":"4184532","appIdConfigured":true,"privateKeyConfigured":true,"source":"configured"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"\#(targetRepository)","ok":true,"visibility_result":"\#(visibility)","installation_id_present":true,"installation_id":\#(doctorInstallationID),"installation_account":"\#(doctorInstallationAccount)","app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
                     stderr: ""
                 )),
                 .success(licenseResult)


### PR DESCRIPTION
## Summary

- Require the doctor App ID to match the configured App identity.
- Require every current read proof to carry a non-empty installation ID and account, matching the selected bot when known.
- Retire and cancel in-flight verification generations on Review Target changes so stale completions cannot authorize the new target.

Closes #872.

## Validation

- swift test --filter BYOGitHubAppCredentialOnboardingTests|ExistingLocalBotReconciliationTests: 77 passed
- swift test: 438 passed across 42 suites
- git diff --check

Dependency: merge PR #903 first so the doctor report fields consumed here are available. PR #879 is independent and untouched.