### PR TITLE
fix(issue-enrichment): bound pagination and fail closed on overflow

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -18,7 +18,23 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+export type GithubPaginationOverflowKind = "issue_comment_marker" | "issue_label_events";
+
+/** A bounded read must fail closed when the caller needs complete results to make a decision. */
+export class GithubPaginationOverflowError extends Error {
+  readonly kind: GithubPaginationOverflowKind;
+
+  constructor(kind: GithubPaginationOverflowKind) {
+    super(kind === "issue_label_events"
+      ? "GitHub issue label event scan exceeded page limit"
+      : "GitHub issue comment marker scan exceeded page limit");
+    this.name = "GithubPaginationOverflowError";
+    this.kind = kind;
+  }
+}
 
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
 export type BoundedGithubList<T> = T[] & {
@@ -347,7 +363,7 @@ export class GitHubApi {
     return boundedGithubList(comments, true);
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedGithubList<{
     event?: string;
     created_at?: string;
     actor?: { login?: string | null } | null;
@@ -365,8 +381,10 @@ export class GitHubApi {
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100) return boundedGithubList(events, false);
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) throw new GithubPaginationOverflowError("issue_label_events");
     }
+    return boundedGithubList(events, true);
   }
 
   async getCollaboratorPermission(
@@ -514,7 +532,7 @@ export class GitHubApi {
     marker: string,
     token: string
   ): Promise<IssueCommentSummary | undefined> {
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const comments = await this.request<IssueCommentSummary[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
@@ -523,6 +541,7 @@ export class GitHubApi {
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
+    throw new GithubPaginationOverflowError("issue_comment_marker");
   }
 
   private isBotAuthoredComment(comment: IssueCommentSummary): boolean {

--- a/src/github.ts
+++ b/src/github.ts
@@ -21,18 +21,16 @@ const MAX_ISSUE_COMMENT_PAGES = 5;
 const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
-export type GithubPaginationOverflowKind = "issue_comment_marker" | "issue_label_events";
+export type GithubPaginationOverflowKind = "issue_comment_marker";
 
 /** A bounded read must fail closed when the caller needs complete results to make a decision. */
 export class GithubPaginationOverflowError extends Error {
   readonly kind: GithubPaginationOverflowKind;
 
-  constructor(kind: GithubPaginationOverflowKind) {
-    super(kind === "issue_label_events"
-      ? "GitHub issue label event scan exceeded page limit"
-      : "GitHub issue comment marker scan exceeded page limit");
+  constructor() {
+    super("GitHub issue comment marker scan exceeded page limit");
     this.name = "GithubPaginationOverflowError";
-    this.kind = kind;
+    this.kind = "issue_comment_marker";
   }
 }
 
@@ -382,7 +380,7 @@ export class GitHubApi {
       );
       events.push(...chunk);
       if (chunk.length < 100) return boundedGithubList(events, false);
-      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) throw new GithubPaginationOverflowError("issue_label_events");
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) return boundedGithubList(events, true);
     }
     return boundedGithubList(events, true);
   }
@@ -541,7 +539,7 @@ export class GitHubApi {
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
-    throw new GithubPaginationOverflowError("issue_comment_marker");
+    throw new GithubPaginationOverflowError();
   }
 
   private isBotAuthoredComment(comment: IssueCommentSummary): boolean {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -452,7 +452,6 @@ export async function buildIssueEvidenceContext(input: {
       ? await input.github.listIssueComments(input.repo, input.issue.number)
       : [];
   const { items: rawComments, rawCount: rawCommentCount, truncated: commentsTruncated } = unpackBoundedGithubList(commentResult);
-  if (commentsTruncated) throw new GithubPaginationOverflowError("issue_comment_marker");
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,7 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
-import { unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
+import { GithubPaginationOverflowError, unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -284,14 +284,16 @@ type IssueEnrichmentComment = {
   user?: { login?: string | null } | null;
 };
 
+type IssueEnrichmentLabelEvent = {
+  event?: string;
+  created_at?: string;
+  actor?: { login?: string | null } | null;
+  label?: { name?: string | null } | null;
+};
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<IssueEnrichmentLabelEvent[] | BoundedGithubList<IssueEnrichmentLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -394,7 +396,9 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const eventResult = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, overflow } = unpackBoundedGithubList(eventResult);
+    if (overflow) throw new GithubPaginationOverflowError("issue_label_events");
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -418,7 +422,8 @@ async function evaluateIssuePromotion(input: {
       },
       evidence
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof GithubPaginationOverflowError && error.kind === "issue_label_events") throw error;
     return { issue: input.issue };
   }
 }
@@ -449,9 +454,11 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, overflow: timelineOverflow } = unpackBoundedGithubList(timelineResult);
+  if (timelineOverflow) throw new GithubPaginationOverflowError("issue_label_events");
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1310,7 +1310,7 @@ export async function runIssueEnrichmentCycle(input: {
           error: message,
           now: new Date(checkedAt)
         });
-        summary[markerOverflow ? "deferred" : "failed"] += 1;
+        summary[markerOverflow ? "deferredRecorded" : "failed"] += 1;
         items.push({ ...item, recordStatus: markerOverflow ? "deferred" : "failed", error: message });
       }
     }

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1283,7 +1283,7 @@ export async function runIssueEnrichmentCycle(input: {
           pullNumber: item.issueNumber,
           enrichment
         });
-        if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.reason}`);
+        if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.error ?? post.reason}`);
         const commentUrl = post.html_url ? redactSecrets(post.html_url) : undefined;
         input.state.recordIssueEnrichment({
           repo: item.repo,

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -284,12 +284,7 @@ type IssueEnrichmentComment = {
   user?: { login?: string | null } | null;
 };
 
-type IssueEnrichmentLabelEvent = {
-  event?: string;
-  created_at?: string;
-  actor?: { login?: string | null } | null;
-  label?: { name?: string | null } | null;
-};
+type IssueEnrichmentLabelEvent = { event?: string; created_at?: string; actor?: { login?: string | null } | null; label?: { name?: string | null } | null };
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
@@ -332,6 +327,7 @@ export type IssueEnrichmentScanReason =
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
   | "burst_threshold_exceeded"
+  | "issue_label_event_overflow"
   | "issue_comment_marker_overflow";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
@@ -384,7 +380,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
-}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
+}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence; promotionOverflow?: boolean }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
     .map((label) => label.trim().toLowerCase())
@@ -397,9 +393,8 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const eventResult = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
-    const { items: events, overflow } = unpackBoundedGithubList(eventResult);
-    if (overflow) throw new GithubPaginationOverflowError("issue_label_events");
+    const { items: events, overflow } = unpackBoundedGithubList(await input.github.listIssueLabelEvents(input.repo, input.issue.number));
+    if (overflow) return { issue: input.issue, promotionOverflow: true };
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -423,8 +418,7 @@ async function evaluateIssuePromotion(input: {
       },
       evidence
     };
-  } catch (error) {
-    if (error instanceof GithubPaginationOverflowError && error.kind === "issue_label_events") throw error;
+  } catch {
     return { issue: input.issue };
   }
 }
@@ -455,11 +449,9 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const timelineResult = input.github.listIssueLabelEvents
+  const { items: rawTimeline, overflow: timelineOverflow } = unpackBoundedGithubList(input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
-    : [];
-  const { items: rawTimeline, overflow: timelineOverflow } = unpackBoundedGithubList(timelineResult);
-  if (timelineOverflow) throw new GithubPaginationOverflowError("issue_label_events");
+    : []);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -496,7 +488,7 @@ export async function buildIssueEvidenceContext(input: {
     linkedItems,
     truncation: {
       comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      timeline: timelineOverflow || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };
@@ -1038,9 +1030,8 @@ export async function runIssueEnrichmentCycle(input: {
                     headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40)
                   }));
                 }
-                if (promotion.evidence) {
-                  promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
-                }
+                if (promotion.promotionOverflow) promotionEvidenceByIssue.set(issueKey(repo, issue.number), undefined as never);
+                else if (promotion.evidence) promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
               }
               return Object.assign(prepared, { scanCompletion: issues.scanCompletion });
             }
@@ -1092,6 +1083,7 @@ export async function runIssueEnrichmentCycle(input: {
     const items: IssueEnrichmentCycleResult["items"] = [];
 
     for (const item of scan.items) {
+      if (promotionEvidenceByIssue.has(issueKey(item.repo, item.issueNumber)) && !promotionEvidenceByIssue.get(issueKey(item.repo, item.issueNumber))) Object.assign(item, { action: "deferred", reason: "issue_label_event_overflow" });
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -331,7 +331,8 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded"
+  | "issue_comment_marker_overflow";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -451,6 +452,7 @@ export async function buildIssueEvidenceContext(input: {
       ? await input.github.listIssueComments(input.repo, input.issue.number)
       : [];
   const { items: rawComments, rawCount: rawCommentCount, truncated: commentsTruncated } = unpackBoundedGithubList(commentResult);
+  if (commentsTruncated) throw new GithubPaginationOverflowError("issue_comment_marker");
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
@@ -1298,18 +1300,19 @@ export async function runIssueEnrichmentCycle(input: {
         items.push({ ...item, recordStatus: "posted", ...(commentUrl ? { commentUrl } : {}) });
       } catch (error) {
         const message = redactSecrets(error instanceof Error ? error.message : String(error));
+        const markerOverflow = message.includes("GitHub issue comment marker scan exceeded page limit");
         input.state.recordIssueEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
           ...(analysisInputHash ? { analysisInputHash } : {}),
-          status: "failed",
-          reason: "analysis_or_post_failed",
+          status: markerOverflow ? "deferred" : "failed",
+          reason: markerOverflow ? "issue_comment_marker_overflow" : "analysis_or_post_failed",
           error: message,
           now: new Date(checkedAt)
         });
-        summary.failed += 1;
-        items.push({ ...item, recordStatus: "failed", error: message });
+        summary[markerOverflow ? "deferred" : "failed"] += 1;
+        items.push({ ...item, recordStatus: markerOverflow ? "deferred" : "failed", error: message });
       }
     }
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -17,7 +17,7 @@ import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js"
 import type { BoundedGithubList } from "../src/github.js";
 import type { IssueAnalysis } from "../src/issue-analysis.js";
 import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
-import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
+import { buildIssueEnrichmentStatus, buildIssueEvidenceContext, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
 import { createTestLicenseAdmission } from "./helpers/license-admission.js";
@@ -3372,7 +3372,7 @@ describe("issue-enrichment pagination overflow", () => {
     try {
       const configPath = join(root, "config.json");
       const statePath = join(root, "state.sqlite");
-      const config = { statePath, issueEnrichment: { enabled: true, postIssueComment: true, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, processExistingOpenIssuesOnActivation: true, repos: { "owner/issue-repo": { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 600_000, promotionMaintainers: [{ login: "trusted-maintainer", validFrom: "2026-08-01T00:00:00Z", validUntil: "2026-09-01T00:00:00Z" }] } } } };
+      const config = { statePath, issueEnrichment: { enabled: true, postIssueComment: true, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 2, maxCommentsPerCycle: 2, processExistingOpenIssuesOnActivation: true, repos: { "owner/issue-repo": { maxIssuesPerCycle: 2, maxCommentsPerCycle: 2, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 600_000, promotionMaintainers: [{ login: "trusted-maintainer", validFrom: "2026-08-01T00:00:00Z", validUntil: "2026-09-01T00:00:00Z" }] } } } };
       writeFileSync(configPath, `${JSON.stringify(config)}\n`);
       const state = new ReviewStateStore(statePath);
       state.recordIssueEnrichmentRepoWatermark({
@@ -3399,12 +3399,13 @@ describe("issue-enrichment pagination overflow", () => {
           overflow: true
         }
       ) as BoundedGithubList<{ event?: string }>;
+      const evidence = await buildIssueEvidenceContext({ repo: "owner/issue-repo", issue, github: { listIssuesForEnrichment: async () => [], listIssueLabelEvents: async () => overflowEvents, canPostAsApp: () => true, upsertIssueComment: async () => ({ action: "created" as const, id: 0 }) }, defaultBranch: "main", headSha: "0".repeat(40) });
       try {
         const result = await runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
           github: {
-            listIssuesForEnrichment: async () => [issue],
+            listIssuesForEnrichment: async () => [issue, { ...issue, number: 739, labels: [] }],
             listIssueLabelEvents: async () => overflowEvents,
             getCollaboratorPermission: async () => "maintain",
             canPostAsApp: () => true,
@@ -3418,10 +3419,10 @@ describe("issue-enrichment pagination overflow", () => {
           checkedAt: "2026-08-23T00:02:00.000Z"
         });
 
-        expect(result.ok).toBe(false);
-        expect(result.summary).toMatchObject({ readFailures: 1, posted: 0, failed: 0 });
-        expect(result.items).toHaveLength(0);
-        expect(postCalls).toBe(0);
+        expect(result.ok).toBe(true);
+        expect(result.summary).toMatchObject({ readFailures: 0, posted: 1, failed: 0, deferredRecorded: 1 });
+        expect(result.items[0]).toMatchObject({ reason: "issue_label_event_overflow", recordStatus: "deferred" }); expect(evidence.timeline).toHaveLength(200); expect(evidence.truncation.timeline).toBe(true);
+        expect(postCalls).toBe(1);
         expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toMatchObject({
           lastCheckedAt: "2026-08-23T00:00:00.000Z"
         });

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -3372,7 +3372,7 @@ describe("issue-enrichment pagination overflow", () => {
     try {
       const configPath = join(root, "config.json");
       const statePath = join(root, "state.sqlite");
-      const config = { statePath, issueEnrichment: { enabled: true, postIssueComment: true, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, processExistingOpenIssuesOnActivation: true, repos: { "owner/issue-repo": { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 600_000, promotionMaintainers: [{ login: "trusted-maintainer", validFrom: "2026-08-01T00:00:00Z", validUntil: "2026-09-01T00:00:00Z" }] } } };
+      const config = { statePath, issueEnrichment: { enabled: true, postIssueComment: true, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, processExistingOpenIssuesOnActivation: true, repos: { "owner/issue-repo": { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 600_000, promotionMaintainers: [{ login: "trusted-maintainer", validFrom: "2026-08-01T00:00:00Z", validUntil: "2026-09-01T00:00:00Z" }] } } } };
       writeFileSync(configPath, `${JSON.stringify(config)}\n`);
       const state = new ReviewStateStore(statePath);
       state.recordIssueEnrichmentRepoWatermark({

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -14,6 +14,7 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
 import type { IssueAnalysis } from "../src/issue-analysis.js";
 import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
@@ -3356,6 +3357,91 @@ describe("sticky enrichment comments", () => {
         });
         expect(result.recommendedActions).toContain("issue enrichment worker is busy; retry after the active lease expires");
         expect(state.listIssueEnrichmentRecords()).toEqual([]);
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("issue-enrichment pagination overflow", () => {
+  it("fails closed on label-event overflow without posting or advancing the watermark", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-label-overflow-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 1,
+          maxCommentsPerCycle: 1,
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              promotionMaintainers: [{
+                login: "trusted-maintainer",
+                validFrom: "2026-08-01T00:00:00Z",
+                validUntil: "2026-09-01T00:00:00Z"
+              }]
+            }
+          }
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      state.recordIssueEnrichmentRepoWatermark({
+        repo: "owner/issue-repo",
+        activatedAt: "2026-08-23T00:00:00.000Z",
+        lastCheckedAt: "2026-08-23T00:00:00.000Z",
+        now: new Date("2026-08-23T00:00:00.000Z")
+      });
+      let postCalls = 0;
+      const issue: GitHubRelatedIssueOrPull = {
+        number: 738,
+        title: "Bounded issue enrichment",
+        state: "open",
+        updated_at: "2026-08-23T00:01:00.000Z",
+        labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
+        body: "Acceptance criteria and owner present."
+      };
+      const overflowEvents = Object.assign(
+        Array.from({ length: 500 }, () => ({ event: "labeled" })),
+        {
+          items: Array.from({ length: 500 }, () => ({ event: "labeled" })),
+          rawCount: 500,
+          truncated: true,
+          overflow: true
+        }
+      ) as BoundedGithubList<{ event?: string }>;
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => [issue],
+            listIssueLabelEvents: async () => overflowEvents,
+            canPostAsApp: () => true,
+            upsertIssueComment: async () => {
+              postCalls += 1;
+              return { action: "created" as const, id: 738, html_url: "https://github.test/comment/738" };
+            }
+          },
+          dryRun: false,
+          includeExisting: true,
+          checkedAt: "2026-08-23T00:02:00.000Z"
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.summary).toMatchObject({ readFailures: 1, posted: 0, failed: 0 });
+        expect(result.items).toHaveLength(0);
+        expect(postCalls).toBe(0);
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toMatchObject({
+          lastCheckedAt: "2026-08-23T00:00:00.000Z"
+        });
       } finally {
         state.close();
       }

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -3372,26 +3372,8 @@ describe("issue-enrichment pagination overflow", () => {
     try {
       const configPath = join(root, "config.json");
       const statePath = join(root, "state.sqlite");
-      writeFileSync(configPath, `${JSON.stringify({
-        statePath,
-        issueEnrichment: {
-          enabled: true,
-          postIssueComment: true,
-          allowlist: ["owner/issue-repo"],
-          maxIssuesPerCycle: 1,
-          maxCommentsPerCycle: 1,
-          processExistingOpenIssuesOnActivation: true,
-          repos: {
-            "owner/issue-repo": {
-              promotionMaintainers: [{
-                login: "trusted-maintainer",
-                validFrom: "2026-08-01T00:00:00Z",
-                validUntil: "2026-09-01T00:00:00Z"
-              }]
-            }
-          }
-        }
-      })}\n`);
+      const config = { statePath, issueEnrichment: { enabled: true, postIssueComment: true, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, processExistingOpenIssuesOnActivation: true, repos: { "owner/issue-repo": { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 600_000, promotionMaintainers: [{ login: "trusted-maintainer", validFrom: "2026-08-01T00:00:00Z", validUntil: "2026-09-01T00:00:00Z" }] } } };
+      writeFileSync(configPath, `${JSON.stringify(config)}\n`);
       const state = new ReviewStateStore(statePath);
       state.recordIssueEnrichmentRepoWatermark({
         repo: "owner/issue-repo",
@@ -3424,6 +3406,7 @@ describe("issue-enrichment pagination overflow", () => {
           github: {
             listIssuesForEnrichment: async () => [issue],
             listIssueLabelEvents: async () => overflowEvents,
+            getCollaboratorPermission: async () => "maintain",
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;

--- a/tests/issue-enrichment-pagination.test.ts
+++ b/tests/issue-enrichment-pagination.test.ts
@@ -34,9 +34,10 @@ describe("issue-enrichment GitHub pagination", () => {
     expect(calls).toHaveLength(5);
   });
 
-  it("fails closed on permanently full label events", async () => {
-    const { calls, error } = await fullStream("events");
-    expect(error).toMatchObject({ message: "GitHub issue label event scan exceeded page limit" });
+  it("bounds permanently full label events for evidence", async () => {
+    const { rows, calls } = await fullStream("events");
+    expect(rows).toHaveLength(500);
+    expect((rows as { overflow?: boolean }).overflow).toBe(true);
     expect(calls).toHaveLength(5);
   });
 

--- a/tests/issue-enrichment-pagination.test.ts
+++ b/tests/issue-enrichment-pagination.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+describe("issue-enrichment GitHub pagination", () => {
+  const originalFetch = globalThis.fetch;
+
+  async function fullStream(kind: "comments" | "events") {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      if (page > 5) throw new Error("pagination probe reached page 6");
+      return new Response(JSON.stringify(Array.from({ length: 100 }, (_, index) =>
+        kind === "comments" ? { id: page * 100 + index, body: "fixture" } : { event: "labeled" }
+      )), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    try {
+      const api = new GitHubApi({ token: "fixture", requestTimeoutMs: 50 });
+      const rows = kind === "comments"
+        ? await api.listIssueCommentsForEnrichment("owner/repo", 451)
+        : await api.listIssueLabelEvents("owner/repo", 451);
+      return { rows, calls };
+    } catch (error) {
+      return { rows: [], calls, error };
+    }
+  }
+
+  afterEach(() => { globalThis.fetch = originalFetch; vi.restoreAllMocks(); });
+
+  it("bounds permanently full enrichment comments", async () => {
+    const { rows, calls } = await fullStream("comments");
+    expect(rows).toHaveLength(500);
+    expect((rows as { overflow?: boolean }).overflow).toBe(true);
+    expect(calls).toHaveLength(5);
+  });
+
+  it("fails closed on permanently full label events", async () => {
+    const { calls, error } = await fullStream("events");
+    expect(error).toMatchObject({ message: "GitHub issue label event scan exceeded page limit" });
+    expect(calls).toHaveLength(5);
+  });
+
+  it("fails closed when marker lookup reaches five full pages", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      if (page > 5) throw new Error("pagination probe reached page 6");
+      return new Response(JSON.stringify(Array.from({ length: 100 }, (_, index) => ({
+        id: page * 100 + index, body: "unrelated", user: { type: "Bot", login: "evaos-code-review-bot[bot]" }
+      }))), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const api = new GitHubApi({ token: "fixture", requestTimeoutMs: 50 });
+    const findMarker = (api as unknown as { findIssueCommentByMarker: (...args: string[]) => Promise<unknown> }).findIssueCommentByMarker.bind(api);
+    await expect(findMarker("owner/repo", "451", "marker", "fixture"))
+      .rejects.toThrow("GitHub issue comment marker scan exceeded page limit");
+    expect(calls).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary

Related: #738

- keep the existing five-page / 500-row bounded enrichment-comment reader
- cap marker lookup at five pages and fail closed before any create
- cap label-event reads at five pages and propagate structured overflow to the enrichment scan
- preserve normal bounded pages and hold the repository watermark on overflow

## Validation

-  passes
- deterministic pagination and watermark fixtures are committed
- focused Vitest is currently blocked before collection in this fresh worktree: missing dependencies / Rolldown native binding
- no heartbeat, release-status, runtime, config, DB, queue, lease, or customer changes

Base: 4a8ff430254c9c5cf4c8358d2e5e966142cc6364
Candidate: 50cbe8775fe6774fe0b95b3e823bb04937531237