### PR TITLE
docs: split Desktop and legacy setup journeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ Use it when you want a GitHub App to review pull requests from a local worker,
 with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
-The current npm CLI (v1.0.4) requires API-backed activation for every repository
+The current npm CLI (v1.0.x) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 provider verification is required for all tiers.
 
-The later managed App/broker path targets public open-source repositories will be free
-with no Activation Key and private/commercial access by entitlement after
-GA. It is separate from the current native BYO journey and is not enforced by
-the current CLI. NeonDiff
+The later managed App/broker targets public open-source repositories will be free with no
+Activation Key; private, internal, and commercial repositories require an active entitlement.
+It remains a separate post-GA path, not current CLI enforcement. NeonDiff
 support licenses cost $1/month or $10/year for individuals,
 or $100/year for organizations. Individual plans include a 7-day trial,
 organization plans include a 30-day trial, and legacy lifetime licenses remain

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ Use it when you want a GitHub App to review pull requests from a local worker,
 with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
-The current npm CLI (v1.0.x) requires API-backed activation for every repository
+The current npm CLI (v1.0.4) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 provider verification is required for all tiers.
 
-Coming with the native app: public open-source repositories will be free with no
-NeonDiff Activation Key, while private, internal, and commercial repositories
-will require an active entitlement. This managed public-free/private-paid model
-ships with the native NeonDiff app and the managed GitHub App broker (#614) and
-is not enforced by the current CLI. NeonDiff
+The later managed App/broker path targets public open-source repositories will be free
+with no Activation Key and private/commercial access by entitlement after
+GA. It is separate from the current native BYO journey and is not enforced by
+the current CLI. NeonDiff
 support licenses cost $1/month or $10/year for individuals,
 or $100/year for organizations. Individual plans include a 7-day trial,
 organization plans include a 30-day trial, and legacy lifetime licenses remain
@@ -70,13 +69,18 @@ evals prove it.
 
 ## Install
 
-Requirements:
+CLI/operator requirements for npm CLI 1.0.4:
 
 - Node.js 26 or newer
 - npm
 - a GitHub App installed on the repos you want to review
 - a model/provider path configured locally, such as GLM/Z.ai, Ollama, or a
   future OpenAI-compatible provider slot
+
+For macOS native first run, use the signed NeonDiff Desktop 1.1.0 UI. The
+signed artifact and distribution availability remain owner-gated; see the
+[Mac GA architecture and release contract](docs/architecture/mac-ga-release-contract.md)
+and [Desktop Mac release runbook](apps/neondiff-desktop/docs/mac-release-runbook.md).
 
 > **v1.0.4 verification notice:** v1.0.4 is the first package intended to enforce
 > mandatory API-backed activation. Verify `npm view neondiff version` and the
@@ -102,18 +106,20 @@ package. To preview without changing your machine:
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
-The public paid B0 Mac beta uses a separate checksum-bound worker bundle from
+**Legacy CLI/operator recovery only — not native Desktop setup:** the checksum-bound
+worker bundle is a separate path from
 the same immutable GitHub prerelease as the app rather than an unpublished npm
 version or an unpinned source checkout. No invitation is required when the
 versioned public GitHub prerelease is published and the neondiff.com
 purchase/download path is live.
 The worker installer requires Node.js 26 or newer resolving through the
 approved stable path `/opt/homebrew/bin/node` or `/usr/local/bin/node`.
-When the app reports **Worker update required**, choose **Install / Update Local
-Worker**. Verify the outer worker bundle ZIP against the prerelease notes, then
+For an existing legacy CLI/LaunchAgent that requires recovery, use **Install /
+Update Local Worker** only after verifying the outer worker bundle ZIP against
+the prerelease notes, then
 verify the extracted release manifest and inner `.tgz` tarball against the
-published SHA-256 values before following the dry-run-first update and rollback
-commands in [docs/SETUP.md](docs/SETUP.md#update-an-existing-local-worker).
+published SHA-256 values before following the legacy `first-install`, update,
+and rollback commands in [docs/SETUP.md](docs/SETUP.md#legacy-clioperator-worker-recovery).
 Retain each verified worker bundle: rollback is available only after a second
 checksum-managed candidate has been installed, and requires the prior
 candidate's exact manifest, published manifest SHA-256, and tarball. The first
@@ -142,9 +148,10 @@ checksum-bound prerelease bundle.
 
 ## Set Up
 
-Follow [docs/SETUP.md](docs/SETUP.md) for the CLI-first setup path (the
-first-run path on non-Mac platforms and the operator/advanced path on Mac). The
-short version is:
+For signed Desktop 1.1.0 native first run, launch the app and follow its UI;
+do not substitute the local dashboard or checksum-worker commands. For npm CLI
+1.0.4 CLI-first, non-Mac, or legacy operator setup, follow
+[docs/SETUP.md](docs/SETUP.md). Its short version is:
 
 ```bash
 neondiff init --config config.local.json
@@ -199,8 +206,8 @@ value or key-file path. The headless app re-derives that device ID from its
 Keychain identity and rejects a mismatched plist before releasing credentials.
 Review and daemon readiness remain separate gates. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
-gates. Unsigned development builds still require an executable global or
-checksum-managed worker before native first run
+gates. Unsigned development builds are not the signed Desktop 1.1.0 customer
+path; use them only for development/operator checks; the signed app
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected

--- a/README.md
+++ b/README.md
@@ -68,18 +68,13 @@ evals prove it.
 
 ## Install
 
-CLI/operator requirements for npm CLI 1.0.4:
+Requirements:
 
 - Node.js 26 or newer
 - npm
 - a GitHub App installed on the repos you want to review
 - a model/provider path configured locally, such as GLM/Z.ai, Ollama, or a
   future OpenAI-compatible provider slot
-
-For macOS native first run, use the signed NeonDiff Desktop 1.1.0 UI. The
-signed artifact and distribution availability remain owner-gated; see the
-[Mac GA architecture and release contract](docs/architecture/mac-ga-release-contract.md)
-and [Desktop Mac release runbook](apps/neondiff-desktop/docs/mac-release-runbook.md).
 
 > **v1.0.4 verification notice:** v1.0.4 is the first package intended to enforce
 > mandatory API-backed activation. Verify `npm view neondiff version` and the
@@ -260,7 +255,7 @@ failure revokes that approval instead of permitting a blind retry. For that
 multi-repository worker, daemon-wide start remains blocked. The selection and
 dry-run approval fail closed if the config, target, pull request, workspace, or
 head changes.
-The same **Verify existing access** action then runs credential-free
+The same **Verify Existing Access** action then runs credential-free
 `license status --refresh true` through that exact matched worker and config.
 It does not read, copy, migrate, or prompt for the worker's Activation Key.
 Useful work unlocks only when GitHub reports the exact repository visibility

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -18,7 +18,7 @@ for the support-tier pricing contract.
 > matching non-prerelease GitHub Release before relying on it; v1.0.3 and
 > earlier do not enforce this boundary.
 
-## Requirements (CLI/operator path)
+## Requirements
 
 - Node.js 26 or newer
 - npm
@@ -265,8 +265,8 @@ For a customer using signed Desktop 1.1.0, the native first-run path is:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
-2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
-   PEM, then choose **Store in Keychain**.
+2. Move the signed app to `/Applications/NeonDiff.app`, launch it, and enter the
+   App ID and private-key PEM, then choose **Store in Keychain**.
 3. In the signed Desktop 1.1.0 UI, complete the displayed repository,
    provider, activation, App-access, and review-readiness steps. The app owns
    native setup; do not use the CLI, local dashboard, or checksum-managed
@@ -397,11 +397,23 @@ remain in setup/recovery and fail closed.
 
 ### Legacy CLI/operator worker recovery
 
-This legacy operator path is not part of signed Desktop 1.1.0 native first run.
-A package version alone is not sufficient: older and compatible technical-beta
-workers may both report `1.0.4`.
+The Mac app checks the exact discovered worker's `review-pr` help contract
+before enabling **Run Dry Review**. A package version alone is not sufficient:
+older and compatible technical-beta workers may both report `1.0.4`.
 
-When an existing legacy worker requires recovery or update:
+For a clean legacy CLI/operator install only, verify the same bundle, manifest,
+and tarball SHA-256 values first, then preview the checksum-bound install:
+
+```bash
+BUNDLE_DIR="$(pwd -P)"
+node install-b0-worker-candidate.mjs first-install \
+  --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
+  --manifest-sha256 <manifest-sha256-from-release> --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
+```
+After reviewing the preview, repeat with `--dry-run false --confirm true`.
+
+If Overview shows **Worker update required**:
 
 1. Do not run or retry a live review from another terminal. The dry-to-live
    approval contract is not proven for that worker.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,10 +1,12 @@
 # NeonDiff Setup
 
-This guide is the CLI-first setup path for the current source-available release,
-and the first-run path on non-Mac platforms. On macOS the native app
-(`apps/neondiff-desktop`) is the human first-run surface; until the native
-broker/launchd proof lands (see the native-broker note below) it hands off to
-this operator/advanced path for setup actions it cannot yet complete natively.
+This guide is the CLI/operator setup path for npm CLI 1.0.4 and the first-run
+path on non-Mac platforms. On macOS, signed NeonDiff Desktop 1.1.0 owns native
+first run through its UI; do not use this guide's CLI, dashboard, or checksum
+worker commands to bootstrap native setup. See the [Mac GA architecture and
+release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac
+release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md) for the
+separate release proof boundary.
 The recommended path installs the `neondiff` npm package; source checkout remains
 a fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
@@ -16,23 +18,20 @@ for the support-tier pricing contract.
 > matching non-prerelease GitHub Release before relying on it; v1.0.3 and
 > earlier do not enforce this boundary.
 
-## Requirements
+## Requirements (CLI/operator path)
 
 - Node.js 26 or newer
 - npm
 - GitHub App credentials for the repos you want to review
 - a provider/model path available on the machine running the worker
-- NeonDiff license key for repository review (the current CLI requires
-  activation for every repository; public open-source review will be free in the
-  native app)
+- NeonDiff license key for repository review (CLI 1.0.4 requires activation for
+  every repository; the later managed path has separate entitlement rules)
 
-The current CLI (v1.0.x) requires API-backed activation for every repository
+The current CLI (v1.0.4) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 GitHub-authoritative visibility (public, private, internal, and unknown) decides
-the tier. Coming with the native app: public open-source repositories will be
-free with no NeonDiff Activation Key, while private, internal, and commercial
-repositories will require an active entitlement (managed GitHub App broker #614;
-not enforced by the current CLI). Support
+the tier. The later managed App/broker targets public-free/private-paid access
+after GA; it is not the current CLI or native BYO setup path. Support
 licenses cost $1/month or $10/year for
 individuals, or $100/year for organizations. Individual plans include a 7-day
 trial, organization plans include a 30-day trial, and legacy lifetime licenses
@@ -262,41 +261,16 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
-For a B0 customer, the native first-run path is:
+For a customer using signed Desktop 1.1.0, the native first-run path is:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
 2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
    PEM, then choose **Store in Keychain**.
-3. On a clean install, if NeonDiff reports that the local worker command is
-   unavailable, choose **Install / Update Local Worker** before **Initialize
-   Local Config**. From the verified extracted bundle, use Node.js 26 or newer
-   through the approved stable path `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`, then preview the credential-free install:
-
-   ```bash
-   BUNDLE_DIR="$(pwd -P)"
-   node install-b0-worker-candidate.mjs first-install \
-     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-     --manifest-sha256 <manifest-sha256-from-release> \
-     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
-     --launchd-label com.electricsheephq.evaos-code-review-bot \
-     --dry-run true
-   ```
-
-   Inspect the public-safe preview, then repeat it with
-   `--dry-run false --confirm true`. It installs only the exact verified CLI
-   into a private versioned current-user directory and writes a 0600
-   credential-free marker. It creates or loads no LaunchAgent, starts no
-   daemon, and never reads or writes GitHub, provider, or license credentials.
-   It refuses an existing LaunchAgent or worker state; use the existing-worker
-   update flow below for those machines. Return to NeonDiff and choose
-   **Install / Update Local Worker** once more to refresh discovery; when the
-   worker is available, choose **Initialize Local Config**. Initialization
-   invokes the non-destructive `neondiff init` path without `--force`, never
-   overwrites an existing config, and keeps bot-isolated runtime, state,
-   evidence, and license paths beside the config. Review and daemon readiness
-   remain separate gates.
+3. In the signed Desktop 1.1.0 UI, complete the displayed repository,
+   provider, activation, App-access, and review-readiness steps. The app owns
+   native setup; do not use the CLI, local dashboard, or checksum-managed
+   worker as a prerequisite or fallback for this journey.
 4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
    Repository**. The app writes the allowlist through the typed local `config
    patch` command and ensures every selected repository has an enabled local
@@ -421,23 +395,23 @@ A local config path, launchd label, App ID, or repository name by itself is not
 authority. Suspended, revoked, pending, mismatched, or server-unrecognized bots
 remain in setup/recovery and fail closed.
 
-### Update an existing local worker
+### Legacy CLI/operator worker recovery
 
-The Mac app checks the exact discovered worker's `review-pr` help contract
-before enabling **Run Dry Review**. A package version alone is not sufficient:
-older and compatible technical-beta workers may both report `1.0.4`.
+This legacy operator path is not part of signed Desktop 1.1.0 native first run.
+A package version alone is not sufficient: older and compatible technical-beta
+workers may both report `1.0.4`.
 
-If Overview shows **Worker update required**:
+When an existing legacy worker requires recovery or update:
 
 1. Do not run or retry a live review from another terminal. The dry-to-live
    approval contract is not proven for that worker.
-2. Choose **Install / Update Local Worker**. Use only the outer worker bundle
-   ZIP named in the same immutable GitHub prerelease and release manifest as the
-   installed app. Before extracting it, compare the bundle ZIP SHA-256 with the
-   prerelease notes. After extraction, compare the release manifest SHA-256 with
-   the prerelease notes, then compare the inner `.tgz` tarball SHA-256 with both
-   the release manifest and the prerelease notes. Do not use an unpinned `main`
-   checkout or trust the ambiguous `1.0.4` version string.
+2. Use only the outer worker bundle ZIP named in the same immutable GitHub
+   prerelease and release manifest as the installed app. Before extracting it,
+   compare the bundle ZIP SHA-256 with the prerelease notes. After extraction,
+   compare the release manifest SHA-256 with the prerelease notes, then compare
+   the inner `.tgz` tarball SHA-256 with both the release manifest and the
+   prerelease notes. Do not use an unpinned `main` checkout or trust the
+   ambiguous `1.0.4` version string.
 3. Confirm `node --version` reports Node.js 26 or newer. From the extracted
    directory, preview the checksum-bound migration using the exact LaunchAgent
    label shown in NeonDiff Settings. The installer requires absolute artifact

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -27,7 +27,7 @@ for the support-tier pricing contract.
 - NeonDiff license key for repository review (CLI 1.0.4 requires activation for
   every repository; the later managed path has separate entitlement rules)
 
-The current CLI (v1.0.4) requires API-backed activation for every repository
+The current CLI (v1.0.x) requires API-backed activation for every repository
 (public, private, internal, and unknown); unknown visibility fails closed, and
 GitHub-authoritative visibility (public, private, internal, and unknown) decides
 the tier. The later managed App/broker targets public-free/private-paid access
@@ -320,7 +320,7 @@ After App access, provider, repository, and activation are verified, the native
 daemon step offers **Preview Start** followed by **Install & Start** when no
 supported LaunchAgent exists. Preview validates the exact signed
 `/Applications/NeonDiff.app`, account-scoped config, customer-owned App ID, and
-the worker sealed inside the signed app. Confirmed install writes one 0600 secret-free plist in
+the sealed helper `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`. Confirmed install writes one 0600 secret-free plist in
 `~/Library/LaunchAgents` and starts it through the current user's launchd
 domain. The plist invokes the signed app's bounded headless mode and contains no
 private-key value or file path. It includes the non-secret broker device ID
@@ -370,7 +370,7 @@ the same Mac. In that exact case it opens a reconciliation path:
   copying its private key. The key file must be a current-user-owned regular
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
-- its single **Verify existing access** action first proves the exact App and
+- its single **Verify Existing Access** action first proves the exact App and
   Review Target with `doctor github --repo`. A legacy credential-bearing
   matched worker then runs credential-free
   `license status --refresh true` through that exact worker and config. A
@@ -401,17 +401,12 @@ The Mac app checks the exact discovered worker's `review-pr` help contract
 before enabling **Run Dry Review**. A package version alone is not sufficient:
 older and compatible technical-beta workers may both report `1.0.4`.
 
-For a clean legacy CLI/operator install only, verify the same bundle, manifest,
-and tarball SHA-256 values first, then preview the checksum-bound install:
-
+For a clean legacy CLI/operator install, verify bundle, manifest, and tarball SHA-256, then preview:
 ```bash
 BUNDLE_DIR="$(pwd -P)"
-node install-b0-worker-candidate.mjs first-install \
-  --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-  --manifest-sha256 <manifest-sha256-from-release> --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
+node install-b0-worker-candidate.mjs first-install --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" --manifest-sha256 <manifest-sha256-from-release> --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
 ```
-After reviewing the preview, repeat with `--dry-run false --confirm true`.
+After review, repeat with `--dry-run false --confirm true`; invoke the private CLI (no PATH or LaunchAgent effect) as `/opt/homebrew/bin/node "$HOME/Library/Application Support/NeonDiffDesktop/Workers/<label>/current/node_modules/neondiff/dist/src/cli.js" init --config config.local.json` (use `/usr/local/bin/node` when approved).
 
 If Overview shows **Worker update required**:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,15 +5,14 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
-The public paid B0 BYO build accepts the customer's own App ID and private key,
-one selected repository, and runs the explicit installation check from the
-wizard. No invitation is required when the versioned public GitHub prerelease is
-published and the neondiff.com purchase/download path is live. The managed B1
-path uses the official NeonDiff App and broker under #613; it is separate from
-B0. This document remains the operator/CLI reference for both paths' App
-identity, permission set, and install boundary. Matching public website
-onboarding copy lives in the website repo under neon-diff-agent-website#52.
+On macOS, the signed Desktop 1.1.0 app is the native first-run surface. This
+page remains the App registration, permission, and selected-repository
+reference for the CLI/operator and native BYO journeys. The official managed B1
+App and broker are a separate post-GA path. See the [Mac GA architecture and
+release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac
+release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
+Matching public website onboarding copy lives in the website repo under
+neon-diff-agent-website#52.
 
 ## Install URL
 
@@ -88,6 +87,10 @@ because milestone or planning days can create large issue bursts.
 
 ## Selected-Repo Install Path
 
+For signed Desktop 1.1.0 native first run, launch the app and follow its UI.
+The checksum-managed `first-install`, update, and rollback commands below are
+legacy CLI/operator recovery only.
+
 > This page covers the shipped **local-worker direct install**, where the worker
 > holds the App private key itself and no OAuth-during-install step is needed. The
 > separate **managed authorization broker** (official App registered, source
@@ -130,42 +133,11 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In native NeonDiff first run, store the App ID and private key. On a clean
-   Mac, choose **Install / Update Local Worker** and complete the checksum-bound
-   `first-install` with Node.js 26 or newer through `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`. Return to NeonDiff, choose **Install / Update Local
-   Worker** once more to refresh discovery, then choose **Initialize Local
-   Config**. Enter the same `owner/repo`, then choose **Add Repository**,
-   **Apply Repository**, and **Verify App Access**.
-   Initialization never uses `--force`; the app updates `pilotRepos` and the
-   selected repository's enabled policy profile through `config patch`, and no
-   operator edits the customer's config file. Existing policy fields for that
-   repository are preserved. If verification reports a missing or disabled
-   repository policy profile, apply the repository again before retrying
-   verification; that
-   message does not mean the App installation is missing. Each new
-   bot config receives isolated runtime, state, evidence, and license paths
-   beside that config rather than the packaged worker's placeholder paths. An
-   account with no bot gets this isolated plan before the initialization action
-   appears; the app never initializes the `_unselected` placeholder.
-   If NeonDiff is quit mid-setup, relaunch restores that exact pending bot and
-   config path and reopens onboarding. It does not silently fall back to an
-   existing local bot on the same account or allocate another numbered config
-   directory; the customer can explicitly choose another account or bot to end
-   the pending flow.
-   If one exact checksum-managed worker exists, these isolated config commands
-   and the bounded private-key-stdin GitHub doctor reuse that worker instead of
-   resolving through a global `neondiff` command. On a clean Mac, the bundle's
-   confirmed `first-install` command creates only a private versioned CLI and
-   credential-free 0600 marker; it creates or loads no LaunchAgent and starts
-   no daemon. The new bot receives no inherited credential environment. Zero
-   or ambiguous managed-worker discovery does not select this reuse path.
-   If the configured local worker command is unavailable, the CLI-backed
-   controls remain disabled and **Install / Update Local Worker** opens the
-   version-matched release guide. Continue only with its checksum-bound
-   manifest/tarball and dry-run-default, confirm-required `first-install`
-   command. Source support does not prove that immutable release publication,
-   signing, clean-Mac execution, review, or daemon readiness has passed.
+7. For npm CLI 1.0.4/operator setup, continue with the CLI steps in
+   [SETUP.md](SETUP.md#1-install-neondiff). For signed Desktop 1.1.0 native
+   first run, launch the app and complete its UI instead. The native path does
+   not require a global CLI or checksum-managed `first-install`; do not choose
+   **Install / Update Local Worker** to bootstrap it.
 
 8. After App access, provider, repository, and activation are verified, use the
    native daemon step's **Preview Start** and **Install & Start** actions. The
@@ -224,7 +196,8 @@ returned head SHA, and requires explicit confirmation before a live post pinned
 to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
-If this matched local worker reports **Worker update required**, choose
+For an existing legacy CLI/LaunchAgent only, if the matched worker reports
+**Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle
 named in the same immutable GitHub prerelease and release manifest as the app.
 Verify the outer bundle ZIP against the prerelease notes before extraction.
@@ -232,7 +205,7 @@ Then verify the release manifest against its SHA-256 in the prerelease notes,
 and verify the inner `.tgz` tarball against the SHA-256 in both the release
 manifest and prerelease notes before following the Node.js 26+, absolute-path,
 dry-run, and confirmed-mutation steps in
-[SETUP.md](./SETUP.md#update-an-existing-local-worker). The label-isolated
+[SETUP.md](./SETUP.md#legacy-clioperator-worker-recovery). The label-isolated
 installer preserves the existing App environment, config, provider state,
 repository allowlist, and private-key file coordinate. Preview rollback before
 confirmed rollback; neither path reads or copies key bytes. When a stable
@@ -260,9 +233,9 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-Run the GitHub-only doctor before provider or daemon checks. For the native B0
-app, use the config created in the app's user-writable Application Support
-directory:
+Run the GitHub-only doctor before provider or daemon checks. For signed Desktop
+1.1.0 native first run, use the app's **Verify App Access** UI action; the CLI
+commands below are for CLI/operator diagnostics:
 
 ```bash
 NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,8 +5,8 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS, signed Desktop 1.1.0 owns native first run through its UI. The public
-paid B0 BYO/customer-owned build accepts the customer's own App ID and private key,
+On macOS, signed Desktop 1.1.0 owns native first run through its UI. The public BYO/customer-owned
+paid B0 build accepts the customer's own App ID and private key,
 one selected repository, and runs the explicit installation check from the wizard.
 No invitation is required when the versioned public GitHub prerelease is
 published and the neondiff.com purchase/download path is live. The managed B1 App

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -7,8 +7,8 @@ configuration, state database, and evidence files.
 
 On macOS, signed Desktop 1.1.0 owns native first run through its UI. The
 public paid BYO/customer-owned B0 build accepts the customer's App ID and private key,
-one selected repository, and runs the explicit installation check. No invitation
-is required when the versioned public GitHub prerelease is published and the
+one selected repository, and runs the explicit installation check. No invitation is required
+when the versioned public GitHub prerelease is published and the
 neondiff.com purchase/download path is live.
 The managed B1 App/broker is separate post-GA; see the [Mac GA architecture and
 release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac release

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,12 +5,15 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS, the signed Desktop 1.1.0 app is the native first-run surface. This
-page remains the App registration, permission, and selected-repository
-reference for the CLI/operator and native BYO journeys. The official managed B1
-App and broker are a separate post-GA path. See the [Mac GA architecture and
-release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac
-release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
+On macOS, signed Desktop 1.1.0 owns native first run through its UI. The public
+paid B0 BYO/customer-owned build accepts the customer's own App ID and private key,
+one selected repository, and runs the explicit installation check from the wizard.
+No invitation is required when the versioned public GitHub prerelease is
+published and the neondiff.com purchase/download path is live. The managed B1 App
+and broker are a separate post-GA path. This document remains the operator/CLI
+reference for both paths' App identity, permission set, and install boundary.
+See the [Mac GA architecture and release contract](architecture/mac-ga-release-contract.md)
+and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 Matching public website onboarding copy lives in the website repo under
 neon-diff-agent-website#52.
 
@@ -233,9 +236,9 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-Run the GitHub-only doctor before provider or daemon checks. For signed Desktop
-1.1.0 native first run, use the app's **Verify App Access** UI action; the CLI
-commands below are for CLI/operator diagnostics:
+Run the GitHub-only doctor before provider or daemon checks. For the native B0
+app, use the config created in the app's user-writable Application Support
+directory:
 
 ```bash
 NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,8 +5,8 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS, signed Desktop 1.1.0 owns native first run through its UI. The public
-paid BYO/customer-owned B0 build accepts the customer's App ID and private key,
+On macOS, signed Desktop 1.1.0 owns native first run through its UI. The
+public paid BYO/customer-owned B0 build accepts the customer's App ID and private key,
 one selected repository, and runs the explicit installation check. No invitation
 is required when the versioned public GitHub prerelease is published and the
 neondiff.com purchase/download path is live.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,17 +5,16 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS, signed Desktop 1.1.0 owns native first run through its UI. The public BYO/customer-owned
-paid B0 build accepts the customer's own App ID and private key,
-one selected repository, and runs the explicit installation check from the wizard.
-No invitation is required when the versioned public GitHub prerelease is
-published and the neondiff.com purchase/download path is live. The managed B1 App
-and broker are a separate post-GA path. This document remains the operator/CLI
-reference for both paths' App identity, permission set, and install boundary.
-See the [Mac GA architecture and release contract](architecture/mac-ga-release-contract.md)
-and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
-Matching public website onboarding copy lives in the website repo under
-neon-diff-agent-website#52.
+On macOS, signed Desktop 1.1.0 owns native first run through its UI. The public
+paid BYO/customer-owned B0 build accepts the customer's App ID and private key,
+one selected repository, and runs the explicit installation check. No invitation
+is required when the versioned public GitHub prerelease is published and the
+neondiff.com purchase/download path is live.
+The managed B1 App/broker is separate post-GA; see the [Mac GA architecture and
+release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac release
+runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md). This remains the
+canonical App registration/recovery reference. Stable onboarding is [neondiff.com/mac](https://www.neondiff.com/mac),
+delivered by website #132 from issue #52.
 
 ## Install URL
 
@@ -90,10 +89,6 @@ because milestone or planning days can create large issue bursts.
 
 ## Selected-Repo Install Path
 
-For signed Desktop 1.1.0 native first run, launch the app and follow its UI.
-The checksum-managed `first-install`, update, and rollback commands below are
-legacy CLI/operator recovery only.
-
 > This page covers the shipped **local-worker direct install**, where the worker
 > holds the App private key itself and no OAuth-during-install step is needed. The
 > separate **managed authorization broker** (official App registered, source
@@ -149,7 +144,8 @@ integration proof under #630.
    config, launchd label, and non-secret activation device ID. Its headless mode
    re-derives that device ID from the existing broker identity in the app-owned
    Keychain, rejects any mismatch before reading credentials, validates the
-   checksum-managed worker, and hands the private key plus API-backed activation
+   sealed helper at `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`,
+   and hands the private key plus API-backed activation
    credential to the local worker only through one bounded JSON stdin envelope.
    It never exports either secret, writes a PEM or license file, places a secret
    in the plist or environment, or uses a generic `security -w` wrapper. Any
@@ -174,7 +170,7 @@ repository-scoped entitlement must still pass before a new dry or live review.
 Local config alone never establishes membership, installation authority, or
 review authorization.
 
-The single **Verify existing access** action first runs `doctor github` for the
+The single **Verify Existing Access** action first runs `doctor github` for the
 exact selected repository. A legacy credential-bearing matched worker then runs
 credential-free `license status --refresh true --json` through that exact
 worker and config. A secret-free Keychain-backed worker instead revalidates the
@@ -199,8 +195,7 @@ returned head SHA, and requires explicit confirmation before a live post pinned
 to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
-For an existing legacy CLI/LaunchAgent only, if the matched worker reports
-**Worker update required**, choose
+If this matched local worker reports **Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle
 named in the same immutable GitHub prerelease and release manifest as the app.
 Verify the outer bundle ZIP against the prerelease notes before extraction.
@@ -236,13 +231,13 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-Run the GitHub-only doctor before provider or daemon checks. For the native B0
-app, use the config created in the app's user-writable Application Support
-directory:
+For signed Desktop 1.1.0 native first run, use **Verify App Access** for a new
+customer-owned App or **Verify Existing Access** for a compatible existing agent
+in the UI. The shell command below is CLI/operator diagnostics only:
 
 ```bash
-NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
-neondiff doctor github --config "$NATIVE_CONFIG" --repo owner/repo --json
+CLI_CONFIG="config.local.json"
+neondiff doctor github --config "$CLI_CONFIG" --repo owner/repo --json
 ```
 
 CLI-first and non-Mac setups may instead use the checkout-local path documented


### PR DESCRIPTION
## Summary
- make signed Desktop 1.1.0 UI the explicit macOS native first-run path
- label npm CLI 1.0.4 and checksum-worker install/update/first-install as CLI/operator or legacy recovery only
- keep the managed App/broker post-GA and link the canonical architecture and Desktop release runbook

Related: #610

## Validation
- `npm run check:public-claims`
- `npm run check:secrets`
- `npm run check:design-source`
- `git diff --check`
- changed files: README.md, docs/SETUP.md, docs/github-app-setup.md
- diff: 200 changed lines (77 insertions, 123 deletions)

## Boundary
This docs slice does not claim GA, signed-artifact availability, distribution completion, runtime/customer readiness, or managed-App production enablement. It does not change source, tests, manifests, launchd, or Desktop code.