### PR TITLE
feat: tighten severe receipt schema contract

### DIFF
--- a/src/severe-verification-receipt-schema.ts
+++ b/src/severe-verification-receipt-schema.ts
@@ -26,7 +26,7 @@ const SHA40 = "^[a-f0-9]{40}$";
 const SHA256 = "^[a-f0-9]{64}$";
 const REPO = "^[A-Za-z0-9_.-]{1,100}$";
 const OWNER = "(?![^/]*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?";
-const SAFE_PATH = "^(?!/)(?![A-Za-z]:)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*[\\\\\\u0000-\\u001f\\u007f-\\u009f])(?!.*\\/$).+$";
+const SAFE_PATH = "^(?!/)(?![A-Za-z]:)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*[\\\\\\u0000-\\u001f\\u007f-\\u009f\\uD800-\\uDFFF])(?!.*\\/$).+$";
 const STATE_RULES: Record<SevereVerificationState, { disposition: SevereVerificationDisposition; complete: boolean; reasons?: readonly SevereVerificationCode[] }> = {
   confirmed: { disposition: "retain", complete: true }, refuted: { disposition: "suppress", complete: true, reasons: ["refuted"] },
   failed: { disposition: "suppress", complete: false, reasons: ["provider_unavailable", "receipt_invalid"] },

--- a/src/severe-verification-receipt-schema.ts
+++ b/src/severe-verification-receipt-schema.ts
@@ -1,0 +1,100 @@
+import { Ajv2020, type ValidateFunction } from "ajv/dist/2020.js";
+
+export const SEVERE_VERIFICATION_STATES = [
+  "confirmed", "refuted", "failed", "malformed", "timeout", "unavailable", "stale_head", "incomplete"
+] as const;
+export const SEVERE_VERIFICATION_CODES = [
+  "not_read", "refuted", "malformed", "timeout", "unavailable", "stale_head", "incomplete", "schema_invalid",
+  "identity_mismatch", "evidence_incomplete", "provider_unavailable", "cap_exceeded", "receipt_invalid"
+] as const;
+export type SevereVerificationState = typeof SEVERE_VERIFICATION_STATES[number];
+export type SevereVerificationCode = typeof SEVERE_VERIFICATION_CODES[number];
+export type SevereVerificationDisposition = "retain" | "suppress";
+export type SevereEvidenceKind = "whole_file" | "module";
+export interface SevereVerificationEvidenceFile {
+  path: string; kind: SevereEvidenceKind; sha256: string; bytes: number; complete: boolean;
+}
+export interface SevereVerificationEvidenceOmission { path: string; code: SevereVerificationCode; }
+export interface SevereVerificationReceipt {
+  schemaVersion: "severe-verifier-v1"; repo: string; pullNumber: number; baseSha: string; headSha: string;
+  findingFingerprint: string; state: SevereVerificationState; disposition: SevereVerificationDisposition;
+  confidence?: number; reasonCode?: SevereVerificationCode;
+  evidence: { files: SevereVerificationEvidenceFile[]; omitted: SevereVerificationEvidenceOmission[]; complete: boolean };
+}
+
+const SHA40 = "^[a-f0-9]{40}$";
+const SHA256 = "^[a-f0-9]{64}$";
+const REPO = "^[A-Za-z0-9_.-]{1,100}$";
+const OWNER = "(?![^/]*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?";
+const SAFE_PATH = "^(?!/)(?![A-Za-z]:)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*[\\\\\\u0000-\\u001f\\u007f-\\u009f])(?!.*\\/$).+$";
+const STATE_RULES: Record<SevereVerificationState, { disposition: SevereVerificationDisposition; complete: boolean; reasons?: readonly SevereVerificationCode[] }> = {
+  confirmed: { disposition: "retain", complete: true }, refuted: { disposition: "suppress", complete: true, reasons: ["refuted"] },
+  failed: { disposition: "suppress", complete: false, reasons: ["provider_unavailable", "receipt_invalid"] },
+  malformed: { disposition: "suppress", complete: false, reasons: ["malformed", "schema_invalid", "receipt_invalid"] },
+  timeout: { disposition: "suppress", complete: false, reasons: ["timeout"] },
+  unavailable: { disposition: "suppress", complete: false, reasons: ["unavailable", "provider_unavailable"] },
+  stale_head: { disposition: "suppress", complete: false, reasons: ["stale_head", "identity_mismatch"] },
+  incomplete: { disposition: "suppress", complete: false, reasons: ["incomplete", "not_read", "evidence_incomplete", "cap_exceeded"] }
+};
+
+const path = { type: "string", minLength: 1, maxLength: 4096, pattern: SAFE_PATH } as const;
+export const SEVERE_VERIFICATION_RECEIPT_JSON_SCHEMA = {
+  $id: "https://neondiff.com/schema/severe-verification-receipt-v1.json", type: "object", additionalProperties: false,
+  required: ["schemaVersion", "repo", "pullNumber", "baseSha", "headSha", "findingFingerprint", "state", "disposition", "evidence"],
+  properties: {
+    schemaVersion: { const: "severe-verifier-v1" }, repo: { type: "string", minLength: 3, maxLength: 140, pattern: `^${OWNER}/${REPO.slice(1, -1)}$` },
+    pullNumber: { type: "integer", minimum: 1, maximum: Number.MAX_SAFE_INTEGER }, baseSha: { type: "string", pattern: SHA40 },
+    headSha: { type: "string", pattern: SHA40 }, findingFingerprint: { type: "string", pattern: "^finding:[a-f0-9]{64}$" },
+    state: { enum: SEVERE_VERIFICATION_STATES }, disposition: { enum: ["retain", "suppress"] },
+    confidence: { type: "number", minimum: 0, maximum: 1 }, reasonCode: { enum: SEVERE_VERIFICATION_CODES },
+    evidence: {
+      type: "object", additionalProperties: false, required: ["files", "omitted", "complete"], noEvidencePathOverlap: true,
+      properties: {
+        files: { type: "array", maxItems: 64, uniqueItems: true, items: {
+          type: "object", additionalProperties: false, required: ["path", "kind", "sha256", "bytes", "complete"],
+          properties: { path, kind: { enum: ["whole_file", "module"] }, sha256: { type: "string", pattern: SHA256 }, bytes: { type: "integer", minimum: 0, maximum: 65_536 }, complete: { type: "boolean" } }
+        } },
+        omitted: { type: "array", maxItems: 64, items: {
+          type: "object", additionalProperties: false, required: ["path", "code"],
+          properties: { path, code: { enum: SEVERE_VERIFICATION_CODES } }
+        } },
+        complete: { type: "boolean" }
+      },
+      anyOf: [{ properties: { files: { type: "array", minItems: 1 } } }, { properties: { omitted: { type: "array", minItems: 1 } } }],
+      allOf: [{ if: { properties: { complete: { const: true } }, required: ["complete"] }, then: { properties: {
+        files: { type: "array", minItems: 1, items: { type: "object", properties: { complete: { const: true } } } },
+        omitted: { type: "array", maxItems: 0 }
+      } } }]
+    }
+  },
+  allOf: SEVERE_VERIFICATION_STATES.map((state) => ({
+    if: { properties: { state: { const: state } }, required: ["state"] },
+    then: {
+      properties: { disposition: { const: STATE_RULES[state].disposition }, evidence: { type: "object", properties: { complete: { const: STATE_RULES[state].complete } } },
+        ...(STATE_RULES[state].reasons ? { reasonCode: { enum: STATE_RULES[state].reasons } } : { reasonCode: false }) },
+      ...(STATE_RULES[state].reasons ? { required: ["reasonCode"] } : {})
+    }
+  }))
+} as const;
+
+export function compileSevereVerificationReceiptSchema(): ValidateFunction<SevereVerificationReceipt> {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addKeyword({ keyword: "noEvidencePathOverlap", type: "object", schemaType: "boolean", validate: (_schema: boolean, evidence: unknown) => {
+    if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return true;
+    const paths = new Set<string>();
+    const files = (evidence as { files?: unknown }).files;
+    if (Array.isArray(files)) for (const file of files) {
+      if (file && typeof file === "object" && !Array.isArray(file) && (file as { kind?: unknown }).kind === "whole_file") {
+        const path = (file as { path?: unknown }).path;
+        if (typeof path === "string" && (paths.has(path) || (paths.add(path), false))) return false;
+      }
+    }
+    const omitted = (evidence as { omitted?: unknown }).omitted;
+    if (Array.isArray(omitted)) for (const item of omitted) {
+      const path = item && typeof item === "object" && !Array.isArray(item) ? (item as { path?: unknown }).path : undefined;
+      if (typeof path === "string" && paths.has(path)) return false;
+    }
+    return true;
+  } });
+  return ajv.compile<SevereVerificationReceipt>(SEVERE_VERIFICATION_RECEIPT_JSON_SCHEMA);
+}

--- a/tests/severe-verification-receipt-schema.test.ts
+++ b/tests/severe-verification-receipt-schema.test.ts
@@ -51,6 +51,15 @@ describe("strict severe verification receipt schema", () => {
     }
   });
 
+  it("rejects lone high/low surrogate path code units at every position", () => {
+    for (const unsafe of ["\uD800x.ts", "src/\uD800x.ts", "src/x\uD800.ts", "\uDC00x.ts", "src/\uDC00x.ts", "src/x\uDC00.ts"]) {
+      const invalid = receipt(); invalid.evidence.files[0].path = unsafe;
+      expect(validate(invalid), unsafe).toBe(false);
+    }
+    const valid = receipt(); valid.evidence.files[0].path = "src/🧪.ts";
+    expect(validate(valid)).toBe(true);
+  });
+
   it("enforces retain/suppress, reason, and completeness semantics", () => {
     const refuted = { ...receipt(), state: "refuted", disposition: "suppress", reasonCode: "refuted" };
     expect(validate(refuted)).toBe(true);

--- a/tests/severe-verification-receipt-schema.test.ts
+++ b/tests/severe-verification-receipt-schema.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { compileSevereVerificationReceiptSchema, type SevereVerificationReceipt } from "../src/severe-verification-receipt-schema.js";
+
+const path = "src/safe file+λ.ts";
+const receipt = (): SevereVerificationReceipt => ({
+  schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7,
+  baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`,
+  state: "confirmed", disposition: "retain",
+  evidence: { files: [{ path, kind: "whole_file", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true }
+});
+const validate = compileSevereVerificationReceiptSchema();
+
+describe("strict severe verification receipt schema", () => {
+  it("accepts exact identity and bounded whole-file/module evidence", () => {
+    expect(validate(receipt())).toBe(true);
+    expect(validate({ ...receipt(), repo: "Electric-Sheep/.github", evidence: { files: [{ ...receipt().evidence.files[0], kind: "module" }], omitted: [], complete: true } })).toBe(true);
+    expect(validate({ ...receipt(), repo: "owner/repo--name" })).toBe(true);
+  });
+
+  it("rejects extra fields, invalid identities, hashes, and evidence bounds", () => {
+    for (const invalid of [
+      { ...receipt(), extra: true }, { ...receipt(), repo: "owner" }, { ...receipt(), repo: "_owner/repo" },
+      { ...receipt(), repo: "owner-/repo" }, { ...receipt(), repo: "owner--name/repo" }, { ...receipt(), repo: "owner/repo name" },
+      { ...receipt(), repo: `${"o".repeat(40)}/repo` }, { ...receipt(), repo: `owner/${"r".repeat(101)}` },
+      { ...receipt(), pullNumber: 0 }, { ...receipt(), headSha: "A".repeat(40) }, { ...receipt(), findingFingerprint: "f".repeat(64) },
+      { ...receipt(), evidence: { files: [], omitted: [], complete: false } },
+      { ...receipt(), evidence: { files: [{ ...receipt().evidence.files[0], complete: false }], omitted: [], complete: true } },
+      { ...receipt(), evidence: { files: receipt().evidence.files, omitted: [{ path: "src/missing.ts", code: "not_read" }], complete: true } },
+      { ...receipt(), evidence: { files: [{ ...receipt().evidence.files[0], bytes: 65_537 }], omitted: [], complete: true } }
+    ]) expect(validate(invalid)).toBe(false);
+  });
+
+  it("rejects duplicate/conflicting whole-file identities and file/omission overlap", () => {
+    const file = receipt().evidence.files[0];
+    for (const duplicate of [{ ...file }, { ...file, sha256: "d".repeat(64), bytes: 43 }]) {
+      const invalid = receipt(); invalid.evidence.files.push(duplicate);
+      expect(validate(invalid)).toBe(false);
+    }
+    const overlap = receipt();
+    overlap.state = "incomplete"; overlap.disposition = "suppress"; overlap.reasonCode = "evidence_incomplete";
+    overlap.evidence.complete = false; overlap.evidence.omitted = [{ path, code: "evidence_incomplete" }];
+    expect(validate(overlap)).toBe(false);
+  });
+
+  it("rejects C0/C1, absolute, traversal, and backslash paths while accepting Unicode", () => {
+    const astral = receipt(); astral.evidence.files[0].path = "src/🧪.ts";
+    expect(validate(astral)).toBe(true);
+    for (const unsafe of ["/src/x.ts", "../x.ts", "src/../x.ts", "C:/x.ts", "src\\x.ts", "src/\u0001x.ts", "src/\u0085x.ts"]) {
+      const invalid = receipt(); invalid.evidence.files[0].path = unsafe;
+      expect(validate(invalid), unsafe).toBe(false);
+    }
+  });
+
+  it("enforces retain/suppress, reason, and completeness semantics", () => {
+    const refuted = { ...receipt(), state: "refuted", disposition: "suppress", reasonCode: "refuted" };
+    expect(validate(refuted)).toBe(true);
+    for (const invalid of [
+      { ...receipt(), disposition: "suppress" }, { ...receipt(), reasonCode: "refuted" },
+      { ...refuted, disposition: "retain" }, { ...receipt(), state: "timeout", disposition: "suppress", reasonCode: "malformed" },
+      { ...receipt(), state: "incomplete", disposition: "suppress", reasonCode: "incomplete" }
+    ]) expect(validate(invalid)).toBe(false);
+  });
+});


### PR DESCRIPTION
Related: #865

## Summary
- add the production-inert `severe-verifier-v1` TypeScript and strict Ajv 2020 schema contract from exact current main
- enforce authoritative GitHub owner syntax (1-39 chars, alphanumeric ends, no consecutive hyphens) with canonical repository characters
- reject duplicate or conflicting `whole_file` paths and any whole-file/omission overlap via a strict schema keyword
- retain exact identity, additionalProperties:false, path safety, bounded hashes/bytes, evidence completeness, and retain/suppress state semantics

## Validation
- `bun test tests/severe-verification-receipt-schema.test.ts` — 5 passed, 35 assertions
- `./node_modules/.bin/tsc --noEmit -p tsconfig.build.json` — passed
- `git diff --check` — passed
- 163 non-generated added lines across two files

## Proof boundary
- production-inert schema/type contract only; no serialized parser, canonicalization, digest, provider, worker, publication, runtime, config, database, release, or customer wiring
- Vitest could not start locally because the Darwin Rollup native binding has a code-signature Team ID mismatch; Bun and TypeScript checks passed
- exact-head CI and independent semantic review remain required