### PR TITLE
docs: make native Mac first-run authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Use it when you want a GitHub App to review pull requests from a local worker,
 with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
-The current npm CLI (v1.0.x) requires API-backed activation for every repository
-(public, private, internal, and unknown); unknown visibility fails closed, and
-provider verification is required for all tiers.
+The npm CLI remains `neondiff@1.0.4` and requires API-backed activation for every
+repository (public, private, internal, and unknown); unknown visibility fails
+closed, and provider verification is required for all tiers. The native Mac
+Desktop release line is `1.1.0`; it is a separate signed Desktop artifact and
+does not silently change the npm CLI version.
 
+The later managed-app path is post-GA and is not the Mac 1.1.0 first-run path.
 Coming with the native app: public open-source repositories will be free with no
 NeonDiff Activation Key, while private, internal, and commercial repositories
-will require an active entitlement. This managed public-free/private-paid model
+will require an active entitlement. That future managed public-free/private-paid model
 ships with the native NeonDiff app and the managed GitHub App broker (#614) and
 is not enforced by the current CLI. NeonDiff
 support licenses cost $1/month or $10/year for individuals,
@@ -142,9 +145,17 @@ checksum-bound prerelease bundle.
 
 ## Set Up
 
-Follow [docs/SETUP.md](docs/SETUP.md) for the CLI-first setup path (the
-first-run path on non-Mac platforms and the operator/advanced path on Mac). The
-short version is:
+On Mac, start with the signed NeonDiff Desktop `1.1.0` app. It is the
+authoritative first-run surface: App, provider, and activation secrets stay in
+Keychain; review work runs through the sealed worker in the app; and an enabled
+`codexRuntime` uses the existing authenticated Codex CLI without NeonDiff
+reading its OAuth material. The local dashboard and npm CLI are diagnostic or
+legacy operator surfaces on Mac. The managed GitHub App/broker remains
+post-GA/non-goal for this BYO path.
+
+Follow [docs/SETUP.md](docs/SETUP.md) for the native Mac flow and for the
+CLI-first path on non-Mac platforms or legacy operator installs. The CLI short
+version is:
 
 ```bash
 neondiff init --config config.local.json
@@ -223,8 +234,8 @@ commands always use the sealed worker; the app never sends Keychain material to
 a global, customer-writable, or checksum-marker-only executable. A verified
 legacy LaunchAgent remains supported without migrating or exporting its
 existing credential environment.
-This
-source path does not prove customer-safe private-key custody, a compatible
+This source path does not claim Mac GA completion. It does not prove
+customer-safe private-key custody, a compatible
 published CLI, signing, billing, canaries, or release readiness.
 After Checkout displays a one-shot NeonDiff Activation Key, return to the
 native **License** pane and paste it there. **Buy an Activation Key** opens the
@@ -303,7 +314,7 @@ Platform operator paths:
 
 | Platform | Daemon path | Status |
 | --- | --- | --- |
-| macOS | launchd with [docs/launchd.md](docs/launchd.md) | Tested beta operator path |
+| macOS | signed Desktop 1.1.0 with [docs/launchd.md](docs/launchd.md) | Native first-run; CLI launchd is legacy/operator only |
 | Linux | systemd with [docs/systemd.md](docs/systemd.md) | Packaged and covered by Ubuntu smoke tests |
 | Docker | Compose recipe with [docs/docker.md](docs/docker.md) | Packaged for local/self-hosted workers |
 | CI runners | One-shot review or dry-run with [docs/ci-runner.md](docs/ci-runner.md) | Documented for Ubuntu-style runners |
@@ -466,7 +477,9 @@ Use [LICENSE.md](LICENSE.md) and [docs/license-boundary.md](docs/license-boundar
 as the canonical public license language. Do not copy older issue comments
 or release notes into public product surfaces when these files are more recent.
 
-For live release operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
+For Mac GA boundaries, use the [Mac GA architecture contract](docs/architecture/mac-ga-release-contract.md)
+and the [Desktop Mac release runbook](apps/neondiff-desktop/docs/mac-release-runbook.md).
+For live beta operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
 and [docs/release-governance.md](docs/release-governance.md). Documentation-only
 changes do not restart launchd or promote a release by themselves.
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Use it when you want a GitHub App to review pull requests from a local worker,
 with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
-The npm CLI remains `neondiff@1.0.4` and requires API-backed activation for every
-repository (public, private, internal, and unknown); unknown visibility fails
-closed, and provider verification is required for all tiers. The native Mac
-Desktop release line is `1.1.0`; it is a separate signed Desktop artifact and
-does not silently change the npm CLI version.
+The current npm CLI (v1.0.x) requires API-backed activation for every repository
+(public, private, internal, and unknown); unknown visibility fails closed, and
+provider verification is required for all tiers. The native Mac Desktop release
+line is `1.1.0`; it is a separate signed Desktop artifact and does not silently
+change the npm CLI version.
 
 The later managed-app path is post-GA and is not the Mac 1.1.0 first-run path.
 Coming with the native app: public open-source repositories will be free with no

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,10 +1,12 @@
 # NeonDiff Setup
 
-This guide is the CLI-first setup path for the current source-available release,
-and the first-run path on non-Mac platforms. On macOS the native app
-(`apps/neondiff-desktop`) is the human first-run surface; until the native
-broker/launchd proof lands (see the native-broker note below) it hands off to
-this operator/advanced path for setup actions it cannot yet complete natively.
+This guide covers two bounded paths. On macOS, signed Desktop `1.1.0` is the
+authoritative first-run surface: Keychain owns credentials, the sealed worker
+performs review, and enabled `codexRuntime` uses the existing Codex CLI. The
+CLI-first path below is non-Mac or legacy/operator Mac; env-backed LaunchAgents
+are not native. Managed App/broker is post-GA/outside BYO. See the [Mac GA
+architecture contract](architecture/mac-ga-release-contract.md) and [Desktop
+Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 The recommended path installs the `neondiff` npm package; source checkout remains
 a fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
@@ -29,7 +31,7 @@ for the support-tier pricing contract.
 The current CLI (v1.0.x) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 GitHub-authoritative visibility (public, private, internal, and unknown) decides
-the tier. Coming with the native app: public open-source repositories will be
+the tier. The future post-GA managed path may make public open-source repositories
 free with no NeonDiff Activation Key, while private, internal, and commercial
 repositories will require an active entitlement (managed GitHub App broker #614;
 not enforced by the current CLI). Support
@@ -40,7 +42,13 @@ remain honored for existing holders but are no longer sold. Provider/model costs
 remain external through your own provider key or local model; NeonDiff does not
 include hosted model credits, unlimited SaaS inference, or bundled provider tokens.
 
-## 1. Install NeonDiff
+## CLI/operator path (non-Mac or legacy Mac)
+
+The following npm, config, and environment-variable commands are CLI/operator
+only. Signed Desktop first run needs no global CLI, manual config edit, or
+exported GitHub private-key path.
+
+### 1. Install NeonDiff
 
 Recommended package install after v1.0.4 is published and verified:
 
@@ -80,7 +88,7 @@ npm run build
 If you intentionally use the source checkout without the global package,
 substitute `./dist/src/cli.js` for `neondiff`.
 
-## 2. Create And Install A Customer-Owned GitHub App
+### 2. Create And Install A Customer-Owned GitHub App
 
 For the public paid B0 BYO beta, create a customer-owned GitHub App in your
 GitHub account or organization and use that App's install URL. The public
@@ -114,7 +122,7 @@ export NEONDIFF_GITHUB_APP_CLIENT_ID="<github-app-client-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
 
-For legacy/direct Mac desktop builds, copy the GitHub App client ID into
+For legacy/direct Mac operator builds only, copy the GitHub App client ID into
 `github.clientId` or `NEONDIFF_GITHUB_APP_CLIENT_ID`. A verified managed beta
 build instead carries the official App's public client ID in its production
 boundary, so first-run does not depend on loading CLI config. Enable Device Flow
@@ -125,7 +133,7 @@ so a fresh-install callback wins without a second authorization. If Device Flow
 is disabled, GitHub returns `device_flow_disabled` and the existing-install path
 fails closed.
 
-## 3. Configure Provider And License
+### 3. Configure Provider And License
 
 Create a local config from the example, then edit it for your local repo
 allowlist, provider path, state path, and evidence path:
@@ -204,11 +212,10 @@ For `review-pr` license blocks, the gate writes its local proof under the
 configured `evidenceDir` as
 `<date>/<owner__repo>/pr-<number>/<head-sha>/license-gate.json`.
 
-The `keychain` backend remains reserved for a separately proven native broker.
-Headless CLI activation currently rejects Keychain writes rather than passing
-license keys through process arguments. v1.0.4 supports the approved file
-backend; the Desktop app remains blocked from useful actions until native
-broker/launchd access is proven.
+The `keychain` backend is reserved for the native sealed-worker boundary.
+Headless CLI activation rejects Keychain writes; `v1.0.4` uses the approved file
+backend. The signed Desktop `1.1.0` BYO path is separate and does not inherit
+these CLI credential rules; unsigned or mixed-marker bundles remain quarantined.
 The local `machineId` sent to the license API is advisory beta metadata derived
 from host name and platform, not hardware attestation or a durable seat-binding
 primitive.
@@ -262,41 +269,26 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
-For a B0 customer, the native first-run path is:
+## Native Mac 1.1.0 first run (signed Desktop)
+
+Use the signed Desktop app from the accepted B0/BYO artifact. Keychain owns the
+GitHub App, provider, and activation secrets; its sealed worker performs
+credential-bearing work; and enabled `codexRuntime` uses the existing Codex CLI
+without NeonDiff reading OAuth material. This section does not claim Mac GA
+completion. Managed App/broker is post-GA/non-goal.
+
+The native first-run path is:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
 2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
    PEM, then choose **Store in Keychain**.
-3. On a clean install, if NeonDiff reports that the local worker command is
-   unavailable, choose **Install / Update Local Worker** before **Initialize
-   Local Config**. From the verified extracted bundle, use Node.js 26 or newer
-   through the approved stable path `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`, then preview the credential-free install:
-
-   ```bash
-   BUNDLE_DIR="$(pwd -P)"
-   node install-b0-worker-candidate.mjs first-install \
-     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-     --manifest-sha256 <manifest-sha256-from-release> \
-     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
-     --launchd-label com.electricsheephq.evaos-code-review-bot \
-     --dry-run true
-   ```
-
-   Inspect the public-safe preview, then repeat it with
-   `--dry-run false --confirm true`. It installs only the exact verified CLI
-   into a private versioned current-user directory and writes a 0600
-   credential-free marker. It creates or loads no LaunchAgent, starts no
-   daemon, and never reads or writes GitHub, provider, or license credentials.
-   It refuses an existing LaunchAgent or worker state; use the existing-worker
-   update flow below for those machines. Return to NeonDiff and choose
-   **Install / Update Local Worker** once more to refresh discovery; when the
-   worker is available, choose **Initialize Local Config**. Initialization
-   invokes the non-destructive `neondiff init` path without `--force`, never
-   overwrites an existing config, and keeps bot-isolated runtime, state,
-   evidence, and license paths beside the config. Review and daemon readiness
-   remain separate gates.
+3. On a clean install, continue with the sealed worker bundled inside the
+   signed app. Do not install a global npm CLI, export a GitHub private-key path,
+   or use the checksum-managed worker installer for native first run. Choose
+   **Initialize Local Config**; initialization is non-destructive, never uses
+   `--force`, and keeps bot-isolated runtime, state, evidence, and license paths
+   beside the config. Review and daemon readiness remain separate gates.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command and ensures every selected repository has an enabled local
@@ -683,10 +675,14 @@ closed, logs `daemon_worktree_cleanup_failed`, and removes nothing. Set
 review workers under the same dedicated account that owns `workRoot`; cleanup
 does not claim visibility into handles owned by unrelated host users.
 
-Launchd and live beta promotion are advanced operator tasks. Use
+The CLI launchd controls and live beta promotion are advanced operator tasks.
+The signed Desktop owns the customer first-run LaunchAgent path. Use
 [docs/launchd.md](launchd.md), [docs/operator-cli.md](operator-cli.md), and
-[docs/beta-release-runbook.md](beta-release-runbook.md) only after dry-run proof
-passes.
+[docs/beta-release-runbook.md](beta-release-runbook.md) only for the explicitly
+scoped CLI/operator path after dry-run proof passes. Use the [Mac GA architecture
+contract](architecture/mac-ga-release-contract.md) and [Desktop Mac release
+runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md) for the native
+release boundary.
 
 On Linux, `neondiff daemon start|stop|status` intentionally does not call
 `launchctl`. It returns JSON with `serviceManager: "systemd"` and points to the
@@ -698,7 +694,7 @@ Platform support at this beta stage:
 
 | Platform | Supervision path | Launch-readiness truth |
 | --- | --- | --- |
-| macOS | launchd | Tested live beta operator path |
+| macOS | signed Desktop 1.1.0; launchd | Native first-run; CLI launchd is legacy/operator only |
 | Linux | systemd or Docker | Packaged and guarded by Ubuntu smoke tests; provider setup still varies by host |
 | CI runners | One-shot dry-run/review commands | Documented for Ubuntu-style runners |
 | Windows | CLI-only | Untested; no supervised daemon claim |
@@ -710,12 +706,14 @@ API state, and update-channel readiness. A local source beta may explicitly
 defer license API, website, or desktop channels only when the manifest marks
 that channel as `requiredForThisRelease: false`.
 
-## Environment Variables
+## Environment Variables (CLI/operator only)
 
 Commands such as `doctor` read these ambient environment variables in
 addition to `config.local.json`. None of them are printed by `--json` output.
 Environment values override the matching config-file value where both are
-set.
+set. This section applies only to non-Mac CLI use and legacy/operator Mac
+workers. The signed Desktop first-run path does not place credentials in
+environment variables or new LaunchAgent plists.
 
 | Variable | Read by | Overrides config value | Notes |
 | --- | --- | --- | --- |

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -1,6 +1,28 @@
-# Launchd Pilot
+# macOS LaunchAgent boundary
 
-Launchd should stay disabled until GitHub App installation is complete and a real ZCode dry-run succeeds without rate limiting.
+Signed Desktop `1.1.0` owns Mac first run. After App/provider/activation/App
+access verification, it validates the signed app and sealed worker, then
+installs a secret-free LaunchAgent. Keychain secrets cross bounded stdin only;
+new plists contain public coordinates and the signed app path, never key values,
+key paths, or `EnvironmentVariables`. Enabled Codex uses the existing CLI session
+without NeonDiff reading OAuth material. Managed App/broker is post-GA/outside BYO.
+See the [Mac GA architecture contract](architecture/mac-ga-release-contract.md)
+and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
+This page does not claim Mac GA completion.
+
+## Native Desktop path
+
+Use the Desktop UI for first-run setup, dry-run approval, and **Install & Start**.
+Do not hand-edit the plist, export credentials, or replace the sealed worker
+with a global or customer-writable executable. A signed app, Keychain identity,
+worker identity, config revision, and selected LaunchAgent label must all match;
+ambiguous or missing evidence fails closed.
+
+## Legacy CLI/operator path
+
+The following environment-backed examples are retained only for existing CLI or
+operator workers, including legacy Mac installations. They are not instructions
+for the native Desktop customer journey.
 
 Recommended first live command:
 
@@ -19,7 +41,9 @@ export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-
 npm run daemon -- --config /absolute/path/to/config.local.json --dry-run true
 ```
 
-When installed as a LaunchAgent, write stdout/stderr to `~/Library/Logs/evaos-code-review-bot/`. On this Mac, launchd failed with `EX_CONFIG` when those paths pointed directly at the Lexar volume; copy the local launch logs into the Lexar evidence packet after each proof window.
+When installed as a LaunchAgent, write stdout/stderr to a user-owned local log
+directory such as `~/Library/Logs/neondiff/`. Keep operator logs outside the
+repository and redact them before sharing.
 
 Set `NODE_OPTIONS=--use-system-ca` in the LaunchAgent environment. Without this
 flag, launchd-started Node processes may fail GitHub App installation reads with
@@ -27,7 +51,7 @@ flag, launchd-started Node processes may fail GitHub App installation reads with
 from an interactive shell. `release:status` reports the loaded launchd
 environment and fails when launchd explicitly omits this option.
 
-Minimum LaunchAgent environment block:
+Minimum legacy LaunchAgent environment block:
 
 ```xml
 <key>EnvironmentVariables</key>
@@ -56,7 +80,7 @@ Use the JSON-first CLI instead of choosing `bootstrap` or `kickstart` from
 plist existence alone. The executable stop/start sequence and confirmation
 requirements live in [the operator CLI guide](operator-cli.md#common-operator-flows).
 
-For a public paid B0 BYO Mac worker update, do not edit `ProgramArguments`,
+For a legacy customer-owned worker update, do not edit `ProgramArguments`,
 `WorkingDirectory`, or credential environment entries by hand. Use the
 checksum-bound worker bundle from the same immutable GitHub prerelease as the
 app, as described in

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -18,7 +18,7 @@ with a global or customer-writable executable. A signed app, Keychain identity,
 worker identity, config revision, and selected LaunchAgent label must all match;
 ambiguous or missing evidence fails closed.
 
-## Legacy CLI/operator path
+## Public BYO and legacy CLI/operator path
 
 The following environment-backed examples are retained only for existing CLI or
 operator workers, including legacy Mac installations. They are not instructions

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -1,20 +1,22 @@
-# NeonDiff Desktop Dev MVP
+# NeonDiff Desktop architecture and local development
 
-The evaluation-first path from this development shell to a GA-quality native
-experience is specified in
-[NeonDiff Desktop GA UX Evaluation And Modernization](superpowers/specs/2026-07-10-neondiff-desktop-ga-ux-evaluation.md)
-and tracked by issue #514. Evaluation and layout stability land before broad
-visual redesign.
-
-NeonDiff Desktop is a SwiftPM macOS app scaffold for issue #115. It is a thin local control panel over the NeonDiff CLI and daemon contracts.
-For the 1.0 launch bar, the Mac app is intentionally a minimal launcher:
-opening the app shows local controls that can start `neondiff dashboard` or open
-the same local HTML dashboard used by the CLI.
+NeonDiff Desktop is the native macOS surface for the Desktop `1.1.0` release
+line, separate from the npm CLI `1.0.4`. The signed app owns Mac first run,
+including Keychain-backed App/provider/activation secrets, its sealed worker,
+and the configured Codex runtime when `codexRuntime` is enabled. The local HTML
+dashboard and npm CLI remain diagnostic or legacy operator surfaces. The managed
+GitHub App/broker is post-GA and outside the BYO path. See the [Mac GA
+architecture contract](architecture/mac-ga-release-contract.md) and [Desktop Mac
+release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md) for the
+canonical boundaries; this page does not claim Mac GA completion.
 
 ## Boundaries
 
 - No review engine runs in the desktop app.
 - No UI path posts GitHub reviews directly.
+- Native first run routes credential-bearing work through the sealed worker in
+  the signed app; new LaunchAgents are secret-free. Codex OAuth material remains
+  owned by the existing Codex CLI session.
 - The native Mac app is the product surface for the Mac customer journey and
   implements native setup/status controls that write through existing CLI
   contracts. The local HTML dashboard is a diagnostic/operator surface for
@@ -47,7 +49,8 @@ lands and a launched-app smoke proves it.
 
 ## CLI Contract
 
-The desktop uses these JSON-first CLI surfaces:
+The desktop uses these JSON-first CLI surfaces through its sealed worker. Manual
+invocation is a CLI/operator diagnostic path, not the native Mac first-run path:
 
 ```bash
 neondiff config inspect --config config.local.json
@@ -202,7 +205,7 @@ proof for the exact configured repository. Changing the App credentials,
 CLI/config path, or allowlist invalidates that proof. This step does not run a
 provider, execute a review, or post to GitHub.
 
-## Local Dashboard Launcher
+## Local Dashboard Launcher (operator/diagnostic)
 
 The dev app no longer opens a browser tab automatically. It exposes explicit
 controls to start the same local dashboard server without opening a browser, or


### PR DESCRIPTION
## Summary
- make signed Desktop 1.1.0 the authoritative Mac first-run surface over Keychain, sealed worker, and configured Codex runtime
- keep npm CLI 1.0.4 and env-backed LaunchAgent guidance explicitly scoped to CLI/operator use
- remove the stale Lexar incident wording and link the canonical Mac GA contract and Desktop release runbook

## Validation
- `npm run check:design-source`
- `npm run check:public-claims`
- `npm run check:secrets`
- `git diff --check`
- forbidden-path scan for `/Volumes/LEXAR`, `/Users/lume`, Lexar/incident text
- 4 docs, 119 insertions, 81 deletions (200 changed lines)

Related: #610

This is source documentation only; it does not claim signing, distribution, runtime, customer readiness, or Mac GA completion.