### PR TITLE
fix(desktop): require dry receipt before live worker start

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -105,7 +105,9 @@ struct FoundationKeychainWorkerLaunchAgentManager:
                 }
                 throw error
             }
-            return "Installed and started the Keychain-backed local review worker without placing its private key in the LaunchAgent."
+            return request.liveAuthorization == nil
+                ? "Installed and started the Keychain-backed local review worker in a dry-run hold; live review remains blocked until an exact receipt is confirmed."
+                : "Installed and started the Keychain-backed local review worker for the exact confirmed dry-review head without placing its private key in the LaunchAgent."
         }.value
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -9,12 +9,14 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
     package let licenseMachineID: String
     package let configPath: String
     package let launchdLabel: String
+    package let liveAuthorization: DesktopKeychainWorkerLiveAuthorization?
 
     package init(
         appID: String,
         licenseMachineID: String,
         configPath: String,
         launchdLabel: String,
+        liveAuthorization: DesktopKeychainWorkerLiveAuthorization? = nil,
         homeDirectory: URL
     ) throws {
         guard appID.range(
@@ -46,6 +48,7 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
         self.licenseMachineID = licenseMachineID
         self.configPath = normalizedConfig.path
         self.launchdLabel = launchdLabel
+        self.liveAuthorization = liveAuthorization
     }
 
     private static func isAccountBotConfig(
@@ -74,6 +77,45 @@ package struct DesktopKeychainWorkerLaunchAgentRequest:
                 options: .regularExpression
             ) != nil
             && suffix[3] == "config.local.json"
+    }
+}
+
+package struct DesktopKeychainWorkerLiveAuthorization:
+    Equatable,
+    Sendable
+{
+    package let repository: String
+    package let pullNumber: Int
+    package let headSHA: String
+
+    package init(
+        repository: String,
+        pullNumber: Int,
+        headSHA: String
+    ) throws {
+        guard repository.range(
+            of: #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidLiveAuthorization
+        }
+        guard pullNumber > 0,
+              Self.isHex(headSHA, length: 40)
+        else {
+            throw DesktopKeychainWorkerLaunchAgentError.invalidLiveAuthorization
+        }
+        self.repository = repository
+        self.pullNumber = pullNumber
+        self.headSHA = headSHA.lowercased()
+    }
+
+    private static func isHex(_ value: String, length: Int) -> Bool {
+        value.utf8.count == length
+            && value.utf8.allSatisfy {
+                ($0 >= 48 && $0 <= 57)
+                    || ($0 >= 65 && $0 <= 70)
+                    || ($0 >= 97 && $0 <= 102)
+            }
     }
 }
 
@@ -129,6 +171,7 @@ package enum DesktopKeychainWorkerLaunchAgentError:
     case invalidLicenseMachineID
     case invalidRepository
     case invalidIssueNumber
+    case invalidLiveAuthorization
     case invalidAppExecutable
     case serializationFailed
 
@@ -146,6 +189,8 @@ package enum DesktopKeychainWorkerLaunchAgentError:
             "The selected issue repository is invalid."
         case .invalidIssueNumber:
             "The selected issue number must be positive."
+        case .invalidLiveAuthorization:
+            "The live transition requires an exact dry-review repository, pull request, and head receipt."
         case .invalidAppExecutable:
             "The signed NeonDiff app executable path is invalid."
         case .serializationFailed:
@@ -194,24 +239,37 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
     package static func headlessArguments(
         request: DesktopKeychainWorkerLaunchAgentRequest
     ) -> [String] {
-        [
+        var arguments = [
             headlessFlag,
             "--config", request.configPath,
             "--launchd-label", request.launchdLabel,
             "--github-app-id", request.appID,
             "--license-machine-id", request.licenseMachineID
         ]
+        if let authorization = request.liveAuthorization {
+            arguments += [
+                "--live-repo", authorization.repository,
+                "--live-pr", String(authorization.pullNumber),
+                "--live-head-sha", authorization.headSHA,
+                "--live-confirmed", "true"
+            ]
+        }
+        return arguments
     }
 
     package static func sealedWorkerDaemonArguments(
         request: DesktopKeychainWorkerLaunchAgentRequest
     ) -> [String] {
-        [
+        var arguments = [
             "daemon",
             "--config", request.configPath,
             "--runtime-credentials-stdin", "true",
-            "--dry-run", "false"
+            "--dry-run", request.liveAuthorization == nil ? "true" : "false"
         ]
+        if request.liveAuthorization != nil {
+            arguments += ["--confirm", "true"]
+        }
+        return arguments
     }
 
     package static func sealedWorkerIssueRunArguments(
@@ -290,16 +348,16 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             : "repositories"
 
         return """
-        Ready to install and start the secret-free local review worker.
+        Ready to install and start the secret-free local review worker in a dry-run hold.
         LaunchAgent: \(plistPath)
         Program: \(appExecutableURL.standardizedFileURL.path)
         ProgramArguments: \(redactedArguments)
         Sealed worker: \(sealedWorkerPath)
         EnvironmentVariables: none
-        Launch policy: RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua; stdout=/dev/null; stderr=/dev/null.
+        Launch policy: RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua; stdout=/dev/null; stderr=/dev/null; daemon starts with --dry-run true until an exact receipt is confirmed.
         Credentials: Keychain-only at runtime; no secret values in the plist, arguments, or environment.
         Repository allowlist: preserved unchanged (\(preservedRepositoryCount) configured \(repositoryLabel)); no config write.
-        Mutation: write only the selected user LaunchAgent, then restart that exact service.
+        Mutation: write only the selected user LaunchAgent, then restart that exact service; no live review is authorized by install alone.
         """
     }
 
@@ -370,7 +428,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         root["StandardOutPath"] as? String == "/dev/null",
         root["StandardErrorPath"] as? String == "/dev/null",
         let programArguments = root["ProgramArguments"] as? [String],
-        [8, 10].contains(programArguments.count),
+        [8, 10, 18].contains(programArguments.count),
         let executablePath = programArguments.first,
         executablePath.hasPrefix("/")
         else {
@@ -419,7 +477,7 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         _ arguments: [String],
         homeDirectory: URL
     ) -> DesktopKeychainWorkerLaunchAgentRequest? {
-        guard arguments.count == 9,
+        guard arguments.count == 9 || arguments.count == 17,
               arguments[0] == headlessFlag,
               arguments[1] == "--config",
               arguments[3] == "--launchd-label",
@@ -428,11 +486,32 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
         else {
             return nil
         }
+        let authorization: DesktopKeychainWorkerLiveAuthorization?
+        if arguments.count == 17 {
+            guard arguments[9] == "--live-repo",
+                  arguments[11] == "--live-pr",
+                  arguments[13] == "--live-head-sha",
+                  arguments[15] == "--live-confirmed",
+                  arguments[16] == "true",
+                  let pullNumber = Int(arguments[12])
+            else {
+                return nil
+            }
+            authorization = try? DesktopKeychainWorkerLiveAuthorization(
+                repository: arguments[10],
+                pullNumber: pullNumber,
+                headSHA: arguments[14]
+            )
+            guard authorization != nil else { return nil }
+        } else {
+            authorization = nil
+        }
         return try? DesktopKeychainWorkerLaunchAgentRequest(
             appID: arguments[6],
             licenseMachineID: arguments[8],
             configPath: arguments[2],
             launchdLabel: arguments[4],
+            liveAuthorization: authorization,
             homeDirectory: homeDirectory
         )
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2480,14 +2480,41 @@ package final class NeonDiffDesktopModel: ObservableObject {
 
     package func startDaemon() {
         guard requireProductionDaemonStartAuthorization() else { return }
+        let liveAuthorization: DesktopKeychainWorkerLiveAuthorization?
+        if existingLocalAgentAccessAvailable {
+            guard scopedLiveReviewConfirmationAvailable,
+                  let approval = scopedDryRunApproval,
+                  let authorization = try? DesktopKeychainWorkerLiveAuthorization(
+                      repository: approval.repo,
+                      pullNumber: approval.pullNumber,
+                      headSHA: approval.headSHA
+                  )
+            else {
+                lastError =
+                    "Run a successful dry review, then confirm the exact repository, pull request, and head before starting the worker."
+                logText = lastError ?? "Exact dry-review confirmation required."
+                return
+            }
+            liveAuthorization = authorization
+        } else {
+            liveAuthorization = nil
+        }
         if keychainWorkerLaunchAgentActive
             || (!existingLocalAgentAccessAvailable
                 && keychainWorkerLaunchAgentInstallAvailable)
         {
-            installAndStartKeychainWorkerLaunchAgent()
+            installAndStartKeychainWorkerLaunchAgent(
+                liveAuthorization: liveAuthorization
+            )
+            if liveAuthorization != nil {
+                invalidateScopedReviewApproval(preserveStatus: true)
+            }
             return
         }
         persistLocalSettings()
+        if liveAuthorization != nil {
+            invalidateScopedReviewApproval(preserveStatus: true)
+        }
         runCLI(
             arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
             displayCommand: startDaemonCommand
@@ -2624,14 +2651,20 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
-    private func installAndStartKeychainWorkerLaunchAgent() {
-        guard let request = keychainWorkerLaunchAgentRequest() else {
+    private func installAndStartKeychainWorkerLaunchAgent(
+        liveAuthorization: DesktopKeychainWorkerLiveAuthorization? = nil
+    ) {
+        guard let request = keychainWorkerLaunchAgentRequest(
+            liveAuthorization: liveAuthorization
+        ) else {
             return
         }
         let manager = dependencies.keychainWorkerLaunchAgentManager
         isKeychainWorkerLaunchAgentOperationInProgress = true
         keychainWorkerLaunchAgentStatus =
-            "Installing and starting the secret-free local review worker…"
+            liveAuthorization == nil
+                ? "Installing and starting the secret-free local review worker in a dry-run hold…"
+                : "Starting the worker for the exact confirmed dry-review head…"
         Task { [weak self] in
             do {
                 let status = try await manager.installAndStart(
@@ -2657,7 +2690,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
         }
     }
 
-    private func keychainWorkerLaunchAgentRequest()
+    private func keychainWorkerLaunchAgentRequest(
+        liveAuthorization: DesktopKeychainWorkerLiveAuthorization? = nil
+    )
         -> DesktopKeychainWorkerLaunchAgentRequest?
     {
         guard let appID = storedBYOGitHubAppId else {
@@ -2687,6 +2722,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
                 licenseMachineID: licenseMachineID,
                 configPath: configPath,
                 launchdLabel: launchdLabel,
+                liveAuthorization: liveAuthorization,
                 homeDirectory: homeDirectory
             )
         } catch {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -105,7 +105,7 @@ import NeonDiffDesktopCore
         #expect(parsed == request)
     }
 
-    @Test func sealedWorkerDaemonRunsLiveAfterExplicitNativeInstall() throws {
+    @Test func newLaunchAgentInstallCannotStartLiveDaemonBeforeDryReceipt() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
         )
@@ -124,10 +124,53 @@ import NeonDiffDesktopCore
             "daemon",
             "--config", config.path,
             "--runtime-credentials-stdin", "true",
-            "--dry-run", "false"
+            "--dry-run", "true"
         ])
         #expect(!arguments.contains(appID))
         #expect(!arguments.contains(licenseMachineID))
+    }
+
+    @Test func exactDryReceiptAndConfirmationEnableLiveDaemonTransition() throws {
+        let config = home.appending(
+            path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
+        )
+        let receipt = try DesktopKeychainWorkerLiveAuthorization(
+            repository: "electricsheephq/evaos-code-review-bot-neondiff",
+            pullNumber: 965,
+            headSHA: String(repeating: "a", count: 40)
+        )
+        let request = try DesktopKeychainWorkerLaunchAgentRequest(
+            appID: appID,
+            licenseMachineID: licenseMachineID,
+            configPath: config.path,
+            launchdLabel: label,
+            liveAuthorization: receipt,
+            homeDirectory: home
+        )
+
+        #expect(DesktopKeychainWorkerLaunchAgentContract
+            .sealedWorkerDaemonArguments(request: request) == [
+                "daemon",
+                "--config", config.path,
+                "--runtime-credentials-stdin", "true",
+                "--dry-run", "false",
+                "--confirm", "true"
+            ])
+        let data = try DesktopKeychainWorkerLaunchAgentContract.propertyListData(
+            request: request,
+            appExecutableURL: appExecutable
+        )
+        let parsed = try #require(
+            DesktopKeychainWorkerLaunchAgentContract.parsePropertyList(
+                data,
+                expectedLabel: label,
+                homeDirectory: home,
+                appExecutableIsSafe: { $0 == self.appExecutable },
+                configExists: { $0 == config }
+            )
+        )
+        #expect(parsed == request)
+        #expect(parsed.liveAuthorization == receipt)
     }
 
     @Test func signedAppIssueRunIsExactLiveAndSecretFree() throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -1830,6 +1830,14 @@ import NeonDiffDesktopCore
         #expect(fixture.model.productionUsefulWorkAvailable)
         #expect(fixture.model.productionDaemonStartAvailable)
 
+        let callCountBeforeUnapprovedStart = fixture.cli.calls.count
+        fixture.model.startDaemon()
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(fixture.cli.calls.count == callCountBeforeUnapprovedStart)
+        #expect(fixture.model.lastError?.contains("successful dry review") == true)
+
         fixture.model.pendingReviewPullNumber = "685"
         fixture.model.runScopedDryReview()
         #expect(await reachesCallCount(fixture, 5))


### PR DESCRIPTION
Closes #965\n\n## What changed\n- New Install & Start writes a secret-free LaunchAgent that starts the daemon with --dry-run true and no live confirmation.\n- Existing Start/Restart requires the existing exact scoped dry-review receipt and explicit confirmation for the same repo, PR, head, config, workspace, and worker compatibility context; it fails closed without that proof.\n- Only the confirmed exact receipt serializes live transition flags; existing labels and repository allowlist behavior remain unchanged.\n\n## Evidence\n- Failing-first baseline: DesktopKeychainWorkerLaunchAgentTests/newLaunchAgentInstallCannotStartLiveDaemonBeforeDryReceipt failed before the fix because generated daemon args contained --dry-run false.\n- swift test --filter DesktopKeychainWorkerLaunchAgentTests (21 passed)\n- swift test --filter ExistingLocalBotReconciliationTests (49 passed)\n- git diff --check passed; 200 changed lines across 5 files.\n\n## Boundary\nNo installed app, launchd, worker, config, Keychain, credential, customer, review, feed, signing, or release mutation was performed. Remote CI, independent semantic checks, packaged clean-Mac launchd proof, and live/customer proof remain required.