### PR TITLE
feat(state): fence quarantined queue identities

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -753,16 +753,21 @@ export class ReviewStateStore {
         finished_at text
       );
 
-      create trigger if not exists reject_quarantined_review_queue_job
+      create trigger if not exists validate_review_queue_job_identity
       before insert on review_queue_jobs
-      when exists (
-        select 1 from review_queue_quarantines
-        where repo = lower(trim(new.repo))
-          and pull_number = new.pull_number
-          and head_sha = lower(trim(new.head_sha))
-      )
       begin
-        select raise(abort, 'review_queue_head_quarantined');
+        select raise(abort, 'review_queue_identity_noncanonical')
+        where new.repo != lower(new.repo)
+          or new.head_sha != lower(new.head_sha)
+          or new.repo glob '*[^a-z0-9._/-]*'
+          or new.head_sha glob '*[^a-z0-9._/-]*';
+        select raise(abort, 'review_queue_head_quarantined')
+        where exists (
+          select 1 from review_queue_quarantines
+          where repo = new.repo
+            and pull_number = new.pull_number
+            and head_sha = new.head_sha
+        );
       end;
 
       create index if not exists idx_review_queue_jobs_state_priority
@@ -2602,7 +2607,9 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
-    if (this.isReviewQueueHeadQuarantined(input.repo, input.pullNumber, input.headSha)) {
+    const repo = normalizeReviewQueueIdentity(input.repo);
+    const headSha = normalizeReviewQueueIdentity(input.headSha);
+    if (this.isReviewQueueHeadQuarantined(repo, input.pullNumber, headSha)) {
       throw new Error("review_queue_head_quarantined");
     }
     const nowIso = (input.now ?? new Date()).toISOString();
@@ -2611,9 +2618,9 @@ export class ReviewStateStore {
     const priority = input.priority ?? (lane === "manual" ? 10 : 50);
     const attemptId = input.attemptId ?? buildReviewQueueAttemptId({
       source,
-      repo: input.repo,
+      repo,
       pullNumber: input.pullNumber,
-      headSha: input.headSha,
+      headSha,
       baseSha: input.baseSha,
       commentId: input.commentId
     });
@@ -2640,10 +2647,10 @@ export class ReviewStateStore {
         queueAttemptId,
         source,
         lane,
-        input.repo,
-        repoOrg(input.repo),
+        repo,
+        repoOrg(repo),
         input.pullNumber,
-        input.headSha,
+        headSha,
         input.baseSha ?? null,
         input.providerId ?? null,
         priority,
@@ -2750,6 +2757,7 @@ export class ReviewStateStore {
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = this.listReviewQueueJobs({ excludeQuarantined: true })
+        .filter((job) => !this.isReviewQueueHeadQuarantined(job.repo, job.pullNumber, job.headSha))
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
         .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
@@ -2948,9 +2956,9 @@ export class ReviewStateStore {
     const quarantinePredicate = input.excludeQuarantined
       ? ` and not exists (
            select 1 from review_queue_quarantines q
-           where q.repo = lower(trim(review_queue_jobs.repo))
+           where q.repo = lower(review_queue_jobs.repo)
              and q.pull_number = review_queue_jobs.pull_number
-             and q.head_sha = lower(trim(review_queue_jobs.head_sha))
+             and q.head_sha = lower(review_queue_jobs.head_sha)
          )`
       : "";
     const rows = (input.repo

--- a/src/state.ts
+++ b/src/state.ts
@@ -281,6 +281,14 @@ export interface ReviewQueueJobRecord {
   finishedAt?: string;
 }
 
+export interface ReviewQueueQuarantineRecord {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  reason: string;
+  createdAt: string;
+}
+
 export interface ReviewReadinessRecord {
   repo: string;
   pullNumber: number;
@@ -707,6 +715,18 @@ export class ReviewStateStore {
         foreign key (session_id) references reviewer_sessions(session_id)
       );
 
+      create table if not exists review_queue_quarantines (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        reason text not null,
+        created_at text not null,
+        check (repo = lower(repo) and head_sha = lower(head_sha)),
+        primary key (repo, pull_number, head_sha)
+      );
+      create index if not exists idx_review_queue_quarantines_identity
+        on review_queue_quarantines (repo, pull_number, head_sha);
+
       create table if not exists review_queue_jobs (
         job_id text primary key,
         attempt_id text not null unique,
@@ -732,6 +752,18 @@ export class ReviewStateStore {
         started_at text,
         finished_at text
       );
+
+      create trigger if not exists reject_quarantined_review_queue_job
+      before insert on review_queue_jobs
+      when exists (
+        select 1 from review_queue_quarantines
+        where repo = lower(trim(new.repo))
+          and pull_number = new.pull_number
+          and head_sha = lower(trim(new.head_sha))
+      )
+      begin
+        select raise(abort, 'review_queue_head_quarantined');
+      end;
 
       create index if not exists idx_review_queue_jobs_state_priority
         on review_queue_jobs (state, priority, created_at);
@@ -2570,6 +2602,9 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    if (this.isReviewQueueHeadQuarantined(input.repo, input.pullNumber, input.headSha)) {
+      throw new Error("review_queue_head_quarantined");
+    }
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2618,6 +2653,40 @@ export class ReviewStateStore {
         nowIso
       );
     return { enqueued: true, job: this.getReviewQueueJob(jobId)! };
+  }
+
+  quarantineReviewQueueHead(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    reason: string;
+    now?: Date;
+  }): ReviewQueueQuarantineRecord {
+    validateReviewQueueInput(input.repo, input.pullNumber, input.headSha);
+    const reason = redactSecrets(input.reason).trim().slice(0, 500);
+    if (!reason) throw new Error("reason must be non-empty");
+    const repo = normalizeReviewQueueIdentity(input.repo);
+    const headSha = normalizeReviewQueueIdentity(input.headSha);
+    const createdAt = (input.now ?? new Date()).toISOString();
+    this.db.prepare(`
+      insert or ignore into review_queue_quarantines
+        (repo, pull_number, head_sha, reason, created_at)
+      values (?, ?, ?, ?, ?)
+    `).run(repo, input.pullNumber, headSha, reason, createdAt);
+    const row = this.db.prepare(`
+      select repo, pull_number, head_sha, reason, created_at
+      from review_queue_quarantines
+      where repo = ? and pull_number = ? and head_sha = ?
+    `).get(repo, input.pullNumber, headSha) as unknown as ReviewQueueQuarantineRow;
+    return mapReviewQueueQuarantineRow(row);
+  }
+
+  private isReviewQueueHeadQuarantined(repo: string, pullNumber: number, headSha: string): boolean {
+    return Boolean(this.db.prepare(`
+      select 1 from review_queue_quarantines
+      where repo = ? and pull_number = ? and head_sha = ?
+      limit 1
+    `).get(normalizeReviewQueueIdentity(repo), pullNumber, normalizeReviewQueueIdentity(headSha)));
   }
 
   leaseNextReviewQueueJobs(input: {
@@ -2680,7 +2749,7 @@ export class ReviewStateStore {
         )
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
-      const eligible = jobs
+      const eligible = this.listReviewQueueJobs({ excludeQuarantined: true })
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
         .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
@@ -2871,10 +2940,19 @@ export class ReviewStateStore {
     state?: ReviewQueueJobState;
     states?: ReviewQueueJobState[];
     limit?: number;
+    excludeQuarantined?: boolean;
   } = {}): ReviewQueueJobRecord[] {
     if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
       throw new Error("limit must be a positive integer");
     }
+    const quarantinePredicate = input.excludeQuarantined
+      ? ` and not exists (
+           select 1 from review_queue_quarantines q
+           where q.repo = lower(trim(review_queue_jobs.repo))
+             and q.pull_number = review_queue_jobs.pull_number
+             and q.head_sha = lower(trim(review_queue_jobs.head_sha))
+         )`
+      : "";
     const rows = (input.repo
       ? this.db
           .prepare(
@@ -2882,7 +2960,7 @@ export class ReviewStateStore {
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
-             where repo = ?
+             where repo = ?${quarantinePredicate}
              order by priority asc, datetime(created_at) asc`
           )
           .all(input.repo)
@@ -2892,6 +2970,7 @@ export class ReviewStateStore {
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
+             where 1 = 1${quarantinePredicate}
              order by priority asc, datetime(created_at) asc`
           )
           .all()) as unknown as ReviewQueueJobRow[];
@@ -4247,6 +4326,14 @@ interface ReviewQueueJobRow {
   finished_at: string | null;
 }
 
+interface ReviewQueueQuarantineRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  reason: string;
+  created_at: string;
+}
+
 interface ReviewReadinessRow {
   repo: string;
   pull_number: number;
@@ -4514,6 +4601,20 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
+}
+
+function mapReviewQueueQuarantineRow(row: ReviewQueueQuarantineRow): ReviewQueueQuarantineRecord {
+  return {
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    reason: row.reason,
+    createdAt: row.created_at
+  };
+}
+
+function normalizeReviewQueueIdentity(value: string): string {
+  return value.trim().toLowerCase();
 }
 
 function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRecord {

--- a/src/state.ts
+++ b/src/state.ts
@@ -2756,9 +2756,9 @@ export class ReviewStateStore {
         )
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
-      const eligible = this.listReviewQueueJobs({ excludeQuarantined: true })
-        .filter((job) => !this.isReviewQueueHeadQuarantined(job.repo, job.pullNumber, job.headSha))
+      const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
+        .filter((job) => !this.isReviewQueueHeadQuarantined(job.repo, job.pullNumber, job.headSha))
         .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
       const active = [

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1260,6 +1260,65 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("case-normalizes quarantine identity and fences enqueue, lease, and direct insert", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-quarantine-identity-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const store = new ReviewStateStore(dbPath);
+    const now = new Date("2026-08-24T00:00:00.000Z");
+    const quarantined = store.enqueueReviewQueueJob({
+      repo: "Owner/Repo",
+      pullNumber: 10,
+      headSha: "AbCd",
+      now
+    }).job;
+    const unrelated = store.enqueueReviewQueueJob({
+      repo: "Owner/Repo",
+      pullNumber: 11,
+      headSha: "Other",
+      now
+    }).job;
+
+    expect(store.quarantineReviewQueueHead({
+      repo: "OWNER/REPO",
+      pullNumber: 10,
+      headSha: "ABCD",
+      reason: "required evidence",
+      now
+    })).toMatchObject({ repo: "owner/repo", pullNumber: 10, headSha: "abcd" });
+    expect(store.getReviewQueueJob(quarantined.jobId)).toMatchObject({ repo: "Owner/Repo", headSha: "AbCd", state: "queued" });
+    expect(() => store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 10, headSha: "abcd", now }))
+      .toThrow("review_queue_head_quarantined");
+    expect(store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      now
+    }).map((job) => job.jobId)).toEqual([unrelated.jobId]);
+
+    const db = new DatabaseSync(dbPath);
+    try {
+      expect(() => db.prepare(`insert into review_queue_jobs
+        (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+        values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'queued', ?, ?)`)
+        .run("direct-quarantined", "direct-attempt", "oWnEr/RePo", "oWnEr", 10, "aBcD", now.toISOString(), now.toISOString()))
+        .toThrow("review_queue_head_quarantined");
+      const indexes = db.prepare("pragma index_list('review_queue_quarantines')").all() as Array<{ name: string }>;
+      expect(indexes.map((index) => index.name)).toContain("idx_review_queue_quarantines_identity");
+      const plan = db.prepare(`explain query plan
+        select 1 from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?`)
+        .all("owner/repo", 10, "abcd") as Array<{ detail: string }>;
+      expect(plan.map((step) => step.detail).join(" ")).toMatch(/INDEX/);
+      const stored = db.prepare(`select repo, pull_number, head_sha, reason
+        from review_queue_quarantines where repo = ? and pull_number = ? and head_sha = ?`)
+        .get("owner/repo", 10, "abcd");
+      expect(stored).toEqual({ repo: "owner/repo", pull_number: 10, head_sha: "abcd", reason: "required evidence" });
+    } finally {
+      db.close();
+      store.close();
+    }
+  });
+
   it("dry-runs and clears expired review queue leases without manual SQL", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-clear-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1278,17 +1278,23 @@ describe("review state store", () => {
       headSha: "Other",
       now
     }).job;
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.prepare("update review_queue_jobs set repo = ?, head_sha = ? where job_id = ?")
+      .run("Owner/Repo\t", "AbCd\n", quarantined.jobId);
+    legacyDb.close();
 
     expect(store.quarantineReviewQueueHead({
-      repo: "OWNER/REPO",
+      repo: "OWNER/REPO\u00a0",
       pullNumber: 10,
-      headSha: "ABCD",
+      headSha: "ABCD\n",
       reason: "required evidence",
       now
     })).toMatchObject({ repo: "owner/repo", pullNumber: 10, headSha: "abcd" });
-    expect(store.getReviewQueueJob(quarantined.jobId)).toMatchObject({ repo: "Owner/Repo", headSha: "AbCd", state: "queued" });
-    expect(() => store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 10, headSha: "abcd", now }))
-      .toThrow("review_queue_head_quarantined");
+    expect(store.getReviewQueueJob(quarantined.jobId)).toMatchObject({ repo: "Owner/Repo\t", headSha: "AbCd\n", state: "queued" });
+    for (const whitespace of ["\t", "\n", "\u00a0"]) {
+      expect(() => store.enqueueReviewQueueJob({ repo: `owner/repo${whitespace}`, pullNumber: 10, headSha: `abcd${whitespace}`, now }))
+        .toThrow("review_queue_head_quarantined");
+    }
     expect(store.leaseNextReviewQueueJobs({
       maxProviderActive: 1,
       maxOrgActive: 1,
@@ -1301,8 +1307,15 @@ describe("review state store", () => {
       expect(() => db.prepare(`insert into review_queue_jobs
         (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'queued', ?, ?)`)
-        .run("direct-quarantined", "direct-attempt", "oWnEr/RePo", "oWnEr", 10, "aBcD", now.toISOString(), now.toISOString()))
+        .run("direct-quarantined", "direct-attempt", "owner/repo", "owner", 10, "abcd", now.toISOString(), now.toISOString()))
         .toThrow("review_queue_head_quarantined");
+      for (const [index, whitespace] of ["\t", "\n", "\u00a0"].entries()) {
+        expect(() => db.prepare(`insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+          values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'queued', ?, ?)`)
+          .run(`direct-noncanonical-${index}`, `direct-noncanonical-attempt-${index}`, `owner/repo${whitespace}`, "owner", 10, `abcd${whitespace}`, now.toISOString(), now.toISOString()))
+          .toThrow("review_queue_identity_noncanonical");
+      }
       const indexes = db.prepare("pragma index_list('review_queue_quarantines')").all() as Array<{ name: string }>;
       expect(indexes.map((index) => index.name)).toContain("idx_review_queue_quarantines_identity");
       const plan = db.prepare(`explain query plan


### PR DESCRIPTION
## Summary

- Adds canonical lowercase quarantine identity storage for repo/pull/head.
- Fences equivalent enqueue and lease admission through indexed SQL lookup.
- Adds a SQLite trigger to reject direct queue inserts for quarantined identities.
- Preserves legacy queue rows and does not transition, claim, receipt, clean up, or account for jobs.

Related: #882

## Proof

- Base: `1e637bb1a60c277ddea580174712d971a4df588b`
- Head: `c405223`
- Changed lines: 162 non-generated (103 additions/2 deletions in `src/state.ts`, 59 additions in `tests/state.test.ts`)
- `git diff --check` passes.
- Temp-DB `tsx` smoke passes: case-variant enqueue rejection, case-variant direct SQL insert rejection, quarantined queued row remains readable, unrelated row leases, canonical stored identity, and indexed query plan.
- Full Vitest focused invocation is currently unavailable in this macOS worktree because the installed optional Rollup native binding fails its platform Team-ID signature check; exact-head CI is authoritative.

## Scope boundary

A1a only. No state-transition CAS, worker/runtime wiring, post claims, receipts, cleanup, expiry/accounting, live DB/config/runtime/customer mutation, merge, or release action.
