### PR TITLE
fix(github): bound issue-enrichment readers

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -18,7 +18,21 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+export type GithubPaginationOverflowKind = "issue_comment_marker";
+
+/** A complete marker scan must fail closed when five full pages cannot establish absence. */
+export class GithubPaginationOverflowError extends Error {
+  readonly kind: GithubPaginationOverflowKind;
+
+  constructor() {
+    super("GitHub issue comment marker scan exceeded page limit");
+    this.name = "GithubPaginationOverflowError";
+    this.kind = "issue_comment_marker";
+  }
+}
 
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
 export type BoundedGithubList<T> = T[] & {
@@ -347,7 +361,7 @@ export class GitHubApi {
     return boundedGithubList(comments, true);
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedGithubList<{
     event?: string;
     created_at?: string;
     actor?: { login?: string | null } | null;
@@ -365,8 +379,10 @@ export class GitHubApi {
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100) return boundedGithubList(events, false);
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) return boundedGithubList(events, true);
     }
+    return boundedGithubList(events, true);
   }
 
   async getCollaboratorPermission(
@@ -514,7 +530,7 @@ export class GitHubApi {
     marker: string,
     token: string
   ): Promise<IssueCommentSummary | undefined> {
-    for (let page = 1; ; page += 1) {
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
       const comments = await this.request<IssueCommentSummary[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
@@ -523,6 +539,7 @@ export class GitHubApi {
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
+    throw new GithubPaginationOverflowError();
   }
 
   private isBotAuthoredComment(comment: IssueCommentSummary): boolean {

--- a/tests/issue-enrichment-pagination-contract.test.ts
+++ b/tests/issue-enrichment-pagination-contract.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GithubPaginationOverflowError, GitHubApi } from "../src/github.js";
+
+describe("bounded issue-enrichment GitHub readers", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("keeps issue comments in page order and marks a full five-page read", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = fullPageTransport("comments", pages);
+    const result = await new GitHubApi({ token: "fixture" }).listIssueCommentsForEnrichment("owner/repo", 738);
+
+    expect(pages).toEqual([1, 2, 3, 4, 5]);
+    expect(result).toHaveLength(500);
+    expect(result.items.slice(0, 3).map((comment) => comment.id)).toEqual([100, 101, 102]);
+    expect(result.items.slice(-3).map((comment) => comment.id)).toEqual([597, 598, 599]);
+    expect(result.rawCount).toBe(500);
+    expect(result.truncated).toBe(true);
+    expect(result.overflow).toBe(true);
+  });
+
+  it("returns label events in page order with explicit truncation metadata", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = fullPageTransport("events", pages);
+    const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+
+    expect(pages).toEqual([1, 2, 3, 4, 5]);
+    expect(result).toHaveLength(500);
+    expect(result.items[0]?.event).toBe("1:0");
+    expect(result.items[499]?.event).toBe("5:99");
+    expect(result.rawCount).toBe(500);
+    expect(result.truncated).toBe(true);
+    expect(result.overflow).toBe(true);
+  });
+
+  it("fails closed after five full marker pages", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = fullPageTransport("marker", pages);
+    const api = new GitHubApi({ token: "fixture" });
+    const findMarker = (api as unknown as { findIssueCommentByMarker: (...args: string[]) => Promise<unknown> }).findIssueCommentByMarker.bind(api);
+
+    await expect(findMarker("owner/repo", "738", "marker", "fixture")).rejects.toMatchObject({
+      name: "GithubPaginationOverflowError",
+      kind: "issue_comment_marker"
+    } satisfies Partial<GithubPaginationOverflowError>);
+    expect(pages).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+function fullPageTransport(kind: "comments" | "events" | "marker", pages: number[]) {
+  return vi.fn(async (url) => {
+    const page = Number(new URL(String(url)).searchParams.get("page"));
+    pages.push(page);
+    const body = Array.from({ length: 100 }, (_unused, index) => {
+      if (kind === "events") return { event: `${page}:${index}` };
+      return {
+        id: page * 100 + index,
+        body: "unrelated",
+        ...(kind === "marker" ? { user: { type: "Bot", login: "evaos-code-review-bot[bot]" } } : {})
+      };
+    });
+    return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+}


### PR DESCRIPTION
Related: #738\n\nAgent-authored bounded P1 pagination slice from current main 471a8d1ea489e1c2dabed4b24da241ef6ea11e7b.\n\n- Caps enrichment issue-comment reads at five pages / 500 rows with existing overflow metadata.\n- Caps marker lookup at five pages and fails closed with GithubPaginationOverflowError.\n- Caps label events at five pages and returns array-compatible items/rawCount/truncated/overflow metadata.\n- Adds focused permanently-full mocked transport fixtures proving page order and exactly five requests.\n\nProof: focused source TypeScript checks and direct tsx transport probes pass. Vitest could not start because the shared dependency tree is missing/invalid native Rollup optional bindings; exact-head CI is required. No enrichment outcome, summary, recommendation, watermark, record, posting, runtime, or customer logic changed.\n\nMerge base is accepted current main; closed PR #935 was not reused or cherry-picked.