### PR TITLE
fix(github): validate discovered customer App identity

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -118,27 +118,16 @@ export interface GitHubRepositoryAccessProof {
   installation_id_present: boolean;
   installation_id?: number;
   installation_account?: string;
+  installation_account_id?: number;
+  installation_account_type?: "User" | "Organization";
   app_slug?: string;
+  bot_login?: string;
   app_can_read_metadata: boolean;
   app_can_read_pull_requests: boolean;
   openPullCount?: number;
   github_api_status?: number;
   github_api_error_class?: GitHubRepositoryAccessErrorClass;
   github_api_error?: string;
-}
-
-interface GitHubInstallationIdentity {
-  id: number;
-  app_id: number;
-  account_login: string;
-  app_slug: string;
-}
-
-interface GitHubInstallationResponse {
-  id: number;
-  app_id?: number;
-  account?: { login?: string };
-  app_slug?: string;
 }
 
 export interface CanonicalGitHubInstallationIdentity {
@@ -153,7 +142,7 @@ export interface CanonicalGitHubInstallationIdentity {
 
 export interface GitHubInstallationIdentityExpectation {
   expectedAppId: string;
-  expectedBotLogin: string;
+  expectedBotLogin?: string;
   repo: string;
 }
 
@@ -198,7 +187,8 @@ export class GitHubApi {
   private readonly privateKey?: string;
   private readonly token?: string;
   private readonly apiBaseUrl: URL;
-  private readonly botLogin: string;
+  private readonly configuredBotLogin?: string;
+  private botLogin?: string;
   private readonly requestTimeoutMs: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
@@ -211,7 +201,8 @@ export class GitHubApi {
     this.privateKey = options.privateKey ?? (options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined);
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
-    this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
+    this.configuredBotLogin = options.botLogin;
+    this.botLogin = options.botLogin;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
   }
 
@@ -262,11 +253,9 @@ export class GitHubApi {
       };
     }
 
-    let installation: GitHubInstallationIdentity;
+    let installation: CanonicalGitHubInstallationIdentity;
     try {
-      installation = parseGitHubInstallationIdentity(
-        await this.getInstallation(repo, { followRedirects: false })
-      );
+      installation = await this.getInstallation(repo, { followRedirects: false });
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
@@ -274,13 +263,16 @@ export class GitHubApi {
       installation_id_present: true,
       installation_id: installation.id,
       installation_account: installation.account_login,
+      installation_account_id: installation.account_id,
+      installation_account_type: installation.account_type,
       app_id: installation.app_id,
-      app_slug: installation.app_slug
+      app_slug: installation.app_slug,
+      bot_login: installation.bot_login
     };
 
     let token: string;
     try {
-      token = await this.getInstallationTokenForId(repo, installation.id);
+      token = await this.getInstallationTokenForId(repo, installation);
     } catch (error) {
       return { ...base, ...installationProof, ...describeGitHubAccessError(error) };
     }
@@ -622,22 +614,31 @@ export class GitHubApi {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
     const installation = await this.getInstallation(repo);
-    return this.getInstallationTokenForId(repo, installation.id);
+    return this.getInstallationTokenForId(repo, installation);
   }
 
   private async getInstallation(
     repo: string,
     options: { followRedirects?: boolean } = {}
-  ): Promise<GitHubInstallationResponse> {
+  ): Promise<CanonicalGitHubInstallationIdentity> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    return this.request<GitHubInstallationResponse>(`/repos/${repo}/installation`, {
+    const response = await this.request<unknown>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
+    const expected: GitHubInstallationIdentityExpectation = { expectedAppId: this.appId, repo };
+    if (this.configuredBotLogin !== undefined) expected.expectedBotLogin = this.configuredBotLogin;
+    const identity = normalizeAndValidateGitHubInstallationIdentity(response, expected);
+    this.botLogin = identity.bot_login;
+    return identity;
   }
 
-  private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {
+  private async getInstallationTokenForId(
+    repo: string,
+    installation: CanonicalGitHubInstallationIdentity
+  ): Promise<string> {
+    const installationId = installation.id;
     const repoCached = this.repoInstallationTokens.get(repo);
     if (repoCached && repoCached.installationId === installationId && repoCached.expiresAt > Date.now() + 60_000) {
       return repoCached.token;
@@ -786,7 +787,9 @@ export function normalizeAndValidateGitHubInstallationIdentity(
   const accountType = readGitHubField(account, "type");
   const appSlug = normalizeGitHubAppSlug(readGitHubField(value, "app_slug"));
   const expectedAppId = readGitHubField(expected, "expectedAppId");
-  const expectedBotLogin = normalizeGitHubBotLogin(readGitHubField(expected, "expectedBotLogin"));
+  const expectedBotLoginValue = readGitHubField(expected, "expectedBotLogin");
+  const expectedBotLogin = normalizeGitHubBotLogin(expectedBotLoginValue);
+  const botLoginConfigured = expectedBotLoginValue !== MISSING_GITHUB_FIELD && expectedBotLoginValue !== undefined;
   const repo = readGitHubField(expected, "repo");
   const repoParts = typeof repo === "string" ? repo.split("/") : [];
   const owner = repoParts.length === 2 && repoParts[1].length > 0 && !/\s/.test(repoParts[1])
@@ -798,7 +801,7 @@ export function normalizeAndValidateGitHubInstallationIdentity(
       || typeof expectedAppId !== "string" || !/^\d+$/.test(expectedAppId.trim())
       || String(appId) !== expectedAppId.trim() || !accountLogin || !owner || accountLogin !== owner
       || (accountType !== "User" && accountType !== "Organization") || !appSlug
-      || !botLogin || botLogin !== expectedBotLogin) {
+      || !botLogin || (botLoginConfigured && botLogin !== expectedBotLogin)) {
     throw new Error("GitHub installation identity failed canonical validation.");
   }
   return Object.freeze({
@@ -830,28 +833,6 @@ function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefin
   if (typeof value !== "string") return undefined;
   const normalized = value.trim().toLowerCase();
   return pattern.test(normalized) ? normalized : undefined;
-}
-
-function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {
-  const installation = value as {
-    id?: unknown;
-    app_id?: unknown;
-    account?: { login?: unknown } | null;
-    app_slug?: unknown;
-  } | null;
-  const positiveInteger = (candidate: unknown): candidate is number =>
-    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
-  const accountLogin = installation?.account?.login;
-  const appSlug = installation?.app_slug;
-  const accountLoginValid = typeof accountLogin === "string"
-    && /^(?!-)(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(accountLogin);
-  const appSlugValid = typeof appSlug === "string"
-    && /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/.test(appSlug);
-  if (!positiveInteger(installation?.id) || !positiveInteger(installation?.app_id)
-      || !accountLoginValid || !appSlugValid) {
-    throw new Error("GitHub installation response is missing canonical identity fields.");
-  }
-  return { id: installation.id, app_id: installation.app_id, account_login: accountLogin, app_slug: appSlug };
 }
 
 function describeGitHubAccessError(error: unknown): Pick<

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -1400,7 +1400,12 @@ function routeMockGitHub(
     (request.url === "/repos/owner/issue-repo/installation" ||
       request.url === "/repos/owner/second-issue-repo/installation")
   ) {
-    respondJson(response, 200, { id: 123 });
+    respondJson(response, 200, {
+      id: 123,
+      app_id: 4184532,
+      account: { id: 7, login: "owner", type: "Organization" },
+      app_slug: "evaos-code-review-bot"
+    });
     return;
   }
   if (request.method === "POST" && request.url === "/app/installations/123/access_tokens") {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -35,6 +35,21 @@ describe("GitHub App read authentication", () => {
     expect(identity.account_login).toBe("owner");
   });
 
+  it("accepts distinct customer App slugs when no bot login is configured", () => {
+    for (const appSlug of ["customer-review-app", "second-customer-app"]) {
+      const identity = normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
+        expectedAppId: "4184532", repo: "owner/repo"
+      });
+      expect(identity.bot_login).toBe(`${appSlug}[bot]`);
+      expect(normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
+        expectedAppId: "4184532", expectedBotLogin: `${appSlug}[bot]`, repo: "owner/repo"
+      }).bot_login).toBe(`${appSlug}[bot]`);
+      expect(() => normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
+        expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+      })).toThrow(/canonical validation/);
+    }
+  });
+
   it.each([
     ["App mismatch", { app_id: 4184533 }, undefined],
     ["account mismatch", { account: { id: 7, login: "other", type: "User" } }, undefined],
@@ -87,7 +102,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -146,7 +161,7 @@ describe("GitHub App read authentication", () => {
         method: init?.method ?? "GET",
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
@@ -186,7 +201,7 @@ describe("GitHub App read authentication", () => {
     const calls: string[] = [];
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
@@ -260,7 +275,7 @@ describe("GitHub App read authentication", () => {
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -291,7 +306,7 @@ describe("GitHub App read authentication", () => {
 
     globalThis.fetch = vi.fn(async (url) => {
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -321,7 +336,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 999, app_slug: "customer-review-app" });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { id: 7, login: "owner", type: "Organization" }, app_slug: "customer-review-app" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -346,8 +361,11 @@ describe("GitHub App read authentication", () => {
       installation_id_present: true,
       installation_id: 123,
       installation_account: "owner",
-      app_id: 999,
+      installation_account_id: 7,
+      installation_account_type: "Organization",
+      app_id: 4184532,
       app_slug: "customer-review-app",
+      bot_login: "customer-review-app[bot]",
       app_can_read_metadata: true,
       app_can_read_pull_requests: true,
       openPullCount: 1
@@ -355,6 +373,51 @@ describe("GitHub App read authentication", () => {
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo"))?.authorization).toBe("Bearer installation-token");
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"))?.authorization)
       .toBe("Bearer installation-token");
+  });
+
+  it("rejects an explicit bot login mismatch before token exchange", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-explicit-bot-mismatch-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let tokenCalls = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse(canonicalInstallation({ app_slug: "customer-review-app" }));
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) tokenCalls += 1;
+      return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+    }) as typeof fetch;
+
+    await expect(new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: "other-app[bot]" }).listOpenPulls("owner/repo"))
+      .rejects.toThrow(/canonical validation/);
+    expect(tokenCalls).toBe(0);
+  });
+
+  it("revalidates explicit identity before a refreshed token exchange", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-refresh-identity-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let installationCalls = 0;
+    let tokenCalls = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        installationCalls += 1;
+        return jsonResponse(canonicalInstallation({ app_slug: installationCalls === 1 ? "customer-review-app" : "other-app" }));
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        tokenCalls += 1;
+        return jsonResponse({ token: "installation-token", expires_at: new Date(Date.now() + 1_000).toISOString() });
+      }
+      return jsonResponse([]);
+    }) as typeof fetch;
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: "customer-review-app[bot]" });
+    await expect(github.listOpenPulls("owner/repo")).resolves.toHaveLength(0);
+    await expect(github.listOpenPulls("owner/repo")).rejects.toThrow(/canonical validation/);
+    expect({ installationCalls, tokenCalls }).toEqual({ installationCalls: 2, tokenCalls: 1 });
   });
 
   it("rejects missing and malformed authoritative installation identity before token exchange", async () => {
@@ -540,7 +603,7 @@ describe("GitHub App read authentication", () => {
       const redirect = init?.redirect;
       calls.push({ url: requestUrl, method, redirect });
       if (requestUrl.endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { id: 7, login: "owner", type: "Organization" }, app_slug: "customer-review-app" });
       }
       if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -582,7 +645,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -610,7 +673,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/404")) return jsonResponse({ message: "Resource not accessible by integration" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -629,7 +692,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "API rate limit exceeded for installation" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -647,7 +710,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -665,7 +728,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -683,7 +746,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation; nested error: Not Found" }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -702,7 +765,7 @@ describe("GitHub App read authentication", () => {
     const leakedToken = "ghp_fake_token";
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: `SAML enforcement ${leakedToken}` }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -732,7 +795,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -789,7 +852,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -910,7 +973,7 @@ function canonicalInstallation(overrides: Record<string, unknown> = {}): Record<
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {
   return (url: string) => {
     if (url.endsWith("/repos/owner/repo/installation")) {
-      return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+      return jsonResponse({ id: 123, app_id: 4184532, account: { id: 7, login: "owner", type: "Organization" }, app_slug: "customer-review-app" });
     }
     if (url.endsWith("/app/installations/123/access_tokens")) {
       return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1526,7 +1526,7 @@ exit 1
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
         response.end(JSON.stringify({
           id: 42,
-          account: { login: "acme" },
+          account: { id: 7, login: "acme", type: "Organization" },
           app_id: 12345,
           app_slug: "customer-review-app"
         }));
@@ -1785,7 +1785,7 @@ exit 1
         response.end(JSON.stringify({
           id: 42,
           app_id: 12345,
-          account: { login: "acme" },
+          account: { id: 7, login: "acme", type: "Organization" },
           app_slug: "customer-review-app"
         }));
         return;


### PR DESCRIPTION
## Summary

- preserve omitted github.botLogin as omitted instead of imposing the internal default
- validate installation responses through the merged trap-free canonical identity projection before token exchange, refresh, or repository proof
- derive runtime bot ownership from the validated App slug and carry account id/type in proof
- update only canonical mocked fixtures and add omitted, matching, mismatch, and refresh side-effect coverage

## Evidence

- base: f56b186e09bde875ba85ee08c95cd47c92bf7bb7
- candidate: 86876520bab90ceee9bfd9633b96f92d248e19e2
- diff: 193 changed non-generated lines
- tests/github-app-read.test.ts: 38/38
- tests/enrichment-cli.test.ts: 32/32
- tests/public-cli.test.ts: 106/106
- strict TypeScript check of src/github.ts: passed
- git diff --check: passed

Canonical npm run build requires the repository CI environment because this fresh worktree has no local tsc binary. No live App, runtime, customer, config/DB/Keychain, release, merge, or install mutation was performed. R2 cache rotation remains out of scope.