### PR TITLE
feat(desktop): bind new-App verification to sealed worker

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
@@ -19,6 +19,18 @@ enum FoundationTrustedBundledWorker {
         )
     }
 
+    static func nativeVerificationCapability(
+        bundle: Bundle = .main,
+        productionBoundary: DesktopProductionBoundary
+    ) -> DesktopNativeVerificationCapability {
+        DesktopNativeVerificationCapability.resolve(
+            productionBoundary: productionBoundary,
+            appBundleURL: bundle.bundleURL,
+            appSignatureIsValid: validateAppSignature,
+            sealedFileIsValid: isSafeSealedWorker
+        )
+    }
+
     static func runningProcessIsTrusted(
         _ processIdentifier: Int32,
         bundle: Bundle = .main

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -38,8 +38,12 @@ enum NeonDiffDesktopCompositionRoot {
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
         let localBotSnapshot =
             LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
+        let nativeVerificationCapability =
+            FoundationTrustedBundledWorker.nativeVerificationCapability(
+                productionBoundary: productionBoundary
+            )
         let trustedBundledWorker =
-            FoundationTrustedBundledWorker.executionContext()
+            nativeVerificationCapability.trustedBundledWorker
         let localBotConfigurations = localBotSnapshot.configurations
         let localBotExecutionContexts =
             localBotSnapshot.executionContexts
@@ -48,12 +52,8 @@ enum NeonDiffDesktopCompositionRoot {
             @Sendable () -> [DesktopLocalBotExecutionContext] = {
                 LaunchAgentLocalBotConfigurationDiscovery
                     .discoverExecutionContexts()
-                    + (
-                        FoundationTrustedBundledWorker
-                            .executionContext()
-                            .map { [$0] }
-                        ?? []
-                    )
+                    + (nativeVerificationCapability.trustedBundledWorker
+                        .map { [$0] } ?? [])
             }
         let localBotDiscoveryProvider:
             @Sendable (String) -> DesktopLocalBotDiscoverySnapshot = {
@@ -65,12 +65,8 @@ enum NeonDiffDesktopCompositionRoot {
                     configurations: snapshot.configurations,
                     executionContexts:
                         snapshot.executionContexts
-                        + (
-                            FoundationTrustedBundledWorker
-                                .executionContext()
-                                .map { [$0] }
-                            ?? []
-                        )
+                        + (nativeVerificationCapability.trustedBundledWorker
+                            .map { [$0] } ?? [])
                 )
             }
         let keychainWorkerLaunchAgentManager:
@@ -111,6 +107,7 @@ enum NeonDiffDesktopCompositionRoot {
             githubBroker: githubBroker,
             accountLink: accountLink,
             productionBoundary: productionBoundary,
+            nativeVerificationCapability: nativeVerificationCapability,
             localWorkerUpdateGuideURL: DesktopReleaseRouting.localWorkerUpdateGuideURL(
                 shortVersion: Bundle.main.object(
                     forInfoDictionaryKey: "CFBundleShortVersionString"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -88,6 +88,68 @@ package struct DesktopProductionBoundary: Sendable {
     }
 }
 
+/// Bundle-derived capability for native new-App verification.
+/// Requires exact BYO markers and sealed-worker proof; existing local-bot
+/// verification remains separate.
+package struct DesktopNativeVerificationCapability: Sendable {
+    package let newAppNativeVerificationAvailable: Bool
+    package let trustedBundledWorker: DesktopLocalBotExecutionContext?
+
+    package static let unavailable = DesktopNativeVerificationCapability(
+        newAppNativeVerificationAvailable: false,
+        trustedBundledWorker: nil
+    )
+
+    private init(
+        newAppNativeVerificationAvailable: Bool,
+        trustedBundledWorker: DesktopLocalBotExecutionContext?
+    ) {
+        self.newAppNativeVerificationAvailable =
+            newAppNativeVerificationAvailable
+        self.trustedBundledWorker = trustedBundledWorker
+    }
+
+    /// Resolve from the produced bundle contract and platform proof callbacks.
+    /// Preferences, license state, and arbitrary contexts cannot grant it.
+    package static func resolve(
+        infoDictionary: [String: Any],
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> Self {
+        resolve(
+            productionBoundary: DesktopProductionBoundary.resolve(
+                infoDictionary: infoDictionary
+            ),
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: appSignatureIsValid,
+            sealedFileIsValid: sealedFileIsValid
+        )
+    }
+
+    package static func resolve(
+        productionBoundary: DesktopProductionBoundary,
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> Self {
+        guard productionBoundary.byoGitHubEnabled,
+              let trustedBundledWorker =
+                DesktopTrustedBundledWorkerContract.executionContext(
+                    appBundleURL: appBundleURL,
+                    appSignatureIsValid: appSignatureIsValid,
+                    sealedFileIsValid: sealedFileIsValid
+                )
+        else {
+            return .unavailable
+        }
+        return DesktopNativeVerificationCapability(
+            newAppNativeVerificationAvailable: true,
+            trustedBundledWorker: trustedBundledWorker
+        )
+    }
+}
+
 private let approvedManagedGitHubBrokerOrigin = URL(
     string: "https://neondiff-license.fly.dev"
 )!
@@ -134,6 +196,8 @@ package struct DesktopAppDependencies {
     package let githubBroker: (any GitHubBrokerConnecting)?
     package let accountLink: (any NeonDiffAccountLinkConnecting)?
     package let productionBoundary: DesktopProductionBoundary
+    package let nativeVerificationCapability:
+        DesktopNativeVerificationCapability
     package let localWorkerUpdateGuideURL: URL
     package let cliWorkingDirectory: URL?
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
@@ -143,6 +207,10 @@ package struct DesktopAppDependencies {
         (@Sendable (String) -> DesktopLocalBotDiscoverySnapshot)?
     package let keychainWorkerLaunchAgentManager:
         any DesktopKeychainWorkerLaunchAgentManaging
+
+    package var newAppNativeVerificationAvailable: Bool {
+        nativeVerificationCapability.newAppNativeVerificationAvailable
+    }
 
     package init(
         clipboard: any DesktopClipboard,
@@ -158,6 +226,8 @@ package struct DesktopAppDependencies {
         githubBroker: (any GitHubBrokerConnecting)? = nil,
         accountLink: (any NeonDiffAccountLinkConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
+        nativeVerificationCapability: DesktopNativeVerificationCapability =
+            .unavailable,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
             shortVersion: nil
         ),
@@ -184,6 +254,7 @@ package struct DesktopAppDependencies {
         self.githubBroker = githubBroker
         self.accountLink = accountLink
         self.productionBoundary = productionBoundary
+        self.nativeVerificationCapability = nativeVerificationCapability
         self.localWorkerUpdateGuideURL = localWorkerUpdateGuideURL
         self.cliWorkingDirectory = cliWorkingDirectory
         self.localBotConfigurations = localBotConfigurations

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -256,6 +256,99 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.activationState != .active)
     }
 
+    @Test func newAppNativeVerificationRequiresExactBYOMarkersAndTrustedWorker() {
+        let appBundleURL = URL(filePath: "/Applications/NeonDiff.app")
+        let byoMarkers: [String: Any] = [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ]
+
+        let available = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { $0 == appBundleURL },
+            sealedFileIsValid: { $0.path.hasSuffix("NeonDiffWorker") }
+        )
+        #expect(available.newAppNativeVerificationAvailable)
+        #expect(
+            available.trustedBundledWorker?.executablePath
+                == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
+        )
+
+        let withoutWorker = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in false }
+        )
+        #expect(!withoutWorker.newAppNativeVerificationAvailable)
+        #expect(withoutWorker.trustedBundledWorker == nil)
+
+        let mixedMarkers = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers.merging([
+                "NeonDiffManagedGitHubBrokerEnabled": true,
+                "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
+            ]) { _, new in new },
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!mixedMarkers.newAppNativeVerificationAvailable)
+
+        let wrongHelperPath = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: URL(filePath: "/Applications/Other.app"),
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!wrongHelperPath.newAppNativeVerificationAvailable)
+
+        let wrongSignature = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in false },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!wrongSignature.newAppNativeVerificationAvailable)
+
+        let wrongHelperProof = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in false }
+        )
+        #expect(!wrongHelperProof.newAppNativeVerificationAvailable)
+
+        let preferenceOnly = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: ["NeonDiffBYOGitHubEnabled": true],
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!preferenceOnly.newAppNativeVerificationAvailable)
+    }
+
+    @Test func compositionBindsNewAppWorkerToTheDerivedCapability() throws {
+        let compositionRoot = sourceBoundaryPackageRoot()
+            .appendingPathComponent(
+                "Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift"
+            )
+        let source = try sourceBoundaryText(at: compositionRoot)
+
+        #expect(source.contains(
+            "FoundationTrustedBundledWorker.nativeVerificationCapability"
+        ))
+        #expect(source.contains(
+            "let trustedBundledWorker =\n            nativeVerificationCapability.trustedBundledWorker"
+        ))
+        #expect(source.contains(
+            "nativeVerificationCapability: nativeVerificationCapability"
+        ))
+        #expect(!source.contains(
+            "FoundationTrustedBundledWorker.executionContext()"
+        ))
+    }
+
     @Test func managedConnectUsesBrokerAndKeychainIdentityWithoutLegacyUserTokenFallback() async throws {
         let broker = ScriptedGitHubBroker(repositories: [
             GitHubBrokerRepository(fullName: "electric/private", visibility: .private),


### PR DESCRIPTION
Closes #974

## Summary

- add the read-only `newAppNativeVerificationAvailable` capability derived from the exact BYO production markers and sealed signed-worker proof
- bind the composition root's trusted worker, dynamic context provider, and `DesktopAppDependencies` to that capability so missing or mismatched helper proof fails closed
- keep existing local-bot verification discovery separate
- add focused marker, mixed-bundle, helper-path, signature/proof, preference-only, and composition tests

## Proof

- Base: `f56b186e09bde875ba85ee08c95cd47c92bf7bb7`
- Candidate: `e540ff4f205c1a63aff8627f0a2b8f30010d7b4a`
- `swift test --filter ManagedGitHubOnboardingTests` (23 passed)
- `swift test --filter ExistingLocalBotReconciliationTests` (49 passed)
- executable target compiled and linked during the focused Swift build
- `git diff --check` clean; 199 changed lines

This slice does not build, sign, install, launch, notarize, release, mutate runtime/Keychain/customer state, or perform clean-Mac onboarding proof. UI/docs gating and release-proof updates remain follow-up slices.
