### PR TITLE
feat(desktop): guard classic ZIP central directory

### DIFF
--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+import { closeSync, constants, fstatSync, openSync, readSync } from "node:fs";
+import { resolve } from "node:path";
+
+const MAX_BYTES = 512 * 1024 * 1024, MAX_RECORDS = 20_000, MAX_METADATA = 16 * 1024 * 1024;
+const EOCD = 0x06054b50, LOCAL = 0x04034b50, CENTRAL = 0x02014b50, ZIP64 = "ZIP64 archive unsupported";
+const fail = (message) => { throw new Error(message); };
+function artifactBytes(descriptor) {
+  const before = fstatSync(descriptor);
+  if (!before.isFile() || before.size > MAX_BYTES) fail("artifact bytes exceed bound");
+  const chunks = [], buffer = Buffer.allocUnsafe(1024 * 1024); let total = 0, count;
+  do { count = readSync(descriptor, buffer, 0, buffer.length, null); if (count) { total += count; if (total > MAX_BYTES) fail("artifact bytes exceed bound"); chunks.push(Buffer.from(buffer.subarray(0, count))); } } while (count);
+  const after = fstatSync(descriptor);
+  if (!after.isFile() || before.size !== after.size || total !== after.size) fail("artifact changed during read");
+  return Buffer.concat(chunks, total);
+}
+function eocdOffset(bytes) {
+  const first = Math.max(0, bytes.length - 22 - 0xffff);
+  let found = -1;
+  for (let offset = bytes.length - 22; offset >= first; offset -= 1) if (bytes.readUInt32LE(offset) === EOCD && offset + 22 + bytes.readUInt16LE(offset + 20) === bytes.length) { if (found !== -1) fail("malformed EOCD"); found = offset; }
+  if (found < 0) fail("malformed EOCD"); return found;
+}
+function guardCentralDirectory(bytes) {
+  if (bytes.length < 22) fail("malformed EOCD");
+  const eocd = eocdOffset(bytes), disk = bytes.readUInt16LE(eocd + 4), directoryDisk = bytes.readUInt16LE(eocd + 6), recordsOnDisk = bytes.readUInt16LE(eocd + 8), records = bytes.readUInt16LE(eocd + 10), size = bytes.readUInt32LE(eocd + 12), offset = bytes.readUInt32LE(eocd + 16);
+  if (recordsOnDisk === 0xffff || records === 0xffff || size === 0xffffffff || offset === 0xffffffff) fail(ZIP64);
+  if (disk !== 0 || directoryDisk !== 0 || recordsOnDisk !== records) fail("multi-disk archive unsupported");
+  if (records > MAX_RECORDS) fail("archive entry bound exceeded");
+  if (size > MAX_METADATA) fail("central metadata bound exceeded");
+  if (offset > eocd || size > eocd - offset || offset + size !== eocd) fail("central directory range invalid");
+  let cursor = offset;
+  for (let index = 0; index < records; index += 1) {
+    if (cursor + 46 > eocd || bytes.readUInt32LE(cursor) !== CENTRAL) fail("central directory malformed");
+    const name = bytes.readUInt16LE(cursor + 28), extra = bytes.readUInt16LE(cursor + 30), comment = bytes.readUInt16LE(cursor + 32), recordSize = 46 + name + extra + comment, entryDisk = bytes.readUInt16LE(cursor + 34), compressed = bytes.readUInt32LE(cursor + 20), expanded = bytes.readUInt32LE(cursor + 24), localOffset = bytes.readUInt32LE(cursor + 42);
+    if (entryDisk === 0xffff || compressed === 0xffffffff || expanded === 0xffffffff || localOffset === 0xffffffff) fail(ZIP64);
+    if (entryDisk !== 0) fail("multi-disk archive unsupported");
+    if (recordSize > eocd - cursor || localOffset >= offset || localOffset + 30 > offset || bytes.readUInt32LE(localOffset) !== LOCAL) fail("central directory range invalid");
+    const localName = bytes.readUInt16LE(localOffset + 26), localExtra = bytes.readUInt16LE(localOffset + 28);
+    if (localOffset + 30 + localName + localExtra + compressed > offset) fail("central directory range invalid");
+    cursor += recordSize;
+  }
+  if (cursor !== eocd) fail("central directory malformed");
+  return { recordCount: records, centralDirectoryOffset: offset, centralDirectorySize: size, eocdOffset: eocd };
+}
+export function guardClassicZipArchive(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input) || Object.keys(input).length !== 1 || !Object.hasOwn(input, "artifactPath") || typeof input.artifactPath !== "string" || !input.artifactPath) fail("archive inputs are malformed");
+  const descriptor = openSync(resolve(input.artifactPath), constants.O_RDONLY | constants.O_NOFOLLOW); let bytes;
+  try { bytes = artifactBytes(descriptor); } finally { closeSync(descriptor); }
+  const envelope = guardCentralDirectory(bytes);
+  return Object.freeze({ ...envelope, artifactBytes: bytes, artifactSHA256: createHash("sha256").update(bytes).digest("hex") });
+}
+export const readBoundedClassicZip = guardClassicZipArchive;

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { readFileSync, mkdtempSync, rmSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { guardClassicZipArchive } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
+
+type Entry = { name: string; extra?: number; comment?: number };
+const roots: string[] = [];
+const u16 = (b: Buffer, p: number, n: number) => b.writeUInt16LE(n, p);
+const u32 = (b: Buffer, p: number, n: number) => b.writeUInt32LE(n, p);
+function classicZip(entries: Entry[]) {
+  const locals: Buffer[] = [], central: Buffer[] = []; let offset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name), extra = Buffer.alloc(entry.extra ?? 0), comment = Buffer.alloc(entry.comment ?? 0);
+    const local = Buffer.alloc(30 + name.length); u32(local, 0, 0x04034b50); u16(local, 4, 20); u16(local, 26, name.length); name.copy(local, 30); locals.push(local);
+    const record = Buffer.alloc(46 + name.length + extra.length + comment.length); u32(record, 0, 0x02014b50); u16(record, 4, 20); u16(record, 6, 20); u16(record, 28, name.length); u16(record, 30, extra.length); u16(record, 32, comment.length); u32(record, 42, offset); name.copy(record, 46); extra.copy(record, 46 + name.length); comment.copy(record, 46 + name.length + extra.length); central.push(record);
+    offset += local.length;
+  }
+  const directory = Buffer.concat(central), eocd = Buffer.alloc(22); u32(eocd, 0, 0x06054b50); u16(eocd, 8, entries.length); u16(eocd, 10, entries.length); u32(eocd, 12, directory.length); u32(eocd, 16, offset);
+  return Buffer.concat([...locals, directory, eocd]);
+}
+function fixture(entries: Entry[]) { const root = mkdtempSync(join(tmpdir(), "neondiff-zip-")); roots.push(root); const artifact = join(root, "NeonDiff.zip"); writeFileSync(artifact, classicZip(entries)); return { root, artifact }; }
+function eocdPatch(artifact: string, field: number, value: number) { const bytes = readFileSync(artifact); u32(bytes, bytes.length - 22 + field, value); writeFileSync(artifact, bytes); }
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+describe("raw bounded classic-ZIP archive guard", () => {
+  it("accepts a small classic ZIP and hashes the exact descriptor bytes", () => {
+    const value = fixture([{ name: "NeonDiff.app/Contents/Info.plist" }]), digest = createHash("sha256").update(readFileSync(value.artifact)).digest("hex");
+    const result = guardClassicZipArchive({ artifactPath: value.artifact });
+    expect(result.artifactSHA256).toBe(digest); expect(result.recordCount).toBe(1); expect(result.centralDirectorySize).toBeGreaterThan(0); expect(result.artifactBytes.length).toBeLessThan(512 * 1024 * 1024);
+  });
+  it("rejects over-count and oversized central metadata before helper/materialization", () => {
+    const overCount = fixture(Array.from({ length: 20001 }, (_, i) => ({ name: `NeonDiff.app/${i}` })));
+    expect(() => guardClassicZipArchive({ artifactPath: overCount.artifact })).toThrow("archive entry bound exceeded");
+    const oversized = fixture(Array.from({ length: 260 }, (_, i) => ({ name: `NeonDiff.app/${i}`, extra: 65535 })));
+    expect(() => guardClassicZipArchive({ artifactPath: oversized.artifact })).toThrow("central metadata bound exceeded");
+    const source = readFileSync(new URL("../scripts/lib/desktop-extracted-app-tree-proof.mjs", import.meta.url), "utf8");
+    expect(source).not.toMatch(/ZipFile|infolist|execFileSync/);
+  });
+  it("fails closed for malformed EOCD, multi-disk, ZIP64 sentinels, and ranges", () => {
+    const malformed = fixture([{ name: "NeonDiff.app/a" }]); const badSignature = readFileSync(malformed.artifact); u32(badSignature, badSignature.length - 22, 0); writeFileSync(malformed.artifact, badSignature);
+    expect(() => guardClassicZipArchive({ artifactPath: malformed.artifact })).toThrow("malformed EOCD");
+    const multi = fixture([{ name: "NeonDiff.app/a" }]); eocdPatch(multi.artifact, 4, 1); expect(() => guardClassicZipArchive({ artifactPath: multi.artifact })).toThrow("multi-disk archive unsupported");
+    const zip64 = fixture([{ name: "NeonDiff.app/a" }]); eocdPatch(zip64.artifact, 10, 0xffff); expect(() => guardClassicZipArchive({ artifactPath: zip64.artifact })).toThrow("ZIP64 archive unsupported");
+    const range = fixture([{ name: "NeonDiff.app/a" }]); eocdPatch(range.artifact, 16, readFileSync(range.artifact).length - 1); expect(() => guardClassicZipArchive({ artifactPath: range.artifact })).toThrow("central directory range invalid");
+  });
+  it("uses O_NOFOLLOW and rejects an artifact over the descriptor cap", () => {
+    const value = fixture([{ name: "NeonDiff.app/a" }]), alias = join(value.root, "alias.zip"); symlinkSync(value.artifact, alias);
+    expect(() => guardClassicZipArchive({ artifactPath: alias })).toThrow();
+    const oversized = join(value.root, "oversized.zip"); writeFileSync(oversized, ""); truncateSync(oversized, 512 * 1024 * 1024 + 1);
+    expect(() => guardClassicZipArchive({ artifactPath: oversized })).toThrow("artifact bytes exceed bound");
+  });
+});


### PR DESCRIPTION
Refs #975

## Scope
- Add a raw Node classic-ZIP EOCD/central-directory guard from exact `main` `f56b186e09bde875ba85ee08c95cd47c92bf7bb7`.
- Enforce O_NOFOLLOW descriptor reads with pre/during/post 512 MiB limits and exact-byte SHA-256.
- Reject over-count, >16 MiB central metadata, malformed EOCD/ranges, multi-disk, and ZIP64 sentinel envelopes before any helper/materialization.
- Add canonical `.test.ts` fixtures for valid classic ZIP, hostile envelopes, no-follow, and descriptor cap.

## Proof
- `node --check scripts/lib/desktop-extracted-app-tree-proof.mjs` PASS
- raw Node bounded-envelope smoke PASS
- `/usr/bin/ditto -c -k --sequesterRsrc --keepParent` archive smoke PASS
- `git diff --cached --check` PASS before commit
- `npm test -- --run tests/desktop-extracted-app-tree-proof.test.ts` is blocked locally: `vitest: command not found` (worktree has no `node_modules`).

This source slice proves only bounded raw classic-ZIP envelope acquisition. It does not implement A2 metadata normalization, A3 extraction, tree/plist proof, release, runtime, or customer behavior.
