### PR TITLE
fix(state): validate exact dry-run promotion receipt

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -1658,6 +1658,17 @@ export class ReviewStateStore {
     if (input.claimTtlMs < 1) throw new Error("claimTtlMs must be at least 1");
     const ownerPid = input.ownerPid ?? process.pid;
     if (!Number.isInteger(ownerPid) || ownerPid < 1) throw new Error("ownerPid must be a positive integer");
+    if (input.consumeProcessedApprovalOnAcquire) {
+      if (input.requiredProcessedStatusForSupersession !== "dry_run") {
+        throw new Error("consuming a processed approval requires dry_run status");
+      }
+      if (
+        !input.requiredProcessedConfigRevisionForSupersession ||
+        !/^[a-f0-9]{64}$/.test(input.requiredProcessedConfigRevisionForSupersession)
+      ) {
+        throw new Error("consuming a processed approval requires a lowercase SHA-256 configuration revision");
+      }
+    }
 
     const now = input.now ?? new Date();
     const claimId = randomUUID();

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2495,6 +2495,72 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("rejects malformed approved dry-run revisions before consuming the receipt", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-approved-revision-shape-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = {
+      repo: "owner/repo",
+      pullNumber: 977,
+      headSha: "a".repeat(40)
+    };
+    const malformedRevision = "not-a-sha";
+    store.recordProcessed({
+      ...head,
+      status: "dry_run",
+      configRevision: malformedRevision,
+      event: "COMMENT"
+    });
+
+    expect(() => store.tryClaimReviewHead({
+      ...head,
+      claimTtlMs: 60_000,
+      allowProcessedOwnerSupersession: true,
+      requiredProcessedStatusForSupersession: "dry_run",
+      requiredProcessedConfigRevisionForSupersession: malformedRevision,
+      consumeProcessedApprovalOnAcquire: true
+    })).toThrow("lowercase SHA-256");
+    expect(store.getProcessedReview(head.repo, head.pullNumber, head.headSha)).toMatchObject({
+      status: "dry_run",
+      configRevision: malformedRevision
+    });
+    store.close();
+  });
+
+  it("consumes one matching dry-run receipt before a concurrent claimant can proceed", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-approved-receipt-race-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = {
+      repo: "owner/repo",
+      pullNumber: 977,
+      headSha: "b".repeat(40)
+    };
+    const revision = "b".repeat(64);
+    store.recordProcessed({ ...head, status: "dry_run", configRevision: revision, event: "COMMENT" });
+
+    const claimInput = {
+      ...head,
+      claimTtlMs: 60_000,
+      allowProcessedOwnerSupersession: true,
+      requiredProcessedStatusForSupersession: "dry_run" as const,
+      requiredProcessedConfigRevisionForSupersession: revision,
+      consumeProcessedApprovalOnAcquire: true
+    };
+    const first = store.tryClaimReviewHeadWithOutcome(claimInput);
+    const second = store.tryClaimReviewHeadWithOutcome(claimInput);
+
+    expect(first.status).toBe("acquired");
+    expect(second).toEqual({ status: "blocked", reason: "active_claim" });
+    expect(store.getProcessedReview(head.repo, head.pullNumber, head.headSha)).toMatchObject({
+      status: "skipped",
+      error: "approved_dry_run_consumed_for_live_post"
+    });
+    store.releaseReviewHeadClaim(first.status === "acquired" ? first.claim.claimId : "");
+    expect(store.tryClaimReviewHeadWithOutcome(claimInput)).toEqual({ status: "blocked", reason: "processed" });
+    store.close();
+  });
+
   it("grants an atomic per-head review claim to exactly one concurrent claimant (#295)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-"));
     roots.push(root);


### PR DESCRIPTION
Closes #977

## What changed
- validate the state CAS's consume-on-acquire path before opening its transaction
- require the exact `dry_run` status and lowercase SHA-256 approval revision
- add fixtures for malformed receipt rejection and one-shot same-head concurrency

## Evidence
- Base: `f56b186e09bde875ba85ee08c95cd47c92bf7bb7`
- Candidate: `45984552be745c5355ed86eeb3eb47611f1940e7`
- `git diff --check` passed
- focused TypeScript check of `src/state.ts` passed
- direct state-store receipt/race probe passed: malformed receipt preserved; one acquired claimant, one `active_claim`, then `processed`
- focused Vitest could not start because the shared Rollup native module is code-signature-invalid (`ERR_DLOPEN_FAILED`); no dependency install or mutation was performed

## Boundary
No daemon, LaunchAgent/plist, runtime, config, database, Keychain, customer, live review, release, or secret mutation was performed. This proves only the state receipt shape/CAS boundary; exact-head/config/provider/allowlist/account/access runtime checks remain in the existing `review-pr` path and still require CI/checker proof.
