### PR TITLE
feat(desktop): separate general worker from new-App capability

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -40,6 +40,11 @@ enum NeonDiffDesktopCompositionRoot {
             LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
         let trustedBundledWorker =
             FoundationTrustedBundledWorker.executionContext()
+        let nativeVerificationCapability =
+            DesktopNativeVerificationCapability.resolve(
+                productionBoundary: productionBoundary,
+                trustedBundledWorker: trustedBundledWorker
+            )
         let localBotConfigurations = localBotSnapshot.configurations
         let localBotExecutionContexts =
             localBotSnapshot.executionContexts
@@ -111,6 +116,7 @@ enum NeonDiffDesktopCompositionRoot {
             githubBroker: githubBroker,
             accountLink: accountLink,
             productionBoundary: productionBoundary,
+            nativeVerificationCapability: nativeVerificationCapability,
             localWorkerUpdateGuideURL: DesktopReleaseRouting.localWorkerUpdateGuideURL(
                 shortVersion: Bundle.main.object(
                     forInfoDictionaryKey: "CFBundleShortVersionString"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -386,6 +386,7 @@ struct OnboardingWizardView: View {
                 }
                 .disabled(
                     !model.byoGitHubCredentialsStored
+                        || !model.newAppNativeVerificationAvailable
                         || !model.localWorkerCLIAvailable
                         || model.repos.filter(\.enabled).count != 1
                         || !model.canEditProviderConfiguration

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -466,7 +466,11 @@ struct ReposView: View {
                             systemImage: "checkmark.shield"
                         )
                     }
-                    .disabled(!model.byoGitHubCredentialsStored || model.isBYOGitHubVerificationInProgress)
+                    .disabled(
+                        !model.byoGitHubCredentialsStored
+                            || !model.newAppNativeVerificationAvailable
+                            || model.isBYOGitHubVerificationInProgress
+                    )
                     .accessibilityIdentifier("neondiff-byo-github-verify")
                 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -88,6 +88,69 @@ package struct DesktopProductionBoundary: Sendable {
     }
 }
 
+/// Bundle-derived capability for native new-App verification.
+package struct DesktopNativeVerificationCapability: Sendable {
+    package let newAppNativeVerificationAvailable: Bool
+
+    package static let unavailable = DesktopNativeVerificationCapability(
+        newAppNativeVerificationAvailable: false
+    )
+    package static let testAvailable = DesktopNativeVerificationCapability(
+        newAppNativeVerificationAvailable: true
+    )
+
+    private init(newAppNativeVerificationAvailable: Bool) {
+        self.newAppNativeVerificationAvailable = newAppNativeVerificationAvailable
+    }
+
+    /// Resolve from the produced bundle contract and platform proof callbacks.
+    /// Preferences, license state, and arbitrary contexts cannot grant it.
+    package static func resolve(
+        infoDictionary: [String: Any],
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> Self {
+        resolve(
+            productionBoundary: DesktopProductionBoundary.resolve(
+                infoDictionary: infoDictionary
+            ),
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: appSignatureIsValid,
+            sealedFileIsValid: sealedFileIsValid
+        )
+    }
+
+    package static func resolve(
+        productionBoundary: DesktopProductionBoundary,
+        appBundleURL: URL,
+        appSignatureIsValid: (URL) -> Bool,
+        sealedFileIsValid: (URL) -> Bool
+    ) -> Self {
+        guard productionBoundary.byoGitHubEnabled,
+              DesktopTrustedBundledWorkerContract.executionContext(
+                  appBundleURL: appBundleURL,
+                  appSignatureIsValid: appSignatureIsValid,
+                  sealedFileIsValid: sealedFileIsValid
+              ) != nil
+        else {
+            return .unavailable
+        }
+        return .testAvailable
+    }
+
+    package static func resolve(
+        productionBoundary: DesktopProductionBoundary,
+        trustedBundledWorker: DesktopLocalBotExecutionContext?
+    ) -> Self {
+        return DesktopNativeVerificationCapability(
+            newAppNativeVerificationAvailable:
+                productionBoundary.byoGitHubEnabled
+                && trustedBundledWorker != nil
+        )
+    }
+}
+
 private let approvedManagedGitHubBrokerOrigin = URL(
     string: "https://neondiff-license.fly.dev"
 )!
@@ -134,6 +197,8 @@ package struct DesktopAppDependencies {
     package let githubBroker: (any GitHubBrokerConnecting)?
     package let accountLink: (any NeonDiffAccountLinkConnecting)?
     package let productionBoundary: DesktopProductionBoundary
+    package let nativeVerificationCapability:
+        DesktopNativeVerificationCapability
     package let localWorkerUpdateGuideURL: URL
     package let cliWorkingDirectory: URL?
     package let localBotConfigurations: [DesktopLocalBotConfiguration]
@@ -143,6 +208,10 @@ package struct DesktopAppDependencies {
         (@Sendable (String) -> DesktopLocalBotDiscoverySnapshot)?
     package let keychainWorkerLaunchAgentManager:
         any DesktopKeychainWorkerLaunchAgentManaging
+
+    package var newAppNativeVerificationAvailable: Bool {
+        nativeVerificationCapability.newAppNativeVerificationAvailable
+    }
 
     package init(
         clipboard: any DesktopClipboard,
@@ -158,6 +227,8 @@ package struct DesktopAppDependencies {
         githubBroker: (any GitHubBrokerConnecting)? = nil,
         accountLink: (any NeonDiffAccountLinkConnecting)? = nil,
         productionBoundary: DesktopProductionBoundary,
+        nativeVerificationCapability: DesktopNativeVerificationCapability =
+            .unavailable,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
             shortVersion: nil
         ),
@@ -184,6 +255,7 @@ package struct DesktopAppDependencies {
         self.githubBroker = githubBroker
         self.accountLink = accountLink
         self.productionBoundary = productionBoundary
+        self.nativeVerificationCapability = nativeVerificationCapability
         self.localWorkerUpdateGuideURL = localWorkerUpdateGuideURL
         self.cliWorkingDirectory = cliWorkingDirectory
         self.localBotConfigurations = localBotConfigurations

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -592,6 +592,10 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && dependencies.productionBoundary.managedGitHubBrokerOrigin == nil
     }
 
+    package var newAppNativeVerificationAvailable: Bool {
+        dependencies.newAppNativeVerificationAvailable
+    }
+
     package var byoGitHubAppIdStored: Bool {
         storedBYOGitHubAppId != nil
     }
@@ -3826,6 +3830,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard !isSetupMutationBlocked else {
             lastError = "Retry account verification before verifying GitHub App setup."
             byoGitHubCredentialStatus = lastError ?? "Account check required"
+            return
+        }
+        guard source != .keychainStdin || newAppNativeVerificationAvailable else {
+            lastError = "Native new-App verification is unavailable in this signed build."
+            byoGitHubCredentialStatus = lastError ?? "Unavailable"
             return
         }
         guard requireLocalWorkerCLI() else {

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ManagedGitHubOnboardingTests.swift
@@ -256,6 +256,110 @@ private struct ActiveManagedActivationClient: ActivationLicenseClienting {
         #expect(fixture.model.activationState != .active)
     }
 
+    @Test func newAppNativeVerificationRequiresExactBYOMarkersAndTrustedWorker() {
+        let appBundleURL = URL(filePath: "/Applications/NeonDiff.app")
+        let byoMarkers: [String: Any] = [
+            "NeonDiffPaidBetaContract": "paid-mac-beta-byo-v1",
+            "NeonDiffBYOGitHubEnabled": true
+        ]
+
+        let available = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { $0 == appBundleURL },
+            sealedFileIsValid: { $0.path.hasSuffix("NeonDiffWorker") }
+        )
+        #expect(available.newAppNativeVerificationAvailable)
+        #expect(!DesktopNativeVerificationCapability.resolve(
+            productionBoundary: .testManaged,
+            trustedBundledWorker: nil
+        ).newAppNativeVerificationAvailable)
+
+        let withoutWorker = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in false }
+        )
+        #expect(!withoutWorker.newAppNativeVerificationAvailable)
+
+        let mixedMarkers = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers.merging([
+                "NeonDiffManagedGitHubBrokerEnabled": true,
+                "NeonDiffGitHubBrokerOrigin": "https://neondiff-license.fly.dev"
+            ]) { _, new in new },
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!mixedMarkers.newAppNativeVerificationAvailable)
+
+        let wrongHelperPath = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: URL(filePath: "/Applications/Other.app"),
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!wrongHelperPath.newAppNativeVerificationAvailable)
+
+        let wrongSignature = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in false },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!wrongSignature.newAppNativeVerificationAvailable)
+
+        let wrongHelperProof = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: byoMarkers,
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in false }
+        )
+        #expect(!wrongHelperProof.newAppNativeVerificationAvailable)
+
+        let preferenceOnly = DesktopNativeVerificationCapability.resolve(
+            infoDictionary: ["NeonDiffBYOGitHubEnabled": true],
+            appBundleURL: appBundleURL,
+            appSignatureIsValid: { _ in true },
+            sealedFileIsValid: { _ in true }
+        )
+        #expect(!preferenceOnly.newAppNativeVerificationAvailable)
+    }
+
+    @Test func compositionBindsNewAppWorkerToTheDerivedCapability() throws {
+        let compositionRoot = sourceBoundaryPackageRoot()
+            .appendingPathComponent(
+                "Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift"
+            )
+        let source = try sourceBoundaryText(at: compositionRoot)
+
+        #expect(source.contains(
+            "FoundationTrustedBundledWorker.executionContext()"
+        ))
+        #expect(source.contains(
+            "DesktopNativeVerificationCapability.resolve"
+        ))
+        #expect(source.contains(
+            "trustedBundledWorker: trustedBundledWorker"
+        ))
+        #expect(source.contains(
+            "nativeVerificationCapability: nativeVerificationCapability"
+        ))
+    }
+
+    @Test func newAppVerificationFailsClosedWithoutDerivedCapability() {
+        let fixture = ModelDependencyFixture(
+            preferenceStrings: ["neondiff.cliPath": "neondiff"],
+            productionBoundary: .testAccountLink,
+            nativeVerificationCapability: .unavailable
+        )
+        fixture.model.verifyBYOGitHubAppCredentials()
+
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.model.lastError?.contains("unavailable") == true)
+    }
+
     @Test func managedConnectUsesBrokerAndKeychainIdentityWithoutLegacyUserTokenFallback() async throws {
         let broker = ScriptedGitHubBroker(repositories: [
             GitHubBrokerRepository(fullName: "electric/private", visibility: .private),

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -255,6 +255,7 @@ struct ModelDependencyFixture {
         localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         localBotExecutionConfigPaths: [String] = [],
         productionBoundary: DesktopProductionBoundary = .testVerified,
+        nativeVerificationCapability: DesktopNativeVerificationCapability = .testAvailable,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
             shortVersion: "1.1.0-beta.37"
         )
@@ -292,6 +293,7 @@ struct ModelDependencyFixture {
             githubAuthenticator: githubAuthenticator,
             githubBroker: githubBroker,
             productionBoundary: productionBoundary,
+            nativeVerificationCapability: nativeVerificationCapability,
             localWorkerUpdateGuideURL: localWorkerUpdateGuideURL,
             localBotConfigurations: localBotConfigurations,
             localBotExecutionContexts: localBotExecutionContexts,


### PR DESCRIPTION
Refs #992

## Summary
- Keep FoundationTrustedBundledWorker as the independent general sealed-worker execution path for managed and BYO builds.
- Derive a Boolean-only new-App verification capability from exact BYO production markers plus current app/helper proof.
- Keep existing-bot verification independent and fail closed when new-App proof is unavailable.

## Proof
- Base: c234391ffc98ae1bcb051991e997b0207789c1ce
- Focused Swift tests: ManagedGitHubOnboardingTests (24), DesktopKeychainWorkerLaunchAgentTests (20), ExistingLocalBotReconciliationTests (49), ProductionBoundaryContractTests (19)
- git diff --check: passed
- Changed lines: 200 total (199 insertions, 1 deletion)

## Boundary
This proves source-level managed/BYO capability separation only. It does not prove installed behavior, signed artifacts, live refresh, release readiness, runtime safety, or customer readiness.