### PR TITLE
feat: add severe receipt Parser C schema boundary

### DIFF
--- a/src/severe-verification-receipt-parser-c.ts
+++ b/src/severe-verification-receipt-parser-c.ts
@@ -16,31 +16,31 @@ const reject = (): never => { throw new TypeError("severe_receipt_schema_invalid
 
 /** Parser C: validate Parser B data and return an isolated plain-data receipt. */
 export function parseSevereVerificationReceipt(input: unknown): SevereVerificationReceipt {
-  const value = copyPlainData(input);
+  const value = copyPlainData(input, new Set<object>());
   if (!validate(value)) reject();
   return value as SevereVerificationReceipt;
 }
 
-function copyPlainData(input: unknown): unknown {
+function copyPlainData(input: unknown, seen: Set<object>): unknown {
   if (input === null) return null;
   const kind = typeof input;
   if (kind === "string" || kind === "boolean") return input;
   if (kind === "number") return Number.isFinite(input) ? input : reject();
   if (kind !== "object") reject();
   if (isProxy(input)) reject();
-
-  let array: boolean;
-  let prototype: object | null;
+  const object = input as object;
+  if (seen.has(object)) reject();
+  seen.add(object);
   try {
-    array = Array.isArray(input);
-    prototype = getPrototypeOf(input);
-  } catch { return reject(); }
-  if (array) return copyArray(input as unknown[], prototype);
-  if (prototype !== Object.prototype) reject();
-  return copyObject(input as Record<string, unknown>);
+    const array = Array.isArray(input);
+    const prototype = getPrototypeOf(object);
+    if (array) return copyArray(object as unknown[], prototype, seen);
+    if (prototype !== Object.prototype) reject();
+    return copyObject(object as Record<string, unknown>, seen);
+  } catch { return reject(); } finally { seen.delete(object); }
 }
 
-function copyObject(input: Record<string, unknown>): Record<string, unknown> {
+function copyObject(input: Record<string, unknown>, seen: Set<object>): Record<string, unknown> {
   let keys: (string | symbol)[];
   try { keys = ownKeys(input); } catch { return reject(); }
   if (keys.length > MAX_OBJECT_KEYS) reject();
@@ -48,12 +48,12 @@ function copyObject(input: Record<string, unknown>): Record<string, unknown> {
   for (const key of keys) {
     if (typeof key !== "string") return reject();
     const value = dataProperty(input, key, true);
-    defineProperty(output, key, { value: copyPlainData(value), enumerable: true, writable: true, configurable: true });
+    defineProperty(output, key, { value: copyPlainData(value, seen), enumerable: true, writable: true, configurable: true });
   }
   return output;
 }
 
-function copyArray(input: unknown[], prototype: object | null): unknown[] {
+function copyArray(input: unknown[], prototype: object | null, seen: Set<object>): unknown[] {
   if (prototype !== Array.prototype) reject();
   const lengthValue = dataProperty(input, "length", false);
   if (typeof lengthValue !== "number" || !Number.isSafeInteger(lengthValue) || lengthValue < 0 || lengthValue > MAX_ARRAY_ITEMS) return reject();
@@ -66,7 +66,7 @@ function copyArray(input: unknown[], prototype: object | null): unknown[] {
   defineProperty(output, "length", { value: length, writable: true, enumerable: false, configurable: false });
   for (let index = 0; index < length; index += 1) {
     const key = String(index);
-    defineProperty(output, key, { value: copyPlainData(dataProperty(input, key, true)), enumerable: true, writable: true, configurable: true });
+    defineProperty(output, key, { value: copyPlainData(dataProperty(input, key, true), seen), enumerable: true, writable: true, configurable: true });
   }
   return output;
 }

--- a/src/severe-verification-receipt-parser-c.ts
+++ b/src/severe-verification-receipt-parser-c.ts
@@ -1,3 +1,4 @@
+import { types as nodeTypes } from "node:util";
 import {
   compileSevereVerificationReceiptSchema,
   type SevereVerificationReceipt
@@ -10,6 +11,7 @@ const ownKeys = Reflect.ownKeys;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const getPrototypeOf = Object.getPrototypeOf;
 const defineProperty = Object.defineProperty;
+const isProxy = nodeTypes.isProxy;
 const reject = (): never => { throw new TypeError("severe_receipt_schema_invalid"); };
 
 /** Parser C: validate Parser B data and return an isolated plain-data receipt. */
@@ -25,6 +27,7 @@ function copyPlainData(input: unknown): unknown {
   if (kind === "string" || kind === "boolean") return input;
   if (kind === "number") return Number.isFinite(input) ? input : reject();
   if (kind !== "object") reject();
+  if (isProxy(input)) reject();
 
   let array: boolean;
   let prototype: object | null;

--- a/src/severe-verification-receipt-parser-c.ts
+++ b/src/severe-verification-receipt-parser-c.ts
@@ -1,0 +1,82 @@
+import {
+  compileSevereVerificationReceiptSchema,
+  type SevereVerificationReceipt
+} from "./severe-verification-receipt-schema.js";
+
+const MAX_OBJECT_KEYS = 16;
+const MAX_ARRAY_ITEMS = 64;
+const validate = compileSevereVerificationReceiptSchema();
+const ownKeys = Reflect.ownKeys;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const getPrototypeOf = Object.getPrototypeOf;
+const defineProperty = Object.defineProperty;
+const reject = (): never => { throw new TypeError("severe_receipt_schema_invalid"); };
+
+/** Parser C: validate Parser B data and return an isolated plain-data receipt. */
+export function parseSevereVerificationReceipt(input: unknown): SevereVerificationReceipt {
+  const value = copyPlainData(input);
+  if (!validate(value)) reject();
+  return value as SevereVerificationReceipt;
+}
+
+function copyPlainData(input: unknown): unknown {
+  if (input === null) return null;
+  const kind = typeof input;
+  if (kind === "string" || kind === "boolean") return input;
+  if (kind === "number") return Number.isFinite(input) ? input : reject();
+  if (kind !== "object") reject();
+
+  let array: boolean;
+  let prototype: object | null;
+  try {
+    array = Array.isArray(input);
+    prototype = getPrototypeOf(input);
+  } catch { return reject(); }
+  if (array) return copyArray(input as unknown[], prototype);
+  if (prototype !== Object.prototype) reject();
+  return copyObject(input as Record<string, unknown>);
+}
+
+function copyObject(input: Record<string, unknown>): Record<string, unknown> {
+  let keys: (string | symbol)[];
+  try { keys = ownKeys(input); } catch { return reject(); }
+  if (keys.length > MAX_OBJECT_KEYS) reject();
+  const output: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (typeof key !== "string") return reject();
+    const value = dataProperty(input, key, true);
+    defineProperty(output, key, { value: copyPlainData(value), enumerable: true, writable: true, configurable: true });
+  }
+  return output;
+}
+
+function copyArray(input: unknown[], prototype: object | null): unknown[] {
+  if (prototype !== Array.prototype) reject();
+  const lengthValue = dataProperty(input, "length", false);
+  if (typeof lengthValue !== "number" || !Number.isSafeInteger(lengthValue) || lengthValue < 0 || lengthValue > MAX_ARRAY_ITEMS) return reject();
+  const length = lengthValue as number;
+  let keys: (string | symbol)[];
+  try { keys = ownKeys(input); } catch { return reject(); }
+  if (keys.length !== length + 1) reject();
+  for (const key of keys) if (key !== "length" && (typeof key !== "string" || !isIndex(key, length))) return reject();
+  const output: unknown[] = [];
+  defineProperty(output, "length", { value: length, writable: true, enumerable: false, configurable: false });
+  for (let index = 0; index < length; index += 1) {
+    const key = String(index);
+    defineProperty(output, key, { value: copyPlainData(dataProperty(input, key, true)), enumerable: true, writable: true, configurable: true });
+  }
+  return output;
+}
+
+function dataProperty(input: object, key: string, enumerable: boolean): unknown {
+  let descriptor: PropertyDescriptor | undefined;
+  try { descriptor = getOwnPropertyDescriptor(input, key); } catch { return reject(); }
+  if (!descriptor || descriptor.get !== undefined || descriptor.set !== undefined || !("value" in descriptor) || descriptor.enumerable !== enumerable) return reject();
+  return descriptor.value;
+}
+
+function isIndex(key: string, length: number): boolean {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index < length && String(index) === key;
+}

--- a/tests/severe-verification-receipt-parser-c.test.ts
+++ b/tests/severe-verification-receipt-parser-c.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseSevereVerificationReceiptJson } from "../src/severe-verification-receipt-parser-b.js";
+import { prepareSerializedSevereVerificationInput } from "../src/severe-verification-receipt-parser-a.js";
+import { parseSevereVerificationReceipt } from "../src/severe-verification-receipt-parser-c.js";
+import type { SevereVerificationReceipt } from "../src/severe-verification-receipt-schema.js";
+
+const receipt = (): SevereVerificationReceipt => ({
+  schemaVersion: "severe-verifier-v1", repo: "owner/repo", pullNumber: 7,
+  baseSha: "b".repeat(40), headSha: "a".repeat(40), findingFingerprint: `finding:${"f".repeat(64)}`,
+  state: "confirmed", disposition: "retain",
+  evidence: { files: [{ path: "src/🧪.ts", kind: "whole_file", sha256: "c".repeat(64), bytes: 42, complete: true }], omitted: [], complete: true }
+});
+const fromB = (value: unknown) => parseSevereVerificationReceiptJson(prepareSerializedSevereVerificationInput(JSON.stringify(value)));
+
+describe("severe receipt Parser C schema/copy boundary", () => {
+  it("consumes Parser B output, preserves exact semantics, and copies all containers", () => {
+    const source = fromB(receipt()) as SevereVerificationReceipt;
+    const parsed = parseSevereVerificationReceipt(source);
+    expect(parsed).toEqual(receipt());
+    expect(parsed).not.toBe(source);
+    expect(parsed.evidence).not.toBe(source.evidence);
+    expect(parsed.evidence.files).not.toBe(source.evidence.files);
+    expect(parsed.evidence.files[0]).not.toBe(source.evidence.files[0]);
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(parsed.evidence.files)).toBe(Array.prototype);
+    parsed.evidence.files[0].path = "changed";
+    expect(source.evidence.files[0].path).toBe("src/🧪.ts");
+    const partial = receipt();
+    partial.state = "incomplete"; partial.disposition = "suppress"; partial.reasonCode = "not_read";
+    partial.evidence.files[0].complete = false; partial.evidence.omitted = [{ path: "src/missing.ts", code: "not_read" }]; partial.evidence.complete = false;
+    expect(parseSevereVerificationReceipt(fromB(partial))).toEqual(partial);
+  });
+
+  it("rejects semantic failures and nested additional properties", () => {
+    const invalid = [
+      { ...receipt(), extra: true },
+      { ...receipt(), state: "refuted", disposition: "retain" },
+      { ...receipt(), evidence: { ...receipt().evidence, files: [{ ...receipt().evidence.files[0], extra: true }] } },
+      { ...receipt(), evidence: { ...receipt().evidence, omitted: [{ path: "src/🧪.ts", code: "not_read" }], complete: false, files: [{ ...receipt().evidence.files[0], complete: false }] }, state: "incomplete", disposition: "suppress", reasonCode: "incomplete" },
+      { ...receipt(), evidence: { files: [], omitted: [], complete: false } }
+    ];
+    for (const value of invalid) expect(() => parseSevereVerificationReceipt(fromB(value))).toThrow("schema_invalid");
+  });
+
+  it("rejects caller-owned prototypes, accessors, symbols, and iterators without invoking them", () => {
+    let touched = false;
+    const accessor = receipt();
+    Object.defineProperty(accessor, "repo", { get() { touched = true; throw new Error("trap"); } });
+    expect(() => parseSevereVerificationReceipt(accessor)).toThrow("schema_invalid");
+    const hostile = receipt();
+    Object.setPrototypeOf(hostile, { get repo() { touched = true; throw new Error("trap"); } });
+    expect(() => parseSevereVerificationReceipt(hostile)).toThrow("schema_invalid");
+    const iterator = receipt();
+    Object.defineProperty(iterator.evidence.files, Symbol.iterator, { value() { touched = true; throw new Error("trap"); } });
+    expect(() => parseSevereVerificationReceipt(iterator)).toThrow("schema_invalid");
+    expect(touched).toBe(false);
+  });
+});

--- a/tests/severe-verification-receipt-parser-c.test.ts
+++ b/tests/severe-verification-receipt-parser-c.test.ts
@@ -66,4 +66,13 @@ describe("severe receipt Parser C schema/copy boundary", () => {
     expect(() => parseSevereVerificationReceipt(nested)).toThrow("schema_invalid");
     expect(touched).toBe(false);
   });
+
+  it("rejects outer and nested cycles without exhausting the stack", () => {
+    const outer = receipt() as SevereVerificationReceipt & { cycle?: unknown };
+    outer.cycle = outer;
+    expect(() => parseSevereVerificationReceipt(outer)).toThrow("schema_invalid");
+    const nested = receipt();
+    (nested.evidence.files[0] as unknown as { cycle?: unknown }).cycle = nested.evidence.files[0];
+    expect(() => parseSevereVerificationReceipt(nested)).toThrow("schema_invalid");
+  });
 });

--- a/tests/severe-verification-receipt-parser-c.test.ts
+++ b/tests/severe-verification-receipt-parser-c.test.ts
@@ -55,4 +55,15 @@ describe("severe receipt Parser C schema/copy boundary", () => {
     expect(() => parseSevereVerificationReceipt(iterator)).toThrow("schema_invalid");
     expect(touched).toBe(false);
   });
+
+  it("rejects transparent proxies before any proxy trap runs", () => {
+    let touched = false;
+    const traps = { get() { touched = true; throw new Error("trap"); }, ownKeys() { touched = true; throw new Error("trap"); }, getPrototypeOf() { touched = true; throw new Error("trap"); } };
+    const outer = new Proxy(receipt(), traps);
+    expect(() => parseSevereVerificationReceipt(outer)).toThrow("schema_invalid");
+    const nested = receipt();
+    nested.evidence.files[0] = new Proxy(nested.evidence.files[0], traps);
+    expect(() => parseSevereVerificationReceipt(nested)).toThrow("schema_invalid");
+    expect(touched).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- consume Parser B parsed output only and validate with the merged strict severe-verification schema
- return a defensive copy without caller-owned prototypes, accessors, symbols, or iterators
- add hostile, nested-schema, identity/evidence, and omission/state fixtures

Related: #865

## Validation

- `git diff --cached --check` PASS
- Bun direct Parser A -> Parser B -> Parser C probes PASS (valid copy, incomplete omission/state, semantic/nested additional-property rejection, frozen input, hostile descriptors)
- Bun bundle of Parser C PASS
- focused Vitest blocked before collection by missing native Rolldown optional binding (`@rolldown/binding-wasm32-wasi`); no dependency install performed
- local TypeScript compiler was unavailable in this fresh worktree; source-only check reached only the unavailable Ajv module resolution due absent worktree dependencies

## Boundary

This PR does not canonicalize, sort, digest, publish, wire workers/runtime, mutate customers, or prove release/customer readiness.