### PR TITLE
docs: document portable eval output root

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -8,12 +8,25 @@ Run it with a local scenario file:
 npm run eval:offline -- --input /path/to/scenario.json
 ```
 
+When `--output-dir` is omitted, the packet is written under the portable
+default `~/.local/share/neondiff/evals/<date>/<run-id>/`. Set
+`NEONDIFF_EVAL_ROOT` to explicitly override that default with another
+directory outside the active git checkout:
+
+```bash
+NEONDIFF_EVAL_ROOT="$HOME/neondiff-evals" \
+  npm run eval:offline -- --input /path/to/scenario.json
+```
+
+The commands below use `--output-root` because those commands require an
+explicit output root.
+
 Run the checked-in local suite fixtures:
 
 ```bash
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
+  --output-root ~/.local/share/neondiff/evals/$(date +%F)/local-suite
 ```
 
 Run the paired sticky-vs-cold fixture:
@@ -21,7 +34,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
+  --output-root ~/.local/share/neondiff/evals/$(date +%F)/sticky-vs-cold-seeded-quality
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -30,7 +43,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab
+  --output-root ~/.local/share/neondiff/evals/$(date +%F)/openwiki-context/eval-gates/ab
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -38,7 +51,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift
+  --output-root ~/.local/share/neondiff/evals/$(date +%F)/openwiki-context/eval-gates/docs-drift
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -52,7 +65,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
+  --output-root ~/.local/share/neondiff/evals/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
   --dry-run true
 ```
 
@@ -65,13 +78,17 @@ The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.
 
-By default, packets are written under:
+The `eval:offline` default packet root is:
 
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/
+~/.local/share/neondiff/evals/<date>/<run-id>/
 ```
 
-Use `--output-dir` for tests or scratch runs.
+`NEONDIFF_EVAL_ROOT` overrides that default when `--output-dir` is omitted; an
+explicit `--output-dir` still takes precedence. The suite, sticky-vs-cold,
+OpenWiki, and review-lenses commands require `--output-root`, as shown above.
+Use `--output-dir` for tests or scratch runs, and keep every chosen output root
+outside the active git checkout.
 
 ## Scenario Shape
 

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -13,12 +13,17 @@
  * recommended config here is a LAB recommendation, not an applied setting.
  */
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 import { loadConfigFromObject, type BotConfig } from "../../src/config.js";
 import { ReviewStateStore } from "../../src/state.js";
 import { riskWeightedQueuePriority } from "../../src/scheduler.js";
 import { buildChangedSurfaceValidationReport } from "../../src/validation-selector.js";
+import {
+  assertPathOutsideProtectedRoot,
+  getProtectedCheckoutRoots,
+  resolvePathFollowingExistingSymlinks
+} from "../../src/path-safety.js";
 import { stringifyRedactedJson } from "../../src/secrets.js";
 import type { PullFilePatch, PullRequestSummary } from "../../src/types.js";
 // Reuse the merged QA-lab harness (#341/#358): scenario file-sets drive the REAL tier, and the
@@ -26,7 +31,20 @@ import type { PullFilePatch, PullRequestSummary } from "../../src/types.js";
 import { QA_LAB_SCENARIOS } from "./scenarios.js";
 import { percentile } from "./stats.js";
 
-const EVIDENCE_DIR = "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/polished-config-lab/risk-queue";
+const configuredEvidenceRoot = process.env.NEONDIFF_EVIDENCE_ROOT?.trim();
+const evidenceRoot = configuredEvidenceRoot
+  ? configuredEvidenceRoot
+  : join(homedir(), ".local", "share", "neondiff", "evidence");
+if (!isAbsolute(evidenceRoot)) throw new Error("NEONDIFF_EVIDENCE_ROOT must be absolute");
+const resolvedEvidenceRoot = resolvePathFollowingExistingSymlinks(resolve(evidenceRoot));
+assertPathOutsideProtectedRoot({
+  path: resolvedEvidenceRoot,
+  protectedRoot: undefined,
+  protectedRoots: getProtectedCheckoutRoots(),
+  pathLabel: "NEONDIFF_EVIDENCE_ROOT",
+  protectedRootLabel: "a protected checkout root"
+});
+const EVIDENCE_DIR = join(resolvedEvidenceRoot, "neondiff-qa-lab", "risk-queue");
 const BASELINE = 50;
 const MAX_WAIT_MINUTES = 60;
 const TICK_MS = 60_000; // one minute per service interval

--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -45,6 +45,13 @@ assertPathOutsideProtectedRoot({
   protectedRootLabel: "a protected checkout root"
 });
 const EVIDENCE_DIR = join(resolvedEvidenceRoot, "neondiff-qa-lab", "risk-queue");
+assertPathOutsideProtectedRoot({
+  path: resolvePathFollowingExistingSymlinks(EVIDENCE_DIR),
+  protectedRoot: undefined,
+  protectedRoots: getProtectedCheckoutRoots(),
+  pathLabel: "NEONDIFF_EVIDENCE_ROOT",
+  protectedRootLabel: "a protected checkout root"
+});
 const BASELINE = 50;
 const MAX_WAIT_MINUTES = 60;
 const TICK_MS = 60_000; // one minute per service interval

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
+import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { Finding, Severity } from "./types.js";
 
@@ -1489,9 +1491,17 @@ function buildLabelEvidence(finding: Finding | EvalLabelInput): Record<string, s
   return Object.keys(evidence).length > 0 ? evidence : undefined;
 }
 
+export function resolveEvalOutputRoot(): string {
+  const configuredRoot = process.env.NEONDIFF_EVAL_ROOT?.trim();
+  const root = configuredRoot
+    ? resolve(configuredRoot)
+    : join(homedir(), ".local", "share", "neondiff", "evals");
+  return assertEvalOutputDirSafe(root);
+}
+
 function defaultEvalOutputDir(input: Pick<EvalScenarioInput, "runId">, now: Date): string {
   const date = now.toISOString().slice(0, 10);
-  return join("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review", date, sanitizePathSegment(input.runId));
+  return join(resolveEvalOutputRoot(), date, sanitizePathSegment(input.runId));
 }
 
 function sanitizePathSegment(value: string): string {
@@ -1520,13 +1530,16 @@ function sha256File(path: string): string {
 
 export function assertEvalOutputDirSafe(outputDir: string): string {
   const resolvedOutput = resolve(outputDir);
-  const gitRoot = findGitRoot(process.cwd());
-  if (!gitRoot) return resolvedOutput;
-  const realOutput = resolveRealPathForPotentialOutput(resolvedOutput);
-  const realGitRoot = realpathSync(gitRoot);
-  const relation = relative(realGitRoot, realOutput);
-  if (relation === "" || (!relation.startsWith("..") && !isAbsolute(relation))) {
-    throw new Error("outputDir must not be inside the current git checkout; write eval packets under /Volumes/LEXAR/Codex/evals or a temp directory");
+  try {
+    assertPathOutsideProtectedRoot({
+      path: resolvedOutput,
+      protectedRoot: undefined,
+      protectedRoots: getProtectedCheckoutRoots(),
+      pathLabel: "outputDir",
+      protectedRootLabel: "a protected checkout root"
+    });
+  } catch {
+    throw new Error("outputDir must not be inside the current git checkout; use NEONDIFF_EVAL_ROOT or a temp directory");
   }
   return resolvedOutput;
 }
@@ -1543,34 +1556,6 @@ export function guardEmptyOutputRoot(outputRoot: string, evalLabel = "sticky-vs-
   }
   if (readdirSync(outputRoot).length > 0) {
     throw new Error(`outputRoot must be empty before running ${evalLabel}; choose a fresh output root to avoid stale artifacts`);
-  }
-}
-
-function resolveRealPathForPotentialOutput(path: string): string {
-  const resolved = resolve(path);
-  if (existsSync(resolved)) return realpathSync(resolved);
-  const segments: string[] = [];
-  let cursor = resolved;
-  while (!existsSync(cursor)) {
-    const parent = dirname(cursor);
-    if (parent === cursor) return resolved;
-    segments.unshift(cursor.slice(parent.length + 1));
-    cursor = parent;
-  }
-  return resolve(realpathSync(cursor), ...segments);
-}
-
-function findGitRoot(start: string): string | undefined {
-  let cursor = resolve(start);
-  for (;;) {
-    const gitPath = join(cursor, ".git");
-    if (existsSync(gitPath)) {
-      const stat = statSync(gitPath);
-      if (stat.isDirectory() || stat.isFile()) return cursor;
-    }
-    const parent = dirname(cursor);
-    if (parent === cursor) return undefined;
-    cursor = parent;
   }
 }
 
@@ -1602,7 +1587,7 @@ function roundMetric(value: number): number {
 
 function defaultStickyVsColdOutputRoot(input: Pick<StickyVsColdScenarioInput, "runId">, now: Date): string {
   const date = now.toISOString().slice(0, 10);
-  return join("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review", date, sanitizePathSegment(input.runId));
+  return join(resolveEvalOutputRoot(), date, sanitizePathSegment(input.runId));
 }
 
 function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1539,7 +1539,7 @@ export function assertEvalOutputDirSafe(outputDir: string): string {
       protectedRootLabel: "a protected checkout root"
     });
   } catch {
-    throw new Error("outputDir must not be inside the current git checkout; use NEONDIFF_EVAL_ROOT or a temp directory");
+    throw new Error("outputDir must not be inside the current git checkout; outside every git checkout; use NEONDIFF_EVAL_ROOT or a temp directory");
   }
   return resolvedOutput;
 }

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -87,5 +87,5 @@ describe("portable output roots", () => {
     expect(result.status).toBe(0);
     expect(output.ok).toBe(true);
     expect(output.evidenceDir).toBe(join(externalRoot, "neondiff-qa-lab", "risk-queue"));
-  });
+  }, 30_000);
 });

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveEvalOutputRoot } from "../src/eval-harness.js";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const tsxCommand = process.env.NEONDIFF_TEST_TSX ?? join(repoRoot, "node_modules", ".bin", "tsx");
+
+describe("portable output roots", () => {
+  const roots: string[] = [];
+  const originalEvalRoot = process.env.NEONDIFF_EVAL_ROOT;
+
+  afterEach(() => {
+    if (originalEvalRoot === undefined) delete process.env.NEONDIFF_EVAL_ROOT;
+    else process.env.NEONDIFF_EVAL_ROOT = originalEvalRoot;
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("uses a portable eval default and accepts an external explicit root", () => {
+    delete process.env.NEONDIFF_EVAL_ROOT;
+    expect(resolveEvalOutputRoot()).toBe(join(homedir(), ".local", "share", "neondiff", "evals"));
+
+    const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-eval-root-"));
+    roots.push(externalRoot);
+    process.env.NEONDIFF_EVAL_ROOT = externalRoot;
+    expect(resolveEvalOutputRoot()).toBe(externalRoot);
+  });
+
+  it("rejects checkout children, dot-dot siblings, and symlink aliases for eval output", () => {
+    for (const root of [repoRoot, join(repoRoot, "..eval")]) {
+      process.env.NEONDIFF_EVAL_ROOT = root;
+      expect(() => resolveEvalOutputRoot()).toThrow(/must not be inside the current git checkout/);
+    }
+
+    const aliasRoot = mkdtempSync(join(tmpdir(), "neondiff-eval-alias-"));
+    roots.push(aliasRoot);
+    const alias = join(aliasRoot, "checkout");
+    symlinkSync(repoRoot, alias, "dir");
+    process.env.NEONDIFF_EVAL_ROOT = alias;
+    expect(() => resolveEvalOutputRoot()).toThrow(/must not be inside the current git checkout/);
+  });
+
+  it("rejects hostile QA roots before creating evidence", () => {
+    const hostileRoot = mkdtempSync(join(repoRoot, ".portable-qa-hostile-"));
+    roots.push(hostileRoot);
+    const result = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
+      cwd: join(repoRoot, "tests"),
+      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: hostileRoot },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("must be outside a protected checkout root");
+    expect(existsSync(join(hostileRoot, "neondiff-qa-lab"))).toBe(false);
+  });
+
+  it("accepts an external QA root", () => {
+    const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-root-"));
+    roots.push(externalRoot);
+    const result = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
+      cwd: join(repoRoot, "tests"),
+      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+    const output = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(output.ok).toBe(true);
+    expect(output.evidenceDir).toBe(join(externalRoot, "neondiff-qa-lab", "risk-queue"));
+  });
+});

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -66,7 +66,7 @@ describe("portable output roots", () => {
       cwd: join(repoRoot, "tests"),
       env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
       encoding: "utf8",
-      timeout: 10_000
+      timeout: 30_000
     });
     const output = JSON.parse(result.stdout);
 

--- a/tests/portable-paths.test.ts
+++ b/tests/portable-paths.test.ts
@@ -57,6 +57,20 @@ describe("portable output roots", () => {
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("must be outside a protected checkout root");
     expect(existsSync(join(hostileRoot, "neondiff-qa-lab"))).toBe(false);
+
+    const externalRoot = mkdtempSync(join(tmpdir(), "neondiff-qa-symlink-"));
+    roots.push(externalRoot);
+    symlinkSync(repoRoot, join(externalRoot, "neondiff-qa-lab"), "dir");
+    const nestedAlias = spawnSync(tsxCommand, [join(repoRoot, "scripts/qa-lab/queue-sim.ts")], {
+      cwd: join(repoRoot, "tests"),
+      env: { ...process.env, NEONDIFF_EVIDENCE_ROOT: externalRoot },
+      encoding: "utf8",
+      timeout: 10_000
+    });
+    expect(nestedAlias.status).toBe(1);
+    expect(nestedAlias.stdout).toBe("");
+    expect(nestedAlias.stderr).toContain("must be outside a protected checkout root");
+    expect(existsSync(join(repoRoot, "risk-queue"))).toBe(false);
   });
 
   it("accepts an external QA root", () => {


### PR DESCRIPTION
Related: #864
Depends on #894; this PR is intentionally stacked on #894 head `67e02c2d2db71a48c0e87b6b14dbbde2de58dee8` and should merge only after #894.

## Summary
- document the supported `~/.local/share/neondiff/evals` eval default
- document `NEONDIFF_EVAL_ROOT` as the explicit override for implicit `eval:offline` output
- replace retired `/Volumes/LEXAR` paths in `docs/eval-harness.md` examples with portable paths

## Validation
- `git diff --check` passed
- docs assertions passed: no `/Volumes/LEXAR` remains in the affected guide; default and override are present
- direct #894 source smoke passed for default and external `NEONDIFF_EVAL_ROOT` resolution
- `npx vitest run tests/portable-paths.test.ts` was blocked before collection by the environment's missing/invalid native Rollup/Rolldown binding

## Scope and proof boundary
- docs-only: `docs/eval-harness.md` (25 insertions, 8 deletions)
- no source, updater, operator CLI, launchd, customer, runtime, release, or merge changes
- this proves documentation alignment with #894 source behavior; it does not prove #894 is merged or release/runtime readiness