### PR TITLE
docs: add reusable legacy operator recovery path

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -513,6 +513,9 @@ LEGACY_WORKER="$HOME/Library/Application Support/NeonDiffDesktop/Workers/$LEGACY
 LEGACY_CLI="$LEGACY_WORKER/node_modules/neondiff/dist/src/cli.js"
 LEGACY_CONFIG="/absolute/path/to/config.local.json"
 LEGACY_MANIFEST_SHA256="<manifest-sha256-from-release>"
+LEGACY_PLIST="$HOME/Library/LaunchAgents/$LEGACY_LABEL.plist"
+LEGACY_SOURCE_CHECKOUT="/absolute/path/to/intended/source/checkout"
+LEGACY_METADATA_READY=false
 
 neondiff_legacy() {
   if [ ! -x "$LEGACY_NODE" ] || [ ! -f "$LEGACY_CLI" ] \
@@ -521,15 +524,44 @@ neondiff_legacy() {
     echo "refusing an unverified legacy worker path" >&2
     return 1
   fi
+  if [ "${1:-}" != "init" ] && [ "$LEGACY_METADATA_READY" != "true" ]; then
+    if [ -e "$LEGACY_PLIST" ]; then
+      LEGACY_APP_ID="$(
+        /usr/bin/plutil -extract EnvironmentVariables.NEONDIFF_GITHUB_APP_ID raw -o - "$LEGACY_PLIST" 2>/dev/null \
+          || /usr/bin/plutil -extract EnvironmentVariables.EVAOS_REVIEW_BOT_APP_ID raw -o - "$LEGACY_PLIST" 2>/dev/null
+      )"
+      LEGACY_KEY_PATH="$(
+        /usr/bin/plutil -extract EnvironmentVariables.NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH raw -o - "$LEGACY_PLIST" 2>/dev/null \
+          || /usr/bin/plutil -extract EnvironmentVariables.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH raw -o - "$LEGACY_PLIST" 2>/dev/null
+      )"
+      [ -n "${LEGACY_APP_ID:-}" ] && export NEONDIFF_GITHUB_APP_ID="$LEGACY_APP_ID"
+      [ -n "${LEGACY_KEY_PATH:-}" ] && export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="$LEGACY_KEY_PATH"
+    fi
+    if [ -z "${NEONDIFF_GITHUB_APP_ID:-}" ] || [ -z "${NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH:-}" ]; then
+      echo "supply preserved App ID and private-key path metadata; key bytes are never read" >&2
+      return 1
+    fi
+    LEGACY_METADATA_READY=true
+  fi
   "$LEGACY_NODE" "$LEGACY_CLI" "$@"
 }
+```
+
+For a first install with no preserved plist, set only the non-secret metadata
+from the approved setup record before the first non-`init` command:
+
+```bash
+export NEONDIFF_GITHUB_APP_ID="<preserved-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/preserved-private-key.pem"
 ```
 
 Use that same function for the complete operator sequence, keeping config and
 artifact paths quoted when they contain spaces:
 
 ```bash
-neondiff_legacy init --config "$LEGACY_CONFIG"
+if [ ! -e "$LEGACY_CONFIG" ]; then
+  neondiff_legacy init --config "$LEGACY_CONFIG"
+fi
 neondiff_legacy doctor github --config "$LEGACY_CONFIG" --json
 neondiff_legacy providers list --config "$LEGACY_CONFIG" --json
 neondiff_legacy providers doctor --config "$LEGACY_CONFIG" --json
@@ -537,19 +569,33 @@ security find-generic-password -s YOUR_APPROVED_SOURCE -w \
   | neondiff_legacy license activate --config "$LEGACY_CONFIG" --license-key-stdin true --json
 neondiff_legacy license status --config "$LEGACY_CONFIG" --refresh true --json
 neondiff_legacy doctor --config "$LEGACY_CONFIG" --json
+LEGACY_CONFIG_REVISION="$(
+  neondiff_legacy config inspect --config "$LEGACY_CONFIG" --json |
+    "$LEGACY_NODE" -e '
+      const fs = require("fs");
+      const revision = JSON.parse(fs.readFileSync(0, "utf8")).revision;
+      if (!/^[a-f0-9]{64}$/.test(revision)) process.exit(1);
+      process.stdout.write(revision);
+    '
+)"
 neondiff_legacy review-pr --config "$LEGACY_CONFIG" --repo owner/name --pr 123 \
-  --expected-config-revision <verified-config-revision> --dry-run true --zcode true
-neondiff_legacy status --json --config "$LEGACY_CONFIG"
-neondiff_legacy runtime-inventory --json --config "$LEGACY_CONFIG"
+  --expected-config-revision "$LEGACY_CONFIG_REVISION" --dry-run true --zcode true
+(
+  cd "$LEGACY_SOURCE_CHECKOUT" || exit 1
+  neondiff_legacy status --json --config "$LEGACY_CONFIG" --launchd-label "$LEGACY_LABEL"
+  neondiff_legacy runtime-inventory --json --config "$LEGACY_CONFIG" --launchd-label "$LEGACY_LABEL"
+)
 neondiff_legacy dashboard --operator true --config "$LEGACY_CONFIG" --limit 10
 ```
 
 The function is private to the current shell: it adds no global `PATH` entry,
 creates or loads no LaunchAgent, and does not install or promote a daemon. Keep
-license keys on the approved stdin path; never place them in argv, config,
-environment, logs, or evidence. This sequence proves operator recovery only;
-it does not prove the native Desktop journey, GA readiness, release promotion,
-or customer readiness.
+license keys on the approved stdin path; the plist step reads only non-secret
+App ID/path metadata and never reads key bytes. The release-health commands run
+from the intended source checkout because they derive branch/cleanliness from
+`process.cwd()`. This sequence proves operator recovery only; it does not prove
+the native Desktop journey, GA readiness, release promotion, or customer
+readiness.
 
 ## 4. Check Readiness
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -497,6 +497,60 @@ worker artifact, this state is a release blocker rather than a prompt to repair
 source files manually.
 The app's own Sparkle update does not update an external local worker.
 
+### Legacy CLI/operator worker recovery
+
+This is an operator-only recovery path for an already verified checksum-managed
+worker. It is not the native Mac customer journey and is not a GA setup claim.
+After the checksum-bound `first-install` or `update` flow above succeeds, bind
+one private shell function to that worker's `current` target. Set the label and
+manifest digest from the same release receipt; do not substitute a global
+`neondiff` package or an unpinned checkout.
+
+```bash
+LEGACY_LABEL="<installed-launchd-label>"
+LEGACY_NODE="/opt/homebrew/bin/node" # or /usr/local/bin/node when approved
+LEGACY_WORKER="$HOME/Library/Application Support/NeonDiffDesktop/Workers/$LEGACY_LABEL/current"
+LEGACY_CLI="$LEGACY_WORKER/node_modules/neondiff/dist/src/cli.js"
+LEGACY_CONFIG="/absolute/path/to/config.local.json"
+LEGACY_MANIFEST_SHA256="<manifest-sha256-from-release>"
+
+neondiff_legacy() {
+  if [ ! -x "$LEGACY_NODE" ] || [ ! -f "$LEGACY_CLI" ] \
+    || [ ! -f "$LEGACY_WORKER/.neondiff-candidate-manifest.sha256" ] \
+    || [ "$(tr -d '\n' < "$LEGACY_WORKER/.neondiff-candidate-manifest.sha256")" != "$LEGACY_MANIFEST_SHA256" ]; then
+    echo "refusing an unverified legacy worker path" >&2
+    return 1
+  fi
+  "$LEGACY_NODE" "$LEGACY_CLI" "$@"
+}
+```
+
+Use that same function for the complete operator sequence, keeping config and
+artifact paths quoted when they contain spaces:
+
+```bash
+neondiff_legacy init --config "$LEGACY_CONFIG"
+neondiff_legacy doctor github --config "$LEGACY_CONFIG" --json
+neondiff_legacy providers list --config "$LEGACY_CONFIG" --json
+neondiff_legacy providers doctor --config "$LEGACY_CONFIG" --json
+security find-generic-password -s YOUR_APPROVED_SOURCE -w \
+  | neondiff_legacy license activate --config "$LEGACY_CONFIG" --license-key-stdin true --json
+neondiff_legacy license status --config "$LEGACY_CONFIG" --refresh true --json
+neondiff_legacy doctor --config "$LEGACY_CONFIG" --json
+neondiff_legacy review-pr --config "$LEGACY_CONFIG" --repo owner/name --pr 123 \
+  --expected-config-revision <verified-config-revision> --dry-run true --zcode true
+neondiff_legacy status --json --config "$LEGACY_CONFIG"
+neondiff_legacy runtime-inventory --json --config "$LEGACY_CONFIG"
+neondiff_legacy dashboard --operator true --config "$LEGACY_CONFIG" --limit 10
+```
+
+The function is private to the current shell: it adds no global `PATH` entry,
+creates or loads no LaunchAgent, and does not install or promote a daemon. Keep
+license keys on the approved stdin path; never place them in argv, config,
+environment, logs, or evidence. This sequence proves operator recovery only;
+it does not prove the native Desktop journey, GA readiness, release promotion,
+or customer readiness.
+
 ## 4. Check Readiness
 
 Run the GitHub-only doctor first. It verifies App installation visibility and


### PR DESCRIPTION
## Summary
- add a private neondiff_legacy shell function bound to the checksum-managed current worker
- use that function through init, GitHub readiness, providers, license, dry review, and operator status commands
- state path quoting, approved Node paths, no PATH or LaunchAgent effect, and the operator-only/non-GA boundary

Related: #610

## Exact candidate
- Base: 471a8d1ea489e1c2dabed4b24da241ef6ea11e7b
- Head: 8bae6fc63f4d1e88349179511e4289cf3d16e0bc
- Changed files: docs/SETUP.md only
- Changed non-generated lines: 54 additions, 0 deletions

## Validation
- npm run check:public-claims
- npm run check:secrets
- npm run check:design-source
- shell syntax check of the new bash snippet
- git diff --check

The focused Vitest attempt could not start because this isolated checkout has no installed dependencies and npm exec reported a missing optional Rolldown native binding. No install or runtime/customer action was performed.

## Boundary
This PR is docs-only and does not claim GA, native Desktop customer readiness, signed artifact publication, release promotion, runtime health, or customer proof. It does not mutate source, tests, manifests, LaunchAgents, worker state, config, DB, Keychain, feed, billing, or customers.