### PR TITLE
feat(github): add canonical verified-installation identity primitive

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -836,13 +836,23 @@ function normalizeGitHubBotLogin(value: unknown): string | undefined {
 function snapshotGitHubDataRecord(value: unknown): Record<string, unknown> | undefined {
   try {
     if (value === null || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return undefined;
-    const descriptors = Object.getOwnPropertyDescriptors(value);
-    if (Object.values(descriptors).some((descriptor) => !("value" in descriptor))) return undefined;
+    if (!hasOnlyDataProperties(value, new Set())) return undefined;
     const snapshot = structuredClone(value);
     return Object.getPrototypeOf(snapshot) === Object.prototype ? snapshot as Record<string, unknown> : undefined;
   } catch {
     return undefined;
   }
+}
+
+function hasOnlyDataProperties(value: object, seen: Set<object>): boolean {
+  if (seen.has(value)) return true;
+  seen.add(value);
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  return Object.values(descriptors).every((descriptor) => {
+    if (!("value" in descriptor)) return false;
+    return descriptor.value === null || typeof descriptor.value !== "object"
+      || hasOnlyDataProperties(descriptor.value, seen);
+  });
 }
 
 function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefined {

--- a/src/github.ts
+++ b/src/github.ts
@@ -140,6 +140,27 @@ interface GitHubInstallationResponse {
   app_slug?: string;
 }
 
+/**
+ * Canonical identity returned by the side-effect-free installation validator.
+ * Keep this value independent of the GitHub response so token resolvers cannot
+ * accidentally retain a live response object or accessor-backed field.
+ */
+export interface CanonicalGitHubInstallationIdentity {
+  id: number;
+  app_id: number;
+  account_id: number;
+  account_login: string;
+  account_type: "User" | "Organization";
+  app_slug: string;
+  bot_login: string;
+}
+
+export interface GitHubInstallationIdentityExpectation {
+  expectedAppId: string;
+  expectedBotLogin: string;
+  repo: string;
+}
+
 export class GitHubApiRequestError extends Error {
   readonly status: number;
   readonly statusText: string;
@@ -750,6 +771,84 @@ function visibilityFromRepositorySummary(repository: RepositorySummary): {
   if (repository.private === true) return { result: "private", source: "private_flag" };
   if (repository.private === false) return { result: "public", source: "private_flag" };
   return { result: "unknown", source: "unavailable" };
+}
+
+const GITHUB_LOGIN_PATTERN = /^(?!-)(?!.*--)[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+const GITHUB_APP_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
+
+/**
+ * Snapshot and validate the complete installation identity before a caller
+ * can use it for token resolution. This primitive deliberately performs no
+ * I/O, token minting, caching, or mutation.
+ */
+export function normalizeAndValidateGitHubInstallationIdentity(
+  value: unknown,
+  expected: GitHubInstallationIdentityExpectation
+): CanonicalGitHubInstallationIdentity {
+  const installation = snapshotGitHubDataRecord(value);
+  const expectations = snapshotGitHubDataRecord(expected);
+  const account = installation && snapshotGitHubDataRecord(installation.account);
+  const positiveInteger = (candidate: unknown): candidate is number =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
+  const expectedAppId = typeof expectations?.expectedAppId === "string" ? expectations.expectedAppId.trim() : undefined;
+  const expectedBotLogin = normalizeGitHubBotLogin(expectations?.expectedBotLogin);
+  const repo = expectations?.repo;
+  const repoParts = typeof repo === "string" ? repo.split("/") : [];
+  const owner = repoParts.length === 2 && repoParts.every((part) => part.length > 0 && !/\s/.test(part))
+    ? normalizeGitHubValue(repoParts[0], GITHUB_LOGIN_PATTERN)
+    : undefined;
+  const appSlug = normalizeGitHubAppSlug(installation?.app_slug);
+  const botLogin = appSlug ? `${appSlug}[bot]` : undefined;
+  const accountLogin = normalizeGitHubValue(account?.login, GITHUB_LOGIN_PATTERN);
+  const accountType = account?.type;
+  if (!installation || !expectations || !account || typeof expectedAppId !== "string"
+      || !/^\d+$/.test(expectedAppId) || !expectedBotLogin || !owner
+      || !positiveInteger(installation.id) || !positiveInteger(installation.app_id)
+      || String(installation.app_id) !== expectedAppId
+      || !positiveInteger(account.id) || !accountLogin || accountLogin !== owner
+      || (accountType !== "User" && accountType !== "Organization")
+      || !appSlug || !botLogin || botLogin !== expectedBotLogin) {
+    throw new Error("GitHub installation identity failed canonical validation.");
+  }
+  return Object.freeze({
+    id: installation.id,
+    app_id: installation.app_id,
+    account_id: account.id,
+    account_login: accountLogin,
+    account_type: accountType,
+    app_slug: appSlug,
+    bot_login: botLogin
+  });
+}
+
+function normalizeGitHubAppSlug(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  const slug = normalized.endsWith("[bot]") ? normalized.slice(0, -5) : normalized;
+  return GITHUB_APP_SLUG_PATTERN.test(slug) ? slug : undefined;
+}
+
+function normalizeGitHubBotLogin(value: unknown): string | undefined {
+  const slug = normalizeGitHubAppSlug(value);
+  return slug ? `${slug}[bot]` : undefined;
+}
+
+function snapshotGitHubDataRecord(value: unknown): Record<string, unknown> | undefined {
+  try {
+    if (value === null || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return undefined;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    if (Object.values(descriptors).some((descriptor) => !("value" in descriptor))) return undefined;
+    const snapshot = structuredClone(value);
+    return Object.getPrototypeOf(snapshot) === Object.prototype ? snapshot as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return pattern.test(normalized) ? normalized : undefined;
 }
 
 function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GitHubApi } from "../src/github.js";
+import { GitHubApi, normalizeAndValidateGitHubInstallationIdentity } from "../src/github.js";
 
 describe("GitHub App read authentication", () => {
   const roots: string[] = [];
@@ -13,6 +13,61 @@ describe("GitHub App read authentication", () => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns one frozen canonical identity from slug or bot-login forms", () => {
+    const installation = canonicalInstallation({
+      app_slug: " EVAOS-CODE-REVIEW-BOT[bot] ",
+      account: { id: 7, login: "Owner", type: "Organization" }
+    });
+    const identity = normalizeAndValidateGitHubInstallationIdentity(installation, {
+      expectedAppId: "4184532",
+      expectedBotLogin: " evaos-code-review-bot ",
+      repo: "OWNER/repo"
+    });
+
+    expect(identity).toEqual({
+      id: 123,
+      app_id: 4184532,
+      account_id: 7,
+      account_login: "owner",
+      account_type: "Organization",
+      app_slug: "evaos-code-review-bot",
+      bot_login: "evaos-code-review-bot[bot]"
+    });
+    expect(Object.isFrozen(identity)).toBe(true);
+  });
+
+  it.each([
+    ["missing installation id", { id: undefined }],
+    ["wrong App id", { app_id: 4184533 }],
+    ["missing account id", { account: { login: "owner", type: "User" } }],
+    ["missing account type", { account: { id: 7, login: "owner" } }],
+    ["wrong account type", { account: { id: 7, login: "owner", type: "Bot" } }],
+    ["wrong owner", { account: { id: 7, login: "other", type: "User" } }],
+    ["wrong App slug", { app_slug: "other-app" }],
+    ["malformed App slug", { app_slug: "Bad_App" }]
+  ])("rejects %s before any token-capable caller can use the result", (_name, override) => {
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(
+      canonicalInstallation(override),
+      { expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo" }
+    )).toThrow(/canonical validation/);
+  });
+
+  it.each(["accessor", "proxy"])("rejects hostile %s input without reading its values", (shape) => {
+    let reads = 0;
+    const installation = shape === "accessor"
+      ? Object.defineProperty(canonicalInstallation(), "id", { get: () => (++reads, 123) })
+      : new Proxy(canonicalInstallation(), {
+        get: () => (++reads, 123)
+      });
+
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(installation, {
+      expectedAppId: "4184532",
+      expectedBotLogin: "evaos-code-review-bot[bot]",
+      repo: "owner/repo"
+    })).toThrow(/canonical validation/);
+    expect(reads).toBe(0);
   });
 
   it("uses installation tokens for PR read calls when App credentials are configured", async () => {
@@ -835,6 +890,16 @@ function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
     statusText,
     headers: { "Content-Type": "application/json" }
   });
+}
+
+function canonicalInstallation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 123,
+    app_id: 4184532,
+    account: { id: 7, login: "owner", type: "User" },
+    app_slug: "evaos-code-review-bot",
+    ...overrides
+  };
 }
 
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -70,6 +70,20 @@ describe("GitHub App read authentication", () => {
     expect(reads).toBe(0);
   });
 
+  it("rejects a nested account accessor before cloning or reading it", () => {
+    let reads = 0;
+    const account = Object.defineProperty({ id: 7, login: "owner", type: "User" }, "login", {
+      get: () => (++reads, "owner")
+    });
+
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ account }), {
+      expectedAppId: "4184532",
+      expectedBotLogin: "evaos-code-review-bot[bot]",
+      repo: "owner/repo"
+    })).toThrow(/canonical validation/);
+    expect(reads).toBe(0);
+  });
+
   it("uses installation tokens for PR read calls when App credentials are configured", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-read-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

- Add a pure, side-effect-free canonical GitHub App installation identity validator/normalizer.
- Require positive safe App and installation IDs, account ID/login/type, canonical App slug/[bot] identity, and exact repository-owner binding.
- Snapshot plain data records and reject accessors/proxies before a canonical identity can be returned.
- Add focused canonical, malformed, and hostile-input tests.

Related: #872

## Scope boundary

This PR intentionally does not wire initial/refresh token resolution, mint tokens, make network calls from the primitive, mutate runtime/scheduler/CLI fixtures, or touch customer/release state. R1v3b owns resolver wiring after this slice merges.

## Validation

- `npm run build` — PASS (Node 24.19.0 emits the repository's existing Node >=26 engine warning only during install; build and postbuild passed).
- Direct canonical/hostile smoke via `node --import tsx` — PASS.
- `git diff --check` — PASS.
- Focused Vitest invocation was attempted but is blocked by the macOS Rollup optional native binary Team-ID mismatch (`ERR_DLOPEN_FAILED`), outside this diff; CI remains required.
- 166 changed lines (including one import deletion), under the 200-line envelope.

Authored by Codex; no live GitHub App, token, customer, config/DB, Keychain, release, or deployment mutation was performed.