### PR TITLE
feat: add serialized severe receipt parser

### DIFF
--- a/src/severe-verification-receipt-parser.ts
+++ b/src/severe-verification-receipt-parser.ts
@@ -3,6 +3,8 @@ import { type SevereVerificationReceipt, compileSevereVerificationReceiptSchema 
 export const MAX_SEVERE_VERIFICATION_RECEIPT_BYTES = 512 * 1024;
 const MAX_JSON_DEPTH = 256;
 const validate = compileSevereVerificationReceiptSchema();
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
 const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
 const intrinsicByteLength = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!.get!;
 const intrinsicByteOffset = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteOffset")!.get!;
@@ -23,8 +25,8 @@ export const parseSevereVerificationReceipt = parseSerializedSevereVerificationR
 
 function decodeInput(input: unknown): string {
   if (typeof input === "string") {
-    if (Buffer.byteLength(input, "utf8") > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
-    const encoded = new TextEncoder().encode(input);
+    if (input.length > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
+    const encoded = encoder.encode(input);
     if (encoded.byteLength > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
     const text = decodeUtf8(encoded);
     if (text !== input) reject("unicode");
@@ -52,8 +54,8 @@ function isIntrinsicByteArray(input: unknown): input is Uint8Array {
   } catch { return false; }
 }
 function hostileOwnProperties(input: Uint8Array): boolean {
-  return Reflect.ownKeys(input).some((key) => {
-    if (typeof key === "string" && /^\d+$/.test(key)) return false;
+  const keys: (string | symbol)[] = ["byteLength", "byteOffset", "buffer", "length", "constructor", "set", "subarray", "slice", "valueOf", "toString", ...Object.getOwnPropertySymbols(input)];
+  return keys.some((key) => {
     const descriptor = Object.getOwnPropertyDescriptor(input, key);
     return Boolean(descriptor && (descriptor.get || descriptor.set || typeof descriptor.value === "function"));
   });
@@ -61,14 +63,14 @@ function hostileOwnProperties(input: Uint8Array): boolean {
 
 function decodeUtf8(bytes: Uint8Array): string {
   if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) reject("bom");
+  let text: string;
   try {
-    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    if (text.startsWith("\uFEFF")) reject("bom");
-    return text;
-  } catch (error) {
-    if (error instanceof Error && error.message === "severe_receipt_bom") throw error;
+    text = decoder.decode(bytes);
+  } catch {
     return reject("utf8");
   }
+  if (text.startsWith("\uFEFF")) reject("bom");
+  return text;
 }
 
 class JsonScanner {
@@ -129,5 +131,5 @@ class JsonScanner {
 function scalar(value: string): boolean { for (let i = 0; i < value.length; i++) { const code = value.charCodeAt(i); if (code >= 0xd800 && code <= 0xdbff) { const next = value.charCodeAt(++i); if (next < 0xdc00 || next > 0xdfff) return false; } else if (code >= 0xdc00 && code <= 0xdfff) return false; } return true; }
 function scanJson(text: string): void { new JsonScanner(text).scan(); }
 function copyReceipt(source: SevereVerificationReceipt): SevereVerificationReceipt {
-  return { schemaVersion: source.schemaVersion, repo: source.repo, pullNumber: source.pullNumber, baseSha: source.baseSha, headSha: source.headSha, findingFingerprint: source.findingFingerprint, state: source.state, disposition: source.disposition, ...(source.confidence === undefined ? {} : { confidence: source.confidence }), ...(source.reasonCode === undefined ? {} : { reasonCode: source.reasonCode }), evidence: { files: source.evidence.files.map((file) => ({ ...file })), omitted: source.evidence.omitted.map((item) => ({ ...item })), complete: source.evidence.complete } };
+  return { schemaVersion: source.schemaVersion, repo: source.repo, pullNumber: source.pullNumber, baseSha: source.baseSha, headSha: source.headSha, findingFingerprint: source.findingFingerprint, state: source.state, disposition: source.disposition, ...(source.confidence === undefined ? {} : { confidence: source.confidence }), ...(source.reasonCode === undefined ? {} : { reasonCode: source.reasonCode }), evidence: { files: source.evidence.files.map((file) => ({ path: file.path, kind: file.kind, sha256: file.sha256, bytes: file.bytes, complete: file.complete })), omitted: source.evidence.omitted.map((item) => ({ path: item.path, code: item.code })), complete: source.evidence.complete } };
 }

--- a/src/severe-verification-receipt-parser.ts
+++ b/src/severe-verification-receipt-parser.ts
@@ -1,0 +1,133 @@
+import { type SevereVerificationReceipt, compileSevereVerificationReceiptSchema } from "./severe-verification-receipt-schema.js";
+
+export const MAX_SEVERE_VERIFICATION_RECEIPT_BYTES = 512 * 1024;
+const MAX_JSON_DEPTH = 256;
+const validate = compileSevereVerificationReceiptSchema();
+const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const intrinsicByteLength = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!.get!;
+const intrinsicByteOffset = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteOffset")!.get!;
+const intrinsicBuffer = Object.getOwnPropertyDescriptor(typedArrayPrototype, "buffer")!.get!;
+const intrinsicSet = Uint8Array.prototype.set;
+const reject = (code: string): never => { throw new Error(`severe_receipt_${code}`); };
+
+export function parseSerializedSevereVerificationReceipt(input: unknown): SevereVerificationReceipt {
+  const text = decodeInput(input);
+  scanJson(text);
+  let value: unknown;
+  try { value = JSON.parse(text) as unknown; } catch { reject("malformed"); }
+  if (!validate(value)) reject("schema_invalid");
+  return copyReceipt(value as SevereVerificationReceipt);
+}
+
+export const parseSevereVerificationReceipt = parseSerializedSevereVerificationReceipt;
+
+function decodeInput(input: unknown): string {
+  if (typeof input === "string") {
+    if (Buffer.byteLength(input, "utf8") > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
+    const encoded = new TextEncoder().encode(input);
+    if (encoded.byteLength > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
+    const text = decodeUtf8(encoded);
+    if (text !== input) reject("unicode");
+    return text;
+  }
+  if (!isIntrinsicByteArray(input)) reject("serialized_input");
+  let length: number;
+  try { length = intrinsicByteLength.call(input); } catch { return reject("serialized_input"); }
+  if (length > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
+  try { if (hostileOwnProperties(input as Uint8Array)) reject("serialized_input"); } catch { return reject("serialized_input"); }
+  let copy: Uint8Array;
+  try {
+    const source = new Uint8Array(intrinsicBuffer.call(input), intrinsicByteOffset.call(input), length);
+    copy = new Uint8Array(length);
+    intrinsicSet.call(copy, source);
+  } catch { return reject("serialized_input"); }
+  return decodeUtf8(copy);
+}
+
+function isIntrinsicByteArray(input: unknown): input is Uint8Array {
+  if (!ArrayBuffer.isView(input)) return false;
+  try {
+    const prototype = Object.getPrototypeOf(input);
+    return prototype === Uint8Array.prototype || prototype === Buffer.prototype;
+  } catch { return false; }
+}
+function hostileOwnProperties(input: Uint8Array): boolean {
+  return Reflect.ownKeys(input).some((key) => {
+    if (typeof key === "string" && /^\d+$/.test(key)) return false;
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    return Boolean(descriptor && (descriptor.get || descriptor.set || typeof descriptor.value === "function"));
+  });
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) reject("bom");
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    if (text.startsWith("\uFEFF")) reject("bom");
+    return text;
+  } catch (error) {
+    if (error instanceof Error && error.message === "severe_receipt_bom") throw error;
+    return reject("utf8");
+  }
+}
+
+class JsonScanner {
+  private position = 0;
+  constructor(private readonly text: string) {}
+  scan(): void { this.value(0); this.space(); if (this.position !== this.text.length) reject("malformed"); }
+  private value(depth: number): void {
+    if (depth > MAX_JSON_DEPTH) reject("depth");
+    this.space();
+    const code = this.text.charCodeAt(this.position);
+    if (code === 34) { this.string(); return; }
+    if (code === 123) { this.object(depth + 1); return; }
+    if (code === 91) { this.array(depth + 1); return; }
+    if (code === 116 && this.literal("true")) return;
+    if (code === 102 && this.literal("false")) return;
+    if (code === 110 && this.literal("null")) return;
+    if (code === 45 || (code >= 48 && code <= 57)) { this.number(); return; }
+    reject("malformed");
+  }
+  private object(depth: number): void {
+    this.position++; this.space(); const keys = new Set<string>();
+    if (this.text.charCodeAt(this.position) === 125) { this.position++; return; }
+    for (;;) {
+      if (this.text.charCodeAt(this.position) !== 34) reject("malformed");
+      const key = this.string(); if (keys.has(key)) reject("duplicate_key"); keys.add(key); this.space();
+      if (this.text.charCodeAt(this.position++) !== 58) reject("malformed");
+      this.value(depth); this.space();
+      const next = this.text.charCodeAt(this.position++);
+      if (next === 125) return;
+      if (next !== 44) reject("malformed");
+      this.space();
+    }
+  }
+  private array(depth: number): void {
+    this.position++; this.space(); if (this.text.charCodeAt(this.position) === 93) { this.position++; return; }
+    for (;;) { this.value(depth); this.space(); const next = this.text.charCodeAt(this.position++); if (next === 93) return; if (next !== 44) reject("malformed"); this.space(); }
+  }
+  private string(): string {
+    this.position++; let value = "";
+    for (;;) {
+      const code = this.text.charCodeAt(this.position++);
+      if (code === 34) { if (!scalar(value)) reject("unicode"); return value; }
+      if (code < 32 || Number.isNaN(code)) reject("malformed");
+      if (code !== 92) { value += String.fromCharCode(code); continue; }
+      const escaped = this.text.charCodeAt(this.position++);
+      const simple = ({34: '"', 92: "\\", 47: "/", 98: "\b", 102: "\f", 110: "\n", 114: "\r", 116: "\t"} as Record<number, string>)[escaped];
+      if (simple !== undefined) { value += simple; continue; }
+      if (escaped !== 117) reject("malformed");
+      let unit = 0; for (let count = 0; count < 4; count++) { const digit = Number.parseInt(this.text[this.position++], 16); if (Number.isNaN(digit)) reject("malformed"); unit = unit * 16 + digit; }
+      value += String.fromCharCode(unit);
+    }
+  }
+  private literal(literal: string): boolean { if (this.text.slice(this.position, this.position + literal.length) !== literal) return false; this.position += literal.length; return true; }
+  private number(): void { const start = this.position; if (this.text[this.position] === "-") this.position++; if (this.text[this.position] === "0") this.position++; else { if (!/[1-9]/.test(this.text[this.position] ?? "")) reject("malformed"); while (/[0-9]/.test(this.text[this.position] ?? "")) this.position++; } if (this.text[this.position] === ".") { this.position++; if (!/[0-9]/.test(this.text[this.position] ?? "")) reject("malformed"); while (/[0-9]/.test(this.text[this.position] ?? "")) this.position++; } if (this.text[this.position] === "e" || this.text[this.position] === "E") { this.position++; if (this.text[this.position] === "+" || this.text[this.position] === "-") this.position++; if (!/[0-9]/.test(this.text[this.position] ?? "")) reject("malformed"); while (/[0-9]/.test(this.text[this.position] ?? "")) this.position++; } if (this.position === start) reject("malformed"); }
+  private space(): void { while ([9, 10, 13, 32].includes(this.text.charCodeAt(this.position))) this.position++; }
+}
+
+function scalar(value: string): boolean { for (let i = 0; i < value.length; i++) { const code = value.charCodeAt(i); if (code >= 0xd800 && code <= 0xdbff) { const next = value.charCodeAt(++i); if (next < 0xdc00 || next > 0xdfff) return false; } else if (code >= 0xdc00 && code <= 0xdfff) return false; } return true; }
+function scanJson(text: string): void { new JsonScanner(text).scan(); }
+function copyReceipt(source: SevereVerificationReceipt): SevereVerificationReceipt {
+  return { schemaVersion: source.schemaVersion, repo: source.repo, pullNumber: source.pullNumber, baseSha: source.baseSha, headSha: source.headSha, findingFingerprint: source.findingFingerprint, state: source.state, disposition: source.disposition, ...(source.confidence === undefined ? {} : { confidence: source.confidence }), ...(source.reasonCode === undefined ? {} : { reasonCode: source.reasonCode }), evidence: { files: source.evidence.files.map((file) => ({ ...file })), omitted: source.evidence.omitted.map((item) => ({ ...item })), complete: source.evidence.complete } };
+}

--- a/src/severe-verification-receipt-parser.ts
+++ b/src/severe-verification-receipt-parser.ts
@@ -9,7 +9,7 @@ const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
 const intrinsicByteLength = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!.get!;
 const intrinsicByteOffset = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteOffset")!.get!;
 const intrinsicBuffer = Object.getOwnPropertyDescriptor(typedArrayPrototype, "buffer")!.get!;
-const intrinsicSet = Uint8Array.prototype.set;
+const intrinsicSet = Uint8Array.prototype.set, intrinsicTag = Object.getOwnPropertyDescriptor(typedArrayPrototype, Symbol.toStringTag)!.get!;
 const reject = (code: string): never => { throw new Error(`severe_receipt_${code}`); };
 
 export function parseSerializedSevereVerificationReceipt(input: unknown): SevereVerificationReceipt {
@@ -50,12 +50,12 @@ function isIntrinsicByteArray(input: unknown): input is Uint8Array {
   if (!ArrayBuffer.isView(input)) return false;
   try {
     const prototype = Object.getPrototypeOf(input);
-    return prototype === Uint8Array.prototype || prototype === Buffer.prototype;
+    return intrinsicTag.call(input) === "Uint8Array" && (prototype === Uint8Array.prototype || prototype === Buffer.prototype);
   } catch { return false; }
 }
 function hostileOwnProperties(input: Uint8Array): boolean {
-  const keys: (string | symbol)[] = ["byteLength", "byteOffset", "buffer", "length", "constructor", "set", "subarray", "slice", "valueOf", "toString", ...Object.getOwnPropertySymbols(input)];
-  return keys.some((key) => {
+  return Reflect.ownKeys(input).some((key) => {
+    if (typeof key === "string" && /^\d+$/.test(key)) return false;
     const descriptor = Object.getOwnPropertyDescriptor(input, key);
     return Boolean(descriptor && (descriptor.get || descriptor.set || typeof descriptor.value === "function"));
   });

--- a/tests/severe-verification-receipt-parser.test.ts
+++ b/tests/severe-verification-receipt-parser.test.ts
@@ -52,8 +52,7 @@ describe("serialized severe receipt parser", () => {
     expect(touched).toBe(false);
     const accessor = new Uint8Array(); Object.defineProperty(accessor, "byteLength", { get() { throw new Error("trap"); } });
     expect(() => parseSerializedSevereVerificationReceipt(accessor)).toThrow("serialized_input");
-    const iterator = new Uint8Array(); Object.defineProperty(iterator, Symbol.iterator, { value() { throw new Error("trap"); } });
-    expect(() => parseSerializedSevereVerificationReceipt(iterator)).toThrow("serialized_input");
+    const iterator = new Uint8Array(); Object.defineProperty(iterator, Symbol.iterator, { value() { throw new Error("trap"); } }); expect(() => parseSerializedSevereVerificationReceipt(iterator)).toThrow("serialized_input"); const evilAccessor = new Uint8Array(); Object.defineProperty(evilAccessor, "evil", { get() { throw new Error("trap"); } }); expect(() => parseSerializedSevereVerificationReceipt(evilAccessor)).toThrow("serialized_input"); const evilFunction = new Uint8Array(); Object.defineProperty(evilFunction, "evil", { value() { throw new Error("trap"); } }); expect(() => parseSerializedSevereVerificationReceipt(evilFunction)).toThrow("serialized_input"); const spoofedInt8 = new Int8Array(); Object.setPrototypeOf(spoofedInt8, Uint8Array.prototype); expect(() => parseSerializedSevereVerificationReceipt(spoofedInt8)).toThrow("serialized_input"); const spoofedClamped = new Uint8ClampedArray(); Object.setPrototypeOf(spoofedClamped, Uint8Array.prototype); expect(() => parseSerializedSevereVerificationReceipt(spoofedClamped)).toThrow("serialized_input");
   });
 
   it("rejects excessive nesting, trailing content, and oversized strings", () => {

--- a/tests/severe-verification-receipt-parser.test.ts
+++ b/tests/severe-verification-receipt-parser.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_SEVERE_VERIFICATION_RECEIPT_BYTES,
+  parseSerializedSevereVerificationReceipt
+} from "../src/severe-verification-receipt-parser.js";
+
+const receipt = () => ({
+  schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7,
+  baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`,
+  state: "confirmed", disposition: "retain",
+  evidence: { files: [{ path: "src/🧪.ts", kind: "whole_file", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true }
+});
+const serialized = () => JSON.stringify(receipt());
+
+describe("serialized severe receipt parser", () => {
+  it("accepts strings, Uint8Arrays, and Buffers, then copies validated data", () => {
+    for (const input of [serialized(), new TextEncoder().encode(serialized()), Buffer.from(serialized())]) {
+      const parsed = parseSerializedSevereVerificationReceipt(input);
+      expect(parsed).toEqual(receipt());
+      expect(parsed).not.toBe(input);
+    }
+  });
+
+  it("rejects duplicate decoded keys before parsing and accepts ordinary JSON whitespace", () => {
+    expect(() => parseSerializedSevereVerificationReceipt(`{"x": {"a": 1, "\\u0061": 2}}`)).toThrow("duplicate_key");
+    expect(parseSerializedSevereVerificationReceipt(` \n${serialized()} \t`)).toEqual(receipt());
+  });
+
+  it("fails closed for BOM, malformed UTF-8, lone surrogates, schema errors, and cap", () => {
+    expect(() => parseSerializedSevereVerificationReceipt(new Uint8Array([0xef, 0xbb, 0xbf, 0x7b, 0x7d]))).toThrow("bom");
+    expect(() => parseSerializedSevereVerificationReceipt(new Uint8Array([0xc0, 0x80]))).toThrow("utf8");
+    expect(() => parseSerializedSevereVerificationReceipt(serialized().replace("src/🧪.ts", "src/\\ud800.ts"))).toThrow("unicode");
+    expect(() => parseSerializedSevereVerificationReceipt(serialized().replace('"pullNumber":7', '"pullNumber":0'))).toThrow("schema");
+    expect(() => parseSerializedSevereVerificationReceipt(new Uint8Array(MAX_SEVERE_VERIFICATION_RECEIPT_BYTES + 1))).toThrow("cap");
+  });
+
+  it("does not traverse proxies or hostile subclasses", () => {
+    let touched = false;
+    const proxy = new Proxy(new Uint8Array(), { get() { touched = true; throw new Error("trap"); } });
+    expect(() => parseSerializedSevereVerificationReceipt(proxy)).toThrow("serialized_input");
+    expect(touched).toBe(false);
+    class Hostile extends Uint8Array { get byteLength() { touched = true; throw new Error("trap"); } }
+    expect(() => parseSerializedSevereVerificationReceipt(new Hostile())).toThrow("serialized_input");
+    expect(touched).toBe(false);
+    const accessor = new Uint8Array(); Object.defineProperty(accessor, "byteLength", { get() { throw new Error("trap"); } });
+    expect(() => parseSerializedSevereVerificationReceipt(accessor)).toThrow("serialized_input");
+    const iterator = new Uint8Array(); Object.defineProperty(iterator, Symbol.iterator, { value() { throw new Error("trap"); } });
+    expect(() => parseSerializedSevereVerificationReceipt(iterator)).toThrow("serialized_input");
+  });
+});

--- a/tests/severe-verification-receipt-parser.test.ts
+++ b/tests/severe-verification-receipt-parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   MAX_SEVERE_VERIFICATION_RECEIPT_BYTES,
+  parseSevereVerificationReceipt,
   parseSerializedSevereVerificationReceipt
 } from "../src/severe-verification-receipt-parser.js";
 
@@ -19,6 +20,13 @@ describe("serialized severe receipt parser", () => {
       expect(parsed).toEqual(receipt());
       expect(parsed).not.toBe(input);
     }
+    const first = parseSerializedSevereVerificationReceipt(serialized());
+    const second = parseSerializedSevereVerificationReceipt(serialized());
+    expect(first.evidence).not.toBe(second.evidence);
+    expect(first.evidence.files).not.toBe(second.evidence.files);
+    first.evidence.files[0].path = "changed";
+    expect(second.evidence.files[0].path).toBe("src/🧪.ts");
+    expect(parseSevereVerificationReceipt(serialized())).toEqual(receipt());
   });
 
   it("rejects duplicate decoded keys before parsing and accepts ordinary JSON whitespace", () => {
@@ -46,5 +54,12 @@ describe("serialized severe receipt parser", () => {
     expect(() => parseSerializedSevereVerificationReceipt(accessor)).toThrow("serialized_input");
     const iterator = new Uint8Array(); Object.defineProperty(iterator, Symbol.iterator, { value() { throw new Error("trap"); } });
     expect(() => parseSerializedSevereVerificationReceipt(iterator)).toThrow("serialized_input");
+  });
+
+  it("rejects excessive nesting, trailing content, and oversized strings", () => {
+    const deep = `${"[".repeat(300)}1${"]".repeat(300)}`;
+    expect(() => parseSerializedSevereVerificationReceipt(deep)).toThrow("depth");
+    expect(() => parseSerializedSevereVerificationReceipt(`${serialized()}{}`)).toThrow("malformed");
+    expect(() => parseSerializedSevereVerificationReceipt("x".repeat(MAX_SEVERE_VERIFICATION_RECEIPT_BYTES + 1))).toThrow("cap");
   });
 });


### PR DESCRIPTION
Related: #865\n\n## Summary\n- add a production-inert parser slice on merged strict schema PR #927\n- accept only primitive strings and intrinsic Uint8Array/Buffer bytes\n- enforce the 512 KiB cap before typed-array property enumeration, byte copying, UTF-8 decode, or JSON parse\n- fatal UTF-8/BOM/scalar checks and a bounded duplicate-decoded-key scan precede one JSON.parse\n- return only an explicit copied validated receipt; canonical ordering/digest is intentionally deferred\n\n## Validation\n- ./node_modules/.bin/tsc --noEmit -p tsconfig.build.json\n- /Users/m1/.local/bin/bun test tests/severe-verification-receipt-schema.test.ts tests/severe-verification-receipt-parser.test.ts (11 passed, 64 assertions)\n- git diff --cached --check\n- 183 added non-generated lines across parser and focused fixtures\n\n## Proof boundary\n- no provider, worker, publication, runtime, config, database, customer, or release wiring\n- canonical ordering and digest remain the next #865 slice\n- exact-head CI and independent acceptance/adversarial review remain required\n