### PR TITLE
fix(issue-enrichment): admit source prep after caps

### DIFF
--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -921,26 +921,7 @@ export async function runIssueEnrichmentCycle(input: {
     }
 
     const sourceSnapshots = new Map<string, PreparedWorktree>();
-    const defaultBranches = new Map<string, string>();
-    if (shouldCollectModelEvidence) {
-      if (!input.config.workRoot) throw new Error("issue_enrichment_model_runtime_paths_required");
-      if (!input.github.getRepo) throw new Error("issue_enrichment_repository_metadata_required");
-      for (const repo of reposToScan) {
-        const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
-        if (!policy.allowed) continue;
-        const metadata = await input.github.getRepo(repo);
-        const defaultBranch = metadata.default_branch?.trim();
-        if (!defaultBranch) throw new Error(`issue_enrichment_default_branch_missing: ${repo}`);
-        sourceSnapshots.set(repo.toLowerCase(), await prepareBranchWorktree({
-          repo,
-          branch: defaultBranch,
-          ...(metadata.clone_url ? { repoUrl: metadata.clone_url } : {}),
-          workRoot: input.config.workRoot,
-          protectedCheckoutRoots: getProtectedCheckoutRoots()
-        }));
-        defaultBranches.set(repo.toLowerCase(), defaultBranch);
-      }
-    }
+    const sourcePreparationFailures = new Map<string, string>();
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
     const issueEvidenceContextByIssue = new Map<string, IssueAnalysisEvidenceContext>();
@@ -1000,7 +981,8 @@ export async function runIssueEnrichmentCycle(input: {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      const analysisInputHash = issue && shouldCompareIssueEnrichmentAnalysisInputHash(existing)
+      if (shouldCollectModelEvidence && existing?.status === "posted" && existing.analysisInputHash) return true;
+      const analysisInputHash = !shouldCollectModelEvidence && issue && shouldCompareIssueEnrichmentAnalysisInputHash(existing)
         ? plannedAnalysisInputHashForItem(item)
         : undefined;
       return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action));
@@ -1021,15 +1003,6 @@ export async function runIssueEnrichmentCycle(input: {
                 });
                 prepared.push(promotion.issue);
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
-                  issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
-                    repo,
-                    issue: promotion.issue,
-                    github: input.github,
-                    defaultBranch: defaultBranches.get(repo.toLowerCase()) ?? "unknown",
-                    headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40)
-                  }));
-                }
                 if (promotion.evidence) {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
@@ -1057,12 +1030,50 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
+    applyGlobalIssueEnrichmentCaps({ items: scanned.items, repoScans: scanned.repos, config, checkedAt, shouldCountItem });
+    if (shouldCollectModelEvidence) {
+      const prepareRepos = async (repos: string[]) => {
+        for (const repo of repos) {
+          const key = repo.toLowerCase();
+          try {
+            if (!input.config.workRoot || !input.github.getRepo) throw new Error(!input.config.workRoot ? "issue_enrichment_model_runtime_paths_required" : "issue_enrichment_repository_metadata_required");
+            const metadata = await input.github.getRepo(repo), branch = metadata.default_branch?.trim();
+            if (!branch) throw new Error(`issue_enrichment_default_branch_missing: ${repo}`);
+            sourceSnapshots.set(key, await prepareBranchWorktree({ repo, branch, ...(metadata.clone_url ? { repoUrl: metadata.clone_url } : {}), workRoot: input.config.workRoot, protectedCheckoutRoots: getProtectedCheckoutRoots() }));
+            for (const item of scanned.items.filter((candidate) => candidate.repo === repo && isIssueEnrichmentCommentAction(candidate.action) && shouldCountItem(candidate))) {
+              const issue = issuesByKey.get(issueKey(repo, item.issueNumber));
+              if (issue) issueEvidenceContextByIssue.set(issueKey(repo, item.issueNumber), await buildIssueEvidenceContext({ repo, issue, github: input.github, defaultBranch: branch, headSha: sourceSnapshots.get(key)!.headSha }));
+            }
+          } catch (error) {
+            sourcePreparationFailures.set(key, redactSecrets(error instanceof Error ? error.message : String(error)));
+          }
+        }
+      };
+      const selectedRepos = [...new Set(scanned.items.filter((item) => isIssueEnrichmentCommentAction(item.action) && shouldCountItem(item)).map((item) => item.repo))];
+      await prepareRepos(selectedRepos);
+      const attemptedRepos = new Set(selectedRepos.map((repo) => repo.toLowerCase()));
+      while (true) {
+        let issues = scanned.items.filter((item) => isIssueEnrichmentCommentAction(item.action) && shouldCountItem(item) && !sourcePreparationFailures.has(item.repo.toLowerCase())).length;
+        let comments = scanned.items.filter((item) => item.action === "would_comment" && shouldCountItem(item) && !sourcePreparationFailures.has(item.repo.toLowerCase())).length;
+        const admittedRepos = new Set<string>();
+        for (const item of scanned.items) {
+          const key = item.repo.toLowerCase();
+          if (item.action !== "deferred" || !item.reason.startsWith("global_") || sourcePreparationFailures.has(key) || !shouldCountItem(item)) continue;
+          if (issues >= config.globalMaxIssuesPerCycle || (config.postIssueComment && comments >= config.globalMaxCommentsPerCycle)) continue;
+          item.action = config.postIssueComment ? "would_comment" : "would_enrich"; item.reason = "eligible"; issues += 1; if (config.postIssueComment) comments += 1;
+          admittedRepos.add(item.repo);
+        }
+        const freshRepos = [...admittedRepos].filter((repo) => !attemptedRepos.has(repo.toLowerCase()));
+        if (freshRepos.length === 0) break;
+        freshRepos.forEach((repo) => attemptedRepos.add(repo.toLowerCase())); await prepareRepos(freshRepos);
+      }
+    }
     applyGlobalIssueEnrichmentCaps({
       items: scanned.items,
       repoScans: scanned.repos,
       config,
       checkedAt,
-      shouldCountItem
+      shouldCountItem: (item) => !sourcePreparationFailures.has(item.repo.toLowerCase()) && shouldCountItem(item)
     });
     const combinedRepos = [...baselineRepos, ...scanned.repos];
     const combinedSummary = summarizeScan(combinedRepos);
@@ -1085,6 +1096,12 @@ export async function runIssueEnrichmentCycle(input: {
 
     for (const item of scan.items) {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
+      const sourcePreparationFailure = sourcePreparationFailures.get(item.repo.toLowerCase());
+      if (sourcePreparationFailure && isIssueEnrichmentCommentAction(item.action) && shouldCountItem(item)) {
+        summary.failed += 1;
+        items.push({ ...item, recordStatus: "failed", error: sourcePreparationFailure });
+        continue;
+      }
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
       const analysisInputHash = shouldCompareIssueEnrichmentAnalysisInputHash(existing) ||

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { loadConfig } from "../src/config.js";
 import {
   buildEnrichmentComment,
@@ -17,9 +17,15 @@ import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js"
 import type { IssueAnalysis } from "../src/issue-analysis.js";
 import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle as runIssueEnrichmentCycleImpl } from "../src/issue-enrichment.js";
-import { ReviewStateStore } from "../src/state.js";
+import { ReviewStateStore, type IssueEnrichmentRecord } from "../src/state.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
 import { createTestLicenseAdmission } from "./helpers/license-admission.js";
+
+const { prepareBranchWorktreeMock } = vi.hoisted(() => ({ prepareBranchWorktreeMock: vi.fn() }));
+vi.mock("../src/git.js", async () => ({
+  ...(await vi.importActual<typeof import("../src/git.js")>("../src/git.js")),
+  prepareBranchWorktree: prepareBranchWorktreeMock
+}));
 
 const issueEnrichmentTestAdmission = await createTestLicenseAdmission({ operation: "issue_enrichment" });
 const fixtureIssueAnalysis = (issue: GitHubRelatedIssueOrPull): IssueAnalysis => ({
@@ -69,6 +75,29 @@ const runIssueEnrichmentCycle = (input: Parameters<typeof runIssueEnrichmentCycl
 const HEAD_A = "a".repeat(40);
 const HEAD_B = "b".repeat(40);
 
+const liveIssueEnrichmentConfig = (workRoot: string, repos: string[], globalCap = 1) => {
+  const repoPolicy = { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 2, lookbackMs: 60_000, processExistingOpenIssuesOnActivation: true };
+  return { workRoot, evidenceDir: join(workRoot, "evidence"), codexRuntime: { enabled: true, cliPath: "/definitely/missing/codex", model: "gpt-5.6-luna", reasoningEffort: "max" as const, timeoutMs: 1_000, maxOutputBytes: 64_000 }, issueEnrichment: {
+    enabled: true, postIssueComment: true, allowlist: repos, allowedLabels: [], allowedReviewers: [], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1,
+    globalMaxIssuesPerCycle: globalCap, globalMaxCommentsPerCycle: globalCap, maxActiveRuns: 1, leaseTtlMs: 60_000, cooldownMs: 60_000,
+    burstWindowMs: 60_000, maxIssuesPerBurst: 2, lookbackMs: 60_000, processExistingOpenIssuesOnActivation: true,
+    repos: Object.fromEntries(repos.map((repo) => [repo, repoPolicy]))
+  }};
+};
+
+function buildCycleState(existing: IssueEnrichmentRecord[] = []) {
+  const existingByKey = new Map(existing.map((record) => [`${record.repo}#${record.issueNumber}`, record]));
+  const records: Array<Parameters<ReviewStateStore["recordIssueEnrichment"]>[0]> = [];
+  const state = {
+    getIssueEnrichmentRecord: (repo: string, issueNumber: number) => existingByKey.get(`${repo}#${issueNumber}`),
+    recordIssueEnrichment: (record: Parameters<ReviewStateStore["recordIssueEnrichment"]>[0]) => (records.push(record), record as ReturnType<ReviewStateStore["recordIssueEnrichment"]>),
+    getIssueEnrichmentRepoWatermark: () => undefined, recordIssueEnrichmentRepoWatermark: () => undefined as never,
+    tryAcquireIssueEnrichmentRunLease: () => ({ leaseId: "test-lease", expiresAt: "2026-08-24T02:00:00.000Z", ownerPid: process.pid }),
+    releaseIssueEnrichmentRunLease: () => undefined
+  };
+  return { records, state };
+}
+
 const pull: PullRequestSummary = {
   number: 77,
   title: "Harden review queue #22",
@@ -89,6 +118,91 @@ describe("sticky enrichment comments", () => {
       github: {} as never,
       dryRun: true
     })).rejects.toThrow("production license admission is required");
+  });
+
+  it("counts hash-bearing reruns inside global caps before source preparation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-hash-cap-"));
+    try {
+      const emptyRepos = Array.from({ length: 53 }, (_value, index) => `owner/empty-${index + 1}`);
+      const rerunRepo = "owner/hash-rerun";
+      const siblingRepo = "owner/sibling";
+      const issueUpdatedAt = "2026-08-24T00:00:00.000Z";
+      const { state } = buildCycleState([{
+        repo: rerunRepo,
+        issueNumber: 971,
+        issueUpdatedAt,
+        analysisInputHash: "f".repeat(64),
+        status: "posted",
+        createdAt: issueUpdatedAt,
+        updatedAt: issueUpdatedAt
+      }]);
+      const repos = [...emptyRepos, rerunRepo, siblingRepo];
+      prepareBranchWorktreeMock.mockReset().mockResolvedValue({ path: process.cwd(), headSha: HEAD_A });
+      const result = await runIssueEnrichmentCycleImpl({
+        config: liveIssueEnrichmentConfig(join(root, "work"), repos),
+        state,
+        github: {
+          listIssuesForEnrichment: async (repo) => {
+            return [rerunRepo, siblingRepo].includes(repo)
+              ? [{ number: repo === rerunRepo ? 971 : 972, title: `Candidate for ${repo}`, state: "open", updated_at: issueUpdatedAt, body: "Acceptance criteria and owner." }]
+              : [];
+          },
+          getRepo: async () => ({ default_branch: "main", clone_url: process.cwd() }),
+          canPostAsApp: () => true,
+          upsertIssueComment: async () => { throw new Error("fixture must not post"); }
+        },
+        dryRun: false, includeExisting: true, checkedAt: "2026-08-24T01:00:00.000Z", licenseAdmission: issueEnrichmentTestAdmission
+      });
+
+      expect(result.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({ repo: rerunRepo, issueNumber: 971, action: "would_comment" }),
+        expect.objectContaining({ repo: siblingRepo, issueNumber: 972, action: "deferred", reason: "global_max_issues_per_cycle" })
+      ]));
+      expect(prepareBranchWorktreeMock).toHaveBeenCalledTimes(1);
+      expect(prepareBranchWorktreeMock.mock.calls[0]?.[0]).toMatchObject({ repo: rerunRepo });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("backfills a healthy sibling after a selected source preparation failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-source-failure-"));
+    try {
+      const failingRepo = "owner/source-fails";
+      const siblingRepo = "owner/sibling";
+      const { state, records } = buildCycleState();
+      prepareBranchWorktreeMock.mockReset().mockImplementation(async ({ repo }: { repo: string }) => {
+        if (repo === failingRepo) throw new Error("mirror unavailable");
+        return { path: process.cwd(), headSha: HEAD_A };
+      });
+      const result = await runIssueEnrichmentCycleImpl({
+        config: liveIssueEnrichmentConfig(join(root, "work"), [failingRepo, siblingRepo], 1),
+        state,
+        github: {
+          listIssuesForEnrichment: async (repo) => [{
+            number: repo === failingRepo ? 971 : 972,
+            title: `Candidate for ${repo}`,
+            state: "open",
+            updated_at: "2026-08-24T00:00:00.000Z",
+            body: "Acceptance criteria and owner."
+          }],
+          getRepo: async () => ({ default_branch: "main", clone_url: process.cwd() }),
+          canPostAsApp: () => true,
+          upsertIssueComment: async () => { throw new Error("fixture must not post"); }
+        },
+        dryRun: false, includeExisting: true, checkedAt: "2026-08-24T01:00:00.000Z", licenseAdmission: issueEnrichmentTestAdmission
+      });
+
+      expect(prepareBranchWorktreeMock.mock.calls.map((call: [{ repo?: string }]) => call[0]?.repo)).toEqual([failingRepo, siblingRepo]);
+      expect(result.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({ repo: failingRepo, issueNumber: 971, action: "would_comment", recordStatus: "failed" }),
+        expect.objectContaining({ repo: siblingRepo, issueNumber: 972, action: "would_comment" })
+      ]));
+      expect(result.items.find((item) => item.repo === failingRepo)?.error).toContain("mirror unavailable");
+      expect(records.some((record) => record.repo === failingRepo)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("loads default-off enrichment config", () => {


### PR DESCRIPTION
Closes #971

## Outcome

Issue enrichment admits candidate repositories before preparing source, keeps hash-bearing posted reruns inside repository/global caps, and backfills global slots after selected source-preparation failures.

## Proof

- Base: f56b186e09bde875ba85ee08c95cd47c92bf7bb7
- Candidate: a81f3b235a8e3297da98722f07d55c3d34c13bfa
- Changed files: src/issue-enrichment.ts; tests/enrichment.test.ts
- Diff: 197 total changed lines (164 additions, 33 deletions)
- `git diff --check`: passed
- Focused Vitest: blocked by environment Rollup native addon Team ID mismatch
- `npm run build`: blocked because this isolated worktree has no dependencies (`tsc: command not found`)
- Direct TypeScript parse/type check of src/issue-enrichment.ts: passed

The PR is agent-authored. No runtime, config, DB, worker, release, customer, or live GitHub comment mutation was performed. Passing this candidate does not prove runtime soak, release readiness, or customer readiness.