### PR TITLE
Expose authoritative GitHub installation proof fields

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -81,10 +81,14 @@ export type GitHubRepositoryAccessErrorClass =
 
 export interface GitHubRepositoryAccessProof {
   repo_full_name: string;
+  app_id?: number;
   readMode: "app_installation" | "fallback_token" | "unconfigured";
   visibility_result: GitHubRepositoryVisibility;
   visibility_source: GitHubRepositoryVisibilitySource;
   installation_id_present: boolean;
+  installation_id?: number;
+  installation_account?: string;
+  app_slug?: string;
   app_can_read_metadata: boolean;
   app_can_read_pull_requests: boolean;
   openPullCount?: number;
@@ -198,25 +202,32 @@ export class GitHubApi {
       };
     }
 
-    let installationId: number;
+    let installation: { id: number; account_login?: string; app_id?: number; app_slug?: string };
     try {
-      installationId = await this.getInstallationId(repo, { followRedirects: false });
+      installation = await this.getInstallation(repo, { followRedirects: false });
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
+    const installationProof = {
+      installation_id_present: true,
+      installation_id: installation.id,
+      ...(installation.account_login ? { installation_account: installation.account_login } : {}),
+      ...(installation.app_id === undefined ? {} : { app_id: installation.app_id }),
+      ...(installation.app_slug ? { app_slug: installation.app_slug } : {})
+    };
 
     let token: string;
     try {
-      token = await this.getInstallationTokenForId(repo, installationId);
+      token = await this.getInstallationTokenForId(repo, installation.id);
     } catch (error) {
-      return { ...base, installation_id_present: true, ...describeGitHubAccessError(error) };
+      return { ...base, ...installationProof, ...describeGitHubAccessError(error) };
     }
 
     let metadata: RepositorySummary;
     try {
       metadata = await this.request<RepositorySummary>(`/repos/${repo}`, { token, followRedirects: false });
     } catch (error) {
-      return { ...base, installation_id_present: true, ...describeGitHubAccessError(error) };
+      return { ...base, ...installationProof, ...describeGitHubAccessError(error) };
     }
 
     const visibility = visibilityFromRepositorySummary(metadata);
@@ -227,7 +238,7 @@ export class GitHubApi {
         readMode,
         visibility_result: visibility.result,
         visibility_source: visibility.source,
-        installation_id_present: true,
+        ...installationProof,
         app_can_read_metadata: true,
         app_can_read_pull_requests: true,
         openPullCount: pulls.length
@@ -238,7 +249,7 @@ export class GitHubApi {
         readMode,
         visibility_result: visibility.result,
         visibility_source: visibility.source,
-        installation_id_present: true,
+        ...installationProof,
         app_can_read_metadata: true,
         app_can_read_pull_requests: false,
         ...describeGitHubAccessError(error)
@@ -507,18 +518,31 @@ export class GitHubApi {
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
-    const installationId = await this.getInstallationId(repo);
-    return this.getInstallationTokenForId(repo, installationId);
+    const installation = await this.getInstallation(repo);
+    return this.getInstallationTokenForId(repo, installation.id);
   }
 
-  private async getInstallationId(repo: string, options: { followRedirects?: boolean } = {}): Promise<number> {
+  private async getInstallation(
+    repo: string,
+    options: { followRedirects?: boolean } = {}
+  ): Promise<{ id: number; account_login?: string; app_id?: number; app_slug?: string }> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    const installation = await this.request<{ id: number }>(`/repos/${repo}/installation`, {
+    const installation = await this.request<{
+      id: number;
+      account?: { login?: string };
+      app_id?: number;
+      app_slug?: string;
+    }>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
-    return installation.id;
+    return {
+      id: installation.id,
+      ...(installation.account?.login ? { account_login: installation.account.login } : {}),
+      ...(installation.app_id === undefined ? {} : { app_id: installation.app_id }),
+      ...(installation.app_slug ? { app_slug: installation.app_slug } : {})
+    };
   }
 
   private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {

--- a/src/github.ts
+++ b/src/github.ts
@@ -97,6 +97,20 @@ export interface GitHubRepositoryAccessProof {
   github_api_error?: string;
 }
 
+interface GitHubInstallationIdentity {
+  id: number;
+  app_id: number;
+  account_login: string;
+  app_slug: string;
+}
+
+interface GitHubInstallationResponse {
+  id: number;
+  app_id?: number;
+  account?: { login?: string };
+  app_slug?: string;
+}
+
 export class GitHubApiRequestError extends Error {
   readonly status: number;
   readonly statusText: string;
@@ -202,18 +216,20 @@ export class GitHubApi {
       };
     }
 
-    let installation: { id: number; account_login?: string; app_id?: number; app_slug?: string };
+    let installation: GitHubInstallationIdentity;
     try {
-      installation = await this.getInstallation(repo, { followRedirects: false });
+      installation = parseGitHubInstallationIdentity(
+        await this.getInstallation(repo, { followRedirects: false })
+      );
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
     const installationProof = {
       installation_id_present: true,
       installation_id: installation.id,
-      ...(installation.account_login ? { installation_account: installation.account_login } : {}),
-      ...(installation.app_id === undefined ? {} : { app_id: installation.app_id }),
-      ...(installation.app_slug ? { app_slug: installation.app_slug } : {})
+      installation_account: installation.account_login,
+      app_id: installation.app_id,
+      app_slug: installation.app_slug
     };
 
     let token: string;
@@ -525,24 +541,13 @@ export class GitHubApi {
   private async getInstallation(
     repo: string,
     options: { followRedirects?: boolean } = {}
-  ): Promise<{ id: number; account_login?: string; app_id?: number; app_slug?: string }> {
+  ): Promise<GitHubInstallationResponse> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    const installation = await this.request<{
-      id: number;
-      account?: { login?: string };
-      app_id?: number;
-      app_slug?: string;
-    }>(`/repos/${repo}/installation`, {
+    return this.request<GitHubInstallationResponse>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
-    return {
-      id: installation.id,
-      ...(installation.account?.login ? { account_login: installation.account.login } : {}),
-      ...(installation.app_id === undefined ? {} : { app_id: installation.app_id }),
-      ...(installation.app_slug ? { app_slug: installation.app_slug } : {})
-    };
   }
 
   private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {
@@ -675,6 +680,28 @@ function visibilityFromRepositorySummary(repository: RepositorySummary): {
   if (repository.private === true) return { result: "private", source: "private_flag" };
   if (repository.private === false) return { result: "public", source: "private_flag" };
   return { result: "unknown", source: "unavailable" };
+}
+
+function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {
+  const installation = value as {
+    id?: unknown;
+    app_id?: unknown;
+    account?: { login?: unknown } | null;
+    app_slug?: unknown;
+  } | null;
+  const positiveInteger = (candidate: unknown): candidate is number =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
+  const accountLogin = installation?.account?.login;
+  const appSlug = installation?.app_slug;
+  const accountLoginValid = typeof accountLogin === "string"
+    && /^(?!-)(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(accountLogin);
+  const appSlugValid = typeof appSlug === "string"
+    && /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/.test(appSlug);
+  if (!positiveInteger(installation?.id) || !positiveInteger(installation?.app_id)
+      || !accountLoginValid || !appSlugValid) {
+    throw new Error("GitHub installation response is missing canonical identity fields.");
+  }
+  return { id: installation.id, app_id: installation.app_id, account_login: accountLogin, app_slug: appSlug };
 }
 
 function describeGitHubAccessError(error: unknown): Pick<

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -297,6 +297,54 @@ describe("GitHub App read authentication", () => {
       .toBe("Bearer installation-token");
   });
 
+  it("rejects missing and malformed authoritative installation identity before token exchange", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-invalid-installation-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    const valid = { id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" };
+    const cases: Array<{ name: string; installation: unknown }> = [
+      { name: "missing installation id", installation: { ...valid, id: undefined } },
+      { name: "null installation id", installation: { ...valid, id: null } },
+      { name: "wrong-type installation id", installation: { ...valid, id: "123" } },
+      { name: "non-positive installation id", installation: { ...valid, id: 0 } },
+      { name: "fractional installation id", installation: { ...valid, id: 1.5 } },
+      { name: "missing App id", installation: { ...valid, app_id: undefined } },
+      { name: "null App id", installation: { ...valid, app_id: null } },
+      { name: "wrong-type App id", installation: { ...valid, app_id: "4184532" } },
+      { name: "non-positive App id", installation: { ...valid, app_id: -1 } },
+      { name: "missing account", installation: { ...valid, account: undefined } },
+      { name: "missing account login", installation: { ...valid, account: {} } },
+      { name: "null account login", installation: { ...valid, account: { login: null } } },
+      { name: "wrong-type account login", installation: { ...valid, account: { login: 42 } } },
+      { name: "empty account login", installation: { ...valid, account: { login: "" } } },
+      { name: "malformed account login", installation: { ...valid, account: { login: "-bad--owner" } } },
+      { name: "oversized account login", installation: { ...valid, account: { login: "a".repeat(40) } } },
+      { name: "missing App slug", installation: { ...valid, app_slug: undefined } },
+      { name: "null App slug", installation: { ...valid, app_slug: null } },
+      { name: "wrong-type App slug", installation: { ...valid, app_slug: 42 } },
+      { name: "malformed App slug", installation: { ...valid, app_slug: "Bad_App" } },
+      { name: "oversized App slug", installation: { ...valid, app_slug: "a".repeat(101) } }
+    ];
+
+    for (const scenario of cases) {
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn(async (url) => {
+        calls.push(String(url));
+        return jsonResponse(scenario.installation);
+      }) as typeof fetch;
+      const proof = await new GitHubApi({ appId: "4184532", privateKeyPath }).probeRepositoryAccess("owner/repo");
+      expect(proof, scenario.name).toMatchObject({
+        installation_id_present: false,
+        app_can_read_metadata: false,
+        app_can_read_pull_requests: false,
+        github_api_error_class: "unknown"
+      });
+      expect(calls, scenario.name).toHaveLength(1);
+    }
+  });
+
   it("classifies App install-scope and visibility lookup failures without treating them as public", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-scope-failures-"));
     roots.push(root);
@@ -415,10 +463,6 @@ describe("GitHub App read authentication", () => {
         visibility_source: scenario.expected.visibility_source ?? "unavailable",
         ...scenario.expected
       });
-      if (scenario.name === "metadata resource inaccessible") {
-        expect({ app_id: proof.app_id, app_slug: proof.app_slug, account: proof.installation_account })
-          .toEqual({ app_id: undefined, app_slug: undefined, account: undefined });
-      }
     }
   });
 
@@ -436,7 +480,7 @@ describe("GitHub App read authentication", () => {
       const redirect = init?.redirect;
       calls.push({ url: requestUrl, method, redirect });
       if (requestUrl.endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
       }
       if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -795,7 +839,9 @@ function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
 
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {
   return (url: string) => {
-    if (url.endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+    if (url.endsWith("/repos/owner/repo/installation")) {
+      return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+    }
     if (url.endsWith("/app/installations/123/access_tokens")) {
       return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
     }

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -261,7 +261,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 999, app_slug: "customer-review-app" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -284,6 +284,10 @@ describe("GitHub App read authentication", () => {
       visibility_result: "public",
       visibility_source: "repository_api",
       installation_id_present: true,
+      installation_id: 123,
+      installation_account: "owner",
+      app_id: 999,
+      app_slug: "customer-review-app",
       app_can_read_metadata: true,
       app_can_read_pull_requests: true,
       openPullCount: 1
@@ -404,12 +408,17 @@ describe("GitHub App read authentication", () => {
       globalThis.fetch = vi.fn(async (url) => scenario.handler(String(url))) as typeof fetch;
       const github = new GitHubApi({ appId: "4184532", privateKeyPath });
 
-      await expect(github.probeRepositoryAccess("owner/repo")).resolves.toMatchObject({
+      const proof = await github.probeRepositoryAccess("owner/repo");
+      expect(proof).toMatchObject({
         repo_full_name: "owner/repo",
         visibility_result: scenario.expected.visibility_result ?? "unknown",
         visibility_source: scenario.expected.visibility_source ?? "unavailable",
         ...scenario.expected
       });
+      if (scenario.name === "metadata resource inaccessible") {
+        expect({ app_id: proof.app_id, app_slug: proof.app_slug, account: proof.installation_account })
+          .toEqual({ app_id: undefined, app_slug: undefined, account: undefined });
+      }
     }
   });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1782,7 +1782,12 @@ exit 1
       const url = new URL(request.url ?? "/", "http://localhost");
       response.setHeader("Content-Type", "application/json");
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
-        response.end(JSON.stringify({ id: 42 }));
+        response.end(JSON.stringify({
+          id: 42,
+          app_id: 12345,
+          account: { login: "acme" },
+          app_slug: "customer-review-app"
+        }));
         return;
       }
       if (request.method === "POST" && url.pathname === "/app/installations/42/access_tokens") {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1524,7 +1524,12 @@ exit 1
       const url = new URL(request.url ?? "/", "http://localhost");
       response.setHeader("Content-Type", "application/json");
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
-        response.end(JSON.stringify({ id: 42 }));
+        response.end(JSON.stringify({
+          id: 42,
+          account: { login: "acme" },
+          app_id: 12345,
+          app_slug: "customer-review-app"
+        }));
         return;
       }
       if (request.method === "POST" && url.pathname === "/app/installations/42/access_tokens") {
@@ -1636,6 +1641,10 @@ exit 1
               visibility_result: "public",
               visibility_source: "repository_api",
               installation_id_present: true,
+              installation_id: 42,
+              installation_account: "acme",
+              app_id: 12345,
+              app_slug: "customer-review-app",
               app_can_read_metadata: true,
               app_can_read_pull_requests: true,
               license_gate_decision: "active_public_entitlement_required",


### PR DESCRIPTION
## Summary

- return the GitHub installation App ID, installation ID, account login, and raw `app_slug` in repository access proof
- preserve those authoritative fields across downstream metadata and pull-read failures
- keep doctor readiness and runtime bot-comment identity unchanged; the runtime identity propagation slice remains a required dependency

Supports #872 and #891.

## Validation

- `PATH=/opt/homebrew/bin:/usr/bin:/bin npm test -- --run tests/github-app-read.test.ts tests/public-cli.test.ts` — 131 passed
- `npm run build`
- `git diff --check`

## Proof boundary

This is production-inert proof transport only. It does not accept identity, mutate runtime bot ownership, clear Desktop BYO authority, activate credentials, or deploy anything.