### PR TITLE
fix(github): require canonical installation identity before mint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONTEXT_BUDGET_CONFIG, type ContextBudgetConfig } from "./conte
 import type { EnrichmentConfig } from "./enrichment.js";
 import type { GitNexusContextConfig } from "./gitnexus-context.js";
 import type { GitHubRelatedContextConfig } from "./github-related-context.js";
+import { normalizeGitHubBotLogin } from "./github.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import { resolveEnvAlias } from "./env-alias.js";
 import type { LicenseConfig } from "./license.js";
@@ -644,6 +645,10 @@ export function loadConfigFromObject(fromFile: unknown): BotConfig {
     valueLabel: "github.privateKeyPath"
   }) ?? merged.github.privateKeyPath;
   merged.github.token = process.env.GITHUB_TOKEN ?? merged.github.token;
+  if (merged.github.botLogin !== undefined) {
+    const normalizedBotLogin = normalizeGitHubBotLogin(merged.github.botLogin); if (!normalizedBotLogin) throw new Error("config.github.botLogin must be a valid GitHub App slug or <slug>[bot]");
+    merged.github.botLogin = normalizedBotLogin;
+  }
   validateConfig(merged);
   applyRuntimeGitHubCredentials(merged.github);
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -87,8 +87,11 @@ export interface GitHubRepositoryAccessProof {
   visibility_source: GitHubRepositoryVisibilitySource;
   installation_id_present: boolean;
   installation_id?: number;
+  installation_account_id?: number;
+  installation_account_type?: "User" | "Organization";
   installation_account?: string;
   app_slug?: string;
+  bot_login?: string;
   app_can_read_metadata: boolean;
   app_can_read_pull_requests: boolean;
   openPullCount?: number;
@@ -100,15 +103,11 @@ export interface GitHubRepositoryAccessProof {
 interface GitHubInstallationIdentity {
   id: number;
   app_id: number;
+  account_id: number;
   account_login: string;
+  account_type: "User" | "Organization";
   app_slug: string;
-}
-
-interface GitHubInstallationResponse {
-  id: number;
-  app_id?: number;
-  account?: { login?: string };
-  app_slug?: string;
+  bot_login: string;
 }
 
 export class GitHubApiRequestError extends Error {
@@ -156,6 +155,7 @@ export class GitHubApi {
   private readonly requestTimeoutMs: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
+  private verifiedInstallations = new Map<string, GitHubInstallationIdentity>();
 
   constructor(options: GitHubApiOptions) {
     if (options.privateKey && options.privateKeyPath) {
@@ -165,7 +165,9 @@ export class GitHubApi {
     this.privateKey = options.privateKey ?? (options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined);
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
-    this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
+    const botLogin = normalizeGitHubBotLogin(options.botLogin ?? DEFAULT_BOT_LOGIN);
+    if (!botLogin) throw new Error("config.github.botLogin must be a valid GitHub App slug or <slug>[bot]");
+    this.botLogin = botLogin;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
   }
 
@@ -218,23 +220,24 @@ export class GitHubApi {
 
     let installation: GitHubInstallationIdentity;
     try {
-      installation = parseGitHubInstallationIdentity(
-        await this.getInstallation(repo, { followRedirects: false })
-      );
+      installation = await this.resolveVerifiedInstallation(repo, { followRedirects: false });
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
     const installationProof = {
       installation_id_present: true,
       installation_id: installation.id,
+      installation_account_id: installation.account_id,
+      installation_account_type: installation.account_type,
       installation_account: installation.account_login,
       app_id: installation.app_id,
-      app_slug: installation.app_slug
+      app_slug: installation.app_slug,
+      bot_login: installation.bot_login
     };
 
     let token: string;
     try {
-      token = await this.getInstallationTokenForId(repo, installation.id);
+      token = await this.getInstallationTokenForInstallation(repo, installation);
     } catch (error) {
       return { ...base, ...installationProof, ...describeGitHubAccessError(error) };
     }
@@ -534,23 +537,41 @@ export class GitHubApi {
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
-    const installation = await this.getInstallation(repo);
-    return this.getInstallationTokenForId(repo, installation.id);
+    const installation = await this.resolveVerifiedInstallation(repo);
+    return this.getInstallationTokenForInstallation(repo, installation);
+  }
+
+  private async resolveVerifiedInstallation(
+    repo: string,
+    options: { followRedirects?: boolean } = {}
+  ): Promise<GitHubInstallationIdentity> {
+    if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
+    const installation = parseGitHubInstallationIdentity(
+      await this.getInstallation(repo, options),
+      { expectedAppId: this.appId, expectedBotLogin: this.botLogin, repo }
+    );
+    const previous = this.verifiedInstallations.get(repo);
+    if (previous && !sameGitHubInstallation(previous, installation)) {
+      throw new Error("GitHub installation identity changed during token refresh.");
+    }
+    this.verifiedInstallations.set(repo, installation);
+    return installation;
   }
 
   private async getInstallation(
     repo: string,
     options: { followRedirects?: boolean } = {}
-  ): Promise<GitHubInstallationResponse> {
+  ): Promise<Record<string, unknown>> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    return this.request<GitHubInstallationResponse>(`/repos/${repo}/installation`, {
+    return this.request<Record<string, unknown>>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
   }
 
-  private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {
+  private async getInstallationTokenForInstallation(repo: string, installation: GitHubInstallationIdentity): Promise<string> {
+    const installationId = installation.id;
     const repoCached = this.repoInstallationTokens.get(repo);
     if (repoCached && repoCached.installationId === installationId && repoCached.expiresAt > Date.now() + 60_000) {
       return repoCached.token;
@@ -682,26 +703,67 @@ function visibilityFromRepositorySummary(repository: RepositorySummary): {
   return { result: "unknown", source: "unavailable" };
 }
 
-function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {
-  const installation = value as {
-    id?: unknown;
-    app_id?: unknown;
-    account?: { login?: unknown } | null;
-    app_slug?: unknown;
-  } | null;
+const GITHUB_LOGIN_PATTERN = /^(?!-)(?!.*--)[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+const GITHUB_APP_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
+
+export function normalizeGitHubBotLogin(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  const slug = normalized.endsWith("[bot]") ? normalized.slice(0, -5) : normalized;
+  return GITHUB_APP_SLUG_PATTERN.test(slug) ? `${slug}[bot]` : undefined;
+}
+
+function parseGitHubInstallationIdentity(
+  value: unknown,
+  expected: { expectedAppId: string; expectedBotLogin: string; repo: string }
+): GitHubInstallationIdentity {
+  const installation = snapshotGitHubDataRecord(value);
+  const account = installation && snapshotGitHubDataRecord(installation.account);
   const positiveInteger = (candidate: unknown): candidate is number =>
     typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
-  const accountLogin = installation?.account?.login;
-  const appSlug = installation?.app_slug;
-  const accountLoginValid = typeof accountLogin === "string"
-    && /^(?!-)(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(accountLogin);
-  const appSlugValid = typeof appSlug === "string"
-    && /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/.test(appSlug);
-  if (!positiveInteger(installation?.id) || !positiveInteger(installation?.app_id)
-      || !accountLoginValid || !appSlugValid) {
-    throw new Error("GitHub installation response is missing canonical identity fields.");
+  const accountLogin = normalizeGitHubValue(account?.login, GITHUB_LOGIN_PATTERN);
+  const owner = normalizeGitHubValue(expected.repo.split("/", 1)[0], GITHUB_LOGIN_PATTERN);
+  const appSlug = normalizeGitHubValue(installation?.app_slug, GITHUB_APP_SLUG_PATTERN);
+  const accountType = account?.type;
+  const botLogin = appSlug ? `${appSlug}[bot]` : undefined;
+  if (!installation || !account || !positiveInteger(installation.id) || !positiveInteger(installation.app_id)
+      || String(installation.app_id) !== expected.expectedAppId.trim() || !positiveInteger(account.id)
+      || !accountLogin || !owner || accountLogin !== owner
+      || (accountType !== "User" && accountType !== "Organization")
+      || !appSlug || !botLogin || botLogin !== expected.expectedBotLogin) {
+    throw new Error("GitHub installation response failed canonical identity verification.");
   }
-  return { id: installation.id, app_id: installation.app_id, account_login: accountLogin, app_slug: appSlug };
+  return {
+    id: installation.id,
+    app_id: installation.app_id,
+    account_id: account.id,
+    account_login: accountLogin,
+    account_type: accountType,
+    app_slug: appSlug,
+    bot_login: botLogin
+  };
+}
+
+function snapshotGitHubDataRecord(value: unknown): Record<string, unknown> | undefined {
+  try {
+    if (value === null || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return undefined;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    if (Object.values(descriptors).some((descriptor) => !("value" in descriptor))) return undefined;
+    const snapshot = structuredClone(value);
+    return Object.getPrototypeOf(snapshot) === Object.prototype ? snapshot as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return pattern.test(normalized) ? normalized : undefined;
+}
+
+function sameGitHubInstallation(left: GitHubInstallationIdentity, right: GitHubInstallationIdentity): boolean {
+  return left.id === right.id && left.app_id === right.app_id && left.account_id === right.account_id && left.account_login === right.account_login && left.account_type === right.account_type && left.app_slug === right.app_slug && left.bot_login === right.bot_login;
 }
 
 function describeGitHubAccessError(error: unknown): Pick<

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -15,6 +15,31 @@ describe("GitHub App read authentication", () => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
+  it("normalizes slug and slug[bot] forms, while omission cannot accept a wrong App", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-identity-config-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let tokenRequests = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/repos/owner/repo/installation")) return jsonResponse({ ...canonicalInstallation(), app_slug: "Customer-Review-App" });
+      if (requestUrl.includes("/access_tokens")) {
+        tokenRequests += 1;
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (requestUrl.endsWith("/repos/owner/repo")) return jsonResponse({ full_name: "owner/repo", private: false });
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    await new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: " customer-review-app " }).getRepo("owner/repo");
+    expect(tokenRequests).toBe(1);
+    tokenRequests = 0;
+    await expect(new GitHubApi({ appId: "4184532", privateKeyPath }).getRepo("owner/repo")).rejects.toThrow();
+    expect(tokenRequests).toBe(0);
+  });
+
   it("uses installation tokens for PR read calls when App credentials are configured", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-read-"));
     roots.push(root);
@@ -261,7 +286,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 999, app_slug: "customer-review-app" });
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -285,9 +310,12 @@ describe("GitHub App read authentication", () => {
       visibility_source: "repository_api",
       installation_id_present: true,
       installation_id: 123,
+      installation_account_id: 7,
+      installation_account_type: "User",
       installation_account: "owner",
-      app_id: 999,
-      app_slug: "customer-review-app",
+      app_id: 4184532,
+      app_slug: "evaos-code-review-bot",
+      bot_login: "evaos-code-review-bot[bot]",
       app_can_read_metadata: true,
       app_can_read_pull_requests: true,
       openPullCount: 1
@@ -303,7 +331,7 @@ describe("GitHub App read authentication", () => {
     const privateKeyPath = join(root, "app.pem");
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
-    const valid = { id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" };
+    const valid = canonicalInstallation();
     const cases: Array<{ name: string; installation: unknown }> = [
       { name: "missing installation id", installation: { ...valid, id: undefined } },
       { name: "null installation id", installation: { ...valid, id: null } },
@@ -315,6 +343,11 @@ describe("GitHub App read authentication", () => {
       { name: "wrong-type App id", installation: { ...valid, app_id: "4184532" } },
       { name: "non-positive App id", installation: { ...valid, app_id: -1 } },
       { name: "missing account", installation: { ...valid, account: undefined } },
+      { name: "missing account id", installation: { ...valid, account: { login: "owner", type: "User" } } },
+      { name: "missing account type", installation: { ...valid, account: { id: 7, login: "owner" } } },
+      { name: "wrong account id type", installation: { ...valid, account: { id: "7", login: "owner", type: "User" } } },
+      { name: "wrong account type", installation: { ...valid, account: { id: 7, login: "owner", type: "Bot" } } },
+      { name: "wrong repository owner", installation: { ...valid, account: { id: 7, login: "victim", type: "User" } } },
       { name: "missing account login", installation: { ...valid, account: {} } },
       { name: "null account login", installation: { ...valid, account: { login: null } } },
       { name: "wrong-type account login", installation: { ...valid, account: { login: 42 } } },
@@ -343,6 +376,49 @@ describe("GitHub App read authentication", () => {
       });
       expect(calls, scenario.name).toHaveLength(1);
     }
+  });
+
+  it.each(["accessor", "proxy"])("rejects %s installation responses before token exchange", async (shape) => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-hostile-installation-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let tokenRequests = 0;
+    const installation = shape === "accessor"
+      ? Object.defineProperty(canonicalInstallation(), "id", { get: () => 123 })
+      : new Proxy(canonicalInstallation(), {});
+    globalThis.fetch = vi.fn(async (url) => String(url).endsWith("/repos/owner/repo/installation")
+      ? { ok: true, status: 200, statusText: "OK", json: async () => installation, text: async () => "" } as Response
+      : (String(url).includes("/access_tokens") ? (++tokenRequests, jsonResponse({ message: "must not mint" }, 500)) : jsonResponse({ message: "unexpected" }, 404))) as typeof fetch;
+
+    await expect(new GitHubApi({ appId: "4184532", privateKeyPath }).getRepo("owner/repo")).rejects.toThrow();
+    expect(tokenRequests).toBe(0);
+  });
+
+  it("re-runs the resolver on refresh and rejects a rotated installation before mint", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-rotated-installation-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let installationCalls = 0;
+    let tokenRequests = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation({ id: ++installationCalls === 1 ? 123 : 456 }));
+      if (requestUrl.includes("/access_tokens")) {
+        tokenRequests += 1;
+        return jsonResponse({ token: "installation-token", expires_at: "2000-01-01T00:00:00Z" });
+      }
+      return requestUrl.endsWith("/repos/owner/repo") ? jsonResponse({ full_name: "owner/repo", private: false }) : jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    await expect(github.getRepo("owner/repo")).resolves.toMatchObject({ full_name: "owner/repo" });
+    await expect(github.getRepo("owner/repo")).rejects.toThrow(/identity changed/);
+    expect(installationCalls).toBe(2);
+    expect(tokenRequests).toBe(1);
   });
 
   it("classifies App install-scope and visibility lookup failures without treating them as public", async () => {
@@ -480,7 +556,7 @@ describe("GitHub App read authentication", () => {
       const redirect = init?.redirect;
       calls.push({ url: requestUrl, method, redirect });
       if (requestUrl.endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+        return jsonResponse({ id: 123 });
       }
       if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -830,17 +906,28 @@ describe("GitHub App read authentication", () => {
 });
 
 function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
-  return new Response(JSON.stringify(body), {
+  const payload = body && typeof body === "object" && !Array.isArray(body) && Object.keys(body).length === 1 && (body as { id?: unknown }).id === 123 ? canonicalInstallation() : body;
+  return new Response(JSON.stringify(payload), {
     status,
     statusText,
     headers: { "Content-Type": "application/json" }
   });
 }
 
+function canonicalInstallation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 123,
+    app_id: 4184532,
+    account: { id: 7, login: "owner", type: "User" },
+    app_slug: "evaos-code-review-bot",
+    ...overrides
+  };
+}
+
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {
   return (url: string) => {
     if (url.endsWith("/repos/owner/repo/installation")) {
-      return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+      return jsonResponse(canonicalInstallation());
     }
     if (url.endsWith("/app/installations/123/access_tokens")) {
       return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1528,7 +1528,7 @@ exit 1
           id: 42,
           account: { login: "acme" },
           app_id: 12345,
-          app_slug: "customer-review-app"
+          app_slug: "evaos-code-review-bot"
         }));
         return;
       }
@@ -1644,7 +1644,7 @@ exit 1
               installation_id: 42,
               installation_account: "acme",
               app_id: 12345,
-              app_slug: "customer-review-app",
+              app_slug: "evaos-code-review-bot",
               app_can_read_metadata: true,
               app_can_read_pull_requests: true,
               license_gate_decision: "active_public_entitlement_required",
@@ -1786,7 +1786,7 @@ exit 1
           id: 42,
           app_id: 12345,
           account: { login: "acme" },
-          app_slug: "customer-review-app"
+          app_slug: "evaos-code-review-bot"
         }));
         return;
       }

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1526,7 +1526,7 @@ exit 1
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
         response.end(JSON.stringify({
           id: 42,
-          account: { login: "acme" },
+          account: { id: 7, login: "acme", type: "User" },
           app_id: 12345,
           app_slug: "evaos-code-review-bot"
         }));
@@ -1785,7 +1785,7 @@ exit 1
         response.end(JSON.stringify({
           id: 42,
           app_id: 12345,
-          account: { login: "acme" },
+          account: { id: 7, login: "acme", type: "User" },
           app_slug: "evaos-code-review-bot"
         }));
         return;


### PR DESCRIPTION
Closes #872

## Summary
- normalize configured GitHub App slug and `<slug>[bot]` to one expected identity
- require primitive installation/App/account identity and exact repository-owner binding before token mint
- snapshot/reject accessor or proxy responses and reject identity rotation on refresh
- update focused fixtures to canonical installation metadata

## Proof
- `npm run build` ✅
- focused `github-app-read` + config suite: 44/44 ✅ (run with a temporary local Rollup WASM fallback because the native binary has an invalid macOS signature)
- `git diff --check` ✅
- no live GitHub/token/customer/runtime mutation performed

Based on exact remote main `471a8d1ea489e1c2dabed4b24da241ef6ea11e7b`. Candidate is R1-only; R2 cache policy and R3 observer/scheduler projection are out of scope.