### PR TITLE
fix(operator): collect complete scoped status inputs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -704,7 +704,8 @@ async function main(): Promise<void> {
     });
     const durableQueue = collectOperatorReviewQueue(args["state-path"] ?? config.statePath, {
       repo: args.repo,
-      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined,
+      leaseTtlMs: config.reviewConcurrency.leaseTtlMs
     });
     const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(args["state-path"] ?? config.statePath, {
       repo: args.repo,
@@ -759,7 +760,8 @@ async function main(): Promise<void> {
     });
     const durableQueue = collectOperatorReviewQueue(statePath, {
       repo: args.repo,
-      now
+      now,
+      leaseTtlMs: config.reviewConcurrency.leaseTtlMs
     });
     const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {
       repo: args.repo,
@@ -821,13 +823,15 @@ async function main(): Promise<void> {
 	    const durableQueue = collectOperatorReviewQueue(statePath, {
 	      repo: args.repo,
 	      state: queueState,
-	      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+	      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined,
+	      leaseTtlMs: config.reviewConcurrency.leaseTtlMs
 	    });
 	    const budgetQueue = collectOperatorReviewQueue(statePath, {
 	      repo: args.repo,
-	      state: queueState
+	      state: queueState,
+	      leaseTtlMs: config.reviewConcurrency.leaseTtlMs
 	    });
-	    const budgetOutput = collectQueueBudget(config, collectBudgetJobsForSelection(statePath, budgetQueue.jobs));
+	    const budgetOutput = collectQueueBudget(config, collectBudgetJobsForSelection(statePath, budgetQueue.jobs, undefined, config.reviewConcurrency.leaseTtlMs));
     const gates = queueHealthGates(queue, durableQueue, budgetOutput.budget);
     const ok = gates.every((gate) => gate.ok);
     const output = {
@@ -858,7 +862,8 @@ async function main(): Promise<void> {
         coverage: report,
         durableQueue: collectOperatorReviewQueue(statePath, {
           repo: args.repo,
-          limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
+          limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined,
+          leaseTtlMs: config.reviewConcurrency.leaseTtlMs
         }),
         readiness: collectOperatorReviewReadiness(statePath, {
           repo: args.repo,
@@ -2293,7 +2298,8 @@ async function main(): Promise<void> {
       const expiredCount = rows.filter((row) => row.expired).length;
       const durableQueue = collectOperatorReviewQueue(statePath, {
         repo: args.repo,
-        now: checkedAt
+        now: checkedAt,
+        leaseTtlMs: config.reviewConcurrency.leaseTtlMs
       });
       const activeProviderCooldowns = state.listRepoProviderCooldowns({ activeOnly: true, now: checkedAt });
       const budget = buildReviewBudgetStatus({
@@ -3046,10 +3052,11 @@ function collectQueueBudget(config: ReturnType<typeof loadConfig>, jobs: ReviewQ
 function collectBudgetJobsForSelection(
   statePath: string,
   selectedJobs: ReviewQueueJobRecord[],
-  now?: Date
+  now?: Date,
+  leaseTtlMs?: number
 ): ReviewQueueJobRecord[] {
   const jobsById = new Map<string, ReviewQueueJobRecord>();
-  for (const job of collectOperatorReviewQueue(statePath, { now }).jobs) {
+  for (const job of collectOperatorReviewQueue(statePath, { now, leaseTtlMs }).jobs) {
     if (job.state === "leased" || job.state === "running") jobsById.set(job.jobId, job);
   }
   for (const job of selectedJobs) {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -375,6 +375,22 @@ export interface OperatorDurableQueueSnapshot {
   }>;
 }
 
+export interface OperatorCollectionCompleteness {
+  state: "complete" | "unavailable";
+  total?: number;
+  visible: number;
+  reason?: "missing_database" | "missing_table";
+}
+
+export interface OperatorDurableQueueSnapshot {
+  completeness?: { queue: OperatorCollectionCompleteness; processedReviews: OperatorCollectionCompleteness; runLeases: OperatorCollectionCompleteness };
+  completeJobs?: ReviewQueueJobRecord[];
+  staleRunLeaseIds?: string[];
+  leaseTtlMs?: number;
+}
+
+type ProviderCooldownRows = ProviderCooldownReviewRecord[] & { completeRows?: ProviderCooldownReviewRecord[]; completeness?: OperatorCollectionCompleteness };
+
 export interface PullStatusExplanation {
   repo: string;
   pullNumber: number;
@@ -958,14 +974,14 @@ export function collectOperatorLeases(statePath: string): OperatorLease[] {
 export function collectOperatorProviderCooldowns(
   statePath: string,
   input: { repo?: string; now?: Date; expiredOnly?: boolean; limit?: number } = {}
-): ProviderCooldownReviewRecord[] {
+): ProviderCooldownRows {
   if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
     throw new Error("limit must be a positive integer");
   }
-  if (!existsSync(statePath)) return [];
+  if (!existsSync(statePath)) return withProviderCooldownCompleteness([], { state: "unavailable", visible: 0, reason: "missing_database" });
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
-    if (!hasTable(db, "processed_reviews")) return [];
+    if (!hasTable(db, "processed_reviews")) return withProviderCooldownCompleteness([], { state: "unavailable", visible: 0, reason: "missing_table" });
     const rows = (input.repo
       ? db
           .prepare(
@@ -1005,7 +1021,8 @@ export function collectOperatorProviderCooldowns(
         };
       if (!input.expiredOnly || record.expired) mapped.push(record);
     }
-    return input.limit ? mapped.slice(0, input.limit) : mapped;
+    const visible = input.limit ? mapped.slice(0, input.limit) : mapped;
+    return withProviderCooldownCompleteness(visible, { state: "complete", total: mapped.length, visible: visible.length }, mapped);
   } finally {
     db.close();
   }
@@ -1113,13 +1130,14 @@ export function collectOperatorRepoProviderCooldowns(
 
 export function collectOperatorReviewQueue(
   statePath: string,
-  input: { repo?: string; state?: ReviewQueueJobState; now?: Date; limit?: number } = {}
+  input: { repo?: string; state?: ReviewQueueJobState; now?: Date; limit?: number; leaseTtlMs?: number } = {}
 ): OperatorDurableQueueSnapshot {
   const now = input.now ?? new Date();
-  if (!existsSync(statePath)) return emptyDurableQueue(now);
+  if (!existsSync(statePath)) return emptyDurableQueue(now, "missing_database");
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
-    if (!hasTable(db, "review_queue_jobs")) return emptyDurableQueue(now);
+    const processed = readProcessedReviewCompleteness(db, input.repo);
+    if (!hasTable(db, "review_queue_jobs")) return emptyDurableQueue(now, "missing_table", processed);
     const selectColumns = reviewQueueSelectColumns(db);
     const rows = (input.repo
       ? db
@@ -1140,7 +1158,11 @@ export function collectOperatorReviewQueue(
     const jobs = rows
       .map(mapReviewQueueJobRow)
       .filter((job) => !input.state || job.state === input.state);
-    return buildDurableQueueSnapshot(jobs, now, input.limit ? jobs.slice(0, input.limit) : jobs);
+    const visibleJobs = input.limit ? jobs.slice(0, input.limit) : jobs;
+    const runLeases = readRunLeaseCompleteness(db, jobs);
+    return buildDurableQueueSnapshot(jobs, now, visibleJobs, readStaleRunLeaseIds(db, now, jobs), input.leaseTtlMs, {
+      queue: { state: "complete", total: jobs.length, visible: visibleJobs.length }, processedReviews: processed, runLeases
+    });
   } finally {
     db.close();
   }
@@ -1766,18 +1788,28 @@ function zcodeTimeoutRecommendedActions(
     : [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
 }
 
-function emptyDurableQueue(now: Date): OperatorDurableQueueSnapshot {
-  return buildDurableQueueSnapshot([], now);
+const DEFAULT_QUEUE_LEASE_TTL_MS = 15 * 60_000;
+
+function withProviderCooldownCompleteness(visible: ProviderCooldownReviewRecord[], completeness: OperatorCollectionCompleteness, completeRows = visible): ProviderCooldownRows {
+  const result = visible as ProviderCooldownRows;
+  Object.defineProperties(result, { completeRows: { value: completeRows, enumerable: false }, completeness: { value: completeness, enumerable: false } });
+  return result;
+}
+
+function emptyDurableQueue(now: Date, reason?: OperatorCollectionCompleteness["reason"], processedReviews: OperatorCollectionCompleteness = { state: "unavailable", visible: 0, reason }, runLeases: OperatorCollectionCompleteness = { state: "unavailable", visible: 0, reason }): OperatorDurableQueueSnapshot {
+  return buildDurableQueueSnapshot([], now, [], [], DEFAULT_QUEUE_LEASE_TTL_MS, { queue: { state: "unavailable", visible: 0, reason }, processedReviews, runLeases });
 }
 
 function buildDurableQueueSnapshot(
   jobs: ReviewQueueJobRecord[],
   now: Date,
-  visibleJobs: ReviewQueueJobRecord[] = jobs
+  visibleJobs: ReviewQueueJobRecord[] = jobs,
+  staleRunLeaseIds: string[] = [], leaseTtlMs = DEFAULT_QUEUE_LEASE_TTL_MS,
+  completeness?: OperatorDurableQueueSnapshot["completeness"]
 ): OperatorDurableQueueSnapshot {
   const summary = summarizeDurableQueueJobs(jobs, now);
   const repos = [...new Set(jobs.map((job) => job.repo))].sort();
-  return {
+  const snapshot: OperatorDurableQueueSnapshot = {
     ok: summary.failed === 0 && summary.retryableProviderDeferred === 0,
     checkedAt: now.toISOString(),
     summary,
@@ -1787,6 +1819,9 @@ function buildDurableQueueSnapshot(
       ...summarizeDurableQueueJobs(jobs.filter((job) => job.repo === repo), now)
     }))
   };
+  Object.defineProperties(snapshot, { completeJobs: { value: jobs, enumerable: false }, staleRunLeaseIds: { value: staleRunLeaseIds, enumerable: false }, leaseTtlMs: { value: leaseTtlMs, enumerable: false } });
+  snapshot.completeness = completeness ?? { queue: { state: "complete", total: jobs.length, visible: visibleJobs.length }, processedReviews: { state: "unavailable", visible: 0 }, runLeases: { state: "unavailable", visible: 0 } };
+  return snapshot;
 }
 
 function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot["summary"] {
@@ -2246,6 +2281,32 @@ function hasTable(db: DatabaseSync, tableName: string): boolean {
 function hasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
   const columns = db.prepare(`pragma table_info(${tableName})`).all() as unknown as Array<{ name: string }>;
   return columns.some((column) => column.name === columnName);
+}
+
+function readProcessedReviewCompleteness(db: DatabaseSync, repo?: string): OperatorCollectionCompleteness {
+  if (!hasTable(db, "processed_reviews")) return { state: "unavailable", visible: 0, reason: "missing_table" };
+  const query = "select count(*) as total from processed_reviews";
+  const row = (repo ? db.prepare(`${query} where repo = ?`).get(repo) : db.prepare(query).get()) as { total?: number };
+  return { state: "complete", total: row.total ?? 0, visible: row.total ?? 0 };
+}
+
+function readRunLeaseCompleteness(db: DatabaseSync, jobs: ReviewQueueJobRecord[]): OperatorCollectionCompleteness {
+  if (!hasTable(db, "review_run_leases")) return { state: "unavailable", visible: 0, reason: "missing_table" };
+  const leaseIds = new Set(jobs.flatMap((job) => job.leaseId ? [job.leaseId] : []));
+  const rows = db.prepare("select lease_id from review_run_leases").all() as unknown as Array<{ lease_id: string }>;
+  const total = rows.filter((row) => leaseIds.has(row.lease_id)).length;
+  return { state: "complete", total, visible: total };
+}
+
+function readStaleRunLeaseIds(db: DatabaseSync, now: Date, jobs: ReviewQueueJobRecord[]): string[] {
+  if (!hasTable(db, "review_run_leases")) return [];
+  const owner = hasColumn(db, "review_run_leases", "owner_pid") ? "owner_pid" : "null as owner_pid";
+  const leaseIds = new Set(jobs.flatMap((job) => job.leaseId ? [job.leaseId] : []));
+  const rows = db.prepare(`select lease_id, expires_at, ${owner} from review_run_leases`).all() as unknown as Array<{ lease_id: string; expires_at: string; owner_pid: number | null }>;
+  return rows.filter((row) => leaseIds.has(row.lease_id)).filter((row) => {
+    const expiresAt = Date.parse(row.expires_at);
+    return !Number.isFinite(expiresAt) || expiresAt <= now.getTime() || (row.owner_pid !== null && !isProcessAlive(row.owner_pid));
+  }).map((row) => row.lease_id);
 }
 
 function reviewQueueSelectColumns(db: DatabaseSync): string {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1779,6 +1779,36 @@ describe("operator CLI summaries", () => {
       expect.objectContaining({ repo: "owner/other", total: 2, failed: 1 }),
       expect.objectContaining({ repo: "owner/repo", total: 3, queued: 1 })
     ]);
+    expect(limited.completeJobs).toHaveLength(5);
+    expect(limited.completeness).toMatchObject({ processedReviews: { state: "unavailable", visible: 0 }, runLeases: { state: "unavailable", visible: 0 } });
+  });
+
+  it("keeps cooldowns and exact selected-repo lease/session rows complete beyond limits", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table processed_reviews (repo text, pull_number integer, head_sha text, status text, event text, review_url text, error text, created_at text)");
+      db.exec("create table review_queue_jobs (job_id text primary key, attempt_id text not null unique, source text not null, lane text not null, repo text not null, org text not null, pull_number integer not null, head_sha text not null, base_sha text, provider_id text, priority integer not null, state text not null, next_eligible_at text, lease_id text, session_id text, comment_id integer, review_url text, last_error text, created_at text not null, updated_at text not null, started_at text, finished_at text)");
+      db.exec("create table review_run_leases (lease_id text primary key, started_at text, expires_at text, owner_pid integer)");
+      const error = "provider_rate_limit_cooldown_until=2026-07-01T00:10:00.000Z; reason=provider_request_rate_limit";
+      for (const [pull, head] of [[1, "cooldown-1"], [2, "cooldown-2"]] as const) db.prepare("insert into processed_reviews values ('owner/repo', ?, ?, 'skipped', null, null, ?, '2026-07-01T00:00:00.000Z')").run(pull, head, error);
+      insertQueueJob(db, "running", "owner/repo", 3, "active-head");
+      insertQueueJob(db, "running", "owner/other", 4, "other-head");
+      db.prepare("update review_queue_jobs set lease_id = ?, session_id = ? where repo = ?").run("selected-lease", "selected-session", "owner/repo");
+      db.prepare("insert into review_run_leases values (?, ?, ?, ?)").run("selected-lease", "2026-07-01T00:00:00.000Z", "2026-07-01T00:30:00.000Z", process.pid);
+      db.prepare("insert into review_run_leases values (?, ?, ?, ?)").run("other-lease", "2026-07-01T00:00:00.000Z", "2026-07-01T00:30:00.000Z", process.pid);
+    } finally { db.close(); }
+
+    const cooldowns = collectOperatorProviderCooldowns(statePath, { repo: "owner/repo", now: new Date("2026-07-01T00:05:00.000Z"), limit: 1 });
+    expect(cooldowns).toHaveLength(1);
+    expect(cooldowns.completeRows).toHaveLength(2);
+    expect(cooldowns.completeness).toMatchObject({ state: "complete", total: 2, visible: 1 });
+    const queue = collectOperatorReviewQueue(statePath, { repo: "owner/repo", now: new Date("2026-07-01T00:05:00.000Z"), limit: 1, leaseTtlMs: 60_000 });
+    expect(queue.jobs).toHaveLength(1);
+    expect(queue.completeJobs?.[0]).toMatchObject({ repo: "owner/repo", leaseId: "selected-lease", sessionId: "selected-session" });
+    expect(queue.staleRunLeaseIds).toEqual([]);
+    expect(queue.leaseTtlMs).toBe(60_000);
+    expect(queue.completeness).toMatchObject({ queue: { state: "complete", total: 1, visible: 1 }, runLeases: { state: "complete", total: 1 } });
   });
 
   it("omits oldest waiting age when durable queue timestamps are malformed", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -13,6 +13,7 @@ import {
   buildReleaseStatusCommandOutput,
   collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
+  collectOperatorProviderCooldowns,
   collectOperatorRepoProviderCooldowns,
   collectOperatorReviewReadiness,
   collectOperatorReviewQueue,


### PR DESCRIPTION
Related: #863

## Outcome

Adds the complete repository-scoped raw collector contract used by later operator truth projection. Display limits now affect only visible rows; complete queue and cooldown rows, processed-history completeness, exact selected-repo lease/session identity, stale lease IDs, and configured lease TTL remain available to typed consumers.

## Scope

- pass config.reviewConcurrency.leaseTtlMs through all seven production queue collection paths
- preserve complete queue and cooldown rows behind display-limited output
- report missing database/table history as unavailable instead of zero
- join lease completeness and stale IDs through selected repository queue lease IDs

This is slice 1 only. Truth projection and presentation remain separate dependent slices.

## Validation

- git diff --check: passed
- focused command attempted: npx vitest run tests/operator-cli.test.ts
- local test discovery blocked by missing optional native Rolldown binding @rolldown/binding-wasm32-wasi; no dependency or lockfile mutation performed
- authoritative Build, test, and package CI requested on this exact head

## Envelope

140 non-generated changed lines (119 additions, 21 deletions), below the 199-line ceiling.

## Safety and proof boundary

Agent-authored. No live status, health, queue, worker, database, config, provider, credential, customer, release, or deployment mutation occurred. This PR can prove source and exact-head CI only; it does not prove truth projection, presentation, merge, runtime health, release readiness, or customer readiness.