### PR TITLE
feat(desktop): authenticate extracted app tree proof

### DIFF
--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+
+const SHA1 = /^[a-f0-9]{40}$/, SHA256 = /^[a-f0-9]{64}$/;
+const KIND = "neondiff.desktop.extracted-tree-proof-v1";
+const INPUT_FIELDS = ["sourceSHA", "artifactSHA256", "records", "bundleMarkers"];
+const MARKER_FIELDS = ["appPath", "bundleID", "version", "build"];
+const PROOF_FIELDS = ["schemaVersion", "kind", "verified", "algorithm", "sourceSHA", "artifactSHA256", "treeSHA256", "records", "bundleMarkers"];
+const authenticated = new WeakSet();
+const fail = (message) => { throw new Error(message); };
+
+function exact(value, fields, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  const keys = Object.keys(value);
+  if (keys.length !== fields.length || keys.some((key) => !fields.includes(key))) fail(`${label} has undeclared fields`);
+  return value;
+}
+function text(value, label) { if (typeof value !== "string" || !value || /[\u0000-\u001f\u007f]/.test(value)) fail(`${label} is malformed`); return value; }
+function digest(value, label, pattern = SHA256) { const result = text(value, label); if (!pattern.test(result)) fail(`${label} is malformed`); return result; }
+function hash(value) { return createHash("sha256").update(value, "utf8").digest("hex"); }
+function safePath(value, label) {
+  const result = text(value, label);
+  if (result !== result.normalize("NFC") || result.startsWith("/") || result.includes("\\") || result.split("/").some((part) => !part || part === "." || part === "..")) fail(`${label} is not a canonical relative path`);
+  return result;
+}
+function canonicalRecords(rawRecords) {
+  if (!Array.isArray(rawRecords) || rawRecords.length === 0) fail("tree records are required");
+  const seen = new Set(); let previous = "";
+  const records = rawRecords.map((raw) => {
+    if (!Array.isArray(raw)) fail("tree record must be an array");
+    const parts = [...raw], type = parts[0], path = safePath(parts[1], "tree record path"), folded = path.toLocaleLowerCase("en-US");
+    if (seen.has(folded) || path <= previous) fail("tree records are not canonical");
+    seen.add(folded); previous = path;
+    if (!["dir", "file", "link"].includes(type)) fail("tree record type is invalid");
+    if (type === "dir" && parts.length !== 2) fail("directory tree record is malformed");
+    if (type === "link") {
+      const target = text(parts[2], "symlink target");
+      if (parts.length !== 3 || target.startsWith("/") || target.includes("\\")) fail("symlink target is malformed");
+      const resolved = posix.normalize(posix.join(posix.dirname(path), target));
+      if (resolved === ".." || resolved.startsWith("../")) fail("symlink escapes bundle root");
+    }
+    if (type === "file" && (parts.length !== 5 || !["-", "x"].includes(parts[2]) || !Number.isSafeInteger(parts[3]) || parts[3] < 0 || !SHA256.test(parts[4]))) fail("file tree record is malformed");
+    return parts;
+  });
+  if (records[0][0] !== "dir" || records[0][1] !== "NeonDiff.app" || records.some((record) => record[1] !== "NeonDiff.app" && !record[1].startsWith("NeonDiff.app/"))) fail("tree does not describe the required app bundle");
+  return records;
+}
+function treeHash(records) {
+  const digest = createHash("sha256");
+  for (const record of canonicalRecords(records)) for (const part of record) { digest.update(String(part), "utf8"); digest.update("\0"); }
+  return digest.digest("hex");
+}
+function freeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { Object.values(value).forEach(freeze); Object.freeze(value); } return value; }
+function readMarkers(raw) {
+  const value = exact(raw, MARKER_FIELDS, "bundle markers");
+  const appPath = value.appPath, bundleID = value.bundleID, version = value.version, build = value.build;
+  if (appPath !== "NeonDiff.app" || bundleID !== "com.electricsheephq.NeonDiffDesktop" || !/^1\.1\.0-(?:beta|rc)\.[1-9][0-9]{0,15}$/.test(text(version, "bundle version")) || !/^\d+$/.test(text(build, "bundle build")) || !Number.isSafeInteger(Number(build))) fail("bundle markers are not canonical");
+  return { appPath, bundleID, version, build };
+}
+
+export function treeProofDigest(records) { return treeHash(records); }
+export function buildExtractedAppTreeProof(input) {
+  const value = exact(input, INPUT_FIELDS, "tree proof inputs");
+  const sourceSHA = digest(value.sourceSHA, "source SHA", SHA1), artifactSHA256 = digest(value.artifactSHA256, "artifact SHA-256");
+  const records = canonicalRecords(value.records), bundleMarkers = readMarkers(value.bundleMarkers);
+  const proof = { schemaVersion: 1, kind: KIND, verified: true, algorithm: "sha256-tree-v1", sourceSHA, artifactSHA256, treeSHA256: treeHash(records), records, bundleMarkers };
+  authenticated.add(proof); return freeze(proof);
+}
+export function serializeExtractedAppTreeProof(proof) {
+  if (!authenticated.has(proof)) fail("proof was not produced by the extracted-tree producer");
+  return `${JSON.stringify(Object.fromEntries(PROOF_FIELDS.map((field) => [field, proof[field]])))}\n`;
+}
+export function extractedAppTreeProofDigest(proof) { return hash(serializeExtractedAppTreeProof(proof)); }

--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -37,9 +37,9 @@ function canonicalRecords(rawRecords) {
       const target = text(parts[2], "symlink target");
       if (parts.length !== 3 || target.startsWith("/") || target.includes("\\")) fail("symlink target is malformed");
       const resolved = posix.normalize(posix.join(posix.dirname(path), target));
-      if (resolved === ".." || resolved.startsWith("../")) fail("symlink escapes bundle root");
+      if (resolved !== "NeonDiff.app" && !resolved.startsWith("NeonDiff.app/")) fail("symlink escapes app root");
     }
-    if (type === "file" && (parts.length !== 5 || !["-", "x"].includes(parts[2]) || !Number.isSafeInteger(parts[3]) || parts[3] < 0 || !SHA256.test(parts[4]))) fail("file tree record is malformed");
+    if (type === "file" && (parts.length !== 5 || !["-", "x"].includes(parts[2]) || !Number.isSafeInteger(parts[3]) || parts[3] < 0 || typeof parts[4] !== "string" || !SHA256.test(parts[4]))) fail("file tree record is malformed");
     return parts;
   });
   if (records[0][0] !== "dir" || records[0][1] !== "NeonDiff.app" || records.some((record) => record[1] !== "NeonDiff.app" && !record[1].startsWith("NeonDiff.app/"))) fail("tree does not describe the required app bundle");
@@ -47,7 +47,7 @@ function canonicalRecords(rawRecords) {
 }
 function treeHash(records) {
   const digest = createHash("sha256");
-  for (const record of canonicalRecords(records)) for (const part of record) { digest.update(String(part), "utf8"); digest.update("\0"); }
+  for (const record of canonicalRecords(records)) { for (const part of record) { digest.update(String(part), "utf8"); digest.update("\0"); } digest.update("\n"); }
   return digest.digest("hex");
 }
 function freeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { Object.values(value).forEach(freeze); Object.freeze(value); } return value; }

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExtractedAppTreeProof,
+  extractedAppTreeProofDigest,
+  serializeExtractedAppTreeProof,
+  treeProofDigest
+} from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
+
+const source = "0123456789abcdef0123456789abcdef01234567";
+const artifact = "a".repeat(64);
+const records = [
+  ["dir", "NeonDiff.app"],
+  ["dir", "NeonDiff.app/Contents"],
+  ["file", "NeonDiff.app/Contents/Info.plist", "-", 3, "b".repeat(64)],
+  ["dir", "NeonDiff.app/Contents/MacOS"],
+  ["file", "NeonDiff.app/Contents/MacOS/NeonDiffDesktop", "x", 7, "c".repeat(64)]
+];
+const markers = { appPath: "NeonDiff.app", bundleID: "com.electricsheephq.NeonDiffDesktop", version: "1.1.0-beta.7", build: "42" };
+
+function fixture() { return { sourceSHA: source, artifactSHA256: artifact, records: records.map((record) => [...record]), bundleMarkers: { ...markers } }; }
+
+describe("authenticated extracted app-tree proof", () => {
+  it("derives deterministic sha256-tree-v1 bytes and snapshots inputs", () => {
+    const first = buildExtractedAppTreeProof(fixture());
+    const second = buildExtractedAppTreeProof(fixture());
+    expect(first).toEqual(second);
+    expect(first.algorithm).toBe("sha256-tree-v1");
+    expect(first.treeSHA256).toBe(treeProofDigest(records));
+    expect(serializeExtractedAppTreeProof(first)).toBe(serializeExtractedAppTreeProof(second));
+    expect(extractedAppTreeProofDigest(first)).toMatch(/^[a-f0-9]{64}$/);
+    expect(Object.isFrozen(first) && Object.isFrozen(first.records[0]) && Object.isFrozen(first.bundleMarkers)).toBe(true);
+    expect(serializeExtractedAppTreeProof(first)).not.toMatch(/\/Users\/|private|secret|token|password|keychain/i);
+  });
+
+  it.each([
+    ["order", (value: any) => { value.records.reverse(); }],
+    ["case duplicate", (value: any) => { value.records.splice(3, 0, ["file", "NeonDiff.app/Contents/info.plist", "-", 3, "b".repeat(64)]); }],
+    ["mode", (value: any) => { value.records[2][2] = "rw"; }],
+    ["size", (value: any) => { value.records[2][3] = -1; }],
+    ["byte digest", (value: any) => { value.records[2][4] = "not-a-sha"; }],
+    ["escaping symlink", (value: any) => { value.records.splice(2, 0, ["link", "NeonDiff.app/Contents/Current", "../../../../outside"]); }],
+    ["bundle marker", (value: any) => { value.bundleMarkers.bundleID = "other.bundle"; }],
+    ["source binding", (value: any) => { value.sourceSHA = "not-a-source-sha"; }],
+    ["artifact binding", (value: any) => { value.artifactSHA256 = "not-an-artifact-sha"; }]
+  ])("rejects hostile %s input", (_label, mutate) => {
+    const value = fixture(); mutate(value);
+    expect(() => buildExtractedAppTreeProof(value)).toThrow();
+  });
+
+  it("rejects forged, spread, JSON, and proxy proofs at serialization", () => {
+    const proof = buildExtractedAppTreeProof(fixture());
+    expect(() => serializeExtractedAppTreeProof({ ...proof })).toThrow();
+    expect(() => serializeExtractedAppTreeProof(JSON.parse(JSON.stringify(proof)))).toThrow();
+    expect(() => serializeExtractedAppTreeProof(new Proxy(proof, {}))).toThrow();
+  });
+
+  it("reads source binding once before a hostile accessor can substitute it", () => {
+    let reads = 0;
+    const value = new Proxy(fixture(), { get(target, key, receiver) {
+      if (key === "sourceSHA") { reads += 1; return reads === 1 ? source : "f".repeat(40); }
+      return Reflect.get(target, key, receiver);
+    } });
+    const proof = buildExtractedAppTreeProof(value);
+    expect(reads).toBe(1);
+    expect(proof.sourceSHA).toBe(source);
+  });
+});

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -25,6 +25,7 @@ describe("authenticated extracted app-tree proof", () => {
     const second = buildExtractedAppTreeProof(fixture());
     expect(first).toEqual(second);
     expect(first.algorithm).toBe("sha256-tree-v1");
+    expect(first.treeSHA256).toBe("962e947f4cc77ba95d402ae8f9a8762bd2ba7bb7588b63243115d8d8688e11ed");
     expect(first.treeSHA256).toBe(treeProofDigest(records));
     expect(serializeExtractedAppTreeProof(first)).toBe(serializeExtractedAppTreeProof(second));
     expect(extractedAppTreeProofDigest(first)).toMatch(/^[a-f0-9]{64}$/);
@@ -38,7 +39,9 @@ describe("authenticated extracted app-tree proof", () => {
     ["mode", (value: any) => { value.records[2][2] = "rw"; }],
     ["size", (value: any) => { value.records[2][3] = -1; }],
     ["byte digest", (value: any) => { value.records[2][4] = "not-a-sha"; }],
+    ["non-primitive byte digest", (value: any) => { value.records[2][4] = ["b".repeat(64)]; }],
     ["escaping symlink", (value: any) => { value.records.splice(2, 0, ["link", "NeonDiff.app/Contents/Current", "../../../../outside"]); }],
+    ["symlink outside app root", (value: any) => { value.records.push(["link", "NeonDiff.app/escape", "../outside"]); }],
     ["bundle marker", (value: any) => { value.bundleMarkers.bundleID = "other.bundle"; }],
     ["source binding", (value: any) => { value.sourceSHA = "not-a-source-sha"; }],
     ["artifact binding", (value: any) => { value.artifactSHA256 = "not-an-artifact-sha"; }]


### PR DESCRIPTION
Related: #895

## Scope

Implements T1 from the accepted #895 split: a repository-owned extracted app-tree proof producer that validates canonical descriptor records and derives `sha256-tree-v1`, required bundle markers, artifact SHA-256, and source/build identity inputs. The proof is recursively frozen and can only be serialized through the module-owned WeakSet authentication guard with fixed field order.

Focused hostile tests cover ordering, relative path and case uniqueness, mode, size, byte SHA-256 shape, symlink escape, bundle-marker/source/artifact validation, accessor snapshotting, and forged/spread/JSON/proxy serialization rejection.

## Validation

- `node --check scripts/lib/desktop-extracted-app-tree-proof.mjs`
- deterministic Node smoke: valid proof + hostile fixture rejection + forged serialization rejection + accessor snapshot; PASS
- `git diff --check`; PASS
- `npm test -- --run tests/desktop-extracted-app-tree-proof.test.ts`; blocked in this fresh worktree because `vitest` is not installed

## Safety boundary

No accepted packet/consumer, Apple/key/tag/feed/build/release code, signing, notarization, upload, install, runtime, customer, config, database, Keychain, or launchd mutation is included. This proves only authenticated T1 proof construction and serialization; it does not prove source/tag authority, Apple acceptance, approved Sparkle key, appcast content, accepted packet, publication, updater, rollback, runtime safety, or customer readiness.
