### PR TITLE
feat(github): project verified installation identity fields

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import { createSign } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { isMap, isProxy, isSet } from "node:util/types";
 import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type { IssueEnrichmentIssueList } from "./issue-enrichment.js";
@@ -138,6 +139,22 @@ interface GitHubInstallationResponse {
   app_id?: number;
   account?: { login?: string };
   app_slug?: string;
+}
+
+export interface CanonicalGitHubInstallationIdentity {
+  id: number;
+  app_id: number;
+  account_id: number;
+  account_login: string;
+  account_type: "User" | "Organization";
+  app_slug: string;
+  bot_login: string;
+}
+
+export interface GitHubInstallationIdentityExpectation {
+  expectedAppId: string;
+  expectedBotLogin: string;
+  repo: string;
 }
 
 export class GitHubApiRequestError extends Error {
@@ -750,6 +767,69 @@ function visibilityFromRepositorySummary(repository: RepositorySummary): {
   if (repository.private === true) return { result: "private", source: "private_flag" };
   if (repository.private === false) return { result: "public", source: "private_flag" };
   return { result: "unknown", source: "unavailable" };
+}
+
+const GITHUB_LOGIN_PATTERN = /^(?!-)(?!.*--)[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+const GITHUB_APP_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
+const MISSING_GITHUB_FIELD = Symbol("missing-github-field");
+
+/** Pure required-field projection; unrelated GitHub metadata is never traversed. */
+export function normalizeAndValidateGitHubInstallationIdentity(
+  value: unknown,
+  expected: GitHubInstallationIdentityExpectation
+): CanonicalGitHubInstallationIdentity {
+  const id = readGitHubField(value, "id");
+  const appId = readGitHubField(value, "app_id");
+  const account = readGitHubField(value, "account");
+  const accountId = readGitHubField(account, "id");
+  const accountLogin = normalizeGitHubValue(readGitHubField(account, "login"), GITHUB_LOGIN_PATTERN);
+  const accountType = readGitHubField(account, "type");
+  const appSlug = normalizeGitHubAppSlug(readGitHubField(value, "app_slug"));
+  const expectedAppId = readGitHubField(expected, "expectedAppId");
+  const expectedBotLogin = normalizeGitHubBotLogin(readGitHubField(expected, "expectedBotLogin"));
+  const repo = readGitHubField(expected, "repo");
+  const repoParts = typeof repo === "string" ? repo.split("/") : [];
+  const owner = repoParts.length === 2 && repoParts[1].length > 0 && !/\s/.test(repoParts[1])
+    ? normalizeGitHubValue(repoParts[0], GITHUB_LOGIN_PATTERN) : undefined;
+  const botLogin = appSlug ? `${appSlug}[bot]` : undefined;
+  const positiveInteger = (candidate: unknown): candidate is number =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
+  if (!positiveInteger(id) || !positiveInteger(appId) || !positiveInteger(accountId)
+      || typeof expectedAppId !== "string" || !/^\d+$/.test(expectedAppId.trim())
+      || String(appId) !== expectedAppId.trim() || !accountLogin || !owner || accountLogin !== owner
+      || (accountType !== "User" && accountType !== "Organization") || !appSlug
+      || !botLogin || botLogin !== expectedBotLogin) {
+    throw new Error("GitHub installation identity failed canonical validation.");
+  }
+  return Object.freeze({
+    id, app_id: appId, account_id: accountId, account_login: accountLogin,
+    account_type: accountType, app_slug: appSlug, bot_login: botLogin
+  });
+}
+
+function readGitHubField(value: unknown, key: string): unknown {
+  if (value === null || typeof value !== "object" || isProxy(value) || isMap(value) || isSet(value)
+      || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return MISSING_GITHUB_FIELD;
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor && descriptor.enumerable && "value" in descriptor ? descriptor.value : MISSING_GITHUB_FIELD;
+}
+
+function normalizeGitHubAppSlug(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  const slug = normalized.endsWith("[bot]") ? normalized.slice(0, -5) : normalized;
+  return GITHUB_APP_SLUG_PATTERN.test(slug) ? slug : undefined;
+}
+
+function normalizeGitHubBotLogin(value: unknown): string | undefined {
+  const slug = normalizeGitHubAppSlug(value);
+  return slug ? `${slug}[bot]` : undefined;
+}
+
+function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return pattern.test(normalized) ? normalized : undefined;
 }
 
 function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GitHubApi } from "../src/github.js";
+import { GitHubApi, normalizeAndValidateGitHubInstallationIdentity } from "../src/github.js";
 
 describe("GitHub App read authentication", () => {
   const roots: string[] = [];
@@ -13,6 +13,66 @@ describe("GitHub App read authentication", () => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("projects required identity fields from normal installation metadata", () => {
+    const response = canonicalInstallation({
+      app_slug: " EVAOS-CODE-REVIEW-BOT[bot] ",
+      account: { id: 7, login: "Owner", type: "Organization" },
+      events: [{ id: 1, payload: { action: "created" } }],
+      single_file_paths: [".github/CODEOWNERS"],
+      permissions: { contents: "read" }
+    });
+    const identity = normalizeAndValidateGitHubInstallationIdentity(response, {
+      expectedAppId: "4184532", expectedBotLogin: " evaos-code-review-bot ", repo: "OWNER/repo"
+    });
+    expect(identity).toEqual({
+      id: 123, app_id: 4184532, account_id: 7, account_login: "owner", account_type: "Organization",
+      app_slug: "evaos-code-review-bot", bot_login: "evaos-code-review-bot[bot]"
+    });
+    expect(Object.isFrozen(identity)).toBe(true);
+    (response.account as Record<string, unknown>).login = "changed";
+    expect(identity.account_login).toBe("owner");
+  });
+
+  it.each([
+    ["App mismatch", { app_id: 4184533 }, undefined],
+    ["account mismatch", { account: { id: 7, login: "other", type: "User" } }, undefined],
+    ["account type mismatch", { account: { id: 7, login: "owner", type: "Bot" } }, undefined],
+    ["bot mismatch", { app_slug: "other-app" }, undefined],
+    ["repository mismatch", {}, "other/repo"],
+    ["missing account id", { account: { login: "owner", type: "User" } }, undefined],
+    ["missing account type", { account: { id: 7, login: "owner" } }, undefined]
+  ])("fails closed for required identity mismatch: %s", (_name, override, repo) => {
+    expect(() => normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation(override), {
+      expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: repo ?? "owner/repo"
+    })).toThrow(/canonical validation/);
+  });
+
+  it("rejects hostile required fields without executing traps or getters", () => {
+    let executions = 0;
+    const trap = { get: () => (++executions, 1), ownKeys: () => (++executions, []), getPrototypeOf: () => (++executions, Object.prototype) };
+    const revocable = Proxy.revocable(canonicalInstallation(), trap);
+    revocable.revoke();
+    const accessor = canonicalInstallation();
+    Object.defineProperty(accessor, "id", { enumerable: true, get: () => (++executions, 123) });
+    const nestedAccessor = canonicalInstallation({ account: Object.defineProperty({ id: 7, type: "User" }, "login", {
+      enumerable: true, get: () => (++executions, "owner")
+    }) });
+    const map = canonicalInstallation({ account: new Map([["id", 7]]) });
+    const set = canonicalInstallation({ account: new Set([7]) });
+    const array = canonicalInstallation({ account: [7, "owner", "User"] });
+    const symbol = canonicalInstallation({ app_id: Symbol("app") });
+    const cycle: Record<string, unknown> = {};
+    cycle.login = cycle;
+    const cyclic = canonicalInstallation({ account: { id: 7, login: cycle, type: "User" } });
+    const inherited = canonicalInstallation({ account: Object.assign(Object.create({ login: "owner" }), { id: 7, type: "User" }) });
+    for (const value of [new Proxy(canonicalInstallation(), trap), revocable.proxy, accessor, nestedAccessor, map, set, array, symbol, cyclic, inherited]) {
+      expect(() => normalizeAndValidateGitHubInstallationIdentity(value, {
+        expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+      })).toThrow(/canonical validation/);
+    }
+    expect(executions).toBe(0);
   });
 
   it("uses installation tokens for PR read calls when App credentials are configured", async () => {
@@ -835,6 +895,16 @@ function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
     statusText,
     headers: { "Content-Type": "application/json" }
   });
+}
+
+function canonicalInstallation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 123,
+    app_id: 4184532,
+    account: { id: 7, login: "owner", type: "Organization" },
+    app_slug: "evaos-code-review-bot",
+    ...overrides
+  };
 }
 
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {


### PR DESCRIPTION
Related: #872

## Scope

Adds a pure, test-only required-field projection for canonical GitHub installation identity. It validates installation ID, App ID, account ID/login/type, expected repository owner, and canonical App slug/bot login. It copies only frozen scalar fields and ignores unrelated standard metadata such as events and single_file_paths.

## Safety

Required-field descriptors and prototypes are checked without invoking getters or Proxy traps. Hostile proxy, revoked proxy, accessor, Map, Set, array, symbol, cycle, and inherited-field fixtures fail closed. No installation/token/cache/runtime/config/DB/Keychain/customer mutation or production wiring is included.

## Proof

- PATH=/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0T7mR5p:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm test -- --run tests/github-app-read.test.ts (35 passed)
- PATH=/opt/homebrew/bin:/Users/m1/.codex/tmp/arg0/codex-arg0T7mR5p:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/m1/.local/bin:/Users/m1/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/m1/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources npm run build (passed)
- git diff --check (clean)
- 151 changed lines in the two owned files

R1v3b remains responsible for routing installation fetch, refresh, token exchange, and proof paths through this primitive.