### PR TITLE
feat(desktop): add failure-atomic transition core

### DIFF
--- a/scripts/lib/desktop-update-command.mjs
+++ b/scripts/lib/desktop-update-command.mjs
@@ -51,3 +51,31 @@ export function planDesktopUpdate({ action, declaration, declarationBytes, packe
     steps: ["wait-for-zero-lease-cycle", "stage-and-verify", "swap-and-restart-exact-service", "verify-poststate"]
   };
 }
+
+export function executeDesktopTransition({ plan, snapshot, ops }) {
+  exact(snapshot, ["cycleBoundary", "timedOut", "activeLeases", "workerPairs", "label", "appSHA256", "accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256", "destinationDevice", "stageDevice"], "transition snapshot");
+  exact(ops, ["stage", "verifyStage", "stopExactService", "exchange", "startExactService", "inspectPoststate"], "transition operations");
+  if (plan?.schemaVersion !== 1 || plan?.dryRun !== true) fail("accepted dry plan is required");
+  if (snapshot.timedOut || snapshot.cycleBoundary !== true || snapshot.activeLeases !== 0) fail("bounded zero-lease cycle boundary is required");
+  if (snapshot.workerPairs !== 1 || snapshot.label !== plan.prestate.label) fail("exactly one selected worker service is required");
+  for (const key of ["appSHA256", "accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256"]) if (snapshot[key] !== plan.prestate[key]) fail(`prestate ${key} drifted`);
+  if (!Number.isInteger(snapshot.destinationDevice) || snapshot.destinationDevice !== snapshot.stageDevice) fail("stage and destination must share one filesystem");
+  for (const name of Object.keys(ops)) if (typeof ops[name] !== "function") fail(`transition operation ${name} is invalid`);
+  ops.stage(plan.candidate); ops.verifyStage(plan.candidate);
+  let stopped = false, swapped = false;
+  try {
+    ops.stopExactService(snapshot.label); stopped = true;
+    ops.exchange(); swapped = true;
+    ops.startExactService(snapshot.label);
+    const poststate = ops.inspectPoststate();
+    exact(poststate, ["version", "build", "appSHA256", "accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256", "label", "workerPairs", "heartbeatFresh", "statusAccepted"], "poststate receipt");
+    if (poststate.version !== plan.candidate.version || poststate.build !== plan.candidate.build || poststate.appSHA256 !== plan.candidate.treeSHA256 || poststate.label !== snapshot.label || poststate.workerPairs !== 1 || poststate.heartbeatFresh !== true || poststate.statusAccepted !== true) fail("installed app or worker poststate is not accepted");
+    for (const key of ["accountIdentitySHA256", "botIdentitySHA256", "configSHA256", "databaseSHA256", "allowlistSHA256", "keychainIdentitySHA256", "plistSHA256"]) if (poststate[key] !== plan.prestate[key]) fail(`poststate ${key} drifted`);
+    return poststate;
+  } catch (error) {
+    if (!stopped) throw error;
+    try { if (swapped) { ops.stopExactService(snapshot.label); ops.exchange(); } ops.startExactService(snapshot.label); }
+    catch (recovery) { fail(`Desktop transition failed and recovery was incomplete: ${error instanceof Error ? error.message : error}; ${recovery instanceof Error ? recovery.message : recovery}`); }
+    throw error;
+  }
+}

--- a/tests/desktop-update-command.test.ts
+++ b/tests/desktop-update-command.test.ts
@@ -1,6 +1,6 @@
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { planDesktopUpdate } from "../scripts/lib/desktop-update-command.mjs";
+import { executeDesktopTransition, planDesktopUpdate } from "../scripts/lib/desktop-update-command.mjs";
 
 const hex = (value: Buffer | string) => createHash("sha256").update(value).digest("hex");
 function fixture() {
@@ -39,5 +39,32 @@ describe("signed Desktop update preflight", () => {
       ["Gatekeeper", (v) => { v.packet.apple.gatekeeper = false; }]
     ];
     for (const [label, mutate] of cases) { const value = fixture(); mutate(value); value.packetBytes = Buffer.from(JSON.stringify(value.packet)); value.input.packetBytes = value.packetBytes; if (label !== "packet digest") value.input.packetSHA256 = hex(value.packetBytes); expect(() => planDesktopUpdate(value.input), label).toThrow(); }
+  });
+});
+
+describe("failure-atomic Desktop transition", () => {
+  function transition(overrides: Record<string, unknown> = {}, failAt = "") {
+    const { input } = fixture(), plan = planDesktopUpdate(input), events: string[] = [];
+    const snapshot = { cycleBoundary: true, timedOut: false, activeLeases: 0, workerPairs: 1, label: plan.prestate.label, appSHA256: plan.prestate.appSHA256, accountIdentitySHA256: plan.prestate.accountIdentitySHA256, botIdentitySHA256: plan.prestate.botIdentitySHA256, configSHA256: plan.prestate.configSHA256, databaseSHA256: plan.prestate.databaseSHA256, allowlistSHA256: plan.prestate.allowlistSHA256, keychainIdentitySHA256: plan.prestate.keychainIdentitySHA256, plistSHA256: plan.prestate.plistSHA256, destinationDevice: 7, stageDevice: 7, ...overrides };
+    let starts = 0;
+    const call = (name: string) => { events.push(name); if (failAt === name || failAt === "start-new" && name === "start" && starts++ === 0) throw new Error(`${name} failed`); };
+    const poststate = { version: plan.candidate.version, build: plan.candidate.build, appSHA256: plan.candidate.treeSHA256, accountIdentitySHA256: plan.prestate.accountIdentitySHA256, botIdentitySHA256: plan.prestate.botIdentitySHA256, configSHA256: plan.prestate.configSHA256, databaseSHA256: plan.prestate.databaseSHA256, allowlistSHA256: plan.prestate.allowlistSHA256, keychainIdentitySHA256: plan.prestate.keychainIdentitySHA256, plistSHA256: plan.prestate.plistSHA256, label: plan.prestate.label, workerPairs: 1, heartbeatFresh: true, statusAccepted: true };
+    const run = () => executeDesktopTransition({ plan, snapshot, ops: { stage: () => call("stage"), verifyStage: () => call("verify"), stopExactService: () => call("stop"), exchange: () => call("exchange"), startExactService: () => call("start"), inspectPoststate: () => poststate } });
+    return { run, events };
+  }
+
+  it("stages and verifies before one exact-service atomic exchange", () => {
+    const value = transition(); expect(value.run()).toMatchObject({ workerPairs: 1, heartbeatFresh: true });
+    expect(value.events).toEqual(["stage", "verify", "stop", "exchange", "start"]);
+  });
+
+  it("rejects lease, timeout, second-worker, cross-device, and state drift before mutation", () => {
+    for (const drift of [{ activeLeases: 1 }, { timedOut: true }, { workerPairs: 2 }, { stageDevice: 8 }, { configSHA256: "0".repeat(64) }]) { const value = transition(drift); expect(value.run).toThrow(); expect(value.events).toEqual([]); }
+  });
+
+  it("does not stop on stage failure and restores prior bytes/service after transition failures", () => {
+    const stage = transition({}, "stage"); expect(stage.run).toThrow(); expect(stage.events).toEqual(["stage"]);
+    const swap = transition({}, "exchange"); expect(swap.run).toThrow(); expect(swap.events).toEqual(["stage", "verify", "stop", "exchange", "start"]);
+    const launchd = transition({}, "start-new"); expect(launchd.run).toThrow(); expect(launchd.events).toEqual(["stage", "verify", "stop", "exchange", "start", "stop", "exchange", "start"]);
   });
 });


### PR DESCRIPTION
Related: #895

Depends on #913.

## Scope

- require a bounded completed cycle with zero leases before mutation
- reject cross-filesystem staging, second workers, and public-safe identity drift
- stage and verify before stopping the exact selected service
- perform one injected atomic exchange and restore prior bytes/service after swap, launch, or poststate failure
- verify exact installed version/build/tree plus preserved account, bot, config, database, allowlist, Keychain identity, plist, label, one worker pair, heartbeat, and accepted status

## Validation

- direct Node transition-order and active-lease smoke: PASS
- `node --check scripts/lib/desktop-update-command.mjs`
- `git diff --check codex/895-update-preflight...HEAD`
- authoritative GitHub CI required because the host rejects the existing Rollup native binding on Team-ID mismatch

## Envelope

56 changed non-generated lines relative to #913. Agent-authored. No app, launchd, feed, config, database, Keychain, runtime, or customer mutation was performed. This PR proves deterministic transaction/recovery logic only.