### PR TITLE
fix: report truthful issue-enrichment lane receipts

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -46,7 +46,7 @@ export interface IssueEnrichmentLaneCounts {
   failed: number;
 }
 
-export type IssueEnrichmentLaneCode = "completed" | "no_candidates" | "result_not_ok" | "cycle_failed";
+export type IssueEnrichmentLaneCode = "completed" | "no_candidates" | "result_not_ok" | "cycle_failed" | "malformed_summary";
 
 export interface IssueEnrichmentLaneReceipt {
   ok: boolean;
@@ -66,17 +66,29 @@ function boundedLaneCount(value: unknown): number {
   return Math.min(1_000_000, Math.max(0, number));
 }
 
+function hasValidIssueEnrichmentLaneSummary(summary: unknown): summary is Record<string, unknown> {
+  if (!summary || typeof summary !== "object" || Array.isArray(summary)) return false;
+  return ISSUE_ENRICHMENT_LANE_COUNT_KEYS.every((key) => {
+    const value = (summary as Record<string, unknown>)[key];
+    return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+  });
+}
+
 export function buildIssueEnrichmentLaneReceipt(result?: IssueEnrichmentCycleResult): IssueEnrichmentLaneReceipt {
+  const summary: unknown = result?.summary;
   const counts = {} as IssueEnrichmentLaneCounts;
-  for (const key of ISSUE_ENRICHMENT_LANE_COUNT_KEYS) counts[key] = boundedLaneCount(result?.summary[key]);
-  const ok = result?.ok === true && counts.readFailures === 0 && counts.failed === 0;
+  for (const key of ISSUE_ENRICHMENT_LANE_COUNT_KEYS) counts[key] = boundedLaneCount(
+    hasValidIssueEnrichmentLaneSummary(summary) ? summary[key] : undefined
+  );
+  const malformed = result !== undefined && !hasValidIssueEnrichmentLaneSummary(summary);
+  const ok = !malformed && result?.ok === true && counts.readFailures === 0 && counts.failed === 0;
   const noCandidates = ok && counts.eligible === 0 && counts.wouldEnrich === 0 && counts.wouldComment === 0 &&
     counts.posted === 0 && counts.dryRunRecorded === 0 && counts.skippedRecorded === 0 &&
     counts.deferredRecorded === 0 && counts.alreadyProcessed === 0;
   return {
     ok,
     stage: "issue_enrichment",
-    code: result === undefined ? "cycle_failed" : !ok ? "result_not_ok" : noCandidates ? "no_candidates" : "completed",
+    code: result === undefined ? "cycle_failed" : malformed ? "malformed_summary" : !ok ? "result_not_ok" : noCandidates ? "no_candidates" : "completed",
     counts
   };
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,6 +25,62 @@ export type DaemonCycleResult =
   | { ok: true; result: RunOnceResult }
   | { ok: false; failureKind: "admission_denied" | "runtime_failure"; error: string };
 
+export interface IssueEnrichmentLaneCounts {
+  reposScanned: number;
+  reposSkipped: number;
+  readFailures: number;
+  issuesSeen: number;
+  eligible: number;
+  skipped: number;
+  wouldEnrich: number;
+  wouldComment: number;
+  deferred: number;
+  baselinedRepos: number;
+  truncatedRepos: number;
+  workerSkipped: number;
+  posted: number;
+  dryRunRecorded: number;
+  skippedRecorded: number;
+  deferredRecorded: number;
+  alreadyProcessed: number;
+  failed: number;
+}
+
+export type IssueEnrichmentLaneCode = "completed" | "no_candidates" | "result_not_ok" | "cycle_failed";
+
+export interface IssueEnrichmentLaneReceipt {
+  ok: boolean;
+  stage: "issue_enrichment";
+  code: IssueEnrichmentLaneCode;
+  counts: IssueEnrichmentLaneCounts;
+}
+
+const ISSUE_ENRICHMENT_LANE_COUNT_KEYS = [
+  "reposScanned", "reposSkipped", "readFailures", "issuesSeen", "eligible", "skipped",
+  "wouldEnrich", "wouldComment", "deferred", "baselinedRepos", "truncatedRepos", "workerSkipped",
+  "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
+] as const satisfies ReadonlyArray<keyof IssueEnrichmentLaneCounts>;
+
+function boundedLaneCount(value: unknown): number {
+  const number = typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : 0;
+  return Math.min(1_000_000, Math.max(0, number));
+}
+
+export function buildIssueEnrichmentLaneReceipt(result?: IssueEnrichmentCycleResult): IssueEnrichmentLaneReceipt {
+  const counts = {} as IssueEnrichmentLaneCounts;
+  for (const key of ISSUE_ENRICHMENT_LANE_COUNT_KEYS) counts[key] = boundedLaneCount(result?.summary[key]);
+  const ok = result?.ok === true && counts.readFailures === 0 && counts.failed === 0;
+  const noCandidates = ok && counts.eligible === 0 && counts.wouldEnrich === 0 && counts.wouldComment === 0 &&
+    counts.posted === 0 && counts.dryRunRecorded === 0 && counts.skippedRecorded === 0 &&
+    counts.deferredRecorded === 0 && counts.alreadyProcessed === 0;
+  return {
+    ok,
+    stage: "issue_enrichment",
+    code: result === undefined ? "cycle_failed" : !ok ? "result_not_ok" : noCandidates ? "no_candidates" : "completed",
+    counts
+  };
+}
+
 export function shouldExitDaemonAfterFailedCycle(result: DaemonCycleResult, runOnce: boolean): boolean {
   return !result.ok && (runOnce || result.failureKind === "admission_denied");
 }
@@ -284,21 +340,23 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
     });
+    const receipt = buildIssueEnrichmentLaneReceipt(issueEnrichment);
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
-      phase: "complete",
+      phase: receipt.ok ? "complete" : "result",
       cycle: input.input.cycle,
       dryRun: input.input.dryRun,
-      result: issueEnrichment
+      receipt
     }));
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const receipt = buildIssueEnrichmentLaneReceipt();
     input.stderr(formatDaemonLog({
       event: "daemon_issue_enrichment_failed",
       level: "error",
+      phase: "failed",
       cycle: input.input.cycle,
       dryRun: input.input.dryRun,
-      error: message
+      receipt
     }));
   }
 }

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildIssueEnrichmentLaneReceipt,
   cleanupReviewWorktreesFromConfig,
   runDaemonCycle as runDaemonCycleImpl,
   shouldExitDaemonAfterFailedCycle,
@@ -517,8 +518,11 @@ describe("daemon cycle resilience", () => {
         event: "daemon_issue_enrichment",
         phase: "complete",
         cycle: 9,
-        result: expect.objectContaining({
-          summary: expect.objectContaining({
+        receipt: expect.objectContaining({
+          ok: true,
+          stage: "issue_enrichment",
+          code: "completed",
+          counts: expect.objectContaining({
             reposScanned: 1,
             dryRunRecorded: 1
           })
@@ -643,10 +647,102 @@ describe("daemon cycle resilience", () => {
     expect(failure).toMatchObject({
       event: "daemon_issue_enrichment_failed",
       level: "error",
-      cycle: 10
+      cycle: 10,
+      receipt: {
+        ok: false,
+        stage: "issue_enrichment",
+        code: "cycle_failed",
+        counts: expect.objectContaining({ failed: 0 })
+      }
     });
-    expect(failure.error).toContain("issue enrichment failed");
-    expect(failure.error).not.toContain("ghp_fake_token");
+    expect(failure.error).toBeUndefined();
+    expect(JSON.stringify(failure)).not.toContain("issue enrichment failed");
+    expect(JSON.stringify(failure)).not.toContain("ghp_fake_token");
+  });
+
+  it("reports an explicit non-success result without making the issue lane look healthy", async () => {
+    const stdout: string[] = [];
+    const result = await runDaemonCycle({
+      cycle: 13,
+      dryRun: false,
+      pilotRepos: [],
+      monitoredRepos: [],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(),
+      issueEnrichmentCycleImpl: async () => ({
+        ...successfulIssueEnrichmentCycleResult(),
+        ok: false,
+        summary: {
+          ...successfulIssueEnrichmentCycleResult().summary,
+          readFailures: 1,
+          failed: 1
+        },
+        items: [{
+          repo: "owner/repo",
+          issueNumber: 99,
+          state: "open",
+          action: "would_comment",
+          reason: "eligible",
+          error: "customer body and ghp_fake_token must never be logged",
+          recordStatus: "failed"
+        }]
+      }),
+      recordHeartbeatImpl: () => undefined,
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+
+    expect(result.ok).toBe(true);
+    const enrichmentLog = stdout
+      .map((line) => JSON.parse(line))
+      .find((entry) => entry.event === "daemon_issue_enrichment");
+    expect(enrichmentLog).toMatchObject({
+      phase: "result",
+      receipt: {
+        ok: false,
+        stage: "issue_enrichment",
+        code: "result_not_ok",
+        counts: { readFailures: 1, failed: 1 }
+      }
+    });
+    expect(JSON.stringify(enrichmentLog)).not.toContain("customer body");
+    expect(JSON.stringify(enrichmentLog)).not.toContain("ghp_fake_token");
+  });
+
+  it("marks a successful zero-candidate issue cycle explicitly", () => {
+    const result = buildIssueEnrichmentLaneReceipt({
+      ...successfulIssueEnrichmentCycleResult(),
+      summary: {
+        ...successfulIssueEnrichmentCycleResult().summary,
+        issuesSeen: 0,
+        eligible: 0,
+        wouldEnrich: 0,
+        wouldComment: 0,
+        skipped: 0,
+        deferred: 0,
+        posted: 0,
+        dryRunRecorded: 0,
+        skippedRecorded: 0,
+        deferredRecorded: 0,
+        alreadyProcessed: 0,
+        failed: 0
+      }
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      stage: "issue_enrichment",
+      code: "no_candidates",
+      counts: expect.objectContaining({
+        issuesSeen: 0,
+        eligible: 0,
+        posted: 0,
+        failed: 0
+      })
+    });
   });
 });
 

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -744,6 +744,24 @@ describe("daemon cycle resilience", () => {
       })
     });
   });
+
+  it("rejects malformed issue summary counts before success classification", () => {
+    const base = successfulIssueEnrichmentCycleResult();
+    const malformed = [
+      { ...base, summary: { ...base.summary, failed: -1 } },
+      { ...base, summary: { ...base.summary, failed: Number.NaN } },
+      { ...base, summary: { ...base.summary, failed: "1" } },
+      { ...base, summary: Object.fromEntries(Object.entries(base.summary).filter(([key]) => key !== "failed")) }
+    ] as unknown as IssueEnrichmentCycleResult[];
+
+    for (const result of malformed) {
+      expect(buildIssueEnrichmentLaneReceipt(result)).toMatchObject({
+        ok: false,
+        stage: "issue_enrichment",
+        code: "malformed_summary"
+      });
+    }
+  });
 });
 
 function successfulRunOnceResult() {


### PR DESCRIPTION
Closes #972

## Summary
- add a typed, bounded issue-enrichment lane receipt with stable stage/code/count fields
- emit the same sanitized receipt for thrown and explicit non-success outcomes without raw exception/result payloads
- distinguish successful no-candidate cycles with `ok: true` and `code: no_candidates` while preserving daemon/review liveness

## Proof
- base: `f56b186e09bde875ba85ee08c95cd47c92bf7bb7`
- focused: `PATH=/opt/homebrew/bin:$PATH npm test -- tests/daemon-loop.test.ts`
- affected: `PATH=/opt/homebrew/bin:$PATH npm test -- tests/daemon-loop.test.ts tests/daemon-log.test.ts tests/operator-cli.test.ts`
- build: `PATH=/opt/homebrew/bin:$PATH npm run build`
- diff: 163 changed lines; `git diff --check` clean

This source/fixture proof does not claim live worker, runtime soak, release, or customer readiness.