### PR TITLE
docs: scope public BYO customer projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,18 @@ The current npm CLI (v1.0.x) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 provider verification is required for all tiers.
 
-Coming with the native app: public open-source repositories will be free with no
-NeonDiff Activation Key, while private, internal, and commercial repositories
-will require an active entitlement. This managed public-free/private-paid model
-ships with the native NeonDiff app and the managed GitHub App broker (#614) and
-is not enforced by the current CLI. NeonDiff
+The public paid B0 BYO path is activation-gated for the exact selected
+customer-owned repository. A public-scoped entitlement may cover that verified
+public target; private or internal targets require private coverage, and
+unknown visibility fails closed. GitHub App access alone does not unlock review:
+provider verification and a target-pinned dry run remain separate gates.
+
+Managed public-free is a separate milestone 20 path using the official NeonDiff
+App and broker (#614). It is not available in the customer-owned B0 BYO build,
+and must not be inferred from a public repository or a successful App check.
+Public open-source repositories will be free only on that future managed path,
+once its release and runtime gates pass.
+NeonDiff
 support licenses cost $1/month or $10/year for individuals,
 or $100/year for organizations. Individual plans include a 7-day trial,
 organization plans include a 30-day trial, and legacy lifetime licenses remain
@@ -178,9 +185,12 @@ the server kill switch and every broker/entitlement decision still fail closed.
 The public paid B0 BYO beta build uses a separate exact
 `paid-mac-beta-byo-v1` release contract with `NeonDiffBYOGitHubEnabled=true` and
 no managed-broker fields. That contract enables the existing local direct/BYO
-path and API-backed native activation without a hidden defaults mutation. It
-is a paid path for every repository and does not claim the managed public-free
-model. The signed release app contains a sealed NeonDiff worker built from the
+path and API-backed native activation without a hidden defaults mutation. It is
+activation-gated for the exact selected repository: public scope may cover a
+verified public target, private coverage is required for private/internal
+targets, and unknown visibility fails closed. It does not make the managed
+public-free milestone 20 path available. The signed release app contains a
+sealed NeonDiff worker built from the
 exact reviewed source and a pinned, SHA-256-verified official Node runtime. A
 clean Mac therefore does not need a global CLI or separate worker install for
 the native setup and review path. The separate checksum-bound bundle remains
@@ -261,6 +271,10 @@ Useful work unlocks only when GitHub reports the exact repository visibility
 and the live API response returns an active entitlement covering that
 visibility; missing, unknown, expired, revoked, malformed, or offline proof
 fails closed.
+Changing the selected repository, account, bot, App, installation, or
+GitHub-reported visibility invalidates the previous proof. Rerun the exact
+repository-scoped GitHub check and entitlement verification before starting
+new work; a successful App-access check by itself does not unlock review.
 During launch it shows a bounded restoring state while that authorized
 account/bot/config intersection is checked; it does not flash empty first-run
 setup or claim that the existing configuration is missing.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -22,17 +22,20 @@ for the support-tier pricing contract.
 - npm
 - GitHub App credentials for the repos you want to review
 - a provider/model path available on the machine running the worker
-- NeonDiff license key for repository review (the current CLI requires
-  activation for every repository; public open-source review will be free in the
-  native app)
+- An API-backed NeonDiff entitlement for the exact selected repository (the
+  current CLI requires activation for every repository; the B0 BYO native path
+  is also activation-gated)
 
 The current CLI (v1.0.x) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 GitHub-authoritative visibility (public, private, internal, and unknown) decides
-the tier. Coming with the native app: public open-source repositories will be
-free with no NeonDiff Activation Key, while private, internal, and commercial
-repositories will require an active entitlement (managed GitHub App broker #614;
-not enforced by the current CLI). Support
+the tier. The public paid B0 BYO native path is also activation-gated for the
+exact selected customer-owned repository: a public-scoped entitlement may cover
+that verified public target, while private/internal targets require private
+coverage. GitHub App access alone does not unlock review; provider verification
+and a target-pinned dry run remain separate gates. Managed public-free remains
+milestone 20, uses the official NeonDiff App and broker (#614), and is not
+available in B0 BYO. Support
 licenses cost $1/month or $10/year for
 individuals, or $100/year for organizations. Individual plans include a 7-day
 trial, organization plans include a 30-day trial, and legacy lifetime licenses
@@ -186,6 +189,13 @@ worktree prep, model/provider calls, or GitHub review posting unless live API
 validation returns an active entitlement covering that operation and visibility.
 Cached entitlement metadata is diagnostic only.
 
+An App installation check proves only current access to the exact selected
+repository. It does not by itself unlock review. Changing the selected target,
+account, bot, App, installation, or GitHub-reported visibility invalidates the
+previous proof; rerun the repository-scoped App check and entitlement
+verification before new work. Unknown, stale, mismatched, expired, revoked,
+malformed, or offline proof fails closed.
+
 Use this matrix when reading doctor or review evidence:
 
 | Repo visibility | License state | Provider state | Expected setup result |
@@ -222,6 +232,8 @@ broker uses it for an in-memory license lookup and never logs, reflects, or
 persists it. Public-repository token requests omit the key and do not call the
 license authority. This path is still rollout-disabled; these contracts do not
 prove production enablement or customer readiness.
+Managed public-free remains the separate milestone 20 path; B0 BYO activation
+must not be presented as managed public-free availability.
 
 The native source composition is also default-off. A release bundle must carry
 all three exact public Info.plist values before the app constructs the managed

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -11,8 +11,11 @@ one selected repository, and runs the explicit installation check from the
 wizard. No invitation is required when the versioned public GitHub prerelease is
 published and the neondiff.com purchase/download path is live. The managed B1
 path uses the official NeonDiff App and broker under #613; it is separate from
-B0. This document remains the operator/CLI reference for both paths' App
-identity, permission set, and install boundary. Matching public website
+B0, remains rollout-gated, and is not available from the customer-owned B0 path.
+Managed public-free remains milestone 20 and must not be inferred from a public
+repository or a successful customer-owned App check. This document remains the
+operator/CLI reference for both paths' App identity, permission set, and install
+boundary. Matching public website
 onboarding copy lives in the website repo under neon-diff-agent-website#52.
 
 ## Install URL
@@ -353,17 +356,21 @@ and fix App credentials before continuing.
 
 ## License Boundary
 
-The supported distribution requires live API-backed activation before public,
-private, internal, or unknown repository work. Legacy `publicReposFree` and
-`privateReposRequireEntitlement` values are migration inputs only and cannot
-weaken the production policy — a local visibility flag would trust the client's
-own claim.
+The customer-owned B0 path requires live API-backed activation before public,
+private, internal, or unknown repository work. The entitlement is bound
+to the exact selected repository and GitHub-authoritative visibility: public
+scope may cover a verified public target, private coverage is required for
+private/internal targets, and unknown visibility fails closed. Legacy `publicReposFree`
+and `privateReposRequireEntitlement` values are migration inputs only and cannot
+weaken this boundary. An App installation check proves
+only repository access; it does not by itself unlock review. Provider
+verification and a target-pinned dry run remain separate gates.
 
-Coming with the native app: public open-source repository review will be free
-with no NeonDiff Activation Key, while private/commercial review will require an
-active entitlement. This managed public-free/private-paid model ships with the
-native NeonDiff app and the server-side GitHub App broker (#614), which verifies
-repository visibility; it is not enforced by the current CLI.
+The managed public-free/private-paid model is a separate milestone 20 path using
+the official NeonDiff App and server-side broker (#614); it is not available in
+B0 BYO. Public open-source repository review will be free only on that future
+managed path, once its own release and runtime gates pass; this is not a B0
+availability claim.
 
 Private repo data stays local to the worker and GitHub App installation. Do not
 send private repository names, diffs, logs, private keys, provider keys, license

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -185,6 +185,14 @@ show one of these access cues:
 - `INSUFFICIENT READ ACCESS` when GitHub reports that the user cannot read the
   repository.
 
+These cues describe the customer-owned B0 BYO path. `PUBLIC · LICENSE ACTIVE`
+means that an active public-scoped entitlement covers this exact selected
+repository; it is not managed public-free access. Managed public-free remains a
+separate milestone 20 path and is not available in B0 BYO. A successful App
+installation check proves only current repository access; it does not by itself
+unlock review. Provider verification and a target-pinned dry run remain separate
+gates. Unknown visibility fails closed.
+
 A stored license key is not treated as active entitlement. Repo selection still
 writes only the local allowlist; the worker's pre-checkout license and GitHub App
 gates remain authoritative for review execution.
@@ -200,7 +208,9 @@ reads the key only on that explicit action, supplies it to
 `doctor github` through bounded stdin, and accepts only typed App-installation
 proof for the exact configured repository. Changing the App credentials,
 CLI/config path, or allowlist invalidates that proof. This step does not run a
-provider, execute a review, or post to GitHub.
+provider, execute a review, or post to GitHub. Changing the selected repository,
+account, bot, App, installation, or reported visibility also invalidates prior
+proof; rerun the exact target checks before new work.
 
 ## Local Dashboard Launcher
 

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -121,6 +121,30 @@ describe("NeonDiff public community funnel", () => {
     }
   });
 
+  it("customer docs keep selected BYO scope separate from future managed public-free", () => {
+    const surfaces = {
+      readme: read("README.md"),
+      setup: read("docs/SETUP.md"),
+      githubApp: read("docs/github-app-setup.md"),
+      desktop: read("docs/neondiff-desktop.md")
+    };
+
+    for (const [name, text] of Object.entries(surfaces)) {
+      const normalized = text.replace(/\s+/g, " ");
+      expect(normalized, name).toMatch(/public paid B0 BYO|customer-owned.*App/i);
+      expect(normalized, name).toMatch(/exact (?:selected )?repository|one selected repository/i);
+      expect(normalized, name).toMatch(/public(?:-repo)? scope|public.*entitlement/i);
+      expect(normalized, name).toMatch(/private(?:\/internal|\/commercial)?.*(?:coverage|entitlement|required)/i);
+      expect(normalized, name).toMatch(/unknown.*fail(?:s|ed) closed/i);
+      expect(normalized, name).toMatch(/managed public-free.*milestone 20|milestone 20.*managed public-free/i);
+      expect(normalized, name).toMatch(/does not (?:by itself )?(?:unlock|prove).*review|remains a separate gate/i);
+    }
+
+    expect(surfaces.readme).not.toMatch(/This managed public-free\/private-paid model\s+ships with the native NeonDiff app/i);
+    expect(surfaces.setup).not.toMatch(/public open-source repositories? will be free with no NeonDiff Activation Key/i);
+    expect(surfaces.githubApp).not.toMatch(/Coming with the native app: public open-source repository review will be free/i);
+  });
+
   it("license boundary surfaces are canonical and avoid open-source claims", () => {
     const license = read("LICENSE.md");
     const boundary = read("docs/license-boundary.md");


### PR DESCRIPTION
## Summary

- Align README, setup, GitHub App, and desktop onboarding docs with the exact selected customer-owned B0 BYO repository scope.
- Require visibility-aware API entitlement proof: public scope for verified public targets, private coverage for private/internal targets, and fail-closed unknown/stale/mismatched recovery.
- Keep managed public-free explicitly separate as milestone 20; an App access check does not unlock review.

Closes #891

## Validation

- `git diff --check` — PASS
- `node scripts/check-public-claims.mjs` — PASS
- `node scripts/check-design-source-contract.mjs` — PASS
- `PATH=/opt/homebrew/bin:/usr/bin:/bin npm test -- tests/public-community-funnel.test.ts --run` — PASS (11/11)
- `node --experimental-strip-types --check tests/public-community-funnel.test.ts` — PASS
- GitNexus detect-changes — low risk, zero affected processes; index is stale (indexed `e41e9c9` in a sibling checkout versus base `dde516e5`).

## Proof boundary

This docs/test slice does not prove executable activation, signed distribution, managed-App availability, website publication, billing, deployment, runtime, or customer readiness. Website onboarding remains in the website repository; no website files were changed.

Agent-authored; no live activation, Keychain, config/database, customer, deployment, or release mutation performed.