### PR TITLE
fix(github): project canonical customer App identity

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -630,6 +630,7 @@ export class GitHubApi {
     const response = await this.request<unknown>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects,
+      allowRedirectResponse: options.followRedirects !== false,
       onResponse: (result) => { responseUrl = result.url; }
     });
     const configuredOwner = repo.split("/")[0];
@@ -711,7 +712,7 @@ export class GitHubApi {
 
   private async request<T>(
     path: string,
-    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean; onResponse?: (response: Response) => void } = {}
+    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean; allowRedirectResponse?: boolean; onResponse?: (response: Response) => void } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
     const controller = new AbortController();
@@ -729,7 +730,8 @@ export class GitHubApi {
         },
         body: options.body === undefined ? undefined : JSON.stringify(options.body)
       });
-      if (!response.ok) {
+      options.onResponse?.(response);
+      if (!response.ok && !(options.allowRedirectResponse && response.status >= 300 && response.status < 400)) {
         const text = await response.text();
         throw new GitHubApiRequestError({
           status: response.status,
@@ -738,7 +740,6 @@ export class GitHubApi {
           responseText: text
         });
       }
-      options.onResponse?.(response);
       return (await response.json()) as T;
     } catch (error) {
       if (error instanceof GitHubApiRequestError) throw error;

--- a/src/github.ts
+++ b/src/github.ts
@@ -8,9 +8,6 @@ import { redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, PullReviewComment, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
 import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 
-/** The bot's own GitHub App login — single source of truth for "who am I" (#345 reuse). */
-export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
-
 /**
  * Hard page cap for the bounded outcome-observation review-comment read (#371). At 100/page this bounds
  * a single PR's comment scan to 500, so a pathological thread count can't drive unbounded GitHub reads
@@ -143,6 +140,7 @@ export interface CanonicalGitHubInstallationIdentity {
 export interface GitHubInstallationIdentityExpectation {
   expectedAppId: string;
   expectedBotLogin?: string;
+  expectedOwner?: string;
   repo: string;
 }
 
@@ -190,6 +188,7 @@ export class GitHubApi {
   private readonly configuredBotLogin?: string;
   private botLogin?: string;
   private readonly requestTimeoutMs: number;
+  private readonly installationIdentities = new Map<string, CanonicalGitHubInstallationIdentity>();
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
 
@@ -208,6 +207,10 @@ export class GitHubApi {
 
   canPostAsApp(): boolean {
     return Boolean(this.appId && this.privateKey);
+  }
+
+  getCanonicalIdentity(repo: string): CanonicalGitHubInstallationIdentity | undefined {
+    return this.installationIdentities.get(repo);
   }
 
   async listOpenPulls(repo: string): Promise<PullRequestSummary[]> {
@@ -605,7 +608,7 @@ export class GitHubApi {
   }
 
   private isBotAuthoredComment(comment: IssueCommentSummary): boolean {
-    return comment.user?.type === "Bot" && comment.user.login === this.botLogin;
+    return Boolean(this.botLogin) && comment.user?.type === "Bot" && comment.user.login === this.botLogin;
   }
 
   private async getInstallationToken(repo: string): Promise<string> {
@@ -623,14 +626,26 @@ export class GitHubApi {
   ): Promise<CanonicalGitHubInstallationIdentity> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
+    let responseUrl = "";
     const response = await this.request<unknown>(`/repos/${repo}/installation`, {
       token: jwt,
-      followRedirects: options.followRedirects
+      followRedirects: options.followRedirects,
+      onResponse: (result) => { responseUrl = result.url; }
     });
-    const expected: GitHubInstallationIdentityExpectation = { expectedAppId: this.appId, repo };
+    const configuredOwner = repo.split("/")[0];
+    const canonicalOwner = responseUrl ? (() => {
+      try {
+        const url = new URL(responseUrl);
+        const match = /\/repos\/([^/]+)\/([^/]+)\/installation$/.exec(url.pathname);
+        return url.origin === this.apiBaseUrl.origin && match?.[2] === repo.split("/")[1] ? match[1] : undefined;
+      } catch { return undefined; }
+    })() : configuredOwner;
+    if (!canonicalOwner) throw new Error("GitHub installation redirect identity is ambiguous.");
+    const expected: GitHubInstallationIdentityExpectation = { expectedAppId: this.appId, expectedOwner: canonicalOwner, repo };
     if (this.configuredBotLogin !== undefined) expected.expectedBotLogin = this.configuredBotLogin;
     const identity = normalizeAndValidateGitHubInstallationIdentity(response, expected);
     this.botLogin = identity.bot_login;
+    this.installationIdentities.set(repo, identity);
     return identity;
   }
 
@@ -696,7 +711,7 @@ export class GitHubApi {
 
   private async request<T>(
     path: string,
-    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean } = {}
+    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean; onResponse?: (response: Response) => void } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
     const controller = new AbortController();
@@ -723,6 +738,7 @@ export class GitHubApi {
           responseText: text
         });
       }
+      options.onResponse?.(response);
       return (await response.json()) as T;
     } catch (error) {
       if (error instanceof GitHubApiRequestError) throw error;
@@ -792,14 +808,15 @@ export function normalizeAndValidateGitHubInstallationIdentity(
   const botLoginConfigured = expectedBotLoginValue !== MISSING_GITHUB_FIELD && expectedBotLoginValue !== undefined;
   const repo = readGitHubField(expected, "repo");
   const repoParts = typeof repo === "string" ? repo.split("/") : [];
-  const owner = repoParts.length === 2 && repoParts[1].length > 0 && !/\s/.test(repoParts[1])
+  const configuredOwner = repoParts.length === 2 && repoParts[1].length > 0 && !/\s/.test(repoParts[1])
     ? normalizeGitHubValue(repoParts[0], GITHUB_LOGIN_PATTERN) : undefined;
+  const expectedOwner = normalizeGitHubValue(readGitHubField(expected, "expectedOwner"), GITHUB_LOGIN_PATTERN) ?? configuredOwner;
   const botLogin = appSlug ? `${appSlug}[bot]` : undefined;
   const positiveInteger = (candidate: unknown): candidate is number =>
     typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
   if (!positiveInteger(id) || !positiveInteger(appId) || !positiveInteger(accountId)
       || typeof expectedAppId !== "string" || !/^\d+$/.test(expectedAppId.trim())
-      || String(appId) !== expectedAppId.trim() || !accountLogin || !owner || accountLogin !== owner
+      || String(appId) !== expectedAppId.trim() || !accountLogin || !expectedOwner || accountLogin !== expectedOwner
       || (accountType !== "User" && accountType !== "Organization") || !appSlug
       || !botLogin || (botLoginConfigured && botLogin !== expectedBotLogin)) {
     throw new Error("GitHub installation identity failed canonical validation.");

--- a/src/github.ts
+++ b/src/github.ts
@@ -118,27 +118,16 @@ export interface GitHubRepositoryAccessProof {
   installation_id_present: boolean;
   installation_id?: number;
   installation_account?: string;
+  installation_account_id?: number;
+  installation_account_type?: "User" | "Organization";
   app_slug?: string;
+  bot_login?: string;
   app_can_read_metadata: boolean;
   app_can_read_pull_requests: boolean;
   openPullCount?: number;
   github_api_status?: number;
   github_api_error_class?: GitHubRepositoryAccessErrorClass;
   github_api_error?: string;
-}
-
-interface GitHubInstallationIdentity {
-  id: number;
-  app_id: number;
-  account_login: string;
-  app_slug: string;
-}
-
-interface GitHubInstallationResponse {
-  id: number;
-  app_id?: number;
-  account?: { login?: string };
-  app_slug?: string;
 }
 
 export interface CanonicalGitHubInstallationIdentity {
@@ -153,7 +142,7 @@ export interface CanonicalGitHubInstallationIdentity {
 
 export interface GitHubInstallationIdentityExpectation {
   expectedAppId: string;
-  expectedBotLogin: string;
+  expectedBotLogin?: string;
   repo: string;
 }
 
@@ -198,7 +187,8 @@ export class GitHubApi {
   private readonly privateKey?: string;
   private readonly token?: string;
   private readonly apiBaseUrl: URL;
-  private readonly botLogin: string;
+  private readonly configuredBotLogin?: string;
+  private botLogin?: string;
   private readonly requestTimeoutMs: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
   private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
@@ -211,7 +201,8 @@ export class GitHubApi {
     this.privateKey = options.privateKey ?? (options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined);
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
-    this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
+    this.configuredBotLogin = options.botLogin;
+    this.botLogin = options.botLogin;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
   }
 
@@ -262,11 +253,9 @@ export class GitHubApi {
       };
     }
 
-    let installation: GitHubInstallationIdentity;
+    let installation: CanonicalGitHubInstallationIdentity;
     try {
-      installation = parseGitHubInstallationIdentity(
-        await this.getInstallation(repo, { followRedirects: false })
-      );
+      installation = await this.getInstallation(repo, { followRedirects: false });
     } catch (error) {
       return { ...base, ...describeGitHubAccessError(error) };
     }
@@ -274,13 +263,16 @@ export class GitHubApi {
       installation_id_present: true,
       installation_id: installation.id,
       installation_account: installation.account_login,
+      installation_account_id: installation.account_id,
+      installation_account_type: installation.account_type,
       app_id: installation.app_id,
-      app_slug: installation.app_slug
+      app_slug: installation.app_slug,
+      bot_login: installation.bot_login
     };
 
     let token: string;
     try {
-      token = await this.getInstallationTokenForId(repo, installation.id);
+      token = await this.getInstallationTokenForId(repo, installation);
     } catch (error) {
       return { ...base, ...installationProof, ...describeGitHubAccessError(error) };
     }
@@ -622,22 +614,31 @@ export class GitHubApi {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
     const installation = await this.getInstallation(repo);
-    return this.getInstallationTokenForId(repo, installation.id);
+    return this.getInstallationTokenForId(repo, installation);
   }
 
   private async getInstallation(
     repo: string,
     options: { followRedirects?: boolean } = {}
-  ): Promise<GitHubInstallationResponse> {
+  ): Promise<CanonicalGitHubInstallationIdentity> {
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    return this.request<GitHubInstallationResponse>(`/repos/${repo}/installation`, {
+    const response = await this.request<unknown>(`/repos/${repo}/installation`, {
       token: jwt,
       followRedirects: options.followRedirects
     });
+    const expected: GitHubInstallationIdentityExpectation = { expectedAppId: this.appId, repo };
+    if (this.configuredBotLogin !== undefined) expected.expectedBotLogin = this.configuredBotLogin;
+    const identity = normalizeAndValidateGitHubInstallationIdentity(response, expected);
+    this.botLogin = identity.bot_login;
+    return identity;
   }
 
-  private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {
+  private async getInstallationTokenForId(
+    repo: string,
+    installation: CanonicalGitHubInstallationIdentity
+  ): Promise<string> {
+    const installationId = installation.id;
     const repoCached = this.repoInstallationTokens.get(repo);
     if (repoCached && repoCached.installationId === installationId && repoCached.expiresAt > Date.now() + 60_000) {
       return repoCached.token;
@@ -786,7 +787,9 @@ export function normalizeAndValidateGitHubInstallationIdentity(
   const accountType = readGitHubField(account, "type");
   const appSlug = normalizeGitHubAppSlug(readGitHubField(value, "app_slug"));
   const expectedAppId = readGitHubField(expected, "expectedAppId");
-  const expectedBotLogin = normalizeGitHubBotLogin(readGitHubField(expected, "expectedBotLogin"));
+  const expectedBotLoginValue = readGitHubField(expected, "expectedBotLogin");
+  const expectedBotLogin = normalizeGitHubBotLogin(expectedBotLoginValue);
+  const botLoginConfigured = expectedBotLoginValue !== MISSING_GITHUB_FIELD && expectedBotLoginValue !== undefined;
   const repo = readGitHubField(expected, "repo");
   const repoParts = typeof repo === "string" ? repo.split("/") : [];
   const owner = repoParts.length === 2 && repoParts[1].length > 0 && !/\s/.test(repoParts[1])
@@ -798,7 +801,7 @@ export function normalizeAndValidateGitHubInstallationIdentity(
       || typeof expectedAppId !== "string" || !/^\d+$/.test(expectedAppId.trim())
       || String(appId) !== expectedAppId.trim() || !accountLogin || !owner || accountLogin !== owner
       || (accountType !== "User" && accountType !== "Organization") || !appSlug
-      || !botLogin || botLogin !== expectedBotLogin) {
+      || !botLogin || (botLoginConfigured && botLogin !== expectedBotLogin)) {
     throw new Error("GitHub installation identity failed canonical validation.");
   }
   return Object.freeze({
@@ -830,28 +833,6 @@ function normalizeGitHubValue(value: unknown, pattern: RegExp): string | undefin
   if (typeof value !== "string") return undefined;
   const normalized = value.trim().toLowerCase();
   return pattern.test(normalized) ? normalized : undefined;
-}
-
-function parseGitHubInstallationIdentity(value: unknown): GitHubInstallationIdentity {
-  const installation = value as {
-    id?: unknown;
-    app_id?: unknown;
-    account?: { login?: unknown } | null;
-    app_slug?: unknown;
-  } | null;
-  const positiveInteger = (candidate: unknown): candidate is number =>
-    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
-  const accountLogin = installation?.account?.login;
-  const appSlug = installation?.app_slug;
-  const accountLoginValid = typeof accountLogin === "string"
-    && /^(?!-)(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(accountLogin);
-  const appSlugValid = typeof appSlug === "string"
-    && /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/.test(appSlug);
-  if (!positiveInteger(installation?.id) || !positiveInteger(installation?.app_id)
-      || !accountLoginValid || !appSlugValid) {
-    throw new Error("GitHub installation response is missing canonical identity fields.");
-  }
-  return { id: installation.id, app_id: installation.app_id, account_login: accountLogin, app_slug: appSlug };
 }
 
 function describeGitHubAccessError(error: unknown): Pick<

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { isBotCommandComment } from "./commands.js";
-import { DEFAULT_BOT_LOGIN } from "./github.js";
 import { redactSecrets } from "./secrets.js";
 import { writeSecureFileSync } from "./temp-files.js";
 import type { ObserveScheduleConfig } from "./config.js";
@@ -231,13 +230,12 @@ function mergeLineMap(into: Map<string, Set<number>>, from: Map<string, Set<numb
 }
 
 function humanThreadTouchesFinding(comments: ObservedReviewComment[], findings: ObservedFinding[], botLogin?: string): boolean {
-  const effectiveBotLogin = botLogin ?? DEFAULT_BOT_LOGIN;
   for (const comment of comments) {
     // A human REPLY thread (in_reply_to_id set) is the dismissal signal; a bot author never counts.
     if (comment.in_reply_to_id === undefined || comment.in_reply_to_id === null) continue;
     // Reuse the shared bot-identity check (#149): excludes user.type === "Bot" OR the app bot login,
     // so a bot reply with a MISSING/variant type (only its login matches) is still not counted human.
-    if (comment.user && isBotCommandComment(comment.user, effectiveBotLogin)) continue;
+    if (!botLogin || (comment.user && isBotCommandComment(comment.user, botLogin))) continue;
     const path = comment.path;
     if (!path) continue;
     const line = typeof comment.line === "number" ? comment.line : comment.original_line;

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -235,7 +235,7 @@ function humanThreadTouchesFinding(comments: ObservedReviewComment[], findings: 
     if (comment.in_reply_to_id === undefined || comment.in_reply_to_id === null) continue;
     // Reuse the shared bot-identity check (#149): excludes user.type === "Bot" OR the app bot login,
     // so a bot reply with a MISSING/variant type (only its login matches) is still not counted human.
-    if (!botLogin || (comment.user && isBotCommandComment(comment.user, botLogin))) continue;
+    if (!comment.user || (botLogin ? isBotCommandComment(comment.user, botLogin) : comment.user.type !== "User")) continue;
     const path = comment.path;
     if (!path) continue;
     const line = typeof comment.line === "number" ? comment.line : comment.original_line;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
+import { GitHubApi, type CanonicalGitHubInstallationIdentity } from "./github.js";
 import {
   authorizeAdmissionForVisibility,
   isAuthenticProductionLicenseAdmission,
@@ -107,6 +107,7 @@ export interface ScheduledRunResult extends RunOnceResult {
 }
 
 export interface SchedulerGitHubApi {
+  getCanonicalIdentity?(repo: string): CanonicalGitHubInstallationIdentity | undefined;
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
@@ -416,6 +417,7 @@ export async function observeScheduledOutcomes(input: {
       const reviewComments = input.github.listPullReviewComments
         ? await input.github.listPullReviewComments(target.repo, target.pullNumber)
         : [];
+      const botLogin = input.config.github.botLogin ?? input.github.getCanonicalIdentity?.(target.repo)?.bot_login;
       return buildObservedPullOutcome({
         merged,
         mergedAt: pull.merged_at,
@@ -425,7 +427,7 @@ export async function observeScheduledOutcomes(input: {
         findings: target.findings,
         subsequentPulls,
         reviewComments,
-        ...(input.config.github.botLogin ? { botLogin: input.config.github.botLogin } : {})
+        ...(botLogin ? { botLogin } : {})
       });
     } catch (error) {
       // Fail-open per target: a deeper-read error degrades to the merge-state cut, never throwing into
@@ -1177,6 +1179,7 @@ async function resolveSchedulerCommandDecision(input: {
   // whether a command may enqueue a review; nothing downstream changes.
   const admittedPublic = admitPublicCommands({
     config: input.config,
+    github: input.github,
     state: input.state,
     repo: input.repo,
     pull: input.pull,
@@ -1267,6 +1270,7 @@ function latestPendingRequestChanges(input: {
 
 export function admitPublicCommands(input: {
   config: BotConfig;
+  github?: SchedulerGitHubApi;
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
@@ -1276,7 +1280,8 @@ export function admitPublicCommands(input: {
 }): ReviewCommand[] {
   const publicCommands = input.config.commands.publicCommands;
   if (!publicCommands?.enabled || input.publicEligible.length === 0) return [];
-  const botLogin = input.config.github.botLogin ?? DEFAULT_BOT_LOGIN;
+  const botLogin = input.config.github.botLogin ?? input.github?.getCanonicalIdentity?.(input.repo)?.bot_login;
+  if (!botLogin) return [];
   const commentsById = new Map(input.comments.map((comment) => [comment.id, comment]));
   const admitted: ReviewCommand[] = [];
   for (const command of input.publicEligible) {
@@ -1687,7 +1692,8 @@ async function repairProcessedHeadStatusCommentIfNeeded(input: {
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha
   });
-  const botLogin = input.config.github.botLogin ?? DEFAULT_BOT_LOGIN;
+  const botLogin = input.config.github.botLogin ?? input.github.getCanonicalIdentity?.(input.repo)?.bot_login;
+  if (!botLogin) return;
   const existing = comments.find((comment) =>
     comment.body?.includes(marker) &&
     comment.user?.type === "Bot" &&

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -1400,7 +1400,12 @@ function routeMockGitHub(
     (request.url === "/repos/owner/issue-repo/installation" ||
       request.url === "/repos/owner/second-issue-repo/installation")
   ) {
-    respondJson(response, 200, { id: 123 });
+    respondJson(response, 200, {
+      id: 123,
+      app_id: 4184532,
+      account: { id: 7, login: "owner", type: "Organization" },
+      app_slug: "evaos-code-review-bot"
+    });
     return;
   }
   if (request.method === "POST" && request.url === "/app/installations/123/access_tokens") {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -35,6 +35,21 @@ describe("GitHub App read authentication", () => {
     expect(identity.account_login).toBe("owner");
   });
 
+  it("accepts distinct customer App slugs when no bot login is configured", () => {
+    for (const appSlug of ["customer-review-app", "second-customer-app"]) {
+      const identity = normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
+        expectedAppId: "4184532", repo: "owner/repo"
+      });
+      expect(identity.bot_login).toBe(`${appSlug}[bot]`);
+      expect(normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
+        expectedAppId: "4184532", expectedBotLogin: `${appSlug}[bot]`, repo: "owner/repo"
+      }).bot_login).toBe(`${appSlug}[bot]`);
+      expect(() => normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
+        expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
+      })).toThrow(/canonical validation/);
+    }
+  });
+
   it.each([
     ["App mismatch", { app_id: 4184533 }, undefined],
     ["account mismatch", { account: { id: 7, login: "other", type: "User" } }, undefined],
@@ -87,7 +102,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -146,7 +161,7 @@ describe("GitHub App read authentication", () => {
         method: init?.method ?? "GET",
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
@@ -186,7 +201,7 @@ describe("GitHub App read authentication", () => {
     const calls: string[] = [];
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
@@ -260,7 +275,7 @@ describe("GitHub App read authentication", () => {
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -291,7 +306,7 @@ describe("GitHub App read authentication", () => {
 
     globalThis.fetch = vi.fn(async (url) => {
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -321,7 +336,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, account: { login: "owner" }, app_id: 999, app_slug: "customer-review-app" });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { id: 7, login: "owner", type: "Organization" }, app_slug: "customer-review-app" });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -346,8 +361,11 @@ describe("GitHub App read authentication", () => {
       installation_id_present: true,
       installation_id: 123,
       installation_account: "owner",
-      app_id: 999,
+      installation_account_id: 7,
+      installation_account_type: "Organization",
+      app_id: 4184532,
       app_slug: "customer-review-app",
+      bot_login: "customer-review-app[bot]",
       app_can_read_metadata: true,
       app_can_read_pull_requests: true,
       openPullCount: 1
@@ -355,6 +373,51 @@ describe("GitHub App read authentication", () => {
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo"))?.authorization).toBe("Bearer installation-token");
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"))?.authorization)
       .toBe("Bearer installation-token");
+  });
+
+  it("rejects an explicit bot login mismatch before token exchange", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-explicit-bot-mismatch-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let tokenCalls = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse(canonicalInstallation({ app_slug: "customer-review-app" }));
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) tokenCalls += 1;
+      return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+    }) as typeof fetch;
+
+    await expect(new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: "other-app[bot]" }).listOpenPulls("owner/repo"))
+      .rejects.toThrow(/canonical validation/);
+    expect(tokenCalls).toBe(0);
+  });
+
+  it("revalidates explicit identity before a refreshed token exchange", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-refresh-identity-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    let installationCalls = 0;
+    let tokenCalls = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        installationCalls += 1;
+        return jsonResponse(canonicalInstallation({ app_slug: installationCalls === 1 ? "customer-review-app" : "other-app" }));
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        tokenCalls += 1;
+        return jsonResponse({ token: "installation-token", expires_at: new Date(Date.now() + 1_000).toISOString() });
+      }
+      return jsonResponse([]);
+    }) as typeof fetch;
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: "customer-review-app[bot]" });
+    await expect(github.listOpenPulls("owner/repo")).resolves.toHaveLength(0);
+    await expect(github.listOpenPulls("owner/repo")).rejects.toThrow(/canonical validation/);
+    expect({ installationCalls, tokenCalls }).toEqual({ installationCalls: 2, tokenCalls: 1 });
   });
 
   it("rejects missing and malformed authoritative installation identity before token exchange", async () => {
@@ -540,7 +603,7 @@ describe("GitHub App read authentication", () => {
       const redirect = init?.redirect;
       calls.push({ url: requestUrl, method, redirect });
       if (requestUrl.endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+        return jsonResponse({ id: 123, app_id: 4184532, account: { id: 7, login: "owner", type: "Organization" }, app_slug: "customer-review-app" });
       }
       if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -582,7 +645,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -610,7 +673,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/404")) return jsonResponse({ message: "Resource not accessible by integration" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -629,7 +692,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "API rate limit exceeded for installation" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -647,7 +710,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -665,7 +728,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -683,7 +746,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation; nested error: Not Found" }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -702,7 +765,7 @@ describe("GitHub App read authentication", () => {
     const leakedToken = "ghp_fake_token";
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: `SAML enforcement ${leakedToken}` }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -732,7 +795,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -789,7 +852,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse({ id: 123 });
+        return jsonResponse(canonicalInstallation());
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -910,7 +973,7 @@ function canonicalInstallation(overrides: Record<string, unknown> = {}): Record<
 function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {
   return (url: string) => {
     if (url.endsWith("/repos/owner/repo/installation")) {
-      return jsonResponse({ id: 123, app_id: 4184532, account: { login: "owner" }, app_slug: "customer-review-app" });
+      return jsonResponse({ id: 123, app_id: 4184532, account: { id: 7, login: "owner", type: "Organization" }, app_slug: "customer-review-app" });
     }
     if (url.endsWith("/app/installations/123/access_tokens")) {
       return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -35,21 +35,6 @@ describe("GitHub App read authentication", () => {
     expect(identity.account_login).toBe("owner");
   });
 
-  it("accepts distinct customer App slugs when no bot login is configured", () => {
-    for (const appSlug of ["customer-review-app", "second-customer-app"]) {
-      const identity = normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
-        expectedAppId: "4184532", repo: "owner/repo"
-      });
-      expect(identity.bot_login).toBe(`${appSlug}[bot]`);
-      expect(normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
-        expectedAppId: "4184532", expectedBotLogin: `${appSlug}[bot]`, repo: "owner/repo"
-      }).bot_login).toBe(`${appSlug}[bot]`);
-      expect(() => normalizeAndValidateGitHubInstallationIdentity(canonicalInstallation({ app_slug: appSlug }), {
-        expectedAppId: "4184532", expectedBotLogin: "evaos-code-review-bot[bot]", repo: "owner/repo"
-      })).toThrow(/canonical validation/);
-    }
-  });
-
   it.each([
     ["App mismatch", { app_id: 4184533 }, undefined],
     ["account mismatch", { account: { id: 7, login: "other", type: "User" } }, undefined],
@@ -102,7 +87,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation());
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -161,7 +146,7 @@ describe("GitHub App read authentication", () => {
         method: init?.method ?? "GET",
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
@@ -201,7 +186,7 @@ describe("GitHub App read authentication", () => {
     const calls: string[] = [];
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
@@ -275,7 +260,7 @@ describe("GitHub App read authentication", () => {
     globalThis.fetch = vi.fn(async (url) => {
       calls.push(String(url));
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation());
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -306,7 +291,7 @@ describe("GitHub App read authentication", () => {
 
     globalThis.fetch = vi.fn(async (url) => {
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation());
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -373,26 +358,6 @@ describe("GitHub App read authentication", () => {
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo"))?.authorization).toBe("Bearer installation-token");
     expect(calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"))?.authorization)
       .toBe("Bearer installation-token");
-  });
-
-  it("rejects an explicit bot login mismatch before token exchange", async () => {
-    const root = mkdtempSync(join(tmpdir(), "github-app-explicit-bot-mismatch-"));
-    roots.push(root);
-    const privateKeyPath = join(root, "app.pem");
-    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
-    let tokenCalls = 0;
-    globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation({ app_slug: "customer-review-app" }));
-      }
-      if (String(url).endsWith("/app/installations/123/access_tokens")) tokenCalls += 1;
-      return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
-    }) as typeof fetch;
-
-    await expect(new GitHubApi({ appId: "4184532", privateKeyPath, botLogin: "other-app[bot]" }).listOpenPulls("owner/repo"))
-      .rejects.toThrow(/canonical validation/);
-    expect(tokenCalls).toBe(0);
   });
 
   it("revalidates explicit identity before a refreshed token exchange", async () => {
@@ -645,7 +610,7 @@ describe("GitHub App read authentication", () => {
       const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
       calls.push({ url: String(url), authorization });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation());
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -673,7 +638,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/404")) return jsonResponse({ message: "Resource not accessible by integration" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -692,7 +657,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "API rate limit exceeded for installation" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -710,7 +675,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403);
       return jsonResponse({ message: "unexpected" }, 404);
@@ -728,7 +693,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -746,7 +711,7 @@ describe("GitHub App read authentication", () => {
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation; nested error: Not Found" }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -765,7 +730,7 @@ describe("GitHub App read authentication", () => {
     const leakedToken = "ghp_fake_token";
 
     globalThis.fetch = vi.fn(async (url) => {
-      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse(canonicalInstallation());
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
       if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: `SAML enforcement ${leakedToken}` }, 403, "Forbidden");
       return jsonResponse({ message: "unexpected" }, 404);
@@ -795,7 +760,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation());
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -852,7 +817,7 @@ describe("GitHub App read authentication", () => {
         body: init?.body ? JSON.parse(String(init.body)) : undefined
       });
       if (String(url).endsWith("/repos/owner/repo/installation")) {
-        return jsonResponse(canonicalInstallation());
+        return jsonResponse({ id: 123 });
       }
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
@@ -953,6 +918,9 @@ describe("GitHub App read authentication", () => {
 });
 
 function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
+  if (body && typeof body === "object" && !Array.isArray(body) && Object.keys(body).length === 1 && "id" in body) {
+    body = { ...canonicalInstallation(), ...(body as Record<string, unknown>) };
+  }
   return new Response(JSON.stringify(body), {
     status,
     statusText,

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1526,7 +1526,7 @@ exit 1
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
         response.end(JSON.stringify({
           id: 42,
-          account: { login: "acme" },
+          account: { id: 7, login: "acme", type: "Organization" },
           app_id: 12345,
           app_slug: "customer-review-app"
         }));
@@ -1785,7 +1785,7 @@ exit 1
         response.end(JSON.stringify({
           id: 42,
           app_id: 12345,
-          account: { login: "acme" },
+          account: { id: 7, login: "acme", type: "Organization" },
           app_slug: "customer-review-app"
         }));
         return;

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -5205,7 +5205,7 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
       maxPatchBytes: 1,
       retryMaxRetries: 0
     },
-    github: {}
+    github: { botLogin: "evaos-code-review-bot[bot]" }
   };
 }
 


### PR DESCRIPTION
Closes #982

## Summary
- derive omitted bot login only from validated installation/App identity
- validate ordinary-transfer redirects against the final canonical repository owner and fail closed on ambiguous/hostile URLs
- retain a frozen per-repository identity projection for GitHub, scheduler status repair, public-command filtering, and observation comment selection
- revalidate rotated installation identity before refreshed token exchange

## Proof
- Base: c234391ffc98ae1bcb051991e997b0207789c1ce
- Candidate: 5aa306d
- Diff: 190 changed lines (under the 200-line bound)
- `npx tsc --noEmit -p tsconfig.build.json` passed
- `git diff --check` passed
- direct Node probes passed for canonical transfer, hostile owner rejection before token exchange, and immutable identity projection
- Vitest collection is blocked locally by the macOS Rollup native module Team ID mismatch before tests run

No live GitHub App, runtime, customer, config/DB/Keychain, release, merge, or install mutation was performed. Customer readiness, runtime promotion, and cache-rotation R2 remain unproven and out of scope.

Agent-authored candidate; please run the required CI and independent checks.