### PR TITLE
fix: report honest issue-enrichment lane receipts

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,6 +25,115 @@ export type DaemonCycleResult =
   | { ok: true; result: RunOnceResult }
   | { ok: false; failureKind: "admission_denied" | "runtime_failure"; error: string };
 
+export interface IssueEnrichmentLaneCounts {
+  reposScanned: number;
+  reposSkipped: number;
+  readFailures: number;
+  issuesSeen: number;
+  eligible: number;
+  skipped: number;
+  wouldEnrich: number;
+  wouldComment: number;
+  deferred: number;
+  baselinedRepos: number;
+  truncatedRepos: number;
+  workerSkipped: number;
+  posted: number;
+  dryRunRecorded: number;
+  skippedRecorded: number;
+  deferredRecorded: number;
+  alreadyProcessed: number;
+  failed: number;
+}
+
+export type IssueEnrichmentLaneCode =
+  | "completed" | "no_candidates" | "lease_skipped" | "blocked" | "result_not_ok" | "cycle_failed" | "malformed_summary";
+export type IssueEnrichmentLaneReason =
+  | "worker_lease_held" | "unknown_failure" | "malformed_summary"
+  | IssueEnrichmentCycleResult["status"]["blockers"][number];
+
+export interface IssueEnrichmentLaneReceipt {
+  ok: boolean;
+  stage: "issue_enrichment";
+  code: IssueEnrichmentLaneCode;
+  counts: IssueEnrichmentLaneCounts;
+  reason?: IssueEnrichmentLaneReason;
+}
+
+const ISSUE_ENRICHMENT_LANE_COUNT_KEYS = [
+  "reposScanned", "reposSkipped", "readFailures", "issuesSeen", "eligible", "skipped",
+  "wouldEnrich", "wouldComment", "deferred", "baselinedRepos", "truncatedRepos", "workerSkipped",
+  "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
+] as const satisfies ReadonlyArray<keyof IssueEnrichmentLaneCounts>;
+
+function boundedLaneCount(value: unknown): number {
+  const number = typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : 0;
+  return Math.min(1_000_000, Math.max(0, number));
+}
+
+function hasValidIssueEnrichmentLaneSummary(summary: unknown): summary is Record<string, unknown> {
+  if (!summary || typeof summary !== "object" || Array.isArray(summary)) return false;
+  return ISSUE_ENRICHMENT_LANE_COUNT_KEYS.every((key) => {
+    const value = (summary as Record<string, unknown>)[key];
+    return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+  });
+}
+
+const ISSUE_ENRICHMENT_LANE_BLOCKERS = [
+  "issue_enrichment_disabled", "issue_enrichment_allowlist_empty", "issue_enrichment_live_posting_disabled",
+  "github_app_credentials_required_for_live_issue_comments", "github_app_issues_permission_required",
+  "issue_enrichment_live_repo_thresholds_required", "issue_enrichment_model_runtime_required"
+] as const;
+
+function safeIssueEnrichmentLaneReason(value: unknown): IssueEnrichmentLaneReason {
+  return value === "worker_lease_held" || value === "unknown_failure" || value === "malformed_summary" ||
+    (typeof value === "string" && (ISSUE_ENRICHMENT_LANE_BLOCKERS as readonly string[]).includes(value))
+    ? value as IssueEnrichmentLaneReason
+    : "unknown_failure";
+}
+
+function thrownIssueEnrichmentLaneReason(error: unknown): IssueEnrichmentLaneReason {
+  const message = error instanceof Error ? error.message : "";
+  return safeIssueEnrichmentLaneReason(
+    ISSUE_ENRICHMENT_LANE_BLOCKERS.find((blocker) => message.includes(blocker))
+  );
+}
+
+export function buildIssueEnrichmentLaneReceipt(
+  result?: IssueEnrichmentCycleResult,
+  failure?: unknown
+): IssueEnrichmentLaneReceipt {
+  const summary: unknown = result?.summary;
+  const counts = {} as IssueEnrichmentLaneCounts;
+  for (const key of ISSUE_ENRICHMENT_LANE_COUNT_KEYS) counts[key] = boundedLaneCount(
+    hasValidIssueEnrichmentLaneSummary(summary) ? summary[key] : undefined
+  );
+  const malformed = result !== undefined && !hasValidIssueEnrichmentLaneSummary(summary);
+  const blocked = result?.status?.state === "blocked";
+  const leaseSkipped = result?.ok === true && counts.workerSkipped > 0;
+  const ok = !malformed && !blocked && result?.ok === true && counts.readFailures === 0 && counts.failed === 0;
+  const noCandidates = ok && counts.eligible === 0 && counts.wouldEnrich === 0 && counts.wouldComment === 0 &&
+    counts.posted === 0 && counts.dryRunRecorded === 0 && counts.skippedRecorded === 0 &&
+    counts.deferredRecorded === 0 && counts.alreadyProcessed === 0 && !leaseSkipped;
+  const reason = result === undefined
+    ? thrownIssueEnrichmentLaneReason(failure)
+    : malformed
+      ? "malformed_summary"
+      : leaseSkipped
+        ? "worker_lease_held"
+        : blocked
+          ? safeIssueEnrichmentLaneReason(result.status?.blockers?.[0])
+          : !ok ? "unknown_failure" : undefined;
+  return {
+    ok,
+    stage: "issue_enrichment",
+    code: result === undefined ? "cycle_failed" : malformed ? "malformed_summary" : leaseSkipped ? "lease_skipped" :
+      blocked ? "blocked" : !ok ? "result_not_ok" : noCandidates ? "no_candidates" : "completed",
+    counts,
+    ...(reason ? { reason } : {})
+  };
+}
+
 export function shouldExitDaemonAfterFailedCycle(result: DaemonCycleResult, runOnce: boolean): boolean {
   return !result.ok && (runOnce || result.failureKind === "admission_denied");
 }
@@ -284,21 +393,23 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
     });
+    const receipt = buildIssueEnrichmentLaneReceipt(issueEnrichment);
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
-      phase: "complete",
+      phase: receipt.ok ? "complete" : "result",
       cycle: input.input.cycle,
       dryRun: input.input.dryRun,
-      result: issueEnrichment
+      receipt
     }));
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const receipt = buildIssueEnrichmentLaneReceipt(undefined, error);
     input.stderr(formatDaemonLog({
       event: "daemon_issue_enrichment_failed",
       level: "error",
+      phase: "failed",
       cycle: input.input.cycle,
       dryRun: input.input.dryRun,
-      error: message
+      receipt
     }));
   }
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,7 +3,11 @@ import { resolve } from "node:path";
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { GitHubApi } from "./github.js";
-import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
+import {
+  DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS,
+  runIssueEnrichmentCycle,
+  type IssueEnrichmentCycleResult
+} from "./issue-enrichment.js";
 import { runScheduledCycle } from "./scheduler.js";
 import {
   isAuthenticProductionLicenseAdmission,
@@ -109,7 +113,11 @@ export function buildIssueEnrichmentLaneReceipt(
     hasValidIssueEnrichmentLaneSummary(summary) ? summary[key] : undefined
   );
   const malformed = result !== undefined && !hasValidIssueEnrichmentLaneSummary(summary);
-  const blocked = result?.status?.state === "blocked";
+  const dryRunIgnoredBlockers = result?.ok === true && result.dryRun && result.status?.state === "blocked" &&
+    result.status.blockers.length > 0 && result.status.blockers.every((blocker) =>
+      DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(blocker)
+    );
+  const blocked = result?.status?.state === "blocked" && !dryRunIgnoredBlockers;
   const leaseSkipped = result?.ok === true && counts.workerSkipped > 0;
   const ok = !malformed && !blocked && result?.ok === true && counts.readFailures === 0 && counts.failed === 0;
   const noCandidates = ok && counts.eligible === 0 && counts.wouldEnrich === 0 && counts.wouldComment === 0 &&

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildIssueEnrichmentLaneReceipt,
   cleanupReviewWorktreesFromConfig,
   runDaemonCycle as runDaemonCycleImpl,
   shouldExitDaemonAfterFailedCycle,
@@ -517,8 +518,11 @@ describe("daemon cycle resilience", () => {
         event: "daemon_issue_enrichment",
         phase: "complete",
         cycle: 9,
-        result: expect.objectContaining({
-          summary: expect.objectContaining({
+        receipt: expect.objectContaining({
+          ok: true,
+          stage: "issue_enrichment",
+          code: "completed",
+          counts: expect.objectContaining({
             reposScanned: 1,
             dryRunRecorded: 1
           })
@@ -643,10 +647,50 @@ describe("daemon cycle resilience", () => {
     expect(failure).toMatchObject({
       event: "daemon_issue_enrichment_failed",
       level: "error",
-      cycle: 10
+      phase: "failed",
+      cycle: 10,
+      receipt: {
+        ok: false,
+        stage: "issue_enrichment",
+        code: "cycle_failed",
+        reason: "unknown_failure",
+        counts: expect.objectContaining({ failed: 0 })
+      }
     });
-    expect(failure.error).toContain("issue enrichment failed");
-    expect(failure.error).not.toContain("ghp_fake_token");
+    expect(failure.error).toBeUndefined();
+    expect(JSON.stringify(failure)).not.toContain("issue enrichment failed");
+    expect(JSON.stringify(failure)).not.toContain("ghp_fake_token");
+  });
+
+  it("distinguishes empty, leased, blocked, and non-success issue receipts", () => {
+    const base = successfulIssueEnrichmentCycleResult();
+    const empty = {
+      ...base,
+      summary: { ...base.summary, issuesSeen: 0, eligible: 0, wouldEnrich: 0, wouldComment: 0, dryRunRecorded: 0 }
+    };
+    expect(buildIssueEnrichmentLaneReceipt(empty)).toMatchObject({ ok: true, code: "no_candidates" });
+    expect(buildIssueEnrichmentLaneReceipt({ ...empty, summary: { ...empty.summary, workerSkipped: 1 } }))
+      .toMatchObject({ ok: true, code: "lease_skipped", reason: "worker_lease_held" });
+    expect(buildIssueEnrichmentLaneReceipt({
+      ...empty,
+      ok: false,
+      status: { ...empty.status, state: "blocked", blockers: ["issue_enrichment_allowlist_empty"] }
+    })).toMatchObject({ ok: false, code: "blocked", reason: "issue_enrichment_allowlist_empty" });
+    expect(buildIssueEnrichmentLaneReceipt({ ...empty, ok: false, summary: { ...empty.summary, failed: 1 } }))
+      .toMatchObject({ ok: false, code: "result_not_ok", reason: "unknown_failure" });
+    expect(buildIssueEnrichmentLaneReceipt(undefined, new Error("issue_enrichment_model_runtime_required; secret")))
+      .toMatchObject({ ok: false, code: "cycle_failed", reason: "issue_enrichment_model_runtime_required" });
+  });
+
+  it("rejects missing, negative, nonfinite, string, null, array, and non-object summaries", () => {
+    const base = successfulIssueEnrichmentCycleResult();
+    const missing = Object.fromEntries(Object.entries(base.summary).filter(([key]) => key !== "failed"));
+    const summaries: unknown[] = [missing, { ...base.summary, failed: -1 }, { ...base.summary, failed: Number.NaN },
+      { ...base.summary, failed: "1" }, null, [], "summary"];
+    for (const summary of summaries) {
+      expect(buildIssueEnrichmentLaneReceipt({ ...base, summary } as IssueEnrichmentCycleResult))
+        .toMatchObject({ ok: false, code: "malformed_summary" });
+    }
   });
 });
 

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -669,10 +669,14 @@ describe("daemon cycle resilience", () => {
       summary: { ...base.summary, issuesSeen: 0, eligible: 0, wouldEnrich: 0, wouldComment: 0, dryRunRecorded: 0 }
     };
     expect(buildIssueEnrichmentLaneReceipt(empty)).toMatchObject({ ok: true, code: "no_candidates" });
+    expect(buildIssueEnrichmentLaneReceipt({ ...base, dryRun: true,
+      status: { ...base.status, state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }))
+      .toMatchObject({ ok: true, code: "completed", counts: { dryRunRecorded: 1 } });
     expect(buildIssueEnrichmentLaneReceipt({ ...empty, summary: { ...empty.summary, workerSkipped: 1 } }))
       .toMatchObject({ ok: true, code: "lease_skipped", reason: "worker_lease_held" });
     expect(buildIssueEnrichmentLaneReceipt({
       ...empty,
+      dryRun: true,
       ok: false,
       status: { ...empty.status, state: "blocked", blockers: ["issue_enrichment_allowlist_empty"] }
     })).toMatchObject({ ok: false, code: "blocked", reason: "issue_enrichment_allowlist_empty" });


### PR DESCRIPTION
Closes #972

## Summary
- emit a typed, bounded issue-enrichment receipt instead of raw result or exception payloads
- distinguish completed work, no candidates, lease contention, blocked results, generic non-success, malformed summaries, and thrown failures
- preserve only allowlisted blocker/failure reasons while keeping review and daemon liveness independent

## Proof
- base: f53754d16ae3e8a4c30bfe8e9d56c5c840a68b03
- head: 1edb4195eed3ec6b6c77176f68a75e3b20cb8032
- changed files: src/daemon.ts, tests/daemon-loop.test.ts
- diff: 164 additions + 9 deletions = 173 changed lines
- focused/affected: PATH=/opt/homebrew/bin:$PATH npm test -- tests/daemon-loop.test.ts tests/daemon-log.test.ts (20 passed)
- build: PATH=/opt/homebrew/bin:$PATH npm run build
- git diff --check: clean

## Proof boundary
This proves source and fixture behavior only. It does not prove the live worker cause, watermark advancement, runtime soak, release readiness, or customer readiness. No runtime, config, database, Keychain, release, billing, or customer state was changed.