### PR TITLE
feat(desktop): add authenticated T1v2 app tree proof

### DIFF
--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+
+const SHA1 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const VERSION = /^1\.1\.0(?:-(?:beta\.[1-9][0-9]{0,3}|rc\.[1-9][0-9]{0,15}))?$/;
+const KIND = "neondiff.desktop.extracted-tree-proof-v1";
+const INPUT_FIELDS = ["sourceSHA", "artifactSHA256", "records", "bundleMarkers"];
+const MARKER_FIELDS = ["appPath", "bundleID", "version", "build"];
+const PROOF_FIELDS = ["schemaVersion", "kind", "verified", "algorithm", "sourceSHA", "artifactSHA256", "treeSHA256", "records", "bundleMarkers"];
+const authenticated = new WeakSet();
+const fail = (message) => { throw new Error(message); };
+
+function exact(value, fields, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== fields.length || keys.some((key) => typeof key !== "string" || !fields.includes(key))) fail(`${label} has undeclared fields`);
+  return value;
+}
+function text(value, label) {
+  if (typeof value !== "string" || !value || /[\u0000-\u001f\u007f]/.test(value)) fail(`${label} is malformed`);
+  return value;
+}
+function digest(value, label, pattern = SHA256) {
+  const result = text(value, label);
+  if (!pattern.test(result)) fail(`${label} is malformed`);
+  return result;
+}
+function hash(value) { return createHash("sha256").update(value, "utf8").digest("hex"); }
+
+// NFC keeps descriptor bytes canonical; NFKC plus the explicit expansions is a
+// locale-independent case-fold identity for the macOS case-insensitive target.
+function macOSCaseFoldIdentity(value) {
+  return value.normalize("NFC").normalize("NFKC").toLowerCase()
+    .replace(/\u00df/g, "ss").replace(/\u03c2/g, "\u03c3");
+}
+function safePath(value, label) {
+  const result = text(value, label);
+  if (result !== result.normalize("NFC") || result.startsWith("/") || result.includes("\\") || result.split("/").some((part) => !part || part === "." || part === "..")) fail(`${label} is not canonical`);
+  return result;
+}
+function canonicalRecords(rawRecords) {
+  if (!Array.isArray(rawRecords) || rawRecords.length === 0) fail("tree records are required");
+  const seen = new Set(); let previous = "";
+  const records = rawRecords.map((raw) => {
+    if (!Array.isArray(raw)) fail("tree record must be an array");
+    const parts = [...raw], type = parts[0], path = safePath(parts[1], "tree record path");
+    if (seen.has(macOSCaseFoldIdentity(path)) || path <= previous) fail("tree records are not canonical");
+    seen.add(macOSCaseFoldIdentity(path)); previous = path;
+    if (!["dir", "file", "link"].includes(type)) fail("tree record type is invalid");
+    if (type === "dir" && parts.length !== 2) fail("directory tree record is malformed");
+    if (type === "link") {
+      const target = text(parts[2], "symlink target");
+      const resolved = posix.normalize(posix.join(posix.dirname(path), target));
+      if (parts.length !== 3 || !target || target !== target.normalize("NFC") || target.startsWith("/") || target.includes("\\") || resolved !== "NeonDiff.app" && !resolved.startsWith("NeonDiff.app/")) fail("symlink escapes app root");
+    }
+    if (type === "file" && (parts.length !== 5 || !["-", "x"].includes(parts[2]) || !Number.isSafeInteger(parts[3]) || parts[3] < 0 || typeof parts[4] !== "string" || !SHA256.test(parts[4]))) fail("file tree record is malformed");
+    return parts;
+  });
+  if (records[0][0] !== "dir" || records[0][1] !== "NeonDiff.app" || records.some((record) => record[1] !== "NeonDiff.app" && !record[1].startsWith("NeonDiff.app/"))) fail("tree does not describe the required app bundle");
+  return records;
+}
+function treeHash(records) {
+  const digest = createHash("sha256");
+  for (const record of canonicalRecords(records)) { for (const part of record) { digest.update(String(part), "utf8"); digest.update("\0"); } digest.update("\n"); }
+  return digest.digest("hex");
+}
+function readMarkers(raw) {
+  const value = exact(raw, MARKER_FIELDS, "bundle markers");
+  const appPath = text(value.appPath, "app path"), bundleID = text(value.bundleID, "bundle ID"), version = text(value.version, "bundle version"), build = text(value.build, "bundle build");
+  if (appPath !== "NeonDiff.app" || bundleID !== "com.electricsheephq.NeonDiffDesktop" || !VERSION.test(version) || !/^[0-9]+$/.test(build) || !Number.isSafeInteger(Number(build))) fail("bundle markers are not canonical");
+  return { appPath, bundleID, version, build };
+}
+function freeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) { Object.values(value).forEach(freeze); Object.freeze(value); }
+  return value;
+}
+
+export function treeProofDigest(records) { return treeHash(records); }
+export function buildExtractedAppTreeProof(input) {
+  const value = exact(input, INPUT_FIELDS, "tree proof inputs");
+  const sourceSHA = digest(value.sourceSHA, "source SHA", SHA1), artifactSHA256 = digest(value.artifactSHA256, "artifact SHA-256");
+  const records = canonicalRecords(value.records), bundleMarkers = readMarkers(value.bundleMarkers);
+  const proof = { schemaVersion: 1, kind: KIND, verified: true, algorithm: "sha256-tree-v1", sourceSHA, artifactSHA256, treeSHA256: treeHash(records), records, bundleMarkers };
+  authenticated.add(proof); return freeze(proof);
+}
+export function serializeExtractedAppTreeProof(proof) {
+  if (!authenticated.has(proof)) fail("proof was not produced by the extracted-tree producer");
+  return `${JSON.stringify(Object.fromEntries(PROOF_FIELDS.map((field) => [field, proof[field]])))}\n`;
+}
+export function extractedAppTreeProofDigest(proof) { return hash(serializeExtractedAppTreeProof(proof)); }

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExtractedAppTreeProof,
+  extractedAppTreeProofDigest,
+  serializeExtractedAppTreeProof,
+  treeProofDigest
+} from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
+
+const source = "0123456789abcdef0123456789abcdef01234567";
+const artifact = "a".repeat(64);
+const records = [
+  ["dir", "NeonDiff.app"],
+  ["dir", "NeonDiff.app/Contents"],
+  ["file", "NeonDiff.app/Contents/Info.plist", "-", 3, "b".repeat(64)],
+  ["dir", "NeonDiff.app/Contents/MacOS"],
+  ["file", "NeonDiff.app/Contents/MacOS/NeonDiffDesktop", "x", 7, "c".repeat(64)]
+];
+const markers = { appPath: "NeonDiff.app", bundleID: "com.electricsheephq.NeonDiffDesktop", version: "1.1.0", build: "42" };
+function fixture() { return { sourceSHA: source, artifactSHA256: artifact, records: records.map((record) => [...record]), bundleMarkers: { ...markers } }; }
+
+describe("authenticated extracted app-tree proof", () => {
+  it.each(["1.1.0", "1.1.0-beta.7", "1.1.0-rc.12"])("accepts supported version %s", (version) => {
+    const value = fixture(); value.bundleMarkers.version = version;
+    const proof = buildExtractedAppTreeProof(value);
+    expect(proof.treeSHA256).toBe("962e947f4cc77ba95d402ae8f9a8762bd2ba7bb7588b63243115d8d8688e11ed");
+    expect(proof.treeSHA256).toBe(treeProofDigest(records));
+    expect(serializeExtractedAppTreeProof(proof)).toContain("\"algorithm\":\"sha256-tree-v1\"");
+    expect(extractedAppTreeProofDigest(proof)).toMatch(/^[a-f0-9]{64}$/);
+    expect(Object.isFrozen(proof) && Object.isFrozen(proof.records[0]) && Object.isFrozen(proof.bundleMarkers)).toBe(true);
+  });
+
+  it.each([
+    ["order", (value: any) => value.records.reverse()],
+    ["case-fold collision", (value: any) => { value.records.splice(3, 0, ["dir", "NeonDiff.app/Contents/STRASSE"]); value.records.splice(3, 0, ["dir", "NeonDiff.app/Contents/Straße"]); }],
+    ["NFD path", (value: any) => value.records.splice(3, 0, ["dir", "NeonDiff.app/Contents/e\u0301"])],
+    ["mode", (value: any) => value.records[2][2] = "rw"],
+    ["size", (value: any) => value.records[2][3] = -1],
+    ["non-primitive digest", (value: any) => value.records[2][4] = ["b".repeat(64)]],
+    ["digest", (value: any) => value.records[2][4] = "not-a-sha"],
+    ["escaping symlink", (value: any) => value.records.splice(2, 0, ["link", "NeonDiff.app/Contents/Current", "../../../../outside"])],
+    ["stable shape", (value: any) => value.bundleMarkers.version = "1.1.1"],
+    ["source binding", (value: any) => value.sourceSHA = "not-a-source-sha"],
+    ["artifact binding", (value: any) => value.artifactSHA256 = "not-an-artifact-sha"]
+  ])("rejects hostile %s input", (_label, mutate) => {
+    const value = fixture();
+    mutate(value);
+    expect(() => buildExtractedAppTreeProof(value)).toThrow();
+  });
+
+  it("rejects forged, spread, JSON, and proxy proofs", () => {
+    const proof = buildExtractedAppTreeProof(fixture());
+    expect(() => serializeExtractedAppTreeProof({ ...proof })).toThrow();
+    expect(() => serializeExtractedAppTreeProof(JSON.parse(JSON.stringify(proof)))).toThrow();
+    expect(() => serializeExtractedAppTreeProof(new Proxy(proof, {}))).toThrow();
+  });
+
+  it("snapshots an accessor once before serialization", () => {
+    let reads = 0;
+    const value = new Proxy(fixture(), { get(target, key, receiver) {
+      if (key === "sourceSHA") { reads += 1; return reads === 1 ? source : "f".repeat(40); }
+      return Reflect.get(target, key, receiver);
+    } });
+    expect(buildExtractedAppTreeProof(value).sourceSHA).toBe(source);
+    expect(reads).toBe(1);
+  });
+});


### PR DESCRIPTION
Related: #895

## Scope

Implements the clean T1v2 extracted-app tree proof successor from the #895 split. The producer derives byte-identical `sha256-tree-v1` records (including per-record newlines), accepts final stable `1.1.0` plus the repository declaration beta/RC forms, validates primitive file digests/modes/sizes and source/artifact bindings, confines normalized symlink targets to `NeonDiff.app`, and rejects Unicode/case-fold collisions for the macOS target. Proofs are recursively frozen and serialization is guarded by a module-private WeakSet with fixed field order.

Focused hostile fixtures cover stable/beta/RC versions, ordering, NFD and Unicode case-fold collisions, modes, sizes, primitive digests, symlink escape, marker/source/artifact substitution, accessor snapshotting, and forged/spread/JSON/proxy serialization.

## Validation

- exact base `471a8d1ea489e1c2dabed4b24da241ef6ea11e7b`
- `node --check scripts/lib/desktop-extracted-app-tree-proof.mjs`
- deterministic Node smoke: canonical digest `962e947f4cc77ba95d402ae8f9a8762bd2ba7bb7588b63243115d8d8688e11ed`, final newline, hostile fixture rejection, and forged serialization rejection; PASS
- `git diff --check`; PASS
- 157 changed non-generated lines across producer/test; `vitest` not run because this isolated checkout has no `node_modules`

## Safety boundary

No accepted packet/consumer, A1/K1/G1/F1/P1, Apple/key/tag/feed/build/release code, signing, notarization, upload, install, runtime, customer, config, database, Keychain, or launchd mutation is included. This proves only authenticated T1v2 extracted tree proof construction and serialization; it does not prove source/tag authority, Apple acceptance, approved Sparkle key, appcast content, accepted packet, publication, updater, rollback, runtime safety, or customer readiness.