### PR TITLE
fix(issue-enrichment): bound newest event pagination

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -21,6 +21,9 @@ const MAX_REVIEW_COMMENT_PAGES = 5;
 const MAX_ISSUE_COMMENT_PAGES = 5;
 export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
+export type GitHubIssueLabelEvent = { id?: number | string; event?: string; created_at?: string; actor?: { login?: string | null } | null; label?: { name?: string | null } | null };
+export type BoundedIssueLabelEventRead = BoundedGithubList<GitHubIssueLabelEvent> & { pagesRead: number; uniqueCount: number; duplicateCount: number; lastPage?: number; terminal: "short_page" | "bounded_tail" | "event_history_unbounded" };
+
 /** Array-compatible metadata for bounded GitHub reads. `rawCount` is the count before downstream filters. */
 export type BoundedGithubList<T> = T[] & {
   items: T[];
@@ -434,26 +437,49 @@ export class GitHubApi {
     });
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>> {
-    const events: Array<{
-      event?: string;
-      created_at?: string;
-      actor?: { login?: string | null } | null;
-      label?: { name?: string | null } | null;
-    }> = [];
-    for (let page = 1; ; page += 1) {
-      const chunk = await this.request<typeof events>(
-        `/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`,
-        { token: await this.getReadToken(repo) }
-      );
-      events.push(...chunk);
-      if (chunk.length < 100) return events;
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedIssueLabelEventRead> {
+    const events: GitHubIssueLabelEvent[] = [];
+    const seen = new Set<string>();
+    let pagesRead = 0;
+    let rawCount = 0;
+    let duplicateCount = 0;
+    const append = (chunk: GitHubIssueLabelEvent[]) => {
+      rawCount += chunk.length;
+      for (const event of chunk) {
+        const id = typeof event.id === "number" || (typeof event.id === "string" && event.id.trim()) ? String(event.id) : undefined;
+        if (id && seen.has(id)) { duplicateCount += 1; continue; }
+        if (id) seen.add(id);
+        events.push(event);
+      }
+    };
+    const readPage = async (page: number) => {
+      let link: string | null = null;
+      const chunk = await this.request<GitHubIssueLabelEvent[]>(`/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`, { token: await this.getReadToken(repo), onResponse: (response) => { link = response.headers.get("link"); } });
+      pagesRead += 1;
+      return { chunk, links: parseIssueEventLinks(link, this.apiBaseUrl.origin) };
+    };
+    const finish = (terminal: BoundedIssueLabelEventRead["terminal"], lastPage?: number) =>
+      boundedIssueLabelEventRead(events, { pagesRead, rawCount, duplicateCount, ...(lastPage === undefined ? {} : { lastPage }), terminal });
+    const first = await readPage(1);
+    append(first.chunk);
+    if (first.chunk.length < 100) return finish("short_page");
+    if (first.links.invalid) return finish("event_history_unbounded");
+    const lastPage = first.links.lastPage;
+    if (lastPage === undefined || lastPage === 1) {
+      const probe = await readPage(2);
+      if (probe.links.invalid) return finish("event_history_unbounded", lastPage);
+      append(probe.chunk);
+      return finish(probe.chunk.length < 100 ? "short_page" : "event_history_unbounded", lastPage);
     }
+    if (first.links.nextPage !== 2) return finish("event_history_unbounded", lastPage);
+    const startPage = Math.max(1, lastPage - 4);
+    for (let page = startPage; page <= lastPage; page += 1) {
+      if (page === 1) continue;
+      const response = await readPage(page);
+      if (response.links.invalid || (response.links.lastPage !== undefined && response.links.lastPage !== lastPage) || (page < lastPage && response.links.nextPage === undefined) || (response.links.nextPage !== undefined && (response.links.nextPage <= page || response.links.nextPage > lastPage)) || (page === lastPage && response.links.nextPage !== undefined) || (response.chunk.length < 100 && page < lastPage)) return finish("event_history_unbounded", lastPage);
+      append(response.chunk);
+    }
+    return finish("bounded_tail", lastPage);
   }
 
   async getCollaboratorPermission(
@@ -695,7 +721,7 @@ export class GitHubApi {
 
   private async request<T>(
     path: string,
-    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean } = {}
+    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean; onResponse?: (response: Response) => void } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
     const controller = new AbortController();
@@ -713,6 +739,7 @@ export class GitHubApi {
         },
         body: options.body === undefined ? undefined : JSON.stringify(options.body)
       });
+      options.onResponse?.(response);
       if (!response.ok) {
         const text = await response.text();
         throw new GitHubApiRequestError({
@@ -733,6 +760,41 @@ export class GitHubApi {
       clearTimeout(timeout);
     }
   }
+}
+
+function boundedIssueLabelEventRead(
+  items: GitHubIssueLabelEvent[],
+  metadata: Pick<BoundedIssueLabelEventRead, "pagesRead" | "rawCount" | "duplicateCount" | "lastPage" | "terminal">
+): BoundedIssueLabelEventRead {
+  const result = items as BoundedIssueLabelEventRead;
+  Object.assign(result, { items: items.slice(), rawCount: metadata.rawCount, pagesRead: metadata.pagesRead, uniqueCount: items.length, duplicateCount: metadata.duplicateCount, terminal: metadata.terminal, truncated: metadata.terminal === "event_history_unbounded", overflow: metadata.terminal === "event_history_unbounded" });
+  if (metadata.lastPage !== undefined) result.lastPage = metadata.lastPage;
+  return result;
+}
+
+function parseIssueEventLinks(value: string | null, origin: string): { lastPage?: number; nextPage?: number; invalid: boolean } {
+  if (!value) return { invalid: false };
+  const seen = new Set<string>();
+  let lastPage: number | undefined;
+  let nextPage: number | undefined;
+  for (const part of value.split(",")) {
+    const match = /^\s*<([^>]+)>\s*;\s*(.*)$/.exec(part); if (!match) return { invalid: true };
+    let target: URL; try { target = new URL(match[1]!); } catch { return { invalid: true }; }
+    if (target.origin !== origin) return { invalid: true };
+    const relMatch = /(?:^|;)\s*rel\s*=\s*(?:"([^"]+)"|'([^']+)'|([^;\s]+))/i.exec(match[2]!); if (!relMatch) return { invalid: true };
+    for (const rawRel of (relMatch[1] ?? relMatch[2] ?? relMatch[3]!).split(/\s+/)) {
+      const rel = rawRel.toLowerCase();
+      if (!["first", "prev", "next", "last"].includes(rel)) continue;
+      if (seen.has(rel)) return { invalid: true };
+      seen.add(rel);
+      const page = target.searchParams.get("page");
+      if (!page || !/^\d+$/.test(page)) return { invalid: true };
+      const number = Number(page);
+      if (!Number.isSafeInteger(number) || number < 1) return { invalid: true };
+      if (rel === "last") lastPage = number; else if (rel === "next") nextPage = number;
+    }
+  }
+  return { lastPage, nextPage, invalid: false };
 }
 
 function normalizePullRequestSummary(pull: PullRequestSummary): PullRequestSummary {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,7 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
-import { unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
+import { unpackBoundedGithubList, type BoundedGithubList, type BoundedIssueLabelEventRead, type GitHubIssueLabelEvent } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -231,6 +231,7 @@ export type IssueEnrichmentScanCompletion = "complete" | "page_limit_reached" | 
 
 export type IssueEnrichmentIssueList = GitHubRelatedIssueOrPull[] & {
   scanCompletion?: IssueEnrichmentScanCompletion;
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
 };
 
 export interface IssueEnrichmentScanResult {
@@ -286,12 +287,7 @@ type IssueEnrichmentComment = {
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<GitHubIssueLabelEvent[] | BoundedGithubList<GitHubIssueLabelEvent> | BoundedIssueLabelEventRead>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -329,7 +325,8 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded"
+  | "event_history_unbounded";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -381,7 +378,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
-}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
+}): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence; eventHistoryUnbounded?: boolean }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
     .map((label) => label.trim().toLowerCase())
@@ -394,7 +391,9 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const eventRead = unpackIssueLabelEvents(await input.github.listIssueLabelEvents(input.repo, input.issue.number));
+    if (eventRead.overflow) return { issue: input.issue, eventHistoryUnbounded: true };
+    const events = eventRead.items;
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -423,6 +422,11 @@ async function evaluateIssuePromotion(input: {
   }
 }
 
+function unpackIssueLabelEvents(result: GitHubIssueLabelEvent[] | BoundedGithubList<GitHubIssueLabelEvent> | BoundedIssueLabelEventRead): { items: GitHubIssueLabelEvent[]; overflow: boolean } {
+  const unpacked = unpackBoundedGithubList(result);
+  return { items: unpacked.items, overflow: unpacked.overflow || (result as Partial<BoundedIssueLabelEventRead>).terminal === "event_history_unbounded" };
+}
+
 function emptyIssueEvidenceContext(headSha: string): IssueAnalysisEvidenceContext {
   return {
     repository: { defaultBranch: "unknown", headSha },
@@ -439,6 +443,7 @@ export async function buildIssueEvidenceContext(input: {
   github: IssueEnrichmentCycleGithub;
   defaultBranch: string;
   headSha: string;
+  onEventHistoryUnbounded?: () => void;
 }): Promise<IssueAnalysisEvidenceContext> {
   const commentResult = input.github.listIssueCommentsForEnrichment
     ? await input.github.listIssueCommentsForEnrichment(input.repo, input.issue.number)
@@ -449,9 +454,11 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const timelineResult = input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
     : [];
+  const { items: rawTimeline, overflow: timelineOverflow } = unpackIssueLabelEvents(timelineResult);
+  if (timelineOverflow) input.onEventHistoryUnbounded?.();
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -479,7 +486,7 @@ export async function buildIssueEvidenceContext(input: {
       updatedAt: boundedIssueContext(redactSecrets(comment.updated_at ?? ""), 100),
       body: boundedIssueContext(redactSecrets(comment.body ?? ""), 8_000)
     })),
-    timeline: rawTimeline.slice(0, 200).map((event) => ({
+    timeline: rawTimeline.slice(-200).map((event) => ({
       event: boundedIssueContext(redactSecrets(event.event ?? ""), 100),
       actor: boundedIssueContext(redactSecrets(event.actor?.login ?? ""), 200),
       createdAt: boundedIssueContext(redactSecrets(event.created_at ?? ""), 100),
@@ -488,7 +495,7 @@ export async function buildIssueEvidenceContext(input: {
     linkedItems,
     truncation: {
       comments: commentsTruncated || rawCommentCount > rawComments.length || externalComments.length > 50,
-      timeline: rawTimeline.length > 200,
+      timeline: timelineOverflow || rawTimeline.length > 200,
       linkedItems: linkedNumbers.length > 20
     }
   };
@@ -697,6 +704,7 @@ export async function collectIssueEnrichmentScan(input: {
     const issueItems = planRepoIssueScan({
       repo,
       issues,
+      scanReasons: issues.scanReasons,
       throttle: policy.throttle,
       suggestions: policy.suggestions,
       repoPolicy: policy.repoPolicy,
@@ -997,6 +1005,7 @@ export async function runIssueEnrichmentCycle(input: {
     };
     const shouldCountItem = (item: IssueEnrichmentScanItem) => {
       if (input.force === true) return true;
+      if (item.reason === "event_history_unbounded") return true;
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
@@ -1011,7 +1020,7 @@ export async function runIssueEnrichmentCycle(input: {
           reader: {
             listIssuesForEnrichment: async (repo, options) => {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
-              const prepared: GitHubRelatedIssueOrPull[] = [];
+              const prepared: GitHubRelatedIssueOrPull[] = [], scanReasons: Record<number, IssueEnrichmentScanReason> = {};
               for (const issue of issues) {
                 const promotion = await evaluateIssuePromotion({
                   repo,
@@ -1019,22 +1028,24 @@ export async function runIssueEnrichmentCycle(input: {
                   override: config.repos?.[repo],
                   github: input.github
                 });
-                prepared.push(promotion.issue);
+                prepared.push(promotion.issue); if (promotion.eventHistoryUnbounded) scanReasons[issue.number] = "event_history_unbounded";
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
-                  issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
+                if (shouldCollectModelEvidence && !promotion.eventHistoryUnbounded) {
+                  const evidenceContext = await buildIssueEvidenceContext({
                     repo,
                     issue: promotion.issue,
                     github: input.github,
                     defaultBranch: defaultBranches.get(repo.toLowerCase()) ?? "unknown",
-                    headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40)
-                  }));
+                    headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40),
+                    onEventHistoryUnbounded: () => { scanReasons[issue.number] = "event_history_unbounded"; }
+                  });
+                  if (!scanReasons[issue.number]) issueEvidenceContextByIssue.set(issueKey(repo, issue.number), evidenceContext);
                 }
                 if (promotion.evidence) {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
               }
-              return Object.assign(prepared, { scanCompletion: issues.scanCompletion });
+              return Object.assign(prepared, { scanCompletion: issues.scanCompletion, scanReasons });
             }
           },
           dryRun: input.dryRun,
@@ -1091,7 +1102,7 @@ export async function runIssueEnrichmentCycle(input: {
         shouldBackfillIssueEnrichmentAnalysisInputHash(existing, issueUpdatedAt, item.action)
         ? plannedAnalysisInputHashForItem(item)
         : undefined;
-      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
+      if (item.reason !== "event_history_unbounded" && input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action)) {
         const refreshedAnalysisInputHash = existing.analysisInputHash ?? analysisInputHash;
         if (!input.dryRun && (
           existing.issueUpdatedAt !== issueUpdatedAt ||
@@ -1378,6 +1389,7 @@ function resolveIssueSuggestionAllowlist(globalAllowlist: string[], repoOverride
 function planRepoIssueScan(input: {
   repo: string;
   issues: GitHubRelatedIssueOrPull[];
+  scanReasons?: Record<number, IssueEnrichmentScanReason>;
   throttle: IssueEnrichmentThrottlePolicy;
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
@@ -1396,7 +1408,7 @@ function planRepoIssueScan(input: {
     maxRelatedRefs: 8,
     ...input.renderPolicy
   }));
-  const eligible = planned.filter((output) => !output.skipped);
+  const eligible = planned.filter((output) => !output.skipped && !input.scanReasons?.[output.issueNumber]);
   const countableEligible = input.shouldCountItem
     ? eligible.filter((output) => input.shouldCountItem!(
         issueScanItem(
@@ -1414,6 +1426,8 @@ function planRepoIssueScan(input: {
   let comments = 0;
 
   return planned.map((output) => {
+    const scanReason = input.scanReasons?.[output.issueNumber];
+    if (scanReason) return issueScanItem(input.repo, output.issueNumber, output.state, "skipped", scanReason, output.url);
     if (output.skipped) {
       return {
         repo: input.repo,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -82,6 +82,12 @@ const pull: PullRequestSummary = {
 };
 
 describe("sticky enrichment comments", () => {
+  it("counts terminal event skips without consuming enrichment caps", async () => {
+    const config = loadConfig(); config.issueEnrichment = { ...config.issueEnrichment!, enabled: true, postIssueComment: true, allowlist: ["owner/repo"], maxIssuesPerBurst: 1 };
+    const result = await collectIssueEnrichmentScan({ config, dryRun: true, includeExisting: true, reader: { listIssuesForEnrichment: async () => Object.assign([{ number: 970, title: "overflow", state: "open" }], { scanReasons: { 970: "event_history_unbounded" as const } }) } });
+    expect(result.items[0]).toMatchObject({ action: "skipped", reason: "event_history_unbounded" }); expect(result.summary).toMatchObject({ skipped: 1, eligible: 0, wouldComment: 0 });
+  });
+
   it("blocks direct issue-enrichment cycles before reading state or GitHub without admission", async () => {
     await expect(runIssueEnrichmentCycleImpl({
       config: {},

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { GitHubApi } from "../src/github.js";
+
+const page = (start: number, count = 100) => Array.from({ length: count }, (_, i) => ({ id: start + i, event: "labeled" }));
+const link = (last: number, next?: number) => `${next ? `<https://api.github.com/events?page=${next}>; rel="next", ` : ""}<https://api.github.com/events?page=${last}>; rel="last"`;
+
+describe("bounded newest issue-event pagination", () => {
+  it("probes exact-100 histories, keeps the newest tail, and fails closed on later metadata", async () => {
+    const oldFetch = globalThis.fetch;
+    try {
+      let mode = "probe";
+      const calls: number[] = [];
+      globalThis.fetch = vi.fn(async (url) => {
+        const n = Number(new URL(String(url)).searchParams.get("page")); calls.push(n);
+        if (mode === "probe") return new Response(JSON.stringify(n === 1 ? page(1) : []));
+        if (mode === "bad") return new Response(JSON.stringify(page(1)), { headers: { link: link(3, 2) } });
+        const body = n === 1 ? page(1) : n === 4 ? [{ id: 401 }, ...page(402, 99)] : n === 5 ? [{ id: 401 }, ...page(502, 99)] : page(n * 100 + 1, n === 8 ? 50 : 100);
+        return new Response(JSON.stringify(body), { headers: { link: link(8, n < 8 ? n + 1 : undefined) } });
+      }) as typeof fetch;
+      let result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+      expect(calls).toEqual([1, 2]); expect(result.terminal).toBe("short_page"); expect(result).toHaveLength(100);
+      calls.length = 0; mode = "tail";
+      result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+      expect(calls).toEqual([1, 4, 5, 6, 7, 8]); expect(result.terminal).toBe("bounded_tail"); expect(result.uniqueCount).toBe(549); expect(result.duplicateCount).toBe(1); expect(result.at(-1)?.id).toBe(850);
+      calls.length = 0; mode = "bad";
+      result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+      expect(calls).toEqual([1, 2]); expect(result.terminal).toBe("event_history_unbounded"); expect(result.overflow).toBe(true);
+    } finally { globalThis.fetch = oldFetch; }
+  });
+});


### PR DESCRIPTION
Closes #970

## Summary
- capture and validate GitHub Link pagination metadata for issue label events
- read page 1 plus at most the newest five tail pages, with one bounded probe for exact-100 histories without usable metadata
- deduplicate event IDs, preserve newest timeline evidence, and fail closed on malformed or inconsistent metadata
- record terminal `event_history_unbounded` skips without consuming enrichment caps or blocking sibling/watermark progress

## Deterministic proof
- `PATH=/opt/homebrew/bin:$PATH npm test -- --run tests/github.test.ts tests/issue-comment-pagination.test.ts tests/enrichment.test.ts` (74 passed)
- `PATH=/opt/homebrew/bin:$PATH npm test -- --run tests/issue-enrichment-evidence.test.ts` (2 passed)
- `PATH=/opt/homebrew/bin:$PATH npm run build` (pass)
- `git diff --check` (pass)
- base: `f56b186e09bde875ba85ee08c95cd47c92bf7bb7`
- candidate: `c1d2c0a6aa6f70a0f097d9d4d6b9dccdf88292e0`
- changed lines: 196 total (154 additions, 42 deletions)

GitNexus was unavailable in this worktree; bounded direct source inspection and exact-head checks were used.

## Proof boundary
This proves source behavior and deterministic mocked fixtures only. It does not prove merge, canonical CI, live GitHub enrichment, worker/runtime soak, release readiness, or customer readiness. No runtime, config, database, Keychain, release, or customer state was changed.
