### PR TITLE
fix(state): make shadow identity backfill lossless

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -53,6 +53,7 @@ export type RepoMemoryNoteKind =
 export type IssueEnrichmentRecordStatus = "dry_run" | "posted" | "skipped" | "deferred" | "failed";
 const REPO_MEMORY_NOTE_KINDS: RepoMemoryNoteKind[] = ["policy_note", "machine_fact", "false_positive", "review_outcome", "proof_preference"];
 const WORKTREE_CLEANUP_GUARD_TTL_MS = 60_000;
+const REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION = "review_queue_jobs_shadow_identity_v1";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -261,9 +262,11 @@ export interface ReviewQueueJobRecord {
   source: ReviewQueueJobSource;
   lane: ReviewQueueJobLane;
   repo: string;
+  repoKey?: string;
   org: string;
   pullNumber: number;
   headSha: string;
+  headShaKey?: string;
   baseSha?: string;
   providerId?: string;
   priority: number;
@@ -558,6 +561,7 @@ export class ReviewStateStore {
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new DatabaseSync(dbPath);
+    this.db.exec("pragma busy_timeout = 5000");
     this.db.exec("pragma foreign_keys = on");
     this.db.exec(`
       create table if not exists processed_reviews (
@@ -713,9 +717,11 @@ export class ReviewStateStore {
         source text not null,
         lane text not null,
         repo text not null,
+        repo_key text,
         org text not null,
         pull_number integer not null,
         head_sha text not null,
+        head_sha_key text,
         base_sha text,
         provider_id text,
         priority integer not null,
@@ -741,6 +747,12 @@ export class ReviewStateStore {
         on review_queue_jobs (repo, pull_number, state);
       create index if not exists idx_review_queue_jobs_provider_state
         on review_queue_jobs (provider_id, state);
+
+      create table if not exists review_state_migrations (
+        name text primary key,
+        completed_at text not null,
+        completed_rowid integer
+      );
 
       create table if not exists review_readiness (
         repo text not null,
@@ -844,6 +856,7 @@ export class ReviewStateStore {
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
     this.ensureReviewQueueJobColumns();
+    this.ensureReviewQueueJobShadowIdentityColumns();
     this.ensureRepoMemoryNoteCoarseColumns();
     this.db.exec(`
       create table if not exists processed_commands (
@@ -2570,6 +2583,7 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewQueueEnqueueResult {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    const shadowIdentity = canonicalReviewQueueIdentity(input.repo, input.headSha);
     const nowIso = (input.now ?? new Date()).toISOString();
     const source = input.source ?? "automatic";
     const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
@@ -2596,9 +2610,9 @@ export class ReviewStateStore {
     this.db
       .prepare(
         `insert into review_queue_jobs
-          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+          (job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
            provider_id, priority, state, session_id, comment_id, created_at, updated_at)
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
       )
       .run(
         jobId,
@@ -2606,9 +2620,11 @@ export class ReviewStateStore {
         source,
         lane,
         input.repo,
+        shadowIdentity?.repoKey ?? null,
         repoOrg(input.repo),
         input.pullNumber,
         input.headSha,
+        shadowIdentity?.headShaKey ?? null,
         input.baseSha ?? null,
         input.providerId ?? null,
         priority,
@@ -2824,7 +2840,7 @@ export class ReviewStateStore {
   getReviewQueueJob(jobId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2838,7 +2854,7 @@ export class ReviewStateStore {
   getReviewQueueJobByAttemptId(attemptId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2853,7 +2869,7 @@ export class ReviewStateStore {
     const retryPrefix = `${attemptId}:after-terminal:`;
     const row = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -2878,7 +2894,7 @@ export class ReviewStateStore {
     const rows = (input.repo
       ? this.db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+            `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
@@ -2888,7 +2904,7 @@ export class ReviewStateStore {
           .all(input.repo)
       : this.db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+            `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                     provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
@@ -2925,7 +2941,7 @@ export class ReviewStateStore {
     ];
     const rows = this.db
       .prepare(
-        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+        `select job_id, attempt_id, source, lane, repo, repo_key, org, pull_number, head_sha, head_sha_key, base_sha,
                 provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
@@ -3685,6 +3701,72 @@ export class ReviewStateStore {
     }
   }
 
+  private ensureReviewQueueJobShadowIdentityColumns(): void {
+    const ensureColumns = (table: string, wanted: Array<[string, string]>) => {
+      this.db.exec("begin immediate");
+      try {
+        const columns = this.db.prepare(`pragma table_info(${table})`).all() as unknown as Array<{ name: string }>;
+        const additions = wanted.filter(([name]) => !columns.some((column) => column.name === name));
+        if (additions.length) this.db.exec(additions.map(([name, type]) => `alter table ${table} add column ${name} ${type}`).join("; "));
+        this.db.exec("commit");
+      } catch (error) {
+        try { this.db.exec("rollback"); } catch { /* migration transaction did not start */ }
+        throw error;
+      }
+    };
+    ensureColumns("review_queue_jobs", [["repo_key", "text"], ["head_sha_key", "text"]]);
+    ensureColumns("review_state_migrations", [["completed_rowid", "integer"]]);
+
+    const getMarker = () => this.db.prepare(
+      "select completed_at, completed_rowid from review_state_migrations where name = ? limit 1"
+    ).get(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION) as { completed_at: string; completed_rowid: number | null } | undefined;
+    const missingPredicate = "(repo_key is null or head_sha_key is null)";
+    let marker = getMarker();
+    if (marker && marker.completed_rowid !== null) {
+      const missing = this.db.prepare(
+        `select 1 from review_queue_jobs where rowid > ? and ${missingPredicate} limit 1`
+      ).get(marker.completed_rowid);
+      if (!missing) return;
+    }
+
+    this.db.exec("begin immediate");
+    try {
+      marker = getMarker();
+      const lowerBound = marker?.completed_rowid ?? 0;
+      const upperBound = Number((this.db.prepare("select coalesce(max(rowid), 0) as rowid from review_queue_jobs").get() as { rowid: number }).rowid);
+      const hasExactBoundary = marker?.completed_rowid !== null && marker?.completed_rowid !== undefined;
+      this.db.exec(`create index if not exists idx_review_queue_jobs_shadow_identity
+        on review_queue_jobs (repo_key, pull_number, head_sha_key)`);
+      const rows = this.db.prepare(`
+        select rowid, repo, head_sha, repo_key, head_sha_key
+        from review_queue_jobs
+        where ${hasExactBoundary ? "rowid > ? and rowid <= ? and " : ""}${missingPredicate}
+      `).all(...(hasExactBoundary ? [lowerBound, upperBound] : [])) as unknown as Array<{
+        rowid: number; repo: unknown; head_sha: unknown; repo_key: string | null; head_sha_key: string | null;
+      }>;
+      const update = this.db.prepare(`
+        update review_queue_jobs
+        set repo_key = coalesce(repo_key, ?), head_sha_key = coalesce(head_sha_key, ?)
+        where rowid = ? and ${missingPredicate}
+      `);
+      for (const row of rows) {
+        const identity = canonicalReviewQueueIdentity(row.repo, row.head_sha);
+        if (identity) update.run(identity.repoKey, identity.headShaKey, row.rowid);
+      }
+      this.db.prepare(`
+        insert into review_state_migrations (name, completed_at, completed_rowid)
+        values (?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), ?)
+        on conflict(name) do update set
+          completed_at = excluded.completed_at,
+          completed_rowid = max(coalesce(review_state_migrations.completed_rowid, 0), excluded.completed_rowid)
+      `).run(REVIEW_QUEUE_SHADOW_IDENTITY_MIGRATION, Math.max(lowerBound, upperBound));
+      this.db.exec("commit");
+    } catch (error) {
+      try { this.db.exec("rollback"); } catch { /* migration transaction did not start */ }
+      throw error;
+    }
+  }
+
   private ensureRepoMemoryNoteCoarseColumns(): void {
     // Additive migration (#302): older DBs gain the coarse false-positive-match columns; existing
     // rows keep NULLs and fall back to exact-only matching.
@@ -3835,6 +3917,24 @@ function validateReviewQueueInput(
   if (commentId !== undefined && (!Number.isInteger(commentId) || commentId < 1)) {
     throw new Error("commentId must be a positive integer");
   }
+}
+
+function canonicalReviewQueueIdentity(repo: unknown, headSha: unknown): { repoKey: string; headShaKey: string } | undefined {
+  if (typeof repo !== "string" || typeof headSha !== "string") return undefined;
+  const [owner, name, extra] = repo.split("/");
+  if (
+    extra !== undefined ||
+    !owner ||
+    !name ||
+    owner === "." ||
+    owner === ".." ||
+    name === "." ||
+    name === ".." ||
+    !/^[A-Za-z0-9_.-]{1,100}$/.test(owner) ||
+    !/^[A-Za-z0-9_.-]{1,100}$/.test(name) ||
+    !/^[0-9a-f]{40}$/i.test(headSha)
+  ) return undefined;
+  return { repoKey: repo.toLowerCase(), headShaKey: headSha.toLowerCase() };
 }
 
 function validatePullAndCommand(pullNumber: number, commandCommentId: number): void {
@@ -4226,10 +4326,12 @@ interface ReviewQueueJobRow {
   attempt_id: string;
   source: ReviewQueueJobSource;
   lane: ReviewQueueJobLane;
-  repo: string;
+  repo: unknown;
+  repo_key: unknown;
   org: string;
   pull_number: number;
-  head_sha: string;
+  head_sha: unknown;
+  head_sha_key: unknown;
   base_sha: string | null;
   provider_id: string | null;
   priority: number;
@@ -4494,10 +4596,12 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     attemptId: row.attempt_id,
     source: row.source,
     lane: row.lane,
-    repo: row.repo,
+    repo: readableQueueText(row.repo),
+    ...(typeof row.repo_key === "string" ? { repoKey: row.repo_key } : {}),
     org: row.org,
     pullNumber: row.pull_number,
-    headSha: row.head_sha,
+    headSha: readableQueueText(row.head_sha),
+    ...(typeof row.head_sha_key === "string" ? { headShaKey: row.head_sha_key } : {}),
     ...(row.base_sha ? { baseSha: row.base_sha } : {}),
     ...(row.provider_id ? { providerId: row.provider_id } : {}),
     priority: row.priority,
@@ -4514,6 +4618,10 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
+}
+
+function readableQueueText(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
 }
 
 function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRecord {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -34,6 +34,74 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("backfills shadow identity through a lossless rowid fence and tolerates malformed history", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-shadow-v3-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec("create table review_queue_jobs (job_id text primary key, attempt_id text, source text, lane text, repo, org text, pull_number integer, head_sha, base_sha text, provider_id text, priority integer, state text, next_eligible_at text, lease_id text, lease_expires_at text, session_id text, comment_id integer, review_url text, last_error text, created_at text, updated_at text, started_at text, finished_at text)");
+    const insert = legacyDb.prepare("insert into review_queue_jobs (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at) values (?, ?, 'automatic', 'background', ?, 'Owner', ?, ?, 50, 'queued', ?, ?)");
+    const at = "2026-08-24T00:00:00.000Z";
+    const add = (id: string, repo: unknown, pullNumber: number, headSha: unknown) => insert.run(id, id, repo, pullNumber, headSha, at, at);
+    const validRepo = "Owner/Configured-Repo";
+    const validHead = "A".repeat(40);
+    add("valid", validRepo, 1, validHead);
+    add("unrelated", "Other/Repo", 2, "B".repeat(40));
+    add("null", null, 3, validHead);
+    add("blob", Buffer.from("legacy-repo"), 4, validHead);
+    add("numeric", 42, 5, 7);
+    add("newline", "Owner/Bad\nRepo", 6, validHead);
+    legacyDb.close();
+
+    const first = new ReviewStateStore(dbPath);
+    expect(first.getReviewQueueJob("valid")).toMatchObject({
+      repo: validRepo, headSha: validHead, repoKey: validRepo.toLowerCase(), headShaKey: validHead.toLowerCase()
+    });
+    expect(first.getReviewQueueJob("unrelated")).toMatchObject({ repo: "Other/Repo", headSha: "B".repeat(40) });
+    for (const id of ["null", "blob", "numeric", "newline"]) {
+      expect(first.getReviewQueueJob(id)?.repoKey).toBeUndefined();
+      expect(first.getReviewQueueJob(id)?.headShaKey).toBeUndefined();
+    }
+    const marker = new DatabaseSync(dbPath, { readOnly: true });
+    const initialFence = marker.prepare("select completed_at, completed_rowid from review_state_migrations where name = ?")
+      .get("review_queue_jobs_shadow_identity_v1") as { completed_at: string; completed_rowid: number };
+    const maxRow = marker.prepare("select max(rowid) as rowid from review_queue_jobs").get() as { rowid: number };
+    expect(initialFence.completed_rowid).toBe(maxRow.rowid);
+    marker.close();
+    first.close();
+
+    const lateDb = new DatabaseSync(dbPath);
+    lateDb.prepare("insert into review_queue_jobs (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at) values (?, ?, 'automatic', 'background', ?, 'Owner', 7, ?, 50, 'queued', ?, ?)").run("equal-ms", "equal-ms", "Owner/Late-Repo", "C".repeat(40), initialFence.completed_at, initialFence.completed_at);
+    lateDb.close();
+
+    // Two openers observe the same post-fence row; the second is idempotent after the first commits.
+    const openerA = new ReviewStateStore(dbPath);
+    const openerB = new ReviewStateStore(dbPath);
+    expect(openerA.getReviewQueueJob("equal-ms")).toMatchObject({ repoKey: "owner/late-repo", headShaKey: "c".repeat(40) });
+    expect(openerB.getReviewQueueJob("equal-ms")).toMatchObject({ repoKey: "owner/late-repo", headShaKey: "c".repeat(40) });
+    openerA.close();
+    openerB.close();
+
+    const malformedDb = new DatabaseSync(dbPath);
+    malformedDb.prepare("insert into review_queue_jobs (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at) values (?, ?, 'automatic', 'background', ?, 'Owner', 8, ?, 50, 'queued', ?, ?)").run("late-malformed", "late-malformed", null, validHead, initialFence.completed_at, initialFence.completed_at);
+    malformedDb.close();
+    const reopen = new ReviewStateStore(dbPath);
+    expect(reopen.getReviewQueueJob("late-malformed")?.repoKey).toBeUndefined();
+    reopen.close();
+    const stableDb = new DatabaseSync(dbPath, { readOnly: true });
+    const stableFence = stableDb.prepare("select completed_rowid from review_state_migrations where name = ?")
+      .get("review_queue_jobs_shadow_identity_v1") as { completed_rowid: number };
+    expect(stableFence.completed_rowid).toBeGreaterThan(initialFence.completed_rowid);
+    const repeat = new ReviewStateStore(dbPath); repeat.close();
+    const repeatedFence = stableDb.prepare("select completed_rowid from review_state_migrations where name = ?")
+      .get("review_queue_jobs_shadow_identity_v1") as { completed_rowid: number };
+    expect(repeatedFence.completed_rowid).toBe(stableFence.completed_rowid);
+    const raw = stableDb.prepare("select repo, head_sha, repo_key, head_sha_key from review_queue_jobs where job_id = ?")
+      .get("valid") as Record<string, unknown>;
+    expect(raw).toEqual({ repo: validRepo, head_sha: validHead, repo_key: validRepo.toLowerCase(), head_sha_key: validHead.toLowerCase() });
+    stableDb.close();
+  });
+
   it("stores normalized issue enrichment public and private hashes and rejects invalid hashes", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-"));
     roots.push(root);


### PR DESCRIPTION
Related: #882

## Summary
- add nullable shadow identity columns while preserving original repo/head bytes
- backfill with a monotonic SQLite rowid fence, including equal-millisecond late rows
- advance the fence past malformed rows and parenthesize nullable-key predicates in probe/backfill SQL
- keep the change state-only; no operator CLI or runtime wiring

## Proof
- base: 5bc362e137733268e394f3f126b9bbec33db4571
- head: e3fb97ffac72f1e342ee606d3d68b2816c00d861
- changed lines: 200 total (188 additions, 12 deletions); owned files only
- `git diff --check` passed
- direct `tsx` temporary-DB smoke passed: legacy backfill, enqueue keys, equal-timestamp late row, malformed-row exclusion, and repeat-open idempotence
- TypeScript transpile parse passed for both owned files

The repository Vitest/tsc commands were attempted but are blocked by the shared checkout dependency state: Rollup's darwin-arm64 native module has an invalid Team ID, and the available TypeScript install lacks `@types/node` and `vitest/globals`.

## Safety boundary
No merge, release, runtime, customer, operator CLI, or live database state was touched.