### PR TITLE
fix: harden GitHub installation identity snapshot

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import { createSign } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { isMap, isProxy, isSet } from "node:util/types";
 import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type { IssueEnrichmentIssueList } from "./issue-enrichment.js";
@@ -138,6 +139,22 @@ interface GitHubInstallationResponse {
   app_id?: number;
   account?: { login?: string };
   app_slug?: string;
+}
+
+export interface CanonicalGitHubInstallationIdentity {
+  id: number;
+  app_id: number;
+  account_id: number;
+  account_login: string;
+  account_type: "User" | "Organization";
+  app_slug: string;
+  bot_login: string;
+}
+
+export interface GitHubInstallationIdentityExpectation {
+  expectedAppId: string;
+  expectedBotLogin: string;
+  repo: string;
 }
 
 export class GitHubApiRequestError extends Error {
@@ -750,6 +767,86 @@ function visibilityFromRepositorySummary(repository: RepositorySummary): {
   if (repository.private === true) return { result: "private", source: "private_flag" };
   if (repository.private === false) return { result: "public", source: "private_flag" };
   return { result: "unknown", source: "unavailable" };
+}
+
+const GITHUB_LOGIN_PATTERN = /^(?!-)(?!.*--)[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+const GITHUB_APP_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
+
+/** Pure, side-effect-free identity snapshot and validation boundary. */
+export function normalizeAndValidateGitHubInstallationIdentity(
+  value: unknown,
+  expected: GitHubInstallationIdentityExpectation
+): CanonicalGitHubInstallationIdentity {
+  const installation = snapshotGitHubRecord(value);
+  const expectations = snapshotGitHubRecord(expected);
+  const account = installation && snapshotGitHubRecord(installation.account);
+  const expectedAppId = typeof expectations?.expectedAppId === "string" ? expectations.expectedAppId.trim() : undefined;
+  const expectedBotLogin = normalizeGitHubBotLogin(expectations?.expectedBotLogin);
+  const repoParts = typeof expectations?.repo === "string" ? expectations.repo.split("/") : [];
+  const owner = repoParts.length === 2 && repoParts.every((part) => part.length > 0 && !/\s/.test(part))
+    ? normalizeGitHubValue(repoParts[0], GITHUB_LOGIN_PATTERN) : undefined;
+  const id = installation?.id;
+  const appId = installation?.app_id;
+  const accountId = account?.id;
+  const accountLogin = normalizeGitHubValue(account?.login, GITHUB_LOGIN_PATTERN);
+  const accountType = account?.type;
+  const appSlug = normalizeGitHubAppSlug(installation?.app_slug);
+  const botLogin = appSlug ? `${appSlug}[bot]` : undefined;
+  const positiveInteger = (candidate: unknown): candidate is number =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
+  if (!installation || !expectations || !account || !expectedAppId || !/^\d+$/.test(expectedAppId)
+      || !expectedBotLogin || !owner || !positiveInteger(id) || !positiveInteger(appId)
+      || String(appId) !== expectedAppId || !positiveInteger(accountId) || accountLogin !== owner
+      || (accountType !== "User" && accountType !== "Organization") || !appSlug || botLogin !== expectedBotLogin) {
+    throw new Error("GitHub installation identity failed canonical validation.");
+  }
+  return Object.freeze({ id, app_id: appId, account_id: accountId, account_login: accountLogin,
+    account_type: accountType, app_slug: appSlug, bot_login: botLogin });
+}
+
+function normalizeGitHubAppSlug(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  const slug = normalized.endsWith("[bot]") ? normalized.slice(0, -5) : normalized;
+  return GITHUB_APP_SLUG_PATTERN.test(slug) ? slug : undefined;
+}
+
+function normalizeGitHubBotLogin(value: unknown): string | undefined {
+  const slug = normalizeGitHubAppSlug(value);
+  return slug ? `${slug}[bot]` : undefined;
+}
+
+function snapshotGitHubRecord(value: unknown): Record<string, unknown> | undefined {
+  const copy = snapshotGitHubValue(value, new WeakSet<object>());
+  return copy && typeof copy === "object" && !Array.isArray(copy) ? copy as Record<string, unknown> : undefined;
+}
+
+function snapshotGitHubValue(value: unknown, active: WeakSet<object>): unknown {
+  if (value === null || typeof value !== "object") {
+    return value === undefined || typeof value === "function" || typeof value === "symbol" || typeof value === "bigint"
+      || (typeof value === "number" && !Number.isFinite(value)) ? undefined : value;
+  }
+  if (isProxy(value) || isMap(value) || isSet(value) || Array.isArray(value)
+      || Object.getPrototypeOf(value) !== Object.prototype || active.has(value)) {
+    return undefined;
+  }
+  active.add(value);
+  const copy = Object.create(null) as Record<string, unknown>;
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = typeof key === "string" ? Object.getOwnPropertyDescriptor(value, key) : undefined;
+    if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) return undefined;
+    const child = snapshotGitHubValue(descriptor.value, active);
+    if (child === undefined) return undefined;
+    Object.defineProperty(copy, key, { value: child, enumerable: true, writable: false, configurable: false });
+  }
+  active.delete(value);
+  return Object.freeze(copy);
+}
+
+function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return pattern.test(normalized) ? normalized : undefined;
 }
 
 function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {

--- a/src/github.ts
+++ b/src/github.ts
@@ -779,7 +779,7 @@ export function normalizeAndValidateGitHubInstallationIdentity(
 ): CanonicalGitHubInstallationIdentity {
   const installation = snapshotGitHubRecord(value);
   const expectations = snapshotGitHubRecord(expected);
-  const account = installation && snapshotGitHubRecord(installation.account);
+  const account = installation?.account as Record<string, unknown> | undefined;
   const expectedAppId = typeof expectations?.expectedAppId === "string" ? expectations.expectedAppId.trim() : undefined;
   const expectedBotLogin = normalizeGitHubBotLogin(expectations?.expectedBotLogin);
   const repoParts = typeof expectations?.repo === "string" ? expectations.repo.split("/") : [];

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GitHubApi } from "../src/github.js";
+import { GitHubApi, normalizeAndValidateGitHubInstallationIdentity } from "../src/github.js";
 
 describe("GitHub App read authentication", () => {
   const roots: string[] = [];
@@ -14,6 +14,63 @@ describe("GitHub App read authentication", () => {
     vi.restoreAllMocks();
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
+
+  it("snapshots and validates one frozen canonical installation identity", () => {
+    const installation = canonicalInstallation({
+      app_slug: " EVAOS-CODE-REVIEW-BOT[bot] ",
+      account: { id: 7, login: "Owner", type: "Organization" }
+    });
+    const identity = normalizeAndValidateGitHubInstallationIdentity(installation, {
+      expectedAppId: "4184532", expectedBotLogin: " evaos-code-review-bot ", repo: "OWNER/repo"
+    });
+    expect(identity).toEqual({ id: 123, app_id: 4184532, account_id: 7, account_login: "owner",
+      account_type: "Organization", app_slug: "evaos-code-review-bot", bot_login: "evaos-code-review-bot[bot]" });
+    expect(Object.isFrozen(identity)).toBe(true);
+    installation.account = { id: 7, login: "changed", type: "User" };
+    expect(identity.account_login).toBe("owner");
+  });
+
+  it.each([
+    ["missing installation id", { id: undefined }], ["wrong App id", { app_id: 4184533 }],
+    ["missing account id", { account: { login: "owner", type: "User" } }],
+    ["missing account type", { account: { id: 7, login: "owner" } }],
+    ["wrong account type", { account: { id: 7, login: "owner", type: "Bot" } }],
+    ["wrong owner", { account: { id: 7, login: "other", type: "User" } }],
+    ["wrong App slug", { app_slug: "other-app" }], ["malformed App slug", { app_slug: "Bad_App" }]
+  ])("rejects %s during canonical validation", (_name, override) => {
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation(override), {
+      expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+    })).toThrow(/canonical validation/);
+  });
+
+  it("rejects outer and nested proxies without executing proxy traps", () => {
+    let traps = 0;
+    const trap = { get: () => (++traps, 1), ownKeys: () => (++traps, []), getPrototypeOf: () => (++traps, Object.prototype) };
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(new Proxy(canonicalInstallation(), trap), {
+      expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+    })).toThrow(/canonical validation/);
+    const nested = canonicalInstallation({ account: new Proxy({ id: 7, login: "owner", type: "User" }, trap) });
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(nested, {
+      expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+    })).toThrow(/canonical validation/);
+    expect(traps).toBe(0);
+  });
+
+  it.each(["accessor", "Map", "Set", "array", "sparse array", "symbol", "inherited identity"])(
+    "rejects hostile plain-data shape: %s", (shape) => {
+      let value: unknown = canonicalInstallation();
+      if (shape === "accessor") Object.defineProperty(value, "id", { enumerable: true, get: () => 123 });
+      if (shape === "Map") value = canonicalInstallation({ account: new Map([["id", 7]]) });
+      if (shape === "Set") value = canonicalInstallation({ account: new Set([7]) });
+      if (shape === "array") value = canonicalInstallation({ extra: [1] });
+      if (shape === "sparse array") value = canonicalInstallation({ extra: Object.assign(new Array(2), { 1: 1 }) });
+      if (shape === "symbol") value = canonicalInstallation({ [Symbol("extra")]: 1 });
+      if (shape === "inherited identity") value = Object.assign(Object.create({ id: 123 }), { app_id: 4184532 });
+      expect(() => normalizeAndValidateGitHubInstallationIdentity(value, {
+        expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+      })).toThrow(/canonical validation/);
+    }
+  );
 
   it("uses installation tokens for PR read calls when App credentials are configured", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-read-"));
@@ -835,6 +892,16 @@ function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
     statusText,
     headers: { "Content-Type": "application/json" }
   });
+}
+
+function canonicalInstallation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 123,
+    app_id: 4184532,
+    account: { id: 7, login: "owner", type: "User" },
+    app_slug: "evaos-code-review-bot",
+    ...overrides
+  };
 }
 
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {


### PR DESCRIPTION
Closes #872

## Summary
- add a pure JSON-safe/plain-data snapshot boundary for installation identity
- reject proxies before traps, Map/Set, accessors, symbols, arrays, cycles, and non-plain prototypes
- validate canonical App ID, installation/account IDs, owner, account type, slug, and [bot] login

## Proof
- base 5bc362e137733268e394f3f126b9bbec33db4571
- head 616ad536a6cc9eb9d81426452b9c20578b21f492
- 165 changed lines in src/github.ts and tests/github-app-read.test.ts
- focused source typecheck: PASS
- deterministic hostile matrix: PASS
- git diff --check: PASS
- Vitest blocked locally by the shared optional Rollup native module signature; CI should provide the authoritative test gate

No token, network, cache, I/O, runtime, customer, or release wiring was added.