### PR TITLE
fix(issue-enrichment): defer label-event overflow safely

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -18,6 +18,7 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
@@ -417,7 +418,7 @@ export class GitHubApi {
     });
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedGithubList<{
     event?: string;
     created_at?: string;
     actor?: { login?: string | null } | null;
@@ -435,8 +436,10 @@ export class GitHubApi {
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100) return boundedGithubList(events, false);
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) return boundedGithubList(events, true);
     }
+    return boundedGithubList(events, true);
   }
 
   async getCollaboratorPermission(

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -231,6 +231,7 @@ export type IssueEnrichmentScanCompletion = "complete" | "page_limit_reached" | 
 
 export type IssueEnrichmentIssueList = GitHubRelatedIssueOrPull[] & {
   scanCompletion?: IssueEnrichmentScanCompletion;
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
 };
 
 export interface IssueEnrichmentScanResult {
@@ -284,14 +285,16 @@ type IssueEnrichmentComment = {
   user?: { login?: string | null } | null;
 };
 
+type IssueEnrichmentLabelEvent = {
+  event?: string;
+  created_at?: string;
+  actor?: { login?: string | null } | null;
+  label?: { name?: string | null } | null;
+};
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<IssueEnrichmentLabelEvent[] | BoundedGithubList<IssueEnrichmentLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -329,7 +332,8 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded"
+  | "issue_label_event_overflow";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -381,7 +385,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
-}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
+}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence; promotionOverflow?: boolean }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
     .map((label) => label.trim().toLowerCase())
@@ -394,7 +398,10 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, truncated, overflow } = unpackBoundedGithubList(
+      await input.github.listIssueLabelEvents(input.repo, input.issue.number)
+    );
+    if (truncated || overflow) return { issue: input.issue, promotionOverflow: true };
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -449,9 +456,10 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, truncated: timelineTruncated, overflow: timelineOverflow } = unpackBoundedGithubList(timelineResult);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -488,7 +496,7 @@ export async function buildIssueEvidenceContext(input: {
     linkedItems,
     truncation: {
       comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      timeline: timelineTruncated || timelineOverflow || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };
@@ -697,6 +705,7 @@ export async function collectIssueEnrichmentScan(input: {
     const issueItems = planRepoIssueScan({
       repo,
       issues,
+      scanReasons: issues.scanReasons,
       throttle: policy.throttle,
       suggestions: policy.suggestions,
       repoPolicy: policy.repoPolicy,
@@ -1012,6 +1021,7 @@ export async function runIssueEnrichmentCycle(input: {
             listIssuesForEnrichment: async (repo, options) => {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
               const prepared: GitHubRelatedIssueOrPull[] = [];
+              const scanReasons: Record<number, IssueEnrichmentScanReason> = {};
               for (const issue of issues) {
                 const promotion = await evaluateIssuePromotion({
                   repo,
@@ -1020,8 +1030,9 @@ export async function runIssueEnrichmentCycle(input: {
                   github: input.github
                 });
                 prepared.push(promotion.issue);
+                if (promotion.promotionOverflow) scanReasons[issue.number] = "issue_label_event_overflow";
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
+                if (shouldCollectModelEvidence && !promotion.promotionOverflow) {
                   issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
                     repo,
                     issue: promotion.issue,
@@ -1034,7 +1045,7 @@ export async function runIssueEnrichmentCycle(input: {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
               }
-              return Object.assign(prepared, { scanCompletion: issues.scanCompletion });
+              return Object.assign(prepared, { scanCompletion: issues.scanCompletion, scanReasons });
             }
           },
           dryRun: input.dryRun,
@@ -1378,6 +1389,7 @@ function resolveIssueSuggestionAllowlist(globalAllowlist: string[], repoOverride
 function planRepoIssueScan(input: {
   repo: string;
   issues: GitHubRelatedIssueOrPull[];
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
@@ -1414,6 +1426,10 @@ function planRepoIssueScan(input: {
   let comments = 0;
 
   return planned.map((output) => {
+    const scanReason = input.scanReasons?.[output.issueNumber];
+    if (scanReason) {
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", scanReason, output.url, nextEligibleAt(input));
+    }
     if (output.skipped) {
       return {
         repo: input.repo,

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+describe("bounded issue-label pagination", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns overflow metadata after exactly five full pages", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      pages.push(page);
+      return new Response(JSON.stringify(Array.from({ length: 100 }, () => ({ event: "labeled" }))), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+
+    expect(pages).toEqual([1, 2, 3, 4, 5]);
+    expect(result).toHaveLength(500);
+    expect(result.items).toHaveLength(500);
+    expect(result.rawCount).toBe(500);
+    expect(result.truncated).toBe(true);
+    expect(result.overflow).toBe(true);
+  });
+
+  it("stops at the first short page without claiming truncation", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const page = Number(new URL(String(url)).searchParams.get("page"));
+      pages.push(page);
+      return new Response(JSON.stringify(Array.from({ length: page === 2 ? 2 : 100 }, () => ({ event: "labeled" }))), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+
+    expect(pages).toEqual([1, 2]);
+    expect(result.rawCount).toBe(102);
+    expect(result.truncated).toBe(false);
+    expect(result.overflow).toBe(false);
+  });
+});

--- a/tests/issue-enrichment.test.ts
+++ b/tests/issue-enrichment.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
+import type { IssueAnalysis } from "../src/issue-analysis.js";
+import { runIssueEnrichmentCycle } from "../src/issue-enrichment.js";
+import { ReviewStateStore } from "../src/state.js";
+import { createTestLicenseAdmission } from "./helpers/license-admission.js";
+
+const admission = await createTestLicenseAdmission({ operation: "issue_enrichment" });
+const analysis = (): IssueAnalysis => ({
+  classification: "needs-repro", priority: "P3", priorityState: "provisional", confidence: "needs-repro",
+  repositoryImpact: "fixture", currentMainApplicability: "fixture", verifiedFacts: [],
+  reproductionOrInvariantGap: "fixture", relatedWork: [], migrationDisposition: "needs-repro",
+  nextGate: "fixture", limitations: [], labelProposals: []
+});
+
+describe("label-event promotion consumer", () => {
+  it("defers only the overflow issue and holds its repository watermark", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-label-overflow-"));
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const config = {
+      statePath,
+      issueEnrichment: {
+        enabled: true, postIssueComment: true, allowlist: ["owner/repo"], maxIssuesPerCycle: 3,
+        maxCommentsPerCycle: 3, processExistingOpenIssuesOnActivation: true,
+        repos: { "owner/repo": { maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, cooldownMs: 60_000,
+          burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 60_000,
+          promotionMaintainers: [{ login: "trusted", validFrom: "2026-01-01T00:00:00Z" }] } }
+      }
+    };
+    writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+    const state = new ReviewStateStore(statePath);
+    const overflowEvents = Object.assign(Array.from({ length: 500 }, () => ({ event: "labeled" })), {
+      items: Array.from({ length: 500 }, () => ({ event: "labeled" })), rawCount: 500, truncated: true, overflow: true
+    }) as BoundedGithubList<{ event?: string }>;
+    const overflowIssue: GitHubRelatedIssueOrPull = {
+      number: 738, title: "overflow", state: "open", updated_at: "2026-08-24T00:01:00Z",
+      labels: [{ name: "upstream-intake" }, { name: "active-continuation" }], body: "fixture"
+    };
+    const ordinaryIssue: GitHubRelatedIssueOrPull = {
+      number: 739, title: "ordinary", state: "open", updated_at: "2026-08-24T00:01:00Z", labels: [], body: "fixture"
+    };
+    state.recordIssueEnrichmentRepoWatermark({ repo: "owner/repo", activatedAt: "2026-08-24T00:00:00Z", lastCheckedAt: "2026-08-24T00:00:00Z", now: new Date("2026-08-24T00:00:00Z") });
+    let posts = 0;
+    try {
+      const result = await runIssueEnrichmentCycle({
+        config: loadConfig(configPath), state, dryRun: false, includeExisting: true, checkedAt: "2026-08-24T00:02:00Z",
+        licenseAdmission: admission, analyzeIssue: async () => analysis(),
+        github: {
+          listIssuesForEnrichment: async () => [overflowIssue, ordinaryIssue],
+          listIssueLabelEvents: async () => overflowEvents,
+          getCollaboratorPermission: async () => "maintain",
+          canPostAsApp: () => true,
+          upsertIssueComment: async () => { posts += 1; return { action: "created" as const, comment: { html_url: "https://github.test/comment" } }; }
+        }
+      });
+
+      expect(result.summary).toMatchObject({ posted: 1, deferred: 1, deferredRecorded: 1, skipped: 0, failed: 0 });
+      expect(result.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({ issueNumber: 738, action: "deferred", reason: "issue_label_event_overflow", recordStatus: "deferred" }),
+        expect.objectContaining({ issueNumber: 739, action: "would_comment", recordStatus: "posted" })
+      ]));
+      expect(posts).toBe(1);
+      expect(state.getIssueEnrichmentRecord("owner/repo", 738)).toMatchObject({ status: "deferred", reason: "issue_label_event_overflow" });
+      expect(state.getIssueEnrichmentRepoWatermark("owner/repo")).toMatchObject({ lastCheckedAt: "2026-08-24T00:00:00.000Z" });
+    } finally {
+      state.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/issue-enrichment.test.ts
+++ b/tests/issue-enrichment.test.ts
@@ -39,17 +39,17 @@ describe("label-event promotion consumer", () => {
       items: Array.from({ length: 500 }, () => ({ event: "labeled" })), rawCount: 500, truncated: true, overflow: true
     }) as BoundedGithubList<{ event?: string }>;
     const overflowIssue: GitHubRelatedIssueOrPull = {
-      number: 738, title: "overflow", state: "open", updated_at: "2026-08-24T00:01:00Z",
+      number: 738, title: "overflow", state: "open", updated_at: "2026-08-24T00:01:00.000Z",
       labels: [{ name: "upstream-intake" }, { name: "active-continuation" }], body: "fixture"
     };
     const ordinaryIssue: GitHubRelatedIssueOrPull = {
-      number: 739, title: "ordinary", state: "open", updated_at: "2026-08-24T00:01:00Z", labels: [], body: "fixture"
+      number: 739, title: "ordinary", state: "open", updated_at: "2026-08-24T00:01:00.000Z", labels: [], body: "fixture"
     };
-    state.recordIssueEnrichmentRepoWatermark({ repo: "owner/repo", activatedAt: "2026-08-24T00:00:00Z", lastCheckedAt: "2026-08-24T00:00:00Z", now: new Date("2026-08-24T00:00:00Z") });
+    state.recordIssueEnrichmentRepoWatermark({ repo: "owner/repo", activatedAt: "2026-08-24T00:00:00.000Z", lastCheckedAt: "2026-08-24T00:00:00.000Z", now: new Date("2026-08-24T00:00:00.000Z") });
     let posts = 0;
     try {
       const result = await runIssueEnrichmentCycle({
-        config: loadConfig(configPath), state, dryRun: false, includeExisting: true, checkedAt: "2026-08-24T00:02:00Z",
+        config: loadConfig(configPath), state, dryRun: false, includeExisting: true, checkedAt: "2026-08-24T00:02:00.000Z",
         licenseAdmission: admission, analyzeIssue: async () => analysis(),
         github: {
           listIssuesForEnrichment: async () => [overflowIssue, ordinaryIssue],


### PR DESCRIPTION
## Summary

Closes #738 (P1b successor slice after merged P1a #945).

- Bound issue label-event reads to five pages / 500 rows with truthful `truncated` and `overflow` metadata.
- Consume that metadata in promotion authorization before removing `upstream-intake`.
- Carry an affected issue's overflow into scan planning as `issue_label_event_overflow`, so only that issue is deferred before posting and repository counters are computed from the final item.
- Preserve timeline truncation evidence and hold the repository watermark when the deferred record is present.

## Proof

- Exact base: `5bc362e137733268e394f3f126b9bbec33db4571` (merged P1a #945).
- Head: `7886125615ad4f3b37f9ae115908a24582d9d4c9`.
- Focused fixtures added in `tests/github.test.ts` and `tests/issue-enrichment.test.ts`.
- Direct Bun transport probe: 5 requests, 500 rows, `truncated=true`, `overflow=true`.
- Direct Bun consumer probe: overflow issue deferred/recorded, ordinary sibling posted once, watermark held.
- `git diff --check` passes; 154 insertions / 15 deletions across four authorized files (169 changed non-generated lines).

Vitest and `tsc` could not run in this fresh worktree because dependencies are absent; `npx`'s cached Vitest is missing its native Rolldown binding. No live worker, database, config, Keychain, customer, or GitHub-post mutation was performed.
