### PR TITLE
feat(state): add atomic queue post authority

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -287,11 +287,7 @@ export interface ReviewQueueJobRecord {
 }
 
 export interface ReviewQueuePostClaim {
-  jobId: string;
-  postKey: string;
-  leaseId: string;
-  reconcileRequired: boolean;
-  receipt?: string;
+  jobId: string; postKey: string; leaseId: string; reconcileRequired: boolean; receipt?: string;
 }
 export interface ReviewReadinessRecord {
   repo: string;
@@ -750,7 +746,6 @@ export class ReviewStateStore {
         repo text not null, pull_number integer not null, head_sha text not null,
         reason text not null, created_at text not null, primary key (repo, pull_number, head_sha)
       );
-
       create table if not exists review_queue_post_claims (
         job_id text not null, post_key text not null, lease_id text not null, claimed_at text not null,
         reconcile_required integer not null default 0, receipt text, receipt_at text,
@@ -2339,16 +2334,19 @@ export class ReviewStateStore {
           const result = this.db
             .prepare(
               `update review_queue_jobs
-               set state = 'queued',
+               set state = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'stale_retired' else 'queued' end,
                    lease_id = null,
                    lease_expires_at = null,
-                   last_error = ?,
-                   updated_at = ?
+                   next_eligible_at = null,
+                   last_error = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'queue_quarantine_operator_retired' else ? end,
+                   updated_at = ?,
+                   finished_at = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then coalesce(finished_at, ?) else finished_at end
                where job_id = ?
                  and state in ('leased', 'running')`
             )
             .run(
               `queue_lease_operator_requeued:${job.staleReason ?? "matched"}`,
+              checkedAt,
               checkedAt,
               job.jobId
             );
@@ -4367,11 +4365,7 @@ interface ReviewQueueJobRow {
 }
 
 interface ReviewQueuePostClaimRow {
-  job_id: string;
-  post_key: string;
-  lease_id: string;
-  reconcile_required: number;
-  receipt: string | null;
+  job_id: string; post_key: string; lease_id: string; reconcile_required: number; receipt: string | null;
 }
 
 interface ReviewReadinessRow {

--- a/src/state.ts
+++ b/src/state.ts
@@ -147,6 +147,11 @@ export interface ReviewRunLease {
   leaseId: string;
   expiresAt: string;
   ownerPid: number;
+  queueJobId?: string;
+  queueLeaseId?: string;
+  repo?: string;
+  pullNumber?: number;
+  headSha?: string;
 }
 
 export interface ReviewHeadClaim {
@@ -281,6 +286,13 @@ export interface ReviewQueueJobRecord {
   finishedAt?: string;
 }
 
+export interface ReviewQueuePostClaim {
+  jobId: string;
+  postKey: string;
+  leaseId: string;
+  reconcileRequired: boolean;
+  receipt?: string;
+}
 export interface ReviewReadinessRecord {
   repo: string;
   pullNumber: number;
@@ -622,7 +634,8 @@ export class ReviewStateStore {
         lease_id text primary key,
         started_at text not null,
         expires_at text not null,
-        owner_pid integer
+        owner_pid integer,
+        queue_job_id text, queue_lease_id text, repo text, pull_number integer, head_sha text
       );
 
       create table if not exists worktree_cleanup_guard (
@@ -732,6 +745,23 @@ export class ReviewStateStore {
         started_at text,
         finished_at text
       );
+
+      create table if not exists review_queue_quarantines (
+        repo text not null, pull_number integer not null, head_sha text not null,
+        reason text not null, created_at text not null, primary key (repo, pull_number, head_sha)
+      );
+
+      create table if not exists review_queue_post_claims (
+        job_id text not null, post_key text not null, lease_id text not null, claimed_at text not null,
+        reconcile_required integer not null default 0, receipt text, receipt_at text,
+        primary key (job_id, post_key)
+      );
+
+      create trigger if not exists reject_quarantined_review_queue_job
+      before insert on review_queue_jobs
+      when exists (select 1 from review_queue_quarantines
+        where repo = new.repo and pull_number = new.pull_number and head_sha = new.head_sha)
+      begin select raise(abort, 'review_queue_head_quarantined'); end;
 
       create index if not exists idx_review_queue_jobs_state_priority
         on review_queue_jobs (state, priority, created_at);
@@ -1543,7 +1573,8 @@ export class ReviewStateStore {
     maxActiveRuns: number,
     leaseTtlMs: number,
     now = new Date(),
-    ownerPid = process.pid
+    ownerPid = process.pid,
+    association?: { queueJobId: string; queueLeaseId: string; repo: string; pullNumber: number; headSha: string }
   ): ReviewRunLease | undefined {
     if (!Number.isInteger(maxActiveRuns)) throw new Error("maxActiveRuns must be an integer");
     if (maxActiveRuns < 1) throw new Error("maxActiveRuns must be at least 1");
@@ -1569,11 +1600,19 @@ export class ReviewStateStore {
         this.db.exec("commit");
         return undefined;
       }
-      this.db
-        .prepare("insert into review_run_leases (lease_id, started_at, expires_at, owner_pid) values (?, ?, ?, ?)")
-        .run(leaseId, startedAt, expiresAt, ownerPid);
+      const inserted = association
+        ? this.db.prepare(`insert into review_run_leases
+            (lease_id, started_at, expires_at, owner_pid, queue_job_id, queue_lease_id, repo, pull_number, head_sha)
+           select ?, ?, ?, ?, j.job_id, j.lease_id, j.repo, j.pull_number, j.head_sha from review_queue_jobs j
+           where j.job_id = ? and j.lease_id = ? and j.repo = ? and j.pull_number = ? and j.head_sha = ?
+             and j.state in ('leased', 'running') and j.lease_expires_at > ?`)
+          .run(leaseId, startedAt, expiresAt, ownerPid, association.queueJobId, association.queueLeaseId,
+            association.repo, association.pullNumber, association.headSha, startedAt)
+        : this.db.prepare("insert into review_run_leases (lease_id, started_at, expires_at, owner_pid) values (?, ?, ?, ?)")
+          .run(leaseId, startedAt, expiresAt, ownerPid);
+      if (Number(inserted.changes) !== 1) { this.db.exec("commit"); return undefined; }
       this.db.exec("commit");
-      return { leaseId, expiresAt, ownerPid };
+      return { leaseId, expiresAt, ownerPid, ...association };
     } catch (error) {
       this.db.exec("rollback");
       throw error;
@@ -2570,6 +2609,7 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    if (this.db.prepare("select 1 from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?").get(input.repo, input.pullNumber, input.headSha)) throw new Error("review_queue_head_quarantined");
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2667,18 +2707,27 @@ export class ReviewStateStore {
       this.db
         .prepare(
           `update review_queue_jobs
-           set state = 'queued',
+           set state = case when exists (select 1 from review_queue_quarantines q
+                 where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number
+                   and q.head_sha = review_queue_jobs.head_sha) then 'stale_retired' else 'queued' end,
                lease_id = null,
                lease_expires_at = null,
-               last_error = 'queue_lease_expired_requeued',
-               updated_at = ?
+               next_eligible_at = null,
+               last_error = case when exists (select 1 from review_queue_quarantines q
+                 where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number
+                   and q.head_sha = review_queue_jobs.head_sha) then 'queue_quarantine_expired_retired'
+                 else 'queue_lease_expired_requeued' end,
+               updated_at = ?,
+               finished_at = case when exists (select 1 from review_queue_quarantines q
+                 where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number
+                   and q.head_sha = review_queue_jobs.head_sha) then coalesce(finished_at, ?) else finished_at end
            where state in ('leased', 'running')
              and (
-               (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
-               or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
+               (lease_expires_at is not null and lease_expires_at <= ?)
+               or (lease_expires_at is null and updated_at <= ?)
              )`
         )
-        .run(nowIso, nowIso, legacyLeaseCutoffIso);
+        .run(nowIso, nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
@@ -2799,6 +2848,75 @@ export class ReviewStateStore {
         input.jobId
       );
     return this.getReviewQueueJob(input.jobId)!;
+  }
+
+  claimReviewQueuePost(input: {
+    jobId: string; repo: string; pullNumber: number; headSha: string; leaseId: string; postKey: string; now?: Date;
+  }): ReviewQueuePostClaim {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    if (!input.postKey.trim()) throw new Error("postKey must be non-empty");
+    const row = this.db.prepare(
+      `insert into review_queue_post_claims
+         (job_id, post_key, lease_id, claimed_at, reconcile_required)
+       select ?, ?, ?, ?, 0 from review_queue_jobs j
+       where j.job_id = ? and j.repo = ? and j.pull_number = ? and j.head_sha = ?
+         and j.lease_id = ? and j.state in ('leased', 'running') and j.lease_expires_at > ?
+         and not exists (select 1 from review_queue_quarantines q
+           where q.repo = j.repo and q.pull_number = j.pull_number and q.head_sha = j.head_sha)
+       on conflict(job_id, post_key) do update set
+         lease_id = case when receipt is null then excluded.lease_id else lease_id end,
+         reconcile_required = 1
+       returning job_id, post_key, lease_id, reconcile_required, receipt`
+    ).get(input.jobId, input.postKey, input.leaseId, nowIso, input.jobId, input.repo,
+      input.pullNumber, input.headSha, input.leaseId, nowIso) as ReviewQueuePostClaimRow | undefined;
+    if (!row) throw new Error("review_queue_post_fenced");
+    return mapReviewQueuePostClaim(row);
+  }
+
+  recordReviewQueuePostReceipt(input: {
+    jobId: string; repo: string; pullNumber: number; headSha: string; leaseId: string;
+    postKey: string; receipt: string; now?: Date;
+  }): ReviewQueuePostClaim {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const receipt = redactSecrets(input.receipt).trim().slice(0, 2_000);
+    if (!receipt) throw new Error("receipt must be non-empty");
+    const row = this.db.prepare(
+      `update review_queue_post_claims as c set receipt = coalesce(receipt, ?), receipt_at = coalesce(receipt_at, ?)
+       where c.job_id = ? and c.post_key = ? and c.lease_id = ? and (c.receipt is null or c.receipt = ?)
+         and exists (select 1 from review_queue_jobs j where j.job_id = c.job_id and j.repo = ?
+           and j.pull_number = ? and j.head_sha = ? and j.lease_id = ? and j.state in ('leased', 'running')
+           and j.lease_expires_at > ? and not exists (select 1 from review_queue_quarantines q
+             where q.repo = j.repo and q.pull_number = j.pull_number and q.head_sha = j.head_sha))
+       returning job_id, post_key, lease_id, reconcile_required, receipt`
+    ).get(receipt, nowIso, input.jobId, input.postKey, input.leaseId, receipt, input.repo,
+      input.pullNumber, input.headSha, input.leaseId, nowIso) as ReviewQueuePostClaimRow | undefined;
+    if (!row) throw new Error("review_queue_post_receipt_conflict");
+    return mapReviewQueuePostClaim(row);
+  }
+
+  quarantineReviewQueueHead(input: {
+    repo: string; pullNumber: number; headSha: string; reason: string; now?: Date;
+  }): void {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const reason = redactSecrets(input.reason).trim().slice(0, 500);
+    if (!reason) throw new Error("reason must be non-empty");
+    this.db.exec("begin immediate");
+    try {
+      this.db.prepare(`insert or ignore into review_queue_quarantines
+        (repo, pull_number, head_sha, reason, created_at) values (?, ?, ?, ?, ?)`)
+        .run(input.repo, input.pullNumber, input.headSha, reason, nowIso);
+      this.db.prepare(`update review_queue_jobs set state = 'stale_retired', next_eligible_at = null,
+        lease_id = null, lease_expires_at = null, last_error = 'required_evidence_quarantined',
+        updated_at = ?, finished_at = coalesce(finished_at, ?)
+        where repo = ? and pull_number = ? and head_sha = ? and
+          (state in ('queued', 'provider_deferred', 'blocked_on_proof') or
+           (state in ('leased', 'running') and lease_expires_at is not null and lease_expires_at <= ?))`)
+        .run(nowIso, nowIso, input.repo, input.pullNumber, input.headSha, nowIso);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
   }
 
   updateReviewQueueJobPriority(input: {
@@ -3673,9 +3791,10 @@ export class ReviewStateStore {
 
   private ensureReviewRunLeaseColumns(): void {
     const columns = this.db.prepare("pragma table_info(review_run_leases)").all() as unknown as Array<{ name: string }>;
-    if (!columns.some((column) => column.name === "owner_pid")) {
-      this.db.exec("alter table review_run_leases add column owner_pid integer");
-    }
+    const names = new Set(columns.map((column) => column.name));
+    const additions = [["owner_pid", "integer"], ["queue_job_id", "text"], ["queue_lease_id", "text"],
+      ["repo", "text"], ["pull_number", "integer"], ["head_sha", "text"]].filter(([name]) => !names.has(name!));
+    for (const [name, type] of additions) this.db.exec(`alter table review_run_leases add column ${name} ${type}`);
   }
 
   private ensureReviewQueueJobColumns(): void {
@@ -4247,6 +4366,14 @@ interface ReviewQueueJobRow {
   finished_at: string | null;
 }
 
+interface ReviewQueuePostClaimRow {
+  job_id: string;
+  post_key: string;
+  lease_id: string;
+  reconcile_required: number;
+  receipt: string | null;
+}
+
 interface ReviewReadinessRow {
   repo: string;
   pull_number: number;
@@ -4514,6 +4641,11 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
+}
+
+function mapReviewQueuePostClaim(row: ReviewQueuePostClaimRow): ReviewQueuePostClaim {
+  return { jobId: row.job_id, postKey: row.post_key, leaseId: row.lease_id,
+    reconcileRequired: row.reconcile_required === 1, ...(row.receipt ? { receipt: row.receipt } : {}) };
 }
 
 function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRecord {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -463,6 +463,7 @@ describe("review state store", () => {
     const blocked = store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:01.000Z"));
 
     expect(first).toBeDefined();
+    expect(first?.queueJobId).toBeUndefined();
     expect(blocked).toBeUndefined();
     store.releaseReviewRunLease(first!.leaseId);
     expect(store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:02.000Z"))).toBeDefined();
@@ -1622,6 +1623,43 @@ describe("review state store", () => {
     })).toEqual([
       expect.objectContaining({ jobId: job.jobId, state: "leased" })
     ]);
+    store.close();
+  });
+
+  it("atomically claims one exact leased post and fences replay receipts", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-post-claim-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-08-24T00:00:00.000Z");
+    const job = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 7, headSha: "head", now }).job;
+    const [lease] = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 10, now });
+    const run = store.tryAcquireReviewRunLease(1, 10, now, process.pid, { queueJobId: job.jobId, queueLeaseId: lease!.leaseId!, repo: job.repo, pullNumber: 7, headSha: "head" });
+    expect(run).toMatchObject({ queueJobId: job.jobId, queueLeaseId: lease!.leaseId, repo: job.repo, pullNumber: 7, headSha: "head" });
+    store.releaseReviewRunLease(run!.leaseId);
+    expect(store.tryAcquireReviewRunLease(1, 10, now, process.pid, { queueJobId: job.jobId, queueLeaseId: "wrong", repo: job.repo, pullNumber: 7, headSha: "head" })).toBeUndefined();
+    const claim = { jobId: job.jobId, repo: job.repo, pullNumber: 7, headSha: "head", leaseId: lease!.leaseId!, postKey: "review" };
+    expect(() => store.claimReviewQueuePost({ ...claim, leaseId: "replaced", now })).toThrow("review_queue_post_fenced");
+    expect(store.claimReviewQueuePost({ ...claim, now })).toMatchObject({ reconcileRequired: false });
+    expect(store.claimReviewQueuePost({ ...claim, now })).toMatchObject({ reconcileRequired: true });
+    expect(store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.com/review/1", now }).receipt).toContain("/1");
+    expect(store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.com/review/1", now }).receipt).toContain("/1");
+    expect(() => store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.com/review/2", now })).toThrow("review_queue_post_receipt_conflict");
+    expect(() => store.claimReviewQueuePost({ ...claim, postKey: "late", now: new Date("2026-08-24T00:00:00.010Z") })).toThrow("review_queue_post_fenced");
+    store.close();
+  });
+
+  it("keeps exact-head quarantine durable and retires expired owners without capacity leaks", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-quarantine-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite")); const now = new Date("2026-08-24T00:00:00.000Z");
+    const blocked = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 8, headSha: "blocked", now }).job;
+    const other = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 9, headSha: "other", now }).job;
+    const [lease] = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, limit: 1, leaseTtlMs: 1, now });
+    store.quarantineReviewQueueHead({ repo: blocked.repo, pullNumber: 8, headSha: "blocked", reason: "required ghp_fake_token", now });
+    expect(() => store.enqueueReviewQueueJob({ repo: blocked.repo, pullNumber: 8, headSha: "blocked", now })).toThrow("review_queue_head_quarantined");
+    expect(() => store.claimReviewQueuePost({ jobId: blocked.jobId, repo: blocked.repo, pullNumber: 8, headSha: "blocked", leaseId: lease!.leaseId!, postKey: "review", now })).toThrow("review_queue_post_fenced");
+    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, now: new Date("2026-08-24T00:00:00.002Z") });
+    expect(leased.map((job) => job.jobId)).toEqual([other.jobId]);
+    expect(store.getReviewQueueJob(blocked.jobId)).toMatchObject({ state: "stale_retired", finishedAt: "2026-08-24T00:00:00.002Z" });
+    expect(store.getReviewQueueJob(blocked.jobId)?.nextEligibleAt).toBeUndefined();
     store.close();
   });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1656,7 +1656,7 @@ describe("review state store", () => {
     store.quarantineReviewQueueHead({ repo: blocked.repo, pullNumber: 8, headSha: "blocked", reason: "required ghp_fake_token", now });
     expect(() => store.enqueueReviewQueueJob({ repo: blocked.repo, pullNumber: 8, headSha: "blocked", now })).toThrow("review_queue_head_quarantined");
     expect(() => store.claimReviewQueuePost({ jobId: blocked.jobId, repo: blocked.repo, pullNumber: 8, headSha: "blocked", leaseId: lease!.leaseId!, postKey: "review", now })).toThrow("review_queue_post_fenced");
-    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, now: new Date("2026-08-24T00:00:00.002Z") });
+    store.clearReviewQueueLeases({ dryRun: false, expiredOnly: true, now: new Date("2026-08-24T00:00:00.002Z") }); const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, now: new Date("2026-08-24T00:00:00.002Z") });
     expect(leased.map((job) => job.jobId)).toEqual([other.jobId]);
     expect(store.getReviewQueueJob(blocked.jobId)).toMatchObject({ state: "stale_retired", finishedAt: "2026-08-24T00:00:00.002Z" });
     expect(store.getReviewQueueJob(blocked.jobId)?.nextEligibleAt).toBeUndefined();


### PR DESCRIPTION
Related: #882
Dependency context: #863

Agent-authored replacement layer 1 for the lease-fence architecture.

- Atomically validates exact job/repo/PR/head/lease/expiry/quarantine while claiming each post key.
- Marks every repeated claim reconciliation-only and commits receipts with current-lease CAS semantics.
- Persists an exact-head quarantine tombstone enforced by an insert trigger.
- Retires expired quarantined leases instead of requeueing or leaking capacity.
- Persists optional scheduled run-lease association with exact queue job ID, opaque queue lease token, repo, PR, and head in the same acquisition transaction; standalone run leases remain unassociated.
- Preserves #910 daemon run/progress/completion migration semantics.

Exact base: d0eb797f069a06d951791283e39d6057cf099a37
Exact head: bdcaa406aab764bac64b76bda15e8b0ec6f47909
Changed non-generated lines: 200 (185 additions, 15 deletions)

Local proof:
- `tests/state.test.ts`: 74/74 passed
- `tests/scheduler.test.ts`: 103/103 passed
- strict source TypeScript check for `src/state.ts`: passed
- `git diff --check`: passed
- repository build was attempted from the isolated worktree; TypeScript could not resolve unrelated `jose`/`stripe` packages because dependencies are not installed in this worktree. Exact-head CI is the authoritative full build/package gate.

Safety boundary: this PR contains state schema and transaction primitives only. It does not wire worker/scheduler posting, perform a GitHub write, claim exactly-once network behavior, merge, deploy, or mutate a live database/runtime.