### PR TITLE
ci(desktop): validate retained history on every event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,28 @@ jobs:
       - name: Validate committed Desktop declaration index
         run: node scripts/validate-desktop-release-declaration.mjs --index docs/releases/desktop/index.json
 
+      - name: Validate Desktop declaration history transition
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then comparison_sha="$PR_BASE_SHA"; else comparison_sha="$PUSH_BEFORE_SHA"; fi
+          if [[ "$comparison_sha" =~ ^0{40}$ ]]; then
+            node scripts/validate-desktop-release-declaration.mjs --index docs/releases/desktop/index.json --initial
+            exit 0
+          fi
+          [[ "$comparison_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "invalid comparison SHA" >&2; exit 1; }
+          git fetch --no-tags origin "$comparison_sha" --depth=1
+          [[ "$(git rev-parse --verify "${comparison_sha}^{commit}")" == "$comparison_sha" ]]
+          [[ "$(git cat-file -t "$comparison_sha")" == "commit" ]]
+          base="$RUNNER_TEMP/desktop-base"
+          mkdir -p "$base"
+          git archive "$comparison_sha" docs/releases/desktop | tar -x -C "$base"
+          test -f "$base/docs/releases/desktop/index.json"
+          node scripts/validate-desktop-release-declaration.mjs --index docs/releases/desktop/index.json --base-index "$base/docs/releases/desktop/index.json"
+
       - name: Enforce Review Bench public-corpus admission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/validate-desktop-release-declaration.mjs
+++ b/scripts/validate-desktop-release-declaration.mjs
@@ -39,7 +39,7 @@ function rejectDuplicateKeys(raw) {
     const keys = objects.at(-1); if (keys.has(key)) fail(`duplicate object key: ${key}`); keys.add(key);
   }
 }
-function readRegular(path) {
+function readRawRegular(path) {
   let fd;
   try {
     fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
@@ -47,10 +47,11 @@ function readRegular(path) {
     const raw = readFileSync(fd, "utf8");
     if (/(?:"build"|"sequence")\s*:\s*(?!"[0-9]+")/.test(raw)) fail("identity fields must be quoted decimal text");
     rejectDuplicateKeys(raw);
-    return JSON.parse(raw);
+    return raw;
   } catch (error) { if (error?.code === "ELOOP") fail(`symlink or non-regular file: ${path}`); throw error; }
   finally { if (fd !== undefined) closeSync(fd); }
 }
+function readRegular(path) { return JSON.parse(readRawRegular(path)); }
 function openDirectory(path) {
   let fd;
   try {
@@ -69,11 +70,32 @@ function pathIn(directory, name) {
 }
 function check(value, valid, label) { if (!valid(value)) fail(`${label} schema invalid: ${ajv.errorsText(valid.errors)}`); }
 function buildCompare(a, b) { const left = BigInt(a), right = BigInt(b); return left < right ? -1 : left > right ? 1 : 0; }
+function validateTransition(index, directory, baseIndexPath) {
+  const base = readRegular(baseIndexPath);
+  check(base, validateIndex, "base index");
+  if (base.status !== "retained") return;
+  if (index.status !== "retained") fail("retained history cannot regress to empty");
+  if (base.declarationPaths.some((name, i) => index.declarationPaths[i] !== name)) fail("retained declaration history must be an exact prefix");
+  const baseDirectory = resolve(dirname(baseIndexPath), base.declarationDirectory), baseHandle = openDirectory(baseDirectory);
+  try {
+    for (const name of base.declarationPaths) {
+      if (readRawRegular(pathIn(directory, name)) !== readRawRegular(pathIn(baseDirectory, name))) fail(`retained declaration rewritten: ${name}`);
+    }
+    if (!sameDirectory(baseDirectory, baseHandle.stat)) fail("base declaration directory changed during validation");
+  } finally { closeSync(baseHandle.fd); }
+}
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length === 2 && args[0] === "--index") return { indexPath: resolve(args[1]), baseIndexPath: null, initial: false };
+  if (args.length === 4 && args[0] === "--index" && args[2] === "--base-index") return { indexPath: resolve(args[1]), baseIndexPath: resolve(args[3]), initial: false };
+  if (args.length === 3 && args[0] === "--index" && args[2] === "--initial") return { indexPath: resolve(args[1]), baseIndexPath: null, initial: true };
+  fail("usage: validate-desktop-release-declaration.mjs --index PATH [--base-index PATH|--initial]");
+}
 
 function main() {
-  if (process.argv.length !== 4 || process.argv[2] !== "--index") fail("usage: validate-desktop-release-declaration.mjs --index PATH");
-  const indexPath = resolve(process.argv[3]), index = readRegular(indexPath);
+  const { indexPath, baseIndexPath, initial } = parseArgs(), index = readRegular(indexPath);
   check(index, validateIndex, "index");
+  if (initial && index.status !== "empty") fail("initial history requires the empty clean-checkout convention");
   const directory = resolve(dirname(indexPath), index.declarationDirectory), handle = openDirectory(directory);
   try {
     const entries = readdirSync(directory, { withFileTypes: true }), listed = new Set(index.declarationPaths);
@@ -83,7 +105,7 @@ function main() {
       if (entry.name === ".gitkeep") { if (!entry.isFile()) fail("empty convention must be a regular file"); convention = true; continue; }
       if (!entry.isFile() || !listed.has(entry.name)) fail(`unindexed declaration entry: ${entry.name}`);
     }
-    if (index.status === "empty") { if (!convention || entries.length !== 1) fail("empty index requires only tracked .gitkeep convention"); return "empty"; }
+    if (index.status === "empty") { if (!convention || entries.length !== 1) fail("empty index requires only tracked .gitkeep convention"); if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during validation"); if (baseIndexPath) { validateTransition(index, directory, baseIndexPath); if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during transition"); } return "empty"; }
     if (convention) fail(".gitkeep is only valid for an empty index");
     const declarations = index.declarationPaths.map((name) => [name, readRegular(pathIn(directory, name))]);
     for (const [name, declaration] of declarations) {
@@ -106,6 +128,7 @@ function main() {
     ordered.forEach(([name, declaration], i) => { if (declaration.predecessor !== (i ? ordered[i - 1][0] : null)) fail(`predecessor mismatch: ${name}`); });
     if (index.currentPath !== ordered.at(-1)[0]) fail("currentPath must be newest compatible declaration");
     if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during validation");
+    if (baseIndexPath) { validateTransition(index, directory, baseIndexPath); if (!sameDirectory(directory, handle.stat)) fail("declaration directory changed during transition"); }
     return `${index.declarationPaths.length} declarations; currentPath=${index.currentPath}`;
   } finally { closeSync(handle.fd); }
 }

--- a/tests/desktop-release-declaration.test.ts
+++ b/tests/desktop-release-declaration.test.ts
@@ -6,11 +6,20 @@ import { describe, expect, it } from "vitest";
 
 const script = "scripts/validate-desktop-release-declaration.mjs", feed = "https://www.neondiff.com/updates/beta/appcast.xml", bundle = "com.electricsheephq.NeonDiffDesktop";
 type Item = { channel?: string; seq?: string; build?: string; feed?: string; predecessor?: string | null; bundle?: string };
-function run(items: Item[], alter: (root: string, paths: string[]) => void = () => {}) {
-  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-")), directory = join(root, "declarations"); mkdirSync(directory);
+function writeFixture(root: string, items: Item[]) {
+  const directory = join(root, "declarations"); mkdirSync(directory, { recursive: true });
   const paths = items.map((item, index) => { const channel = item.channel ?? "beta", seq = item.seq ?? String(index + 1), build = item.build ?? String(index + 100), version = `1.1.0-${channel}.${seq}`, path = `v${version}.json`, predecessor = item.predecessor === undefined ? (index ? `v1.1.0-${items[index - 1].channel ?? "beta"}.${items[index - 1].seq ?? String(index)}.json` : null) : item.predecessor; writeFileSync(join(directory, path), JSON.stringify({ schemaVersion: 1, product: "neondiff-desktop", version, tag: `v${version}`, channel, sequence: seq, build, predecessor, contract: "paid-mac-beta-byo-v1", distribution: { bundleId: item.bundle ?? bundle, appPath: "NeonDiff.app", artifactName: `NeonDiff-${version}-build${build}-macOS.zip`, releaseClass: "paid-beta", origins: { github: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff", site: "https://www.neondiff.com", feed: item.feed ?? feed } } })); return path; });
   if (!items.length) writeFileSync(join(directory, ".gitkeep"), "");
-  const index = join(root, "index.json"); writeFileSync(index, JSON.stringify({ schemaVersion: 1, status: items.length ? "retained" : "empty", declarationDirectory: "declarations", declarationPaths: paths, currentPath: paths.at(-1) ?? null })); alter(root, paths); const result = spawnSync(process.execPath, [script, "--index", index], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
+  const index = join(root, "index.json"); writeFileSync(index, JSON.stringify({ schemaVersion: 1, status: items.length ? "retained" : "empty", declarationDirectory: "declarations", declarationPaths: paths, currentPath: paths.at(-1) ?? null })); return { index, paths };
+}
+function run(items: Item[], alter: (root: string, paths: string[]) => void = () => {}) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-")), fixture = writeFixture(root, items); alter(root, fixture.paths); const result = spawnSync(process.execPath, [script, "--index", fixture.index], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
+}
+function runInitial(items: Item[]) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-initial-")), fixture = writeFixture(root, items), result = spawnSync(process.execPath, [script, "--index", fixture.index, "--initial"], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
+}
+function runTransition(baseItems: Item[], currentItems: Item[], alter: (root: string) => void = () => {}) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-transition-")), base = writeFixture(join(root, "base"), baseItems), current = writeFixture(join(root, "current"), currentItems); alter(root); const result = spawnSync(process.execPath, [script, "--index", current.index, "--base-index", base.index], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); return result;
 }
 
 describe("versioned desktop declaration index", () => {
@@ -22,5 +31,17 @@ describe("versioned desktop declaration index", () => {
     expect(run([{ build: "100" }], (root) => { const path = join(root, "declarations", "v1.1.0-beta.1.json"), raw = readFileSync(path, "utf8").replace('"build":"100"', '"build":"100","build":"101"'); writeFileSync(path, raw); }).status).not.toBe(0);
     expect(run([{ build: "100" }], (root) => { const path = join(root, "declarations", "v1.1.0-beta.1.json"), raw = readFileSync(path, "utf8").replace('"site":"https://www.neondiff.com"', '"site":"https://www.neondiff.com","site":"https://www.neondiff.com"'); writeFileSync(path, raw); }).status).not.toBe(0);
     expect(run([{ build: "100" }], (root, paths) => symlinkSync(join(root, "declarations", paths[0]), join(root, "declarations", "alias.json"))).status).not.toBe(0);
+  });
+  it("enforces initial and retained-history transitions", () => {
+    const base = [{ build: "100" }], appended = [{ build: "100" }, { build: "101" }];
+    expect(runInitial([]).status).toBe(0);
+    expect(runInitial(base).status).not.toBe(0);
+    expect(runTransition(base, appended).status).toBe(0);
+    expect(runTransition(base, []).status).not.toBe(0);
+    expect(runTransition(base, [{ build: "101" }]).status).not.toBe(0);
+    expect(runTransition(base, base, (root) => { renameSync(join(root, "current", "declarations"), join(root, "current", "declarations-real")); symlinkSync(join(root, "current", "declarations-real"), join(root, "current", "declarations")); }).status).not.toBe(0);
+  });
+  it("fails closed when the accepted comparison index is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-declaration-missing-")), fixture = writeFixture(root, []), result = spawnSync(process.execPath, [script, "--index", fixture.index, "--base-index", join(root, "missing-index.json")], { cwd: process.cwd(), encoding: "utf8" }); rmSync(root, { recursive: true, force: true }); expect(result.status).not.toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up for #875 after core declaration slice #889. This clean current-main PR adds fail-closed retained-history transition validation for pull requests against the exact base SHA and direct pushes against github.event.before, including zero-before initial-history handling and missing/shallow/ambiguous comparison-object checks. It preserves immutable retained bytes, current directory identity checks, and all accepted declaration semantics. No #892 ancestry is used. No release, artifact, feed, install, runtime, or customer mutation.