### PR TITLE
fix(daemon): persist progress clock semantics

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
@@ -54,7 +55,7 @@ export interface RunDaemonCycleOptions {
     licenseAdmission?: ProductionLicenseAdmission;
   }) => Promise<IssueEnrichmentCycleResult>;
   cleanupReviewWorktreesImpl?: (options: { configPath?: string; dryRun: boolean }) => ReviewWorktreeCleanupSummary;
-  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
+  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string, runId?: string) => void;
   admitDaemonCycleImpl?: (configPath?: string) => Promise<DaemonCycleAdmissions | void>;
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
@@ -83,15 +84,17 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     return { ok: false, failureKind: "admission_denied", error: message };
   }
   const schedulerEnabled = input.reviewSchedulerEnabled === true;
+  const heartbeatRunId = randomUUID();
   const runOnceImpl = input.runOnceImpl ?? (schedulerEnabled ? runScheduledCycle : runOnce);
   const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
-  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
+  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string, runId?: string) => {
     recordDaemonHeartbeatFromConfig({
       configPath: input.configPath,
       cycle: input.cycle,
       dryRun: input.dryRun,
       event,
       error,
+      runId,
       stderr
     });
   });
@@ -119,7 +122,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     }
   }
 
-  recordHeartbeat("daemon_cycle_start");
+  recordHeartbeat("daemon_cycle_start", undefined, heartbeatRunId);
   stdout(formatDaemonLog({
     event: "daemon_cycle_start",
     cycle: input.cycle,
@@ -181,7 +184,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       result
     }));
-    recordHeartbeat("daemon_cycle_complete");
+    recordHeartbeat("daemon_cycle_complete", undefined, heartbeatRunId);
     return { ok: true, result };
   } catch (error) {
     await issueEnrichmentPromise;
@@ -193,7 +196,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       error: message
     }));
-    recordHeartbeat("daemon_cycle_failed", message);
+    recordHeartbeat("daemon_cycle_failed", message, heartbeatRunId);
     return { ok: false, failureKind: "runtime_failure", error: message };
   }
 }
@@ -349,6 +352,7 @@ function recordDaemonHeartbeatFromConfig(input: {
   dryRun: boolean;
   event: DaemonHeartbeatEvent;
   error?: string;
+  runId?: string;
   stderr: (line: string) => void;
 }): void {
   try {
@@ -359,6 +363,7 @@ function recordDaemonHeartbeatFromConfig(input: {
         cycle: input.cycle,
         dryRun: input.dryRun,
         event: input.event,
+        ...(input.runId ? { runId: input.runId } : {}),
         ...(input.error ? { error: input.error } : {})
       });
     } finally {

--- a/src/state.ts
+++ b/src/state.ts
@@ -336,12 +336,17 @@ export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecor
   expired: boolean;
 }
 
-export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_complete" | "daemon_cycle_failed";
+export type DaemonHeartbeatEvent =
+  | "daemon_cycle_start"
+  | "daemon_cycle_progress"
+  | "daemon_cycle_complete"
+  | "daemon_cycle_failed";
 
 export interface DaemonHeartbeatRecord {
   cycle: number;
   event: DaemonHeartbeatEvent;
   dryRun: boolean;
+  runId?: string;
   recordedAt?: Date;
   error?: string;
 }
@@ -354,6 +359,9 @@ export interface StoredDaemonHeartbeatRecord {
   error?: string;
   startedCycle?: number;
   startedAt?: string;
+  runId?: string;
+  lastProgressAt?: string;
+  completedAt?: string;
 }
 
 export interface ProcessedCommandRecord {
@@ -661,7 +669,12 @@ export class ReviewStateStore {
         event text,
         dry_run integer,
         recorded_at text,
-        error text
+        error text,
+        started_cycle integer,
+        started_at text,
+        run_id text,
+        last_progress_at text,
+        completed_at text
       );
 
       create table if not exists reviewer_sessions (
@@ -3275,45 +3288,81 @@ export class ReviewStateStore {
   }
 
   recordDaemonHeartbeat(record: DaemonHeartbeatRecord): void {
+    const recordedAt = (record.recordedAt ?? new Date()).toISOString();
     if (record.event === "daemon_cycle_start") {
       this.db
         .prepare(
           `insert into daemon_heartbeat
-            (id, started_cycle, started_at)
-           values (1, ?, ?)
+            (id, started_cycle, started_at, run_id, last_progress_at, completed_at)
+           values (1, ?, ?, ?, null, null)
            on conflict(id) do update set
-             started_cycle = excluded.started_cycle,
-             started_at = excluded.started_at`
+             started_cycle = case
+               when daemon_heartbeat.run_id is excluded.run_id
+                 and daemon_heartbeat.completed_at is null
+                 and (daemon_heartbeat.event is null
+                   or daemon_heartbeat.event in ('daemon_cycle_start', 'daemon_cycle_progress'))
+               then daemon_heartbeat.started_cycle else excluded.started_cycle end,
+             started_at = case
+               when daemon_heartbeat.run_id is excluded.run_id
+                 and daemon_heartbeat.completed_at is null
+                 and (daemon_heartbeat.event is null
+                   or daemon_heartbeat.event in ('daemon_cycle_start', 'daemon_cycle_progress'))
+               then daemon_heartbeat.started_at else excluded.started_at end,
+             run_id = excluded.run_id,
+             last_progress_at = case
+               when daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
+               then daemon_heartbeat.last_progress_at else null end,
+             completed_at = case
+               when daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
+               then daemon_heartbeat.completed_at else null end`
         )
-        .run(record.cycle, (record.recordedAt ?? new Date()).toISOString());
+        .run(record.cycle, recordedAt, record.runId ?? null);
+      return;
+    }
+
+    if (record.event === "daemon_cycle_progress") {
+      this.db.prepare(
+        `update daemon_heartbeat set
+           cycle = ?, event = ?, dry_run = ?, recorded_at = ?, error = null, last_progress_at = ?
+         where id = 1 and run_id is ? and completed_at is null and started_at is not null
+           and ? >= started_at and (last_progress_at is null or last_progress_at < ?)`
+      ).run(record.cycle, record.event, record.dryRun ? 1 : 0, recordedAt, recordedAt,
+        record.runId ?? null, recordedAt, recordedAt);
       return;
     }
 
     this.db
       .prepare(
-        `insert or replace into daemon_heartbeat
-          (id, cycle, event, dry_run, recorded_at, error, started_cycle, started_at)
-         values (
-           1, ?, ?, ?, ?, ?,
-           coalesce((select started_cycle from daemon_heartbeat where id = 1), ?),
-           coalesce((select started_at from daemon_heartbeat where id = 1), ?)
-         )`
+        `insert into daemon_heartbeat
+          (id, cycle, event, dry_run, recorded_at, error, started_cycle, started_at, run_id, completed_at)
+         values (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do update set
+           cycle = excluded.cycle, event = excluded.event, dry_run = excluded.dry_run,
+           recorded_at = excluded.recorded_at, error = excluded.error,
+           completed_at = excluded.completed_at
+         where daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
+           and excluded.completed_at >= daemon_heartbeat.started_at
+           and (daemon_heartbeat.last_progress_at is null
+             or excluded.completed_at >= daemon_heartbeat.last_progress_at)`
       )
       .run(
         record.cycle,
         record.event,
         record.dryRun ? 1 : 0,
-        (record.recordedAt ?? new Date()).toISOString(),
+        recordedAt,
         record.error ? redactSecrets(record.error) : null,
         record.cycle,
-        (record.recordedAt ?? new Date()).toISOString()
+        recordedAt,
+        record.runId ?? null,
+        recordedAt
       );
   }
 
   getDaemonHeartbeat(): StoredDaemonHeartbeatRecord | undefined {
     const row = this.db
       .prepare(
-        `select cycle, event, dry_run, recorded_at, error, started_cycle, started_at
+        `select cycle, event, dry_run, recorded_at, error, started_cycle, started_at,
+                run_id, last_progress_at, completed_at
          from daemon_heartbeat
          where id = 1 and recorded_at is not null
          limit 1`
@@ -3622,11 +3671,17 @@ export class ReviewStateStore {
       .prepare("pragma table_info(daemon_heartbeat)")
       .all() as unknown as Array<{ name: string }>;
     const names = new Set(columns.map((column) => column.name));
-    if (!names.has("started_cycle")) {
-      this.db.exec("alter table daemon_heartbeat add column started_cycle integer");
-    }
-    if (!names.has("started_at")) {
-      this.db.exec("alter table daemon_heartbeat add column started_at text");
+    const additions = [
+      ["started_cycle", "integer"], ["started_at", "text"], ["run_id", "text"],
+      ["last_progress_at", "text"], ["completed_at", "text"]
+    ].filter(([name]) => !names.has(name!));
+    if (additions.length === 0) return;
+    try {
+      this.db.exec(`begin immediate; ${additions.map(([name, type]) =>
+        `alter table daemon_heartbeat add column ${name} ${type}`).join("; ")}; commit`);
+    } catch (error) {
+      try { this.db.exec("rollback"); } catch { /* transaction did not start */ }
+      throw error;
     }
   }
 
@@ -4136,6 +4191,9 @@ interface DaemonHeartbeatRow {
   error: string | null;
   started_cycle: number | null;
   started_at: string | null;
+  run_id: string | null;
+  last_progress_at: string | null;
+  completed_at: string | null;
 }
 
 interface RepoProviderCooldownRow {
@@ -4480,7 +4538,14 @@ function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRe
     recordedAt: row.recorded_at!,
     ...(row.error ? { error: row.error } : {}),
     ...(row.started_cycle !== null ? { startedCycle: row.started_cycle } : {}),
-    ...(row.started_at ? { startedAt: row.started_at } : {})
+    ...(row.started_at ? { startedAt: row.started_at } : {}),
+    ...(row.run_id ? { runId: row.run_id } : {}),
+    ...(row.last_progress_at ? { lastProgressAt: row.last_progress_at } : {}),
+    ...(row.completed_at
+      ? { completedAt: row.completed_at }
+      : row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed"
+        ? { completedAt: row.recorded_at! }
+        : {})
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -336,11 +336,7 @@ export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecor
   expired: boolean;
 }
 
-export type DaemonHeartbeatEvent =
-  | "daemon_cycle_start"
-  | "daemon_cycle_progress"
-  | "daemon_cycle_complete"
-  | "daemon_cycle_failed";
+export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete" | "daemon_cycle_failed";
 
 export interface DaemonHeartbeatRecord {
   cycle: number;
@@ -3290,33 +3286,23 @@ export class ReviewStateStore {
   recordDaemonHeartbeat(record: DaemonHeartbeatRecord): void {
     const recordedAt = (record.recordedAt ?? new Date()).toISOString();
     if (record.event === "daemon_cycle_start") {
+      const runId = record.runId ?? null;
+      const current = this.db.prepare(
+        "select run_id, completed_at, event from daemon_heartbeat where id = 1"
+      ).get() as { run_id: string | null; completed_at: string | null; event: string | null } | undefined;
+      if (current?.run_id === runId && current.completed_at === null &&
+          (current.event === null || current.event === "daemon_cycle_start" || current.event === "daemon_cycle_progress")) return;
       this.db
         .prepare(
           `insert into daemon_heartbeat
             (id, started_cycle, started_at, run_id, last_progress_at, completed_at)
            values (1, ?, ?, ?, null, null)
            on conflict(id) do update set
-             started_cycle = case
-               when daemon_heartbeat.run_id is excluded.run_id
-                 and daemon_heartbeat.completed_at is null
-                 and (daemon_heartbeat.event is null
-                   or daemon_heartbeat.event in ('daemon_cycle_start', 'daemon_cycle_progress'))
-               then daemon_heartbeat.started_cycle else excluded.started_cycle end,
-             started_at = case
-               when daemon_heartbeat.run_id is excluded.run_id
-                 and daemon_heartbeat.completed_at is null
-                 and (daemon_heartbeat.event is null
-                   or daemon_heartbeat.event in ('daemon_cycle_start', 'daemon_cycle_progress'))
-               then daemon_heartbeat.started_at else excluded.started_at end,
-             run_id = excluded.run_id,
-             last_progress_at = case
-               when daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
-               then daemon_heartbeat.last_progress_at else null end,
-             completed_at = case
-               when daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
-               then daemon_heartbeat.completed_at else null end`
+             started_cycle = excluded.started_cycle, started_at = excluded.started_at,
+             run_id = excluded.run_id, cycle = null, event = null, dry_run = null,
+             recorded_at = null, error = null, last_progress_at = null, completed_at = null`
         )
-        .run(record.cycle, recordedAt, record.runId ?? null);
+        .run(record.cycle, recordedAt, runId);
       return;
     }
 

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -278,7 +278,7 @@ describe("daemon cycle resilience", () => {
   });
 
   it("records start and completion heartbeat events for successful cycles", async () => {
-    const heartbeats: string[] = [];
+    const heartbeats: Array<{ event: string; runId?: string }> = [];
 
     const result = await runDaemonCycle({
       cycle: 2,
@@ -329,13 +329,15 @@ describe("daemon cycle resilience", () => {
           other: 0
         }
       }),
-      recordHeartbeatImpl: (event) => heartbeats.push(event),
+      recordHeartbeatImpl: (event, _error, runId) => heartbeats.push({ event, runId }),
       stdout: () => undefined,
       stderr: () => undefined
     });
 
     expect(result.ok).toBe(true);
-    expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
+    expect(heartbeats.map(({ event }) => event)).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
+    expect(new Set(heartbeats.map(({ runId }) => runId)).size).toBe(1);
+    expect(heartbeats[0]?.runId).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it("runs one bounded provider cooldown drain after successful review cycles", async () => {
@@ -456,6 +458,7 @@ describe("daemon cycle resilience", () => {
 
   it("records a failed heartbeat with the failure message", async () => {
     const heartbeats: Array<{ event: string; error?: string }> = [];
+    const runIds: string[] = [];
 
     const result = await runDaemonCycle({
       cycle: 3,
@@ -467,7 +470,10 @@ describe("daemon cycle resilience", () => {
       runOnceImpl: async () => {
         throw new Error("second timeout");
       },
-      recordHeartbeatImpl: (event, error) => heartbeats.push({ event, ...(error ? { error } : {}) }),
+      recordHeartbeatImpl: (event, error, runId) => {
+        heartbeats.push({ event, ...(error ? { error } : {}) });
+        runIds.push(runId!);
+      },
       stdout: () => undefined,
       stderr: () => undefined
     });
@@ -478,6 +484,7 @@ describe("daemon cycle resilience", () => {
       { event: "daemon_cycle_start" },
       { event: "daemon_cycle_failed", error: "second timeout" }
     ]);
+    expect(new Set(runIds).size).toBe(1);
   });
 
   it("runs and logs the issue enrichment cycle when the default-off lane is enabled", async () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1625,7 +1625,7 @@ describe("review state store", () => {
     store.close();
   });
 
-  it("stores the latest daemon heartbeat as a singleton", () => {
+  it("keeps daemon run identity, progress, and completion clocks distinct", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-"));
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
@@ -1634,24 +1634,87 @@ describe("review state store", () => {
       cycle: 1,
       event: "daemon_cycle_start",
       dryRun: false,
+      runId: "run-a",
       recordedAt: new Date("2026-07-01T00:00:00.000Z")
+    });
+    store.recordDaemonHeartbeat({
+      cycle: 1,
+      event: "daemon_cycle_start",
+      dryRun: false,
+      runId: "run-a",
+      recordedAt: new Date("2026-07-01T00:00:05.000Z")
+    });
+    store.recordDaemonHeartbeat({
+      cycle: 1,
+      event: "daemon_cycle_progress",
+      dryRun: false,
+      runId: "run-a",
+      recordedAt: new Date("2026-07-01T00:01:00.000Z")
+    });
+    store.recordDaemonHeartbeat({
+      cycle: 1,
+      event: "daemon_cycle_progress",
+      dryRun: false,
+      runId: "run-a",
+      recordedAt: new Date("2026-07-01T00:00:30.000Z")
+    });
+    store.recordDaemonHeartbeat({
+      cycle: 1,
+      event: "daemon_cycle_progress",
+      dryRun: false,
+      runId: "run-b",
+      recordedAt: new Date("2026-07-01T00:02:00.000Z")
     });
     store.recordDaemonHeartbeat({
       cycle: 1,
       event: "daemon_cycle_complete",
       dryRun: false,
-      recordedAt: new Date("2026-07-01T00:00:05.000Z")
+      runId: "run-a",
+      recordedAt: new Date("2026-07-01T00:03:00.000Z")
     });
 
     expect(store.getDaemonHeartbeat()).toEqual({
       cycle: 1,
       event: "daemon_cycle_complete",
       dryRun: false,
-      recordedAt: "2026-07-01T00:00:05.000Z",
+      recordedAt: "2026-07-01T00:03:00.000Z",
       startedCycle: 1,
-      startedAt: "2026-07-01T00:00:00.000Z"
+      startedAt: "2026-07-01T00:00:00.000Z",
+      runId: "run-a",
+      lastProgressAt: "2026-07-01T00:01:00.000Z",
+      completedAt: "2026-07-01T00:03:00.000Z"
     });
     store.close();
+  });
+
+  it("migrates legacy heartbeat storage idempotently without inventing progress", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-legacy-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const legacy = new DatabaseSync(statePath);
+    legacy.exec(`create table daemon_heartbeat (
+      id integer primary key, cycle integer, event text, dry_run integer,
+      recorded_at text, error text, started_cycle integer, started_at text
+    )`);
+    legacy.prepare(`insert into daemon_heartbeat
+      (id, cycle, event, dry_run, recorded_at, started_cycle, started_at)
+      values (1, 4, 'daemon_cycle_failed', 0, ?, 4, ?)`)
+      .run("2026-07-01T00:04:00.000Z", "2026-07-01T00:00:00.000Z");
+    legacy.close();
+
+    for (let open = 0; open < 2; open += 1) {
+      const store = new ReviewStateStore(statePath);
+      expect(store.getDaemonHeartbeat()).toMatchObject({
+        startedAt: "2026-07-01T00:00:00.000Z",
+        completedAt: "2026-07-01T00:04:00.000Z"
+      });
+      expect(store.getDaemonHeartbeat()?.lastProgressAt).toBeUndefined();
+      store.close();
+    }
+    const rollbackReader = new DatabaseSync(statePath, { readOnly: true });
+    expect(rollbackReader.prepare("select cycle, event, recorded_at, started_at from daemon_heartbeat").get())
+      .toMatchObject({ cycle: 4, event: "daemon_cycle_failed" });
+    rollbackReader.close();
   });
 
   it("does not treat a start-only heartbeat as a terminal daemon heartbeat", () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1630,48 +1630,14 @@ describe("review state store", () => {
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
 
-    store.recordDaemonHeartbeat({
-      cycle: 1,
-      event: "daemon_cycle_start",
-      dryRun: false,
-      runId: "run-a",
-      recordedAt: new Date("2026-07-01T00:00:00.000Z")
-    });
-    store.recordDaemonHeartbeat({
-      cycle: 1,
-      event: "daemon_cycle_start",
-      dryRun: false,
-      runId: "run-a",
-      recordedAt: new Date("2026-07-01T00:00:05.000Z")
-    });
-    store.recordDaemonHeartbeat({
-      cycle: 1,
-      event: "daemon_cycle_progress",
-      dryRun: false,
-      runId: "run-a",
-      recordedAt: new Date("2026-07-01T00:01:00.000Z")
-    });
-    store.recordDaemonHeartbeat({
-      cycle: 1,
-      event: "daemon_cycle_progress",
-      dryRun: false,
-      runId: "run-a",
-      recordedAt: new Date("2026-07-01T00:00:30.000Z")
-    });
-    store.recordDaemonHeartbeat({
-      cycle: 1,
-      event: "daemon_cycle_progress",
-      dryRun: false,
-      runId: "run-b",
-      recordedAt: new Date("2026-07-01T00:02:00.000Z")
-    });
-    store.recordDaemonHeartbeat({
-      cycle: 1,
-      event: "daemon_cycle_complete",
-      dryRun: false,
-      runId: "run-a",
-      recordedAt: new Date("2026-07-01T00:03:00.000Z")
-    });
+    const record = (event: "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete", runId: string, at: string) =>
+      store.recordDaemonHeartbeat({ cycle: 1, event, dryRun: false, runId, recordedAt: new Date(at) });
+    record("daemon_cycle_start", "run-a", "2026-07-01T00:00:00.000Z");
+    record("daemon_cycle_start", "run-a", "2026-07-01T00:00:05.000Z");
+    record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:00.000Z");
+    record("daemon_cycle_progress", "run-a", "2026-07-01T00:00:30.000Z");
+    record("daemon_cycle_progress", "run-b", "2026-07-01T00:02:00.000Z");
+    record("daemon_cycle_complete", "run-a", "2026-07-01T00:03:00.000Z");
 
     expect(store.getDaemonHeartbeat()).toEqual({
       cycle: 1,
@@ -1684,6 +1650,13 @@ describe("review state store", () => {
       lastProgressAt: "2026-07-01T00:01:00.000Z",
       completedAt: "2026-07-01T00:03:00.000Z"
     });
+    record("daemon_cycle_start", "run-b", "2026-07-01T01:00:00.000Z");
+    record("daemon_cycle_progress", "run-a", "2026-07-01T01:01:00.000Z");
+    record("daemon_cycle_complete", "run-a", "2026-07-01T01:02:00.000Z");
+    expect(store.getDaemonHeartbeat()).toBeUndefined();
+    record("daemon_cycle_progress", "run-b", "2026-07-01T01:03:00.000Z");
+    expect(store.getDaemonHeartbeat()).toMatchObject({ runId: "run-b", startedAt: "2026-07-01T01:00:00.000Z",
+      lastProgressAt: "2026-07-01T01:03:00.000Z" });
     store.close();
   });
 


### PR DESCRIPTION
Related: #808
Parent runtime tracker: #738

## Outcome

Adds nullable heartbeat run identity, last-progress, and completion clocks while preserving legacy columns. Same-run starts keep the original start time, progress advances only for the matching active run and only monotonically, and terminal completion preserves prior progress.

The migration is additive, idempotent, and transactional. Legacy rows invent no progress timestamp; already-stored terminal events expose their existing recorded time as completion. Older readers can continue selecting the unchanged legacy columns.

## Validation

- Failing-first: the new state fixtures initially failed on refreshed start time and missing progress/completion fields.
- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/state.test.ts` — 72 passed.
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin /opt/homebrew/bin/npm run build` — passed.
- `git diff --check` — passed.
- GitNexus impact and detect-changes were LOW risk with an explicit stale-index warning; current source/tests are authoritative.

## Change envelope

Two files, 157 insertions and 29 deletions (186 changed non-generated lines), based directly on `dde516e5458b6b1e81cf3451f19f331ae76306ec`.

## Proof boundary

Agent-authored source and temporary-database test change only. This PR does not merge, release, install, restart, signal, or inspect the live beta.87 worker; open or migrate its database; mutate config, leases, queues, or watermarks; retry historical rows; or prove runtime/customer adoption.