### PR TITLE
fix(issue-enrichment): bound newest event history tail

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -21,6 +21,10 @@ const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
+export interface GitHubIssueLabelEvent { id?: number | string; event?: string; created_at?: string; actor?: { login?: string | null } | null; label?: { name?: string | null } | null; }
+
+export type BoundedIssueLabelEventRead = BoundedGithubList<GitHubIssueLabelEvent> & { pagesRead: number; uniqueCount: number; duplicateCount: number; lastPage?: number; terminal: "short_page" | "bounded_tail" | "event_history_unbounded" };
+
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
 export type BoundedGithubList<T> = T[] & {
   items: T[];
@@ -434,26 +438,32 @@ export class GitHubApi {
     });
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>> {
-    const events: Array<{
-      event?: string;
-      created_at?: string;
-      actor?: { login?: string | null } | null;
-      label?: { name?: string | null } | null;
-    }> = [];
-    for (let page = 1; ; page += 1) {
-      const chunk = await this.request<typeof events>(
-        `/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`,
-        { token: await this.getReadToken(repo) }
-      );
-      events.push(...chunk);
-      if (chunk.length < 100) return events;
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedIssueLabelEventRead> {
+    const pathForPage = (page: number) => `/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`;
+    let link: string | null = null;
+    const readPage = async (page: number) => this.request<GitHubIssueLabelEvent[]>(pathForPage(page), { token: await this.getReadToken(repo), onResponse: (response) => { if (page === 1) link = response.headers.get("link"); } });
+    const firstPage = await readPage(1);
+    const events: GitHubIssueLabelEvent[] = [];
+    const seen = new Set<string>();
+    let rawCount = 0;
+    let duplicateCount = 0;
+    const append = (chunk: GitHubIssueLabelEvent[]) => { rawCount += chunk.length; for (const event of chunk) { const identity = issueLabelEventIdentity(event); if (identity && seen.has(identity)) { duplicateCount += 1; continue; } if (identity) seen.add(identity); events.push(event); } };
+    append(firstPage);
+    if (firstPage.length < 100) return boundedIssueLabelEventRead(events, { pagesRead: 1, rawCount, duplicateCount, terminal: "short_page" });
+
+    const lastPage = parseLastPageFromLink(link);
+    if (lastPage === undefined) return boundedIssueLabelEventRead(events, { pagesRead: 1, rawCount, duplicateCount, terminal: "event_history_unbounded" });
+
+    const startPage = Math.max(1, lastPage - 4);
+    let pagesRead = 1;
+    for (let page = startPage; page <= lastPage; page += 1) {
+      if (page === 1) continue;
+      const response = await readPage(page);
+      pagesRead += 1;
+      append(response);
+      if (response.length < 100 && page < lastPage) return boundedIssueLabelEventRead(events, { pagesRead, rawCount, duplicateCount, lastPage, terminal: "event_history_unbounded" });
     }
+    return boundedIssueLabelEventRead(events, { pagesRead, rawCount, duplicateCount, lastPage, terminal: "bounded_tail" });
   }
 
   async getCollaboratorPermission(
@@ -695,7 +705,7 @@ export class GitHubApi {
 
   private async request<T>(
     path: string,
-    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean } = {}
+    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean; onResponse?: (response: Response) => void } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
     const controller = new AbortController();
@@ -713,6 +723,7 @@ export class GitHubApi {
         },
         body: options.body === undefined ? undefined : JSON.stringify(options.body)
       });
+      options.onResponse?.(response);
       if (!response.ok) {
         const text = await response.text();
         throw new GitHubApiRequestError({
@@ -734,6 +745,18 @@ export class GitHubApi {
     }
   }
 }
+
+function boundedIssueLabelEventRead(items: GitHubIssueLabelEvent[], metadata: Pick<BoundedIssueLabelEventRead, "pagesRead" | "rawCount" | "duplicateCount" | "lastPage" | "terminal">): BoundedIssueLabelEventRead {
+  const result = items as BoundedIssueLabelEventRead;
+  result.items = items.slice(); result.rawCount = metadata.rawCount; result.pagesRead = metadata.pagesRead; result.uniqueCount = items.length; result.duplicateCount = metadata.duplicateCount;
+  if (metadata.lastPage !== undefined) result.lastPage = metadata.lastPage;
+  result.terminal = metadata.terminal; result.truncated = metadata.terminal === "event_history_unbounded"; result.overflow = result.truncated;
+  return result;
+}
+
+function issueLabelEventIdentity(event: GitHubIssueLabelEvent): string | undefined { return typeof event.id === "number" && Number.isSafeInteger(event.id) ? `number:${event.id}` : typeof event.id === "string" && event.id.trim() ? `string:${event.id}` : undefined; }
+
+function parseLastPageFromLink(link: string | null): number | undefined { const parts = link?.split(",") ?? []; const lastEntries = parts.filter((part) => /(?:^|;)\s*rel\s*=\s*["']last["']/.test(part)); if (lastEntries.length !== 1) return undefined; const target = /^\s*<([^>]+)>/.exec(lastEntries[0]!); if (!target) return undefined; try { const page = new URL(target[1]!).searchParams.get("page"); const last = Number(page); if (!page || !/^\d+$/.test(page) || !Number.isSafeInteger(last) || last < 1) return undefined; const nextEntries = parts.filter((part) => /(?:^|;)\s*rel\s*=\s*["']next["']/.test(part)); const nextTarget = nextEntries.length === 1 && /^\s*<([^>]+)>/.exec(nextEntries[0]!); const nextPage = nextTarget ? new URL(nextTarget[1]!).searchParams.get("page") : undefined; return nextEntries.length > 1 || (nextTarget && (!nextPage || !/^\d+$/.test(nextPage) || Number(nextPage) > last)) ? undefined : last; } catch { return undefined; } }
 
 function normalizePullRequestSummary(pull: PullRequestSummary): PullRequestSummary {
   return {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,7 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
-import { unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
+import { unpackBoundedGithubList, type BoundedGithubList, type BoundedIssueLabelEventRead, type GitHubIssueLabelEvent } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -231,6 +231,7 @@ export type IssueEnrichmentScanCompletion = "complete" | "page_limit_reached" | 
 
 export type IssueEnrichmentIssueList = GitHubRelatedIssueOrPull[] & {
   scanCompletion?: IssueEnrichmentScanCompletion;
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
 };
 
 export interface IssueEnrichmentScanResult {
@@ -286,12 +287,7 @@ type IssueEnrichmentComment = {
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GitHubIssueLabelEvent[] | BoundedGithubList<GitHubIssueLabelEvent> | BoundedIssueLabelEventRead>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -329,7 +325,8 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded"
+  | "event_history_unbounded";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -381,7 +378,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
-}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
+}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence; eventHistoryUnbounded?: boolean }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
     .map((label) => label.trim().toLowerCase())
@@ -394,7 +391,9 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const eventRead = unpackIssueLabelEvents(await input.github.listIssueLabelEvents(input.repo, input.issue.number));
+    if (eventRead.overflow) return { issue: input.issue, eventHistoryUnbounded: true };
+    const events = eventRead.items;
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -423,6 +422,12 @@ async function evaluateIssuePromotion(input: {
   }
 }
 
+function unpackIssueLabelEvents(result: GitHubIssueLabelEvent[] | BoundedGithubList<GitHubIssueLabelEvent> | BoundedIssueLabelEventRead): { items: GitHubIssueLabelEvent[]; overflow: boolean } {
+  const unpacked = unpackBoundedGithubList(result);
+  const terminal = (result as Partial<BoundedIssueLabelEventRead>).terminal;
+  return { items: unpacked.items, overflow: unpacked.overflow || terminal === "event_history_unbounded" };
+}
+
 function emptyIssueEvidenceContext(headSha: string): IssueAnalysisEvidenceContext {
   return {
     repository: { defaultBranch: "unknown", headSha },
@@ -439,6 +444,7 @@ export async function buildIssueEvidenceContext(input: {
   github: IssueEnrichmentCycleGithub;
   defaultBranch: string;
   headSha: string;
+  onEventHistoryUnbounded?: () => void;
 }): Promise<IssueAnalysisEvidenceContext> {
   const commentResult = input.github.listIssueCommentsForEnrichment
     ? await input.github.listIssueCommentsForEnrichment(input.repo, input.issue.number)
@@ -449,9 +455,11 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, overflow: timelineOverflow } = unpackIssueLabelEvents(timelineResult);
+  if (timelineOverflow) input.onEventHistoryUnbounded?.();
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -488,7 +496,7 @@ export async function buildIssueEvidenceContext(input: {
     linkedItems,
     truncation: {
       comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      timeline: timelineOverflow || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };
@@ -697,6 +705,7 @@ export async function collectIssueEnrichmentScan(input: {
     const issueItems = planRepoIssueScan({
       repo,
       issues,
+      scanReasons: issues.scanReasons,
       throttle: policy.throttle,
       suggestions: policy.suggestions,
       repoPolicy: policy.repoPolicy,
@@ -996,6 +1005,7 @@ export async function runIssueEnrichmentCycle(input: {
       return analysisInputHash;
     };
     const shouldCountItem = (item: IssueEnrichmentScanItem) => {
+      if (item.reason === "event_history_unbounded") return false;
       if (input.force === true) return true;
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
@@ -1012,6 +1022,7 @@ export async function runIssueEnrichmentCycle(input: {
             listIssuesForEnrichment: async (repo, options) => {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
               const prepared: GitHubRelatedIssueOrPull[] = [];
+              const scanReasons: Record<number, IssueEnrichmentScanReason> = {};
               for (const issue of issues) {
                 const promotion = await evaluateIssuePromotion({
                   repo,
@@ -1020,21 +1031,23 @@ export async function runIssueEnrichmentCycle(input: {
                   github: input.github
                 });
                 prepared.push(promotion.issue);
+                if (promotion.eventHistoryUnbounded) scanReasons[issue.number] = "event_history_unbounded";
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
+                if (shouldCollectModelEvidence && !promotion.eventHistoryUnbounded) {
                   issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
                     repo,
                     issue: promotion.issue,
                     github: input.github,
                     defaultBranch: defaultBranches.get(repo.toLowerCase()) ?? "unknown",
-                    headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40)
+                    headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40),
+                    onEventHistoryUnbounded: () => { scanReasons[issue.number] = "event_history_unbounded"; }
                   }));
                 }
                 if (promotion.evidence) {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
               }
-              return Object.assign(prepared, { scanCompletion: issues.scanCompletion });
+              return Object.assign(prepared, { scanCompletion: issues.scanCompletion, scanReasons });
             }
           },
           dryRun: input.dryRun,
@@ -1091,7 +1104,8 @@ export async function runIssueEnrichmentCycle(input: {
         shouldBackfillIssueEnrichmentAnalysisInputHash(existing, issueUpdatedAt, item.action)
         ? plannedAnalysisInputHashForItem(item)
         : undefined;
-      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
+      const terminalAlreadyRecorded = item.reason === "event_history_unbounded" && input.force !== true && existing?.status === "skipped" && existing.reason === item.reason && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action);
+      if ((item.reason !== "event_history_unbounded" || terminalAlreadyRecorded) && input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
         const refreshedAnalysisInputHash = existing.analysisInputHash ?? analysisInputHash;
         if (!input.dryRun && (
           existing.issueUpdatedAt !== issueUpdatedAt ||
@@ -1378,6 +1392,7 @@ function resolveIssueSuggestionAllowlist(globalAllowlist: string[], repoOverride
 function planRepoIssueScan(input: {
   repo: string;
   issues: GitHubRelatedIssueOrPull[];
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
@@ -1397,8 +1412,8 @@ function planRepoIssueScan(input: {
     ...input.renderPolicy
   }));
   const eligible = planned.filter((output) => !output.skipped);
-  const countableEligible = input.shouldCountItem
-    ? eligible.filter((output) => input.shouldCountItem!(
+  const countableEligible = eligible.filter((output) => !input.scanReasons?.[output.issueNumber]).filter((output) => input.shouldCountItem
+    ? input.shouldCountItem!(
         issueScanItem(
           input.repo,
           output.issueNumber,
@@ -1407,13 +1422,17 @@ function planRepoIssueScan(input: {
           "eligible",
           output.url
         )
-      ))
-    : eligible;
+      )
+    : true);
   const burstExceeded = countableEligible.length > input.throttle.maxIssuesPerBurst;
   let enriched = 0;
   let comments = 0;
 
   return planned.map((output) => {
+    const scanReason = input.scanReasons?.[output.issueNumber];
+    if (scanReason) {
+      return issueScanItem(input.repo, output.issueNumber, output.state, "skipped", scanReason, output.url);
+    }
     if (output.skipped) {
       return {
         repo: input.repo,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -14,6 +14,7 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import type { BoundedGithubList } from "../src/github.js";
 import type { IssueAnalysis } from "../src/issue-analysis.js";
 import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
@@ -82,6 +83,46 @@ const pull: PullRequestSummary = {
 };
 
 describe("sticky enrichment comments", () => {
+  it("records terminal event-history overflow without cooldown, admission, posting, or watermark starvation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-event-history-terminal-"));
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = loadConfig();
+    config.issueEnrichment = { ...config.issueEnrichment!, enabled: true, postIssueComment: true, allowlist: ["owner/repo"], maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, maxIssuesPerBurst: 3, processExistingOpenIssuesOnActivation: true, repos: { "owner/repo": { maxIssuesPerCycle: 3, maxCommentsPerCycle: 3, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 3, lookbackMs: 60_000, promotionMaintainers: [{ login: "trusted", validFrom: "2026-01-01T00:00:00Z" }] } } };
+    const overflowEvents = Object.assign([{ event: "labeled" }], { items: [], rawCount: 100, truncated: true, overflow: true }) as BoundedGithubList<{ event?: string }>;
+    const overflowIssue: GitHubRelatedIssueOrPull = { number: 970, title: "Unbounded history", state: "open", updated_at: "2026-08-24T00:00:00.000Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }], body: "fixture" };
+    const sibling: GitHubRelatedIssueOrPull = { number: 971, title: "Sibling", state: "open", updated_at: overflowIssue.updated_at, body: "fixture" };
+    let posts = 0;
+    state.recordIssueEnrichmentRepoWatermark({ repo: "owner/repo", activatedAt: "2026-08-24T00:00:00.000Z", lastCheckedAt: "2026-08-24T00:00:00.000Z", now: new Date("2026-08-24T00:00:00.000Z") });
+    const github = {
+      listIssuesForEnrichment: async () => [overflowIssue, sibling],
+      listIssueLabelEvents: async () => overflowEvents,
+      getCollaboratorPermission: async () => "maintain" as const,
+      canPostAsApp: () => true,
+      upsertIssueComment: async () => ({ action: "created" as const, id: ++posts, html_url: "https://github.test/comment" })
+    };
+    try {
+      const result = await runIssueEnrichmentCycle({
+        config,
+        state,
+        github,
+        dryRun: false,
+        includeExisting: true,
+        checkedAt: "2026-08-24T00:01:00.000Z"
+      });
+
+      expect(result.items.find((item) => item.issueNumber === 970)).toMatchObject({ action: "skipped", reason: "event_history_unbounded", recordStatus: "skipped" });
+      expect(result.items.find((item) => item.issueNumber === 970)?.nextEligibleAt).toBeUndefined();
+      expect(result.items.find((item) => item.issueNumber === 971)).toMatchObject({ action: "would_comment", recordStatus: "posted" });
+      expect(result.summary).toMatchObject({ skippedRecorded: 1, posted: 1, failed: 0, deferred: 0 });
+      expect(posts).toBe(1);
+      expect(state.getIssueEnrichmentRecord("owner/repo", 970)).toMatchObject({ status: "skipped", reason: "event_history_unbounded" });
+      expect(state.getIssueEnrichmentRepoWatermark("owner/repo")).toMatchObject({ lastCheckedAt: "2026-08-24T00:01:00.000Z" });
+    } finally {
+      state.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("blocks direct issue-enrichment cycles before reading state or GitHub without admission", async () => {
     await expect(runIssueEnrichmentCycleImpl({
       config: {},

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+const json = (body: unknown, link?: string) => new Response(JSON.stringify(body), { status: 200, headers: { ...(link ? { link } : {}) } });
+const page = (start: number, count = 100) => Array.from({ length: count }, (_, i) => ({ id: start + i, event: "labeled" }));
+const run = async (handler: (n: number) => Response) => {
+  const old = globalThis.fetch; const calls: number[] = [];
+  globalThis.fetch = vi.fn(async (url) => { const n = Number(new URL(String(url)).searchParams.get("page")); calls.push(n); return handler(n); }) as typeof fetch;
+  try { return { result: await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970), calls }; }
+  finally { globalThis.fetch = old; }
+};
+
+describe("bounded newest issue-event pagination", () => {
+  it("keeps a short history bounded", async () => {
+    const { result, calls } = await run(() => json(page(1, 2)));
+    expect(calls).toEqual([1]); expect(result.terminal).toBe("short_page"); expect(result.pagesRead).toBe(1);
+  });
+  it("uses a five-page tail, skips page-one overlap, and deduplicates IDs", async () => {
+    const { result, calls } = await run((n) => {
+      const body = n === 1 ? page(1) : n === 4 ? [{ id: 401, event: "labeled" }, ...page(402, 99)] : n === 5 ? [{ id: 401, event: "labeled" }, ...page(502, 99)] : page(n * 100 + 1, n === 8 ? 50 : 100);
+      return json(body, '<https://api.github.com/events?page=8>; rel="last"');
+    });
+    expect(calls).toEqual([1, 4, 5, 6, 7, 8]); expect(result.lastPage).toBe(8);
+    expect(result.pagesRead).toBe(6); expect(result.uniqueCount).toBe(549); expect(result.duplicateCount).toBe(1); expect(result.terminal).toBe("bounded_tail");
+  });
+  it("reads exactly five pages when the last page is five", async () => {
+    const { result, calls } = await run((n) => json(page((n - 1) * 100 + 1), '<https://api.github.com/events?page=5>; rel="last"'));
+    expect(calls).toEqual([1, 2, 3, 4, 5]); expect(result).toHaveLength(500); expect(result.lastPage).toBe(5);
+  });
+  it.each([undefined, '<https://api.github.com/events?page=nope>; rel="last"', '<https://api.github.com/events?page=0>; rel="last"', '<https://api.github.com/events?page=3>; rel="next", <https://api.github.com/events?page=2>; rel="last"'])
+    ("makes untrusted last-page metadata terminal", async (link) => {
+      const { result, calls } = await run(() => json(page(1), link));
+      expect(calls).toEqual([1]); expect(result.terminal).toBe("event_history_unbounded"); expect(result.overflow).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #970

## Summary
- preserve and validate GitHub Link `rel="last"` metadata for issue events
- inspect the bounded newest five-page tail with page-one deduplication
- classify untrusted event history as terminal `event_history_unbounded` audit skips that do not consume caps, post, or hold repository watermarks

## Deterministic proof
- `PATH=/opt/homebrew/bin:$PATH npm test -- --run tests/github.test.ts tests/enrichment.test.ts` (78 passed)
- `npm run build` (pass)
- `git diff --check` (pass)
- base: `f56b186e09bde875ba85ee08c95cd47c92bf7bb7`
- candidate: `5967510d95d8483241a1a45669a8b4db8864c35f`
- non-generated diff: 198 lines

GitNexus was unavailable for this worktree (`Repository not indexed`); direct bounded source inspection and exact-head checks were used.