### PR TITLE
fix(issue-enrichment): bound label-event overflow retries

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -18,6 +18,7 @@ export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
  */
 const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
+const MAX_ISSUE_LABEL_EVENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
@@ -417,7 +418,7 @@ export class GitHubApi {
     });
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedGithubList<{
     event?: string;
     created_at?: string;
     actor?: { login?: string | null } | null;
@@ -435,8 +436,10 @@ export class GitHubApi {
         { token: await this.getReadToken(repo) }
       );
       events.push(...chunk);
-      if (chunk.length < 100) return events;
+      if (chunk.length < 100) return boundedGithubList(events, false);
+      if (page === MAX_ISSUE_LABEL_EVENT_PAGES) return boundedGithubList(events, true);
     }
+    return boundedGithubList(events, true);
   }
 
   async getCollaboratorPermission(

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -231,6 +231,7 @@ export type IssueEnrichmentScanCompletion = "complete" | "page_limit_reached" | 
 
 export type IssueEnrichmentIssueList = GitHubRelatedIssueOrPull[] & {
   scanCompletion?: IssueEnrichmentScanCompletion;
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
 };
 
 export interface IssueEnrichmentScanResult {
@@ -284,14 +285,16 @@ type IssueEnrichmentComment = {
   user?: { login?: string | null } | null;
 };
 
+type IssueEnrichmentLabelEvent = {
+  event?: string;
+  created_at?: string;
+  actor?: { login?: string | null } | null;
+  label?: { name?: string | null } | null;
+};
+
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<IssueEnrichmentLabelEvent[] | BoundedGithubList<IssueEnrichmentLabelEvent>>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -329,7 +332,8 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded"
+  | "issue_label_event_overflow";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -381,7 +385,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
-}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
+}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence; promotionOverflow?: boolean }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
     .map((label) => label.trim().toLowerCase())
@@ -394,7 +398,10 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const { items: events, truncated, overflow } = unpackBoundedGithubList(
+      await input.github.listIssueLabelEvents(input.repo, input.issue.number)
+    );
+    if (truncated || overflow) return { issue: input.issue, promotionOverflow: true };
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -449,9 +456,10 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, truncated: timelineTruncated, overflow: timelineOverflow } = unpackBoundedGithubList(timelineResult);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -488,7 +496,7 @@ export async function buildIssueEvidenceContext(input: {
     linkedItems,
     truncation: {
       comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      timeline: timelineTruncated || timelineOverflow || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };
@@ -697,6 +705,7 @@ export async function collectIssueEnrichmentScan(input: {
     const issueItems = planRepoIssueScan({
       repo,
       issues,
+      scanReasons: issues.scanReasons,
       throttle: policy.throttle,
       suggestions: policy.suggestions,
       repoPolicy: policy.repoPolicy,
@@ -997,6 +1006,7 @@ export async function runIssueEnrichmentCycle(input: {
     };
     const shouldCountItem = (item: IssueEnrichmentScanItem) => {
       if (input.force === true) return true;
+      if (item.reason === "issue_label_event_overflow") return true;
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
@@ -1012,6 +1022,7 @@ export async function runIssueEnrichmentCycle(input: {
             listIssuesForEnrichment: async (repo, options) => {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
               const prepared: GitHubRelatedIssueOrPull[] = [];
+              const scanReasons: Record<number, IssueEnrichmentScanReason> = {};
               for (const issue of issues) {
                 const promotion = await evaluateIssuePromotion({
                   repo,
@@ -1020,8 +1031,9 @@ export async function runIssueEnrichmentCycle(input: {
                   github: input.github
                 });
                 prepared.push(promotion.issue);
+                if (promotion.promotionOverflow) scanReasons[issue.number] = "issue_label_event_overflow";
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
+                if (shouldCollectModelEvidence && !promotion.promotionOverflow) {
                   issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
                     repo,
                     issue: promotion.issue,
@@ -1034,7 +1046,7 @@ export async function runIssueEnrichmentCycle(input: {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
               }
-              return Object.assign(prepared, { scanCompletion: issues.scanCompletion });
+              return Object.assign(prepared, { scanCompletion: issues.scanCompletion, scanReasons });
             }
           },
           dryRun: input.dryRun,
@@ -1091,7 +1103,18 @@ export async function runIssueEnrichmentCycle(input: {
         shouldBackfillIssueEnrichmentAnalysisInputHash(existing, issueUpdatedAt, item.action)
         ? plannedAnalysisInputHashForItem(item)
         : undefined;
-      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
+      const preservesOverflowCooldown = item.reason === "issue_label_event_overflow" &&
+        input.force !== true &&
+        existing?.status === "deferred" &&
+        existing.reason === item.reason &&
+        Boolean(existing.nextEligibleAt) &&
+        shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action);
+      const authoritativeDeferral = item.reason === "issue_label_event_overflow" && !preservesOverflowCooldown;
+      const effectiveOverflowNextEligibleAt = preservesOverflowCooldown ? existing?.nextEligibleAt : item.nextEligibleAt;
+      const effectiveItem = effectiveOverflowNextEligibleAt
+        ? { ...item, nextEligibleAt: effectiveOverflowNextEligibleAt }
+        : item;
+      if (!authoritativeDeferral && !preservesOverflowCooldown && input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
         const refreshedAnalysisInputHash = existing.analysisInputHash ?? analysisInputHash;
         if (!input.dryRun && (
           existing.issueUpdatedAt !== issueUpdatedAt ||
@@ -1112,11 +1135,11 @@ export async function runIssueEnrichmentCycle(input: {
           });
         }
         summary.alreadyProcessed += 1;
-        items.push({ ...item, skippedExisting: true, recordStatus: existing.status });
+        items.push({ ...effectiveItem, skippedExisting: true, recordStatus: existing.status });
         continue;
       }
       if (input.dryRun) {
-        items.push({ ...item });
+        items.push({ ...effectiveItem });
         continue;
       }
 
@@ -1141,11 +1164,11 @@ export async function runIssueEnrichmentCycle(input: {
           issueUpdatedAt,
           status: "deferred",
           reason: item.reason,
-          nextEligibleAt: item.nextEligibleAt,
+          nextEligibleAt: effectiveItem.nextEligibleAt,
           now: new Date(checkedAt)
         });
         summary.deferredRecorded += 1;
-        items.push({ ...item, recordStatus: "deferred" });
+        items.push({ ...effectiveItem, recordStatus: "deferred" });
         continue;
       }
 
@@ -1378,6 +1401,7 @@ function resolveIssueSuggestionAllowlist(globalAllowlist: string[], repoOverride
 function planRepoIssueScan(input: {
   repo: string;
   issues: GitHubRelatedIssueOrPull[];
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
@@ -1397,8 +1421,8 @@ function planRepoIssueScan(input: {
     ...input.renderPolicy
   }));
   const eligible = planned.filter((output) => !output.skipped);
-  const countableEligible = input.shouldCountItem
-    ? eligible.filter((output) => input.shouldCountItem!(
+  const countableEligible = eligible.filter((output) => !input.scanReasons?.[output.issueNumber]).filter((output) => input.shouldCountItem
+    ? input.shouldCountItem!(
         issueScanItem(
           input.repo,
           output.issueNumber,
@@ -1407,13 +1431,17 @@ function planRepoIssueScan(input: {
           "eligible",
           output.url
         )
-      ))
-    : eligible;
+      )
+    : true);
   const burstExceeded = countableEligible.length > input.throttle.maxIssuesPerBurst;
   let enriched = 0;
   let comments = 0;
 
   return planned.map((output) => {
+    const scanReason = input.scanReasons?.[output.issueNumber];
+    if (scanReason) {
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", scanReason, output.url, nextEligibleAt(input));
+    }
     if (output.skipped) {
       return {
         repo: input.repo,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -14,6 +14,7 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
 import type { IssueAnalysis } from "../src/issue-analysis.js";
 import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
@@ -82,6 +83,68 @@ const pull: PullRequestSummary = {
 };
 
 describe("sticky enrichment comments", () => {
+  it("keeps overflow deadlines truthful across first-run, dry/live reruns, expiry, and recovery", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-label-overflow-v3-"));
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = loadConfig();
+    config.issueEnrichment = { ...config.issueEnrichment!, enabled: true, postIssueComment: true, allowlist: ["owner/repo"], maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, maxIssuesPerBurst: 1, processExistingOpenIssuesOnActivation: true, repos: { "owner/repo": { maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 1, lookbackMs: 60_000, promotionMaintainers: [{ login: "trusted", validFrom: "2026-01-01T00:00:00Z" }] } } };
+    const overflowIssue: GitHubRelatedIssueOrPull = { number: 738, title: "Overflow", state: "open", updated_at: "2026-08-24T00:00:00.000Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }], body: "fixture" };
+    const sibling: GitHubRelatedIssueOrPull = { number: 739, title: "Sibling", state: "open", updated_at: overflowIssue.updated_at, body: "fixture" };
+    const overflowEvents = Object.assign(Array.from({ length: 500 }, () => ({ event: "labeled" })), { items: [], rawCount: 500, truncated: true, overflow: true }) as BoundedGithubList<{ event?: string }>;
+    const resolvedEvents = [{ event: "labeled", created_at: "2026-08-24T00:00:00.000Z", actor: { login: "trusted" }, label: { name: "active-continuation" } }];
+    let resolved = false;
+    let posts = 0;
+    state.recordIssueEnrichmentRepoWatermark({ repo: "owner/repo", activatedAt: "2026-08-24T00:00:00.000Z", lastCheckedAt: "2026-08-24T00:00:00.000Z", now: new Date("2026-08-24T00:00:00.000Z") });
+    const github = {
+      listIssuesForEnrichment: async () => [overflowIssue, sibling],
+      listIssueLabelEvents: async (_repo: string, issueNumber: number) => issueNumber === 738 ? (resolved ? resolvedEvents : overflowEvents) : [],
+      getCollaboratorPermission: async () => "maintain" as const,
+      canPostAsApp: () => true,
+      upsertIssueComment: async () => ({ action: "created" as const, id: ++posts, html_url: "https://github.test/comment" })
+    };
+    const run = (dryRun: boolean, checkedAt: string) => runIssueEnrichmentCycle({ config, state, github, dryRun, includeExisting: true, checkedAt });
+    try {
+      const first = await run(false, "2026-08-24T00:00:30.000Z");
+      expect(first.summary).toMatchObject({ eligible: 1, deferred: 1, deferredRecorded: 1, posted: 1, failed: 0 });
+      expect(first.items.find((item) => item.issueNumber === 738)).toMatchObject({ action: "deferred", nextEligibleAt: "2026-08-24T00:01:30.000Z", recordStatus: "deferred" });
+      expect(posts).toBe(1);
+      expect(state.getIssueEnrichmentRepoWatermark("owner/repo")).toMatchObject({ lastCheckedAt: "2026-08-24T00:00:00.000Z" });
+      state.recordIssueEnrichment({ repo: "owner/repo", issueNumber: 738, issueUpdatedAt: overflowIssue.updated_at!, status: "posted", now: new Date("2026-08-24T00:00:30.000Z") });
+      const sameTimestamp = await run(false, "2026-08-24T00:00:30.000Z");
+      const dryBeforeExpiry = await run(true, "2026-08-24T00:01:00.000Z");
+      expect(sameTimestamp.items.find((item) => item.issueNumber === 738)).toMatchObject({ nextEligibleAt: "2026-08-24T00:01:30.000Z", recordStatus: "deferred" });
+      expect(dryBeforeExpiry.items.find((item) => item.issueNumber === 738)).toMatchObject({ nextEligibleAt: "2026-08-24T00:01:30.000Z" });
+      expect(state.getIssueEnrichmentRecord("owner/repo", 738)).toMatchObject({ status: "deferred", nextEligibleAt: "2026-08-24T00:01:30.000Z" });
+      const exactExpiry = await run(false, "2026-08-24T00:01:30.000Z");
+      expect(exactExpiry.items.find((item) => item.issueNumber === 738)).toMatchObject({ nextEligibleAt: "2026-08-24T00:02:30.000Z" });
+      resolved = true;
+      const recovered = await run(false, "2026-08-24T00:02:31.000Z");
+      expect(recovered.items.find((item) => item.issueNumber === 738)).toMatchObject({ action: "would_comment", recordStatus: "posted" });
+      expect(state.getIssueEnrichmentRecord("owner/repo", 738)).toMatchObject({ status: "posted" });
+      expect(state.getIssueEnrichmentRepoWatermark("owner/repo")).toMatchObject({ lastCheckedAt: "2026-08-24T00:02:31.000Z" });
+      expect(posts).toBe(2);
+    } finally { state.close(); rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it("excludes overflow from burst accounting while preserving the global comment cap", async () => {
+    const config = loadConfig();
+    config.issueEnrichment = { ...config.issueEnrichment!, enabled: true, postIssueComment: true, allowlist: ["owner/repo"], maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, maxIssuesPerBurst: 2, globalMaxCommentsPerCycle: 1 };
+    const scan = await collectIssueEnrichmentScan({
+      config, dryRun: true, includeExisting: true, checkedAt: "2026-08-24T00:00:00.000Z",
+      reader: { listIssuesForEnrichment: async () => Object.assign([
+        { number: 738, title: "Overflow", state: "open", body: "fixture" },
+        { number: 739, title: "Sibling one", state: "open", body: "fixture" },
+        { number: 740, title: "Sibling two", state: "open", body: "fixture" }
+      ], { scanReasons: { 738: "issue_label_event_overflow" as const } }) }
+    });
+    expect(scan.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ issueNumber: 738, action: "deferred", reason: "issue_label_event_overflow" }),
+      expect.objectContaining({ issueNumber: 739, action: "would_comment", reason: "eligible" }),
+      expect.objectContaining({ issueNumber: 740, action: "deferred", reason: "global_max_comments_per_cycle" })
+    ]));
+    expect(scan.summary).toMatchObject({ eligible: 2, wouldComment: 1, deferred: 2 });
+  });
+
   it("blocks direct issue-enrichment cycles before reading state or GitHub without admission", async () => {
     await expect(runIssueEnrichmentCycleImpl({
       config: {},

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("bounded label-event pagination", () => {
+  it("terminates on a short page and caps a permanently full stream at five pages", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      const pages: number[] = [];
+      globalThis.fetch = vi.fn(async (url) => {
+        const page = Number(new URL(String(url)).searchParams.get("page"));
+        pages.push(page);
+        return jsonResponse(page === 2 ? [{ event: "labeled" }] : Array.from({ length: 100 }, () => ({ event: "labeled" })));
+      }) as typeof fetch;
+      const complete = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+      expect(pages).toEqual([1, 2]);
+      expect(complete).toHaveLength(101);
+      expect(complete.truncated).toBe(false);
+      expect(complete.overflow).toBe(false);
+
+      pages.length = 0;
+      globalThis.fetch = vi.fn(async (url) => {
+        pages.push(Number(new URL(String(url)).searchParams.get("page")));
+        return jsonResponse(Array.from({ length: 100 }, () => ({ event: "labeled" })));
+      }) as typeof fetch;
+      const overflow = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 738);
+      expect(pages).toEqual([1, 2, 3, 4, 5]);
+      expect(overflow).toHaveLength(500);
+      expect(overflow.rawCount).toBe(500);
+      expect(overflow.truncated).toBe(true);
+      expect(overflow.overflow).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Related: #738

Claim class: pr_ready for source and focused validation only.

## What changed

- Bound GitHub issue label-event reads to five 100-row pages with truthful short-page/full-page metadata.
- Consume overflow before promotion authorization, label removal, model evidence, scan summaries, burst/global caps, and watermark advancement.
- Centralize one effective overflow retry deadline before dry/live branches so returned items and durable deferred rows agree.
- Preserve ordinary sibling progress, no-duplicate posting, and recovery after exact expiry.

## Validation

- PATH=/opt/homebrew/bin:$PATH npm test -- --run tests/github.test.ts tests/enrichment.test.ts (73 passed)
- PATH=/opt/homebrew/bin:$PATH npm test -- --run tests/github.test.ts tests/issue-comment-pagination.test.ts tests/enrichment.test.ts (74 passed)
- PATH=/opt/homebrew/bin:$PATH npm run build (passed)
- git diff --check (passed)

Full-project tsc --noEmit remains noisy with unrelated pre-existing test/declaration errors; source build typecheck passed.

## Proof boundary

This PR proves bounded source behavior and deterministic mocked fixtures only. It does not prove merge, canonical remote CI, installed worker adoption, live GitHub enrichment, release, runtime safety, or customer readiness. No live worker/config/database/lease/queue/Keychain/customer state was changed.