### PR TITLE
feat(state): add indexed queue shadow identity

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -53,6 +53,7 @@ export type RepoMemoryNoteKind =
 export type IssueEnrichmentRecordStatus = "dry_run" | "posted" | "skipped" | "deferred" | "failed";
 const REPO_MEMORY_NOTE_KINDS: RepoMemoryNoteKind[] = ["policy_note", "machine_fact", "false_positive", "review_outcome", "proof_preference"];
 const WORKTREE_CLEANUP_GUARD_TTL_MS = 60_000;
+const REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION = "review_queue_jobs_shadow_identity_v1";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -840,6 +841,11 @@ export class ReviewStateStore {
         started_at text not null,
         expires_at text not null,
         owner_pid integer
+      );
+
+      create table if not exists review_state_migrations (
+        name text primary key,
+        completed_at text not null
       );
     `);
     this.ensureProcessedReviewColumns();
@@ -3700,6 +3706,7 @@ export class ReviewStateStore {
     if (additions.length > 0) {
       this.db.exec(`begin immediate; ${additions.map((name) => `alter table review_queue_jobs add column ${name} text`).join("; ")}; commit`);
     }
+    if (this.db.prepare("select 1 from review_state_migrations where name = ? limit 1").get(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION)) return;
     this.db.exec(`create index if not exists idx_review_queue_jobs_shadow_identity
       on review_queue_jobs (repo_key, pull_number, head_sha_key)`);
 
@@ -3725,6 +3732,8 @@ export class ReviewStateStore {
         const identity = canonicalReviewQueueIdentity(row.repo, row.head_sha);
         if (identity) backfill.run(identity.repoKey, identity.headShaKey, row.rowid);
       }
+      this.db.prepare("insert or ignore into review_state_migrations (name, completed_at) values (?, datetime('now'))")
+        .run(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION);
       this.db.exec("commit");
     } catch (error) {
       try { this.db.exec("rollback"); } catch { /* transaction did not start */ }

--- a/src/state.ts
+++ b/src/state.ts
@@ -261,9 +261,11 @@ export interface ReviewQueueJobRecord {
   source: ReviewQueueJobSource;
   lane: ReviewQueueJobLane;
   repo: string;
+  repoKey?: string;
   org: string;
   pullNumber: number;
   headSha: string;
+  headShaKey?: string;
   baseSha?: string;
   providerId?: string;
   priority: number;
@@ -716,6 +718,8 @@ export class ReviewStateStore {
         org text not null,
         pull_number integer not null,
         head_sha text not null,
+        repo_key text,
+        head_sha_key text,
         base_sha text,
         provider_id text,
         priority integer not null,
@@ -844,6 +848,7 @@ export class ReviewStateStore {
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
     this.ensureReviewQueueJobColumns();
+    this.ensureReviewQueueJobShadowIdentityColumns();
     this.ensureRepoMemoryNoteCoarseColumns();
     this.db.exec(`
       create table if not exists processed_commands (
@@ -2570,6 +2575,7 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    const shadowIdentity = canonicalReviewQueueIdentity(input.repo, input.headSha);
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2596,9 +2602,9 @@ export class ReviewStateStore {
     this.db
       .prepare(
         `insert into review_queue_jobs
-          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+          (job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
            provider_id, priority, state, session_id, comment_id, created_at, updated_at)
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
       )
       .run(
         jobId,
@@ -2606,9 +2612,11 @@ export class ReviewStateStore {
         source,
         lane,
         input.repo,
+        shadowIdentity?.repoKey ?? null,
         repoOrg(input.repo),
         input.pullNumber,
         input.headSha,
+        shadowIdentity?.headShaKey ?? null,
         input.baseSha ?? null,
         input.providerId ?? null,
         priority,
@@ -2824,7 +2832,7 @@ export class ReviewStateStore {
   getReviewQueueJob(jobId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2838,7 +2846,7 @@ export class ReviewStateStore {
   getReviewQueueJobByAttemptId(attemptId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2853,7 +2861,7 @@ export class ReviewStateStore {
     const retryPrefix = `${attemptId}:after-terminal:`;
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2878,7 +2886,7 @@ export class ReviewStateStore {
     const rows = (input.repo
       ? this.db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+            `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
@@ -2888,7 +2896,7 @@ export class ReviewStateStore {
           .all(input.repo)
       : this.db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+            `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
@@ -2925,7 +2933,7 @@ export class ReviewStateStore {
     ];
     const rows = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -3685,6 +3693,45 @@ export class ReviewStateStore {
     }
   }
 
+  private ensureReviewQueueJobShadowIdentityColumns(): void {
+    const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
+    const names = new Set(columns.map((column) => column.name));
+    const additions = ["repo_key", "head_sha_key"].filter((name) => !names.has(name));
+    if (additions.length > 0) {
+      this.db.exec(`begin immediate; ${additions.map((name) => `alter table review_queue_jobs add column ${name} text`).join("; ")}; commit`);
+    }
+    this.db.exec(`create index if not exists idx_review_queue_jobs_shadow_identity
+      on review_queue_jobs (repo_key, pull_number, head_sha_key)`);
+
+    const rows = this.db.prepare(`
+      select rowid, repo, head_sha, repo_key, head_sha_key
+      from review_queue_jobs
+      where repo_key is null or head_sha_key is null
+    `).all() as unknown as Array<{
+      rowid: number;
+      repo: string;
+      head_sha: string;
+      repo_key: string | null;
+      head_sha_key: string | null;
+    }>;
+    const backfill = this.db.prepare(`
+      update review_queue_jobs
+      set repo_key = coalesce(repo_key, ?), head_sha_key = coalesce(head_sha_key, ?)
+      where rowid = ? and (repo_key is null or head_sha_key is null)
+    `);
+    this.db.exec("begin immediate");
+    try {
+      for (const row of rows) {
+        const identity = canonicalReviewQueueIdentity(row.repo, row.head_sha);
+        if (identity) backfill.run(identity.repoKey, identity.headShaKey, row.rowid);
+      }
+      this.db.exec("commit");
+    } catch (error) {
+      try { this.db.exec("rollback"); } catch { /* transaction did not start */ }
+      throw error;
+    }
+  }
+
   private ensureRepoMemoryNoteCoarseColumns(): void {
     // Additive migration (#302): older DBs gain the coarse false-positive-match columns; existing
     // rows keep NULLs and fall back to exact-only matching.
@@ -3835,6 +3882,25 @@ function validateReviewQueueInput(
   if (commentId !== undefined && (!Number.isInteger(commentId) || commentId < 1)) {
     throw new Error("commentId must be a positive integer");
   }
+}
+
+function canonicalReviewQueueIdentity(repo: string, headSha: string): { repoKey: string; headShaKey: string } | undefined {
+  const [owner, name, extra] = repo.split("/");
+  if (
+    extra !== undefined ||
+    !owner ||
+    !name ||
+    owner === "." ||
+    owner === ".." ||
+    name === "." ||
+    name === ".." ||
+    !/^[A-Za-z0-9_.-]{1,100}$/.test(owner) ||
+    !/^[A-Za-z0-9_.-]{1,100}$/.test(name) ||
+    !/^[0-9a-f]{40}$/i.test(headSha)
+  ) {
+    return undefined;
+  }
+  return { repoKey: repo.toLowerCase(), headShaKey: headSha.toLowerCase() };
 }
 
 function validatePullAndCommand(pullNumber: number, commandCommentId: number): void {
@@ -4227,9 +4293,11 @@ interface ReviewQueueJobRow {
   source: ReviewQueueJobSource;
   lane: ReviewQueueJobLane;
   repo: string;
+  repo_key: string | null;
   org: string;
   pull_number: number;
   head_sha: string;
+  head_sha_key: string | null;
   base_sha: string | null;
   provider_id: string | null;
   priority: number;
@@ -4495,9 +4563,11 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     source: row.source,
     lane: row.lane,
     repo: row.repo,
+    ...(row.repo_key ? { repoKey: row.repo_key } : {}),
     org: row.org,
     pullNumber: row.pull_number,
     headSha: row.head_sha,
+    ...(row.head_sha_key ? { headShaKey: row.head_sha_key } : {}),
     ...(row.base_sha ? { baseSha: row.base_sha } : {}),
     ...(row.provider_id ? { providerId: row.provider_id } : {}),
     priority: row.priority,

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -34,6 +34,96 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("backfills indexed shadow identity without rewriting linked configured bytes", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-shadow-identity-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const repo = "Owner/Configured-Repo";
+    const headSha = "A".repeat(40);
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      create table review_queue_jobs (
+        job_id text primary key,
+        attempt_id text not null unique,
+        source text not null,
+        lane text not null,
+        repo text not null,
+        org text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        base_sha text,
+        provider_id text,
+        priority integer not null,
+        state text not null,
+        next_eligible_at text,
+        lease_id text,
+        lease_expires_at text,
+        session_id text,
+        comment_id integer,
+        review_url text,
+        last_error text,
+        created_at text not null,
+        updated_at text not null,
+        started_at text,
+        finished_at text
+      );
+    `);
+    legacyDb.prepare(`
+      insert into review_queue_jobs
+        (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+      values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'queued', ?, ?)
+    `).run("legacy-valid", "attempt-valid", repo, "Owner", 7, headSha, "2026-08-24T00:00:00.000Z", "2026-08-24T00:00:00.000Z");
+    legacyDb.prepare(`
+      insert into review_queue_jobs
+        (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+      values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'queued', ?, ?)
+    `).run("legacy-malformed", "attempt-malformed", `${repo}\t`, "Owner", 8, `${headSha}\n`, "2026-08-24T00:00:00.000Z", "2026-08-24T00:00:00.000Z");
+    legacyDb.close();
+
+    const store = new ReviewStateStore(dbPath);
+    expect(store.getReviewQueueJob("legacy-valid")).toMatchObject({
+      repo,
+      headSha,
+      repoKey: repo.toLowerCase(),
+      headShaKey: headSha.toLowerCase()
+    });
+    store.assignReviewerSessionJob({ repo, pullNumber: 7, headSha, ttlMs: 60_000, headCountLimit: 10 });
+    store.recordProcessed({ repo, pullNumber: 7, headSha, status: "posted" });
+    expect(store.getReviewerSessionJob(repo, 7, headSha)).toMatchObject({ repo, headSha });
+    expect(store.getProcessedReview(repo, 7, headSha)).toMatchObject({ repo, headSha });
+    store.close();
+
+    const migratedDb = new DatabaseSync(dbPath);
+    try {
+      const valid = migratedDb.prepare(`
+        select repo, head_sha, repo_key, head_sha_key from review_queue_jobs where job_id = ?
+      `).get("legacy-valid");
+      const malformed = migratedDb.prepare(`
+        select repo, head_sha, repo_key, head_sha_key from review_queue_jobs where job_id = ?
+      `).get("legacy-malformed");
+      expect(valid).toEqual({ repo, head_sha: headSha, repo_key: repo.toLowerCase(), head_sha_key: headSha.toLowerCase() });
+      expect(malformed).toEqual({ repo: `${repo}\t`, head_sha: `${headSha}\n`, repo_key: null, head_sha_key: null });
+      const indexes = migratedDb.prepare("pragma index_list('review_queue_jobs')").all() as Array<{ name: string }>;
+      expect(indexes.map((index) => index.name)).toContain("idx_review_queue_jobs_shadow_identity");
+      const plan = migratedDb.prepare(`
+        explain query plan
+        select 1 from review_queue_jobs where repo_key = ? and pull_number = ? and head_sha_key = ?
+      `).all(repo.toLowerCase(), 7, headSha.toLowerCase()) as Array<{ detail: string }>;
+      expect(plan.map((step) => step.detail).join(" ")).toMatch(/INDEX/);
+    } finally {
+      migratedDb.close();
+    }
+
+    const reopened = new ReviewStateStore(dbPath);
+    expect(reopened.getReviewQueueJob("legacy-valid")).toMatchObject({
+      repo,
+      headSha,
+      repoKey: repo.toLowerCase(),
+      headShaKey: headSha.toLowerCase()
+    });
+    reopened.close();
+  });
+
   it("stores normalized issue enrichment public and private hashes and rejects invalid hashes", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -110,6 +110,13 @@ describe("review state store", () => {
         select 1 from review_queue_jobs where repo_key = ? and pull_number = ? and head_sha_key = ?
       `).all(repo.toLowerCase(), 7, headSha.toLowerCase()) as Array<{ detail: string }>;
       expect(plan.map((step) => step.detail).join(" ")).toMatch(/INDEX/);
+      expect(migratedDb.prepare("select completed_at from review_state_migrations where name = ?")
+        .get("review_queue_jobs_shadow_identity_v1")).toBeDefined();
+      migratedDb.prepare(`
+        insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+        values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'queued', ?, ?)
+      `).run("late-valid", "late-attempt", repo, "Owner", 9, headSha, "2026-08-24T00:00:00.000Z", "2026-08-24T00:00:00.000Z");
     } finally {
       migratedDb.close();
     }
@@ -122,6 +129,10 @@ describe("review state store", () => {
       headShaKey: headSha.toLowerCase()
     });
     reopened.close();
+    const afterReopen = new DatabaseSync(dbPath);
+    expect(afterReopen.prepare("select repo_key, head_sha_key from review_queue_jobs where job_id = ?")
+      .get("late-valid")).toEqual({ repo_key: null, head_sha_key: null });
+    afterReopen.close();
   });
 
   it("stores normalized issue enrichment public and private hashes and rejects invalid hashes", () => {


### PR DESCRIPTION
## A1a1 canonical shadow identity schema successor

Related: #882

Base: 471a8d1ea489e1c2dabed4b24da241ef6ea11e7b
Head: 3c2b133ca655c2db4ee14db6393a2e9c5274227a

This slice only adds additive queue shadow identity schema support:

- preserves original queue repo/head bytes;
- adds nullable repo_key/head_sha_key fields and an indexed shadow identity;
- backfills only strict owner/repo plus 40-hex SHA rows, deterministically and idempotently;
- leaves malformed legacy rows readable with null shadow keys;
- populates shadow keys for newly enqueued valid identities without changing configured bytes;
- does not add enqueue, lease, direct-insert, transition, claim, receipt, cleanup, or accounting fences.

Focused deterministic receipt:

- legacy mixed-case row readback preserved Owner/Configured-Repo and uppercase SHA bytes;
- linked reviewer-session and processed-review lookups preserved exact configured bytes;
- valid shadow keys were lowercase owner/repo and SHA;
- tab/LF legacy row remained readable with null shadow keys;
- pragma index_list exposed idx_review_queue_jobs_shadow_identity;
- EXPLAIN QUERY PLAN used the covering shadow identity index;
- direct SQL insert without shadow fields remained accepted (no A1a2 fence);
- 168 changed non-generated lines; git diff --check passed.

Local environment boundary: the focused Vitest file could not start because this checkout has no local vitest binary; the shared dependency tree has a Rollup native module signature mismatch, and TypeScript reports missing node/vitest global type definitions. The deterministic receipt above was run with the existing tsx tool against the isolated worktree. Exact-head CI remains authoritative for the repository test/build gate.

No live DB, queue, worker, config, Keychain, customer, or GitHub review/status mutation was performed.
