### PR TITLE
docs: publish conditional Mac GA journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,19 @@ package. To preview without changing your machine:
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
-**Legacy CLI/operator recovery only — not signed Desktop 1.1.0 setup:** the
-separate checksum-bound worker bundle is
+**Current beta.87 B0 BYO worker path — not signed Desktop 1.1.0 GA setup:** the
+separate checksum-bound worker bundle remains required for the current public
+paid B0 path before native initialization. It is
 the same immutable GitHub prerelease as the app rather than an unpublished npm
 version or an unpinned source checkout. No invitation is required when the
 versioned public GitHub prerelease is published and the neondiff.com
 purchase/download path is live.
+For a clean B0 install with no existing worker, LaunchAgent, marker, or state,
+choose **Install / Update Local Worker** and use the checksum-bound `first-install`
+preview followed by the confirmed install before **Initialize Local Config**. An
+existing worker or LaunchAgent, including a stale or broken one, must use the
+`update` flow instead; `first-install` refuses existing state. Follow the
+[existing-worker update steps](docs/SETUP.md#update-an-existing-local-worker).
 The worker installer requires Node.js 26 or newer resolving through the
 approved stable path `/opt/homebrew/bin/node` or `/usr/local/bin/node`.
 When the app reports **Worker update required**, choose **Install / Update Local

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ package. To preview without changing your machine:
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
-The public paid B0 Mac beta uses a separate checksum-bound worker bundle from
+**Legacy CLI/operator recovery only — not signed Desktop 1.1.0 setup:** the
+separate checksum-bound worker bundle is
 the same immutable GitHub prerelease as the app rather than an unpublished npm
 version or an unpinned source checkout. No invitation is required when the
 versioned public GitHub prerelease is published and the neondiff.com
@@ -142,9 +143,8 @@ checksum-bound prerelease bundle.
 
 ## Set Up
 
-Follow [docs/SETUP.md](docs/SETUP.md) for the CLI-first setup path (the
-first-run path on non-Mac platforms and the operator/advanced path on Mac). The
-short version is:
+Signed Desktop 1.1.0 is the planned native GA first-run path at `/Applications/NeonDiff.app`;
+it becomes primary only after the immutable signed GA artifact, `/mac` surface, and promotion gates are live. Until then, the public paid B0 BYO beta is current. For npm CLI 1.0.4 CLI-first, non-Mac, or legacy operator setup, follow [docs/SETUP.md](docs/SETUP.md):
 
 ```bash
 neondiff init --config config.local.json
@@ -158,12 +158,11 @@ neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
-For the Mac customer journey, the native macOS app (`apps/neondiff-desktop`) is
-the human first-run surface. The local HTML dashboard is an operator/diagnostic
-surface for CLI-first and non-Mac setups, not the product UI. It shows license
-status, GitHub App status, daemon status, and provider readiness, and its
-provider card includes a `Verify API Key` control that reports redacted
-pass/fail output.
+For the planned signed Desktop 1.1.0 Mac journey, `/Applications/NeonDiff.app` becomes
+the primary first-run surface only after the immutable signed GA artifact, `/mac` surface, and promotion gates are live; until then the public paid B0 BYO beta remains current. Its
+planned LaunchAgent uses the sealed helper `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`. **Verify App Access** is for a new App; an existing compatible agent uses **Verify Existing Access**.
+Codex runtime and dry-run approval precede live review. The app shows license status, GitHub App status, daemon status, and provider readiness;
+the HTML dashboard remains CLI-first/non-Mac diagnostics, not native UI.
 The managed native path binds activation and private-repository token issuance
 to the same Keychain-backed broker device identity and exact GitHub-selected
 repository. The raw Activation Key remains Keychain-owned: it crosses bounded
@@ -180,9 +179,9 @@ The public paid B0 BYO beta build uses a separate exact
 no managed-broker fields. That contract enables the existing local direct/BYO
 path and API-backed native activation without a hidden defaults mutation. It
 is a paid path for every repository and does not claim the managed public-free
-model. The signed release app contains a sealed NeonDiff worker built from the
+model. When the immutable signed GA artifact is published, the signed release app contains a sealed NeonDiff worker built from the
 exact reviewed source and a pinned, SHA-256-verified official Node runtime. A
-clean Mac therefore does not need a global CLI or separate worker install for
+After those gates, a clean Mac therefore does not need a global CLI or separate worker install for
 the native setup and review path. The separate checksum-bound bundle remains
 available for the customer-owned local-agent path; its explicit `first-install`
 command installs only its verified CLI in a private current-user version
@@ -199,9 +198,9 @@ value or key-file path. The headless app re-derives that device ID from its
 Keychain identity and rejects a mismatched plist before releasing credentials.
 Review and daemon readiness remain separate gates. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
-gates. Unsigned development builds still require an executable global or
-checksum-managed worker before native first run
-exposes **Initialize Local Config** (non-destructive; never force-overwrites),
+gates. Unsigned development builds are not the signed Desktop 1.1.0 customer
+path; use them only for development/operator checks. Once GA promotion is complete, the signed app exposes
+**Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected
 `pilotRepos` allowlist and an enabled policy profile for each selected

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -11,7 +11,7 @@ customer-owned BYO beta remains current until the immutable signed GA artifact,
 `/mac` surface, and promotion gates are live. The planned GA path accepts a
 customer-owned App ID/private key; new App uses **Verify App Access**, existing
 agent uses **Verify Existing Access**. The managed official App/broker is
-separate post-GA. Planned stable onboarding is [neondiff.com/mac](https://www.neondiff.com); see the
+separate post-GA. Planned stable onboarding is [neondiff.com/mac](https://www.neondiff.com/mac); see the
 [Mac GA architecture and release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 
 ## Install URL
@@ -129,11 +129,34 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In the promoted signed Desktop 1.1.0 journey, once its immutable artifact and `/mac` promotion gates are live, move the app to `/Applications/NeonDiff.app` and
-   launch it. Store the App ID/private key in Keychain, then choose **Initialize
-   Local Config**, **Add Repository**, and **Apply Repository**. Choose **Verify App
-   Access** for a new App or **Verify Existing Access** for an existing agent.
-   Checksum-worker commands below are legacy recovery only, not native setup.
+7. Until the signed Desktop 1.1.0 artifact and `/mac` promotion gates are live,
+   the public paid B0 BYO path remains current. Launch NeonDiff, store the
+   customer-owned App ID/private-key PEM in Keychain, and if the worker command
+   is unavailable choose **Install / Update Local Worker**. From the verified
+   extracted bundle, use Node.js 26 or newer through `/opt/homebrew/bin/node` or
+   `/usr/local/bin/node`, then preview and confirm the checksum-bound install:
+
+   ```bash
+   BUNDLE_DIR="$(pwd -P)"
+   node install-b0-worker-candidate.mjs first-install \
+     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
+     --manifest-sha256 <manifest-sha256-from-release> \
+     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
+     --launchd-label com.electricsheephq.evaos-code-review-bot \
+     --dry-run true
+   ```
+
+   Inspect the preview, then repeat with `--dry-run false --confirm true`.
+   This installs only the verified CLI and a credential-free marker; it creates
+   or loads no LaunchAgent, starts no daemon, and reads or writes no credentials.
+   Return to NeonDiff and choose **Install / Update Local Worker** once more to
+   refresh discovery, then choose **Initialize Local Config**, **Add Repository**,
+   and **Apply Repository**. Choose **Verify App Access** for a new App or
+   **Verify Existing Access** for an existing agent.
+
+   After those promotion gates are live, move the signed Desktop 1.1.0 app to
+   `/Applications/NeonDiff.app` for the promoted native journey; the
+   checksum-worker commands above are then legacy recovery only.
 
 8. After App access, provider, repository, and activation are verified, use the
    native daemon step's **Preview Start** and **Install & Start** actions. The

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -130,11 +130,13 @@ integration proof under #630.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
 7. Until the signed Desktop 1.1.0 artifact and `/mac` promotion gates are live,
-   the public paid B0 BYO path remains current. Launch NeonDiff, store the
-   customer-owned App ID/private-key PEM in Keychain, and if the worker command
-   is unavailable choose **Install / Update Local Worker**. From the verified
+   the public paid B0 BYO path remains current. Launch NeonDiff and store the
+   customer-owned App ID/private-key PEM in Keychain. On a clean install with no
+   existing worker, LaunchAgent, marker, or state, if the worker command is
+   unavailable choose **Install / Update Local Worker**. From the verified
    extracted bundle, use Node.js 26 or newer through `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`, then preview and confirm the checksum-bound install:
+   `/usr/local/bin/node`, then preview and confirm the checksum-bound
+   `first-install`:
 
    ```bash
    BUNDLE_DIR="$(pwd -P)"
@@ -147,8 +149,13 @@ integration proof under #630.
    ```
 
    Inspect the preview, then repeat with `--dry-run false --confirm true`.
-   This installs only the verified CLI and a credential-free marker; it creates
-   or loads no LaunchAgent, starts no daemon, and reads or writes no credentials.
+   This clean-install command installs only the verified CLI and a
+   credential-free marker; it creates or loads no LaunchAgent, starts no daemon,
+   and reads or writes no credentials. It refuses an existing LaunchAgent,
+   worker, marker, or state. If NeonDiff detects any existing or stale worker
+   state, do not run `first-install`; choose **Install / Update Local Worker**
+   and follow the [existing-worker update flow](SETUP.md#update-an-existing-local-worker)
+   with the existing LaunchAgent label.
    Return to NeonDiff and choose **Install / Update Local Worker** once more to
    refresh discovery, then choose **Initialize Local Config**, **Add Repository**,
    and **Apply Repository**. Choose **Verify App Access** for a new App or
@@ -253,13 +260,18 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-For the promoted signed Desktop 1.1.0 journey, use **Verify App Access** for a new
-customer-owned App or **Verify Existing Access** for a compatible existing agent in
-the UI; before promotion, the shell command below is CLI/operator diagnostics only:
+For the current public paid B0 BYO beta, use native **Verify App Access** for a new
+customer-owned App or **Verify Existing Access** for a compatible existing agent
+after the selected repository is applied. These native actions are the supported
+B0 verification path; they use the account- and bot-selected config created by
+NeonDiff. The shell command below is optional CLI/operator diagnostics only. If
+you use it for native B0 troubleshooting, set `SELECTED_CONFIG` to the exact
+selected config path shown by NeonDiff (under its account-scoped Application
+Support directory), not the checkout-local `config.local.json`:
 
 ```bash
-CLI_CONFIG="config.local.json"
-neondiff doctor github --config "$CLI_CONFIG" --repo owner/repo --json
+SELECTED_CONFIG="/absolute/path/from-NeonDiff-to-the-selected-bot/config.local.json"
+neondiff doctor github --config "$SELECTED_CONFIG" --repo owner/repo --json
 ```
 
 CLI-first and non-Mac setups may instead use the checkout-local path documented

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -158,8 +158,10 @@ integration proof under #630.
    with the existing LaunchAgent label.
    Return to NeonDiff and choose **Install / Update Local Worker** once more to
    refresh discovery, then choose **Initialize Local Config**, **Add Repository**,
-   and **Apply Repository**. Choose **Verify App Access** for a new App or
-   **Verify Existing Access** for an existing agent.
+   and **Apply Repository**. For a compatible existing local bot, choose
+   **Verify Existing Access**. **Verify App Access** for a new App belongs to
+   the signed Desktop 1.1.0 path after its trusted bundled worker and promotion
+   gates are live; do not treat the checksum-bound beta worker as that GA path.
 
    After those promotion gates are live, move the signed Desktop 1.1.0 app to
    `/Applications/NeonDiff.app` for the promoted native journey; the
@@ -260,14 +262,15 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-For the current public paid B0 BYO beta, use native **Verify App Access** for a new
-customer-owned App or **Verify Existing Access** for a compatible existing agent
-after the selected repository is applied. These native actions are the supported
-B0 verification path; they use the account- and bot-selected config created by
-NeonDiff. The shell command below is optional CLI/operator diagnostics only. If
-you use it for native B0 troubleshooting, set `SELECTED_CONFIG` to the exact
-selected config path shown by NeonDiff (under its account-scoped Application
-Support directory), not the checkout-local `config.local.json`:
+For the current public paid B0 BYO beta, native **Verify Existing Access** is
+supported for a compatible existing local bot after the selected repository is
+applied. Native **Verify App Access** for a new customer-owned App requires the
+signed Desktop 1.1.0 trusted bundled-worker path and is not a current beta
+claim; use it only after the GA artifact and promotion gates are live. The shell
+command below is optional CLI/operator diagnostics only. If you use it for B0
+troubleshooting, set `SELECTED_CONFIG` to the exact selected config path shown
+by NeonDiff (under its account-scoped Application Support directory), not the
+checkout-local `config.local.json`:
 
 ```bash
 SELECTED_CONFIG="/absolute/path/from-NeonDiff-to-the-selected-bot/config.local.json"

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,15 +5,14 @@ runs on your own machine or server. The App identity is what authors review
 comments in GitHub; your local worker holds the App ID, private key, provider
 configuration, state database, and evidence files.
 
-On macOS the native app (`apps/neondiff-desktop`) is the human first-run surface.
-The public paid B0 BYO build accepts the customer's own App ID and private key,
-one selected repository, and runs the explicit installation check from the
-wizard. No invitation is required when the versioned public GitHub prerelease is
-published and the neondiff.com purchase/download path is live. The managed B1
-path uses the official NeonDiff App and broker under #613; it is separate from
-B0. This document remains the operator/CLI reference for both paths' App
-identity, permission set, and install boundary. Matching public website
-onboarding copy lives in the website repo under neon-diff-agent-website#52.
+On macOS, signed Desktop 1.1.0 is the planned native GA journey at
+`/Applications/NeonDiff.app`; it is not current GA availability. The current public paid
+customer-owned BYO beta remains current until the immutable signed GA artifact,
+`/mac` surface, and promotion gates are live. The planned GA path accepts a
+customer-owned App ID/private key; new App uses **Verify App Access**, existing
+agent uses **Verify Existing Access**. The managed official App/broker is
+separate post-GA. Planned stable onboarding is [neondiff.com/mac](https://www.neondiff.com); see the
+[Mac GA architecture and release contract](architecture/mac-ga-release-contract.md) and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 
 ## Install URL
 
@@ -130,42 +129,11 @@ integration proof under #630.
 4. Pick one repository for the B0 onboarding run.
 5. Confirm the permissions above.
 6. Save the generated private key outside this repository.
-7. In native NeonDiff first run, store the App ID and private key. On a clean
-   Mac, choose **Install / Update Local Worker** and complete the checksum-bound
-   `first-install` with Node.js 26 or newer through `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`. Return to NeonDiff, choose **Install / Update Local
-   Worker** once more to refresh discovery, then choose **Initialize Local
-   Config**. Enter the same `owner/repo`, then choose **Add Repository**,
-   **Apply Repository**, and **Verify App Access**.
-   Initialization never uses `--force`; the app updates `pilotRepos` and the
-   selected repository's enabled policy profile through `config patch`, and no
-   operator edits the customer's config file. Existing policy fields for that
-   repository are preserved. If verification reports a missing or disabled
-   repository policy profile, apply the repository again before retrying
-   verification; that
-   message does not mean the App installation is missing. Each new
-   bot config receives isolated runtime, state, evidence, and license paths
-   beside that config rather than the packaged worker's placeholder paths. An
-   account with no bot gets this isolated plan before the initialization action
-   appears; the app never initializes the `_unselected` placeholder.
-   If NeonDiff is quit mid-setup, relaunch restores that exact pending bot and
-   config path and reopens onboarding. It does not silently fall back to an
-   existing local bot on the same account or allocate another numbered config
-   directory; the customer can explicitly choose another account or bot to end
-   the pending flow.
-   If one exact checksum-managed worker exists, these isolated config commands
-   and the bounded private-key-stdin GitHub doctor reuse that worker instead of
-   resolving through a global `neondiff` command. On a clean Mac, the bundle's
-   confirmed `first-install` command creates only a private versioned CLI and
-   credential-free 0600 marker; it creates or loads no LaunchAgent and starts
-   no daemon. The new bot receives no inherited credential environment. Zero
-   or ambiguous managed-worker discovery does not select this reuse path.
-   If the configured local worker command is unavailable, the CLI-backed
-   controls remain disabled and **Install / Update Local Worker** opens the
-   version-matched release guide. Continue only with its checksum-bound
-   manifest/tarball and dry-run-default, confirm-required `first-install`
-   command. Source support does not prove that immutable release publication,
-   signing, clean-Mac execution, review, or daemon readiness has passed.
+7. In the promoted signed Desktop 1.1.0 journey, once its immutable artifact and `/mac` promotion gates are live, move the app to `/Applications/NeonDiff.app` and
+   launch it. Store the App ID/private key in Keychain, then choose **Initialize
+   Local Config**, **Add Repository**, and **Apply Repository**. Choose **Verify App
+   Access** for a new App or **Verify Existing Access** for an existing agent.
+   Checksum-worker commands below are legacy recovery only, not native setup.
 
 8. After App access, provider, repository, and activation are verified, use the
    native daemon step's **Preview Start** and **Install & Start** actions. The
@@ -174,7 +142,8 @@ integration proof under #630.
    config, launchd label, and non-secret activation device ID. Its headless mode
    re-derives that device ID from the existing broker identity in the app-owned
    Keychain, rejects any mismatch before reading credentials, validates the
-   checksum-managed worker, and hands the private key plus API-backed activation
+   sealed helper at `/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`,
+   and hands the private key plus API-backed activation
    credential to the local worker only through one bounded JSON stdin envelope.
    It never exports either secret, writes a PEM or license file, places a secret
    in the plist or environment, or uses a generic `security -w` wrapper. Any
@@ -239,7 +208,8 @@ confirmed rollback; neither path reads or copies key bytes. When a stable
 Homebrew Node command resolves to the same binary as `process.execPath`, the
 installer keeps the stable command instead of pinning a versioned Cellar path.
 
-Keep the private key and local config out of git. A typical shell setup is:
+The public-funnel condition is: No invitation is required when the versioned public GitHub prerelease is published and the neondiff.com purchase/download path is live. Its shell PEM recovery is CLI/operator-only; signed Desktop 1.1.0 uses
+Keychain, not this PEM path. Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
@@ -260,13 +230,13 @@ not GitHub approval of the public App.
 
 ## Verify Installation
 
-Run the GitHub-only doctor before provider or daemon checks. For the native B0
-app, use the config created in the app's user-writable Application Support
-directory:
+For the promoted signed Desktop 1.1.0 journey, use **Verify App Access** for a new
+customer-owned App or **Verify Existing Access** for a compatible existing agent in
+the UI; before promotion, the shell command below is CLI/operator diagnostics only:
 
 ```bash
-NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
-neondiff doctor github --config "$NATIVE_CONFIG" --repo owner/repo --json
+CLI_CONFIG="config.local.json"
+neondiff doctor github --config "$CLI_CONFIG" --repo owner/repo --json
 ```
 
 CLI-first and non-Mac setups may instead use the checkout-local path documented


### PR DESCRIPTION
## Summary
- carry the accepted public/customer README and GitHub App setup split from PR #955
- keep the current public paid B0 customer-owned BYO beta explicit
- make signed Desktop 1.1.0 and `/mac` conditional on published artifact and promotion gates
- preserve customer-owned new/existing App verification, Codex dry-before-live, Keychain/PEM, invitation, and post-GA managed-App boundaries

## Proof
- `npm run check:public-claims`
- `npm run check:design-source`
- `npm run check:secrets`
- `git diff --check`
- exact owned-file diff hash matches PR #955: `ab75af31f05da7bb626ce2df4e1902d6ff0d25634b522640799310698d54c92a`

Scope is limited to `README.md` and `docs/github-app-setup.md`; `docs/SETUP.md` and source/tests are intentionally excluded.

Refs #610