### PR TITLE
feat(desktop): verify Sparkle feed enclosure proof

### DIFF
--- a/scripts/lib/desktop-feed-enclosure-proof.mjs
+++ b/scripts/lib/desktop-feed-enclosure-proof.mjs
@@ -1,0 +1,62 @@
+import { createHash, createPublicKey, verify } from "node:crypto";
+
+const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const ENCLOSURE_FIELDS = ["url", "version", "build", "shortVersionString", "channel", "artifactName", "artifactSHA256", "edSignature"];
+const PROOF_FIELDS = ["schemaVersion", "kind", "verified", "channel", "url", "artifactName", "artifactSHA256", "version", "build", "shortVersionString", "edSignature", "signedContentSHA256"];
+const KIND = "neondiff.desktop.feed-enclosure-proof-v1";
+const fail = (message) => { throw new Error(message); };
+
+function exactObject(value, fields, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  const keys = Object.keys(value);
+  if (keys.length !== fields.length || keys.some((key) => !fields.includes(key))) fail(`${label} has undeclared fields`);
+  return value;
+}
+function text(value, label) { if (typeof value !== "string" || value.length === 0) fail(`${label} is required`); return value; }
+function base64(value, bytes, label) {
+  const encoded = text(value, label);
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)) fail(`${label} is malformed`);
+  const decoded = Buffer.from(encoded, "base64");
+  if (decoded.length !== bytes || decoded.toString("base64") !== encoded) fail(`${label} has the wrong length`);
+  return decoded;
+}
+function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+function canonicalBytes(value) {
+  if (!(Buffer.isBuffer(value) || value instanceof Uint8Array)) fail("signedContent must be bytes");
+  return Buffer.from(value);
+}
+function validateEnclosure(enclosure) {
+  const value = exactObject(enclosure, ENCLOSURE_FIELDS, "enclosure");
+  const url = new URL(text(value.url, "enclosure.url"));
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) fail("enclosure.url must be a public HTTPS artifact URL");
+  const version = text(value.version, "enclosure.version"), build = text(value.build, "enclosure.build");
+  if (!/^\d+\.\d+\.\d+(?:-(?:beta|rc)\.[1-9]\d{0,15})?$/.test(version) || !/^\d+$/.test(build)) fail("enclosure version/build is malformed");
+  const prerelease = version.match(/-(beta|rc)\./)?.[1] ?? null;
+  if (value.shortVersionString !== version || !["beta", "rc", "stable"].includes(value.channel) || (prerelease ?? "stable") !== value.channel) fail("enclosure identity is malformed");
+  const artifactName = `NeonDiff-${version}-build${build}-macOS.zip`;
+  if (value.artifactName !== artifactName || !url.pathname.endsWith(`/${artifactName}`)) fail("enclosure artifact identity is not canonical");
+  if (!/^[a-f0-9]{64}$/.test(value.artifactSHA256)) fail("enclosure artifact SHA-256 is malformed");
+  base64(value.edSignature, 64, "enclosure.edSignature");
+  return value;
+}
+function validateProof(proof) {
+  const value = exactObject(proof, PROOF_FIELDS, "proof");
+  if (value.schemaVersion !== 1 || value.kind !== KIND || value.verified !== true) fail("proof is not verified");
+  validateEnclosure({ url: value.url, version: value.version, build: value.build, shortVersionString: value.shortVersionString, channel: value.channel, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, edSignature: value.edSignature });
+  if (value.signedContentSHA256 !== value.artifactSHA256) fail("proof content digest is not bound to the artifact");
+  return value;
+}
+
+export function buildFeedEnclosureProof(enclosure, { acceptedPublicKey, signedContent } = {}) {
+  const value = validateEnclosure(enclosure), bytes = canonicalBytes(signedContent);
+  if (sha256(bytes) !== value.artifactSHA256) fail("signed content digest does not match enclosure artifact");
+  const publicKey = base64(acceptedPublicKey, 32, "acceptedPublicKey"), signature = base64(value.edSignature, 64, "enclosure.edSignature");
+  const key = createPublicKey({ key: Buffer.concat([SPKI_ED25519_PREFIX, publicKey]), format: "der", type: "spki" });
+  if (!verify(null, bytes, key, signature)) fail("Sparkle EdDSA signature verification failed");
+  return { schemaVersion: 1, kind: KIND, verified: true, channel: value.channel, url: value.url, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, version: value.version, build: value.build, shortVersionString: value.shortVersionString, edSignature: value.edSignature, signedContentSHA256: sha256(bytes) };
+}
+export function serializeFeedEnclosureProof(proof) {
+  const value = validateProof(proof);
+  return `${JSON.stringify(Object.fromEntries(PROOF_FIELDS.map((field) => [field, value[field]])))}\n`;
+}
+export function feedEnclosureProofDigest(proof) { return sha256(Buffer.from(serializeFeedEnclosureProof(proof), "utf8")); }

--- a/scripts/lib/desktop-feed-enclosure-proof.mjs
+++ b/scripts/lib/desktop-feed-enclosure-proof.mjs
@@ -1,9 +1,12 @@
 import { createHash, createPublicKey, verify } from "node:crypto";
 
 const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const OFFICIAL_ARTIFACT_PREFIX = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/";
 const ENCLOSURE_FIELDS = ["url", "version", "build", "shortVersionString", "channel", "artifactName", "artifactSHA256", "edSignature"];
-const PROOF_FIELDS = ["schemaVersion", "kind", "verified", "channel", "url", "artifactName", "artifactSHA256", "version", "build", "shortVersionString", "edSignature", "signedContentSHA256"];
+const PROOF_FIELDS = ["schemaVersion", "kind", "verified", "signatureScope", "channel", "url", "artifactName", "artifactSHA256", "version", "build", "shortVersionString", "edSignature", "publicKeyFingerprint", "signedContentSHA256"];
 const KIND = "neondiff.desktop.feed-enclosure-proof-v1";
+const SIGNATURE_SCOPE = "sparkle-artifact-bytes";
+const verifiedProofs = new WeakSet();
 const fail = (message) => { throw new Error(message); };
 
 function exactObject(value, fields, label) {
@@ -28,22 +31,25 @@ function canonicalBytes(value) {
 function validateEnclosure(enclosure) {
   const value = exactObject(enclosure, ENCLOSURE_FIELDS, "enclosure");
   const url = new URL(text(value.url, "enclosure.url"));
-  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) fail("enclosure.url must be a public HTTPS artifact URL");
+  if (url.toString() !== value.url || url.protocol !== "https:" || url.username || url.password || url.search || url.hash || !value.url.startsWith(OFFICIAL_ARTIFACT_PREFIX)) fail("enclosure.url must be the canonical official artifact URL");
   const version = text(value.version, "enclosure.version"), build = text(value.build, "enclosure.build");
   if (!/^\d+\.\d+\.\d+(?:-(?:beta|rc)\.[1-9]\d{0,15})?$/.test(version) || !/^\d+$/.test(build)) fail("enclosure version/build is malformed");
   const prerelease = version.match(/-(beta|rc)\./)?.[1] ?? null;
   if (value.shortVersionString !== version || !["beta", "rc", "stable"].includes(value.channel) || (prerelease ?? "stable") !== value.channel) fail("enclosure identity is malformed");
   const artifactName = `NeonDiff-${version}-build${build}-macOS.zip`;
-  if (value.artifactName !== artifactName || !url.pathname.endsWith(`/${artifactName}`)) fail("enclosure artifact identity is not canonical");
+  if (value.artifactName !== artifactName) fail("enclosure artifact name is not canonical");
+  const path = url.pathname;
+  const pathMatch = path.match(/^\/electricsheephq\/evaos-code-review-bot-neondiff\/releases\/download\/([^/]+)\/([^/]+)$/);
+  if (!pathMatch || pathMatch[1] !== `v${version}` || pathMatch[2] !== artifactName) fail("enclosure artifact identity is not canonical");
   if (!/^[a-f0-9]{64}$/.test(value.artifactSHA256)) fail("enclosure artifact SHA-256 is malformed");
   base64(value.edSignature, 64, "enclosure.edSignature");
   return value;
 }
 function validateProof(proof) {
   const value = exactObject(proof, PROOF_FIELDS, "proof");
-  if (value.schemaVersion !== 1 || value.kind !== KIND || value.verified !== true) fail("proof is not verified");
+  if (!verifiedProofs.has(proof) || value.schemaVersion !== 1 || value.kind !== KIND || value.verified !== true || value.signatureScope !== SIGNATURE_SCOPE) fail("proof is not verified");
   validateEnclosure({ url: value.url, version: value.version, build: value.build, shortVersionString: value.shortVersionString, channel: value.channel, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, edSignature: value.edSignature });
-  if (value.signedContentSHA256 !== value.artifactSHA256) fail("proof content digest is not bound to the artifact");
+  if (value.signedContentSHA256 !== value.artifactSHA256 || !/^sha256:[a-f0-9]{64}$/.test(value.publicKeyFingerprint)) fail("proof content or key identity is malformed");
   return value;
 }
 
@@ -53,7 +59,9 @@ export function buildFeedEnclosureProof(enclosure, { acceptedPublicKey, signedCo
   const publicKey = base64(acceptedPublicKey, 32, "acceptedPublicKey"), signature = base64(value.edSignature, 64, "enclosure.edSignature");
   const key = createPublicKey({ key: Buffer.concat([SPKI_ED25519_PREFIX, publicKey]), format: "der", type: "spki" });
   if (!verify(null, bytes, key, signature)) fail("Sparkle EdDSA signature verification failed");
-  return { schemaVersion: 1, kind: KIND, verified: true, channel: value.channel, url: value.url, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, version: value.version, build: value.build, shortVersionString: value.shortVersionString, edSignature: value.edSignature, signedContentSHA256: sha256(bytes) };
+  const proof = Object.freeze({ schemaVersion: 1, kind: KIND, verified: true, signatureScope: SIGNATURE_SCOPE, channel: value.channel, url: value.url, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, version: value.version, build: value.build, shortVersionString: value.shortVersionString, edSignature: value.edSignature, publicKeyFingerprint: `sha256:${sha256(publicKey)}`, signedContentSHA256: sha256(bytes) });
+  verifiedProofs.add(proof);
+  return proof;
 }
 export function serializeFeedEnclosureProof(proof) {
   const value = validateProof(proof);

--- a/scripts/lib/desktop-feed-enclosure-proof.mjs
+++ b/scripts/lib/desktop-feed-enclosure-proof.mjs
@@ -30,20 +30,21 @@ function canonicalBytes(value) {
 }
 function validateEnclosure(enclosure) {
   const value = exactObject(enclosure, ENCLOSURE_FIELDS, "enclosure");
-  const url = new URL(text(value.url, "enclosure.url"));
-  if (url.toString() !== value.url || url.protocol !== "https:" || url.username || url.password || url.search || url.hash || !value.url.startsWith(OFFICIAL_ARTIFACT_PREFIX)) fail("enclosure.url must be the canonical official artifact URL");
-  const version = text(value.version, "enclosure.version"), build = text(value.build, "enclosure.build");
+  const urlText = text(value.url, "enclosure.url"), url = new URL(urlText);
+  if (url.toString() !== urlText || /[?#]/.test(urlText) || url.protocol !== "https:" || url.username || url.password || url.search || url.hash || !urlText.startsWith(OFFICIAL_ARTIFACT_PREFIX)) fail("enclosure.url must be the canonical official artifact URL");
+  const version = text(value.version, "enclosure.version"), build = text(value.build, "enclosure.build"), shortVersionString = text(value.shortVersionString, "enclosure.shortVersionString");
+  const channel = value.channel, artifactNameInput = text(value.artifactName, "enclosure.artifactName"), artifactSHA256 = text(value.artifactSHA256, "enclosure.artifactSHA256"), edSignature = text(value.edSignature, "enclosure.edSignature");
   if (!/^\d+\.\d+\.\d+(?:-(?:beta|rc)\.[1-9]\d{0,15})?$/.test(version) || !/^\d+$/.test(build)) fail("enclosure version/build is malformed");
   const prerelease = version.match(/-(beta|rc)\./)?.[1] ?? null;
-  if (value.shortVersionString !== version || !["beta", "rc", "stable"].includes(value.channel) || (prerelease ?? "stable") !== value.channel) fail("enclosure identity is malformed");
+  if (shortVersionString !== version || !["beta", "rc", "stable"].includes(channel) || (prerelease ?? "stable") !== channel) fail("enclosure identity is malformed");
   const artifactName = `NeonDiff-${version}-build${build}-macOS.zip`;
-  if (value.artifactName !== artifactName) fail("enclosure artifact name is not canonical");
+  if (artifactNameInput !== artifactName) fail("enclosure artifact name is not canonical");
   const path = url.pathname;
   const pathMatch = path.match(/^\/electricsheephq\/evaos-code-review-bot-neondiff\/releases\/download\/([^/]+)\/([^/]+)$/);
   if (!pathMatch || pathMatch[1] !== `v${version}` || pathMatch[2] !== artifactName) fail("enclosure artifact identity is not canonical");
-  if (!/^[a-f0-9]{64}$/.test(value.artifactSHA256)) fail("enclosure artifact SHA-256 is malformed");
-  base64(value.edSignature, 64, "enclosure.edSignature");
-  return value;
+  if (!/^[a-f0-9]{64}$/.test(artifactSHA256)) fail("enclosure artifact SHA-256 is malformed");
+  const signatureBytes = base64(edSignature, 64, "enclosure.edSignature");
+  return { url: urlText, version, build, shortVersionString, channel, artifactName, artifactSHA256, edSignature, signatureBytes };
 }
 function validateProof(proof) {
   const value = exactObject(proof, PROOF_FIELDS, "proof");
@@ -56,7 +57,7 @@ function validateProof(proof) {
 export function buildFeedEnclosureProof(enclosure, { acceptedPublicKey, signedContent } = {}) {
   const value = validateEnclosure(enclosure), bytes = canonicalBytes(signedContent);
   if (sha256(bytes) !== value.artifactSHA256) fail("signed content digest does not match enclosure artifact");
-  const publicKey = base64(acceptedPublicKey, 32, "acceptedPublicKey"), signature = base64(value.edSignature, 64, "enclosure.edSignature");
+  const publicKey = base64(acceptedPublicKey, 32, "acceptedPublicKey"), signature = value.signatureBytes;
   const key = createPublicKey({ key: Buffer.concat([SPKI_ED25519_PREFIX, publicKey]), format: "der", type: "spki" });
   if (!verify(null, bytes, key, signature)) fail("Sparkle EdDSA signature verification failed");
   const proof = Object.freeze({ schemaVersion: 1, kind: KIND, verified: true, signatureScope: SIGNATURE_SCOPE, channel: value.channel, url: value.url, artifactName: value.artifactName, artifactSHA256: value.artifactSHA256, version: value.version, build: value.build, shortVersionString: value.shortVersionString, edSignature: value.edSignature, publicKeyFingerprint: `sha256:${sha256(publicKey)}`, signedContentSHA256: sha256(bytes) });

--- a/tests/desktop-feed-enclosure-proof.test.ts
+++ b/tests/desktop-feed-enclosure-proof.test.ts
@@ -7,7 +7,7 @@ const artifactSHA256 = "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd
 const signature = "kdfWQEYJInL03AG3nHvaoXVLgg0tqI1z+VUWuR/kcaangjaZ4ZTrN1s3ISdTnOqPhqrvx9uEoqqZ8/iVhCc4Ag==";
 
 function enclosure() {
-  return { url: "https://www.neondiff.com/updates/beta/NeonDiff-1.1.0-beta.7-build42-macOS.zip", version: "1.1.0-beta.7", build: "42", shortVersionString: "1.1.0-beta.7", channel: "beta", artifactName: "NeonDiff-1.1.0-beta.7-build42-macOS.zip", artifactSHA256, edSignature: signature };
+  return { url: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/v1.1.0-beta.7/NeonDiff-1.1.0-beta.7-build42-macOS.zip", version: "1.1.0-beta.7", build: "42", shortVersionString: "1.1.0-beta.7", channel: "beta", artifactName: "NeonDiff-1.1.0-beta.7-build42-macOS.zip", artifactSHA256, edSignature: signature };
 }
 const options = { acceptedPublicKey: Buffer.from(publicKey, "hex").toString("base64"), signedContent };
 
@@ -27,6 +27,9 @@ describe("desktop feed enclosure proof", () => {
     ["missing field", (value: any) => { delete value.edSignature; }],
     ["malformed signature", (value: any) => { value.edSignature = "not-base64"; }],
     ["substituted URL", (value: any) => { value.url = value.url.replace("beta.7", "beta.8"); }],
+    ["localhost URL", (value: any) => { value.url = value.url.replace("github.com", "localhost"); }],
+    ["private URL", (value: any) => { value.url = value.url.replace("github.com", "192.168.1.4"); }],
+    ["noncanonical URL", (value: any) => { value.url = value.url.replace("/download/", "/download/../download/"); }],
     ["substituted artifact digest", (value: any) => { value.artifactSHA256 = "a".repeat(64); }]
   ])("rejects %s", (_label, mutate) => {
     const value = enclosure(); mutate(value);
@@ -37,7 +40,11 @@ describe("desktop feed enclosure proof", () => {
     expect(() => buildFeedEnclosureProof(enclosure(), { ...options, acceptedPublicKey: "11".repeat(32) })).toThrow();
     expect(() => buildFeedEnclosureProof(enclosure(), { ...options, signedContent: Buffer.from("substituted") })).toThrow();
     const proof = buildFeedEnclosureProof(enclosure(), options);
+    expect(proof.publicKeyFingerprint).toBe("sha256:21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9");
+    expect(proof.signatureScope).toBe("sparkle-artifact-bytes");
     expect(() => serializeFeedEnclosureProof({ ...proof, verified: false })).toThrow();
+    expect(() => serializeFeedEnclosureProof({ ...proof })).toThrow();
+    expect(() => serializeFeedEnclosureProof(JSON.parse(serializeFeedEnclosureProof(proof)))).toThrow();
     const { signedContentSHA256: _omitted, ...missing } = proof;
     expect(() => serializeFeedEnclosureProof(missing)).toThrow();
   });

--- a/tests/desktop-feed-enclosure-proof.test.ts
+++ b/tests/desktop-feed-enclosure-proof.test.ts
@@ -30,6 +30,8 @@ describe("desktop feed enclosure proof", () => {
     ["localhost URL", (value: any) => { value.url = value.url.replace("github.com", "localhost"); }],
     ["private URL", (value: any) => { value.url = value.url.replace("github.com", "192.168.1.4"); }],
     ["noncanonical URL", (value: any) => { value.url = value.url.replace("/download/", "/download/../download/"); }],
+    ["bare query delimiter", (value: any) => { value.url += "?"; }],
+    ["bare fragment delimiter", (value: any) => { value.url += "#"; }],
     ["substituted artifact digest", (value: any) => { value.artifactSHA256 = "a".repeat(64); }]
   ])("rejects %s", (_label, mutate) => {
     const value = enclosure(); mutate(value);
@@ -47,5 +49,17 @@ describe("desktop feed enclosure proof", () => {
     expect(() => serializeFeedEnclosureProof(JSON.parse(serializeFeedEnclosureProof(proof)))).toThrow();
     const { signedContentSHA256: _omitted, ...missing } = proof;
     expect(() => serializeFeedEnclosureProof(missing)).toThrow();
+  });
+
+  it("snapshots the verified signature against accessor substitution", () => {
+    const substituted = Buffer.alloc(64, 1).toString("base64");
+    let reads = 0;
+    const proxied = new Proxy(enclosure(), { get(target, key, receiver) {
+      if (key === "edSignature") { reads += 1; return reads < 3 ? signature : substituted; }
+      return Reflect.get(target, key, receiver);
+    } });
+    const proof = buildFeedEnclosureProof(proxied, options);
+    expect(reads).toBe(1);
+    expect(proof.edSignature).toBe(signature);
   });
 });

--- a/tests/desktop-feed-enclosure-proof.test.ts
+++ b/tests/desktop-feed-enclosure-proof.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildFeedEnclosureProof, feedEnclosureProofDigest, serializeFeedEnclosureProof } from "../scripts/lib/desktop-feed-enclosure-proof.mjs";
+
+const publicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const signedContent = Buffer.from("NeonDiff-1.1.0-beta.7-build42-macOS.zip");
+const artifactSHA256 = "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd36db03d5";
+const signature = "kdfWQEYJInL03AG3nHvaoXVLgg0tqI1z+VUWuR/kcaangjaZ4ZTrN1s3ISdTnOqPhqrvx9uEoqqZ8/iVhCc4Ag==";
+
+function enclosure() {
+  return { url: "https://www.neondiff.com/updates/beta/NeonDiff-1.1.0-beta.7-build42-macOS.zip", version: "1.1.0-beta.7", build: "42", shortVersionString: "1.1.0-beta.7", channel: "beta", artifactName: "NeonDiff-1.1.0-beta.7-build42-macOS.zip", artifactSHA256, edSignature: signature };
+}
+const options = { acceptedPublicKey: Buffer.from(publicKey, "hex").toString("base64"), signedContent };
+
+describe("desktop feed enclosure proof", () => {
+  it("verifies Sparkle bytes and stays deterministic across DTO key order", () => {
+    const first = buildFeedEnclosureProof(enclosure(), options);
+    const reversed = Object.fromEntries(Object.entries(enclosure()).reverse());
+    const second = buildFeedEnclosureProof(reversed, options);
+    expect(second).toEqual(first);
+    expect(serializeFeedEnclosureProof(first)).toBe(serializeFeedEnclosureProof(second));
+    expect(feedEnclosureProofDigest(first)).toMatch(/^[a-f0-9]{64}$/);
+    expect(serializeFeedEnclosureProof(first)).not.toContain(publicKey);
+  });
+
+  it.each([
+    ["extra field", (value: any) => { value.privateKey = "never-accepted"; }],
+    ["missing field", (value: any) => { delete value.edSignature; }],
+    ["malformed signature", (value: any) => { value.edSignature = "not-base64"; }],
+    ["substituted URL", (value: any) => { value.url = value.url.replace("beta.7", "beta.8"); }],
+    ["substituted artifact digest", (value: any) => { value.artifactSHA256 = "a".repeat(64); }]
+  ])("rejects %s", (_label, mutate) => {
+    const value = enclosure(); mutate(value);
+    expect(() => buildFeedEnclosureProof(value, options)).toThrow();
+  });
+
+  it("rejects wrong key, wrong bytes, and false or missing proof", () => {
+    expect(() => buildFeedEnclosureProof(enclosure(), { ...options, acceptedPublicKey: "11".repeat(32) })).toThrow();
+    expect(() => buildFeedEnclosureProof(enclosure(), { ...options, signedContent: Buffer.from("substituted") })).toThrow();
+    const proof = buildFeedEnclosureProof(enclosure(), options);
+    expect(() => serializeFeedEnclosureProof({ ...proof, verified: false })).toThrow();
+    const { signedContentSHA256: _omitted, ...missing } = proof;
+    expect(() => serializeFeedEnclosureProof(missing)).toThrow();
+  });
+});


### PR DESCRIPTION
## Scope

Implements #895 successor A: a production-inert feed-enclosure proof producer that accepts an exact public DTO, verifies the Sparkle Ed25519 signature over exact artifact bytes against an explicit raw public key, and emits a fixed-order secret-free proof/digest.

## Evidence

- Base: `4a8ff430254c9c5cf4c8358d2e5e966142cc6364`
- Candidate: `fb3a52e36a6180f3fec7e8c8b05d682289dbb846`
- 106 added non-generated lines across producer/tests
- `node --check scripts/lib/desktop-feed-enclosure-proof.mjs`: PASS
- direct Node Ed25519/order/substitution smoke: PASS
- `git diff --check`: PASS
- Vitest attempted but host Rollup native binding is rejected for Team-ID mismatch; TypeScript check lacks installed node/vitest type packages

No signing, publication, feed, install, runtime, customer, or downstream receipt mutation is included. This proves only the producer contract; it does not prove release, hosted-feed, runtime, or customer readiness.