### PR TITLE
feat(desktop): add accepted release provenance producer

### DIFF
--- a/scripts/lib/desktop-release-provenance.mjs
+++ b/scripts/lib/desktop-release-provenance.mjs
@@ -1,16 +1,21 @@
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 
 const SHA1 = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const FEEDS = Object.freeze({ beta: "https://www.neondiff.com/updates/beta/appcast.xml", stable: "https://www.neondiff.com/updates/stable/appcast.xml" });
+const { default: Ajv } = createRequire(import.meta.url)("ajv/dist/2020.js");
+const validateDeclaration = new Ajv({ allErrors: true, strict: true }).compile(JSON.parse(readFileSync(new URL("../../docs/schema/desktop-release-declaration-v1.schema.json", import.meta.url), "utf8")));
 const fail = (message) => { throw new Error(message); };
 const string = (value, label) => { if (typeof value !== "string" || value.length === 0) fail(`${label} is required`); return value; };
 const digest = (value, label, pattern) => { const result = string(value, label); if (!pattern.test(result)) fail(`${label} is malformed`); return result; };
+const proof = (value, kind, label) => { if (value?.schemaVersion !== 1 || value.kind !== kind || value.verified !== true) fail(`${label} proof is not verified`); return value; };
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
 
 function releaseIdentity(declaration) {
   const version = string(declaration?.version, "declaration version"), tag = string(declaration?.tag, "declaration tag");
-  const match = version.match(/^1\.1\.0-(beta|rc)\.([1-9][0-9]{0,15})$/) ?? (version === "1.1.0" ? [version, "stable", ""] : null);
+  const match = version.match(/^1\.1\.0-(beta|rc)\.([1-9][0-9]{0,15})$/);
   if (!match || tag !== `v${version}` || declaration?.channel !== match[1]) fail("declaration release identity is invalid");
   return { version, tag, channel: match[1] };
 }
@@ -18,6 +23,7 @@ function releaseIdentity(declaration) {
 export function buildAcceptedReleaseProvenance(metadata) {
   const { declaration, tagMetadata, annotatedTagMetadata, releaseMetadata, artifactMetadata, feedMetadata } = metadata ?? {};
   if (declaration?.schemaVersion !== 1 || declaration?.product !== "neondiff-desktop" || declaration?.contract !== "paid-mac-beta-byo-v1") fail("declaration is not validated Desktop metadata");
+  if (!validateDeclaration(declaration)) fail("declaration is outside the canonical v1 schema");
   const release = releaseIdentity(declaration), build = string(declaration?.build, "declaration build");
   if (!/^[0-9]+$/.test(build)) fail("declaration build is malformed");
   const artifactName = string(declaration?.distribution?.artifactName, "declaration artifact name");
@@ -29,12 +35,18 @@ export function buildAcceptedReleaseProvenance(metadata) {
   if (releaseMetadata?.tag_name !== release.tag || releaseMetadata?.draft !== false || releaseMetadata?.immutable !== true || releaseMetadata?.prerelease !== (release.channel !== "stable") || assets.length !== 1) fail("release metadata is not an immutable identity match");
   const asset = assets[0], artifactSHA256 = digest(asset?.digest?.replace(/^sha256:/, ""), "artifact SHA-256", SHA256);
   if (asset.digest !== `sha256:${artifactSHA256}` || asset.browser_download_url !== `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${release.tag}/${artifactName}`) fail("release asset metadata is not canonical");
+  const identityProof = proof(metadata?.identityProof, "neondiff.desktop.release-identity-validation-v1", "release identity");
+  if (identityProof.releaseTag !== release.tag || identityProof.sourceCommitSHA !== sourceCommitSHA || identityProof.tagObjectSHA !== tagObjectSHA || identityProof.artifactSHA256 !== artifactSHA256) fail("release identity proof does not match validated metadata");
   if (artifactMetadata?.treeAlgorithm !== "sha256-tree-v1") fail("tree digest algorithm is not supported");
   const appSHA256 = digest(artifactMetadata?.appSHA256, "app SHA-256", SHA256), treeSHA256 = digest(artifactMetadata?.treeSHA256, "tree SHA-256", SHA256);
   if (artifactMetadata?.artifactSHA256 !== artifactSHA256) fail("artifact metadata does not match release metadata");
+  const artifactProof = proof(artifactMetadata?.proof, "neondiff.desktop.artifact-proof-v1", "artifact");
+  if (artifactProof.appSHA256 !== appSHA256 || artifactProof.treeAlgorithm !== "sha256-tree-v1" || artifactProof.treeSHA256 !== treeSHA256 || artifactProof.artifactSHA256 !== artifactSHA256) fail("artifact proof does not match validated metadata");
   const feedChannel = string(feedMetadata?.channel, "feed channel");
   if (!Object.hasOwn(FEEDS, feedChannel) || feedMetadata.url !== FEEDS[feedChannel] || declaration?.distribution?.origins?.feed !== feedMetadata.url || feedChannel !== (release.channel === "stable" ? "stable" : "beta")) fail("feed identity does not match release metadata");
   const appcastSHA256 = digest(feedMetadata.appcastSHA256, "appcast SHA-256", SHA256);
+  const feedProof = proof(feedMetadata?.proof, "neondiff.desktop.feed-proof-v1", "feed");
+  if (feedProof.channel !== feedChannel || feedProof.url !== feedMetadata.url || feedProof.appcastSHA256 !== appcastSHA256) fail("feed proof does not match validated metadata");
   return { schemaVersion: 1, kind: "neondiff.desktop.accepted-release-provenance", product: "neondiff-desktop", release: { tag: release.tag, version: release.version, channel: release.channel, build, artifactName }, source: { commitSHA: sourceCommitSHA, tagObjectSHA }, artifacts: { appSHA256, treeAlgorithm: "sha256-tree-v1", treeSHA256, artifactSHA256 }, feed: { channel: feedChannel, url: feedMetadata.url, appcastSHA256 } };
 }
 

--- a/scripts/lib/desktop-release-provenance.mjs
+++ b/scripts/lib/desktop-release-provenance.mjs
@@ -1,0 +1,48 @@
+import { createHash } from "node:crypto";
+
+const SHA1 = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const FEEDS = Object.freeze({ beta: "https://www.neondiff.com/updates/beta/appcast.xml", stable: "https://www.neondiff.com/updates/stable/appcast.xml" });
+const fail = (message) => { throw new Error(message); };
+const string = (value, label) => { if (typeof value !== "string" || value.length === 0) fail(`${label} is required`); return value; };
+const digest = (value, label, pattern) => { const result = string(value, label); if (!pattern.test(result)) fail(`${label} is malformed`); return result; };
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+function releaseIdentity(declaration) {
+  const version = string(declaration?.version, "declaration version"), tag = string(declaration?.tag, "declaration tag");
+  const match = version.match(/^1\.1\.0-(beta|rc)\.([1-9][0-9]{0,15})$/) ?? (version === "1.1.0" ? [version, "stable", ""] : null);
+  if (!match || tag !== `v${version}` || declaration?.channel !== match[1]) fail("declaration release identity is invalid");
+  return { version, tag, channel: match[1] };
+}
+
+export function buildAcceptedReleaseProvenance(metadata) {
+  const { declaration, tagMetadata, annotatedTagMetadata, releaseMetadata, artifactMetadata, feedMetadata } = metadata ?? {};
+  if (declaration?.schemaVersion !== 1 || declaration?.product !== "neondiff-desktop" || declaration?.contract !== "paid-mac-beta-byo-v1") fail("declaration is not validated Desktop metadata");
+  const release = releaseIdentity(declaration), build = string(declaration?.build, "declaration build");
+  if (!/^[0-9]+$/.test(build)) fail("declaration build is malformed");
+  const artifactName = string(declaration?.distribution?.artifactName, "declaration artifact name");
+  if (artifactName !== `NeonDiff-${release.version}-build${build}-macOS.zip`) fail("declaration artifact identity is invalid");
+  const tagObjectSHA = digest(tagMetadata?.object?.sha, "annotated tag-object SHA", SHA1), sourceCommitSHA = digest(annotatedTagMetadata?.object?.sha, "source commit SHA", SHA1);
+  if (tagMetadata?.ref !== `refs/tags/${release.tag}` || tagMetadata?.object?.type !== "tag") fail("release tag metadata is not annotated");
+  if (annotatedTagMetadata?.sha !== tagObjectSHA || annotatedTagMetadata?.tag !== release.tag || annotatedTagMetadata?.object?.type !== "commit") fail("annotated tag metadata does not match");
+  const assets = Array.isArray(releaseMetadata?.assets) ? releaseMetadata.assets.filter((item) => item?.name === artifactName) : [];
+  if (releaseMetadata?.tag_name !== release.tag || releaseMetadata?.draft !== false || releaseMetadata?.immutable !== true || releaseMetadata?.prerelease !== (release.channel !== "stable") || assets.length !== 1) fail("release metadata is not an immutable identity match");
+  const asset = assets[0], artifactSHA256 = digest(asset?.digest?.replace(/^sha256:/, ""), "artifact SHA-256", SHA256);
+  if (asset.digest !== `sha256:${artifactSHA256}` || asset.browser_download_url !== `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${release.tag}/${artifactName}`) fail("release asset metadata is not canonical");
+  if (artifactMetadata?.treeAlgorithm !== "sha256-tree-v1") fail("tree digest algorithm is not supported");
+  const appSHA256 = digest(artifactMetadata?.appSHA256, "app SHA-256", SHA256), treeSHA256 = digest(artifactMetadata?.treeSHA256, "tree SHA-256", SHA256);
+  if (artifactMetadata?.artifactSHA256 !== artifactSHA256) fail("artifact metadata does not match release metadata");
+  const feedChannel = string(feedMetadata?.channel, "feed channel");
+  if (!Object.hasOwn(FEEDS, feedChannel) || feedMetadata.url !== FEEDS[feedChannel] || declaration?.distribution?.origins?.feed !== feedMetadata.url || feedChannel !== (release.channel === "stable" ? "stable" : "beta")) fail("feed identity does not match release metadata");
+  const appcastSHA256 = digest(feedMetadata.appcastSHA256, "appcast SHA-256", SHA256);
+  return { schemaVersion: 1, kind: "neondiff.desktop.accepted-release-provenance", product: "neondiff-desktop", release: { tag: release.tag, version: release.version, channel: release.channel, build, artifactName }, source: { commitSHA: sourceCommitSHA, tagObjectSHA }, artifacts: { appSHA256, treeAlgorithm: "sha256-tree-v1", treeSHA256, artifactSHA256 }, feed: { channel: feedChannel, url: feedMetadata.url, appcastSHA256 } };
+}
+
+export function serializeAcceptedReleaseProvenance(metadata) {
+  const receipt = buildAcceptedReleaseProvenance(metadata);
+  return `${JSON.stringify(receipt)}\n`;
+}
+
+export function acceptedReleaseProvenanceDigest(metadata) {
+  return sha256(Buffer.from(serializeAcceptedReleaseProvenance(metadata)));
+}

--- a/tests/desktop-release-provenance.test.ts
+++ b/tests/desktop-release-provenance.test.ts
@@ -4,12 +4,37 @@ import { acceptedReleaseProvenanceDigest, buildAcceptedReleaseProvenance, serial
 const source = "0123456789abcdef0123456789abcdef01234567", tagObject = "abcdef0123456789abcdef0123456789abcdef01";
 function fixture(channel: "beta" | "stable" = "beta") {
   const version = channel === "stable" ? "1.1.0" : "1.1.0-beta.7", tag = `v${version}`, build = "42", feed = `https://www.neondiff.com/updates/${channel}/appcast.xml`, artifactName = `NeonDiff-${version}-build${build}-macOS.zip`, artifactSHA256 = "a".repeat(64);
-  return { declaration: { schemaVersion: 1, product: "neondiff-desktop", contract: "paid-mac-beta-byo-v1", version, tag, channel, build, distribution: { artifactName, origins: { feed } } }, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: channel !== "stable", immutable: true, assets: [{ name: artifactName, digest: `sha256:${artifactSHA256}`, browser_download_url: `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${tag}/${artifactName}` }] }, artifactMetadata: { appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64), artifactSHA256 }, feedMetadata: { channel, url: feed, appcastSHA256: "d".repeat(64) } };
+  return { declaration: { schemaVersion: 1, product: "neondiff-desktop", contract: "paid-mac-beta-byo-v1", version, tag, channel, sequence: "7", build, predecessor: null, distribution: { bundleId: "com.electricsheephq.NeonDiffDesktop", appPath: "NeonDiff.app", artifactName, releaseClass: "paid-beta", origins: { github: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff", site: "https://www.neondiff.com", feed } } }, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: channel !== "stable", immutable: true, assets: [{ name: artifactName, digest: `sha256:${artifactSHA256}`, browser_download_url: `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${tag}/${artifactName}` }] }, identityProof: { schemaVersion: 1, kind: "neondiff.desktop.release-identity-validation-v1", verified: true, releaseTag: tag, sourceCommitSHA: source, tagObjectSHA: tagObject, artifactSHA256 }, artifactMetadata: { appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64), artifactSHA256, proof: { schemaVersion: 1, kind: "neondiff.desktop.artifact-proof-v1", verified: true, appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64), artifactSHA256 } }, feedMetadata: { channel, url: feed, appcastSHA256: "d".repeat(64), proof: { schemaVersion: 1, kind: "neondiff.desktop.feed-proof-v1", verified: true, channel, url: feed, appcastSHA256: "d".repeat(64) } } };
 }
 
 describe("accepted Desktop release provenance", () => {
+  it("rejects declarations outside the repository canonical v1 schema", () => {
+    expect(() => buildAcceptedReleaseProvenance(fixture("stable"))).toThrow();
+    const oversized = fixture();
+    oversized.declaration.version = "1.1.0-beta.10000";
+    expect(() => buildAcceptedReleaseProvenance(oversized)).toThrow();
+    const incomplete = fixture();
+    delete (incomplete.declaration as Partial<typeof incomplete.declaration>).sequence;
+    expect(() => buildAcceptedReleaseProvenance(incomplete)).toThrow();
+  });
+
+  it("rejects absent, false, or unrelated upstream identity and byte/feed proofs", () => {
+    const missingIdentity = fixture();
+    delete (missingIdentity as Partial<typeof missingIdentity>).identityProof;
+    expect(() => buildAcceptedReleaseProvenance(missingIdentity)).toThrow();
+    const unrelatedIdentity = fixture();
+    unrelatedIdentity.identityProof.sourceCommitSHA = "f".repeat(40);
+    expect(() => buildAcceptedReleaseProvenance(unrelatedIdentity)).toThrow();
+    const falseArtifact = fixture();
+    falseArtifact.artifactMetadata.proof.verified = false;
+    expect(() => buildAcceptedReleaseProvenance(falseArtifact)).toThrow();
+    const missingFeed = fixture();
+    delete (missingFeed.feedMetadata as Partial<typeof missingFeed.feedMetadata>).proof;
+    expect(() => buildAcceptedReleaseProvenance(missingFeed)).toThrow();
+  });
+
   it("derives source/tag/artifact/tree/app and explicit beta or stable feed identities", () => {
-    for (const channel of ["beta", "stable"] as const) {
+    for (const channel of ["beta"] as const) {
       const receipt = buildAcceptedReleaseProvenance(fixture(channel));
       expect(receipt).toMatchObject({ schemaVersion: 1, source: { commitSHA: source, tagObjectSHA: tagObject }, artifacts: { appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64), artifactSHA256: "a".repeat(64) }, feed: { channel } });
       expect(JSON.parse(serializeAcceptedReleaseProvenance(fixture(channel)))).toEqual(receipt);

--- a/tests/desktop-release-provenance.test.ts
+++ b/tests/desktop-release-provenance.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { acceptedReleaseProvenanceDigest, buildAcceptedReleaseProvenance, serializeAcceptedReleaseProvenance } from "../scripts/lib/desktop-release-provenance.mjs";
+
+const source = "0123456789abcdef0123456789abcdef01234567", tagObject = "abcdef0123456789abcdef0123456789abcdef01";
+function fixture(channel: "beta" | "stable" = "beta") {
+  const version = channel === "stable" ? "1.1.0" : "1.1.0-beta.7", tag = `v${version}`, build = "42", feed = `https://www.neondiff.com/updates/${channel}/appcast.xml`, artifactName = `NeonDiff-${version}-build${build}-macOS.zip`, artifactSHA256 = "a".repeat(64);
+  return { declaration: { schemaVersion: 1, product: "neondiff-desktop", contract: "paid-mac-beta-byo-v1", version, tag, channel, build, distribution: { artifactName, origins: { feed } } }, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: channel !== "stable", immutable: true, assets: [{ name: artifactName, digest: `sha256:${artifactSHA256}`, browser_download_url: `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${tag}/${artifactName}` }] }, artifactMetadata: { appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64), artifactSHA256 }, feedMetadata: { channel, url: feed, appcastSHA256: "d".repeat(64) } };
+}
+
+describe("accepted Desktop release provenance", () => {
+  it("derives source/tag/artifact/tree/app and explicit beta or stable feed identities", () => {
+    for (const channel of ["beta", "stable"] as const) {
+      const receipt = buildAcceptedReleaseProvenance(fixture(channel));
+      expect(receipt).toMatchObject({ schemaVersion: 1, source: { commitSHA: source, tagObjectSHA: tagObject }, artifacts: { appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64), artifactSHA256: "a".repeat(64) }, feed: { channel } });
+      expect(JSON.parse(serializeAcceptedReleaseProvenance(fixture(channel)))).toEqual(receipt);
+    }
+  });
+  it("is deterministic, digestable, and contains no secret-looking input fields", () => {
+    const value = fixture(), first = serializeAcceptedReleaseProvenance(value);
+    expect(first).toBe(serializeAcceptedReleaseProvenance(value));
+    expect(acceptedReleaseProvenanceDigest(value)).toMatch(/^[0-9a-f]{64}$/);
+    expect(first).not.toMatch(/secret|token|key|private|password/i);
+  });
+  it("fails closed for absent, malformed, mismatched, or mutable provenance", () => {
+    const cases = [
+      (v: ReturnType<typeof fixture>) => { delete (v.artifactMetadata as Partial<typeof v.artifactMetadata>).treeSHA256; },
+      (v: ReturnType<typeof fixture>) => { v.artifactMetadata.treeAlgorithm = "sha256"; },
+      (v: ReturnType<typeof fixture>) => { v.annotatedTagMetadata.object.sha = "not-a-sha"; },
+      (v: ReturnType<typeof fixture>) => { v.annotatedTagMetadata.sha = source; },
+      (v: ReturnType<typeof fixture>) => { v.releaseMetadata.immutable = false; },
+      (v: ReturnType<typeof fixture>) => { v.releaseMetadata.assets[0].digest = `sha256:${"e".repeat(64)}`; },
+      (v: ReturnType<typeof fixture>) => { v.feedMetadata.channel = "stable"; },
+      (v: ReturnType<typeof fixture>) => { v.declaration.distribution.origins.feed = "https://example.invalid/feed"; }
+    ];
+    for (const mutate of cases) { const value = fixture(); mutate(value); expect(() => buildAcceptedReleaseProvenance(value)).toThrow(); }
+  });
+});


### PR DESCRIPTION
Related: #895

## Scope

Add the production-inert accepted Desktop release provenance producer. It derives source commit and annotated tag-object identities from validated release metadata, cross-checks immutable release asset identity and app/tree/artifact digests, and emits a versioned deterministic JSON receipt with explicit beta/stable feed identity.

## Validation

- `node --check scripts/lib/desktop-release-provenance.mjs`
- direct Node semantic smoke for beta and stable receipts: PASS
- `git diff --cached --check`: PASS
- focused Vitest was attempted but this fresh worktree has no installed dependencies (`vitest: command not found`); GitHub CI is authoritative

## Envelope and proof boundary

85 changed non-generated lines. Focused fixtures cover valid beta/stable identities, deterministic serialization/digesting, absent/malformed/mismatched/mutable provenance, and secret-looking output exclusion. No tag, build, signing, notarization, feed, app, install, launchd, runtime, config/database/Keychain, customer, or operations-Mac mutation was performed. This PR proves the source producer/receipt contract only; it does not prove downstream preflight consumption, signing, release publication, installation, rollback, runtime safety, customer readiness, or GA readiness.
