### PR TITLE
feat: add bounded issue-comment pagination primitive

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -28,6 +28,22 @@ export type BoundedGithubList<T> = T[] & {
   overflow: boolean;
 };
 
+/**
+ * Additive P1a issue-comment pagination receipt (#738). This reader is intentionally not used by
+ * command acknowledgement, marker lookup, or issue enrichment until their consumers are updated in
+ * separate slices.
+ */
+export interface BoundedIssueCommentRead {
+  items: IssueCommentCommandSource[];
+  pagesRead: number;
+  rawCount: number;
+  uniqueCount: number;
+  duplicateCount: number;
+  terminal: "short_page" | "page_cap";
+  truncated: boolean;
+  overflow: boolean;
+}
+
 function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
   const result = items as BoundedGithubList<T>;
   result.items = items.slice();
@@ -35,6 +51,19 @@ function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList
   result.truncated = truncated;
   result.overflow = truncated;
   return result;
+}
+
+function boundedIssueCommentRead(
+  items: IssueCommentCommandSource[],
+  metadata: Pick<BoundedIssueCommentRead, "pagesRead" | "rawCount" | "duplicateCount" | "terminal">
+): BoundedIssueCommentRead {
+  return {
+    items: items.slice(),
+    ...metadata,
+    uniqueCount: items.length,
+    truncated: metadata.terminal === "page_cap",
+    overflow: metadata.terminal === "page_cap"
+  };
 }
 
 export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
@@ -345,6 +374,47 @@ export class GitHubApi {
       if (page === MAX_ISSUE_COMMENT_PAGES) return boundedGithubList(comments, true);
     }
     return boundedGithubList(comments, true);
+  }
+
+  /**
+   * Read issue comments with a deterministic five-page/500-row bound (#738 P1a). GitHub's page order
+   * is preserved and duplicate IDs keep their first occurrence. The receipt is additive and this
+   * primitive is deliberately unused by existing command, marker, and enrichment callers.
+   */
+  async listIssueCommentsBounded(repo: string, issueNumber: number): Promise<BoundedIssueCommentRead> {
+    const comments: IssueCommentCommandSource[] = [];
+    const seen = new Set<number>();
+    let rawCount = 0;
+    let duplicateCount = 0;
+    for (let page = 1; page <= MAX_ISSUE_COMMENT_PAGES; page += 1) {
+      const chunk = await this.request<IssueCommentCommandSource[]>(
+        `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+        { token: await this.getReadToken(repo) }
+      );
+      rawCount += chunk.length;
+      for (const comment of chunk) {
+        if (seen.has(comment.id)) {
+          duplicateCount += 1;
+          continue;
+        }
+        seen.add(comment.id);
+        comments.push(comment);
+      }
+      if (chunk.length < 100) {
+        return boundedIssueCommentRead(comments, {
+          pagesRead: page,
+          rawCount,
+          duplicateCount,
+          terminal: "short_page"
+        });
+      }
+    }
+    return boundedIssueCommentRead(comments, {
+      pagesRead: MAX_ISSUE_COMMENT_PAGES,
+      rawCount,
+      duplicateCount,
+      terminal: "page_cap"
+    });
   }
 
   async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{

--- a/tests/issue-comment-pagination.test.ts
+++ b/tests/issue-comment-pagination.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+describe("bounded issue-comment pagination primitive", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("caps a permanently full stream at five pages and deduplicates in first-seen order", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const request = new URL(String(url));
+      const page = Number(request.searchParams.get("page"));
+      pages.push(page);
+      const ids = Array.from({ length: 100 }, (_unused, index) => page * 1000 + index);
+      if (page > 1) ids[0] = 1000;
+      return jsonResponse(ids.map((id) => ({ id })));
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueCommentsBounded("owner/repo", 738);
+
+    expect(pages).toEqual([1, 2, 3, 4, 5]);
+    expect(result.items.slice(0, 4).map((comment) => comment.id)).toEqual([1000, 1001, 1002, 1003]);
+    expect(result.items.at(-1)?.id).toBe(5099);
+    expect(result.items).toHaveLength(496);
+    expect(result.pagesRead).toBe(5);
+    expect(result.rawCount).toBe(500);
+    expect(result.uniqueCount).toBe(496);
+    expect(result.duplicateCount).toBe(4);
+    expect(result.terminal).toBe("page_cap");
+    expect(result.truncated).toBe(true);
+    expect(result.overflow).toBe(true);
+  });
+
+  it("stops on a short page and records terminal metadata", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const request = new URL(String(url));
+      const page = Number(request.searchParams.get("page"));
+      pages.push(page);
+      if (page === 1) return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: index + 1 })));
+      return jsonResponse([{ id: 100 }, { id: 101 }]);
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueCommentsBounded("owner/repo", 738);
+
+    expect(pages).toEqual([1, 2]);
+    expect(result.items.map((comment) => comment.id).slice(-3)).toEqual([99, 100, 101]);
+    expect(result.items).toHaveLength(101);
+    expect(result.pagesRead).toBe(2);
+    expect(result.rawCount).toBe(102);
+    expect(result.uniqueCount).toBe(101);
+    expect(result.duplicateCount).toBe(1);
+    expect(result.terminal).toBe("short_page");
+    expect(result.truncated).toBe(false);
+    expect(result.overflow).toBe(false);
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}


### PR DESCRIPTION
Related: #738. Summary: Add an additive five-page/500-row issue-comment reader with raw, unique, duplicate, terminal, truncation, and overflow metadata; preserve GitHub page order and first-seen comment IDs; add focused full-page and short-page transport fixtures. Proof: issue-comment pagination 2 passed; GitHub read 26 passed; enrichment consumer suites 81 passed; npm run build passed; git diff --check passed. Scope: No command acknowledgement, marker lookup/upsert, enrichment promotion, label events, watermark, runtime, DB, config, customer, or GitHub-post behavior changed. Existing unbounded command comment reader remains unchanged. Exact base 471a8d1ea489e1c2dabed4b24da241ef6ea11e7b; candidate head f859fc1da13afc2e63597d13439f1ad6955944d3.