### PR TITLE
feat(desktop): add signed update preflight plan

### DIFF
--- a/scripts/desktop-update-command.mjs
+++ b/scripts/desktop-update-command.mjs
@@ -2,7 +2,7 @@
 import { constants, closeSync, fstatSync, openSync, readFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { planDesktopUpdate } from "./lib/desktop-update-command.mjs";
+import { desktopValidatorPath, planDesktopUpdate, selectDesktopDeclarationPath } from "./lib/desktop-update-command.mjs";
 
 function fail(message) { throw new Error(message); }
 function parse(values) {
@@ -22,12 +22,13 @@ function main() {
   const [action, ...values] = process.argv.slice(2), args = parse(values);
   if (!action) fail("usage: desktop-update-command.mjs <update|rollback|reupdate> --index PATH --packet PATH --packet-sha256 SHA --artifact PATH --team-id ID [--dry-run true]");
   if ((args.get("--dry-run") ?? "true") !== "true") fail("live Desktop mutation is not implemented; dry-run must remain true");
-  const indexPath = resolve(need(args, "index")), validation = spawnSync(process.execPath, [new URL("./validate-desktop-release-declaration.mjs", import.meta.url).pathname, "--index", indexPath], { encoding: "utf8" });
+  const indexPath = resolve(need(args, "index")), validation = spawnSync(process.execPath, [desktopValidatorPath(import.meta.url), "--index", indexPath], { encoding: "utf8" });
   if (validation.status !== 0) fail("Desktop declaration index is not accepted");
   const index = JSON.parse(readRegular(indexPath, "declaration index"));
-  if (index.status !== "retained" || !index.currentPath || basename(index.currentPath) !== index.currentPath) fail("declaration index has no current release");
-  const declarationBytes = readRegular(join(dirname(indexPath), index.declarationDirectory, index.currentPath), "Desktop declaration"), declaration = JSON.parse(declarationBytes);
   const packetBytes = readRegular(resolve(need(args, "packet")), "accepted packet"), packet = JSON.parse(packetBytes), artifactBytes = readRegular(resolve(need(args, "artifact")), "Desktop artifact");
+  const declarationPath = selectDesktopDeclarationPath(action, index, packet);
+  if (basename(declarationPath) !== declarationPath) fail("Desktop declaration path is invalid");
+  const declarationBytes = readRegular(join(dirname(indexPath), index.declarationDirectory, declarationPath), "Desktop declaration"), declaration = JSON.parse(declarationBytes);
   console.log(JSON.stringify(planDesktopUpdate({ action, declaration, declarationBytes, packet, packetBytes, packetSHA256: need(args, "packet-sha256"), artifactBytes, expectedTeamID: need(args, "team-id") })));
 }
 try { main(); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; }

--- a/scripts/desktop-update-command.mjs
+++ b/scripts/desktop-update-command.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { constants, closeSync, fstatSync, openSync, readFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { planDesktopUpdate } from "./lib/desktop-update-command.mjs";
+
+function fail(message) { throw new Error(message); }
+function parse(values) {
+  const args = new Map();
+  for (let i = 0; i < values.length; i += 2) { const key = values[i], value = values[i + 1]; if (!key?.startsWith("--") || value === undefined || args.has(key)) fail("invalid or duplicate argument"); args.set(key, value); }
+  return args;
+}
+function need(args, key) { const value = args.get(`--${key}`); if (!value) fail(`--${key} is required`); return value; }
+function readRegular(path, label) {
+  if (!isAbsolute(path)) fail(`${label} path must be absolute`);
+  let fd;
+  try { fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0)); if (!fstatSync(fd).isFile()) fail(`${label} must be a regular file`); return readFileSync(fd); }
+  catch (error) { if (error?.code === "ELOOP") fail(`${label} must not be a symlink`); throw error; }
+  finally { if (fd !== undefined) closeSync(fd); }
+}
+function main() {
+  const [action, ...values] = process.argv.slice(2), args = parse(values);
+  if (!action) fail("usage: desktop-update-command.mjs <update|rollback|reupdate> --index PATH --packet PATH --packet-sha256 SHA --artifact PATH --team-id ID [--dry-run true]");
+  if ((args.get("--dry-run") ?? "true") !== "true") fail("live Desktop mutation is not implemented; dry-run must remain true");
+  const indexPath = resolve(need(args, "index")), validation = spawnSync(process.execPath, [new URL("./validate-desktop-release-declaration.mjs", import.meta.url).pathname, "--index", indexPath], { encoding: "utf8" });
+  if (validation.status !== 0) fail("Desktop declaration index is not accepted");
+  const index = JSON.parse(readRegular(indexPath, "declaration index"));
+  if (index.status !== "retained" || !index.currentPath || basename(index.currentPath) !== index.currentPath) fail("declaration index has no current release");
+  const declarationBytes = readRegular(join(dirname(indexPath), index.declarationDirectory, index.currentPath), "Desktop declaration"), declaration = JSON.parse(declarationBytes);
+  const packetBytes = readRegular(resolve(need(args, "packet")), "accepted packet"), packet = JSON.parse(packetBytes), artifactBytes = readRegular(resolve(need(args, "artifact")), "Desktop artifact");
+  console.log(JSON.stringify(planDesktopUpdate({ action, declaration, declarationBytes, packet, packetBytes, packetSHA256: need(args, "packet-sha256"), artifactBytes, expectedTeamID: need(args, "team-id") })));
+}
+try { main(); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; }

--- a/scripts/lib/desktop-update-command.mjs
+++ b/scripts/lib/desktop-update-command.mjs
@@ -29,7 +29,7 @@ export function planDesktopUpdate({ action, declaration, declarationBytes, packe
   exact(packet.release, ["version", "tag", "channel", "build", "artifactName", "artifactSHA256", "treeSHA256"], "release receipt");
   exact(packet.sparkle, ["publicKey", "edSignature", "feedURL", "entrySHA256"], "Sparkle receipt");
   exact(packet.apple, ["teamID", "notarized", "stapled", "gatekeeper"], "Apple receipt");
-  exact(packet.prestate, ["appSHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "plistSHA256", "label", "wrapperPID", "wrapperPath", "helperPID", "helperPath"], "prestate receipt");
+  exact(packet.prestate, ["appSHA256", "accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256", "label", "wrapperPID", "wrapperPath", "helperPID", "helperPath"], "prestate receipt");
   const release = packet.release, expected = [declaration.version, declaration.tag, declaration.channel, declaration.build, declaration.distribution?.artifactName];
   if (JSON.stringify([release.version, release.tag, release.channel, release.build, release.artifactName]) !== JSON.stringify(expected)) fail("accepted packet disagrees with declaration identity");
   hashes(release, ["artifactSHA256", "treeSHA256"], "release receipt");
@@ -42,7 +42,7 @@ export function planDesktopUpdate({ action, declaration, declarationBytes, packe
   if (!verified) fail("Sparkle signature verification failed");
   if (!/^[A-Z0-9]{10}$/.test(expectedTeamID ?? "") || packet.apple.teamID !== expectedTeamID) fail("approved Team ID mismatch");
   if (packet.apple.notarized !== true || packet.apple.stapled !== true || packet.apple.gatekeeper !== true) fail("Apple notarization, staple, and Gatekeeper proof are required");
-  hashes(packet.prestate, ["appSHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "plistSHA256"], "prestate receipt");
+  hashes(packet.prestate, ["appSHA256", "accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256"], "prestate receipt");
   if (!LABEL.test(packet.prestate.label) || !Number.isInteger(packet.prestate.wrapperPID) || packet.prestate.wrapperPID < 1 || !Number.isInteger(packet.prestate.helperPID) || packet.prestate.helperPID < 1 || packet.prestate.wrapperPath !== "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop" || packet.prestate.helperPath !== "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker") fail("prestate worker identity is invalid");
   return {
     schemaVersion: 1, dryRun: true, action, packetSHA256,

--- a/scripts/lib/desktop-update-command.mjs
+++ b/scripts/lib/desktop-update-command.mjs
@@ -1,0 +1,53 @@
+import { createHash, createPublicKey, verify } from "node:crypto";
+
+const SHA = /^[0-9a-f]{64}$/;
+const LABEL = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const ACTIONS = new Set(["update", "rollback", "reupdate"]);
+function fail(message) { throw new Error(message); }
+function exact(value, keys, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...keys].sort())) fail(`${label} shape is invalid`);
+}
+function hash(value) { return createHash("sha256").update(value).digest("hex"); }
+function hashes(value, keys, label) {
+  for (const key of keys) if (!SHA.test(value[key] ?? "")) fail(`${label} ${key} is invalid`);
+}
+function base64(value, bytes, label) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) fail(`${label} is invalid`);
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.byteLength !== bytes || decoded.toString("base64") !== value) fail(`${label} is invalid`);
+  return decoded;
+}
+
+export function planDesktopUpdate({ action, declaration, declarationBytes, packet, packetBytes, packetSHA256, artifactBytes, expectedTeamID }) {
+  if (!ACTIONS.has(action)) fail("update action is invalid");
+  if (!Buffer.isBuffer(packetBytes) || !Buffer.isBuffer(artifactBytes)) fail("accepted packet and artifact must be immutable bytes");
+  if (!SHA.test(packetSHA256 ?? "") || hash(packetBytes) !== packetSHA256) fail("accepted packet digest mismatch");
+  if (JSON.stringify(packet) !== packetBytes.toString("utf8")) fail("accepted packet must be canonical JSON");
+  exact(packet, ["schemaVersion", "declarationSHA256", "release", "sparkle", "apple", "prestate"], "accepted packet");
+  if (packet.schemaVersion !== 1) fail("accepted packet schema is invalid");
+  if (!Buffer.isBuffer(declarationBytes) || !SHA.test(packet.declarationSHA256 ?? "") || hash(declarationBytes) !== packet.declarationSHA256) fail("accepted declaration digest mismatch");
+  exact(packet.release, ["version", "tag", "channel", "build", "artifactName", "artifactSHA256", "treeSHA256"], "release receipt");
+  exact(packet.sparkle, ["publicKey", "edSignature", "feedURL", "entrySHA256"], "Sparkle receipt");
+  exact(packet.apple, ["teamID", "notarized", "stapled", "gatekeeper"], "Apple receipt");
+  exact(packet.prestate, ["appSHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "plistSHA256", "label", "wrapperPID", "wrapperPath", "helperPID", "helperPath"], "prestate receipt");
+  const release = packet.release, expected = [declaration.version, declaration.tag, declaration.channel, declaration.build, declaration.distribution?.artifactName];
+  if (JSON.stringify([release.version, release.tag, release.channel, release.build, release.artifactName]) !== JSON.stringify(expected)) fail("accepted packet disagrees with declaration identity");
+  hashes(release, ["artifactSHA256", "treeSHA256"], "release receipt");
+  if (hash(artifactBytes) !== release.artifactSHA256) fail("artifact digest mismatch");
+  hashes(packet.sparkle, ["entrySHA256"], "Sparkle receipt");
+  if (packet.sparkle.feedURL !== declaration.distribution?.origins?.feed) fail("Sparkle feed disagrees with declaration");
+  const signature = base64(packet.sparkle.edSignature, 64, "Sparkle signature"), keyBytes = base64(packet.sparkle.publicKey, 44, "Sparkle public key");
+  let verified = false;
+  try { verified = verify(null, artifactBytes, createPublicKey({ key: keyBytes, format: "der", type: "spki" }), signature); } catch { verified = false; }
+  if (!verified) fail("Sparkle signature verification failed");
+  if (!/^[A-Z0-9]{10}$/.test(expectedTeamID ?? "") || packet.apple.teamID !== expectedTeamID) fail("approved Team ID mismatch");
+  if (packet.apple.notarized !== true || packet.apple.stapled !== true || packet.apple.gatekeeper !== true) fail("Apple notarization, staple, and Gatekeeper proof are required");
+  hashes(packet.prestate, ["appSHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "plistSHA256"], "prestate receipt");
+  if (!LABEL.test(packet.prestate.label) || !Number.isInteger(packet.prestate.wrapperPID) || packet.prestate.wrapperPID < 1 || !Number.isInteger(packet.prestate.helperPID) || packet.prestate.helperPID < 1 || packet.prestate.wrapperPath !== "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop" || packet.prestate.helperPath !== "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker") fail("prestate worker identity is invalid");
+  return {
+    schemaVersion: 1, dryRun: true, action, packetSHA256,
+    candidate: { version: release.version, build: release.build, channel: release.channel, declarationSHA256: packet.declarationSHA256, artifactSHA256: release.artifactSHA256, treeSHA256: release.treeSHA256, feedEntrySHA256: packet.sparkle.entrySHA256 },
+    prestate: { ...packet.prestate },
+    steps: ["wait-for-zero-lease-cycle", "stage-and-verify", "swap-and-restart-exact-service", "verify-poststate"]
+  };
+}

--- a/scripts/lib/desktop-update-command.mjs
+++ b/scripts/lib/desktop-update-command.mjs
@@ -1,7 +1,9 @@
 import { createHash, createPublicKey, verify } from "node:crypto";
+import { fileURLToPath } from "node:url";
 
 const SHA = /^[0-9a-f]{64}$/;
-const LABEL = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const LABEL = /^[A-Za-z0-9][A-Za-z0-9.-]{2,127}$/;
+const ED25519_SPKI = Buffer.from("302a300506032b6570032100", "hex");
 const ACTIONS = new Set(["update", "rollback", "reupdate"]);
 function fail(message) { throw new Error(message); }
 function exact(value, keys, label) {
@@ -36,14 +38,14 @@ export function planDesktopUpdate({ action, declaration, declarationBytes, packe
   if (hash(artifactBytes) !== release.artifactSHA256) fail("artifact digest mismatch");
   hashes(packet.sparkle, ["entrySHA256"], "Sparkle receipt");
   if (packet.sparkle.feedURL !== declaration.distribution?.origins?.feed) fail("Sparkle feed disagrees with declaration");
-  const signature = base64(packet.sparkle.edSignature, 64, "Sparkle signature"), keyBytes = base64(packet.sparkle.publicKey, 44, "Sparkle public key");
+  const signature = base64(packet.sparkle.edSignature, 64, "Sparkle signature"), rawKey = base64(packet.sparkle.publicKey, 32, "Sparkle public key");
   let verified = false;
-  try { verified = verify(null, artifactBytes, createPublicKey({ key: keyBytes, format: "der", type: "spki" }), signature); } catch { verified = false; }
+  try { verified = verify(null, artifactBytes, createPublicKey({ key: Buffer.concat([ED25519_SPKI, rawKey]), format: "der", type: "spki" }), signature); } catch { verified = false; }
   if (!verified) fail("Sparkle signature verification failed");
   if (!/^[A-Z0-9]{10}$/.test(expectedTeamID ?? "") || packet.apple.teamID !== expectedTeamID) fail("approved Team ID mismatch");
   if (packet.apple.notarized !== true || packet.apple.stapled !== true || packet.apple.gatekeeper !== true) fail("Apple notarization, staple, and Gatekeeper proof are required");
   hashes(packet.prestate, ["appSHA256", "accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256"], "prestate receipt");
-  if (!LABEL.test(packet.prestate.label) || !Number.isInteger(packet.prestate.wrapperPID) || packet.prestate.wrapperPID < 1 || !Number.isInteger(packet.prestate.helperPID) || packet.prestate.helperPID < 1 || packet.prestate.wrapperPath !== "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop" || packet.prestate.helperPath !== "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker") fail("prestate worker identity is invalid");
+  if (typeof packet.prestate.label !== "string" || !LABEL.test(packet.prestate.label) || !Number.isInteger(packet.prestate.wrapperPID) || packet.prestate.wrapperPID < 1 || !Number.isInteger(packet.prestate.helperPID) || packet.prestate.helperPID < 1 || packet.prestate.wrapperPath !== "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop" || packet.prestate.helperPath !== "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker") fail("prestate worker identity is invalid");
   return {
     schemaVersion: 1, dryRun: true, action, packetSHA256,
     candidate: { version: release.version, build: release.build, channel: release.channel, declarationSHA256: packet.declarationSHA256, artifactSHA256: release.artifactSHA256, treeSHA256: release.treeSHA256, feedEntrySHA256: packet.sparkle.entrySHA256 },
@@ -51,3 +53,11 @@ export function planDesktopUpdate({ action, declaration, declarationBytes, packe
     steps: ["wait-for-zero-lease-cycle", "stage-and-verify", "swap-and-restart-exact-service", "verify-poststate"]
   };
 }
+
+export function selectDesktopDeclarationPath(action, index, packet) {
+  const target = `${packet?.release?.tag}.json`;
+  if (index?.status !== "retained" || !Array.isArray(index.declarationPaths) || !index.declarationPaths.includes(target)) fail("accepted packet declaration is not retained");
+  if (action !== "rollback" && index.currentPath !== target) fail("update packet declaration is not current");
+  return action === "rollback" ? target : index.currentPath;
+}
+export function desktopValidatorPath(baseURL) { return fileURLToPath(new URL("../validate-desktop-release-declaration.mjs", baseURL)); }

--- a/tests/desktop-update-command.test.ts
+++ b/tests/desktop-update-command.test.ts
@@ -1,6 +1,7 @@
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
-import { planDesktopUpdate } from "../scripts/lib/desktop-update-command.mjs";
+import { desktopValidatorPath, planDesktopUpdate, selectDesktopDeclarationPath } from "../scripts/lib/desktop-update-command.mjs";
 
 const hex = (value: Buffer | string) => createHash("sha256").update(value).digest("hex");
 function fixture() {
@@ -9,7 +10,7 @@ function fixture() {
   const declarationBytes = Buffer.from(JSON.stringify(declaration)), packet = {
     schemaVersion: 1, declarationSHA256: hex(declarationBytes),
     release: { version: declaration.version, tag: declaration.tag, channel: declaration.channel, build: declaration.build, artifactName: declaration.distribution.artifactName, artifactSHA256: hex(artifact), treeSHA256: "b".repeat(64) },
-    sparkle: { publicKey: publicKey.export({ type: "spki", format: "der" }).toString("base64"), edSignature: sign(null, artifact, privateKey).toString("base64"), feedURL: declaration.distribution.origins.feed, entrySHA256: "c".repeat(64) },
+    sparkle: { publicKey: Buffer.from(publicKey.export({ type: "spki", format: "der" })).subarray(-32).toString("base64"), edSignature: sign(null, artifact, privateKey).toString("base64"), feedURL: declaration.distribution.origins.feed, entrySHA256: "c".repeat(64) },
     apple: { teamID: "TEAM123456", notarized: true, stapled: true, gatekeeper: true },
     prestate: { appSHA256: "d".repeat(64), accountIdentitySHA256: "3".repeat(64), botIdentitySHA256: "4".repeat(64), configSHA256: "e".repeat(64), databaseSHA256: "f".repeat(64), allowlistSHA256: "1".repeat(64), keychainIdentitySHA256: "5".repeat(64), plistSHA256: "2".repeat(64), label: "com.electricsheephq.neondiff", wrapperPID: 101, wrapperPath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop", helperPID: 102, helperPath: "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker" }
   };
@@ -36,8 +37,17 @@ describe("signed Desktop update preflight", () => {
       ["build", (v) => { v.packet.release.build = "11093"; }],
       ["notarization", (v) => { v.packet.apple.notarized = false; }],
       ["stapling", (v) => { v.packet.apple.stapled = false; }],
-      ["Gatekeeper", (v) => { v.packet.apple.gatekeeper = false; }]
+      ["Gatekeeper", (v) => { v.packet.apple.gatekeeper = false; }],
+      ["launchd label", (v) => { v.packet.prestate.label = "bot_label"; }]
     ];
     for (const [label, mutate] of cases) { const value = fixture(); mutate(value); value.packetBytes = Buffer.from(JSON.stringify(value.packet)); value.input.packetBytes = value.packetBytes; if (label !== "packet digest") value.input.packetSHA256 = hex(value.packetBytes); expect(() => planDesktopUpdate(value.input), label).toThrow(); }
+  });
+  it("selects retained rollback identity and decodes validator file URLs", () => {
+    const value = fixture(), prior = "v1.1.0-beta.87.json", index = { status: "retained", declarationPaths: [prior, `${value.packet.release.tag}.json`], currentPath: `${value.packet.release.tag}.json` };
+    value.packet.release.tag = "v1.1.0-beta.87";
+    expect(selectDesktopDeclarationPath("rollback", index, value.packet)).toBe(prior);
+    expect(() => selectDesktopDeclarationPath("update", index, value.packet)).toThrow();
+    const base = pathToFileURL("/tmp/Neon Diff%#/scripts/lib/desktop-update-command.mjs").href;
+    expect(desktopValidatorPath(base)).toBe("/tmp/Neon Diff%#/scripts/validate-desktop-release-declaration.mjs");
   });
 });

--- a/tests/desktop-update-command.test.ts
+++ b/tests/desktop-update-command.test.ts
@@ -11,7 +11,7 @@ function fixture() {
     release: { version: declaration.version, tag: declaration.tag, channel: declaration.channel, build: declaration.build, artifactName: declaration.distribution.artifactName, artifactSHA256: hex(artifact), treeSHA256: "b".repeat(64) },
     sparkle: { publicKey: publicKey.export({ type: "spki", format: "der" }).toString("base64"), edSignature: sign(null, artifact, privateKey).toString("base64"), feedURL: declaration.distribution.origins.feed, entrySHA256: "c".repeat(64) },
     apple: { teamID: "TEAM123456", notarized: true, stapled: true, gatekeeper: true },
-    prestate: { appSHA256: "d".repeat(64), configSHA256: "e".repeat(64), databaseSHA256: "f".repeat(64), allowlistSHA256: "1".repeat(64), plistSHA256: "2".repeat(64), label: "com.electricsheephq.neondiff", wrapperPID: 101, wrapperPath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop", helperPID: 102, helperPath: "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker" }
+    prestate: { appSHA256: "d".repeat(64), accountIdentitySHA256: "3".repeat(64), botIdentitySHA256: "4".repeat(64), configSHA256: "e".repeat(64), databaseSHA256: "f".repeat(64), allowlistSHA256: "1".repeat(64), keychainIdentitySHA256: "5".repeat(64), plistSHA256: "2".repeat(64), label: "com.electricsheephq.neondiff", wrapperPID: 101, wrapperPath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop", helperPID: 102, helperPath: "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker" }
   };
   const packetBytes = Buffer.from(JSON.stringify(packet));
   return { artifact, declaration, packet, packetBytes, input: { action: "update", declaration, declarationBytes, packet, packetBytes, packetSHA256: hex(packetBytes), artifactBytes: artifact, expectedTeamID: "TEAM123456" } };

--- a/tests/desktop-update-command.test.ts
+++ b/tests/desktop-update-command.test.ts
@@ -1,0 +1,43 @@
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { planDesktopUpdate } from "../scripts/lib/desktop-update-command.mjs";
+
+const hex = (value: Buffer | string) => createHash("sha256").update(value).digest("hex");
+function fixture() {
+  const artifact = Buffer.from("immutable desktop zip"), { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const declaration = { version: "1.1.0-rc.1", tag: "v1.1.0-rc.1", channel: "rc", build: "11092", distribution: { artifactName: "NeonDiff-1.1.0-rc.1-build11092-macOS.zip", origins: { feed: "https://www.neondiff.com/updates/beta/appcast.xml" } } };
+  const declarationBytes = Buffer.from(JSON.stringify(declaration)), packet = {
+    schemaVersion: 1, declarationSHA256: hex(declarationBytes),
+    release: { version: declaration.version, tag: declaration.tag, channel: declaration.channel, build: declaration.build, artifactName: declaration.distribution.artifactName, artifactSHA256: hex(artifact), treeSHA256: "b".repeat(64) },
+    sparkle: { publicKey: publicKey.export({ type: "spki", format: "der" }).toString("base64"), edSignature: sign(null, artifact, privateKey).toString("base64"), feedURL: declaration.distribution.origins.feed, entrySHA256: "c".repeat(64) },
+    apple: { teamID: "TEAM123456", notarized: true, stapled: true, gatekeeper: true },
+    prestate: { appSHA256: "d".repeat(64), configSHA256: "e".repeat(64), databaseSHA256: "f".repeat(64), allowlistSHA256: "1".repeat(64), plistSHA256: "2".repeat(64), label: "com.electricsheephq.neondiff", wrapperPID: 101, wrapperPath: "/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop", helperPID: 102, helperPath: "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker" }
+  };
+  const packetBytes = Buffer.from(JSON.stringify(packet));
+  return { artifact, declaration, packet, packetBytes, input: { action: "update", declaration, declarationBytes, packet, packetBytes, packetSHA256: hex(packetBytes), artifactBytes: artifact, expectedTeamID: "TEAM123456" } };
+}
+
+describe("signed Desktop update preflight", () => {
+  it("emits a redacted non-mutating plan bound to accepted bytes", () => {
+    const { input } = fixture(), plan = planDesktopUpdate(input);
+    expect(plan).toMatchObject({ dryRun: true, action: "update", candidate: { version: "1.1.0-rc.1", build: "11092" }, prestate: { label: "com.electricsheephq.neondiff" } });
+    expect(plan.steps).toEqual(["wait-for-zero-lease-cycle", "stage-and-verify", "swap-and-restart-exact-service", "verify-poststate"]);
+    expect(JSON.stringify(plan)).not.toMatch(/publicKey|edSignature|TEAM123456|packetBytes|artifactBytes/i);
+  });
+
+  it("rejects every signed-release identity failure before planning", () => {
+    const cases: Array<[string, (value: ReturnType<typeof fixture>) => void]> = [
+      ["packet digest", (v) => { v.input.packetSHA256 = "0".repeat(64); }],
+      ["declaration digest", (v) => { v.packet.declarationSHA256 = "0".repeat(64); }],
+      ["artifact digest", (v) => { v.packet.release.artifactSHA256 = "0".repeat(64); }],
+      ["Sparkle signature", (v) => { v.packet.sparkle.edSignature = Buffer.alloc(64).toString("base64"); }],
+      ["Team ID", (v) => { v.packet.apple.teamID = "OTHERTEAM"; }],
+      ["tag", (v) => { v.packet.release.tag = "v1.1.0-rc.2"; }],
+      ["build", (v) => { v.packet.release.build = "11093"; }],
+      ["notarization", (v) => { v.packet.apple.notarized = false; }],
+      ["stapling", (v) => { v.packet.apple.stapled = false; }],
+      ["Gatekeeper", (v) => { v.packet.apple.gatekeeper = false; }]
+    ];
+    for (const [label, mutate] of cases) { const value = fixture(); mutate(value); value.packetBytes = Buffer.from(JSON.stringify(value.packet)); value.input.packetBytes = value.packetBytes; if (label !== "packet digest") value.input.packetSHA256 = hex(value.packetBytes); expect(() => planDesktopUpdate(value.input), label).toThrow(); }
+  });
+});


### PR DESCRIPTION
Related: #895

## Scope

- consume the merged Desktop declaration identity without redefining it
- bind a canonical immutable accepted packet and ZIP digest
- verify Sparkle Ed25519, approved Team ID, notarization, staple, and Gatekeeper receipts
- emit only a redacted non-mutating update plan

## Validation

- direct Node semantic smoke: PASS (valid plan plus Gatekeeper, Team ID, and build rejection)
- `node --check scripts/desktop-update-command.mjs`
- `node --check scripts/lib/desktop-update-command.mjs`
- `git diff --check`
- focused Vitest was attempted locally but the host rejected the existing Rollup native binding because its Team ID differs from the invoking process; authoritative GitHub CI is required

## Envelope

129 changed non-generated lines. Agent-authored. No tag, build, signing, notarization, feed, install, launchd, runtime, Keychain, config, database, or customer mutation was performed. This PR proves source preflight/dry-plan behavior only.