### PR TITLE
fix(scheduler): quarantine incomplete evidence before leasing

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,8 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi, unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
+import { resolveEvidenceCommandDecision, type EvidenceCommandDecision, type EvidenceRead } from "./evidence-decision.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -43,6 +44,7 @@ import {
   REVIEW_POSTED_HEAD_CHANGED_ERROR,
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
+  isRetryableApprovedDryRunPrePostFailure,
   ReviewStateStore,
   type ProcessedStatus,
   type ProcessedCommandAction,
@@ -50,7 +52,8 @@ import {
   type ReviewerSessionJobState,
   type ReviewQueueJobRecord,
   type ReviewQueueJobState,
-  type ReviewQueueJobSource
+  type ReviewQueueJobSource,
+  type ReviewEvidenceQuarantine
 } from "./state.js";
 import type { ChangedSurfaceValidationReport, PullFilePatch, PullRequestSummary, PullReviewComment, ReviewEvent } from "./types.js";
 import type { IssueCommentCommandSource } from "./commands.js";
@@ -110,6 +113,7 @@ export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueCommentCommandSource>>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
@@ -170,6 +174,7 @@ export async function runScheduledCycleWithDeps(input: {
     throw new Error("runScheduledCycleWithDeps requires config.reviewScheduler.enabled=true");
   }
   const result = emptyScheduledRunResult();
+  const evidenceQuarantines: ReviewEvidenceQuarantine[] = [];
   const now = input.now ?? new Date();
   const eventClock = input.clock ?? (() => input.now ?? new Date());
   const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
@@ -242,6 +247,14 @@ export async function runScheduledCycleWithDeps(input: {
         },
         onCommandFetchError: () => {
           result.commandFetchErrors += 1;
+        },
+        onEvidenceQuarantine: (quarantine, applied) => {
+          evidenceQuarantines.push(quarantine);
+          result.queue.failedQueueJobs += applied.failedQueueJobs;
+          result.queue.staleRetired += applied.retiredQueueJobs;
+        },
+        onEvidenceRetirement: (retired) => {
+          result.queue.staleRetired += retired;
         }
       });
       applyEnqueueStatus(result, enqueueStatus);
@@ -276,6 +289,12 @@ export async function runScheduledCycleWithDeps(input: {
     peakJobsInFlight: 0
   };
   const repoActiveLimitOverrides = buildRepoActiveLimitOverrides(config, input.state.listReviewQueueJobs());
+  const leaseNow = eventClock();
+  for (const quarantine of evidenceQuarantines) {
+    const applied = input.state.quarantineIncompleteReviewEvidence({ ...quarantine, now: leaseNow, leaseTtlMs: config.reviewConcurrency.leaseTtlMs });
+    result.queue.failedQueueJobs += applied.failedQueueJobs;
+    result.queue.staleRetired += applied.retiredQueueJobs;
+  }
   // Lease exactly one bounded batch. The durable transaction applies provider/org/repo/manual
   // constraints atomically; this cycle never continuously drains behind the admitted batch.
   const leased = input.state.leaseNextReviewQueueJobs({
@@ -287,8 +306,9 @@ export async function runScheduledCycleWithDeps(input: {
     manualCommandReserve: Math.min(scheduler.manualCommandReserve, effectiveSlots),
     limit: effectiveSlots,
     leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
+    quarantines: evidenceQuarantines,
     ...(config.riskWeightedQueue?.aging ? { aging: config.riskWeightedQueue.aging } : {}),
-    now: eventClock()
+    now: leaseNow
   });
   result.queue.leased = leased.length;
   result.queue.execution.started = leased.length;
@@ -509,6 +529,7 @@ type EnqueueStatus =
   | "skipped_capacity"
   | "skipped_finishing_touch_draft"
   | "skipped_stale_head"
+  | "required_evidence_incomplete"
   | "provider_deferred"
   | "closed_retired";
 
@@ -526,6 +547,8 @@ async function enqueuePullIfEligible(input: {
   allowActivationBaselineCommandLookup?: boolean;
   onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
+  onEvidenceQuarantine?: (quarantine: ReviewEvidenceQuarantine, result: { failedQueueJobs: number; retiredQueueJobs: number }) => void;
+  onEvidenceRetirement?: (retired: number) => void;
   automaticPriorityOverride?: number;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) {
@@ -578,7 +601,20 @@ async function enqueuePullIfEligible(input: {
     return "skipped_processed";
   }
 
-  const commandDecision = await resolveSchedulerCommandDecision(input);
+  const resolution = await resolveSchedulerCommandDecision(input);
+  const commandDecision = resolution.decision;
+  if (!resolution.evidenceComplete && !commandDecision.shouldReview && commandDecision.action !== "stop") {
+    if (processed && !isRetryableProcessedHead(processed)) {
+      const retired = await retireSupersededQueueJobsForPull({ ...input, silent: true });
+      input.onEvidenceRetirement?.(retired);
+      backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
+      return "skipped_processed";
+    }
+    const quarantine = { repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha, reason: "incomplete_evidence" };
+    const applied = input.state.quarantineIncompleteReviewEvidence({ ...quarantine, now: input.now, leaseTtlMs: input.config.reviewConcurrency.leaseTtlMs });
+    input.onEvidenceQuarantine?.(quarantine, applied);
+    return "required_evidence_incomplete";
+  }
   if (commandDecision.action !== "none") {
     if (commandDecision.shouldReview) {
       await retireSupersededQueueJobsForPull(input);
@@ -1065,7 +1101,8 @@ async function retireSupersededQueueJobsForPull(input: {
   dryRun: boolean;
   now: Date;
   onStatusCommentFailure?: () => void;
-}): Promise<void> {
+  silent?: boolean;
+}): Promise<number> {
   const jobs = input.state.listReviewQueueJobsForPull({
     repo: input.repo,
     pullNumber: input.pull.number,
@@ -1088,18 +1125,13 @@ async function retireSupersededQueueJobsForPull(input: {
       now: input.now
     });
     updateReviewerSessionJobFromQueueStatus({ state: input.state, job }, "skipped", "skipped");
-    await syncReviewStatusComment({
-      config: input.config,
-      github: input.github,
-      dryRun: input.dryRun,
-      repo: input.repo,
-      pull: pullForQueueJob(job, input.pull),
-      state: "stale_head",
-      details: "Superseded by a newer PR head.",
-      onStatusCommentFailure: input.onStatusCommentFailure,
-      now: input.now
+    if (!input.silent) await syncReviewStatusComment({
+      config: input.config, github: input.github, dryRun: input.dryRun,
+      repo: input.repo, pull: pullForQueueJob(job, input.pull), state: "stale_head",
+      details: "Superseded by a newer PR head.", onStatusCommentFailure: input.onStatusCommentFailure, now: input.now
     });
   }
+  return jobs.length;
 }
 
 async function retireQueuedJobsForClosedPull(input: {
@@ -1155,15 +1187,34 @@ async function resolveSchedulerCommandDecision(input: {
   repo: string;
   pull: PullRequestSummary;
   onCommandFetchError?: () => void;
-}): Promise<CommandDecision> {
-  if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
-  let comments: IssueCommentCommandSource[];
+}): Promise<{ decision: CommandDecision; evidenceComplete: boolean; reason: EvidenceCommandDecision["reason"] }> {
+  let bounded: EvidenceRead;
   try {
-    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+    const raw = input.github.listIssueCommentsForEnrichment
+      ? await input.github.listIssueCommentsForEnrichment(input.repo, input.pull.number)
+      : await input.github.listIssueComments(input.repo, input.pull.number);
+    const result = unpackBoundedGithubList(raw);
+    bounded = { status: result.truncated ? "truncated" : "complete", comments: result.items };
   } catch {
-    input.onCommandFetchError?.();
-    return { action: "none", shouldReview: false };
+    bounded = { status: "failed" };
   }
+  let uncapped: EvidenceRead | undefined;
+  if (bounded.status !== "complete" || input.config.commands.enabled) {
+    try { uncapped = { status: "complete", comments: await input.github.listIssueComments(input.repo, input.pull.number) }; }
+    catch { input.onCommandFetchError?.(); uncapped = { status: "failed" }; }
+  }
+  const evidence = resolveEvidenceCommandDecision({
+    config: input.config.commands,
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    bounded,
+    uncapped,
+    isProcessedCommand: (command) => input.state.hasProcessedCommand(input.repo, input.pull.number, input.pull.head.sha, command.commentId)
+  });
+  const evidenceComplete = evidence.evidenceComplete;
+  if (!input.config.commands.enabled || !evidenceComplete) return { decision: evidence.decision, evidenceComplete, reason: evidence.reason };
+  const comments = uncapped?.status === "complete" ? uncapped.comments : bounded.status === "failed" ? [] : bounded.comments;
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   const authorizationRequests = collectReviewEventAuthorizationAttempts(comments, input.config.commands, {
     repo: input.repo,
@@ -1195,15 +1246,14 @@ async function resolveSchedulerCommandDecision(input: {
     : undefined;
   if (requestChanges && !newerStop) {
     return {
-      action: "request-changes",
-      shouldReview: true,
-      commandId: requestChanges.commentId,
-      command: {
+      decision: {
         action: "request-changes",
-        commentId: requestChanges.commentId,
-        author: requestChanges.author,
-        body: ""
-      }
+        shouldReview: true,
+        commandId: requestChanges.commentId,
+        command: { action: "request-changes", commentId: requestChanges.commentId, author: requestChanges.author, body: "" }
+      },
+      evidenceComplete,
+      reason: evidence.reason
     };
   }
   if (requestChanges && newerStop) {
@@ -1217,7 +1267,7 @@ async function resolveSchedulerCommandDecision(input: {
       author: requestChanges.author
     });
   }
-  return decideCommandAction({
+  return { decision: decideCommandAction({
     commands: authorizedCommands.filter((command) =>
       !isFinishingTouchCommandAction(command.action) ||
       (repoProfile.allowed && isFinishingTouchActionEnabled(command.action, repoProfile.profile.finishingTouches))
@@ -1227,7 +1277,7 @@ async function resolveSchedulerCommandDecision(input: {
     headSha: input.pull.head.sha,
     hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
       input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
-  });
+  }), evidenceComplete, reason: evidence.reason };
 }
 
 function latestPendingRequestChanges(input: {
@@ -2055,6 +2105,10 @@ function readinessStateForProcessedStatus(
   }
 }
 
+function isRetryableProcessedHead(processed: { status: ProcessedStatus; error?: string }): boolean {
+  return processed.status === "failed" || Boolean(parseProviderCooldownError(processed.error)) || isRetryableApprovedDryRunPrePostFailure(processed);
+}
+
 function readinessReasonForProcessedHead(processed: { status: ProcessedStatus; error?: string }): string {
   const providerCooldown = parseProviderCooldownError(processed.error);
   if (providerCooldown) return `processed_head_provider_deferred: ${providerCooldown.reason ?? "provider_cooldown"}`;
@@ -2623,6 +2677,8 @@ function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): 
       break;
     case "skipped_stale_head":
       result.skippedStaleHead += 1;
+      break;
+    case "required_evidence_incomplete":
       break;
     default:
       assertNever(status);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BotConfig } from "../src/config.js";
 import { runScheduledCycleWithDeps as runScheduledCycleWithDepsImpl, type SchedulerGitHubApi } from "../src/scheduler.js";
+import type { BoundedGithubList } from "../src/github.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import { reviewPull as reviewPullImpl, type ReviewPullInput, type ReviewPullResult } from "../src/worker.js";
@@ -3517,6 +3518,64 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("quarantines incomplete evidence before leasing and preserves unrelated work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-evidence-order-")); roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]); config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const oldJob = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_B }).job;
+    const currentJob = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A }).job;
+    const statusCalls: StatusCommentCall[] = [], reviewed: string[] = [];
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]], ["org/repo-b", [pull("org/repo-b", 1, HEAD_C)]]]), new Map(), statusCalls, new Map([["org/repo-a#1", new Error("bounded ghp_secret")], ["org/repo-b#1", boundedComments([])]]));
+    const result = await runScheduledCycleWithDeps({ config, github: { ...github, listIssueComments: async () => [] }, state, options: { dryRun: false, useZCode: false }, reviewPullImpl: async ({ state: s, repo, pull: p }) => { reviewed.push(repo); s.recordProcessed({ repo, pullNumber: p.number, headSha: p.head.sha, status: "posted", event: "COMMENT" }); return "reviewed"; }, now: new Date("2026-07-01T00:00:00.000Z") });
+    expect(reviewed).toEqual(["org/repo-b"]); expect(result.queue).toMatchObject({ leased: 1, failedQueueJobs: 1, staleRetired: 1 });
+    expect(state.getReviewQueueJob(currentJob.jobId)).toMatchObject({ state: "failed", finishedAt: expect.any(String) });
+    expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "stale_retired", finishedAt: expect.any(String) });
+    expect(statusCalls.every((c) => c.repo !== "org/repo-a")).toBe(true); expect(JSON.stringify(result)).not.toContain("ghp_"); state.close();
+  });
+
+  it("fails closed without a queue job while complete stop evidence survives uncapped failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-evidence-fail-")); roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]); config.reviewStatusComment!.enabled = true; config.commands = { enabled: true, botMentions: ["@neondiff"], trustedAuthors: ["maintainer"], acknowledge: false };
+    const state = new ReviewStateStore(config.statePath), statusCalls: StatusCommentCall[] = [], stop = comment(991, "maintainer", "@neondiff stop");
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]], ["org/repo-b", [pull("org/repo-b", 1, HEAD_B)]]]), new Map(), statusCalls, new Map([["org/repo-a#1", new Error("bounded ghp_orphan")], ["org/repo-b#1", boundedComments([stop])]]));
+    const result = await runScheduledCycleWithDeps({ config, github: { ...github, listIssueComments: async () => { throw new Error("uncapped failed"); } }, state, options: { dryRun: false, useZCode: false }, reviewPullImpl: async () => "skipped_command_stop" });
+    expect(result.skippedCommandStop).toBe(1); expect(statusCalls).toEqual([]); expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "failed", reason: "incomplete_evidence" });
+    expect(state.listReviewQueueJobs({ state: "command_recorded" })).toEqual([expect.objectContaining({ repo: "org/repo-b", commentId: 991 })]); state.close();
+  });
+
+  it("does not let retryable processed heads bypass evidence quarantine", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-evidence-processed-")); roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]), state = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A }).job;
+    state.recordProcessed({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, status: "failed", error: "transient" });
+    const result = await runScheduledCycleWithDeps({ config, github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), undefined, new Map([["org/repo-a#1", new Error("bounded failed")]])), state, options: { dryRun: false, useZCode: false }, reviewPullImpl: async () => "reviewed" });
+    expect(result.queue).toMatchObject({ leased: 0, failedQueueJobs: 1 }); expect(state.getReviewQueueJob(job.jobId)).toMatchObject({ state: "failed" }); state.close();
+  });
+
+  it("silently retires superseded work for a terminal processed head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-evidence-terminal-")); roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]); config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath), statusCalls: StatusCommentCall[] = [];
+    const oldJob = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_B }).job;
+    state.recordProcessed({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, status: "posted", event: "COMMENT" });
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls, new Map([["org/repo-a#1", new Error("bounded failed")]]));
+    const result = await runScheduledCycleWithDeps({ config, github: { ...github, listIssueComments: async () => [] }, state, options: { dryRun: false, useZCode: false }, reviewPullImpl: async () => "reviewed" });
+    expect(result.queue).toMatchObject({ leased: 0, staleRetired: 1 }); expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "stale_retired" }); expect(statusCalls).toEqual([]); expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)?.state).not.toBe("failed"); state.close();
+  });
+
+  it("admits page-6 request-changes and rechecks an expired exact head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-evidence-page-")); roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]); config.commands = { enabled: true, botMentions: ["@neondiff"], trustedAuthors: ["maintainer"], acknowledge: false };
+    const state = new ReviewStateStore(config.statePath), t0 = new Date("2026-07-01T00:00:00.000Z");
+    const expired = state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 1, headSha: HEAD_B }).job;
+    state.updateReviewQueueJobState({ jobId: expired.jobId, state: "running", leaseId: "lease-b", leaseExpiresAt: "2026-07-01T00:00:00.001Z", clearLease: false, now: t0 });
+    const bounded = Array.from({ length: 500 }, (_u, i) => comment(i + 1, "maintainer", "discussion"));
+    const request = `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`;
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]], ["org/repo-b", [pull("org/repo-b", 1, HEAD_B)]]]), new Map(), undefined, new Map([["org/repo-a#1", boundedComments(bounded, true)], ["org/repo-b#1", new Error("read failed")]]));
+    const result = await runScheduledCycleWithDeps({ config, github: { ...github, listIssueComments: async (repo) => repo === "org/repo-a" ? [...bounded, comment(501, "maintainer", request)] : Promise.reject(new Error("read failed")) }, state, options: { dryRun: false, useZCode: false }, reviewPullImpl: async ({ state: s, repo, pull: p }) => { s.recordProcessed({ repo, pullNumber: p.number, headSha: p.head.sha, status: "posted", event: "REQUEST_CHANGES" }); return "reviewed_command"; }, now: t0, clock: () => new Date("2026-07-01T00:00:00.002Z") });
+    expect(result.commandReviewRequested).toBe(1); expect(result.queue.failedQueueJobs).toBe(1); expect(state.getReviewQueueJob(expired.jobId)).toMatchObject({ state: "failed" }); expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([expect.objectContaining({ source: "manual_command", commentId: 501 })]); state.close();
+  });
+
   it("assigns scheduler jobs to reusable repo-sticky reviewer sessions when enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-"));
     roots.push(root);
@@ -5212,7 +5271,8 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
 function githubFromMap(
   pullsByRepo: Map<string, PullRequestSummary[]>,
   commentsByPull = new Map<string, ReturnType<typeof comment>[]>(),
-  statusCalls?: StatusCommentCall[]
+  statusCalls?: StatusCommentCall[],
+  boundedByPull = new Map<string, BoundedGithubList<ReturnType<typeof comment>> | Error>()
 ): SchedulerGitHubApi {
   return {
     listOpenPulls: async (repo) => pullsByRepo.get(repo)?.filter((entry) => entry.state === undefined || entry.state === "open") ?? [],
@@ -5222,6 +5282,11 @@ function githubFromMap(
       return pull;
     },
     listIssueComments: async (repo, issueNumber) => commentsByPull.get(`${repo}#${issueNumber}`) ?? [],
+    listIssueCommentsForEnrichment: async (repo, issueNumber) => {
+      const value = boundedByPull.get(`${repo}#${issueNumber}`);
+      if (value instanceof Error) throw value;
+      return value ?? boundedComments([]);
+    },
     ...(statusCalls
       ? {
           canPostAsApp: () => true,
@@ -5232,6 +5297,10 @@ function githubFromMap(
         }
       : {})
   };
+}
+
+function boundedComments(comments: ReturnType<typeof comment>[], truncated = false): BoundedGithubList<ReturnType<typeof comment>> {
+  return Object.assign(comments, { items: comments.slice(), rawCount: comments.length, truncated, overflow: truncated });
 }
 
 interface StatusCommentCall {


### PR DESCRIPTION
Related: #882

Slice 3 of 3, stacked on #901 and #899.

Proof:
- 157 additions, 32 deletions relative to slice 2; 189 changed lines
- state, decision, scheduler, and GitHub-read suites: 211/211 passed with Node 26
- git diff --check passed
- GitNexus change detection reports HIGH scheduler-flow impact across 13 symbols and 8 flows; the index is stale, so exact source/tests and CI are authoritative

Safety:
- incomplete inferred/no-command evidence fails closed
- trusted page-6 review/request-changes remains admitted
- retryable processed heads quarantine; terminal processed heads retire superseded work silently
- exact-head quarantine is reapplied transactionally before leasing
- scoped failed/stale-retired counters remain truthful
- no runtime, live DB, config, worker, provider, customer, status, comment, or review mutation