### PR TITLE
fix(issue-enrichment): hold label-event overflow authoritatively

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -18,6 +18,7 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
@@ -417,7 +418,7 @@ export class GitHubApi {
     });
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedGithubList<{
     event?: string;
     created_at?: string;
     actor?: { login?: string | null } | null;
@@ -435,8 +436,10 @@ export class GitHubApi {
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100) return boundedGithubList(events, false);
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) return boundedGithubList(events, true);
     }
+    return boundedGithubList(events, true);
   }
 
   async getCollaboratorPermission(

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1164,7 +1164,7 @@ export async function runIssueEnrichmentCycle(input: {
           now: new Date(checkedAt)
         });
         summary.deferredRecorded += 1;
-        items.push({ ...item, recordStatus: "deferred" });
+        items.push({ ...item, nextEligibleAt: deferralNextEligibleAt, recordStatus: "deferred" });
         continue;
       }
 

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1103,8 +1103,14 @@ export async function runIssueEnrichmentCycle(input: {
         shouldBackfillIssueEnrichmentAnalysisInputHash(existing, issueUpdatedAt, item.action)
         ? plannedAnalysisInputHashForItem(item)
         : undefined;
-      const authoritativeDeferral = item.reason === "issue_label_event_overflow";
-      if (!authoritativeDeferral && input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
+      const preservesOverflowCooldown = item.reason === "issue_label_event_overflow" &&
+        existing?.status === "deferred" &&
+        existing.reason === item.reason &&
+        Boolean(existing.nextEligibleAt) &&
+        shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action);
+      const authoritativeDeferral = item.reason === "issue_label_event_overflow" && !preservesOverflowCooldown;
+      const deferralNextEligibleAt = preservesOverflowCooldown ? existing?.nextEligibleAt ?? item.nextEligibleAt : item.nextEligibleAt;
+      if (!authoritativeDeferral && !preservesOverflowCooldown && input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
         const refreshedAnalysisInputHash = existing.analysisInputHash ?? analysisInputHash;
         if (!input.dryRun && (
           existing.issueUpdatedAt !== issueUpdatedAt ||
@@ -1154,7 +1160,7 @@ export async function runIssueEnrichmentCycle(input: {
           issueUpdatedAt,
           status: "deferred",
           reason: item.reason,
-          nextEligibleAt: item.nextEligibleAt,
+          nextEligibleAt: deferralNextEligibleAt,
           now: new Date(checkedAt)
         });
         summary.deferredRecorded += 1;
@@ -1411,8 +1417,8 @@ function planRepoIssueScan(input: {
     ...input.renderPolicy
   }));
   const eligible = planned.filter((output) => !output.skipped);
-  const countableEligible = input.shouldCountItem
-    ? eligible.filter((output) => input.shouldCountItem!(
+  const countableEligible = eligible.filter((output) => !input.scanReasons?.[output.issueNumber]).filter((output) => input.shouldCountItem
+    ? input.shouldCountItem!(
         issueScanItem(
           input.repo,
           output.issueNumber,
@@ -1421,8 +1427,8 @@ function planRepoIssueScan(input: {
           "eligible",
           output.url
         )
-      ))
-    : eligible;
+      )
+    : true);
   const burstExceeded = countableEligible.length > input.throttle.maxIssuesPerBurst;
   let enriched = 0;
   let comments = 0;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -231,6 +231,7 @@ export type IssueEnrichmentScanCompletion = "complete" | "page_limit_reached" | 
 
 export type IssueEnrichmentIssueList = GitHubRelatedIssueOrPull[] & {
   scanCompletion?: IssueEnrichmentScanCompletion;
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
 };
 
 export interface IssueEnrichmentScanResult {
@@ -284,14 +285,16 @@ type IssueEnrichmentComment = {
   user?: { login?: string | null } | null;
 };
 
+type IssueEnrichmentLabelEvent = {
+  event?: string;
+  created_at?: string;
+  actor?: { login?: string | null } | null;
+  label?: { name?: string | null } | null;
+};
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<IssueEnrichmentLabelEvent[] | BoundedGithubList<IssueEnrichmentLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -329,7 +332,8 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded"
+  | "issue_label_event_overflow";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -381,7 +385,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
-}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
+}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence; promotionOverflow?: boolean }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
     .map((label) => label.trim().toLowerCase())
@@ -394,7 +398,10 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, truncated, overflow } = unpackBoundedGithubList(
+      await input.github.listIssueLabelEvents(input.repo, input.issue.number)
+    );
+    if (truncated || overflow) return { issue: input.issue, promotionOverflow: true };
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -449,9 +456,10 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, truncated: timelineTruncated, overflow: timelineOverflow } = unpackBoundedGithubList(timelineResult);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -488,7 +496,7 @@ export async function buildIssueEvidenceContext(input: {
     linkedItems,
     truncation: {
       comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      timeline: timelineTruncated || timelineOverflow || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };
@@ -697,6 +705,7 @@ export async function collectIssueEnrichmentScan(input: {
     const issueItems = planRepoIssueScan({
       repo,
       issues,
+      scanReasons: issues.scanReasons,
       throttle: policy.throttle,
       suggestions: policy.suggestions,
       repoPolicy: policy.repoPolicy,
@@ -997,6 +1006,7 @@ export async function runIssueEnrichmentCycle(input: {
     };
     const shouldCountItem = (item: IssueEnrichmentScanItem) => {
       if (input.force === true) return true;
+      if (item.reason === "issue_label_event_overflow") return true;
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
@@ -1012,6 +1022,7 @@ export async function runIssueEnrichmentCycle(input: {
             listIssuesForEnrichment: async (repo, options) => {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
               const prepared: GitHubRelatedIssueOrPull[] = [];
+              const scanReasons: Record<number, IssueEnrichmentScanReason> = {};
               for (const issue of issues) {
                 const promotion = await evaluateIssuePromotion({
                   repo,
@@ -1020,8 +1031,9 @@ export async function runIssueEnrichmentCycle(input: {
                   github: input.github
                 });
                 prepared.push(promotion.issue);
+                if (promotion.promotionOverflow) scanReasons[issue.number] = "issue_label_event_overflow";
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
+                if (shouldCollectModelEvidence && !promotion.promotionOverflow) {
                   issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
                     repo,
                     issue: promotion.issue,
@@ -1034,7 +1046,7 @@ export async function runIssueEnrichmentCycle(input: {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
               }
-              return Object.assign(prepared, { scanCompletion: issues.scanCompletion });
+              return Object.assign(prepared, { scanCompletion: issues.scanCompletion, scanReasons });
             }
           },
           dryRun: input.dryRun,
@@ -1091,7 +1103,8 @@ export async function runIssueEnrichmentCycle(input: {
         shouldBackfillIssueEnrichmentAnalysisInputHash(existing, issueUpdatedAt, item.action)
         ? plannedAnalysisInputHashForItem(item)
         : undefined;
-      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
+      const authoritativeDeferral = item.reason === "issue_label_event_overflow";
+      if (!authoritativeDeferral && input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
         const refreshedAnalysisInputHash = existing.analysisInputHash ?? analysisInputHash;
         if (!input.dryRun && (
           existing.issueUpdatedAt !== issueUpdatedAt ||
@@ -1378,6 +1391,7 @@ function resolveIssueSuggestionAllowlist(globalAllowlist: string[], repoOverride
 function planRepoIssueScan(input: {
   repo: string;
   issues: GitHubRelatedIssueOrPull[];
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
@@ -1414,6 +1428,10 @@ function planRepoIssueScan(input: {
   let comments = 0;
 
   return planned.map((output) => {
+    const scanReason = input.scanReasons?.[output.issueNumber];
+    if (scanReason) {
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", scanReason, output.url, nextEligibleAt(input));
+    }
     if (output.skipped) {
       return {
         repo: input.repo,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1025,6 +1025,7 @@ describe("sticky enrichment comments", () => {
     try {
       const result = await runIssueEnrichmentCycle({ config, state, github: { listIssuesForEnrichment: async () => [issue], listIssueLabelEvents: async () => events, getCollaboratorPermission: async () => "maintain", canPostAsApp: () => false, upsertIssueComment: async () => { throw new Error("overflow must not post"); } }, dryRun: false, includeExisting: true, checkedAt: "2026-08-24T00:00:30.000Z" });
       expect(result.summary).toMatchObject({ alreadyProcessed: 0, deferredRecorded: 1, posted: 0, failed: 0 });
+      expect(result.items.find((item) => item.issueNumber === 738)).toMatchObject({ nextEligibleAt: "2026-08-24T00:01:00.000Z" });
       expect(state.getIssueEnrichmentRecord("owner/issue-repo", 738)).toMatchObject({ reason: "issue_label_event_overflow", nextEligibleAt: "2026-08-24T00:01:00.000Z" });
     } finally { state.close(); rmSync(root, { recursive: true, force: true }); }
   });

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -14,6 +14,7 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
 import type { IssueAnalysis } from "../src/issue-analysis.js";
 import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
@@ -1013,6 +1014,21 @@ describe("sticky enrichment comments", () => {
     }
   });
 
+  it("preserves an existing overflow cooldown before expiry", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-overflow-cooldown-"));
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = loadConfig();
+    config.issueEnrichment = { ...config.issueEnrichment!, enabled: true, postIssueComment: false, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 5, maxCommentsPerCycle: 0, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 60_000, processExistingOpenIssuesOnActivation: true, repos: { "owner/issue-repo": { promotionMaintainers: [{ login: "trusted", validFrom: "2026-01-01T00:00:00Z" }] } } };
+    const issue: GitHubRelatedIssueOrPull = { number: 738, title: "Overflowed label history", state: "open", updated_at: "2026-08-24T00:00:00.000Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }], body: "Continue current-main work." };
+    const events = Object.assign([], { items: [], rawCount: 500, truncated: true, overflow: true }) as BoundedGithubList<{ event?: string }>;
+    state.recordIssueEnrichment({ repo: "owner/issue-repo", issueNumber: 738, issueUpdatedAt: issue.updated_at!, status: "deferred", reason: "issue_label_event_overflow", nextEligibleAt: "2026-08-24T00:01:00.000Z", now: new Date("2026-08-24T00:00:00.000Z") });
+    try {
+      const result = await runIssueEnrichmentCycle({ config, state, github: { listIssuesForEnrichment: async () => [issue], listIssueLabelEvents: async () => events, getCollaboratorPermission: async () => "maintain", canPostAsApp: () => false, upsertIssueComment: async () => { throw new Error("overflow must not post"); } }, dryRun: false, includeExisting: true, checkedAt: "2026-08-24T00:00:30.000Z" });
+      expect(result.summary).toMatchObject({ alreadyProcessed: 0, deferredRecorded: 1, posted: 0, failed: 0 });
+      expect(state.getIssueEnrichmentRecord("owner/issue-repo", 738)).toMatchObject({ reason: "issue_label_event_overflow", nextEligibleAt: "2026-08-24T00:01:00.000Z" });
+    } finally { state.close(); rmSync(root, { recursive: true, force: true }); }
+  });
+
   it("fails closed without posting when structured issue analysis fails", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-model-failure-"));
     try {
@@ -1452,6 +1468,22 @@ describe("sticky enrichment comments", () => {
         deferred: 3
       });
       expect(scan.items.every((item) => item.action === "deferred" && item.reason === "burst_threshold_exceeded")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes overflowed scan reasons from burst threshold accounting", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-overflow-burst-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({ issueEnrichment: { enabled: true, postIssueComment: false, allowlist: ["owner/issue-repo"], maxIssuesPerCycle: 5, maxCommentsPerCycle: 0, maxIssuesPerBurst: 1 } })}\n`);
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath), dryRun: true, includeExisting: true, checkedAt: "2026-07-03T00:00:00.000Z",
+        reader: { listIssuesForEnrichment: async () => Object.assign([{ number: 20, title: "Overflowed issue", state: "open", body: "Acceptance criteria and owner present." }, { number: 21, title: "Ordinary sibling", state: "open", body: "Acceptance criteria and owner present." }], { scanReasons: { 20: "issue_label_event_overflow" as const } }) }
+      });
+      expect(scan.items).toEqual(expect.arrayContaining([expect.objectContaining({ issueNumber: 20, action: "deferred", reason: "issue_label_event_overflow" }), expect.objectContaining({ issueNumber: 21, action: "would_enrich", reason: "eligible" })]));
+      expect(scan.summary).toMatchObject({ issuesSeen: 2, eligible: 1, wouldEnrich: 1, deferred: 1 });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/issue-comment-pagination.test.ts
+++ b/tests/issue-comment-pagination.test.ts
@@ -58,6 +58,30 @@ describe("bounded issue-comment pagination primitive", () => {
     expect(result.truncated).toBe(false);
     expect(result.overflow).toBe(false);
   });
+
+  it("bounds label-event reads and preserves short-page termination", async () => {
+    const pages: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const request = new URL(String(url));
+      const page = Number(request.searchParams.get("page"));
+      pages.push(page);
+      const events = page === 2 ? [{ event: "labeled" }] : Array.from({ length: 100 }, () => ({ event: "labeled" }));
+      return jsonResponse(events);
+    }) as typeof fetch;
+    const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+    expect(pages).toEqual([1, 2]);
+    expect(result).toHaveLength(101);
+    expect(result.rawCount).toBe(101);
+    expect(result.truncated).toBe(false);
+    expect(result.overflow).toBe(false);
+
+    globalThis.fetch = vi.fn(async () => jsonResponse(Array.from({ length: 100 }, () => ({ event: "labeled" })))) as typeof fetch;
+    const overflow = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+    expect(overflow).toHaveLength(500);
+    expect(overflow.rawCount).toBe(500);
+    expect(overflow.truncated).toBe(true);
+    expect(overflow.overflow).toBe(true);
+  });
 });
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/tests/issue-enrichment.test.ts
+++ b/tests/issue-enrichment.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
+import type { IssueAnalysis } from "../src/issue-analysis.js";
+import { runIssueEnrichmentCycle } from "../src/issue-enrichment.js";
+import { ReviewStateStore } from "../src/state.js";
+import { createTestLicenseAdmission } from "./helpers/license-admission.js";
+
+const admission = await createTestLicenseAdmission({ operation: "issue_enrichment" });
+const analysis = (): IssueAnalysis => ({
+  classification: "needs-repro", priority: "P3", priorityState: "provisional", confidence: "needs-repro",
+  repositoryImpact: "fixture", currentMainApplicability: "fixture", verifiedFacts: [],
+  reproductionOrInvariantGap: "fixture", relatedWork: [], migrationDisposition: "needs-repro",
+  nextGate: "fixture", limitations: [], labelProposals: []
+});
+
+describe("label-event promotion consumer", () => {
+  it("holds overflow authoritatively across same-timestamp reruns while siblings post", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-label-overflow-"));
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const config = { statePath, issueEnrichment: {
+      enabled: true, postIssueComment: true, allowlist: ["owner/repo"], maxIssuesPerCycle: 3,
+      maxCommentsPerCycle: 3, processExistingOpenIssuesOnActivation: true,
+      repos: { "owner/repo": { maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, cooldownMs: 60_000,
+        burstWindowMs: 60_000, maxIssuesPerBurst: 10, lookbackMs: 60_000,
+        promotionMaintainers: [{ login: "trusted", validFrom: "2026-01-01T00:00:00Z" }] }
+    } } };
+    writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+    const state = new ReviewStateStore(statePath);
+    const events = Object.assign(Array.from({ length: 500 }, () => ({ event: "labeled" })), {
+      items: Array.from({ length: 500 }, () => ({ event: "labeled" })), rawCount: 500, truncated: true, overflow: true
+    }) as BoundedGithubList<{ event?: string }>;
+    const issueUpdatedAt = "2026-08-24T00:01:00.000Z";
+    const overflow: GitHubRelatedIssueOrPull = { number: 738, title: "overflow", state: "open",
+      updated_at: issueUpdatedAt, labels: [{ name: "upstream-intake" }, { name: "active-continuation" }], body: "fixture" };
+    const sibling: GitHubRelatedIssueOrPull = { number: 739, title: "sibling", state: "open",
+      updated_at: "2026-08-24T00:01:00.000Z", labels: [], body: "fixture" };
+    state.recordIssueEnrichmentRepoWatermark({ repo: "owner/repo", activatedAt: "2026-08-24T00:00:00.000Z", lastCheckedAt: "2026-08-24T00:00:00.000Z", now: new Date("2026-08-24T00:00:00.000Z") });
+    state.recordIssueEnrichment({ repo: "owner/repo", issueNumber: 738, issueUpdatedAt, status: "posted", now: new Date("2026-08-24T00:01:00.000Z") });
+    let posts = 0;
+    const run = () => runIssueEnrichmentCycle({
+      config: loadConfig(configPath), state, dryRun: false, includeExisting: true, checkedAt: "2026-08-24T00:02:00.000Z",
+      licenseAdmission: admission, analyzeIssue: async () => analysis(), github: {
+        listIssuesForEnrichment: async () => [overflow, sibling], listIssueLabelEvents: async () => events,
+        getCollaboratorPermission: async () => "maintain", canPostAsApp: () => true,
+        upsertIssueComment: async () => { posts += 1; return { action: "created" as const, id: posts, html_url: "https://github.test/comment" }; }
+      }
+    });
+    try {
+      const first = await run();
+      expect(first.summary).toMatchObject({ posted: 1, deferred: 1, deferredRecorded: 1, failed: 0 });
+      expect(first.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({ issueNumber: 738, action: "deferred", reason: "issue_label_event_overflow", recordStatus: "deferred" }),
+        expect.objectContaining({ issueNumber: 739, action: "would_comment", recordStatus: "posted" })
+      ]));
+      expect(posts).toBe(1);
+      expect(state.getIssueEnrichmentRecord("owner/repo", 738)).toMatchObject({ status: "deferred", reason: "issue_label_event_overflow" });
+      expect(state.getIssueEnrichmentRepoWatermark("owner/repo")).toMatchObject({ lastCheckedAt: "2026-08-24T00:00:00.000Z" });
+      const rerun = await run();
+      expect(rerun.summary).toMatchObject({ posted: 0, deferred: 1, deferredRecorded: 1 });
+      expect(posts).toBe(1);
+      expect(state.getIssueEnrichmentRecord("owner/repo", 738)).toMatchObject({ status: "deferred" });
+      expect(state.getIssueEnrichmentRepoWatermark("owner/repo")).toMatchObject({ lastCheckedAt: "2026-08-24T00:00:00.000Z" });
+    } finally { state.close(); rmSync(root, { recursive: true, force: true }); }
+  });
+});


### PR DESCRIPTION
Refs #738\n\n## Summary\n- bound label-event reads to five pages / 500 rows with truthful overflow metadata\n- make label-event overflow a durable authoritative deferral before existing-record reconciliation\n- preserve sibling posting and hold the repository watermark across first run and same-timestamp rerun\n\n## Proof\n- npm run build (pass)\n- deterministic tsx transport proof (short page 101 rows; overflow 500 rows)\n- deterministic tsx cycle proof (sibling posts once; overflow deferred and durable; watermark unchanged on first run and same-timestamp rerun)\n- git diff --check (pass)\n\nVitest invocation was blocked by the macOS Rollup native-binding signature mismatch in this environment; focused behavior was exercised through the deterministic tsx proof above.