### PR TITLE
feat(state): add tolerant queue shadow identity backfill

### DIFF
--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1957,10 +1957,12 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     attemptId: row.attempt_id,
     source: row.source,
     lane: row.lane,
-    repo: row.repo,
+    repo: readableQueueText(row.repo),
+    ...(typeof row.repo_key === "string" ? { repoKey: row.repo_key } : {}),
     org: row.org,
     pullNumber: row.pull_number,
-    headSha: row.head_sha,
+    headSha: readableQueueText(row.head_sha),
+    ...(typeof row.head_sha_key === "string" ? { headShaKey: row.head_sha_key } : {}),
     ...(row.base_sha ? { baseSha: row.base_sha } : {}),
     ...(row.provider_id ? { providerId: row.provider_id } : {}),
     priority: row.priority,
@@ -1977,6 +1979,10 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
+}
+
+function readableQueueText(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
 }
 
 function upsertDashboardItem(
@@ -2252,7 +2258,9 @@ function reviewQueueSelectColumns(db: DatabaseSync): string {
   const leaseExpiresAtColumn = hasColumn(db, "review_queue_jobs", "lease_expires_at")
     ? "lease_expires_at"
     : "null as lease_expires_at";
-  return `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+  const repoKeyColumn = hasColumn(db, "review_queue_jobs", "repo_key") ? "repo_key" : "null as repo_key";
+  const headShaKeyColumn = hasColumn(db, "review_queue_jobs", "head_sha_key") ? "head_sha_key" : "null as head_sha_key";
+  return `select job_id, attempt_id, source, lane, repo, ${repoKeyColumn}, org, pull_number, head_sha, ${headShaKeyColumn}, base_sha,
                  provider_id, priority, state, next_eligible_at, lease_id, ${leaseExpiresAtColumn}, session_id,
                  comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at`;
 }
@@ -2367,10 +2375,12 @@ interface ReviewQueueJobRow {
   attempt_id: string;
   source: ReviewQueueJobRecord["source"];
   lane: ReviewQueueJobRecord["lane"];
-  repo: string;
+  repo: unknown;
+  repo_key: unknown;
   org: string;
   pull_number: number;
-  head_sha: string;
+  head_sha: unknown;
+  head_sha_key: unknown;
   base_sha: string | null;
   provider_id: string | null;
   priority: number;

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1957,12 +1957,10 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     attemptId: row.attempt_id,
     source: row.source,
     lane: row.lane,
-    repo: readableQueueText(row.repo),
-    ...(typeof row.repo_key === "string" ? { repoKey: row.repo_key } : {}),
+    repo: row.repo,
     org: row.org,
     pullNumber: row.pull_number,
-    headSha: readableQueueText(row.head_sha),
-    ...(typeof row.head_sha_key === "string" ? { headShaKey: row.head_sha_key } : {}),
+    headSha: row.head_sha,
     ...(row.base_sha ? { baseSha: row.base_sha } : {}),
     ...(row.provider_id ? { providerId: row.provider_id } : {}),
     priority: row.priority,
@@ -1979,10 +1977,6 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
-}
-
-function readableQueueText(value: unknown): string {
-  return typeof value === "string" ? value : value == null ? "" : String(value);
 }
 
 function upsertDashboardItem(
@@ -2258,9 +2252,7 @@ function reviewQueueSelectColumns(db: DatabaseSync): string {
   const leaseExpiresAtColumn = hasColumn(db, "review_queue_jobs", "lease_expires_at")
     ? "lease_expires_at"
     : "null as lease_expires_at";
-  const repoKeyColumn = hasColumn(db, "review_queue_jobs", "repo_key") ? "repo_key" : "null as repo_key";
-  const headShaKeyColumn = hasColumn(db, "review_queue_jobs", "head_sha_key") ? "head_sha_key" : "null as head_sha_key";
-  return `select job_id, attempt_id, source, lane, repo, ${repoKeyColumn}, org, pull_number, head_sha, ${headShaKeyColumn}, base_sha,
+  return `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
                  provider_id, priority, state, next_eligible_at, lease_id, ${leaseExpiresAtColumn}, session_id,
                  comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at`;
 }
@@ -2375,12 +2367,10 @@ interface ReviewQueueJobRow {
   attempt_id: string;
   source: ReviewQueueJobRecord["source"];
   lane: ReviewQueueJobRecord["lane"];
-  repo: unknown;
-  repo_key: unknown;
+  repo: string;
   org: string;
   pull_number: number;
-  head_sha: unknown;
-  head_sha_key: unknown;
+  head_sha: string;
   base_sha: string | null;
   provider_id: string | null;
   priority: number;

--- a/src/state.ts
+++ b/src/state.ts
@@ -3707,18 +3707,30 @@ export class ReviewStateStore {
       this.db.exec(`begin immediate; ${additions.map((name) =>
         `alter table review_queue_jobs add column ${name} text`).join("; ")}; commit`);
     }
-    if (this.db.prepare("select 1 from review_state_migrations where name = ? limit 1")
-      .get(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION)) return;
+    let completedAt = (this.db.prepare("select completed_at from review_state_migrations where name = ? limit 1")
+      .get(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION) as { completed_at: string } | undefined)?.completed_at;
+    const hasMissingShadowKeys = () => Boolean(this.db.prepare(
+      `select 1 from review_queue_jobs where repo_key is null or head_sha_key is null
+       ${completedAt ? "and julianday(created_at) > julianday(?)" : ""} limit 1`
+    ).get(...(completedAt ? [completedAt] : [])));
+    if (completedAt && !hasMissingShadowKeys()) return;
 
     this.db.exec("begin immediate");
     try {
+      completedAt = (this.db.prepare("select completed_at from review_state_migrations where name = ? limit 1")
+        .get(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION) as { completed_at: string } | undefined)?.completed_at;
+      if (completedAt && !hasMissingShadowKeys()) {
+        this.db.exec("commit");
+        return;
+      }
       this.db.exec(`create index if not exists idx_review_queue_jobs_shadow_identity
         on review_queue_jobs (repo_key, pull_number, head_sha_key)`);
       const rows = this.db.prepare(`
         select rowid, repo, head_sha, repo_key, head_sha_key
         from review_queue_jobs
         where repo_key is null or head_sha_key is null
-      `).all() as unknown as Array<{
+        ${completedAt ? "and julianday(created_at) > julianday(?)" : ""}
+      `).all(...(completedAt ? [completedAt] : [])) as unknown as Array<{
         rowid: number; repo: unknown; head_sha: unknown; repo_key: string | null; head_sha_key: string | null;
       }>;
       const update = this.db.prepare(`
@@ -3730,7 +3742,7 @@ export class ReviewStateStore {
         const identity = canonicalReviewQueueIdentity(row.repo, row.head_sha);
         if (identity) update.run(identity.repoKey, identity.headShaKey, row.rowid);
       }
-      this.db.prepare("insert into review_state_migrations (name, completed_at) values (?, datetime('now'))")
+      this.db.prepare("insert or ignore into review_state_migrations (name, completed_at) values (?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))")
         .run(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION);
       this.db.exec("commit");
     } catch (error) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -53,6 +53,7 @@ export type RepoMemoryNoteKind =
 export type IssueEnrichmentRecordStatus = "dry_run" | "posted" | "skipped" | "deferred" | "failed";
 const REPO_MEMORY_NOTE_KINDS: RepoMemoryNoteKind[] = ["policy_note", "machine_fact", "false_positive", "review_outcome", "proof_preference"];
 const WORKTREE_CLEANUP_GUARD_TTL_MS = 60_000;
+const REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION = "review_queue_jobs_shadow_identity_v1";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -261,9 +262,11 @@ export interface ReviewQueueJobRecord {
   source: ReviewQueueJobSource;
   lane: ReviewQueueJobLane;
   repo: string;
+  repoKey?: string;
   org: string;
   pullNumber: number;
   headSha: string;
+  headShaKey?: string;
   baseSha?: string;
   providerId?: string;
   priority: number;
@@ -713,9 +716,11 @@ export class ReviewStateStore {
         source text not null,
         lane text not null,
         repo text not null,
+        repo_key text,
         org text not null,
         pull_number integer not null,
         head_sha text not null,
+        head_sha_key text,
         base_sha text,
         provider_id text,
         priority integer not null,
@@ -741,6 +746,11 @@ export class ReviewStateStore {
         on review_queue_jobs (repo, pull_number, state);
       create index if not exists idx_review_queue_jobs_provider_state
         on review_queue_jobs (provider_id, state);
+
+      create table if not exists review_state_migrations (
+        name text primary key,
+        completed_at text not null
+      );
 
       create table if not exists review_readiness (
         repo text not null,
@@ -844,6 +854,7 @@ export class ReviewStateStore {
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
     this.ensureReviewQueueJobColumns();
+    this.ensureReviewQueueJobShadowIdentityColumns();
     this.ensureRepoMemoryNoteCoarseColumns();
     this.db.exec(`
       create table if not exists processed_commands (
@@ -2570,6 +2581,7 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    const shadowIdentity = canonicalReviewQueueIdentity(input.repo, input.headSha);
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2596,9 +2608,9 @@ export class ReviewStateStore {
     this.db
       .prepare(
         `insert into review_queue_jobs
-          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+          (job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
            provider_id, priority, state, session_id, comment_id, created_at, updated_at)
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
       )
       .run(
         jobId,
@@ -2606,9 +2618,11 @@ export class ReviewStateStore {
         source,
         lane,
         input.repo,
+        shadowIdentity?.repoKey ?? null,
         repoOrg(input.repo),
         input.pullNumber,
         input.headSha,
+        shadowIdentity?.headShaKey ?? null,
         input.baseSha ?? null,
         input.providerId ?? null,
         priority,
@@ -2824,7 +2838,7 @@ export class ReviewStateStore {
   getReviewQueueJob(jobId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2838,7 +2852,7 @@ export class ReviewStateStore {
   getReviewQueueJobByAttemptId(attemptId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2853,7 +2867,7 @@ export class ReviewStateStore {
     const retryPrefix = `${attemptId}:after-terminal:`;
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2878,7 +2892,7 @@ export class ReviewStateStore {
     const rows = (input.repo
       ? this.db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+            `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
@@ -2888,7 +2902,7 @@ export class ReviewStateStore {
           .all(input.repo)
       : this.db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+            `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
@@ -2925,7 +2939,7 @@ export class ReviewStateStore {
     ];
     const rows = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -3685,6 +3699,46 @@ export class ReviewStateStore {
     }
   }
 
+  private ensureReviewQueueJobShadowIdentityColumns(): void {
+    const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
+    const names = new Set(columns.map((column) => column.name));
+    const additions = ["repo_key", "head_sha_key"].filter((name) => !names.has(name));
+    if (additions.length > 0) {
+      this.db.exec(`begin immediate; ${additions.map((name) =>
+        `alter table review_queue_jobs add column ${name} text`).join("; ")}; commit`);
+    }
+    if (this.db.prepare("select 1 from review_state_migrations where name = ? limit 1")
+      .get(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION)) return;
+
+    this.db.exec("begin immediate");
+    try {
+      this.db.exec(`create index if not exists idx_review_queue_jobs_shadow_identity
+        on review_queue_jobs (repo_key, pull_number, head_sha_key)`);
+      const rows = this.db.prepare(`
+        select rowid, repo, head_sha, repo_key, head_sha_key
+        from review_queue_jobs
+        where repo_key is null or head_sha_key is null
+      `).all() as unknown as Array<{
+        rowid: number; repo: unknown; head_sha: unknown; repo_key: string | null; head_sha_key: string | null;
+      }>;
+      const update = this.db.prepare(`
+        update review_queue_jobs
+        set repo_key = coalesce(repo_key, ?), head_sha_key = coalesce(head_sha_key, ?)
+        where rowid = ? and (repo_key is null or head_sha_key is null)
+      `);
+      for (const row of rows) {
+        const identity = canonicalReviewQueueIdentity(row.repo, row.head_sha);
+        if (identity) update.run(identity.repoKey, identity.headShaKey, row.rowid);
+      }
+      this.db.prepare("insert into review_state_migrations (name, completed_at) values (?, datetime('now'))")
+        .run(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION);
+      this.db.exec("commit");
+    } catch (error) {
+      try { this.db.exec("rollback"); } catch { /* migration transaction did not start */ }
+      throw error;
+    }
+  }
+
   private ensureRepoMemoryNoteCoarseColumns(): void {
     // Additive migration (#302): older DBs gain the coarse false-positive-match columns; existing
     // rows keep NULLs and fall back to exact-only matching.
@@ -3835,6 +3889,24 @@ function validateReviewQueueInput(
   if (commentId !== undefined && (!Number.isInteger(commentId) || commentId < 1)) {
     throw new Error("commentId must be a positive integer");
   }
+}
+
+function canonicalReviewQueueIdentity(repo: unknown, headSha: unknown): { repoKey: string; headShaKey: string } | undefined {
+  if (typeof repo !== "string" || typeof headSha !== "string") return undefined;
+  const [owner, name, extra] = repo.split("/");
+  if (
+    extra !== undefined ||
+    !owner ||
+    !name ||
+    owner === "." ||
+    owner === ".." ||
+    name === "." ||
+    name === ".." ||
+    !/^[A-Za-z0-9_.-]{1,100}$/.test(owner) ||
+    !/^[A-Za-z0-9_.-]{1,100}$/.test(name) ||
+    !/^[0-9a-f]{40}$/i.test(headSha)
+  ) return undefined;
+  return { repoKey: repo.toLowerCase(), headShaKey: headSha.toLowerCase() };
 }
 
 function validatePullAndCommand(pullNumber: number, commandCommentId: number): void {
@@ -4226,10 +4298,12 @@ interface ReviewQueueJobRow {
   attempt_id: string;
   source: ReviewQueueJobSource;
   lane: ReviewQueueJobLane;
-  repo: string;
+  repo: unknown;
+  repo_key: unknown;
   org: string;
   pull_number: number;
-  head_sha: string;
+  head_sha: unknown;
+  head_sha_key: unknown;
   base_sha: string | null;
   provider_id: string | null;
   priority: number;
@@ -4494,10 +4568,12 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     attemptId: row.attempt_id,
     source: row.source,
     lane: row.lane,
-    repo: row.repo,
+    repo: readableQueueText(row.repo),
+    ...(typeof row.repo_key === "string" ? { repoKey: row.repo_key } : {}),
     org: row.org,
     pullNumber: row.pull_number,
-    headSha: row.head_sha,
+    headSha: readableQueueText(row.head_sha),
+    ...(typeof row.head_sha_key === "string" ? { headShaKey: row.head_sha_key } : {}),
     ...(row.base_sha ? { baseSha: row.base_sha } : {}),
     ...(row.provider_id ? { providerId: row.provider_id } : {}),
     priority: row.priority,
@@ -4514,6 +4590,10 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
+}
+
+function readableQueueText(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
 }
 
 function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRecord {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectOperatorReviewQueue } from "../src/operator-cli.js";
 import { parseProviderCooldownError, ReviewStateStore } from "../src/state.js";
 
 describe("review state store", () => {
@@ -32,6 +33,76 @@ describe("review state store", () => {
     expect(store.getProcessedReview("electricsheephq/WorldOS", 1205, "abc123")?.createdAt).toBe("2026-08-23T00:00:00.900Z");
     expect(store.hasProcessed("electricsheephq/WorldOS", 1205, "def456")).toBe(false);
     store.close();
+  });
+
+  it("backfills strict shadow identity without rewriting hostile legacy queue rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-shadow-v2-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      create table review_queue_jobs (
+        job_id text primary key, attempt_id text, source text, lane text, repo,
+        org text, pull_number integer, head_sha, base_sha text, provider_id text,
+        priority integer, state text, next_eligible_at text, lease_id text,
+        lease_expires_at text, session_id text, comment_id integer, review_url text,
+        last_error text, created_at text, updated_at text, started_at text, finished_at text
+      )
+    `);
+    const insert = legacyDb.prepare(`
+      insert into review_queue_jobs
+        (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+      values (?, ?, 'automatic', 'background', ?, 'Owner', 1, ?, 50, 'queued', '2026-08-24T00:00:00.000Z', '2026-08-24T00:00:00.000Z')
+    `);
+    const add = (id: string, repo: unknown, headSha: unknown) => insert.run(id, id, repo, headSha);
+    const validRepo = "Owner/Configured-Repo";
+    const validHead = "A".repeat(40);
+    add("valid", validRepo, validHead);
+    add("blob", Buffer.from("legacy-repo"), validHead);
+    add("null", null, validHead);
+    add("numeric", 42, 7);
+    add("tab", "Owner/Bad\tRepo", validHead);
+    add("lf", "Owner/Bad\nRepo", validHead);
+    add("nbsp", "Owner/Bad\u00a0Repo", validHead);
+    legacyDb.close();
+
+    const store = new ReviewStateStore(dbPath);
+    const jobs = store.listReviewQueueJobs();
+    const byId = new Map(jobs.map((job) => [job.jobId, job]));
+    expect(byId.get("valid")).toMatchObject({
+      repo: validRepo,
+      headSha: validHead,
+      repoKey: validRepo.toLowerCase(),
+      headShaKey: validHead.toLowerCase()
+    });
+    for (const id of ["blob", "null", "numeric", "tab", "lf", "nbsp"]) {
+      expect(byId.get(id)?.repoKey).toBeUndefined();
+      expect(byId.get(id)?.headShaKey).toBeUndefined();
+    }
+    store.recordProcessed({ repo: validRepo, pullNumber: 1, headSha: validHead, status: "posted" });
+    store.assignReviewerSessionJob({
+      repo: validRepo, pullNumber: 1, headSha: validHead, ttlMs: 60_000, headCountLimit: 2, allowProcessed: true
+    });
+    expect(store.getProcessedReview(validRepo, 1, validHead)?.repo).toBe(validRepo);
+    expect(store.getReviewerSessionJob(validRepo, 1, validHead)?.headSha).toBe(validHead);
+    const enqueued = store.enqueueReviewQueueJob({ repo: "OWNER/New-Repo", pullNumber: 2, headSha: "B".repeat(40) });
+    expect(enqueued.job).toMatchObject({ repo: "OWNER/New-Repo", repoKey: "owner/new-repo", headShaKey: "b".repeat(40) });
+    store.close();
+
+    const operatorQueue = collectOperatorReviewQueue(dbPath);
+    expect(operatorQueue.jobs).toHaveLength(8);
+    const reopened = new ReviewStateStore(dbPath);
+    expect(reopened.listReviewQueueJobs()).toHaveLength(8);
+    reopened.close();
+    const verify = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const raw = verify.prepare("select repo, head_sha, repo_key, head_sha_key from review_queue_jobs where job_id = ?").get("valid") as Record<string, unknown>;
+      expect(raw).toEqual({ repo: validRepo, head_sha: validHead, repo_key: validRepo.toLowerCase(), head_sha_key: validHead.toLowerCase() });
+      expect(verify.prepare("select name from review_state_migrations where name = ?").get("review_queue_jobs_shadow_identity_v1")).toBeTruthy();
+      expect(verify.prepare("pragma index_list(review_queue_jobs)").all()).toEqual(expect.arrayContaining([expect.objectContaining({ name: "idx_review_queue_jobs_shadow_identity" })]));
+    } finally {
+      verify.close();
+    }
   });
 
   it("stores normalized issue enrichment public and private hashes and rejects invalid hashes", () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -91,8 +91,14 @@ describe("review state store", () => {
 
     const operatorQueue = collectOperatorReviewQueue(dbPath);
     expect(operatorQueue.jobs).toHaveLength(8);
+    const lateDb = new DatabaseSync(dbPath);
+    lateDb.prepare("insert into review_queue_jobs (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at) values (?, ?, 'automatic', 'background', ?, 'Owner', 3, ?, 50, 'queued', ?, ?)").run("late", "late", "Owner/Late-Repo", "C".repeat(40), "2099-01-01T00:00:00.000Z", "2099-01-01T00:00:00.000Z");
+    lateDb.close();
+    const lateOpen = new ReviewStateStore(dbPath);
+    expect(lateOpen.getReviewQueueJob("late")).toMatchObject({ repoKey: "owner/late-repo", headShaKey: "c".repeat(40) });
+    lateOpen.close();
     const reopened = new ReviewStateStore(dbPath);
-    expect(reopened.listReviewQueueJobs()).toHaveLength(8);
+    expect(reopened.listReviewQueueJobs()).toHaveLength(9);
     reopened.close();
     const verify = new DatabaseSync(dbPath, { readOnly: true });
     try {


### PR DESCRIPTION
Related: #882

## A1a1v2 shadow identity successor

Base: 471a8d1ea489e1c2dabed4b24da241ef6ea11e7b
Head: 749732ae50f50a1df090178d0a524865b793bf45

This additive state slice preserves original queue repo/head bytes, adds nullable indexed shadow keys, and backfills only primitive strict owner/repo plus 40-hex SHA strings. BLOB, NULL, numeric, tab, LF, NBSP, and malformed legacy values remain readable with no valid shadow key. Newly enqueued valid identities receive lowercase shadow keys without adding A1a2 enqueue/lease/direct-insert fencing or any transition/claim/receipt/accounting behavior.

## Deterministic proof

- 178 changed non-generated lines; git diff --check passes.
- Hostile temp-DB matrix receipt: /Users/m1/Codex/evidence/neondiff/2026-08-23/mac-ga-1.1.0/a1a1v2-shadow-identity/receipt.md
- Matrix output proves original bytes, linked session/processed lookups, zero malformed shadow keys, atomic marker recovery, completed reopen, indexed EXPLAIN QUERY PLAN, and operator queue readability.
- Targeted TypeScript for src/state.ts and src/operator-cli.ts passes.
- Focused Vitest is environment-blocked in this checkout (no local vitest binary; sibling Rollup native signature mismatch); exact-head CI is authoritative.

No live DB, worker, runtime, config, Keychain, customer, or GitHub review/status mutation was performed. Agent-authored candidate; please run exact-head CI and independent acceptance/adversarial checks.