### PR TITLE
feat(desktop): add cross-release provenance receipt

### DIFF
--- a/scripts/lib/desktop-release-provenance.mjs
+++ b/scripts/lib/desktop-release-provenance.mjs
@@ -1,0 +1,50 @@
+import { createHash } from "node:crypto";
+import { validateReleaseDeclaration } from "../validate-desktop-release-declaration.mjs";
+
+const SHA1 = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const REPO = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff";
+const fail = (message) => { throw new Error(message); };
+const text = (value, label) => { if (typeof value !== "string" || value.length === 0) fail(`${label} is required`); return value; };
+const hex = (value, label, pattern) => { const result = text(value, label); if (!pattern.test(result)) fail(`${label} is malformed`); return result; };
+const proof = (value, kind, label) => { if (value?.schemaVersion !== 1 || value.kind !== kind || value.verified !== true) fail(`${label} proof is not verified`); return value; };
+const same = (actual, expected, label) => { if (actual !== expected) fail(`${label} does not match`); };
+
+function acceptedMetadata(metadata) {
+  const { declaration, declarationValidation, tagMetadata, annotatedTagMetadata, releaseMetadata, identityProof, artifactMetadata, feedMetadata } = metadata ?? {};
+  const validation = validateReleaseDeclaration(declaration);
+  const declarationProof = proof(declarationValidation, "neondiff.desktop.release-declaration-validation-v1", "declaration");
+  for (const key of ["releaseTag", "version", "channel", "sequence", "build", "artifactName", "feed"]) same(declarationProof[key], validation[key === "releaseTag" ? "releaseTag" : key], `declaration ${key}`);
+  const { releaseTag: tag, version, channel, sequence, build, artifactName, feed } = validation;
+  const tagObjectSHA = hex(tagMetadata?.object?.sha, "annotated tag-object SHA", SHA1);
+  const sourceCommitSHA = hex(annotatedTagMetadata?.object?.sha, "source commit SHA", SHA1);
+  same(tagMetadata?.ref, `refs/tags/${tag}`, "release tag ref");
+  same(tagMetadata?.object?.type, "tag", "release tag type");
+  if (annotatedTagMetadata?.sha !== tagObjectSHA || annotatedTagMetadata?.tag !== tag || annotatedTagMetadata?.object?.type !== "commit") fail("annotated tag metadata does not match");
+  const assets = Array.isArray(releaseMetadata?.assets) ? releaseMetadata.assets.filter((item) => item?.name === artifactName) : [];
+  if (releaseMetadata?.tag_name !== tag || releaseMetadata?.draft !== false || releaseMetadata?.prerelease !== true || releaseMetadata?.immutable !== true || assets.length !== 1) fail("release metadata is not an immutable identity match");
+  const asset = assets[0], artifactSHA256 = hex(asset?.digest?.replace(/^sha256:/, ""), "artifact SHA-256", SHA256);
+  const artifactURL = `${REPO}/releases/download/${tag}/${artifactName}`;
+  if (asset.digest !== `sha256:${artifactSHA256}` || asset.browser_download_url !== artifactURL) fail("release asset metadata is not canonical");
+  const identity = proof(identityProof, "neondiff.desktop.release-identity-validation-v2", "release identity");
+  for (const [key, value] of Object.entries({ releaseTag: tag, sourceCommitSHA, tagObjectSHA, artifactName, artifactSHA256 })) same(identity[key], value, `release identity ${key}`);
+  const appSHA256 = hex(artifactMetadata?.appSHA256, "app SHA-256", SHA256), treeSHA256 = hex(artifactMetadata?.treeSHA256, "tree SHA-256", SHA256);
+  same(artifactMetadata?.releaseTag, tag, "artifact release tag"); same(artifactMetadata?.artifactName, artifactName, "artifact name"); same(artifactMetadata?.artifactSHA256, artifactSHA256, "artifact digest"); same(artifactMetadata?.treeAlgorithm, "sha256-tree-v1", "tree algorithm");
+  const artifact = proof(artifactMetadata?.proof, "neondiff.desktop.artifact-proof-v2", "artifact");
+  for (const [key, value] of Object.entries({ releaseTag: tag, artifactName, artifactSHA256, appSHA256, treeAlgorithm: "sha256-tree-v1", treeSHA256 })) same(artifact[key], value, `artifact proof ${key}`);
+  const feedURL = feedMetadata?.url;
+  if (feedMetadata?.channel !== channel || feedURL !== feed || feedMetadata?.appcastSHA256 !== feedMetadata?.proof?.appcastSHA256) fail("feed identity does not match declaration");
+  const appcastSHA256 = hex(feedMetadata?.appcastSHA256, "appcast SHA-256", SHA256), feedReceipt = proof(feedMetadata?.proof, "neondiff.desktop.feed-enclosure-proof-v2", "feed");
+  for (const [key, value] of Object.entries({ channel, url: feedURL, releaseTag: tag, artifactName, artifactSHA256, appcastSHA256 })) same(feedReceipt[key], value, `feed proof ${key}`);
+  const enclosure = feedReceipt.enclosure, declaredEnclosure = feedMetadata?.enclosure;
+  if (!declaredEnclosure || declaredEnclosure.url !== enclosure?.url || declaredEnclosure.version !== enclosure?.version || declaredEnclosure.build !== enclosure?.build || declaredEnclosure.shortVersionString !== enclosure?.shortVersionString || declaredEnclosure.edSignature !== enclosure?.edSignature || declaredEnclosure.signatureVerified !== enclosure?.signatureVerified || enclosure.url !== artifactURL || enclosure.version !== build || enclosure.build !== build || enclosure.shortVersionString !== version || enclosure.signatureVerified !== true || typeof enclosure.edSignature !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(enclosure.edSignature)) fail("feed enclosure identity or signature is not verified");
+  return { tag, version, channel, sequence, build, artifactName, sourceCommitSHA, tagObjectSHA, artifactSHA256, appSHA256, treeSHA256, appcastSHA256, feed: feedURL, enclosure };
+}
+
+export function buildAcceptedReleaseProvenance(metadata) {
+  const value = acceptedMetadata(metadata);
+  return { schemaVersion: 1, kind: "neondiff.desktop.accepted-release-provenance-v2", product: "neondiff-desktop", release: { tag: value.tag, version: value.version, channel: value.channel, sequence: value.sequence, build: value.build, artifactName: value.artifactName }, source: { commitSHA: value.sourceCommitSHA, tagObjectSHA: value.tagObjectSHA }, artifacts: { artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, appSHA256: value.appSHA256, treeAlgorithm: "sha256-tree-v1", treeSHA256: value.treeSHA256 }, feed: { channel: value.channel, url: value.feed, appcastSHA256: value.appcastSHA256, releaseTag: value.tag, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, enclosure: value.enclosure } };
+}
+
+export function serializeAcceptedReleaseProvenance(metadata) { return `${JSON.stringify(buildAcceptedReleaseProvenance(metadata))}\n`; }
+export function acceptedReleaseProvenanceDigest(metadata) { return createHash("sha256").update(serializeAcceptedReleaseProvenance(metadata)).digest("hex"); }

--- a/scripts/validate-desktop-release-declaration.mjs
+++ b/scripts/validate-desktop-release-declaration.mjs
@@ -3,6 +3,7 @@
 import { createRequire } from "node:module";
 import { closeSync, constants, fstatSync, openSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const BETA_FEED = "https://www.neondiff.com/updates/beta/appcast.xml";
 const MAX_SAFE = "9007199254740991";
@@ -70,6 +71,14 @@ function pathIn(directory, name) {
 }
 function check(value, valid, label) { if (!valid(value)) fail(`${label} schema invalid: ${ajv.errorsText(valid.errors)}`); }
 function buildCompare(a, b) { const left = BigInt(a), right = BigInt(b); return left < right ? -1 : left > right ? 1 : 0; }
+export function validateReleaseDeclaration(declaration, declarationName = null) {
+  check(declaration, validateDeclaration, "declaration");
+  const match = declaration.version.match(/^1\.1\.0-(beta|rc)\.([1-9][0-9]{0,15})$/), sequence = match?.[2] ?? "";
+  if (!match || declaration.tag !== `v${declaration.version}` || declarationName !== null && declarationName !== `${declaration.tag}.json` || declaration.channel !== match[1] || declaration.sequence !== sequence || sequence.length > 15 && sequence > MAX_SAFE) fail("mixed declaration identity");
+  const artifactName = `NeonDiff-${declaration.version}-build${declaration.build}-macOS.zip`;
+  if (declaration.distribution.artifactName !== artifactName || declaration.distribution.origins.feed !== BETA_FEED) fail("unsupported channel/feed identity");
+  return { schemaVersion: 1, kind: "neondiff.desktop.release-declaration-validation-v1", verified: true, releaseTag: declaration.tag, version: declaration.version, channel: declaration.channel, sequence, build: declaration.build, artifactName, feed: BETA_FEED };
+}
 function validateTransition(index, directory, baseIndexPath) {
   const base = readRegular(baseIndexPath);
   check(base, validateIndex, "base index");
@@ -109,10 +118,7 @@ function main() {
     if (convention) fail(".gitkeep is only valid for an empty index");
     const declarations = index.declarationPaths.map((name) => [name, readRegular(pathIn(directory, name))]);
     for (const [name, declaration] of declarations) {
-      check(declaration, validateDeclaration, `declaration ${name}`);
-      const match = declaration.version.match(/^1\.1\.0-(beta|rc)\.([1-9][0-9]{0,15})$/), sequence = match?.[2] ?? "";
-      if (!match || declaration.tag !== `v${declaration.version}` || name !== `${declaration.tag}.json` || declaration.channel !== match[1] || declaration.sequence !== sequence || sequence.length > 15 && sequence > MAX_SAFE) fail(`mixed declaration identity: ${name}`);
-      if (declaration.distribution.artifactName !== `NeonDiff-${declaration.version}-build${declaration.build}-macOS.zip` || declaration.distribution.origins.feed !== BETA_FEED) fail(`unsupported channel/feed identity: ${name}`);
+      validateReleaseDeclaration(declaration, name);
     }
     const ordered = [...declarations].sort((a, b) => buildCompare(a[1].build, b[1].build) || a[0].localeCompare(b[0]));
     if (ordered.some((item, i) => i && buildCompare(item[1].build, ordered[i - 1][1].build) <= 0)) fail("retained builds must be unique and strictly increasing");
@@ -133,4 +139,6 @@ function main() {
   } finally { closeSync(handle.fd); }
 }
 
-try { console.log(main()); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; }
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try { console.log(main()); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; }
+}

--- a/tests/desktop-release-provenance.test.ts
+++ b/tests/desktop-release-provenance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { validateReleaseDeclaration } from "../scripts/validate-desktop-release-declaration.mjs";
+import { acceptedReleaseProvenanceDigest, buildAcceptedReleaseProvenance, serializeAcceptedReleaseProvenance } from "../scripts/lib/desktop-release-provenance.mjs";
+
+const source = "0123456789abcdef0123456789abcdef01234567";
+const tagObject = "abcdef0123456789abcdef0123456789abcdef01";
+const artifactSHA256 = "a".repeat(64);
+const artifactURL = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/v1.1.0-beta.7/NeonDiff-1.1.0-beta.7-build42-macOS.zip";
+
+function fixture() {
+  const version = "1.1.0-beta.7", tag = `v${version}`, build = "42", feed = "https://www.neondiff.com/updates/beta/appcast.xml";
+  const declaration = { schemaVersion: 1, product: "neondiff-desktop", contract: "paid-mac-beta-byo-v1", version, tag, channel: "beta", sequence: "7", build, predecessor: null, distribution: { bundleId: "com.electricsheephq.NeonDiffDesktop", appPath: "NeonDiff.app", artifactName: `NeonDiff-${version}-build${build}-macOS.zip`, releaseClass: "paid-beta", origins: { github: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff", site: "https://www.neondiff.com", feed } } };
+  const declarationValidation = validateReleaseDeclaration(declaration);
+  const identityProof = { schemaVersion: 1, kind: "neondiff.desktop.release-identity-validation-v2", verified: true, releaseTag: tag, sourceCommitSHA: source, tagObjectSHA: tagObject, artifactName: declaration.distribution.artifactName, artifactSHA256 };
+  const artifactProof = { schemaVersion: 1, kind: "neondiff.desktop.artifact-proof-v2", verified: true, releaseTag: tag, artifactName: declaration.distribution.artifactName, artifactSHA256, appSHA256: "b".repeat(64), treeAlgorithm: "sha256-tree-v1", treeSHA256: "c".repeat(64) };
+  const enclosure = { url: artifactURL, version: build, build, shortVersionString: version, edSignature: "c2lnbmF0dXJlNw==", signatureVerified: true };
+  const feedProof = { schemaVersion: 1, kind: "neondiff.desktop.feed-enclosure-proof-v2", verified: true, channel: "beta", url: feed, releaseTag: tag, artifactName: declaration.distribution.artifactName, artifactSHA256, appcastSHA256: "d".repeat(64), enclosure };
+  return { declaration, declarationValidation, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: true, immutable: true, assets: [{ name: declaration.distribution.artifactName, digest: `sha256:${artifactSHA256}`, browser_download_url: artifactURL }] }, identityProof, artifactMetadata: { ...artifactProof, proof: artifactProof }, feedMetadata: { channel: "beta", url: feed, appcastSHA256: "d".repeat(64), enclosure, proof: feedProof } };
+}
+
+describe("accepted Desktop release provenance", () => {
+  it("accepts canonical validation and emits one deterministic receipt", () => {
+    const value = fixture(), receipt = buildAcceptedReleaseProvenance(value);
+    expect(receipt).toMatchObject({ release: { tag: "v1.1.0-beta.7", sequence: "7", build: "42" }, source: { commitSHA: source, tagObjectSHA: tagObject }, artifacts: { artifactSHA256, treeAlgorithm: "sha256-tree-v1" }, feed: { releaseTag: "v1.1.0-beta.7", artifactName: value.declaration.distribution.artifactName, enclosure: { version: "42", build: "42", shortVersionString: "1.1.0-beta.7", edSignature: "c2lnbmF0dXJlNw==" } } });
+    expect(JSON.parse(serializeAcceptedReleaseProvenance(value))).toEqual(receipt);
+    expect(acceptedReleaseProvenanceDigest(value)).toMatch(/^[0-9a-f]{64}$/);
+    expect(serializeAcceptedReleaseProvenance(value)).toBe(serializeAcceptedReleaseProvenance(value));
+  });
+
+  it("rejects validator-invariant and verification failures", () => {
+    for (const mutate of [
+      (v: any) => { v.declaration.sequence = "8"; },
+      (v: any) => { v.declaration.version = "1.1.0-rc.9007199254740992"; v.declaration.tag = `v${v.declaration.version}`; v.declaration.channel = "rc"; },
+      (v: any) => { v.identityProof.verified = false; },
+      (v: any) => { v.artifactMetadata.proof.verified = false; },
+      (v: any) => { v.feedMetadata.proof.verified = false; }
+    ]) { const value = fixture(); mutate(value); expect(() => buildAcceptedReleaseProvenance(value)).toThrow(); }
+  });
+
+  it("rejects cross-release source, tag, artifact, and feed-enclosure substitution", () => {
+    for (const mutate of [
+      (v: any) => { v.identityProof.releaseTag = "v1.1.0-beta.8"; },
+      (v: any) => { v.annotatedTagMetadata.object.sha = "f".repeat(40); },
+      (v: any) => { v.releaseMetadata.assets[0].digest = `sha256:${"e".repeat(64)}`; },
+      (v: any) => { v.artifactMetadata.proof.artifactName = "NeonDiff-1.1.0-beta.8-build43-macOS.zip"; },
+      (v: any) => { v.feedMetadata.proof.releaseTag = "v1.1.0-beta.8"; },
+      (v: any) => { v.feedMetadata.proof.enclosure.shortVersionString = "1.1.0-beta.8"; },
+      (v: any) => { v.feedMetadata.proof.enclosure.build = "43"; },
+      (v: any) => { v.feedMetadata.proof.enclosure.url = v.feedMetadata.proof.enclosure.url.replace("beta.7", "beta.8"); }
+    ]) { const value = fixture(); mutate(value); expect(() => buildAcceptedReleaseProvenance(value)).toThrow(); }
+  });
+});


### PR DESCRIPTION
Related: #895

## Scope

Adds a production-inert accepted Desktop release provenance producer from the canonical declaration validator plus verified source/tag, immutable release asset, tree/app, and feed-enclosure receipts. The receipt binds one release tag, artifact name/digest, enclosure URL/version/build/signature identity, and channel; cross-release substitution fails closed.

## Validation

- `node --check scripts/lib/desktop-release-provenance.mjs`
- `node --check scripts/validate-desktop-release-declaration.mjs`
- existing empty declaration validator: PASS
- direct accepted-receipt smoke and deterministic digest: PASS
- `git diff --cached --check`: PASS
- focused Vitest attempted; host Rollup native binding is rejected due Team-ID mismatch

115 changed lines (including tests), current main base `d0eb797f069a06d951791283e39d6057cf099a37`. No signing, publication, install, feed/runtime/customer mutation, secret access, or downstream consumer is included. This proves the producer/receipt contract only; it does not prove release readiness or runtime/customer readiness.