### PR TITLE
fix(state): serialize queue lease column migration

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -558,6 +558,7 @@ export class ReviewStateStore {
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new DatabaseSync(dbPath);
+    this.db.exec("pragma busy_timeout = 5000");
     this.db.exec("pragma foreign_keys = on");
     this.db.exec(`
       create table if not exists processed_reviews (
@@ -3679,9 +3680,16 @@ export class ReviewStateStore {
   }
 
   private ensureReviewQueueJobColumns(): void {
-    const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
-    if (!columns.some((column) => column.name === "lease_expires_at")) {
-      this.db.exec("alter table review_queue_jobs add column lease_expires_at text");
+    this.db.exec("begin immediate");
+    try {
+      const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
+      if (!columns.some((column) => column.name === "lease_expires_at")) {
+        this.db.exec("alter table review_queue_jobs add column lease_expires_at text");
+      }
+      this.db.exec("commit");
+    } catch (error) {
+      try { this.db.exec("rollback"); } catch { /* migration transaction did not start */ }
+      throw error;
     }
   }
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -32,6 +33,95 @@ describe("review state store", () => {
     expect(store.getProcessedReview("electricsheephq/WorldOS", 1205, "abc123")?.createdAt).toBe("2026-08-23T00:00:00.900Z");
     expect(store.hasProcessed("electricsheephq/WorldOS", 1205, "def456")).toBe(false);
     store.close();
+  });
+
+  it("migrates a legacy queue schema without a duplicate column under two openers", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-queue-lease-migration-race-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const lockDb = new DatabaseSync(dbPath);
+    lockDb.exec(`
+      create table review_queue_jobs (
+        job_id text primary key,
+        attempt_id text not null unique,
+        source text not null,
+        lane text not null,
+        repo text not null,
+        org text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        base_sha text,
+        provider_id text,
+        priority integer not null,
+        state text not null,
+        next_eligible_at text,
+        lease_id text,
+        session_id text,
+        comment_id integer,
+        review_url text,
+        last_error text,
+        created_at text not null,
+        updated_at text not null,
+        started_at text,
+        finished_at text
+      );
+      insert into review_queue_jobs
+        (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, priority, state, created_at, updated_at)
+      values ('legacy-job', 'legacy-attempt', 'automatic', 'background', 'owner/repo', 'owner', 1, 'legacy-head', 50, 'queued',
+        '2026-08-24T00:00:00.000Z', '2026-08-24T00:00:00.000Z');
+    `);
+    lockDb.exec("begin immediate");
+
+    const startPath = join(root, "start");
+    const openerScript = `
+      import { existsSync, writeFileSync } from "node:fs";
+      import { ReviewStateStore } from ${JSON.stringify(join(process.cwd(), "src/state.ts"))};
+      const wait = new Int32Array(new SharedArrayBuffer(4));
+      writeFileSync(process.env.READY_PATH, "ready");
+      while (!existsSync(process.env.START_PATH)) Atomics.wait(wait, 0, 0, 10);
+      const store = new ReviewStateStore(process.env.DB_PATH);
+      store.close();
+    `;
+    const launch = (readyPath: string) => new Promise<{ code: number | null; output: string }>((resolve) => {
+      const child = spawn(process.execPath, ["--import", "tsx/esm", "--input-type=module", "-e", openerScript], {
+        cwd: process.cwd(),
+        env: { ...process.env, DB_PATH: dbPath, READY_PATH: readyPath, START_PATH: startPath },
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      let output = "";
+      child.stdout.on("data", (chunk) => { output += chunk; });
+      child.stderr.on("data", (chunk) => { output += chunk; });
+      child.on("close", (code) => resolve({ code, output }));
+    });
+    const openerA = launch(join(root, "ready-a"));
+    const openerB = launch(join(root, "ready-b"));
+    const deadline = Date.now() + 5_000;
+    while (!existsSync(join(root, "ready-a")) || !existsSync(join(root, "ready-b"))) {
+      if (Date.now() > deadline) throw new Error("two-opener fixture did not become ready");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    writeFileSync(startPath, "go");
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    lockDb.exec("commit");
+    lockDb.close();
+
+    const [resultA, resultB] = await Promise.all([openerA, openerB]);
+    expect(resultA.code, resultA.output).toBe(0);
+    expect(resultA.output).toBe("");
+    expect(resultB.code, resultB.output).toBe(0);
+    expect(resultB.output).toBe("");
+
+    const checkDb = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const columns = checkDb.prepare("pragma table_info(review_queue_jobs)").all() as Array<{ name: string }>;
+      expect(columns.map((column) => column.name)).toContain("lease_expires_at");
+      expect(columns.filter((column) => column.name === "lease_expires_at")).toHaveLength(1);
+      expect(checkDb.prepare("select count(*) as count from review_queue_jobs").get()).toEqual({ count: 1 });
+      expect(checkDb.prepare("select repo, head_sha from review_queue_jobs where job_id = ?").get("legacy-job"))
+        .toEqual({ repo: "owner/repo", head_sha: "legacy-head" });
+    } finally {
+      checkDb.close();
+    }
   });
 
   it("stores normalized issue enrichment public and private hashes and rejects invalid hashes", () => {


### PR DESCRIPTION
## Summary

- Configure a bounded SQLite busy timeout before ReviewStateStore schema work.
- Recheck review_queue_jobs columns inside BEGIN IMMEDIATE before adding lease_expires_at, making concurrent reopen migration idempotent.
- Add a deterministic two-opener legacy-schema fixture that preserves the existing queue row and asserts exactly one lease_expires_at column.

Related: #882

## Validation

- Baseline regression fixture on exact main: both openers hit ERR_SQLITE_ERROR database is locked at src/state.ts:562 while the legacy DB write lock was held.
- PATH=/opt/homebrew/bin:/usr/bin:/bin npx vitest run tests/state.test.ts -t "migrates a legacy queue schema without a duplicate column under two openers" — PASS.
- PATH=/opt/homebrew/bin:/usr/bin:/bin npx vitest run tests/state.test.ts — 73 passed.
- PATH=/opt/homebrew/bin:/usr/bin:/bin npm run build — PASS.
- git diff --check — PASS.

Base: a2fe473f41ee688f427e0b581d4e2a89422aa07f. Changes are limited to src/state.ts and tests/state.test.ts; shadow-identity migration work from #957 is not included. No merge, runtime, customer, config, or secret mutation performed.