### PR TITLE
fix(desktop): reject incomplete BYO authority proof

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -4216,6 +4216,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 botLogin: report.github.botLogin
             )
         }
+        if selectedReviewRepository != nil {
+            guard byoVerifiedVisibility != "unknown" else {
+                byoGitHubCredentialsVerified = false
+                lastError = "GitHub did not return authoritative visibility for the selected repository. Restore App access and verify again."
+                byoGitHubCredentialStatus = lastError ?? "Repository visibility unavailable"
+                return
+            }
+            guard byoGitHubAccessAuthority != nil else {
+                byoGitHubCredentialsVerified = false
+                lastError = "The bundled worker did not return exact GitHub App and installation identity. Update or reinstall the worker, then verify again."
+                byoGitHubCredentialStatus = lastError ?? "Worker update required"
+                return
+            }
+        }
         let repositories = report.github.readChecks.map(\.repo).sorted {
             $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
         }.joined(separator: ", ")

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -287,7 +287,7 @@ struct BYOGitHubAppCredentialOnboardingTests {
     @Test func explicitVerificationReadsKeychainAndUsesOnlyBoundedCLIStdin() async throws {
         let doctorResult = CLIRunResult(
             exitCode: 0,
-            stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","readChecks":[{"repo":"acme/demo","ok":true,"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
+            stdout: #"{"ok":true,"command":"doctor github","appCredentials":{"appIdConfigured":true,"privateKeyConfigured":true,"source":"stdin"},"github":{"canPostAsApp":true,"readMode":"app_installation","botLogin":"fixture-bot","readChecks":[{"repo":"acme/demo","ok":true,"visibility_result":"public","installation_id":42001,"installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true}]}}"#,
             stderr: ""
         )
         let fixture = ModelDependencyFixture(
@@ -337,6 +337,33 @@ struct BYOGitHubAppCredentialOnboardingTests {
         #expect(!fixture.model.canAdvanceOnboarding)
         #expect(!fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.productionDaemonStopAvailable)
+    }
+
+    @Test func verificationRejectsIncompleteAuthorityFromAnOlderWorker() async {
+        for missingField in ["visibility_result", "installation_id"] {
+            let field = missingField == "visibility_result"
+                ? #""visibility_result":"public","#
+                : #""installation_id":42001,"#
+            let readCheck = doctorReadCheck(repo: "acme/demo")
+                .replacingOccurrences(of: field, with: "")
+            let fixture = ModelDependencyFixture(
+                cliOutcomes: [.success(doctorResult(readChecks: readCheck))],
+                preferenceStrings: availableCLIPreference,
+                productionBoundary: exactB0Boundary
+            )
+            fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+            fixture.model.pendingBYOGitHubAppId = "123456"
+            fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+            fixture.model.storeBYOGitHubAppCredentials()
+
+            fixture.model.verifyBYOGitHubAppCredentials()
+            await waitForBYOVerification(fixture)
+
+            #expect(!fixture.model.byoGitHubCredentialsVerified)
+            #expect(fixture.model.lastError?.contains(
+                missingField == "visibility_result" ? "authoritative visibility" : "Update or reinstall"
+            ) == true)
+        }
     }
 
     @Test func byoRepositoryReadinessDoesNotUnlockUnactivatedUsefulWork() async {


### PR DESCRIPTION
## Summary

- fail selected-repository verification when GitHub visibility is missing/unknown
- fail with actionable worker-update recovery when raw App/installation identity is absent
- keep full-allowlist credential verification available before a single activation target is selected

## Dependency

Stacked on #911. After #911 merges, retarget/rebase to `main`; do not merge this stack first.

## Proof

- `swift test --package-path apps/neondiff-desktop --filter BYOGitHubAppCredentialOnboardingTests` — 26/26 passed
- deterministic missing visibility and missing installation-ID cases fail closed
- `git diff --check` — passed
- GitNexus compare: low risk, 2 files/10 symbols/0 processes; stale index orientation-only
- 43 changed non-generated lines relative to #911

Addresses #911 review threads 3839234581 and 3839234584 without a second review-driven rewrite of #911.

## Boundaries

Source/PR proof only. No merge, worker update/install, activation, Keychain/config/runtime, billing, deployment, release, or customer mutation.