### PR TITLE
feat(desktop): produce accepted release packet

### DIFF
--- a/scripts/lib/desktop-accepted-release-packet.mjs
+++ b/scripts/lib/desktop-accepted-release-packet.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { posix } from "node:path";
 import { serializeFeedEnclosureProof } from "./desktop-feed-enclosure-proof.mjs";
 
 const SHA1 = /^[a-f0-9]{40}$/, SHA256 = /^[a-f0-9]{64}$/;
@@ -10,6 +11,20 @@ function exact(value, fields, label) { if (!value || typeof value !== "object" |
 function snap(value, fields, label) { exact(value, fields, label); return Object.fromEntries(fields.map((field) => [field, value[field]])); }
 function loose(value, fields, label) { if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`); return Object.fromEntries(fields.map((field) => [field, value[field]])); }
 function hash(value) { return createHash("sha256").update(value, "utf8").digest("hex"); }
+function treeHash(records) {
+  if (!Array.isArray(records) || records.length === 0) fail("tree records are required");
+  const digest = createHash("sha256"); let prior = "";
+  for (const record of records) {
+    const parts = Array.isArray(record) ? [...record] : [];
+    if (!["dir", "file", "link"].includes(parts[0]) || typeof parts[1] !== "string" || !parts[1] || parts[1].startsWith("/") || parts[1] <= prior) fail("tree records are not canonical");
+    prior = parts[1];
+    if (parts[0] === "dir" && parts.length !== 2) fail("directory tree record is malformed");
+    if (parts[0] === "link" && (parts.length !== 3 || typeof parts[2] !== "string" || !parts[2] || parts[2].startsWith("/") || ["..", "../"].some((prefix) => posix.normalize(posix.join(posix.dirname(parts[1]), parts[2])) === prefix || posix.normalize(posix.join(posix.dirname(parts[1]), parts[2])).startsWith(prefix)))) fail("link tree record is malformed");
+    if (parts[0] === "file" && (parts.length !== 5 || !["-", "x"].includes(parts[2]) || !Number.isSafeInteger(parts[3]) || parts[3] < 0 || !SHA256.test(parts[4]))) fail("file tree record is malformed");
+    for (const part of parts) { digest.update(String(part), "utf8"); digest.update("\0"); } digest.update("\n");
+  }
+  return digest.digest("hex");
+}
 function freeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { Object.values(value).forEach(freeze); Object.freeze(value); } return value; }
 function safeIdentity(value, label) { const result = text(value, label); if (/\/|\\|private|secret|token|password|keychain/i.test(result)) fail(`${label} is not public-safe`); return result; }
 
@@ -17,6 +32,7 @@ const INPUT_FIELDS = ["identity", "tagMetadata", "annotatedTagMetadata", "releas
 const IDENTITY_FIELDS = ["releaseTag", "sourceSHA", "tagObjectSHA", "version", "channel", "build", "artifactName", "artifactSHA256", "artifactLength", "artifactURL"];
 const PACKET_FIELDS = ["schemaVersion", "kind", "source", "tag", "release", "artifact", "tree", "apple", "feed"];
 const accepted = new WeakSet();
+export function treeProofDigest(records) { return treeHash(records); }
 
 export function buildAcceptedReleasePacket(input) {
   exact(input, INPUT_FIELDS, "release packet inputs");
@@ -41,9 +57,9 @@ export function buildAcceptedReleasePacket(input) {
   const enclosure = JSON.parse(serializeFeedEnclosureProof(input.enclosureProof));
   const e = snap(enclosure, ["schemaVersion", "kind", "verified", "signatureScope", "channel", "url", "artifactName", "artifactSHA256", "version", "build", "shortVersionString", "edSignature", "publicKeyFingerprint", "signedContentSHA256"], "enclosure proof");
   if (e.channel !== i.channel || e.url !== artifactURL || e.artifactName !== i.artifactName || e.artifactSHA256 !== artifactSHA256 || e.version !== version || e.build !== build || e.shortVersionString !== version || e.signedContentSHA256 !== artifactSHA256 || !/^sha256:[a-f0-9]{64}$/.test(e.publicKeyFingerprint)) fail("enclosure proof does not match release identity");
-  const t = snap(input.treeProof, ["schemaVersion", "kind", "verified", "algorithm", "treeSHA256", "bundleMarkers"], "tree proof"), marker = snap(t.bundleMarkers, ["appPath", "bundleID", "version", "build"], "bundle markers");
+  const t = snap(input.treeProof, ["schemaVersion", "kind", "verified", "algorithm", "sourceSHA", "artifactSHA256", "treeSHA256", "records", "bundleMarkers"], "tree proof"), marker = snap(t.bundleMarkers, ["appPath", "bundleID", "version", "build"], "bundle markers");
   if (t.schemaVersion !== 1 || t.kind !== "neondiff.desktop.extracted-tree-proof-v1" || t.verified !== true || t.algorithm !== "sha256-tree-v1") fail("tree proof is not verified");
-  const treeSHA256 = digest(t.treeSHA256, "tree SHA-256"); if (marker.appPath !== "NeonDiff.app" || marker.bundleID !== "com.electricsheephq.NeonDiffDesktop" || marker.version !== version || marker.build !== build) fail("bundle markers do not match release identity");
+  const treeSHA256 = treeHash(t.records); if (t.sourceSHA !== sourceSHA || t.artifactSHA256 !== artifactSHA256 || t.treeSHA256 !== treeSHA256 || marker.appPath !== "NeonDiff.app" || marker.bundleID !== "com.electricsheephq.NeonDiffDesktop" || marker.version !== version || marker.build !== build) fail("tree proof does not match release identity");
   const a = snap(input.appleProof, ["schemaVersion", "kind", "verified", "teamID", "codesignIdentity", "notarizationIdentity", "stapleIdentity", "gatekeeperIdentity"], "Apple proof");
   if (a.schemaVersion !== 1 || a.kind !== "neondiff.desktop.apple-release-proof-v1" || a.verified !== true || a.teamID !== "TC6MS3T6NN") fail("Apple proof is not verified");
   const apple = { teamID: a.teamID, codesignIdentity: safeIdentity(a.codesignIdentity, "codesign identity"), notarizationIdentity: safeIdentity(a.notarizationIdentity, "notarization identity"), stapleIdentity: safeIdentity(a.stapleIdentity, "staple identity"), gatekeeperIdentity: safeIdentity(a.gatekeeperIdentity, "Gatekeeper identity") };

--- a/scripts/lib/desktop-accepted-release-packet.mjs
+++ b/scripts/lib/desktop-accepted-release-packet.mjs
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import { serializeFeedEnclosureProof } from "./desktop-feed-enclosure-proof.mjs";
+
+const SHA1 = /^[a-f0-9]{40}$/, SHA256 = /^[a-f0-9]{64}$/;
+const REPO = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff";
+const fail = (message) => { throw new Error(message); };
+const text = (value, label) => { if (typeof value !== "string" || value.length === 0 || /[\u0000-\u001f\u007f]/.test(value)) fail(`${label} is malformed`); return value; };
+const digest = (value, label, pattern = SHA256) => { const result = text(value, label); if (!pattern.test(result)) fail(`${label} is malformed`); return result; };
+function exact(value, fields, label) { if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`); const keys = Object.keys(value); if (keys.length !== fields.length || keys.some((key) => !fields.includes(key))) fail(`${label} has undeclared fields`); return value; }
+function snap(value, fields, label) { exact(value, fields, label); return Object.fromEntries(fields.map((field) => [field, value[field]])); }
+function loose(value, fields, label) { if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`); return Object.fromEntries(fields.map((field) => [field, value[field]])); }
+function hash(value) { return createHash("sha256").update(value, "utf8").digest("hex"); }
+function freeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { Object.values(value).forEach(freeze); Object.freeze(value); } return value; }
+function safeIdentity(value, label) { const result = text(value, label); if (/\/|\\|private|secret|token|password|keychain/i.test(result)) fail(`${label} is not public-safe`); return result; }
+
+const INPUT_FIELDS = ["identity", "tagMetadata", "annotatedTagMetadata", "releaseMetadata", "enclosureProof", "treeProof", "appleProof", "feedEntry"];
+const IDENTITY_FIELDS = ["releaseTag", "sourceSHA", "tagObjectSHA", "version", "channel", "build", "artifactName", "artifactSHA256", "artifactLength", "artifactURL"];
+const PACKET_FIELDS = ["schemaVersion", "kind", "source", "tag", "release", "artifact", "tree", "apple", "feed"];
+const accepted = new WeakSet();
+
+export function buildAcceptedReleasePacket(input) {
+  exact(input, INPUT_FIELDS, "release packet inputs");
+  const i = snap(input.identity, IDENTITY_FIELDS, "release identity");
+  const tag = text(i.releaseTag, "release tag"), match = tag.match(/^v(1\.1\.0-(beta|rc)\.([1-9][0-9]{0,15}))$/);
+  if (!match || i.version !== match[1] || i.channel !== match[2]) fail("release identity is malformed");
+  const version = text(i.version, "release version"), build = text(i.build, "artifact build");
+  if (!/^[0-9]+$/.test(build) || !Number.isSafeInteger(Number(build)) || i.artifactName !== `NeonDiff-${version}-build${build}-macOS.zip`) fail("artifact identity is malformed");
+  const sourceSHA = digest(i.sourceSHA, "reviewed source SHA", SHA1), tagObjectSHA = digest(i.tagObjectSHA, "annotated tag-object SHA", SHA1), artifactSHA256 = digest(i.artifactSHA256, "artifact SHA-256");
+  if (!Number.isSafeInteger(i.artifactLength) || i.artifactLength < 1) fail("artifact length is malformed");
+  const artifactURL = `${REPO}/releases/download/${tag}/${i.artifactName}`;
+  if (i.artifactURL !== artifactURL) fail("artifact URL is not canonical");
+  const tm = loose(input.tagMetadata, ["ref", "object"], "tag metadata"), to = loose(tm.object, ["type", "sha"], "tag object");
+  const at = loose(input.annotatedTagMetadata, ["sha", "tag", "object"], "annotated tag metadata"), ao = loose(at.object, ["type", "sha"], "peeled tag");
+  if (tm.ref !== `refs/tags/${tag}` || to.type !== "tag" || to.sha !== tagObjectSHA || at.sha !== tagObjectSHA || at.tag !== tag || ao.type !== "commit" || ao.sha !== sourceSHA) fail("tag identity does not match validated release output");
+  const rm = loose(input.releaseMetadata, ["tag_name", "draft", "prerelease", "immutable", "assets"], "release metadata");
+  if (rm.tag_name !== tag || rm.draft !== false || rm.prerelease !== true || rm.immutable !== true || !Array.isArray(rm.assets)) fail("release metadata is not immutable");
+  const assets = rm.assets.filter((asset) => asset && asset.name === i.artifactName); if (assets.length !== 1) fail("release asset is not unique");
+  const asset = loose(assets[0], ["name", "digest", "size", "browser_download_url"], "release asset");
+  if (asset.name !== i.artifactName || asset.digest !== `sha256:${artifactSHA256}` || asset.size !== i.artifactLength || asset.browser_download_url !== artifactURL) fail("release asset does not match validated output");
+
+  const enclosure = JSON.parse(serializeFeedEnclosureProof(input.enclosureProof));
+  const e = snap(enclosure, ["schemaVersion", "kind", "verified", "signatureScope", "channel", "url", "artifactName", "artifactSHA256", "version", "build", "shortVersionString", "edSignature", "publicKeyFingerprint", "signedContentSHA256"], "enclosure proof");
+  if (e.channel !== i.channel || e.url !== artifactURL || e.artifactName !== i.artifactName || e.artifactSHA256 !== artifactSHA256 || e.version !== version || e.build !== build || e.shortVersionString !== version || e.signedContentSHA256 !== artifactSHA256 || !/^sha256:[a-f0-9]{64}$/.test(e.publicKeyFingerprint)) fail("enclosure proof does not match release identity");
+  const t = snap(input.treeProof, ["schemaVersion", "kind", "verified", "algorithm", "treeSHA256", "bundleMarkers"], "tree proof"), marker = snap(t.bundleMarkers, ["appPath", "bundleID", "version", "build"], "bundle markers");
+  if (t.schemaVersion !== 1 || t.kind !== "neondiff.desktop.extracted-tree-proof-v1" || t.verified !== true || t.algorithm !== "sha256-tree-v1") fail("tree proof is not verified");
+  const treeSHA256 = digest(t.treeSHA256, "tree SHA-256"); if (marker.appPath !== "NeonDiff.app" || marker.bundleID !== "com.electricsheephq.NeonDiffDesktop" || marker.version !== version || marker.build !== build) fail("bundle markers do not match release identity");
+  const a = snap(input.appleProof, ["schemaVersion", "kind", "verified", "teamID", "codesignIdentity", "notarizationIdentity", "stapleIdentity", "gatekeeperIdentity"], "Apple proof");
+  if (a.schemaVersion !== 1 || a.kind !== "neondiff.desktop.apple-release-proof-v1" || a.verified !== true || a.teamID !== "TC6MS3T6NN") fail("Apple proof is not verified");
+  const apple = { teamID: a.teamID, codesignIdentity: safeIdentity(a.codesignIdentity, "codesign identity"), notarizationIdentity: safeIdentity(a.notarizationIdentity, "notarization identity"), stapleIdentity: safeIdentity(a.stapleIdentity, "staple identity"), gatekeeperIdentity: safeIdentity(a.gatekeeperIdentity, "Gatekeeper identity") };
+  if (!apple.codesignIdentity.startsWith("Developer ID Application:") || !/^accepted(?::|$)/i.test(apple.notarizationIdentity) || !/^valid(?::|$)/i.test(apple.stapleIdentity) || !/^accepted(?::|$)/i.test(apple.gatekeeperIdentity)) fail("Apple identities are not accepted");
+  const f = snap(input.feedEntry, ["channel", "version", "build", "url", "artifactName", "artifactSHA256", "artifactLength", "edSignature"], "feed entry");
+  if (f.channel !== i.channel || f.version !== version || f.build !== build || f.url !== artifactURL || f.artifactName !== i.artifactName || f.artifactSHA256 !== artifactSHA256 || f.artifactLength !== i.artifactLength || f.edSignature !== e.edSignature) fail("feed entry does not match enclosure proof");
+  const feed = { channel: f.channel, version: f.version, build: f.build, url: f.url, artifactName: f.artifactName, artifactSHA256: f.artifactSHA256, artifactLength: f.artifactLength, edSignature: f.edSignature };
+  const body = { schemaVersion: 1, kind: "neondiff.desktop.accepted-release-packet-v1", source: { commitSHA: sourceSHA }, tag: { name: tag, objectSHA: tagObjectSHA }, release: { version, build, channel: i.channel }, artifact: { name: i.artifactName, url: artifactURL, length: i.artifactLength, sha256: artifactSHA256, edSignature: e.edSignature, publicKeyFingerprint: e.publicKeyFingerprint }, tree: { algorithm: "sha256-tree-v1", sha256: treeSHA256, bundleMarkers: marker }, apple, feed: { ...feed, entrySHA256: hash(JSON.stringify(feed)) } };
+  const packet = { ...body, packetDigest: hash(JSON.stringify(body)) }; accepted.add(packet); return freeze(packet);
+}
+
+export function serializeAcceptedReleasePacket(packet) {
+  if (!accepted.has(packet)) fail("packet was not produced by the accepted packet producer");
+  const body = Object.fromEntries(PACKET_FIELDS.map((field) => [field, packet[field]]));
+  if (hash(JSON.stringify(body)) !== packet.packetDigest) fail("packet digest is invalid");
+  return `${JSON.stringify({ ...body, packetDigest: packet.packetDigest })}\n`;
+}
+export function acceptedReleasePacketDigest(input) { return buildAcceptedReleasePacket(input).packetDigest; }
+export const buildAcceptedDesktopReleasePacket = buildAcceptedReleasePacket;
+export const serializeAcceptedDesktopReleasePacket = serializeAcceptedReleasePacket;

--- a/tests/desktop-accepted-release-packet.test.ts
+++ b/tests/desktop-accepted-release-packet.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildFeedEnclosureProof } from "../scripts/lib/desktop-feed-enclosure-proof.mjs";
+import { buildAcceptedReleasePacket, serializeAcceptedReleasePacket } from "../scripts/lib/desktop-accepted-release-packet.mjs";
+
+const source = "0123456789abcdef0123456789abcdef01234567", tagObject = "abcdef0123456789abcdef0123456789abcdef01";
+const digest = "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd36db03d5", tree = "b".repeat(64), publicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const url = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/v1.1.0-beta.7/NeonDiff-1.1.0-beta.7-build42-macOS.zip";
+
+function fixture() {
+  const enclosure = buildFeedEnclosureProof({ url, version: "1.1.0-beta.7", build: "42", shortVersionString: "1.1.0-beta.7", channel: "beta", artifactName: "NeonDiff-1.1.0-beta.7-build42-macOS.zip", artifactSHA256: "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd36db03d5", edSignature: "kdfWQEYJInL03AG3nHvaoXVLgg0tqI1z+VUWuR/kcaangjaZ4ZTrN1s3ISdTnOqPhqrvx9uEoqqZ8/iVhCc4Ag==" }, { acceptedPublicKey: Buffer.from(publicKey, "hex").toString("base64"), signedContent: Buffer.from("NeonDiff-1.1.0-beta.7-build42-macOS.zip") });
+  const artifact = "NeonDiff-1.1.0-beta.7-build42-macOS.zip", tag = "v1.1.0-beta.7";
+  return { identity: { releaseTag: tag, sourceSHA: source, tagObjectSHA: tagObject, version: "1.1.0-beta.7", channel: "beta", build: "42", artifactName: artifact, artifactSHA256: digest, artifactLength: 4242, artifactURL: url }, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: true, immutable: true, assets: [{ name: artifact, digest: `sha256:${digest}`, size: 4242, browser_download_url: url }] }, enclosureProof: enclosure, treeProof: { schemaVersion: 1, kind: "neondiff.desktop.extracted-tree-proof-v1", verified: true, algorithm: "sha256-tree-v1", treeSHA256: tree, bundleMarkers: { appPath: "NeonDiff.app", bundleID: "com.electricsheephq.NeonDiffDesktop", version: "1.1.0-beta.7", build: "42" } }, appleProof: { schemaVersion: 1, kind: "neondiff.desktop.apple-release-proof-v1", verified: true, teamID: "TC6MS3T6NN", codesignIdentity: "Developer ID Application: NeonDiff", notarizationIdentity: "accepted", stapleIdentity: "valid", gatekeeperIdentity: "accepted" }, feedEntry: { channel: "beta", version: "1.1.0-beta.7", build: "42", url, artifactName: artifact, artifactSHA256: digest, artifactLength: 4242, edSignature: enclosure.edSignature } };
+}
+
+describe("accepted Desktop release packet", () => {
+  it("emits deterministic frozen public-safe bytes bound to validated proofs", () => {
+    const value = fixture(), first = buildAcceptedReleasePacket(value), second = buildAcceptedReleasePacket({ ...value, identity: { ...value.identity } });
+    expect(first).toEqual(second);
+    expect(Object.isFrozen(first) && Object.isFrozen(first.artifact) && Object.isFrozen(first.feed)).toBe(true);
+    expect(serializeAcceptedReleasePacket(first)).toBe(serializeAcceptedReleasePacket(second));
+    expect(first.source.commitSHA).toBe(source);
+    expect(first.tag.objectSHA).toBe(tagObject);
+    expect(first.artifact).toMatchObject({ length: 4242, sha256: digest, url });
+    expect(first.tree).toMatchObject({ sha256: tree, algorithm: "sha256-tree-v1" });
+    expect(JSON.stringify(first)).not.toMatch(/private|secret|token|password|keychain|\/Users\//i);
+  });
+
+  it.each(["sourceSHA", "tagObjectSHA", "artifactSHA256", "artifactLength", "treeSHA256", "teamID", "notarizationIdentity", "stapleIdentity", "gatekeeperIdentity"])("rejects %s substitution", (field) => {
+    const value: any = fixture();
+    if (field in value.identity) value.identity[field] = field.endsWith("SHA") ? "f".repeat(64) : field === "artifactLength" ? 1 : "other";
+    else if (field === "treeSHA256") value.treeProof.treeSHA256 = "f".repeat(64);
+    else value.appleProof[field] = "other";
+    expect(() => buildAcceptedReleasePacket(value)).toThrow();
+  });
+
+  it("rejects malformed proofs, extra authority fields, and accessor substitution", () => {
+    const extra: any = fixture(); extra.appleProof.privateKey = "never"; expect(() => buildAcceptedReleasePacket(extra)).toThrow();
+    const falseProof: any = fixture(); falseProof.treeProof.verified = false; expect(() => buildAcceptedReleasePacket(falseProof)).toThrow();
+    let reads = 0; const value: any = fixture(); value.identity = new Proxy(value.identity, { get(target, key, receiver) { if (key === "sourceSHA") { reads += 1; return reads === 1 ? source : "f".repeat(40); } return Reflect.get(target, key, receiver); } });
+    expect(() => buildAcceptedReleasePacket(value)).not.toThrow(); expect(reads).toBe(1);
+  });
+});

--- a/tests/desktop-accepted-release-packet.test.ts
+++ b/tests/desktop-accepted-release-packet.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { buildFeedEnclosureProof } from "../scripts/lib/desktop-feed-enclosure-proof.mjs";
-import { buildAcceptedReleasePacket, serializeAcceptedReleasePacket } from "../scripts/lib/desktop-accepted-release-packet.mjs";
+import { buildAcceptedReleasePacket, serializeAcceptedReleasePacket, treeProofDigest } from "../scripts/lib/desktop-accepted-release-packet.mjs";
 
 const source = "0123456789abcdef0123456789abcdef01234567", tagObject = "abcdef0123456789abcdef0123456789abcdef01";
-const digest = "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd36db03d5", tree = "b".repeat(64), publicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const digest = "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd36db03d5", publicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+const records = [["dir", "NeonDiff.app"], ["dir", "NeonDiff.app/Contents"], ["file", "NeonDiff.app/Contents/Info.plist", "-", 1, "c".repeat(64)]];
 const url = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/v1.1.0-beta.7/NeonDiff-1.1.0-beta.7-build42-macOS.zip";
 
 function fixture() {
   const enclosure = buildFeedEnclosureProof({ url, version: "1.1.0-beta.7", build: "42", shortVersionString: "1.1.0-beta.7", channel: "beta", artifactName: "NeonDiff-1.1.0-beta.7-build42-macOS.zip", artifactSHA256: "26e3f3b46951073f491eb4bce9ed29f37373a71f8660f09f1e5565dd36db03d5", edSignature: "kdfWQEYJInL03AG3nHvaoXVLgg0tqI1z+VUWuR/kcaangjaZ4ZTrN1s3ISdTnOqPhqrvx9uEoqqZ8/iVhCc4Ag==" }, { acceptedPublicKey: Buffer.from(publicKey, "hex").toString("base64"), signedContent: Buffer.from("NeonDiff-1.1.0-beta.7-build42-macOS.zip") });
   const artifact = "NeonDiff-1.1.0-beta.7-build42-macOS.zip", tag = "v1.1.0-beta.7";
-  return { identity: { releaseTag: tag, sourceSHA: source, tagObjectSHA: tagObject, version: "1.1.0-beta.7", channel: "beta", build: "42", artifactName: artifact, artifactSHA256: digest, artifactLength: 4242, artifactURL: url }, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: true, immutable: true, assets: [{ name: artifact, digest: `sha256:${digest}`, size: 4242, browser_download_url: url }] }, enclosureProof: enclosure, treeProof: { schemaVersion: 1, kind: "neondiff.desktop.extracted-tree-proof-v1", verified: true, algorithm: "sha256-tree-v1", treeSHA256: tree, bundleMarkers: { appPath: "NeonDiff.app", bundleID: "com.electricsheephq.NeonDiffDesktop", version: "1.1.0-beta.7", build: "42" } }, appleProof: { schemaVersion: 1, kind: "neondiff.desktop.apple-release-proof-v1", verified: true, teamID: "TC6MS3T6NN", codesignIdentity: "Developer ID Application: NeonDiff", notarizationIdentity: "accepted", stapleIdentity: "valid", gatekeeperIdentity: "accepted" }, feedEntry: { channel: "beta", version: "1.1.0-beta.7", build: "42", url, artifactName: artifact, artifactSHA256: digest, artifactLength: 4242, edSignature: enclosure.edSignature } };
+  return { identity: { releaseTag: tag, sourceSHA: source, tagObjectSHA: tagObject, version: "1.1.0-beta.7", channel: "beta", build: "42", artifactName: artifact, artifactSHA256: digest, artifactLength: 4242, artifactURL: url }, tagMetadata: { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }, annotatedTagMetadata: { sha: tagObject, tag, object: { type: "commit", sha: source } }, releaseMetadata: { tag_name: tag, draft: false, prerelease: true, immutable: true, assets: [{ name: artifact, digest: `sha256:${digest}`, size: 4242, browser_download_url: url }] }, enclosureProof: enclosure, treeProof: { schemaVersion: 1, kind: "neondiff.desktop.extracted-tree-proof-v1", verified: true, algorithm: "sha256-tree-v1", sourceSHA: source, artifactSHA256: digest, treeSHA256: treeProofDigest(records), records, bundleMarkers: { appPath: "NeonDiff.app", bundleID: "com.electricsheephq.NeonDiffDesktop", version: "1.1.0-beta.7", build: "42" } }, appleProof: { schemaVersion: 1, kind: "neondiff.desktop.apple-release-proof-v1", verified: true, teamID: "TC6MS3T6NN", codesignIdentity: "Developer ID Application: NeonDiff", notarizationIdentity: "accepted", stapleIdentity: "valid", gatekeeperIdentity: "accepted" }, feedEntry: { channel: "beta", version: "1.1.0-beta.7", build: "42", url, artifactName: artifact, artifactSHA256: digest, artifactLength: 4242, edSignature: enclosure.edSignature } };
 }
 
 describe("accepted Desktop release packet", () => {
@@ -21,7 +22,7 @@ describe("accepted Desktop release packet", () => {
     expect(first.source.commitSHA).toBe(source);
     expect(first.tag.objectSHA).toBe(tagObject);
     expect(first.artifact).toMatchObject({ length: 4242, sha256: digest, url });
-    expect(first.tree).toMatchObject({ sha256: tree, algorithm: "sha256-tree-v1" });
+    expect(first.tree).toMatchObject({ sha256: treeProofDigest(records), algorithm: "sha256-tree-v1" });
     expect(JSON.stringify(first)).not.toMatch(/private|secret|token|password|keychain|\/Users\//i);
   });
 
@@ -38,5 +39,10 @@ describe("accepted Desktop release packet", () => {
     const falseProof: any = fixture(); falseProof.treeProof.verified = false; expect(() => buildAcceptedReleasePacket(falseProof)).toThrow();
     let reads = 0; const value: any = fixture(); value.identity = new Proxy(value.identity, { get(target, key, receiver) { if (key === "sourceSHA") { reads += 1; return reads === 1 ? source : "f".repeat(40); } return Reflect.get(target, key, receiver); } });
     expect(() => buildAcceptedReleasePacket(value)).not.toThrow(); expect(reads).toBe(1);
+  });
+
+  it("rejects tree evidence or source binding drift", () => {
+    const evidence: any = fixture(); evidence.treeProof.records[2][4] = "d".repeat(64); expect(() => buildAcceptedReleasePacket(evidence)).toThrow();
+    const sourceBinding: any = fixture(); sourceBinding.treeProof.sourceSHA = "f".repeat(40); expect(() => buildAcceptedReleasePacket(sourceBinding)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Related: #895

- adds a deterministic, frozen, public-safe accepted Desktop release packet producer
- binds the validator-shaped release identity to raw annotated-tag and immutable asset metadata
- binds the merged #931 Sparkle enclosure proof to extracted-tree, Apple signing/notary/staple/Gatekeeper, and feed-entry identities
- emits fixed-order feed and packet SHA-256 digests

## Validation

- `node --check scripts/lib/desktop-accepted-release-packet.mjs`
- `git diff --check`
- standalone Node canonical fixture: PASS (frozen packet, deterministic serialization, packet digest)
- focused Vitest command attempted: `npx vitest run tests/desktop-accepted-release-packet.test.ts`
  - BLOCKED before test collection by the host's existing Rollup native binding Team-ID mismatch (`ERR_DLOPEN_FAILED`)

## Scope and proof boundary

- Base: `1e637bb1a60c277ddea580174712d971a4df588b`
- Head: `acb44489184975bc1773950d0388c218f9050373`
- 108 added non-generated lines across two files
- no preflight consumer, release publication, signing, notarization, feed, install, runtime, customer, or secret mutation
- proves packet construction/validation only; does not prove artifact publication, runtime update/rollback, or customer readiness
