### PR TITLE
feat(state): add queue lease CAS and quarantine primitives

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -279,6 +279,15 @@ export interface ReviewQueueJobRecord {
   updatedAt: string;
   startedAt?: string;
   finishedAt?: string;
+  quarantineRequested?: boolean;
+}
+
+export interface ReviewQueueQuarantineReceipt {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  requiredEvidence: string;
+  createdAt: string;
 }
 
 export interface ReviewReadinessRecord {
@@ -721,7 +730,18 @@ export class ReviewStateStore {
         created_at text not null,
         updated_at text not null,
         started_at text,
-        finished_at text
+        finished_at text,
+        quarantine_requested integer not null default 0,
+        quarantine_reason text
+      );
+
+      create table if not exists review_queue_quarantine_receipts (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        required_evidence text not null,
+        created_at text not null,
+        primary key (repo, pull_number, head_sha)
       );
 
       create index if not exists idx_review_queue_jobs_state_priority
@@ -2510,6 +2530,7 @@ export class ReviewStateStore {
     repo: string;
     pullNumber: number;
     headSha: string;
+    expectedSessionId?: string;
     jobState: ReviewerSessionJobState;
     processedReviewStatus?: ProcessedStatus;
     now?: Date;
@@ -2519,14 +2540,20 @@ export class ReviewStateStore {
       throw new Error(`No reviewer session job for ${input.repo}#${input.pullNumber}@${input.headSha}`);
     }
     const timestamp = (input.now ?? new Date()).toISOString();
-    this.db
+    const result = this.db
       .prepare(
         `update reviewer_session_jobs
          set job_state = ?,
              started_at = case when ? = 'running' and started_at is null then ? else started_at end,
              finished_at = case when ? in ('completed', 'skipped', 'failed') then ? else finished_at end,
              processed_review_status = coalesce(?, processed_review_status)
-         where repo = ? and pull_number = ? and head_sha = ?`
+         where repo = ? and pull_number = ? and head_sha = ?
+           and (? is null or (session_id = ? and exists (
+             select 1 from reviewer_sessions
+             where reviewer_sessions.session_id = reviewer_session_jobs.session_id
+               and reviewer_sessions.state in ('warming', 'active', 'draining')
+               and reviewer_sessions.expires_at > ?
+           )))`
       )
       .run(
         input.jobState,
@@ -2537,8 +2564,14 @@ export class ReviewStateStore {
         input.processedReviewStatus ?? null,
         input.repo,
         input.pullNumber,
-        input.headSha
+        input.headSha,
+        input.expectedSessionId ?? null,
+        input.expectedSessionId ?? null,
+        timestamp
       );
+    if (input.expectedSessionId !== undefined && Number(result.changes) !== 1) {
+      throw new Error("reviewer_session_ownership_lost");
+    }
     const updated = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
     if (input.jobState === "completed" || input.jobState === "skipped" || input.jobState === "failed") {
       this.expireDrainedReviewerSessionIfComplete(existing.sessionId);
@@ -2664,9 +2697,10 @@ export class ReviewStateStore {
                last_error = 'queue_lease_expired_requeued',
                updated_at = ?
            where state in ('leased', 'running')
+             and quarantine_requested = 0
              and (
-               (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
-               or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
+               (lease_expires_at is not null and lease_expires_at <= ?)
+               or (lease_expires_at is null and updated_at <= ?)
              )`
         )
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
@@ -2717,7 +2751,8 @@ export class ReviewStateStore {
                    else last_error
                  end,
                  updated_at = ?
-             where job_id = ? and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
+             where job_id = ? and state in ('queued', 'provider_deferred', 'blocked_on_proof')
+               and quarantine_requested = 0`
           )
           .run(leaseId, leaseExpiresAt, nowIso, job.jobId);
         providerActive.set(provider, providerCount + 1);
@@ -2739,6 +2774,7 @@ export class ReviewStateStore {
     jobId: string;
     state: ReviewQueueJobState;
     nextEligibleAt?: string;
+    expectedLeaseId?: string;
     leaseId?: string;
     leaseExpiresAt?: string;
     clearLease?: boolean;
@@ -2757,11 +2793,12 @@ export class ReviewStateStore {
       input.state === "provider_deferred" ||
       input.state === "blocked_on_proof"
     );
-    this.db
+    const guarded = input.expectedLeaseId !== undefined;
+    const result = this.db
       .prepare(
         `update review_queue_jobs
          set state = ?,
-             next_eligible_at = ?,
+             next_eligible_at = case when ? then null else ? end,
              lease_id = case when ? then null else coalesce(?, lease_id) end,
              lease_expires_at = case when ? then null else coalesce(?, lease_expires_at) end,
              session_id = coalesce(?, session_id),
@@ -2770,10 +2807,17 @@ export class ReviewStateStore {
              updated_at = ?,
              started_at = case when ? = 'running' and started_at is null then ? else started_at end,
              finished_at = case when ? then ? else finished_at end
-         where job_id = ?`
+         where job_id = ?
+           and (
+             ? = 0 or (
+               state in ('leased', 'running') and lease_id = ? and lease_expires_at > ?
+               and (quarantine_requested = 0 or ? = 1)
+             )
+           )`
       )
       .run(
         input.state,
+        terminal ? 1 : 0,
         input.nextEligibleAt ?? null,
         clearLease ? 1 : 0,
         input.leaseId ?? null,
@@ -2787,9 +2831,89 @@ export class ReviewStateStore {
         nowIso,
         terminal ? 1 : 0,
         nowIso,
-        input.jobId
+        input.jobId,
+        guarded ? 1 : 0,
+        input.expectedLeaseId ?? null,
+        nowIso,
+        guarded && terminal && input.state !== "posted" && input.state !== "command_recorded" ? 1 : 0
       );
+    if (guarded && Number(result.changes) !== 1) throw new Error("review_queue_lease_lost");
     return this.getReviewQueueJob(input.jobId)!;
+  }
+
+  fenceReviewQueueJob(input: {
+    jobId: string;
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    leaseId: string;
+    now?: Date;
+  }): ReviewQueueJobRecord | undefined {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const owned = this.db.prepare(
+      `select 1 from review_queue_jobs
+       where job_id = ? and repo = ? and pull_number = ? and head_sha = ?
+         and state in ('leased', 'running') and lease_id = ? and lease_expires_at > ?
+         and quarantine_requested = 0 limit 1`
+    ).get(input.jobId, input.repo, input.pullNumber, input.headSha, input.leaseId, nowIso);
+    return owned ? this.getReviewQueueJob(input.jobId) : undefined;
+  }
+
+  quarantineReviewQueueJobs(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    reason: string;
+    now?: Date;
+  }): ReviewQueueJobRecord[] {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const reason = redactSecrets(input.reason).slice(0, 500);
+    this.db.exec("begin immediate");
+    try {
+      const jobs = this.listReviewQueueJobs().filter((job) =>
+        job.repo === input.repo && job.pullNumber === input.pullNumber && job.headSha === input.headSha
+      );
+      for (const job of jobs) {
+        if (job.state === "leased" || job.state === "running") {
+          this.db.prepare(
+            `update review_queue_jobs set quarantine_requested = 1, quarantine_reason = ?, updated_at = ? where job_id = ?`
+          ).run(reason, nowIso, job.jobId);
+        } else if (job.state === "queued" || job.state === "provider_deferred" || job.state === "blocked_on_proof") {
+          this.db.prepare(
+            `update review_queue_jobs
+             set state = 'stale_retired', next_eligible_at = null, lease_id = null, lease_expires_at = null,
+                 quarantine_requested = 1, quarantine_reason = ?, updated_at = ?, finished_at = coalesce(finished_at, ?)
+             where job_id = ? and state in ('queued', 'provider_deferred', 'blocked_on_proof')`
+          ).run(reason, nowIso, nowIso, job.jobId);
+        }
+      }
+      this.db.exec("commit");
+      return jobs.map((job) => this.getReviewQueueJob(job.jobId)!).filter(Boolean);
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  recordReviewQueueQuarantineReceipt(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    requiredEvidence: string;
+    now?: Date;
+  }): ReviewQueueQuarantineReceipt {
+    const requiredEvidence = redactSecrets(input.requiredEvidence).trim().slice(0, 2_000);
+    if (!requiredEvidence) throw new Error("requiredEvidence must be non-empty");
+    const createdAt = (input.now ?? new Date()).toISOString();
+    this.db.prepare(
+      `insert or ignore into review_queue_quarantine_receipts
+       (repo, pull_number, head_sha, required_evidence, created_at) values (?, ?, ?, ?, ?)`
+    ).run(input.repo, input.pullNumber, input.headSha, requiredEvidence, createdAt);
+    return this.db.prepare(
+      `select repo, pull_number as pullNumber, head_sha as headSha,
+              required_evidence as requiredEvidence, created_at as createdAt
+       from review_queue_quarantine_receipts where repo = ? and pull_number = ? and head_sha = ?`
+    ).get(input.repo, input.pullNumber, input.headSha) as unknown as ReviewQueueQuarantineReceipt;
   }
 
   updateReviewQueueJobPriority(input: {
@@ -2817,7 +2941,7 @@ export class ReviewStateStore {
       .prepare(
         `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
-                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at, quarantine_requested
          from review_queue_jobs
          where job_id = ?
          limit 1`
@@ -2831,7 +2955,7 @@ export class ReviewStateStore {
       .prepare(
         `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
-                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at, quarantine_requested
          from review_queue_jobs
          where attempt_id = ?
          limit 1`
@@ -2846,7 +2970,7 @@ export class ReviewStateStore {
       .prepare(
         `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
-                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at, quarantine_requested
          from review_queue_jobs
          where substr(attempt_id, 1, ?) = ?
            and state in ('queued', 'leased', 'running', 'provider_deferred', 'blocked_on_proof')
@@ -2871,7 +2995,7 @@ export class ReviewStateStore {
           .prepare(
             `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
-                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at, quarantine_requested
              from review_queue_jobs
              where repo = ?
              order by priority asc, datetime(created_at) asc`
@@ -2881,7 +3005,7 @@ export class ReviewStateStore {
           .prepare(
             `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
-                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at, quarantine_requested
              from review_queue_jobs
              order by priority asc, datetime(created_at) asc`
           )
@@ -2918,7 +3042,7 @@ export class ReviewStateStore {
       .prepare(
         `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
-                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at, quarantine_requested
          from review_queue_jobs
          where repo = ?
            and pull_number = ?
@@ -3639,9 +3763,10 @@ export class ReviewStateStore {
 
   private ensureReviewQueueJobColumns(): void {
     const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
-    if (!columns.some((column) => column.name === "lease_expires_at")) {
-      this.db.exec("alter table review_queue_jobs add column lease_expires_at text");
-    }
+    const names = new Set(columns.map((column) => column.name));
+    if (!names.has("lease_expires_at")) this.db.exec("alter table review_queue_jobs add column lease_expires_at text");
+    if (!names.has("quarantine_requested")) this.db.exec("alter table review_queue_jobs add column quarantine_requested integer not null default 0");
+    if (!names.has("quarantine_reason")) this.db.exec("alter table review_queue_jobs add column quarantine_reason text");
   }
 
   private ensureRepoMemoryNoteCoarseColumns(): void {
@@ -4201,6 +4326,7 @@ interface ReviewQueueJobRow {
   updated_at: string;
   started_at: string | null;
   finished_at: string | null;
+  quarantine_requested: number | null;
 }
 
 interface ReviewReadinessRow {
@@ -4468,7 +4594,8 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(row.started_at ? { startedAt: row.started_at } : {}),
-    ...(row.finished_at ? { finishedAt: row.finished_at } : {})
+    ...(row.finished_at ? { finishedAt: row.finished_at } : {}),
+    ...(row.quarantine_requested === 1 ? { quarantineRequested: true } : {})
   };
 }
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2698,6 +2698,30 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("fences replaced and millisecond-expired queue owners with the opaque lease token", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-cas-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite")); const now = new Date("2026-08-23T00:00:00.900Z");
+    const job = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 1, headSha: "head", now });
+    const first = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 1, now });
+    const replaced = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 2, now: new Date("2026-08-23T00:00:00.902Z") });
+    expect(replaced[0]?.leaseId).toBeDefined(); expect(replaced[0]?.leaseId).not.toBe(first[0]?.leaseId);
+    expect(() => store.updateReviewQueueJobState({ jobId: job.job.jobId, state: "failed", expectedLeaseId: first[0]!.leaseId, now: new Date("2026-08-23T00:00:00.903Z") })).toThrow("review_queue_lease_lost");
+    expect(store.updateReviewQueueJobState({ jobId: job.job.jobId, state: "failed", expectedLeaseId: replaced[0]!.leaseId, now: new Date("2026-08-23T00:00:00.903Z") }).finishedAt).toBe("2026-08-23T00:00:00.903Z"); store.close();
+  });
+
+  it("quarantines one exact head, preserves its owner, and records an idempotent receipt", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-quarantine-")); roots.push(root); const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-08-23T00:00:00.000Z"); const active = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-a", now }); const other = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-b", now });
+    const [lease] = store.leaseNextReviewQueueJobs({ maxProviderActive: 2, maxOrgActive: 2, maxRepoActive: 2, limit: 1, now });
+    expect(store.quarantineReviewQueueJobs({ repo: "owner/repo", pullNumber: 2, headSha: "head-a", reason: "missing_evidence", now })).toHaveLength(1);
+    expect(store.getReviewQueueJob(active.job.jobId)).toMatchObject({ state: "leased", quarantineRequested: true }); expect(store.fenceReviewQueueJob({ jobId: active.job.jobId, repo: "owner/repo", pullNumber: 2, headSha: "head-a", leaseId: lease!.leaseId, now })).toBeUndefined();
+    expect(store.leaseNextReviewQueueJobs({ maxProviderActive: 2, maxOrgActive: 2, maxRepoActive: 2, now }).map((job) => job.jobId)).toEqual([other.job.jobId]);
+    const terminal = store.updateReviewQueueJobState({ jobId: active.job.jobId, state: "stale_retired", expectedLeaseId: lease!.leaseId, nextEligibleAt: "2026-08-24T00:00:00.000Z", now: new Date("2026-08-23T00:00:01.000Z") });
+    expect(terminal).toMatchObject({ state: "stale_retired", quarantineRequested: true, finishedAt: "2026-08-23T00:00:01.000Z" }); expect(terminal.nextEligibleAt).toBeUndefined();
+    const input = { repo: "owner/repo", pullNumber: 3, headSha: "head-none", requiredEvidence: "required ghp_fake_token", now }; const first = store.recordReviewQueueQuarantineReceipt(input); const repeat = store.recordReviewQueueQuarantineReceipt({ ...input, requiredEvidence: "different ghp_other_token" });
+    expect(first).toEqual(repeat); expect(first.requiredEvidence).toContain("[redacted-secret]"); store.close();
+  });
+
   it("atomically rate-limits a public command per {repo,pr,head,author,action} within the cooldown window (#345)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-pubcmd-cooldown-"));
     roots.push(root);


### PR DESCRIPTION
Related: #882

Layer 1/4 of the approved lease-fence architecture.

- Adds opaque lease-token CAS fencing for terminal queue transitions.
- Preserves active lease/session ownership while marking quarantine intent.
- Retires queued/provider/proof-blocked exact-head work transactionally.
- Adds an idempotent redacted quarantine receipt for the no-job case.
- Uses millisecond-precision lease expiry and clears terminal retry deadlines.

Exact base: 602c7e8f632933c6576cbf1eda56dd8e235b64ac
Exact head: 86c1a9f2f3238ecf6fac7bf36feac646262f4195
Changed non-generated lines: 193 (172 additions, 21 deletions)

Local proof:
- state + scheduler: 176/176 passed (Node 26, Vitest)
- diff-check: passed

The base advanced only in desktop CI validation files; the state patch was rebased without overlap. This PR supplies state primitives only. Worker-side external-write fencing, evidence reconciliation, and scheduler integration remain separate layers. No live state or runtime was mutated.