### PR TITLE
feat(state): fence queue posting and quarantine exact heads

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -218,6 +218,7 @@ export interface ClearReviewQueueLeasesResult {
   expiredMatched: number;
   activeMatched: number;
   requeued: number;
+  retired: number;
   deletedRunLeases: number;
   jobs: ReviewQueueLeaseClearCandidate[];
   runLeases: ReviewRunLeaseClearCandidate[];
@@ -755,7 +756,13 @@ export class ReviewStateStore {
       create trigger if not exists reject_quarantined_review_queue_job
       before insert on review_queue_jobs
       when exists (select 1 from review_queue_quarantines
-        where repo = new.repo and pull_number = new.pull_number and head_sha = new.head_sha)
+        where lower(repo) = lower(new.repo) and pull_number = new.pull_number and lower(head_sha) = lower(new.head_sha))
+      begin select raise(abort, 'review_queue_head_quarantined'); end;
+
+      create trigger if not exists reject_case_variant_quarantined_review_queue_job
+      before insert on review_queue_jobs
+      when exists (select 1 from review_queue_quarantines
+        where lower(repo) = lower(new.repo) and pull_number = new.pull_number and lower(head_sha) = lower(new.head_sha))
       begin select raise(abort, 'review_queue_head_quarantined'); end;
 
       create index if not exists idx_review_queue_jobs_state_priority
@@ -2318,20 +2325,24 @@ export class ReviewStateStore {
 	        runLeases.length;
       const activeMatched = matched - expiredMatched;
       let requeued = 0;
+      let retired = 0;
       let deletedRunLeases = 0;
 
       if (!dryRun) {
         for (const job of jobs) {
+          const quarantined = Boolean(this.db.prepare(`select 1 from review_queue_quarantines q
+            where lower(q.repo) = lower(?) and q.pull_number = ? and lower(q.head_sha) = lower(?)`)
+            .get(job.repo, job.pullNumber, job.headSha));
           const result = this.db
             .prepare(
               `update review_queue_jobs
-               set state = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'stale_retired' else 'queued' end,
+               set state = case when exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(review_queue_jobs.repo) and q.pull_number = review_queue_jobs.pull_number and lower(q.head_sha) = lower(review_queue_jobs.head_sha)) then 'stale_retired' else 'queued' end,
                    lease_id = null,
                    lease_expires_at = null,
                    next_eligible_at = null,
-                   last_error = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'queue_quarantine_operator_retired' else ? end,
+                   last_error = case when exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(review_queue_jobs.repo) and q.pull_number = review_queue_jobs.pull_number and lower(q.head_sha) = lower(review_queue_jobs.head_sha)) then 'queue_quarantine_operator_retired' else ? end,
                    updated_at = ?,
-                   finished_at = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then coalesce(finished_at, ?) else finished_at end
+                   finished_at = case when exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(review_queue_jobs.repo) and q.pull_number = review_queue_jobs.pull_number and lower(q.head_sha) = lower(review_queue_jobs.head_sha)) then coalesce(finished_at, ?) else finished_at end
                where job_id = ?
                  and state in ('leased', 'running')`
             )
@@ -2341,7 +2352,8 @@ export class ReviewStateStore {
               checkedAt,
               job.jobId
             );
-          requeued += Number(result.changes);
+          if (quarantined) retired += Number(result.changes);
+          else requeued += Number(result.changes);
         }
         for (const lease of runLeases) {
           deletedRunLeases += Number(
@@ -2364,6 +2376,7 @@ export class ReviewStateStore {
         expiredMatched,
         activeMatched,
         requeued,
+        retired,
         deletedRunLeases,
         jobs,
         runLeases
@@ -2598,7 +2611,7 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
-    if (this.db.prepare("select 1 from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?").get(input.repo, input.pullNumber, input.headSha)) throw new Error("review_queue_head_quarantined");
+    if (this.db.prepare("select 1 from review_queue_quarantines where lower(repo) = lower(?) and pull_number = ? and lower(head_sha) = lower(?)").get(input.repo, input.pullNumber, input.headSha)) throw new Error("review_queue_head_quarantined");
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2696,13 +2709,13 @@ export class ReviewStateStore {
       this.db
         .prepare(
           `update review_queue_jobs
-           set state = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'stale_retired' else 'queued' end,
+           set state = case when exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(review_queue_jobs.repo) and q.pull_number = review_queue_jobs.pull_number and lower(q.head_sha) = lower(review_queue_jobs.head_sha)) then 'stale_retired' else 'queued' end,
                lease_id = null,
                lease_expires_at = null,
                next_eligible_at = null,
-               last_error = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'queue_quarantine_expired_retired' else 'queue_lease_expired_requeued' end,
+               last_error = case when exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(review_queue_jobs.repo) and q.pull_number = review_queue_jobs.pull_number and lower(q.head_sha) = lower(review_queue_jobs.head_sha)) then 'queue_quarantine_expired_retired' else 'queue_lease_expired_requeued' end,
                updated_at = ?,
-               finished_at = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then coalesce(finished_at, ?) else finished_at end
+               finished_at = case when exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(review_queue_jobs.repo) and q.pull_number = review_queue_jobs.pull_number and lower(q.head_sha) = lower(review_queue_jobs.head_sha)) then coalesce(finished_at, ?) else finished_at end
            where state in ('leased', 'running')
              and (lease_expires_at is not null and lease_expires_at <= ? or lease_expires_at is null and updated_at <= ?)
              `
@@ -2711,7 +2724,7 @@ export class ReviewStateStore {
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso) &&
-          !this.db.prepare("select 1 from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?").get(job.repo, job.pullNumber, job.headSha))
+          !this.db.prepare("select 1 from review_queue_quarantines where lower(repo) = lower(?) and pull_number = ? and lower(head_sha) = lower(?)").get(job.repo, job.pullNumber, job.headSha))
         .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
       const active = [
@@ -2791,12 +2804,11 @@ export class ReviewStateStore {
     const nowIso = (input.now ?? new Date()).toISOString();
     this.db.exec("begin immediate");
     try {
-    const quarantined = ["queued", "provider_deferred", "blocked_on_proof"].includes(input.state) &&
-      this.db.prepare(`select 1 from review_queue_quarantines q join review_queue_jobs j on j.repo = q.repo
-        and j.pull_number = q.pull_number and j.head_sha = q.head_sha where j.job_id = ?`).get(input.jobId);
+    const quarantined = Boolean(this.db.prepare(`select 1 from review_queue_quarantines q join review_queue_jobs j on lower(j.repo) = lower(q.repo)
+        and j.pull_number = q.pull_number and lower(j.head_sha) = lower(q.head_sha) where j.job_id = ?`).get(input.jobId));
     const targetState = quarantined ? "stale_retired" : input.state;
     const terminal = isTerminalQueueState(targetState);
-    const clearLease = input.clearLease ?? (
+    const clearLease = quarantined ? true : input.clearLease ?? (
       terminal ||
       input.state === "queued" ||
       input.state === "provider_deferred" ||
@@ -2851,9 +2863,9 @@ export class ReviewStateStore {
     const row = this.db.prepare(
       `insert into review_queue_post_claims (job_id, post_key, lease_id, claimed_at, reconcile_required)
        select ?, ?, ?, ?, 0 from review_queue_jobs j
-       where j.job_id = ? and j.repo = ? and j.pull_number = ? and j.head_sha = ?
+       where j.job_id = ? and lower(j.repo) = lower(?) and j.pull_number = ? and lower(j.head_sha) = lower(?)
          and j.lease_id = ? and j.state in ('leased', 'running') and j.lease_expires_at > ?
-         and not exists (select 1 from review_queue_quarantines q where q.repo = j.repo and q.pull_number = j.pull_number and q.head_sha = j.head_sha)
+         and not exists (select 1 from review_queue_quarantines q where lower(q.repo) = lower(j.repo) and q.pull_number = j.pull_number and lower(q.head_sha) = lower(j.head_sha))
        on conflict(job_id, post_key) do update set
          lease_id = case when receipt is null then excluded.lease_id else lease_id end,
          reconcile_required = 1
@@ -2874,10 +2886,10 @@ export class ReviewStateStore {
     const row = this.db.prepare(
       `update review_queue_post_claims as c set receipt = coalesce(receipt, ?), receipt_at = coalesce(receipt_at, ?)
        where c.job_id = ? and c.post_key = ? and c.lease_id = ? and (c.receipt is null or c.receipt = ?)
-         and exists (select 1 from review_queue_jobs j where j.job_id = c.job_id and j.repo = ?
-           and j.pull_number = ? and j.head_sha = ? and j.lease_id = ? and j.state in ('leased', 'running')
+         and exists (select 1 from review_queue_jobs j where j.job_id = c.job_id and lower(j.repo) = lower(?)
+           and j.pull_number = ? and lower(j.head_sha) = lower(?) and j.lease_id = ? and j.state in ('leased', 'running')
            and j.lease_expires_at > ? and not exists (select 1 from review_queue_quarantines q
-             where q.repo = j.repo and q.pull_number = j.pull_number and q.head_sha = j.head_sha))
+             where lower(q.repo) = lower(j.repo) and q.pull_number = j.pull_number and lower(q.head_sha) = lower(j.head_sha)))
        returning job_id, post_key, lease_id, reconcile_required, receipt`
     ).get(receipt, nowIso, input.jobId, input.postKey, input.leaseId, receipt, input.repo,
       input.pullNumber, input.headSha, input.leaseId, nowIso) as ReviewQueuePostClaimRow | undefined;
@@ -2892,15 +2904,17 @@ export class ReviewStateStore {
     const nowIso = (input.now ?? new Date()).toISOString();
     const reason = redactSecrets(input.reason).trim().slice(0, 500);
     if (!reason) throw new Error("reason must be non-empty");
+    const repo = input.repo.toLowerCase();
+    const headSha = input.headSha.toLowerCase();
     this.db.exec("begin immediate");
     try {
       this.db.prepare(`insert or ignore into review_queue_quarantines
         (repo, pull_number, head_sha, reason, created_at) values (?, ?, ?, ?, ?)`).run(
-          input.repo, input.pullNumber, input.headSha, reason, nowIso);
+          repo, input.pullNumber, headSha, reason, nowIso);
       this.db.prepare(`update review_queue_jobs set state = 'stale_retired', next_eligible_at = null,
         lease_id = null, lease_expires_at = null, last_error = 'required_evidence_quarantined',
         updated_at = ?, finished_at = coalesce(finished_at, ?)
-        where repo = ? and pull_number = ? and head_sha = ? and
+        where lower(repo) = lower(?) and pull_number = ? and lower(head_sha) = lower(?) and
           (state in ('queued', 'provider_deferred', 'blocked_on_proof') or
            (state in ('leased', 'running') and lease_expires_at is not null and lease_expires_at <= ?))`).run(
              nowIso, nowIso, input.repo, input.pullNumber, input.headSha, nowIso);
@@ -3168,7 +3182,7 @@ export class ReviewStateStore {
     jobId?: string;
   }): ReviewQueueLeaseClearCandidate[] {
     return this.listReviewQueueJobs({ states: ["leased", "running"] })
-      .filter((job) => !input.repo || job.repo === input.repo)
+      .filter((job) => !input.repo || job.repo.toLowerCase() === input.repo.toLowerCase())
       .filter((job) => input.pullNumber === undefined || job.pullNumber === input.pullNumber)
       .filter((job) => !input.jobId || job.jobId === input.jobId)
       .map((job) => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -281,6 +281,14 @@ export interface ReviewQueueJobRecord {
   finishedAt?: string;
 }
 
+export interface ReviewQueuePostClaim {
+  jobId: string;
+  postKey: string;
+  leaseId: string;
+  reconcileRequired: boolean;
+  receipt?: string;
+}
+
 export interface ReviewReadinessRecord {
   repo: string;
   pullNumber: number;
@@ -732,6 +740,23 @@ export class ReviewStateStore {
         started_at text,
         finished_at text
       );
+
+      create table if not exists review_queue_quarantines (
+        repo text not null, pull_number integer not null, head_sha text not null,
+        reason text not null, created_at text not null, primary key (repo, pull_number, head_sha)
+      );
+
+      create table if not exists review_queue_post_claims (
+        job_id text not null, post_key text not null, lease_id text not null, claimed_at text not null,
+        reconcile_required integer not null default 0, receipt text, receipt_at text,
+        primary key (job_id, post_key)
+      );
+
+      create trigger if not exists reject_quarantined_review_queue_job
+      before insert on review_queue_jobs
+      when exists (select 1 from review_queue_quarantines
+        where repo = new.repo and pull_number = new.pull_number and head_sha = new.head_sha)
+      begin select raise(abort, 'review_queue_head_quarantined'); end;
 
       create index if not exists idx_review_queue_jobs_state_priority
         on review_queue_jobs (state, priority, created_at);
@@ -2300,16 +2325,19 @@ export class ReviewStateStore {
           const result = this.db
             .prepare(
               `update review_queue_jobs
-               set state = 'queued',
+               set state = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'stale_retired' else 'queued' end,
                    lease_id = null,
                    lease_expires_at = null,
-                   last_error = ?,
-                   updated_at = ?
+                   next_eligible_at = null,
+                   last_error = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'queue_quarantine_operator_retired' else ? end,
+                   updated_at = ?,
+                   finished_at = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then coalesce(finished_at, ?) else finished_at end
                where job_id = ?
                  and state in ('leased', 'running')`
             )
             .run(
               `queue_lease_operator_requeued:${job.staleReason ?? "matched"}`,
+              checkedAt,
               checkedAt,
               job.jobId
             );
@@ -2570,6 +2598,7 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    if (this.db.prepare("select 1 from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?").get(input.repo, input.pullNumber, input.headSha)) throw new Error("review_queue_head_quarantined");
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2667,21 +2696,22 @@ export class ReviewStateStore {
       this.db
         .prepare(
           `update review_queue_jobs
-           set state = 'queued',
+           set state = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'stale_retired' else 'queued' end,
                lease_id = null,
                lease_expires_at = null,
-               last_error = 'queue_lease_expired_requeued',
-               updated_at = ?
+               next_eligible_at = null,
+               last_error = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then 'queue_quarantine_expired_retired' else 'queue_lease_expired_requeued' end,
+               updated_at = ?,
+               finished_at = case when exists (select 1 from review_queue_quarantines q where q.repo = review_queue_jobs.repo and q.pull_number = review_queue_jobs.pull_number and q.head_sha = review_queue_jobs.head_sha) then coalesce(finished_at, ?) else finished_at end
            where state in ('leased', 'running')
-             and (
-               (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
-               or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
-             )`
+             and (lease_expires_at is not null and lease_expires_at <= ? or lease_expires_at is null and updated_at <= ?)
+             `
         )
-        .run(nowIso, nowIso, legacyLeaseCutoffIso);
+        .run(nowIso, nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
-        .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
+        .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso) &&
+          !this.db.prepare("select 1 from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?").get(job.repo, job.pullNumber, job.headSha))
         .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
       const active = [
@@ -2759,7 +2789,13 @@ export class ReviewStateStore {
     const existing = this.getReviewQueueJob(input.jobId);
     if (!existing) throw new Error(`No review queue job for jobId ${input.jobId}`);
     const nowIso = (input.now ?? new Date()).toISOString();
-    const terminal = isTerminalQueueState(input.state);
+    this.db.exec("begin immediate");
+    try {
+    const quarantined = ["queued", "provider_deferred", "blocked_on_proof"].includes(input.state) &&
+      this.db.prepare(`select 1 from review_queue_quarantines q join review_queue_jobs j on j.repo = q.repo
+        and j.pull_number = q.pull_number and j.head_sha = q.head_sha where j.job_id = ?`).get(input.jobId);
+    const targetState = quarantined ? "stale_retired" : input.state;
+    const terminal = isTerminalQueueState(targetState);
     const clearLease = input.clearLease ?? (
       terminal ||
       input.state === "queued" ||
@@ -2770,7 +2806,7 @@ export class ReviewStateStore {
       .prepare(
         `update review_queue_jobs
          set state = ?,
-             next_eligible_at = ?,
+             next_eligible_at = case when ? then null else ? end,
              lease_id = case when ? then null else coalesce(?, lease_id) end,
              lease_expires_at = case when ? then null else coalesce(?, lease_expires_at) end,
              session_id = coalesce(?, session_id),
@@ -2782,7 +2818,8 @@ export class ReviewStateStore {
          where job_id = ?`
       )
       .run(
-        input.state,
+        targetState,
+        terminal ? 1 : 0,
         input.nextEligibleAt ?? null,
         clearLease ? 1 : 0,
         input.leaseId ?? null,
@@ -2792,13 +2829,86 @@ export class ReviewStateStore {
         input.reviewUrl ?? null,
         input.lastError ? redactSecrets(input.lastError) : null,
         nowIso,
-        input.state,
+        targetState,
         nowIso,
         terminal ? 1 : 0,
         nowIso,
         input.jobId
       );
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
     return this.getReviewQueueJob(input.jobId)!;
+  }
+
+  claimReviewQueuePost(input: {
+    jobId: string; repo: string; pullNumber: number; headSha: string; leaseId: string; postKey: string; now?: Date;
+  }): ReviewQueuePostClaim {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    if (!input.postKey.trim()) throw new Error("postKey must be non-empty");
+    const row = this.db.prepare(
+      `insert into review_queue_post_claims (job_id, post_key, lease_id, claimed_at, reconcile_required)
+       select ?, ?, ?, ?, 0 from review_queue_jobs j
+       where j.job_id = ? and j.repo = ? and j.pull_number = ? and j.head_sha = ?
+         and j.lease_id = ? and j.state in ('leased', 'running') and j.lease_expires_at > ?
+         and not exists (select 1 from review_queue_quarantines q where q.repo = j.repo and q.pull_number = j.pull_number and q.head_sha = j.head_sha)
+       on conflict(job_id, post_key) do update set
+         lease_id = case when receipt is null then excluded.lease_id else lease_id end,
+         reconcile_required = 1
+       returning job_id, post_key, lease_id, reconcile_required, receipt`
+    ).get(input.jobId, input.postKey, input.leaseId, nowIso, input.jobId, input.repo,
+      input.pullNumber, input.headSha, input.leaseId, nowIso) as ReviewQueuePostClaimRow | undefined;
+    if (!row) throw new Error("review_queue_post_fenced");
+    return mapReviewQueuePostClaim(row);
+  }
+
+  recordReviewQueuePostReceipt(input: {
+    jobId: string; repo: string; pullNumber: number; headSha: string; leaseId: string;
+    postKey: string; receipt: string; now?: Date;
+  }): ReviewQueuePostClaim {
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const receipt = redactSecrets(input.receipt).trim().slice(0, 2_000);
+    if (!receipt) throw new Error("receipt must be non-empty");
+    const row = this.db.prepare(
+      `update review_queue_post_claims as c set receipt = coalesce(receipt, ?), receipt_at = coalesce(receipt_at, ?)
+       where c.job_id = ? and c.post_key = ? and c.lease_id = ? and (c.receipt is null or c.receipt = ?)
+         and exists (select 1 from review_queue_jobs j where j.job_id = c.job_id and j.repo = ?
+           and j.pull_number = ? and j.head_sha = ? and j.lease_id = ? and j.state in ('leased', 'running')
+           and j.lease_expires_at > ? and not exists (select 1 from review_queue_quarantines q
+             where q.repo = j.repo and q.pull_number = j.pull_number and q.head_sha = j.head_sha))
+       returning job_id, post_key, lease_id, reconcile_required, receipt`
+    ).get(receipt, nowIso, input.jobId, input.postKey, input.leaseId, receipt, input.repo,
+      input.pullNumber, input.headSha, input.leaseId, nowIso) as ReviewQueuePostClaimRow | undefined;
+    if (!row) throw new Error("review_queue_post_receipt_conflict");
+    return mapReviewQueuePostClaim(row);
+  }
+
+  quarantineReviewQueueHead(input: {
+    repo: string; pullNumber: number; headSha: string; reason: string; now?: Date;
+  }): void {
+    validateReviewQueueInput(input.repo, input.pullNumber, input.headSha);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const reason = redactSecrets(input.reason).trim().slice(0, 500);
+    if (!reason) throw new Error("reason must be non-empty");
+    this.db.exec("begin immediate");
+    try {
+      this.db.prepare(`insert or ignore into review_queue_quarantines
+        (repo, pull_number, head_sha, reason, created_at) values (?, ?, ?, ?, ?)`).run(
+          input.repo, input.pullNumber, input.headSha, reason, nowIso);
+      this.db.prepare(`update review_queue_jobs set state = 'stale_retired', next_eligible_at = null,
+        lease_id = null, lease_expires_at = null, last_error = 'required_evidence_quarantined',
+        updated_at = ?, finished_at = coalesce(finished_at, ?)
+        where repo = ? and pull_number = ? and head_sha = ? and
+          (state in ('queued', 'provider_deferred', 'blocked_on_proof') or
+           (state in ('leased', 'running') and lease_expires_at is not null and lease_expires_at <= ?))`).run(
+             nowIso, nowIso, input.repo, input.pullNumber, input.headSha, nowIso);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
   }
 
   updateReviewQueueJobPriority(input: {
@@ -4247,6 +4357,14 @@ interface ReviewQueueJobRow {
   finished_at: string | null;
 }
 
+interface ReviewQueuePostClaimRow {
+  job_id: string;
+  post_key: string;
+  lease_id: string;
+  reconcile_required: number;
+  receipt: string | null;
+}
+
 interface ReviewReadinessRow {
   repo: string;
   pull_number: number;
@@ -4513,6 +4631,16 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     updatedAt: row.updated_at,
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
+  };
+}
+
+function mapReviewQueuePostClaim(row: ReviewQueuePostClaimRow): ReviewQueuePostClaim {
+  return {
+    jobId: row.job_id,
+    postKey: row.post_key,
+    leaseId: row.lease_id,
+    reconcileRequired: row.reconcile_required === 1,
+    ...(row.receipt ? { receipt: row.receipt } : {})
   };
 }
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1260,6 +1260,36 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("claims an exact leased post once and CASes its receipt", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-post-cas-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-08-24T00:00:00.000Z");
+    const job = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 7, headSha: "head", now }).job;
+    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 100, now })[0]!;
+    const claim = { jobId: job.jobId, repo: job.repo, pullNumber: 7, headSha: "head", leaseId: leased.leaseId!, postKey: "review" };
+    expect(store.claimReviewQueuePost({ ...claim, now })).toMatchObject({ reconcileRequired: false });
+    expect(store.claimReviewQueuePost({ ...claim, now })).toMatchObject({ reconcileRequired: true });
+    expect(store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.test/review/1", now })).toMatchObject({ receipt: "https://github.test/review/1" });
+    expect(store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.test/review/1", now })).toMatchObject({ receipt: "https://github.test/review/1" });
+    expect(() => store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.test/review/2", now })).toThrow("review_queue_post_receipt_conflict");
+    store.close();
+  });
+
+  it("keeps a quarantined head out of requeue and releases expired capacity", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-quarantine-cas-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-08-24T00:00:00.000Z");
+    const blocked = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 8, headSha: "blocked", now }).job;
+    const other = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 9, headSha: "other", now }).job;
+    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 1, now })[0]!;
+    store.quarantineReviewQueueHead({ repo: blocked.repo, pullNumber: 8, headSha: "blocked", reason: "required evidence", now });
+    expect(() => store.enqueueReviewQueueJob({ repo: blocked.repo, pullNumber: 8, headSha: "blocked", now })).toThrow("review_queue_head_quarantined");
+    expect(() => store.claimReviewQueuePost({ jobId: blocked.jobId, repo: blocked.repo, pullNumber: 8, headSha: "blocked", leaseId: leased.leaseId!, postKey: "review", now })).toThrow("review_queue_post_fenced");
+    expect(store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, now: new Date("2026-08-24T00:00:00.002Z") }).map((job) => job.jobId)).toEqual([other.jobId]);
+    expect(store.getReviewQueueJob(blocked.jobId)).toMatchObject({ state: "stale_retired", finishedAt: "2026-08-24T00:00:00.002Z" });
+    store.close();
+  });
+
   it("dry-runs and clears expired review queue leases without manual SQL", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-clear-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1290,6 +1290,40 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("case-folds quarantine coordinates and fences every direct queue transition", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-quarantine-casefold-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-08-24T00:00:00.000Z");
+    const job = store.enqueueReviewQueueJob({ repo: "Owner/Repo", pullNumber: 10, headSha: "AbCd", now }).job;
+    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 60_000, now })[0]!;
+    const claim = { jobId: job.jobId, repo: "owner/repo", pullNumber: 10, headSha: "abcd", leaseId: leased.leaseId!, postKey: "review" };
+    expect(store.claimReviewQueuePost({ ...claim, now })).toMatchObject({ reconcileRequired: false });
+
+    store.quarantineReviewQueueHead({ repo: "OWNER/REPO", pullNumber: 10, headSha: "ABCD", reason: "required evidence", now });
+    expect(() => store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 10, headSha: "abcd", now })).toThrow("review_queue_head_quarantined");
+    expect(() => store.claimReviewQueuePost({ ...claim, now })).toThrow("review_queue_post_fenced");
+    expect(() => store.recordReviewQueuePostReceipt({ ...claim, receipt: "https://github.test/review/10", now })).toThrow("review_queue_post_receipt_conflict");
+    expect(store.updateReviewQueueJobState({ jobId: job.jobId, state: "posted", leaseId: leased.leaseId, reviewUrl: "https://github.test/review/10", now })).toMatchObject({
+      state: "stale_retired",
+      leaseId: undefined
+    });
+    store.close();
+  });
+
+  it("reports quarantined lease cleanup as retirement instead of requeue", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-quarantine-retirement-count-")); roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-08-24T00:00:00.000Z");
+    const job = store.enqueueReviewQueueJob({ repo: "Owner/Repo", pullNumber: 11, headSha: "AbCd", now }).job;
+    store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 1, maxRepoActive: 1, leaseTtlMs: 1, now });
+    store.quarantineReviewQueueHead({ repo: "owner/repo", pullNumber: 11, headSha: "abcd", reason: "required evidence", now });
+
+    const cleared = store.clearReviewQueueLeases({ dryRun: false, expiredOnly: true, now: new Date("2026-08-24T00:00:00.002Z") });
+    expect(cleared).toMatchObject({ matched: 1, requeued: 0, retired: 1 });
+    expect(store.getReviewQueueJob(job.jobId)).toMatchObject({ state: "stale_retired", lastError: "queue_quarantine_operator_retired" });
+    store.close();
+  });
+
   it("dry-runs and clears expired review queue leases without manual SQL", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-clear-"));
     roots.push(root);


### PR DESCRIPTION
Related: #882\n\nLayer 1A state-only candidate from exact current main d0eb797f069a06d951791283e39d6057cf099a37.\n\n- Atomically claims an exact queued job/repo/PR/head/current opaque lease ID/expiry and post key.\n- Repeated claims return reconciliation-only; receipt writes are idempotent CAS and reject stale/conflicting authority.\n- Exact-head quarantine is a durable trigger-enforced admission tombstone. Queue expiry, operator cleanup, direct state re-enqueue, and leasing retire or exclude quarantined work.\n- No review-run association, worker/scheduler wiring, external posting, live DB/config/runtime/customer mutation, or Layer 1B behavior.\n\nProof:\n- Changed paths: src/state.ts, tests/state.test.ts\n- Changed lines: 190 (174 additions, 16 deletions)\n- Strict source TypeScript check: passed\n- git diff --check: passed\n- Direct post-CAS and quarantine/requeue smoke checks via tsx: passed\n- Vitest focused test command attempted but local Rollup native module is rejected by macOS Team-ID signature mismatch; exact-head CI is required for full test/build proof.\n\nSafety boundary: this PR does not claim exactly-once external network behavior or runtime/customer readiness. #921 is evidence only and is not the merge base.