### PR TITLE
docs: make signed Desktop 1.1.0 native journey primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ neondiff doctor --config config.local.json --json
 For the planned signed Desktop 1.1.0 Mac journey, `/Applications/NeonDiff.app` becomes
 the primary first-run surface only after the immutable signed GA artifact, `/mac` surface, and promotion gates are live; until then the public paid B0 BYO beta remains current. Its
 planned LaunchAgent uses the sealed helper `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`. **Verify App Access** is for a new App; an existing compatible agent uses **Verify Existing Access**.
-Codex runtime and dry-run approval precede live review. The app shows license, GitHub App, daemon, and provider status;
+Codex runtime and dry-run approval precede live review. The app shows license status, GitHub App status, daemon status, and provider readiness;
 the HTML dashboard remains CLI-first/non-Mac diagnostics, not native UI.
 The managed native path binds activation and private-repository token issuance
 to the same Keychain-backed broker device identity and exact GitHub-selected

--- a/README.md
+++ b/README.md
@@ -143,9 +143,8 @@ checksum-bound prerelease bundle.
 
 ## Set Up
 
-Signed Desktop 1.1.0 native first run moves the app to `/Applications/NeonDiff.app`
-and follows its UI; CLI/dashboard/worker commands are not prerequisites. For
-npm CLI 1.0.4 CLI-first, non-Mac, or legacy operator setup, follow [docs/SETUP.md](docs/SETUP.md):
+Signed Desktop 1.1.0 is the planned native GA first-run path at `/Applications/NeonDiff.app`;
+it becomes primary only after the immutable signed GA artifact, `/mac` surface, and promotion gates are live. Until then, the public paid B0 BYO beta is current. For npm CLI 1.0.4 CLI-first, non-Mac, or legacy operator setup, follow [docs/SETUP.md](docs/SETUP.md):
 
 ```bash
 neondiff init --config config.local.json
@@ -159,13 +158,11 @@ neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
-For the signed Desktop 1.1.0 Mac journey, `/Applications/NeonDiff.app` owns
-first run and its LaunchAgent uses the sealed helper
-`/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`. A new App uses
-**Verify App Access**; an existing compatible agent uses **Verify Existing Access**.
-Codex runtime and dry-run approval precede live review. The app shows license
-status, GitHub App status, daemon status, and provider readiness; the HTML
-dashboard remains CLI-first/non-Mac diagnostics, not native UI.
+For the planned signed Desktop 1.1.0 Mac journey, `/Applications/NeonDiff.app` becomes
+the primary first-run surface only after the immutable signed GA artifact, `/mac` surface, and promotion gates are live; until then the public paid B0 BYO beta remains current. Its
+planned LaunchAgent uses the sealed helper `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`. **Verify App Access** is for a new App; an existing compatible agent uses **Verify Existing Access**.
+Codex runtime and dry-run approval precede live review. The app shows license, GitHub App, daemon, and provider status;
+the HTML dashboard remains CLI-first/non-Mac diagnostics, not native UI.
 The managed native path binds activation and private-repository token issuance
 to the same Keychain-backed broker device identity and exact GitHub-selected
 repository. The raw Activation Key remains Keychain-owned: it crosses bounded
@@ -182,9 +179,9 @@ The public paid B0 BYO beta build uses a separate exact
 no managed-broker fields. That contract enables the existing local direct/BYO
 path and API-backed native activation without a hidden defaults mutation. It
 is a paid path for every repository and does not claim the managed public-free
-model. The signed release app contains a sealed NeonDiff worker built from the
+model. When the immutable signed GA artifact is published, the signed release app contains a sealed NeonDiff worker built from the
 exact reviewed source and a pinned, SHA-256-verified official Node runtime. A
-clean Mac therefore does not need a global CLI or separate worker install for
+After those gates, a clean Mac therefore does not need a global CLI or separate worker install for
 the native setup and review path. The separate checksum-bound bundle remains
 available for the customer-owned local-agent path; its explicit `first-install`
 command installs only its verified CLI in a private current-user version
@@ -202,7 +199,7 @@ Keychain identity and rejects a mismatched plist before releasing credentials.
 Review and daemon readiness remain separate gates. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
 gates. Unsigned development builds are not the signed Desktop 1.1.0 customer
-path; use them only for development/operator checks. The signed app exposes
+path; use them only for development/operator checks. Once GA promotion is complete, the signed app exposes
 **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ package. To preview without changing your machine:
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
-The public paid B0 Mac beta uses a separate checksum-bound worker bundle from
+**Legacy CLI/operator recovery only — not signed Desktop 1.1.0 setup:** the
+separate checksum-bound worker bundle is
 the same immutable GitHub prerelease as the app rather than an unpublished npm
 version or an unpinned source checkout. No invitation is required when the
 versioned public GitHub prerelease is published and the neondiff.com
@@ -142,9 +143,9 @@ checksum-bound prerelease bundle.
 
 ## Set Up
 
-Follow [docs/SETUP.md](docs/SETUP.md) for the CLI-first setup path (the
-first-run path on non-Mac platforms and the operator/advanced path on Mac). The
-short version is:
+Signed Desktop 1.1.0 native first run moves the app to `/Applications/NeonDiff.app`
+and follows its UI; CLI/dashboard/worker commands are not prerequisites. For
+npm CLI 1.0.4 CLI-first, non-Mac, or legacy operator setup, follow [docs/SETUP.md](docs/SETUP.md):
 
 ```bash
 neondiff init --config config.local.json
@@ -158,12 +159,13 @@ neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
-For the Mac customer journey, the native macOS app (`apps/neondiff-desktop`) is
-the human first-run surface. The local HTML dashboard is an operator/diagnostic
-surface for CLI-first and non-Mac setups, not the product UI. It shows license
-status, GitHub App status, daemon status, and provider readiness, and its
-provider card includes a `Verify API Key` control that reports redacted
-pass/fail output.
+For the signed Desktop 1.1.0 Mac journey, `/Applications/NeonDiff.app` owns
+first run and its LaunchAgent uses the sealed helper
+`/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`. A new App uses
+**Verify App Access**; an existing compatible agent uses **Verify Existing Access**.
+Codex runtime and dry-run approval precede live review. The app shows license
+status, GitHub App status, daemon status, and provider readiness; the HTML
+dashboard remains CLI-first/non-Mac diagnostics, not native UI.
 The managed native path binds activation and private-repository token issuance
 to the same Keychain-backed broker device identity and exact GitHub-selected
 repository. The raw Activation Key remains Keychain-owned: it crosses bounded
@@ -199,9 +201,9 @@ value or key-file path. The headless app re-derives that device ID from its
 Keychain identity and rejects a mismatched plist before releasing credentials.
 Review and daemon readiness remain separate gates. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
-gates. Unsigned development builds still require an executable global or
-checksum-managed worker before native first run
-exposes **Initialize Local Config** (non-destructive; never force-overwrites),
+gates. Unsigned development builds are not the signed Desktop 1.1.0 customer
+path; use them only for development/operator checks. The signed app exposes
+**Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected
 `pilotRepos` allowlist and an enabled policy profile for each selected

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,10 +1,10 @@
 # NeonDiff Setup
 
-This guide is the CLI-first setup path for the current source-available release,
-and the first-run path on non-Mac platforms. On macOS the native app
-(`apps/neondiff-desktop`) is the human first-run surface; until the native
-broker/launchd proof lands (see the native-broker note below) it hands off to
-this operator/advanced path for setup actions it cannot yet complete natively.
+This guide is the CLI/operator setup path for npm CLI 1.0.4 and non-Mac first
+run. On macOS, signed Desktop 1.1.0 at `/Applications/NeonDiff.app` owns native
+first run; CLI/dashboard/checksum-worker commands below are not prerequisites.
+See the [Mac GA architecture and release contract](architecture/mac-ga-release-contract.md)
+and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 The recommended path installs the `neondiff` npm package; source checkout remains
 a fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
@@ -207,8 +207,7 @@ configured `evidenceDir` as
 The `keychain` backend remains reserved for a separately proven native broker.
 Headless CLI activation currently rejects Keychain writes rather than passing
 license keys through process arguments. v1.0.4 supports the approved file
-backend; the Desktop app remains blocked from useful actions until native
-broker/launchd access is proven.
+backend; signed Desktop 1.1.0 keeps activation in its app-owned Keychain path.
 The local `machineId` sent to the license API is advisory beta metadata derived
 from host name and platform, not hardware attestation or a durable seat-binding
 primitive.
@@ -262,50 +261,18 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
-For a B0 customer, the native first-run path is:
+For signed Desktop 1.1.0 native first run, move the app to `/Applications/NeonDiff.app` and follow its UI:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
-2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
-   PEM, then choose **Store in Keychain**.
-3. On a clean install, if NeonDiff reports that the local worker command is
-   unavailable, choose **Install / Update Local Worker** before **Initialize
-   Local Config**. From the verified extracted bundle, use Node.js 26 or newer
-   through the approved stable path `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`, then preview the credential-free install:
-
-   ```bash
-   BUNDLE_DIR="$(pwd -P)"
-   node install-b0-worker-candidate.mjs first-install \
-     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-     --manifest-sha256 <manifest-sha256-from-release> \
-     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
-     --launchd-label com.electricsheephq.evaos-code-review-bot \
-     --dry-run true
-   ```
-
-   Inspect the public-safe preview, then repeat it with
-   `--dry-run false --confirm true`. It installs only the exact verified CLI
-   into a private versioned current-user directory and writes a 0600
-   credential-free marker. It creates or loads no LaunchAgent, starts no
-   daemon, and never reads or writes GitHub, provider, or license credentials.
-   It refuses an existing LaunchAgent or worker state; use the existing-worker
-   update flow below for those machines. Return to NeonDiff and choose
-   **Install / Update Local Worker** once more to refresh discovery; when the
-   worker is available, choose **Initialize Local Config**. Initialization
-   invokes the non-destructive `neondiff init` path without `--force`, never
-   overwrites an existing config, and keeps bot-isolated runtime, state,
-   evidence, and license paths beside the config. Review and daemon readiness
-   remain separate gates.
-4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
-   Repository**. The app writes the allowlist through the typed local `config
-   patch` command and ensures every selected repository has an enabled local
-   policy profile; the customer does not edit a config file. Existing
-   per-repository policy fields are preserved.
-5. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
-   the exact configured repository through that App installation. If the local
-   profile is missing or disabled, apply the repository again before retrying
-   verification.
+2. Move the app to `/Applications/NeonDiff.app`; enter the App ID/private key
+   in its UI and choose **Store in Keychain**.
+3. Choose **Initialize Local Config**, add/apply the selected `owner/repo`, and
+   let the app write the allowlist without an operator config edit.
+4. Choose **Verify App Access** for a new App or **Verify Existing Access** for
+   a compatible agent; both checks bind the exact target.
+5. Configure provider/Codex, activate, then use **Preview Start** and **Run Dry
+   Review** before any confirmed live post.
 
 If verification reports a missing or disabled repository policy profile,
 choose **Apply Repository** again before retrying **Verify App Access**. This is a local
@@ -327,14 +294,9 @@ the app rejects it if any authorized bot now owns the same config identity.
 Choosing another account or explicitly choosing an existing bot ends the
 pending setup.
 
-When the same Mac already has one exact checksum-managed worker for the selected
-LaunchAgent label, the app reuses that worker for the isolated bot's `init`,
-`config inspect`, `config patch`, and private-key-stdin GitHub doctor commands.
-Within that proven one-worker case, it does not resolve those commands through
-an older global `neondiff` package, and it does not pass the existing bot's App
-ID or private-key file environment into the new bot process. Zero or ambiguous
-managed-worker discovery does not select this reuse path; installing and proving
-exactly one managed worker is a separate distribution gate.
+The signed app needs no global CLI or checksum-managed worker; its LaunchAgent
+invokes the sealed helper `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`.
+Legacy recovery below is operator-only, not native first-run setup.
 
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate
@@ -396,7 +358,7 @@ the same Mac. In that exact case it opens a reconciliation path:
   copying its private key. The key file must be a current-user-owned regular
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
-- its single **Verify existing access** action first proves the exact App and
+- its single **Verify Existing Access** action first proves the exact App and
   Review Target with `doctor github --repo`. A legacy credential-bearing
   matched worker then runs credential-free
   `license status --refresh true` through that exact worker and config. A
@@ -499,23 +461,21 @@ The app's own Sparkle update does not update an external local worker.
 
 ## 4. Check Readiness
 
-Run the GitHub-only doctor first. It verifies App installation visibility and
-repo read access without running ZCode, calling a provider, posting comments, or
-printing secrets:
+For signed Desktop 1.1.0, use **Verify App Access** or **Verify Existing Access**
+in the UI; credentials go only to the sealed helper. The shell command below is
+CLI/operator diagnostics only and verifies App/repo access without provider or
+posting side effects:
 
 ```bash
 neondiff doctor github --config config.local.json --json
 ```
 
-The public paid B0 BYO desktop keeps the customer-owned App private key in the
-macOS Keychain. Its explicit **Verify App Access** action sends that key only to
-the local CLI's bounded stdin for this check. The native app's clean-install
-config lives in its user-writable Application Support directory; the equivalent
-CLI contract is:
+The CLI contract uses a checkout-local config and a private key supplied through
+bounded stdin; the signed app keeps both in its app-owned Keychain path:
 
 ```bash
-NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
-neondiff doctor github --config "$NATIVE_CONFIG" \
+CLI_CONFIG="config.local.json"
+neondiff doctor github --config "$CLI_CONFIG" \
   --github-app-id "<numeric-app-id>" \
   --github-app-private-key-stdin true --json < "/path/to/app-private-key.pem"
 ```
@@ -561,7 +521,7 @@ neondiff doctor --config config.local.json --json
 This SETUP guide is the operator/advanced CLI-first path, and the first-run path
 on non-Mac platforms. The local HTML dashboard is the operator/diagnostic surface
 it drives. On Mac, the native macOS app is the human first-run product surface.
-The exact B0 bundle lets the customer store the customer-owned App key in
+The signed Desktop 1.1.0 app lets the customer store the customer-owned App key in
 Keychain, select and apply one repository, and verify that installation without
 an operator editing local files. For a reconciled existing worker with a
 multi-repository allowlist, choose one **Review Target** in the repository

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,9 +1,10 @@
 # NeonDiff Setup
 
 This guide is the CLI/operator setup path for npm CLI 1.0.4 and non-Mac first
-run. On macOS, signed Desktop 1.1.0 at `/Applications/NeonDiff.app` owns native
-first run; CLI/dashboard/checksum-worker commands below are not prerequisites.
-See the [Mac GA architecture and release contract](architecture/mac-ga-release-contract.md)
+run. The current product is the public paid B0 BYO beta. The planned signed
+Desktop 1.1.0 journey at `/Applications/NeonDiff.app` becomes primary only after
+its immutable GA artifact, `/mac` surface, and promotion gates are live. See the
+[Mac GA architecture and release contract](architecture/mac-ga-release-contract.md)
 and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 The recommended path installs the `neondiff` npm package; source checkout remains
 a fallback for contributors and reviewers who want to inspect or build locally. See
@@ -261,7 +262,7 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
-For signed Desktop 1.1.0 native first run, move the app to `/Applications/NeonDiff.app` and follow its UI:
+For the planned signed Desktop 1.1.0 GA journey, once the immutable artifact and `/mac` promotion gates are live, move the app to `/Applications/NeonDiff.app` and follow its UI:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
@@ -294,7 +295,7 @@ the app rejects it if any authorized bot now owns the same config identity.
 Choosing another account or explicitly choosing an existing bot ends the
 pending setup.
 
-The signed app needs no global CLI or checksum-managed worker; its LaunchAgent
+For that promoted GA journey, the signed app needs no global CLI or checksum-managed worker; its LaunchAgent
 invokes the sealed helper `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`.
 Legacy recovery below is operator-only, not native first-run setup.
 
@@ -461,10 +462,9 @@ The app's own Sparkle update does not update an external local worker.
 
 ## 4. Check Readiness
 
-For signed Desktop 1.1.0, use **Verify App Access** or **Verify Existing Access**
-in the UI; credentials go only to the sealed helper. The shell command below is
-CLI/operator diagnostics only and verifies App/repo access without provider or
-posting side effects:
+For the promoted signed Desktop 1.1.0 journey, use **Verify App Access** or **Verify Existing Access**
+in the UI; before promotion, use the CLI/operator diagnostic below. Credentials go only to
+the sealed helper, and the shell command verifies App/repo access without provider or posting side effects:
 
 ```bash
 neondiff doctor github --config config.local.json --json
@@ -521,7 +521,7 @@ neondiff doctor --config config.local.json --json
 This SETUP guide is the operator/advanced CLI-first path, and the first-run path
 on non-Mac platforms. The local HTML dashboard is the operator/diagnostic surface
 it drives. On Mac, the native macOS app is the human first-run product surface.
-The signed Desktop 1.1.0 app lets the customer store the customer-owned App key in
+The promoted signed Desktop 1.1.0 app lets the customer store the customer-owned App key in
 Keychain, select and apply one repository, and verify that installation without
 an operator editing local files. For a reconciled existing worker with a
 multi-repository allowlist, choose one **Review Target** in the repository

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,15 +5,14 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
-The public paid B0 BYO build accepts the customer's own App ID and private key,
-one selected repository, and runs the explicit installation check from the
-wizard. No invitation is required when the versioned public GitHub prerelease is
-published and the neondiff.com purchase/download path is live. The managed B1
-path uses the official NeonDiff App and broker under #613; it is separate from
-B0. This document remains the operator/CLI reference for both paths' App
-identity, permission set, and install boundary. Matching public website
-onboarding copy lives in the website repo under neon-diff-agent-website#52.
+On macOS, signed Desktop 1.1.0 at `/Applications/NeonDiff.app` owns native
+first run. The public paid customer-owned BYO/GA path accepts a customer-owned App ID/private key;
+new App uses **Verify App Access**, existing agent **Verify Existing Access**.
+The sealed helper is `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`.
+The managed official App/broker is separate post-GA. Stable onboarding is
+[neondiff.com/mac](https://www.neondiff.com/mac); see the [Mac GA architecture
+and release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac
+release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 
 ## Install URL
 
@@ -130,42 +129,11 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In native NeonDiff first run, store the App ID and private key. On a clean
-   Mac, choose **Install / Update Local Worker** and complete the checksum-bound
-   `first-install` with Node.js 26 or newer through `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`. Return to NeonDiff, choose **Install / Update Local
-   Worker** once more to refresh discovery, then choose **Initialize Local
-   Config**. Enter the same `owner/repo`, then choose **Add Repository**,
-   **Apply Repository**, and **Verify App Access**.
-   Initialization never uses `--force`; the app updates `pilotRepos` and the
-   selected repository's enabled policy profile through `config patch`, and no
-   operator edits the customer's config file. Existing policy fields for that
-   repository are preserved. If verification reports a missing or disabled
-   repository policy profile, apply the repository again before retrying
-   verification; that
-   message does not mean the App installation is missing. Each new
-   bot config receives isolated runtime, state, evidence, and license paths
-   beside that config rather than the packaged worker's placeholder paths. An
-   account with no bot gets this isolated plan before the initialization action
-   appears; the app never initializes the `_unselected` placeholder.
-   If NeonDiff is quit mid-setup, relaunch restores that exact pending bot and
-   config path and reopens onboarding. It does not silently fall back to an
-   existing local bot on the same account or allocate another numbered config
-   directory; the customer can explicitly choose another account or bot to end
-   the pending flow.
-   If one exact checksum-managed worker exists, these isolated config commands
-   and the bounded private-key-stdin GitHub doctor reuse that worker instead of
-   resolving through a global `neondiff` command. On a clean Mac, the bundle's
-   confirmed `first-install` command creates only a private versioned CLI and
-   credential-free 0600 marker; it creates or loads no LaunchAgent and starts
-   no daemon. The new bot receives no inherited credential environment. Zero
-   or ambiguous managed-worker discovery does not select this reuse path.
-   If the configured local worker command is unavailable, the CLI-backed
-   controls remain disabled and **Install / Update Local Worker** opens the
-   version-matched release guide. Continue only with its checksum-bound
-   manifest/tarball and dry-run-default, confirm-required `first-install`
-   command. Source support does not prove that immutable release publication,
-   signing, clean-Mac execution, review, or daemon readiness has passed.
+7. In signed Desktop 1.1.0, move the app to `/Applications/NeonDiff.app` and
+   launch it. Store the App ID/private key in Keychain, then choose **Initialize
+   Local Config**, **Add Repository**, and **Apply Repository**. Choose **Verify App
+   Access** for a new App or **Verify Existing Access** for an existing agent.
+   Checksum-worker commands below are legacy recovery only, not native setup.
 
 8. After App access, provider, repository, and activation are verified, use the
    native daemon step's **Preview Start** and **Install & Start** actions. The
@@ -174,7 +142,8 @@ integration proof under #630.
    config, launchd label, and non-secret activation device ID. Its headless mode
    re-derives that device ID from the existing broker identity in the app-owned
    Keychain, rejects any mismatch before reading credentials, validates the
-   checksum-managed worker, and hands the private key plus API-backed activation
+   sealed helper at `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`,
+   and hands the private key plus API-backed activation
    credential to the local worker only through one bounded JSON stdin envelope.
    It never exports either secret, writes a PEM or license file, places a secret
    in the plist or environment, or uses a generic `security -w` wrapper. Any
@@ -239,7 +208,8 @@ confirmed rollback; neither path reads or copies key bytes. When a stable
 Homebrew Node command resolves to the same binary as `process.execPath`, the
 installer keeps the stable command instead of pinning a versioned Cellar path.
 
-Keep the private key and local config out of git. A typical shell setup is:
+The public-funnel condition is: No invitation is required when the versioned public GitHub prerelease is published and the neondiff.com purchase/download path is live. Its shell PEM recovery is CLI/operator-only; signed Desktop 1.1.0 uses
+Keychain, not this PEM path. Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
@@ -260,13 +230,13 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-Run the GitHub-only doctor before provider or daemon checks. For the native B0
-app, use the config created in the app's user-writable Application Support
-directory:
+For signed Desktop 1.1.0 native first run, use **Verify App Access** for a new
+customer-owned App or **Verify Existing Access** for a compatible existing
+agent in the UI. The shell command below is CLI/operator diagnostics only:
 
 ```bash
-NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
-neondiff doctor github --config "$NATIVE_CONFIG" --repo owner/repo --json
+CLI_CONFIG="config.local.json"
+neondiff doctor github --config "$CLI_CONFIG" --repo owner/repo --json
 ```
 
 CLI-first and non-Mac setups may instead use the checkout-local path documented

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,14 +5,14 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS, signed Desktop 1.1.0 at `/Applications/NeonDiff.app` owns native
-first run. The public paid customer-owned BYO/GA path accepts a customer-owned App ID/private key;
-new App uses **Verify App Access**, existing agent **Verify Existing Access**.
-The sealed helper is `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`.
-The managed official App/broker is separate post-GA. Stable onboarding is
-[neondiff.com/mac](https://www.neondiff.com/mac); see the [Mac GA architecture
-and release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac
-release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
+On macOS, signed Desktop 1.1.0 is the planned native GA journey at
+`/Applications/NeonDiff.app`; it is not current GA availability. The current public paid
+customer-owned BYO beta remains current until the immutable signed GA artifact,
+`/mac` surface, and promotion gates are live. The planned GA path accepts a
+customer-owned App ID/private key; new App uses **Verify App Access**, existing
+agent uses **Verify Existing Access**. The managed official App/broker is
+separate post-GA. Planned stable onboarding is [neondiff.com/mac](https://www.neondiff.com); see the
+[Mac GA architecture and release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 
 ## Install URL
 
@@ -129,7 +129,7 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In signed Desktop 1.1.0, move the app to `/Applications/NeonDiff.app` and
+7. In the promoted signed Desktop 1.1.0 journey, once its immutable artifact and `/mac` promotion gates are live, move the app to `/Applications/NeonDiff.app` and
    launch it. Store the App ID/private key in Keychain, then choose **Initialize
    Local Config**, **Add Repository**, and **Apply Repository**. Choose **Verify App
    Access** for a new App or **Verify Existing Access** for an existing agent.
@@ -230,9 +230,9 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-For signed Desktop 1.1.0 native first run, use **Verify App Access** for a new
-customer-owned App or **Verify Existing Access** for a compatible existing
-agent in the UI. The shell command below is CLI/operator diagnostics only:
+For the promoted signed Desktop 1.1.0 journey, use **Verify App Access** for a new
+customer-owned App or **Verify Existing Access** for a compatible existing agent in
+the UI; before promotion, the shell command below is CLI/operator diagnostics only:
 
 ```bash
 CLI_CONFIG="config.local.json"


### PR DESCRIPTION
Closes #610\n\n## What changed\n- Make signed Desktop 1.1.0 at /Applications/NeonDiff.app the primary Mac customer path.\n- Make customer-owned BYO/GA Verify App Access, Verify Existing Access, Codex, and dry-run-before-live steps explicit.\n- Keep PEM/env recovery CLI/operator-only and preserve CLI 1.0.4 plus managed-App post-GA boundaries.\n- Use the exact conditional public-funnel sentence; no unconditional no-invitation claim is added.\n\n## Validation\n- npm run build\n- npm run check:design-source\n- npm run check:public-claims\n- npm run check:secrets\n- npm run check:secret-corpus-boundary\n- npm run check:secret-rule-differential\n- git diff --check\n- Deterministic public-funnel contract check: pass\n\nVitest public-funnel and public-release-readiness suites were attempted but are blocked before collection by the host Node 24/Rollup darwin-arm64 code-signature mismatch. Publication privacy requires the CI-only PUBLICATION_PRIVACY_BLOCKLIST_B64 and was not run.\n\n## Proof boundary\nDocs candidate only. This PR does not prove release publication, download availability, signing/notarization, runtime, billing, onboarding, customer readiness, merge, or deployment. No tests, runtime, config, Keychain, customer, billing, release, or deployment systems were changed.