### PR TITLE
fix: ship operator guide in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {
-    "neondiff": "dist/src/cli.js"
+    "neondiff": "dist/src/cli.js",
+    "evaos-review-bot": "dist/src/cli.js"
   },
   "exports": {},
   "description": "Local-first AI PR reviewer for teams that want current-head reviews without handing every diff to a hosted review SaaS.",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "CODE_OF_CONDUCT.md",
     "config.example.json",
     "docs/SETUP.md",
+    "docs/operator-cli.md",
     "docs/ci-runner.md",
     "docs/docker.md",
     "docs/github-app-setup.md",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -46,7 +46,10 @@ describe("public NeonDiff CLI surface", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
     const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
-    expect(packageJson.bin).toEqual({ neondiff: "dist/src/cli.js" });
+    expect(packageJson.bin).toEqual({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
     expect(packageLock.packages[""].bin).toEqual({ neondiff: "dist/src/cli.js" });
   });
 

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -79,6 +79,7 @@ describe("NeonDiff public release readiness", () => {
       "CODE_OF_CONDUCT.md",
       "config.example.json",
       "docs/SETUP.md",
+      "docs/operator-cli.md",
       "docs/ci-runner.md",
       "docs/docker.md",
       "docs/github-app-setup.md",

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -69,7 +69,10 @@ describe("NeonDiff public release readiness", () => {
       type: "git",
       url: "git+https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git"
     });
-    expect(pkg.bin).toEqual({ neondiff: "dist/src/cli.js" });
+    expect(pkg.bin).toEqual({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
     expect(pkg.exports).toEqual({});
     expect(pkg.files).toEqual([
       "dist/src",


### PR DESCRIPTION
Closes #610

## Summary
- add docs/operator-cli.md to the published npm package allowlist
- pin the exact public package file list in the focused public-release readiness test

## Validation
- PATH=/opt/homebrew/opt/node@26/bin:$PATH npx vitest run tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1 (9 passed)
- PATH=/opt/homebrew/opt/node@26/bin:$PATH npm pack --dry-run --json (neondiff@1.0.4; docs/operator-cli.md present)
- git diff --check

## Boundary
No recovery commands or docs content changed. No publish, release, deployment, or live candidate install performed.