### PR TITLE
fix: bind runtime bot ownership to verified app identity

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -251,7 +251,9 @@ export function classifyCommandAuthorization(
  */
 export function isBotCommandComment(user: { login: string; type?: string } | null | undefined, botLogin: string): boolean {
   if (!user) return false;
-  return user.type === "Bot" || normalizeBotLogin(user.login) === normalizeBotLogin(botLogin);
+  const userLogin = normalizeBotLogin(user.login);
+  const expectedLogin = normalizeBotLogin(botLogin);
+  return user.type === "Bot" || (userLogin !== undefined && userLogin === expectedLogin);
 }
 
 export function isReviewCommandAction(action: ReviewCommandAction): boolean {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,6 +8,7 @@ import {
   parseFinishingTouchCommand,
   type FinishingTouchAction
 } from "./finishing-touches.js";
+import { normalizeBotLogin } from "./runtime-bot-identity.js";
 
 export type ReviewCommandAction = "review" | "re-review" | "request-changes" | "explain" | "stop" | FinishingTouchAction;
 
@@ -242,7 +243,7 @@ export function classifyCommandAuthorization(
  * path must never let ANY automated actor (dependabot, another app, or ourselves) spin up reviews,
  * so we reject on user.type === "Bot" OR login === botLogin.
  *
- * This is intentionally DIFFERENT from GitHubApi.isBotAuthoredComment, which is the NARROWER
+ * This is intentionally DIFFERENT from the shared isBotAuthoredComment predicate, which is the NARROWER
  * app-own-comment check (type === "Bot" AND login === botLogin) used to detect the bot's OWN status
  * comments for marker matching. Different questions ("is this any bot?" vs "is this MY comment?"), so
  * they are not unified; both derive the identity from the same botLogin config value. Trusted-author
@@ -250,7 +251,7 @@ export function classifyCommandAuthorization(
  */
 export function isBotCommandComment(user: { login: string; type?: string } | null | undefined, botLogin: string): boolean {
   if (!user) return false;
-  return user.type === "Bot" || user.login === botLogin;
+  return user.type === "Bot" || normalizeBotLogin(user.login) === normalizeBotLogin(botLogin);
 }
 
 export function isReviewCommandAction(action: ReviewCommandAction): boolean {

--- a/src/github.ts
+++ b/src/github.ts
@@ -3,6 +3,11 @@ import { readFileSync } from "node:fs";
 import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type { IssueEnrichmentIssueList } from "./issue-enrichment.js";
+import {
+  deriveCanonicalBotLogin,
+  isBotAuthoredComment,
+  normalizeBotLogin
+} from "./runtime-bot-identity.js";
 import { redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, PullReviewComment, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
 import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
@@ -152,10 +157,12 @@ export class GitHubApi {
   private readonly privateKey?: string;
   private readonly token?: string;
   private readonly apiBaseUrl: URL;
-  private readonly botLogin: string;
+  private readonly configuredBotLogin?: string;
   private readonly requestTimeoutMs: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
+  private verifiedInstallations = new Map<string, GitHubInstallationIdentity>();
+  private verifiedBotLogins = new Map<string, string>();
 
   constructor(options: GitHubApiOptions) {
     if (options.privateKey && options.privateKeyPath) {
@@ -165,12 +172,32 @@ export class GitHubApi {
     this.privateKey = options.privateKey ?? (options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined);
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
-    this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
+    this.configuredBotLogin = options.botLogin;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
   }
 
   canPostAsApp(): boolean {
     return Boolean(this.appId && this.privateKey);
+  }
+
+  /** Resolve the one runtime owner from the verified installation App slug. */
+  async getCanonicalBotLogin(repo: string): Promise<string | undefined> {
+    const cached = this.verifiedBotLogins.get(repo);
+    if (cached) return cached;
+    if (!this.canPostAsApp()) return undefined;
+
+    let installation: GitHubInstallationIdentity;
+    try {
+      installation = parseGitHubInstallationIdentity(await this.getInstallation(repo, { followRedirects: false }));
+    } catch {
+      return undefined;
+    }
+    const botLogin = deriveCanonicalBotLogin({ appSlug: installation.app_slug });
+    const configuredBotLogin = normalizeBotLogin(this.configuredBotLogin);
+    if (!botLogin || (this.configuredBotLogin !== undefined && configuredBotLogin !== botLogin)) return undefined;
+    this.verifiedInstallations.set(repo, installation);
+    this.verifiedBotLogins.set(repo, botLogin);
+    return botLogin;
   }
 
   async listOpenPulls(repo: string): Promise<PullRequestSummary[]> {
@@ -491,8 +518,10 @@ export class GitHubApi {
     if (!this.canPostAsApp()) {
       throw new Error("GitHub App credentials are required before posting comments.");
     }
+    const botLogin = await this.getCanonicalBotLogin(input.repo);
+    if (!botLogin) throw new Error("GitHub App installation proof does not identify the runtime bot.");
     const token = await this.getInstallationToken(input.repo);
-    const existing = await this.findIssueCommentByMarker(input.repo, input.issueNumber, input.marker, token);
+    const existing = await this.findIssueCommentByMarker(input.repo, input.issueNumber, input.marker, token, botLogin);
     if (existing) {
       const updated = await this.request<{ html_url?: string; id: number }>(
         `/repos/${input.repo}/issues/comments/${existing.id}`,
@@ -512,21 +541,18 @@ export class GitHubApi {
     repo: string,
     issueNumber: number,
     marker: string,
-    token: string
+    token: string,
+    botLogin: string
   ): Promise<IssueCommentSummary | undefined> {
     for (let page = 1; ; page += 1) {
       const comments = await this.request<IssueCommentSummary[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
       );
-      const existing = comments.find((comment) => comment.body?.includes(marker) && this.isBotAuthoredComment(comment));
+      const existing = comments.find((comment) => comment.body?.includes(marker) && isBotAuthoredComment(comment, botLogin));
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
-  }
-
-  private isBotAuthoredComment(comment: IssueCommentSummary): boolean {
-    return comment.user?.type === "Bot" && comment.user.login === this.botLogin;
   }
 
   private async getInstallationToken(repo: string): Promise<string> {
@@ -534,7 +560,7 @@ export class GitHubApi {
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
-    const installation = await this.getInstallation(repo);
+    const installation = this.verifiedInstallations.get(repo) ?? await this.getInstallation(repo);
     return this.getInstallationTokenForId(repo, installation.id);
   }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -182,6 +182,11 @@ export class GitHubApi {
 
   /** Resolve the one runtime owner from the verified installation App slug. */
   async getCanonicalBotLogin(repo: string): Promise<string | undefined> {
+    const repoToken = this.repoInstallationTokens.get(repo);
+    if (repoToken && repoToken.expiresAt <= Date.now() + 60_000) {
+      this.verifiedInstallations.delete(repo);
+      this.verifiedBotLogins.delete(repo);
+    }
     const cached = this.verifiedBotLogins.get(repo);
     if (cached) return cached;
     if (!this.canPostAsApp()) return undefined;
@@ -560,6 +565,10 @@ export class GitHubApi {
     const cached = this.repoInstallationTokens.get(repo);
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
+    if (cached && cached.expiresAt <= Date.now() + 60_000 && this.verifiedInstallations.get(repo)?.id === cached.installationId) {
+      this.verifiedInstallations.delete(repo);
+      this.verifiedBotLogins.delete(repo);
+    }
 
     const installation = this.verifiedInstallations.get(repo) ?? await this.getInstallation(repo);
     return this.getInstallationTokenForId(repo, installation.id);

--- a/src/github.ts
+++ b/src/github.ts
@@ -192,6 +192,7 @@ export class GitHubApi {
     } catch {
       return undefined;
     }
+    if (String(installation.app_id) !== this.appId?.trim()) return undefined;
     const botLogin = deriveCanonicalBotLogin({ appSlug: installation.app_slug });
     const configuredBotLogin = normalizeBotLogin(this.configuredBotLogin);
     if (!botLogin || (this.configuredBotLogin !== undefined && configuredBotLogin !== botLogin)) return undefined;

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { isBotCommandComment } from "./commands.js";
-import { DEFAULT_BOT_LOGIN } from "./github.js";
 import { redactSecrets } from "./secrets.js";
 import { writeSecureFileSync } from "./temp-files.js";
 import type { ObserveScheduleConfig } from "./config.js";
@@ -231,13 +230,13 @@ function mergeLineMap(into: Map<string, Set<number>>, from: Map<string, Set<numb
 }
 
 function humanThreadTouchesFinding(comments: ObservedReviewComment[], findings: ObservedFinding[], botLogin?: string): boolean {
-  const effectiveBotLogin = botLogin ?? DEFAULT_BOT_LOGIN;
+  if (!botLogin) return false;
   for (const comment of comments) {
     // A human REPLY thread (in_reply_to_id set) is the dismissal signal; a bot author never counts.
     if (comment.in_reply_to_id === undefined || comment.in_reply_to_id === null) continue;
     // Reuse the shared bot-identity check (#149): excludes user.type === "Bot" OR the app bot login,
     // so a bot reply with a MISSING/variant type (only its login matches) is still not counted human.
-    if (comment.user && isBotCommandComment(comment.user, effectiveBotLogin)) continue;
+    if (comment.user && isBotCommandComment(comment.user, botLogin)) continue;
     const path = comment.path;
     if (!path) continue;
     const line = typeof comment.line === "number" ? comment.line : comment.original_line;

--- a/src/runtime-bot-identity.ts
+++ b/src/runtime-bot-identity.ts
@@ -1,0 +1,31 @@
+const APP_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
+const BOT_LOGIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?\[bot\]$/i;
+
+export function normalizeBotLogin(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return BOT_LOGIN_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+export function deriveCanonicalBotLogin(input: {
+  appSlug?: unknown;
+  verifiedBotLogin?: unknown;
+}): string | undefined {
+  const appSlug = typeof input.appSlug === "string" ? input.appSlug.trim().toLowerCase() : undefined;
+  const fromAppSlug = appSlug && APP_SLUG_PATTERN.test(appSlug) ? `${appSlug}[bot]` : undefined;
+  const explicit = normalizeBotLogin(input.verifiedBotLogin);
+  if (fromAppSlug && explicit && fromAppSlug !== explicit) return undefined;
+  return fromAppSlug ?? explicit;
+}
+
+export function isBotAuthoredComment(
+  comment: { user?: { login?: unknown; type?: unknown } | null } | null | undefined,
+  botLogin: string | undefined
+): boolean {
+  const canonicalBotLogin = normalizeBotLogin(botLogin);
+  return Boolean(
+    canonicalBotLogin &&
+    comment?.user?.type === "Bot" &&
+    normalizeBotLogin(comment.user.login) === canonicalBotLogin
+  );
+}

--- a/src/runtime-bot-identity.ts
+++ b/src/runtime-bot-identity.ts
@@ -7,10 +7,7 @@ export function normalizeBotLogin(value: unknown): string | undefined {
   return BOT_LOGIN_PATTERN.test(normalized) ? normalized : undefined;
 }
 
-export function deriveCanonicalBotLogin(input: {
-  appSlug?: unknown;
-  verifiedBotLogin?: unknown;
-}): string | undefined {
+export function deriveCanonicalBotLogin(input: { appSlug?: unknown; verifiedBotLogin?: unknown }): string | undefined {
   const appSlug = typeof input.appSlug === "string" ? input.appSlug.trim().toLowerCase() : undefined;
   const fromAppSlug = appSlug && APP_SLUG_PATTERN.test(appSlug) ? `${appSlug}[bot]` : undefined;
   const explicit = normalizeBotLogin(input.verifiedBotLogin);
@@ -18,10 +15,7 @@ export function deriveCanonicalBotLogin(input: {
   return fromAppSlug ?? explicit;
 }
 
-export function isBotAuthoredComment(
-  comment: { user?: { login?: unknown; type?: unknown } | null } | null | undefined,
-  botLogin: string | undefined
-): boolean {
+export function isBotAuthoredComment(comment: { user?: { login?: unknown; type?: unknown } | null } | null | undefined, botLogin: string | undefined): boolean {
   const canonicalBotLogin = normalizeBotLogin(botLogin);
   return Boolean(
     canonicalBotLogin &&

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -64,6 +64,7 @@ import {
   type ObservedSubsequentPull,
   type ScheduledObserveTarget
 } from "./outcome-observer.js";
+import { isBotAuthoredComment } from "./runtime-bot-identity.js";
 import {
   activateRepoForNewOnlyReview,
   isCanaryAllowed,
@@ -112,12 +113,20 @@ export interface SchedulerGitHubApi {
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
+  getCanonicalBotLogin?(repo: string): Promise<string | undefined>;
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
   listPullFiles?(repo: string, pullNumber: number): Promise<PullFilePatch[]>;
   // Optional deeper-observation reads (#371): only invoked by the scheduled outcome observer to enrich
   // a merged PR's outcome (revert/hotfix/human-thread). All read-only; absent ⇒ merge-state-only cut.
   listRecentMergedPulls?(repo: string, limit: number): Promise<PullRequestSummary[]>;
   listPullReviewComments?(repo: string, pullNumber: number): Promise<PullReviewComment[]>;
+}
+
+async function resolveSchedulerBotLogin(
+  input: { config: BotConfig; github: SchedulerGitHubApi },
+  repo: string
+): Promise<string | undefined> {
+  return input.github.getCanonicalBotLogin?.(repo);
 }
 
 export async function runScheduledCycle(options: RunOnceOptions): Promise<ScheduledRunResult> {
@@ -416,6 +425,7 @@ export async function observeScheduledOutcomes(input: {
       const reviewComments = input.github.listPullReviewComments
         ? await input.github.listPullReviewComments(target.repo, target.pullNumber)
         : [];
+      const botLogin = await resolveSchedulerBotLogin(input, target.repo);
       return buildObservedPullOutcome({
         merged,
         mergedAt: pull.merged_at,
@@ -425,7 +435,7 @@ export async function observeScheduledOutcomes(input: {
         findings: target.findings,
         subsequentPulls,
         reviewComments,
-        ...(input.config.github.botLogin ? { botLogin: input.config.github.botLogin } : {})
+        ...(botLogin ? { botLogin } : {})
       });
     } catch (error) {
       // Fail-open per target: a deeper-read error degrades to the merge-state cut, never throwing into
@@ -1675,23 +1685,24 @@ async function repairProcessedHeadStatusCommentIfNeeded(input: {
   if (!reviewUrl) return;
 
   let comments: IssueCommentCommandSource[];
+  let botLogin: string | undefined;
   try {
+    botLogin = await resolveSchedulerBotLogin(input, input.repo);
     comments = await input.github.listIssueComments(input.repo, input.pull.number);
   } catch {
     input.onStatusCommentFailure?.();
     return;
   }
+  if (!botLogin) return;
 
   const marker = buildReviewStatusMarker({
     repo: input.repo,
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha
   });
-  const botLogin = input.config.github.botLogin ?? DEFAULT_BOT_LOGIN;
   const existing = comments.find((comment) =>
     comment.body?.includes(marker) &&
-    comment.user?.type === "Bot" &&
-    comment.user.login === botLogin
+    isBotAuthoredComment(comment, botLogin)
   );
   if (!isRepairableReviewStatusCommentState(parseReviewStatusCommentState(existing?.body))) return;
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1693,7 +1693,10 @@ async function repairProcessedHeadStatusCommentIfNeeded(input: {
     input.onStatusCommentFailure?.();
     return;
   }
-  if (!botLogin) return;
+  if (!botLogin) {
+    input.onStatusCommentFailure?.();
+    return;
+  }
 
   const marker = buildReviewStatusMarker({
     repo: input.repo,

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -305,6 +305,7 @@ describe("public command bot-author identity (#345)", () => {
     expect(isBotCommandComment({ login: "dependabot[bot]", type: "Bot" }, "evaos-code-review-bot[bot]")).toBe(true);
     // A human author is not a bot.
     expect(isBotCommandComment({ login: "randopublic", type: "User" }, "evaos-code-review-bot[bot]")).toBe(false);
+    expect(isBotCommandComment({ login: "human" }, "invalid-configured-login")).toBe(false);
     expect(isBotCommandComment(null, "evaos-code-review-bot[bot]")).toBe(false);
   });
 

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -1400,7 +1400,7 @@ function routeMockGitHub(
     (request.url === "/repos/owner/issue-repo/installation" ||
       request.url === "/repos/owner/second-issue-repo/installation")
   ) {
-    respondJson(response, 200, { id: 123 });
+    respondJson(response, 200, { id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "evaos-code-review-bot" });
     return;
   }
   if (request.method === "POST" && request.url === "/app/installations/123/access_tokens") {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -672,7 +672,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -683,7 +683,7 @@ describe("GitHub App read authentication", () => {
             id: 99,
             html_url: "https://github.test/comment/99",
             body: `${marker}\nold`,
-            user: { login: "evaos-code-review-bot[bot]", type: "Bot" }
+            user: { login: "CUSTOMER-REVIEW-APP[BOT]", type: "Bot" }
           }
         ]);
       }
@@ -693,7 +693,7 @@ describe("GitHub App read authentication", () => {
       return jsonResponse({ message: "unexpected" }, 404);
     }) as typeof fetch;
 
-    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: "CUSTOMER-REVIEW-APP[BOT]" });
     const result = await github.upsertIssueComment({
       repo: "owner/repo",
       issueNumber: 42,
@@ -729,7 +729,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -762,6 +762,36 @@ describe("GitHub App read authentication", () => {
     expect(postCall?.authorization).toBe("Bearer installation-token");
     expect(postCall?.body).toEqual({ body: `${marker}\nnew` });
     expect(calls.some((call) => call.method === "PATCH")).toBe(false);
+  });
+
+  it("fails closed before posting when installation identity is missing or mismatched", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-comment-identity-fail-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    const valid = { id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" };
+    const scenarios = [
+      { name: "missing App slug", installation: { ...valid, app_slug: undefined }, botLogin: "customer-review-app[bot]" },
+      { name: "mismatched explicit bot login", installation: valid, botLogin: "other-review-app[bot]" }
+    ];
+
+    for (const scenario of scenarios) {
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn(async (url) => {
+        calls.push(String(url));
+        if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(scenario.installation);
+        return jsonResponse({ message: "must not continue without verified identity" }, 500);
+      }) as typeof fetch;
+      const github = new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: scenario.botLogin });
+      await expect(github.upsertIssueComment({
+        repo: "owner/repo",
+        issueNumber: 42,
+        marker: "<!-- marker -->",
+        body: "<!-- marker -->\nnew"
+      }), scenario.name).rejects.toThrow(/installation proof does not identify the runtime bot/);
+      expect(calls, scenario.name).toHaveLength(1);
+    }
   });
 
   it("listPullReviewComments is hard-capped: it stops paging after the cap even if pages stay full (#371 bounded read)", async () => {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -662,6 +662,7 @@ describe("GitHub App read authentication", () => {
 
     const marker = "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->";
     const calls: Array<{ url: string; method: string; authorization?: string; body?: unknown }> = [];
+    let installationCalls = 0;
     globalThis.fetch = vi.fn(async (url, init) => {
       const method = init?.method ?? "GET";
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
@@ -672,10 +673,11 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+        installationCalls += 1;
+        return jsonResponse({ id: installationCalls === 1 ? 123 : 456, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
       }
-      if (String(url).endsWith("/app/installations/123/access_tokens")) {
-        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (/\/app\/installations\/(123|456)\/access_tokens$/.test(String(url))) {
+        return jsonResponse({ token: "installation-token", expires_at: installationCalls === 1 ? "2000-01-01T00:00:00Z" : "2999-01-01T00:00:00Z" });
       }
       if (String(url).endsWith("/repos/owner/repo/issues/42/comments?per_page=100&page=1")) {
         return jsonResponse([
@@ -708,6 +710,9 @@ describe("GitHub App read authentication", () => {
     expect(
       calls.some((call) => call.method === "POST" && call.url.endsWith("/repos/owner/repo/issues/42/comments"))
     ).toBe(false);
+    await github.upsertIssueComment({ repo: "owner/repo", issueNumber: 42, marker, body: `${marker}\nnew` });
+    expect(installationCalls).toBe(2);
+    expect(calls.some((call) => call.url.endsWith("/app/installations/456/access_tokens"))).toBe(true);
   });
 
   it("creates a marked PR walkthrough comment when only user-authored marker comments exist", async () => {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -773,6 +773,7 @@ describe("GitHub App read authentication", () => {
     const valid = { id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" };
     const scenarios = [
       { name: "missing App slug", installation: { ...valid, app_slug: undefined }, botLogin: "customer-review-app[bot]" },
+      { name: "mismatched App id", installation: { ...valid, app_id: 999 }, botLogin: "customer-review-app[bot]" },
       { name: "mismatched explicit bot login", installation: valid, botLogin: "other-review-app[bot]" }
     ];
 

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -588,6 +588,7 @@ const HUMAN_THREAD: PullReviewComment[] = [
  * target merged PR is #1@sha1; `subsequent` are later merged PRs (revert / hotfix) the reader scans.
  */
 function deepGithub(input: {
+  botLogin?: string;
   merged?: boolean;
   mergeCommitSha?: string;
   pullTitle?: string;
@@ -599,6 +600,7 @@ function deepGithub(input: {
   return {
     listOpenPulls: async () => [],
     listIssueComments: async () => [],
+    getCanonicalBotLogin: async () => input.botLogin ?? "evaos-code-review-bot[bot]",
     getPull: async (_repo, pullNumber) =>
       ({
         number: pullNumber,
@@ -772,6 +774,13 @@ describe("buildObservedPullOutcome enrichment (#371)", () => {
       botLogin: "my-bot[bot]"
     });
     expect(humanReply.humanThreadResolved).toBe(true);
+  });
+
+  it("does not use the default login when verified custom identity is unavailable", () => {
+    expect(buildObservedPullOutcome({
+      merged: true, pullNumber: 1, findings: [OBSERVED_FINDING], subsequentPulls: [],
+      reviewComments: [{ path: "src/save.ts", line: 42, in_reply_to_id: 9, user: { login: "CUSTOM-REVIEW-APP[BOT]" } }]
+    }).humanThreadResolved).toBe(false);
   });
 });
 

--- a/tests/runtime-bot-identity.test.ts
+++ b/tests/runtime-bot-identity.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  deriveCanonicalBotLogin,
-  isBotAuthoredComment
-} from "../src/runtime-bot-identity.js";
+import { deriveCanonicalBotLogin, isBotAuthoredComment } from "../src/runtime-bot-identity.js";
 
 describe("runtime bot identity", () => {
   it("derives a case-normalized login from an authoritative App slug", () => {
@@ -11,14 +8,8 @@ describe("runtime bot identity", () => {
   });
 
   it("accepts an explicit verified login only when it agrees with the App slug", () => {
-    expect(deriveCanonicalBotLogin({
-      appSlug: "customer-review-app",
-      verifiedBotLogin: "CUSTOMER-REVIEW-APP[BOT]"
-    })).toBe("customer-review-app[bot]");
-    expect(deriveCanonicalBotLogin({
-      appSlug: "customer-review-app",
-      verifiedBotLogin: "other-review-app[bot]"
-    })).toBeUndefined();
+    expect(deriveCanonicalBotLogin({ appSlug: "customer-review-app", verifiedBotLogin: "CUSTOMER-REVIEW-APP[BOT]" })).toBe("customer-review-app[bot]");
+    expect(deriveCanonicalBotLogin({ appSlug: "customer-review-app", verifiedBotLogin: "other-review-app[bot]" })).toBeUndefined();
   });
 
   it("fails closed for missing or malformed proof and non-bot authors", () => {

--- a/tests/runtime-bot-identity.test.ts
+++ b/tests/runtime-bot-identity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveCanonicalBotLogin,
+  isBotAuthoredComment
+} from "../src/runtime-bot-identity.js";
+
+describe("runtime bot identity", () => {
+  it("derives a case-normalized login from an authoritative App slug", () => {
+    expect(deriveCanonicalBotLogin({ appSlug: "Customer-Review-App" })).toBe("customer-review-app[bot]");
+    expect(isBotAuthoredComment({ user: { login: "CUSTOMER-REVIEW-APP[BOT]", type: "Bot" } }, "customer-review-app[bot]")).toBe(true);
+  });
+
+  it("accepts an explicit verified login only when it agrees with the App slug", () => {
+    expect(deriveCanonicalBotLogin({
+      appSlug: "customer-review-app",
+      verifiedBotLogin: "CUSTOMER-REVIEW-APP[BOT]"
+    })).toBe("customer-review-app[bot]");
+    expect(deriveCanonicalBotLogin({
+      appSlug: "customer-review-app",
+      verifiedBotLogin: "other-review-app[bot]"
+    })).toBeUndefined();
+  });
+
+  it("fails closed for missing or malformed proof and non-bot authors", () => {
+    expect(deriveCanonicalBotLogin({})).toBeUndefined();
+    expect(deriveCanonicalBotLogin({ appSlug: "customer_review_app" })).toBeUndefined();
+    expect(isBotAuthoredComment({ user: { login: "customer-review-app[bot]", type: "User" } }, "customer-review-app[bot]")).toBe(false);
+    expect(isBotAuthoredComment({ user: { login: "customer-review-app[bot]", type: "Bot" } }, undefined)).toBe(false);
+  });
+});

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -2301,6 +2301,7 @@ describe("provider-aware review scheduler", () => {
           ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
         ])),
         canPostAsApp: () => true,
+        getCanonicalBotLogin: async () => undefined,
         upsertIssueComment: async () => {
           throw new Error("GitHub API 500");
         }

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -5222,6 +5222,7 @@ function githubFromMap(
       return pull;
     },
     listIssueComments: async (repo, issueNumber) => commentsByPull.get(`${repo}#${issueNumber}`) ?? [],
+    getCanonicalBotLogin: async () => "evaos-code-review-bot[bot]",
     ...(statusCalls
       ? {
           canPostAsApp: () => true,


### PR DESCRIPTION
Related: #872

Summary:
- Derive one canonical runtime bot login from verified installation app_slug, with explicit configured botLogin accepted only when it agrees.
- Use one case-normalized narrow ownership predicate for marker reconciliation in GitHubApi and scheduler status repair; preserve broad third-party bot loop protection in command admission.
- Add custom-slug, case-only, duplicate-prevention, and fail-closed fixtures.

Base: 4a8ff430254c9c5cf4c8358d2e5e966142cc6364
Head: a7d24f3435794d5f1587d797f4ac123c3af59224

Validation:
- Focused GitHub/identity tests: 30 passed.
- Scheduler/observation/commands tests: 164 passed.
- Enrichment core: 70 passed.
- Local enrichment CLI and full TypeScript build remain environment-blocked by dependency resolution (tsx, jose, stripe, ajv); CI is authoritative.

Proof boundary: no live GitHub/App/runtime/customer writes or live installation proof; this PR proves the bounded source and mocked transport path only.