### PR TITLE
chore(release): stage v1.0.5 operator package candidate

### DIFF
--- a/docs/release-candidates/v1.0.5.json
+++ b/docs/release-candidates/v1.0.5.json
@@ -1,0 +1,36 @@
+{
+  "version": "v1.0.5",
+  "packageVersion": "1.0.5",
+  "previousReleasedPackageVersion": "1.0.4",
+  "state": "unreleased_candidate",
+  "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/610",
+  "packageSurface": {
+    "binaries": {
+      "neondiff": "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    },
+    "files": [
+      "docs/operator-cli.md"
+    ]
+  },
+  "registry": {
+    "state": "not_published",
+    "latest": "1.0.4",
+    "releaseCandidatePresent": false
+  },
+  "immutablePredecessor": {
+    "manifest": "docs/public-release-manifest.json",
+    "candidate": "docs/release-candidates/v1.0.4.json"
+  },
+  "proofBoundary": {
+    "allowed": [
+      "package and lockfile metadata agree on v1.0.5",
+      "npm pack --dry-run includes docs/operator-cli.md and both CLI binaries resolve to dist/src/cli.js"
+    ],
+    "forbidden": [
+      "npm publication, GitHub Release, tag, or provenance is claimed",
+      "published v1.0.4 manifest, evidence, tag, or package bytes are changed",
+      "Desktop, runtime, customer, billing, or release state is mutated"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "neondiff",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "ajv": "^8.20.0",
         "validate-npm-package-license": "^3.0.4"
       },
       "bin": {
-        "neondiff": "dist/src/cli.js"
+        "neondiff": "dist/src/cli.js",
+        "evaos-review-bot": "dist/src/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.0.15",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "neondiff",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {
-    "neondiff": "dist/src/cli.js"
+    "neondiff": "dist/src/cli.js",
+    "evaos-review-bot": "dist/src/cli.js"
   },
   "exports": {},
   "description": "Local-first AI PR reviewer for teams that want current-head reviews without handing every diff to a hosted review SaaS.",
@@ -21,6 +22,7 @@
     "CODE_OF_CONDUCT.md",
     "config.example.json",
     "docs/SETUP.md",
+    "docs/operator-cli.md",
     "docs/ci-runner.md",
     "docs/docker.md",
     "docs/github-app-setup.md",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -46,8 +46,14 @@ describe("public NeonDiff CLI surface", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
     const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
-    expect(packageJson.bin).toEqual({ neondiff: "dist/src/cli.js" });
-    expect(packageLock.packages[""].bin).toEqual({ neondiff: "dist/src/cli.js" });
+    expect(packageJson.bin).toEqual({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
+    expect(packageLock.packages[""].bin).toEqual({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
   });
 
   it("shows public commands in help output", async () => {
@@ -57,9 +63,9 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.licenseBoundary).toMatchObject({
       sourceAvailableCommercial: true,
       activationRequired: expect.stringContaining("live API-backed activation"),
-      packageVersion: "1.0.4",
+      packageVersion: "1.0.5",
       releaseState:
-        "This package reports 1.0.4; verify the matching npm version and GitHub Release before relying on activation enforcement."
+        "This package reports 1.0.5; verify the matching npm version and GitHub Release before relying on activation enforcement."
     });
     expect(output.licenseBoundary.releaseState).not.toContain("1.0.3");
     expect(output.licenseBoundary.releaseState).not.toContain("staged");

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -60,7 +60,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("1.0.4");
+    expect(pkg.version).toBe("1.0.5");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -69,7 +69,10 @@ describe("NeonDiff public release readiness", () => {
       type: "git",
       url: "git+https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git"
     });
-    expect(pkg.bin).toEqual({ neondiff: "dist/src/cli.js" });
+    expect(pkg.bin).toEqual({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
     expect(pkg.exports).toEqual({});
     expect(pkg.files).toEqual([
       "dist/src",
@@ -79,6 +82,7 @@ describe("NeonDiff public release readiness", () => {
       "CODE_OF_CONDUCT.md",
       "config.example.json",
       "docs/SETUP.md",
+      "docs/operator-cli.md",
       "docs/ci-runner.md",
       "docs/docker.md",
       "docs/github-app-setup.md",
@@ -94,12 +98,15 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("1.0.4");
+    expect(lock.version).toBe("1.0.5");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "1.0.4",
+      version: "1.0.5",
       license: "SEE LICENSE IN LICENSE.md",
-      bin: { neondiff: "dist/src/cli.js" }
+      bin: {
+        neondiff: "dist/src/cli.js",
+        "evaos-review-bot": "dist/src/cli.js"
+      }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
@@ -491,6 +498,60 @@ describe("NeonDiff public release readiness", () => {
       expect(existsSync(artifact.ref ?? "")).toBe(true);
       expect(createHash("sha256").update(read(artifact.ref ?? "")).digest("hex")).toBe(artifact.sha256);
     }
+  });
+
+  it("declares the unreleased v1.0.5 operator-surface candidate without publication proof", () => {
+    const candidatePath = "docs/release-candidates/v1.0.5.json";
+    expect(existsSync(candidatePath)).toBe(true);
+    if (!existsSync(candidatePath)) return;
+    const candidate = JSON.parse(read(candidatePath)) as {
+      version?: string;
+      packageVersion?: string;
+      previousReleasedPackageVersion?: string;
+      state?: string;
+      trackingIssue?: string;
+      packageSurface?: {
+        binaries?: Record<string, string>;
+        files?: string[];
+      };
+      registry?: { state?: string; latest?: string; releaseCandidatePresent?: boolean };
+      proofBoundary?: { allowed?: string[]; forbidden?: string[] };
+    };
+
+    expect(candidate).toMatchObject({
+      version: "v1.0.5",
+      packageVersion: "1.0.5",
+      previousReleasedPackageVersion: "1.0.4",
+      state: "unreleased_candidate",
+      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/610",
+      packageSurface: {
+        binaries: {
+          neondiff: "dist/src/cli.js",
+          "evaos-review-bot": "dist/src/cli.js"
+        },
+        files: ["docs/operator-cli.md"]
+      },
+      registry: {
+        state: "not_published",
+        latest: "1.0.4",
+        releaseCandidatePresent: false
+      }
+    });
+    expect(candidate).not.toHaveProperty("candidateSourceSha");
+    expect(candidate).not.toHaveProperty("releaseCommit");
+    expect(candidate).not.toHaveProperty("githubReleaseUrl");
+    expect(candidate).not.toHaveProperty("publishRunUrl");
+    expect(candidate).not.toHaveProperty("packageArtifact");
+    expect(candidate).not.toHaveProperty("publicationProofPath");
+    expect(candidate.proofBoundary?.allowed).toEqual([
+      "package and lockfile metadata agree on v1.0.5",
+      "npm pack --dry-run includes docs/operator-cli.md and both CLI binaries resolve to dist/src/cli.js"
+    ]);
+    expect(candidate.proofBoundary?.forbidden).toEqual([
+      "npm publication, GitHub Release, tag, or provenance is claimed",
+      "published v1.0.4 manifest, evidence, tag, or package bytes are changed",
+      "Desktop, runtime, customer, billing, or release state is mutated"
+    ]);
   });
 
   it("locks published package identity to downloaded registry tarball proof after state stamps", () => {


### PR DESCRIPTION
## Summary

Related: #610

- Stage a separately versioned unreleased neondiff 1.0.5 candidate.
- Ship docs/operator-cli.md in the npm allowlist and map neondiff plus evaos-review-bot to dist/src/cli.js.
- Synchronize package-lock and focused public CLI/release tests.
- Add docs/release-candidates/v1.0.5.json with explicit not-published state and no artifact digest or provenance claims.

## Validation

- PATH=/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0T7mR5p:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npx vitest run tests/public-release-readiness.test.ts tests/public-cli.test.ts (116 passed)
- PATH=/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0T7mR5p:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm run build
- npm pack --dry-run (neondiff@1.0.5; docs/operator-cli.md and dist/src/cli.js present)
- git diff --check

Published v1.0.4 manifest, candidate, evidence, and package bytes are unchanged. No npm publication, GitHub Release/tag, Desktop/runtime/customer, billing, or release-state mutation was performed.