### PR TITLE
feat: add severe receipt Parser A input boundary

### DIFF
--- a/src/severe-verification-receipt-parser-a.ts
+++ b/src/severe-verification-receipt-parser-a.ts
@@ -1,0 +1,78 @@
+export const MAX_SEVERE_VERIFICATION_RECEIPT_BYTES = 512 * 1024;
+
+export type SerializedSevereVerificationInput = string | Uint8Array;
+
+const IntrinsicUint8Array = Uint8Array;
+const intrinsicIsView = ArrayBuffer.isView;
+const intrinsicGetPrototypeOf = Object.getPrototypeOf;
+const intrinsicOwnKeys = Reflect.ownKeys;
+const typedArrayPrototype = intrinsicGetPrototypeOf(IntrinsicUint8Array.prototype);
+const intrinsicByteLength = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!.get!;
+const intrinsicByteOffset = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteOffset")!.get!;
+const intrinsicBuffer = Object.getOwnPropertyDescriptor(typedArrayPrototype, "buffer")!.get!;
+const intrinsicTag = Object.getOwnPropertyDescriptor(typedArrayPrototype, Symbol.toStringTag)!.get!;
+const intrinsicSet = IntrinsicUint8Array.prototype.set;
+const intrinsicBufferPrototype = typeof Buffer === "function" ? Buffer.prototype : undefined;
+
+const reject = (code: string): never => { throw new TypeError(`severe_receipt_${code}`); };
+
+/** Parser A: preserve text, or copy an intrinsically branded byte view for Parser B. */
+export function prepareSerializedSevereVerificationInput(input: unknown): SerializedSevereVerificationInput {
+  if (typeof input === "string") {
+    if (!withinByteCap(input)) reject("cap_exceeded");
+    return input;
+  }
+  if (!isIntrinsicByteArray(input)) reject("serialized_input");
+  const bytes = input as Uint8Array;
+
+  let length: number;
+  try { length = intrinsicByteLength.call(bytes); } catch { return reject("serialized_input"); }
+  if (length > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) reject("cap_exceeded");
+  if (!hasOnlyCanonicalIndices(bytes, length)) reject("serialized_input");
+
+  try {
+    const source = new IntrinsicUint8Array(
+      intrinsicBuffer.call(bytes), intrinsicByteOffset.call(bytes), length
+    );
+    const copy = new IntrinsicUint8Array(length);
+    intrinsicSet.call(copy, source);
+    return copy;
+  } catch { return reject("serialized_input"); }
+}
+
+function isIntrinsicByteArray(input: unknown): input is Uint8Array {
+  if (!intrinsicIsView(input)) return false;
+  try {
+    const prototype = intrinsicGetPrototypeOf(input);
+    return intrinsicTag.call(input) === "Uint8Array" &&
+      (prototype === IntrinsicUint8Array.prototype || prototype === intrinsicBufferPrototype);
+  } catch { return false; }
+}
+
+function hasOnlyCanonicalIndices(input: Uint8Array, length: number): boolean {
+  for (const key of intrinsicOwnKeys(input)) {
+    if (typeof key !== "string" || !isCanonicalIndex(key, length)) return false;
+  }
+  return true;
+}
+
+function isCanonicalIndex(key: string, length: number): boolean {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index < length && String(index) === key;
+}
+
+function withinByteCap(value: string): boolean {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x7f) bytes += 1;
+    else if (code <= 0x7ff) bytes += 2;
+    else if (code >= 0xd800 && code <= 0xdbff && value.charCodeAt(index + 1) >= 0xdc00 && value.charCodeAt(index + 1) <= 0xdfff) {
+      bytes += 4;
+      index += 1;
+    } else bytes += 3;
+    if (bytes > MAX_SEVERE_VERIFICATION_RECEIPT_BYTES) return false;
+  }
+  return true;
+}

--- a/tests/severe-verification-receipt-parser-a.test.ts
+++ b/tests/severe-verification-receipt-parser-a.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_SEVERE_VERIFICATION_RECEIPT_BYTES,
+  prepareSerializedSevereVerificationInput
+} from "../src/severe-verification-receipt-parser-a.js";
+
+const prepare = prepareSerializedSevereVerificationInput;
+
+describe("severe receipt Parser A input boundary", () => {
+  it("accepts primitive strings and intrinsic Uint8Array/Buffer inputs", () => {
+    const text = "{\"ok\":true}";
+    expect(prepare(text)).toBe(text);
+    expect(prepare(new Uint8Array([1, 2, 3]))).toEqual(new Uint8Array([1, 2, 3]));
+    expect(prepare(Buffer.from([4, 5, 6]))).toEqual(new Uint8Array([4, 5, 6]));
+  });
+
+  it("returns a defensive byte copy", () => {
+    const source = new Uint8Array([1, 2, 3]);
+    const copy = prepare(source);
+    source[0] = 9;
+    expect(copy).toEqual(new Uint8Array([1, 2, 3]));
+    if (copy instanceof Uint8Array) copy[1] = 8;
+    expect(source).toEqual(new Uint8Array([9, 2, 3]));
+  });
+
+  it("enforces the cap before enumerating or copying", () => {
+    let enumerated = false;
+    const oversized = new Uint8Array(MAX_SEVERE_VERIFICATION_RECEIPT_BYTES + 1);
+    Object.defineProperty(oversized, "oversized", {
+      enumerable: true,
+      get() { enumerated = true; throw new Error("getter invoked"); }
+    });
+    expect(() => prepare(oversized)).toThrow("cap_exceeded");
+    expect(enumerated).toBe(false);
+    expect(() => prepare("x".repeat(MAX_SEVERE_VERIFICATION_RECEIPT_BYTES + 1))).toThrow("cap_exceeded");
+  });
+
+  it.each(["00", "01", "999999999999999999999999999999999999999999999999999999"]) (
+    "rejects noncanonical numeric-looking own key %s without invoking it",
+    (key) => {
+      let invoked = false;
+      const input = new Uint8Array([7]);
+      Object.defineProperty(input, key, {
+        configurable: true,
+        get() { invoked = true; throw new Error("getter invoked"); }
+      });
+      expect(() => prepare(input)).toThrow("serialized_input");
+      expect(invoked).toBe(false);
+    }
+  );
+
+  it("rejects -0 and arbitrary non-byte inputs", () => {
+    expect(() => prepare({ "-0": 1 })).toThrow("serialized_input");
+    expect(() => prepare(() => "bytes")).toThrow("serialized_input");
+  });
+
+  it("rejects accessors, functions, symbols, and non-index own properties", () => {
+    const accessor = new Uint8Array([1]);
+    Object.defineProperty(accessor, "evil", { get() { throw new Error("getter invoked"); } });
+    expect(() => prepare(accessor)).toThrow("serialized_input");
+
+    const functionValue = new Uint8Array([1]);
+    Object.defineProperty(functionValue, "evil", { value: () => { throw new Error("called"); } });
+    expect(() => prepare(functionValue)).toThrow("serialized_input");
+
+    const symbolValue = new Uint8Array([1]);
+    Object.defineProperty(symbolValue, Symbol("evil"), { value: 1 });
+    expect(() => prepare(symbolValue)).toThrow("serialized_input");
+  });
+
+  it("rejects proxies, subclasses, and prototype-spoofed typed arrays without traps", () => {
+    let trapped = false;
+    const proxy = new Proxy(new Uint8Array([1]), {
+      get() { trapped = true; throw new Error("trap"); },
+      ownKeys() { trapped = true; throw new Error("trap"); }
+    });
+    expect(() => prepare(proxy)).toThrow("serialized_input");
+    expect(trapped).toBe(false);
+
+    class Child extends Uint8Array {}
+    expect(() => prepare(new Child([1]))).toThrow("serialized_input");
+
+    const int8 = new Int8Array([1]);
+    Object.setPrototypeOf(int8, Uint8Array.prototype);
+    expect(() => prepare(int8)).toThrow("serialized_input");
+
+    const clamped = new Uint8ClampedArray([1]);
+    Object.setPrototypeOf(clamped, Uint8Array.prototype);
+    expect(() => prepare(clamped)).toThrow("serialized_input");
+  });
+
+  it("accepts only canonical integer indices", () => {
+    const input = new Uint8Array([7, 8]);
+    expect(prepare(input)).toEqual(new Uint8Array([7, 8]));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the Parser A serialized input boundary for issue #865.
- Accepts primitive strings and intrinsically branded Uint8Array/Buffer values.
- Enforces the 512 KiB UTF-8 byte cap before own-key enumeration or byte copying.
- Rejects proxies, subclasses, spoofed typed-array brands, symbols, accessors/functions, and noncanonical/out-of-range own keys without invoking hostile behavior.
- Returns primitive strings unchanged and defensive Uint8Array copies for byte inputs.

This is source/test-only and intentionally does not perform UTF-8 decoding, JSON parsing, schema validation, digesting, or publication wiring. It starts at current main `1e637bb1a60c277ddea580174712d971a4df588b`; PR #930 was not used as a merge base.

## Validation

- Targeted TypeScript compile: pass.
- Direct tsx runtime fixtures: pass (string, Uint8Array, Buffer, defensive copy, cap-before-enumeration, canonical-key, proxy/subclass/spoof, Unicode cap).
- `git diff --check`: pass.
- Vitest focused run is environment-blocked by Rollup native optional binary code-signature mismatch (`ERR_DLOPEN_FAILED`); no test assertion failure observed.
- GitNexus MCP tools were unavailable in this worker; direct source/scope inspection was used with that proof boundary recorded.
