### PR TITLE
fix(desktop): separate native verification from trusted worker

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
@@ -19,6 +19,18 @@ enum FoundationTrustedBundledWorker {
         )
     }
 
+    static func nativeVerificationCapability(
+        bundle: Bundle = .main,
+        productionBoundary: DesktopProductionBoundary
+    ) -> DesktopNativeVerificationCapability {
+        DesktopNativeVerificationCapability.resolve(
+            productionBoundary: productionBoundary,
+            appBundleURL: bundle.bundleURL,
+            appSignatureIsValid: validateAppSignature,
+            sealedFileIsValid: isSafeSealedWorker
+        )
+    }
+
     static func runningProcessIsTrusted(
         _ processIdentifier: Int32,
         bundle: Bundle = .main

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationTrustedBundledWorker.swift
@@ -19,18 +19,6 @@ enum FoundationTrustedBundledWorker {
         )
     }
 
-    static func nativeVerificationCapability(
-        bundle: Bundle = .main,
-        productionBoundary: DesktopProductionBoundary
-    ) -> DesktopNativeVerificationCapability {
-        DesktopNativeVerificationCapability.resolve(
-            productionBoundary: productionBoundary,
-            appBundleURL: bundle.bundleURL,
-            appSignatureIsValid: validateAppSignature,
-            sealedFileIsValid: isSafeSealedWorker
-        )
-    }
-
     static func runningProcessIsTrusted(
         _ processIdentifier: Int32,
         bundle: Bundle = .main

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -38,8 +38,12 @@ enum NeonDiffDesktopCompositionRoot {
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
         let localBotSnapshot =
             LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
+        let nativeVerificationCapability =
+            FoundationTrustedBundledWorker.nativeVerificationCapability(
+                productionBoundary: productionBoundary
+            )
         let trustedBundledWorker =
-            FoundationTrustedBundledWorker.executionContext()
+            nativeVerificationCapability.trustedBundledWorker
         let localBotConfigurations = localBotSnapshot.configurations
         let localBotExecutionContexts =
             localBotSnapshot.executionContexts
@@ -48,12 +52,8 @@ enum NeonDiffDesktopCompositionRoot {
             @Sendable () -> [DesktopLocalBotExecutionContext] = {
                 LaunchAgentLocalBotConfigurationDiscovery
                     .discoverExecutionContexts()
-                    + (
-                        FoundationTrustedBundledWorker
-                            .executionContext()
-                            .map { [$0] }
-                        ?? []
-                    )
+                    + (nativeVerificationCapability.trustedBundledWorker
+                        .map { [$0] } ?? [])
             }
         let localBotDiscoveryProvider:
             @Sendable (String) -> DesktopLocalBotDiscoverySnapshot = {
@@ -65,12 +65,8 @@ enum NeonDiffDesktopCompositionRoot {
                     configurations: snapshot.configurations,
                     executionContexts:
                         snapshot.executionContexts
-                        + (
-                            FoundationTrustedBundledWorker
-                                .executionContext()
-                                .map { [$0] }
-                            ?? []
-                        )
+                        + (nativeVerificationCapability.trustedBundledWorker
+                            .map { [$0] } ?? [])
                 )
             }
         let keychainWorkerLaunchAgentManager:
@@ -111,6 +107,7 @@ enum NeonDiffDesktopCompositionRoot {
             githubBroker: githubBroker,
             accountLink: accountLink,
             productionBoundary: productionBoundary,
+            nativeVerificationCapability: nativeVerificationCapability,
             localWorkerUpdateGuideURL: DesktopReleaseRouting.localWorkerUpdateGuideURL(
                 shortVersion: Bundle.main.object(
                     forInfoDictionaryKey: "CFBundleShortVersionString"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -38,12 +38,13 @@ enum NeonDiffDesktopCompositionRoot {
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
         let localBotSnapshot =
             LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
-        let nativeVerificationCapability =
-            FoundationTrustedBundledWorker.nativeVerificationCapability(
-                productionBoundary: productionBoundary
-            )
         let trustedBundledWorker =
-            nativeVerificationCapability.trustedBundledWorker
+            FoundationTrustedBundledWorker.executionContext()
+        let nativeVerificationCapability =
+            DesktopNativeVerificationCapability.resolve(
+                productionBoundary: productionBoundary,
+                trustedBundledWorker: trustedBundledWorker
+            )
         let localBotConfigurations = localBotSnapshot.configurations
         let localBotExecutionContexts =
             localBotSnapshot.executionContexts
@@ -52,8 +53,12 @@ enum NeonDiffDesktopCompositionRoot {
             @Sendable () -> [DesktopLocalBotExecutionContext] = {
                 LaunchAgentLocalBotConfigurationDiscovery
                     .discoverExecutionContexts()
-                    + (nativeVerificationCapability.trustedBundledWorker
-                        .map { [$0] } ?? [])
+                    + (
+                        FoundationTrustedBundledWorker
+                            .executionContext()
+                            .map { [$0] }
+                        ?? []
+                    )
             }
         let localBotDiscoveryProvider:
             @Sendable (String) -> DesktopLocalBotDiscoverySnapshot = {
@@ -65,8 +70,12 @@ enum NeonDiffDesktopCompositionRoot {
                     configurations: snapshot.configurations,
                     executionContexts:
                         snapshot.executionContexts
-                        + (nativeVerificationCapability.trustedBundledWorker
-                            .map { [$0] } ?? [])
+                        + (
+                            FoundationTrustedBundledWorker
+                                .executionContext()
+                                .map { [$0] }
+                            ?? []
+                        )
                 )
             }
         let keychainWorkerLaunchAgentManager:

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -386,6 +386,7 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     !model.byoGitHubCredentialsStored
+                        || !model.newAppNativeVerificationAvailable
                         || !model.localWorkerCLIAvailable
                         || model.repos.filter(\.enabled).count != 1
                         || !model.canEditProviderConfiguration

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -466,7 +466,11 @@ struct ReposView: View {
                             systemImage: "checkmark.shield"
                         )
                     }
-                    .disabled(!model.byoGitHubCredentialsStored || model.isBYOGitHubVerificationInProgress)
+                    .disabled(
+                        !model.byoGitHubCredentialsStored
+                            || !model.newAppNativeVerificationAvailable
+                            || model.isBYOGitHubVerificationInProgress
+                    )
                     .accessibilityIdentifier("neondiff-byo-github-verify")
                 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -99,6 +99,10 @@ package struct DesktopNativeVerificationCapability: Sendable {
         newAppNativeVerificationAvailable: false,
         trustedBundledWorker: nil
     )
+    package static let testAvailable = DesktopNativeVerificationCapability(
+        newAppNativeVerificationAvailable: true,
+        trustedBundledWorker: nil
+    )
 
     private init(
         newAppNativeVerificationAvailable: Bool,
@@ -140,6 +144,21 @@ package struct DesktopNativeVerificationCapability: Sendable {
                     appSignatureIsValid: appSignatureIsValid,
                     sealedFileIsValid: sealedFileIsValid
                 )
+        else {
+            return .unavailable
+        }
+        return DesktopNativeVerificationCapability(
+            newAppNativeVerificationAvailable: true,
+            trustedBundledWorker: trustedBundledWorker
+        )
+    }
+
+    package static func resolve(
+        productionBoundary: DesktopProductionBoundary,
+        trustedBundledWorker: DesktopLocalBotExecutionContext?
+    ) -> Self {
+        guard productionBoundary.byoGitHubEnabled,
+              let trustedBundledWorker
         else {
             return .unavailable
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -88,6 +88,68 @@ package struct DesktopProductionBoundary: Sendable {
     }
 }
 
+/// Bundle-derived capability for native new-App verification.
+/// Requires exact BYO markers and sealed-worker proof; existing local-bot
+/// verification remains separate.
+package struct DesktopNativeVerificationCapability: Sendable {
+    package let newAppNativeVerificationAvailable: Bool
+    package let trustedBundledWorker: DesktopLocalBotExecutionContext?
+
+    package static let unavailable = DesktopNativeVerificationCapability(
+        newAppNativeVerificationAvailable: false,
+        trustedBundledWorker: nil
+    )
+
+    private init(
+        newAppNativeVerificationAvailable: Bool,
+        trustedBundledWorker: DesktopLocalBotExecutionContext?
+    ) {
+        self.newAppNativeVerificationAvailable =
+            newAppNativeVerificationAvailable
+        self.trustedBundledWorker = trustedBundledWorker
+    }
+
+    /// Resolve from the produced bundle contract and platform proof callbacks.
+    /// Preferences, license state, and arbitrary contexts cannot grant it.
+    package static func resolve(
+        infoDictionary: [String: Any],
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> Self {
+        resolve(
+            productionBoundary: DesktopProductionBoundary.resolve(
+                infoDictionary: infoDictionary
+            ),
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: appSignatureIsValid,
+            sealedFileIsValid: sealedFileIsValid
+        )
+    }
+
+    package static func resolve(
+        productionBoundary: DesktopProductionBoundary,
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> Self {
+        guard productionBoundary.byoGitHubEnabled,
+              let trustedBundledWorker =
+                DesktopTrustedBundledWorkerContract.executionContext(
+                    appBundleURL: appBundleURL,
+                    appSignatureIsValid: appSignatureIsValid,
+                    sealedFileIsValid: sealedFileIsValid
+                )
+        else {
+            return .unavailable
+        }
+        return DesktopNativeVerificationCapability(
+            newAppNativeVerificationAvailable: true,
+            trustedBundledWorker: trustedBundledWorker
+        )
+    }
+}
+
 private let approvedManagedGitHubBrokerOrigin = URL(
     string: "https://neondiff-license.fly.dev"
 )!
@@ -134,6 +196,8 @@ package struct DesktopAppDependencies {
     package let githubBroker: (any GitHubBrokerConnecting)?
     package let accountLink: (any NeonDiffAccountLinkConnecting)?
     package let productionBoundary: DesktopProductionBoundary
+    package let nativeVerificationCapability:
+        DesktopNativeVerificationCapability
     package let localWorkerUpdateGuideURL: URL
     package let cliWorkingDirectory: URL?
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
@@ -143,6 +207,10 @@ package struct DesktopAppDependencies {
         (@Sendable (String) -> DesktopLocalBotDiscoverySnapshot)?
     package let keychainWorkerLaunchAgentManager:
         any DesktopKeychainWorkerLaunchAgentManaging
+
+    package var newAppNativeVerificationAvailable: Bool {
+        nativeVerificationCapability.newAppNativeVerificationAvailable
+    }
 
     package init(
         clipboard: any DesktopClipboard,
@@ -158,6 +226,8 @@ package struct DesktopAppDependencies {
         githubBroker: (any GitHubBrokerConnecting)? = nil,
         accountLink: (any NeonDiffAccountLinkConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
+        nativeVerificationCapability: DesktopNativeVerificationCapability =
+            .unavailable,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
             shortVersion: nil
         ),
@@ -184,6 +254,7 @@ package struct DesktopAppDependencies {
         self.githubBroker = githubBroker
         self.accountLink = accountLink
         self.productionBoundary = productionBoundary
+        self.nativeVerificationCapability = nativeVerificationCapability
         self.localWorkerUpdateGuideURL = localWorkerUpdateGuideURL
         self.cliWorkingDirectory = cliWorkingDirectory
         self.localBotConfigurations = localBotConfigurations

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -89,28 +89,18 @@ package struct DesktopProductionBoundary: Sendable {
 }
 
 /// Bundle-derived capability for native new-App verification.
-/// Requires exact BYO markers and sealed-worker proof; existing local-bot
-/// verification remains separate.
 package struct DesktopNativeVerificationCapability: Sendable {
     package let newAppNativeVerificationAvailable: Bool
-    package let trustedBundledWorker: DesktopLocalBotExecutionContext?
 
     package static let unavailable = DesktopNativeVerificationCapability(
-        newAppNativeVerificationAvailable: false,
-        trustedBundledWorker: nil
+        newAppNativeVerificationAvailable: false
     )
     package static let testAvailable = DesktopNativeVerificationCapability(
-        newAppNativeVerificationAvailable: true,
-        trustedBundledWorker: nil
+        newAppNativeVerificationAvailable: true
     )
 
-    private init(
-        newAppNativeVerificationAvailable: Bool,
-        trustedBundledWorker: DesktopLocalBotExecutionContext?
-    ) {
-        self.newAppNativeVerificationAvailable =
-            newAppNativeVerificationAvailable
-        self.trustedBundledWorker = trustedBundledWorker
+    private init(newAppNativeVerificationAvailable: Bool) {
+        self.newAppNativeVerificationAvailable = newAppNativeVerificationAvailable
     }
 
     /// Resolve from the produced bundle contract and platform proof callbacks.
@@ -138,33 +128,25 @@ package struct DesktopNativeVerificationCapability: Sendable {
         sealedFileIsValid: (URL) -> Bool
     ) -> Self {
         guard productionBoundary.byoGitHubEnabled,
-              let trustedBundledWorker =
-                DesktopTrustedBundledWorkerContract.executionContext(
-                    appBundleURL: appBundleURL,
-                    appSignatureIsValid: appSignatureIsValid,
-                    sealedFileIsValid: sealedFileIsValid
-                )
+              DesktopTrustedBundledWorkerContract.executionContext(
+                  appBundleURL: appBundleURL,
+                  appSignatureIsValid: appSignatureIsValid,
+                  sealedFileIsValid: sealedFileIsValid
+              ) != nil
         else {
             return .unavailable
         }
-        return DesktopNativeVerificationCapability(
-            newAppNativeVerificationAvailable: true,
-            trustedBundledWorker: trustedBundledWorker
-        )
+        return .testAvailable
     }
 
     package static func resolve(
         productionBoundary: DesktopProductionBoundary,
         trustedBundledWorker: DesktopLocalBotExecutionContext?
     ) -> Self {
-        guard productionBoundary.byoGitHubEnabled,
-              let trustedBundledWorker
-        else {
-            return .unavailable
-        }
         return DesktopNativeVerificationCapability(
-            newAppNativeVerificationAvailable: true,
-            trustedBundledWorker: trustedBundledWorker
+            newAppNativeVerificationAvailable:
+                productionBoundary.byoGitHubEnabled
+                && trustedBundledWorker != nil
         )
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -592,6 +592,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && dependencies.productionBoundary.managedGitHubBrokerOrigin == nil
     }
 
+    package var newAppNativeVerificationAvailable: Bool {
+        dependencies.newAppNativeVerificationAvailable
+    }
+
     package var byoGitHubAppIdStored: Bool {
         storedBYOGitHubAppId != nil
     }
@@ -3826,6 +3830,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard !isSetupMutationBlocked else {
             lastError = "Retry account verification before verifying GitHub App setup."
             byoGitHubCredentialStatus = lastError ?? "Account check required"
+            return
+        }
+        guard source != .keychainStdin || newAppNativeVerificationAvailable else {
+            lastError = "Native new-App verification is unavailable in this signed build."
+            byoGitHubCredentialStatus = lastError ?? "Unavailable"
             return
         }
         guard requireLocalWorkerCLI() else {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -256,6 +256,99 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.activationState != .active)
     }
 
+    @Test func newAppNativeVerificationRequiresExactBYOMarkersAndTrustedWorker() {
+        let appBundleURL = URL(filePath: "/Applications/NeonDiff.app")
+        let byoMarkers: [String: Any] = [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ]
+
+        let available = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { $0 == appBundleURL },
+            sealedFileIsValid: { $0.path.hasSuffix("NeonDiffWorker") }
+        )
+        #expect(available.newAppNativeVerificationAvailable)
+        #expect(
+            available.trustedBundledWorker?.executablePath
+                == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
+        )
+
+        let withoutWorker = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in false }
+        )
+        #expect(!withoutWorker.newAppNativeVerificationAvailable)
+        #expect(withoutWorker.trustedBundledWorker == nil)
+
+        let mixedMarkers = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers.merging([
+                "NeonDiffManagedGitHubBrokerEnabled": true,
+                "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
+            ]) { _, new in new },
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!mixedMarkers.newAppNativeVerificationAvailable)
+
+        let wrongHelperPath = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: URL(filePath: "/Applications/Other.app"),
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!wrongHelperPath.newAppNativeVerificationAvailable)
+
+        let wrongSignature = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in false },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!wrongSignature.newAppNativeVerificationAvailable)
+
+        let wrongHelperProof = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in false }
+        )
+        #expect(!wrongHelperProof.newAppNativeVerificationAvailable)
+
+        let preferenceOnly = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: ["NeonDiffBYOGitHubEnabled": true],
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!preferenceOnly.newAppNativeVerificationAvailable)
+    }
+
+    @Test func compositionBindsNewAppWorkerToTheDerivedCapability() throws {
+        let compositionRoot = sourceBoundaryPackageRoot()
+            .appendingPathComponent(
+                "Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift"
+            )
+        let source = try sourceBoundaryText(at: compositionRoot)
+
+        #expect(source.contains(
+            "FoundationTrustedBundledWorker.nativeVerificationCapability"
+        ))
+        #expect(source.contains(
+            "let trustedBundledWorker =\n            nativeVerificationCapability.trustedBundledWorker"
+        ))
+        #expect(source.contains(
+            "nativeVerificationCapability: nativeVerificationCapability"
+        ))
+        #expect(!source.contains(
+            "FoundationTrustedBundledWorker.executionContext()"
+        ))
+    }
+
     @Test func managedConnectUsesBrokerAndKeychainIdentityWithoutLegacyUserTokenFallback() async throws {
         let broker = ScriptedGitHubBroker(repositories: [
             GitHubBrokerRepository(fullName: "electric/private", visibility: .private),

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -274,6 +274,10 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             available.trustedBundledWorker?.executablePath
                 == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
         )
+        #expect(!DesktopNativeVerificationCapability.resolve(
+            productionBoundary: .testManaged,
+            trustedBundledWorker: available.trustedBundledWorker
+        ).newAppNativeVerificationAvailable)
 
         let withoutWorker = DesktopNativeVerificationCapability.resolve(
             infoDictionary: byoMarkers,
@@ -336,17 +340,30 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         let source = try sourceBoundaryText(at: compositionRoot)
 
         #expect(source.contains(
-            "FoundationTrustedBundledWorker.nativeVerificationCapability"
+            "FoundationTrustedBundledWorker.executionContext()"
         ))
         #expect(source.contains(
-            "let trustedBundledWorker =\n            nativeVerificationCapability.trustedBundledWorker"
+            "DesktopNativeVerificationCapability.resolve"
+        ))
+        #expect(source.contains(
+            "trustedBundledWorker: trustedBundledWorker"
         ))
         #expect(source.contains(
             "nativeVerificationCapability: nativeVerificationCapability"
         ))
-        #expect(!source.contains(
-            "FoundationTrustedBundledWorker.executionContext()"
-        ))
+    }
+
+    @Test func newAppVerificationFailsClosedWithoutDerivedCapability() {
+        let fixture = ModelDependencyFixture(
+            preferenceStrings: ["neondiff.cliPath": "neondiff"],
+            productionBoundary: .testAccountLink,
+            nativeVerificationCapability: .unavailable
+        )
+        fixture.model.verifyBYOGitHubAppCredentials()
+
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.model.newAppNativeVerificationAvailable == false)
+        #expect(fixture.model.lastError?.contains("unavailable") == true)
     }
 
     @Test func managedConnectUsesBrokerAndKeychainIdentityWithoutLegacyUserTokenFallback() async throws {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -270,13 +270,9 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             sealedFileIsValid: { $0.path.hasSuffix("NeonDiffWorker") }
         )
         #expect(available.newAppNativeVerificationAvailable)
-        #expect(
-            available.trustedBundledWorker?.executablePath
-                == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker"
-        )
         #expect(!DesktopNativeVerificationCapability.resolve(
             productionBoundary: .testManaged,
-            trustedBundledWorker: available.trustedBundledWorker
+            trustedBundledWorker: nil
         ).newAppNativeVerificationAvailable)
 
         let withoutWorker = DesktopNativeVerificationCapability.resolve(
@@ -286,7 +282,6 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
             sealedFileIsValid: { _ in false }
         )
         #expect(!withoutWorker.newAppNativeVerificationAvailable)
-        #expect(withoutWorker.trustedBundledWorker == nil)
 
         let mixedMarkers = DesktopNativeVerificationCapability.resolve(
             infoDictionary: byoMarkers.merging([
@@ -362,7 +357,6 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         fixture.model.verifyBYOGitHubAppCredentials()
 
         #expect(fixture.cli.calls.isEmpty)
-        #expect(fixture.model.newAppNativeVerificationAvailable == false)
         #expect(fixture.model.lastError?.contains("unavailable") == true)
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -255,6 +255,7 @@ struct ModelDependencyFixture {
         localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         localBotExecutionConfigPaths: [String] = [],
         productionBoundary: DesktopProductionBoundary = .testVerified,
+        nativeVerificationCapability: DesktopNativeVerificationCapability = .testAvailable,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
             shortVersion: "1.1.0-beta.37"
         )
@@ -292,6 +293,7 @@ struct ModelDependencyFixture {
             githubAuthenticator: githubAuthenticator,
             githubBroker: githubBroker,
             productionBoundary: productionBoundary,
+            nativeVerificationCapability: nativeVerificationCapability,
             localWorkerUpdateGuideURL: localWorkerUpdateGuideURL,
             localBotConfigurations: localBotConfigurations,
             localBotExecutionContexts: localBotExecutionContexts,


### PR DESCRIPTION
Closes #974

## Summary

- preserve the general sealed trusted-worker context for managed and BYO signed bundles
- derive a separate read-only native new-App verification capability from exact BYO markers plus trusted-worker proof
- fail closed in the model and disable new-App verification actions when that capability is absent; existing-bot verification stays on its separate source path
- add focused marker, helper-proof, managed-separation, composition, and fail-closed tests

## Proof

- Base: f53754d16ae3e8a4c30bfe8e9d56c5c840a68b03 (current origin/main; handoff base f56b186 was reconciled after #981 advanced main)
- Head: 454611912a258868d09f433706ce7e9a3aab86b5
- Changed: 7 Desktop source/test files; 199 additions + 1 deletion = 200 total lines
- swift build: passed
- git diff --check: passed
- focused swift test build compiled changed sources/tests but test executable link is blocked on this host by unresolved Swift Testing framework symbols (including Testing.SourceLocation); explicit framework-link fallback reproduces the same environment failure

No installed app, launchd worker, runtime, config, DB, Keychain, release, signing, or customer state was touched. This PR does not prove signed-artifact, clean-Mac, release, runtime, or customer readiness.