### PR TITLE
docs: correct native setup architecture

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -295,12 +295,12 @@ the app rejects it if any authorized bot now owns the same config identity.
 Choosing another account or explicitly choosing an existing bot ends the
 pending setup.
 
-For that promoted GA journey, the LaunchAgent `Program` is the signed
-`/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop` wrapper. It dispatches
-`--neondiff-worker-daemon` to the sealed helper
-`/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`; it is not a direct
-helper LaunchAgent. Legacy recovery below is operator-only, not native first-run
-setup.
+For that promoted GA journey, the LaunchAgent `ProgramArguments` begins with the
+signed `/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop` wrapper and
+`--neondiff-worker-daemon`. The wrapper dispatches the request to the sealed helper
+`/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`; the plist does not
+directly invoke the helper. Legacy recovery below is operator-only, not native
+first-run setup.
 
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -473,10 +473,15 @@ the sealed helper, and the shell command verifies App/repo access without provid
 neondiff doctor github --config config.local.json --json
 ```
 
-The CLI contract uses the local `config.local.json` file for non-secret
-configuration, while private keys and other runtime secrets remain Keychain-only
-and cross only bounded stdin. The signed app does not store the config file in
-Keychain. The equivalent CLI contract is:
+The CLI/operator contract uses the local `config.local.json` file for non-secret
+configuration and may reference a customer-owned PEM through
+`github.privateKeyPath` (or `NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH`). Keep that
+file outside the repository, current-user-owned, and protected by restrictive
+permissions; never put its key bytes in config, arguments, environment values,
+logs, or evidence. The signed Desktop/LaunchAgent path is different: its private
+key remains app-owned Keychain material, and the plist, arguments, and
+environment contain neither the key nor a private-key path. The equivalent CLI
+contract is:
 
 ```bash
 CLI_CONFIG="config.local.json"
@@ -489,11 +494,12 @@ The relative `config.local.json` examples elsewhere in this guide remain the
 separate CLI-first/operator path; they do not inspect the native app's config.
 
 The private key must be one unencrypted RSA PKCS#1 or PKCS#8 PEM no larger than
-64 KiB. Do not put the private-key bytes in arguments, environment variables,
-config, logs, or evidence. The reconciled-existing-worker path may supply only
-the already-configured private-key file path to the exact child process. A
-passing doctor proves only current installation/repository read access for the
-configured allowlist; it does not execute or post a review.
+64 KiB. A CLI/operator config may contain only its file path, never the key
+bytes. The reconciled-existing-worker path may supply only the already-configured
+private-key file path to the exact child process; keep that file current-user-owned
+with no group/other permissions. A passing doctor proves only current
+installation/repository read access for the configured allowlist; it does not
+execute or post a review.
 
 The signed Mac app uses the same bounded stdin credential contract for
 `review-pr` and the raw long-running daemon. It routes every credential-bearing

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,10 +1,11 @@
 # NeonDiff Setup
 
-This guide is the CLI-first setup path for the current source-available release,
-and the first-run path on non-Mac platforms. On macOS the native app
-(`apps/neondiff-desktop`) is the human first-run surface; until the native
-broker/launchd proof lands (see the native-broker note below) it hands off to
-this operator/advanced path for setup actions it cannot yet complete natively.
+This guide is the CLI/operator setup path for npm CLI 1.0.4 and non-Mac first
+run. The current product is the public paid B0 BYO beta. The planned signed
+Desktop 1.1.0 journey at `/Applications/NeonDiff.app` becomes primary only after
+its immutable GA artifact, `/mac` surface, and promotion gates are live. See the
+[Mac GA architecture and release contract](architecture/mac-ga-release-contract.md)
+and [Desktop Mac release runbook](../apps/neondiff-desktop/docs/mac-release-runbook.md).
 The recommended path installs the `neondiff` npm package; source checkout remains
 a fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
@@ -207,8 +208,7 @@ configured `evidenceDir` as
 The `keychain` backend remains reserved for a separately proven native broker.
 Headless CLI activation currently rejects Keychain writes rather than passing
 license keys through process arguments. v1.0.4 supports the approved file
-backend; the Desktop app remains blocked from useful actions until native
-broker/launchd access is proven.
+backend; signed Desktop 1.1.0 keeps activation in its app-owned Keychain path.
 The local `machineId` sent to the license API is advisory beta metadata derived
 from host name and platform, not hardware attestation or a durable seat-binding
 primitive.
@@ -262,50 +262,18 @@ manual UserDefaults rollout mutation. It does not make the managed App path
 available and is not proof that GitHub private-key custody, the compatible CLI
 package, billing, signing, or customer canaries have passed.
 
-For a B0 customer, the native first-run path is:
+For the planned signed Desktop 1.1.0 GA journey, once the immutable artifact and `/mac` promotion gates are live, move the app to `/Applications/NeonDiff.app` and follow its UI:
 
 1. Create and install a customer-owned GitHub App with the permissions in
    [`github-app-setup.md`](github-app-setup.md), selecting one repository.
-2. Launch NeonDiff and enter the App's numeric ID and downloaded private-key
-   PEM, then choose **Store in Keychain**.
-3. On a clean install, if NeonDiff reports that the local worker command is
-   unavailable, choose **Install / Update Local Worker** before **Initialize
-   Local Config**. From the verified extracted bundle, use Node.js 26 or newer
-   through the approved stable path `/opt/homebrew/bin/node` or
-   `/usr/local/bin/node`, then preview the credential-free install:
-
-   ```bash
-   BUNDLE_DIR="$(pwd -P)"
-   node install-b0-worker-candidate.mjs first-install \
-     --manifest "$BUNDLE_DIR/neondiff-1.1.0-beta.N-b0-candidate-manifest.json" \
-     --manifest-sha256 <manifest-sha256-from-release> \
-     --tarball "$BUNDLE_DIR/neondiff-1.1.0-beta.N.tgz" \
-     --launchd-label com.electricsheephq.evaos-code-review-bot \
-     --dry-run true
-   ```
-
-   Inspect the public-safe preview, then repeat it with
-   `--dry-run false --confirm true`. It installs only the exact verified CLI
-   into a private versioned current-user directory and writes a 0600
-   credential-free marker. It creates or loads no LaunchAgent, starts no
-   daemon, and never reads or writes GitHub, provider, or license credentials.
-   It refuses an existing LaunchAgent or worker state; use the existing-worker
-   update flow below for those machines. Return to NeonDiff and choose
-   **Install / Update Local Worker** once more to refresh discovery; when the
-   worker is available, choose **Initialize Local Config**. Initialization
-   invokes the non-destructive `neondiff init` path without `--force`, never
-   overwrites an existing config, and keeps bot-isolated runtime, state,
-   evidence, and license paths beside the config. Review and daemon readiness
-   remain separate gates.
-4. Enter that same `owner/repo`, choose **Add Repository**, then **Apply
-   Repository**. The app writes the allowlist through the typed local `config
-   patch` command and ensures every selected repository has an enabled local
-   policy profile; the customer does not edit a config file. Existing
-   per-repository policy fields are preserved.
-5. Choose **Verify App Access**. Continue remains disabled until GitHub verifies
-   the exact configured repository through that App installation. If the local
-   profile is missing or disabled, apply the repository again before retrying
-   verification.
+2. Move the app to `/Applications/NeonDiff.app`; enter the App ID/private key
+   in its UI and choose **Store in Keychain**.
+3. Choose **Initialize Local Config**, add/apply the selected `owner/repo`, and
+   let the app write the allowlist without an operator config edit.
+4. Choose **Verify App Access** for a new App or **Verify Existing Access** for
+   a compatible agent; both checks bind the exact target.
+5. Configure provider/Codex, activate, then use **Preview Start**, **Install & Start**,
+   and **Run Dry Review** before any confirmed live post.
 
 If verification reports a missing or disabled repository policy profile,
 choose **Apply Repository** again before retrying **Verify App Access**. This is a local
@@ -327,14 +295,12 @@ the app rejects it if any authorized bot now owns the same config identity.
 Choosing another account or explicitly choosing an existing bot ends the
 pending setup.
 
-When the same Mac already has one exact checksum-managed worker for the selected
-LaunchAgent label, the app reuses that worker for the isolated bot's `init`,
-`config inspect`, `config patch`, and private-key-stdin GitHub doctor commands.
-Within that proven one-worker case, it does not resolve those commands through
-an older global `neondiff` package, and it does not pass the existing bot's App
-ID or private-key file environment into the new bot process. Zero or ambiguous
-managed-worker discovery does not select this reuse path; installing and proving
-exactly one managed worker is a separate distribution gate.
+For that promoted GA journey, the LaunchAgent `Program` is the signed
+`/Applications/NeonDiff.app/Contents/MacOS/NeonDiffDesktop` wrapper. It dispatches
+`--neondiff-worker-daemon` to the sealed helper
+`/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker`; it is not a direct
+helper LaunchAgent. Legacy recovery below is operator-only, not native first-run
+setup.
 
 This first-run step proves only current App installation and repository access.
 Provider verification, activation, dry run, and live review remain separate
@@ -396,7 +362,7 @@ the same Mac. In that exact case it opens a reconciliation path:
   copying its private key. The key file must be a current-user-owned regular
   file with no group/other permissions. Only its file path—not its key bytes—is
   supplied as a child-process environment coordinate for the exact config;
-- its single **Verify existing access** action first proves the exact App and
+- its single **Verify Existing Access** action first proves the exact App and
   Review Target with `doctor github --repo`. A legacy credential-bearing
   matched worker then runs credential-free
   `license status --refresh true` through that exact worker and config. A
@@ -499,23 +465,22 @@ The app's own Sparkle update does not update an external local worker.
 
 ## 4. Check Readiness
 
-Run the GitHub-only doctor first. It verifies App installation visibility and
-repo read access without running ZCode, calling a provider, posting comments, or
-printing secrets:
+For the promoted signed Desktop 1.1.0 journey, use **Verify App Access** or **Verify Existing Access**
+in the UI; before promotion, use the CLI/operator diagnostic below. Credentials go only to
+the sealed helper, and the shell command verifies App/repo access without provider or posting side effects:
 
 ```bash
 neondiff doctor github --config config.local.json --json
 ```
 
-The public paid B0 BYO desktop keeps the customer-owned App private key in the
-macOS Keychain. Its explicit **Verify App Access** action sends that key only to
-the local CLI's bounded stdin for this check. The native app's clean-install
-config lives in its user-writable Application Support directory; the equivalent
-CLI contract is:
+The CLI contract uses the local `config.local.json` file for non-secret
+configuration, while private keys and other runtime secrets remain Keychain-only
+and cross only bounded stdin. The signed app does not store the config file in
+Keychain. The equivalent CLI contract is:
 
 ```bash
-NATIVE_CONFIG="$HOME/Library/Application Support/NeonDiffDesktop/config.local.json"
-neondiff doctor github --config "$NATIVE_CONFIG" \
+CLI_CONFIG="config.local.json"
+neondiff doctor github --config "$CLI_CONFIG" \
   --github-app-id "<numeric-app-id>" \
   --github-app-private-key-stdin true --json < "/path/to/app-private-key.pem"
 ```


### PR DESCRIPTION
Related: #610

## What changed
- Correct the bounded native operator setup successor from closed PR #955.
- Require **Preview Start**, **Install & Start**, then **Run Dry Review** before any confirmed live post.
- Keep `config.local.json` as local configuration; private keys and runtime secrets remain Keychain-only.
- Document the LaunchAgent `NeonDiffDesktop` wrapper dispatching `--neondiff-worker-daemon` to the sealed `NeonDiffWorker` helper.
- Preserve the conditional GA/B0 boundary and change only `docs/SETUP.md`.

## Validation
- `git diff --check` — pass
- `npm run check:public-claims` — pass
- `npm run check:design-source` — pass
- `npm run check:secrets` — pass
- Deterministic setup assertions — pass (Install & Start ordering, config/Keychain custody, wrapper/helper topology, no `/Volumes/LEXAR` or pre-native wording)
- Diff: 32 insertions, 67 deletions; 99 total changed lines
- Corpus-boundary and secret-rule differential checks were blocked because this fresh worktree has no `dist/`; `npm run build` was blocked by missing local `tsc` type packages. Vitest funnel/readiness checks were blocked by the known Rollup Darwin code-signature mismatch.

## Proof boundary
Docs-only candidate. This PR does not prove merge, release publication, signing/notarization, runtime installation, billing, customer readiness, deployment, or live Keychain/LaunchAgent state. No source, tests, config, app, worker, customer, billing, or release systems were changed.