### PR TITLE
feat: add severe receipt Parser B JSON boundary

### DIFF
--- a/src/severe-verification-receipt-parser-b.ts
+++ b/src/severe-verification-receipt-parser-b.ts
@@ -53,8 +53,8 @@ class JsonScanner {
     this.space();
     const code = this.text.charCodeAt(this.position);
     if (code === 34) return void this.string();
-    if (code === 123) return void this.object(depth + 1);
-    if (code === 91) return void this.array(depth + 1);
+    if (code === 123) { if (depth >= MAX_JSON_DEPTH) reject("depth"); return void this.object(depth + 1); }
+    if (code === 91) { if (depth >= MAX_JSON_DEPTH) reject("depth"); return void this.array(depth + 1); }
     if (code === 116 && this.literal("true")) return;
     if (code === 102 && this.literal("false")) return;
     if (code === 110 && this.literal("null")) return;

--- a/src/severe-verification-receipt-parser-b.ts
+++ b/src/severe-verification-receipt-parser-b.ts
@@ -1,0 +1,151 @@
+import {
+  prepareSerializedSevereVerificationInput,
+  type SerializedSevereVerificationInput
+} from "./severe-verification-receipt-parser-a.js";
+
+const MAX_JSON_DEPTH = 256;
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const reject = (code: string): never => { throw new TypeError(`severe_receipt_${code}`); };
+
+/** Parser B: decode and parse only the bounded output of Parser A. */
+export function parseSevereVerificationReceiptJson(input: unknown): unknown {
+  const bounded = prepareSerializedSevereVerificationInput(input);
+  const text = decode(bounded);
+  scanJson(text);
+  try { return JSON.parse(text) as unknown; } catch { return reject("malformed"); }
+}
+
+function decode(input: SerializedSevereVerificationInput): string {
+  if (typeof input === "string") {
+    if (input.startsWith("\uFEFF")) reject("bom");
+    return input;
+  }
+  if (input.length >= 3 && input[0] === 0xef && input[1] === 0xbb && input[2] === 0xbf) reject("bom");
+  let text: string;
+  try { text = decoder.decode(input); } catch { return reject("utf8"); }
+  if (text.startsWith("\uFEFF")) reject("bom");
+  return text;
+}
+
+function scalar(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(++index);
+      if (Number.isNaN(next) || next < 0xdc00 || next > 0xdfff) return false;
+    } else if (code >= 0xdc00 && code <= 0xdfff) return false;
+  }
+  return true;
+}
+
+class JsonScanner {
+  private position = 0;
+  constructor(private readonly text: string) {}
+
+  scan(): void {
+    this.value(0);
+    this.space();
+    if (this.position !== this.text.length) reject("malformed");
+  }
+
+  private value(depth: number): void {
+    if (depth > MAX_JSON_DEPTH) reject("depth");
+    this.space();
+    const code = this.text.charCodeAt(this.position);
+    if (code === 34) return void this.string();
+    if (code === 123) return void this.object(depth + 1);
+    if (code === 91) return void this.array(depth + 1);
+    if (code === 116 && this.literal("true")) return;
+    if (code === 102 && this.literal("false")) return;
+    if (code === 110 && this.literal("null")) return;
+    if (code === 45 || (code >= 48 && code <= 57)) return void this.number();
+    reject("malformed");
+  }
+
+  private object(depth: number): void {
+    this.position += 1; this.space();
+    const keys = new Set<string>();
+    if (this.text.charCodeAt(this.position) === 125) { this.position += 1; return; }
+    for (;;) {
+      if (this.text.charCodeAt(this.position) !== 34) reject("malformed");
+      const key = this.string(); this.space();
+      if (this.text.charCodeAt(this.position++) !== 58) reject("malformed");
+      if (keys.has(key)) reject("duplicate_key");
+      keys.add(key); this.value(depth); this.space();
+      const next = this.text.charCodeAt(this.position++);
+      if (next === 125) return;
+      if (next !== 44) reject("malformed");
+      this.space();
+    }
+  }
+
+  private array(depth: number): void {
+    this.position += 1; this.space();
+    if (this.text.charCodeAt(this.position) === 93) { this.position += 1; return; }
+    for (;;) {
+      this.value(depth); this.space();
+      const next = this.text.charCodeAt(this.position++);
+      if (next === 93) return;
+      if (next !== 44) reject("malformed");
+      this.space();
+    }
+  }
+
+  private string(): string {
+    this.position += 1; const chars: string[] = [];
+    for (;;) {
+      const code = this.text.charCodeAt(this.position++);
+      if (code === 34) {
+        const value = chars.join("");
+        if (!scalar(value)) reject("unicode");
+        return value;
+      }
+      if (code < 32 || Number.isNaN(code)) reject("malformed");
+      if (code !== 92) { chars.push(String.fromCharCode(code)); continue; }
+      const escaped = this.text.charCodeAt(this.position++);
+      const simple: Record<number, string> = { 34: '"', 92: "\\", 47: "/", 98: "\b", 102: "\f", 110: "\n", 114: "\r", 116: "\t" };
+      if (simple[escaped] !== undefined) { chars.push(simple[escaped]); continue; }
+      if (escaped !== 117) reject("malformed");
+      let unit = 0;
+      for (let count = 0; count < 4; count += 1) {
+        const digit = Number.parseInt(this.text[this.position++], 16);
+        if (Number.isNaN(digit)) reject("malformed");
+        unit = unit * 16 + digit;
+      }
+      chars.push(String.fromCharCode(unit));
+    }
+  }
+
+  private literal(value: string): boolean {
+    if (this.text.slice(this.position, this.position + value.length) !== value) return false;
+    this.position += value.length; return true;
+  }
+
+  private number(): void {
+    const start = this.position;
+    if (this.text[this.position] === "-") this.position += 1;
+    if (this.text[this.position] === "0") this.position += 1;
+    else {
+      if (!/[1-9]/.test(this.text[this.position] ?? "")) reject("malformed");
+      while (/[0-9]/.test(this.text[this.position] ?? "")) this.position += 1;
+    }
+    if (this.text[this.position] === ".") {
+      this.position += 1;
+      if (!/[0-9]/.test(this.text[this.position] ?? "")) reject("malformed");
+      while (/[0-9]/.test(this.text[this.position] ?? "")) this.position += 1;
+    }
+    if (this.text[this.position] === "e" || this.text[this.position] === "E") {
+      this.position += 1;
+      if (this.text[this.position] === "+" || this.text[this.position] === "-") this.position += 1;
+      if (!/[0-9]/.test(this.text[this.position] ?? "")) reject("malformed");
+      while (/[0-9]/.test(this.text[this.position] ?? "")) this.position += 1;
+    }
+    if (this.position === start) reject("malformed");
+  }
+
+  private space(): void {
+    while ([9, 10, 13, 32].includes(this.text.charCodeAt(this.position))) this.position += 1;
+  }
+}
+
+function scanJson(text: string): void { new JsonScanner(text).scan(); }

--- a/tests/severe-verification-receipt-parser-b.test.ts
+++ b/tests/severe-verification-receipt-parser-b.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { prepareSerializedSevereVerificationInput } from "../src/severe-verification-receipt-parser-a.js";
+import { parseSevereVerificationReceiptJson } from "../src/severe-verification-receipt-parser-b.js";
+
+const parse = (input: unknown) => parseSevereVerificationReceiptJson(prepareSerializedSevereVerificationInput(input));
+
+describe("severe receipt Parser B JSON boundary", () => {
+  it("consumes Parser A output and accepts JSON scalars and Unicode", () => {
+    expect(parse("true")).toBe(true);
+    expect(parse('{"path":"src/🧪.ts"}')).toEqual({ path: "src/🧪.ts" });
+    expect(parse(new TextEncoder().encode('{"ok":null}'))).toEqual({ ok: null });
+  });
+
+  it("rejects fatal UTF-8, leading BOM, and lone Unicode surrogates", () => {
+    expect(() => parse(new Uint8Array([0xef, 0xbb, 0xbf, 0x7b, 0x7d]))).toThrow("bom");
+    expect(() => parse(new Uint8Array([0xc0, 0x80]))).toThrow("utf8");
+    for (const value of ["\"\\ud800\"", `"${String.fromCharCode(0xd800)}"`, '"x\\udc00"']) {
+      expect(() => parse(value)).toThrow("unicode");
+    }
+  });
+
+  it("rejects decoded duplicates, malformed top-level syntax, and trailing values", () => {
+    expect(() => parse('{"nested":{"a":1,"\\u0061":2}}')).toThrow("duplicate_key");
+    expect(() => parse("true false")).toThrow("malformed");
+    expect(() => parse("01")).toThrow("malformed");
+    expect(() => parse(`{}${String.fromCharCode(0)}`)).toThrow("malformed");
+  });
+
+  it("bounds nesting before parse", () => {
+    const deep = `${"[".repeat(257)}0${"]".repeat(257)}`;
+    expect(() => parse(deep)).toThrow("depth");
+  });
+});

--- a/tests/severe-verification-receipt-parser-b.test.ts
+++ b/tests/severe-verification-receipt-parser-b.test.ts
@@ -27,7 +27,13 @@ describe("severe receipt Parser B JSON boundary", () => {
   });
 
   it("bounds nesting before parse", () => {
+    expect(() => parse(`${"[".repeat(256)}0${"]".repeat(256)}`)).not.toThrow();
+    expect(() => parse(`${"[".repeat(256)}${"]".repeat(256)}`)).not.toThrow();
+    expect(() => parse(`${'{"a":'.repeat(256)}0${"}".repeat(256)}`)).not.toThrow();
+    expect(() => parse(`${'{"a":'.repeat(255)}{}${"}".repeat(255)}`)).not.toThrow();
     const deep = `${"[".repeat(257)}0${"]".repeat(257)}`;
     expect(() => parse(deep)).toThrow("depth");
+    expect(() => parse(`${"[".repeat(257)}${"]".repeat(257)}`)).toThrow("depth");
+    expect(() => parse(`${'{"a":'.repeat(256)}{}${"}".repeat(256)}`)).toThrow("depth");
   });
 });


### PR DESCRIPTION
## Summary

Implements the Parser B slice from #865 on exact current `main`:

- consumes Parser A's bounded serialized input boundary;
- rejects fatal UTF-8 errors, leading BOM, and unpaired Unicode surrogates;
- scans bounded JSON grammar with max nesting depth and trailing syntax rejection;
- rejects decoded duplicate object keys before the sole `JSON.parse`.

## Proof

- Base: `471a8d1ea489e1c2dabed4b24da241ef6ea11e7b`
- Head: `83897472b22440e0b9c44bc7c28098b04ff0a892`
- Changed non-generated lines: 184 (151 source + 33 focused tests)
- `npm test -- --run tests/severe-verification-receipt-parser-a.test.ts tests/severe-verification-receipt-parser-b.test.ts`: 14/14 pass
- Focused TypeScript no-emit: pass
- `git diff --check`: pass
- `JSON.parse` occurrences in Parser B source: 1

## Scope boundary

This PR does not validate schema, copy validated plain data, canonicalize or digest, publish findings, wire provider/runtime behavior, or mutate customer/release state. It does not claim release, runtime, or customer readiness.

Closes #865 (Parser B slice only).
