### PR TITLE
feat: add pure issue-enrichment receipt classifier

### DIFF
--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -42,24 +42,31 @@ function zeroCounts(): IssueEnrichmentReceiptCounts {
   return Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, 0])) as IssueEnrichmentReceiptCounts;
 }
 
-function validSummary(value: unknown): value is Record<string, unknown> {
-  return isRecord(value) && ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.every((key) => {
-    const count = value[key];
-    return typeof count === "number" && Number.isFinite(count) && Number.isInteger(count) && count >= 0;
-  });
-}
-
-function boundedCounts(summary: Record<string, unknown>): IssueEnrichmentReceiptCounts {
+function snapshotSummary(value: unknown): IssueEnrichmentReceiptCounts | undefined {
+  if (!isRecord(value)) return undefined;
   const counts = zeroCounts();
-  for (const key of ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS) {
-    counts[key] = Math.min(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP, summary[key] as number);
+  try {
+    for (const key of ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS) {
+      const count = value[key];
+      if (typeof count !== "number" || !Number.isFinite(count) || !Number.isInteger(count) || count < 0) return undefined;
+      counts[key] = Math.min(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP, count);
+    }
+  } catch {
+    return undefined;
   }
   return counts;
 }
 
 function safeThrownReason(error: unknown): IssueEnrichmentLaneReason {
-  const text = typeof error === "string" ? error : isRecord(error) && typeof error.message === "string" ? error.message : error instanceof Error ? error.message : "";
-  const blocker = [...BLOCKERS].find((candidate) => text.includes(candidate));
+  let text = "";
+  try {
+    const message = typeof error === "string" ? error : isRecord(error) ? error.message : undefined;
+    text = typeof message === "string" ? message.trim() : "";
+  } catch {
+    return "unknown_failure";
+  }
+  const blocker = [...BLOCKERS].find((candidate) => text === candidate ||
+    (text.startsWith(candidate) && !/[A-Za-z0-9_]/.test(text[candidate.length] ?? "")));
   return blocker ?? "unknown_failure";
 }
 
@@ -69,16 +76,29 @@ function safeBlockedReason(value: unknown, dryRun: boolean): IssueEnrichmentLane
   return dryRun && DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(blocker) ? undefined : blocker;
 }
 
+function firstBlockedReason(value: unknown, dryRun: boolean): IssueEnrichmentLaneReason | undefined {
+  if (!Array.isArray(value)) return undefined;
+  try {
+    const blockers = value as unknown[];
+    for (let index = 0, limit = Math.min(blockers.length, 32); index < limit; index++) {
+      const reason = safeBlockedReason(blockers[index], dryRun);
+      if (reason) return reason;
+    }
+  } catch { /* malformed hostile arrays fail closed */ }
+  return undefined;
+}
+
 export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentLaneReceipt {
   if (input.kind === "thrown") {
     return { ok: false, stage: "issue_enrichment", code: "cycle_failed", counts: zeroCounts(), reason: safeThrownReason(input.error) };
   }
   const result = isRecord(input.result) ? input.result : undefined;
-  const summary = result?.summary;
-  if (!validSummary(summary)) {
+  let summary: unknown;
+  try { summary = result?.summary; } catch { summary = undefined; }
+  const counts = snapshotSummary(summary);
+  if (!counts) {
     return { ok: false, stage: "issue_enrichment", code: "malformed_summary", counts: zeroCounts(), reason: "malformed_summary" };
   }
-  const counts = boundedCounts(summary);
   if (counts.workerSkipped > 0) {
     return { ok: true, stage: "issue_enrichment", code: "lease_skipped", counts, reason: "worker_lease_held" };
   }
@@ -90,8 +110,9 @@ export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInpu
     return { ok: false, stage: "issue_enrichment", code: "result_not_ok", counts, reason: counts.readFailures > 0 ? "read_failure" : "item_failure" };
   }
   const dryRun = result?.dryRun === true;
-  const blockers = Array.isArray(status?.blockers) ? status.blockers : [];
-  const blockedReason = status?.state === "blocked" ? blockers.map((blocker) => safeBlockedReason(blocker, dryRun)).find(Boolean) : undefined;
+  let blockers: unknown;
+  try { blockers = status?.blockers; } catch { blockers = undefined; }
+  const blockedReason = status?.state === "blocked" ? firstBlockedReason(blockers, dryRun) : undefined;
   const hasScanEvidence = ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.some((key) => counts[key] > 0);
   if (blockedReason && !hasScanEvidence) {
     return { ok: false, stage: "issue_enrichment", code: "blocked", counts, reason: blockedReason };
@@ -105,5 +126,5 @@ export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInpu
 
 /** Compatibility shape for the parent daemon integration; classification remains discriminated internally. */
 export function buildIssueEnrichmentLaneReceipt(result?: unknown, failure?: unknown): IssueEnrichmentLaneReceipt {
-  return classifyIssueEnrichmentReceipt(result === undefined ? { kind: "thrown", error: failure } : { kind: "result", result });
+  return classifyIssueEnrichmentReceipt(arguments.length !== 1 ? { kind: "thrown", error: failure } : { kind: "result", result });
 }

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -1,0 +1,109 @@
+import {
+  DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS,
+  type IssueEnrichmentBlocker
+} from "./issue-enrichment.js";
+
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP = 1_000_000;
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS = [
+  "reposScanned", "reposSkipped", "readFailures", "issuesSeen", "eligible", "skipped", "wouldEnrich",
+  "wouldComment", "deferred", "baselinedRepos", "truncatedRepos", "workerSkipped", "posted", "dryRunRecorded",
+  "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
+] as const;
+export type IssueEnrichmentReceiptCounts = { [K in typeof ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS[number]]: number };
+export type IssueEnrichmentLaneCode =
+  | "completed" | "no_candidates" | "lease_skipped" | "disabled" | "blocked" | "result_not_ok" | "cycle_failed" | "malformed_summary";
+export type IssueEnrichmentLaneReason =
+  | "worker_lease_held" | "read_failure" | "item_failure" | "unknown_failure" | "malformed_summary" | IssueEnrichmentBlocker;
+export interface IssueEnrichmentLaneReceipt {
+  ok: boolean;
+  stage: "issue_enrichment";
+  code: IssueEnrichmentLaneCode;
+  counts: IssueEnrichmentReceiptCounts;
+  reason?: IssueEnrichmentLaneReason;
+}
+
+export type IssueEnrichmentReceiptInput =
+  | { kind: "thrown"; error: unknown }
+  | { kind: "result"; result: unknown };
+
+const BLOCKERS = new Set<IssueEnrichmentBlocker>([
+  "issue_enrichment_disabled", "issue_enrichment_allowlist_empty", "issue_enrichment_live_posting_disabled",
+  "github_app_credentials_required_for_live_issue_comments", "github_app_issues_permission_required",
+  "issue_enrichment_live_repo_thresholds_required", "issue_enrichment_model_runtime_required"
+]);
+const usefulKeys: ReadonlyArray<keyof IssueEnrichmentReceiptCounts> = [
+  "eligible", "wouldEnrich", "wouldComment", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed"
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+function zeroCounts(): IssueEnrichmentReceiptCounts {
+  return Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, 0])) as IssueEnrichmentReceiptCounts;
+}
+
+function validSummary(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.every((key) => {
+    const count = value[key];
+    return typeof count === "number" && Number.isFinite(count) && Number.isInteger(count) && count >= 0;
+  });
+}
+
+function boundedCounts(summary: Record<string, unknown>): IssueEnrichmentReceiptCounts {
+  const counts = zeroCounts();
+  for (const key of ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS) {
+    counts[key] = Math.min(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP, summary[key] as number);
+  }
+  return counts;
+}
+
+function safeThrownReason(error: unknown): IssueEnrichmentLaneReason {
+  const text = typeof error === "string" ? error : isRecord(error) && typeof error.message === "string" ? error.message : error instanceof Error ? error.message : "";
+  const blocker = [...BLOCKERS].find((candidate) => text.includes(candidate));
+  return blocker ?? "unknown_failure";
+}
+
+function safeBlockedReason(value: unknown, dryRun: boolean): IssueEnrichmentLaneReason | undefined {
+  if (typeof value !== "string" || !BLOCKERS.has(value as IssueEnrichmentBlocker)) return undefined;
+  const blocker = value as IssueEnrichmentBlocker;
+  return dryRun && DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(blocker) ? undefined : blocker;
+}
+
+export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentLaneReceipt {
+  if (input.kind === "thrown") {
+    return { ok: false, stage: "issue_enrichment", code: "cycle_failed", counts: zeroCounts(), reason: safeThrownReason(input.error) };
+  }
+  const result = isRecord(input.result) ? input.result : undefined;
+  const summary = result?.summary;
+  if (!validSummary(summary)) {
+    return { ok: false, stage: "issue_enrichment", code: "malformed_summary", counts: zeroCounts(), reason: "malformed_summary" };
+  }
+  const counts = boundedCounts(summary);
+  if (counts.workerSkipped > 0) {
+    return { ok: true, stage: "issue_enrichment", code: "lease_skipped", counts, reason: "worker_lease_held" };
+  }
+  const status = isRecord(result?.status) ? result.status : undefined;
+  if (status?.state === "disabled") {
+    return { ok: true, stage: "issue_enrichment", code: "disabled", counts: zeroCounts() };
+  }
+  if (counts.readFailures > 0 || counts.failed > 0) {
+    return { ok: false, stage: "issue_enrichment", code: "result_not_ok", counts, reason: counts.readFailures > 0 ? "read_failure" : "item_failure" };
+  }
+  const dryRun = result?.dryRun === true;
+  const blockers = Array.isArray(status?.blockers) ? status.blockers : [];
+  const blockedReason = status?.state === "blocked" ? blockers.map((blocker) => safeBlockedReason(blocker, dryRun)).find(Boolean) : undefined;
+  const hasScanEvidence = ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.some((key) => counts[key] > 0);
+  if (blockedReason && !hasScanEvidence) {
+    return { ok: false, stage: "issue_enrichment", code: "blocked", counts, reason: blockedReason };
+  }
+  if (result?.ok !== true) {
+    return { ok: false, stage: "issue_enrichment", code: "result_not_ok", counts, reason: "unknown_failure" };
+  }
+  const noCandidates = usefulKeys.every((key) => counts[key] === 0);
+  return { ok: true, stage: "issue_enrichment", code: noCandidates ? "no_candidates" : "completed", counts };
+}
+
+/** Compatibility shape for the parent daemon integration; classification remains discriminated internally. */
+export function buildIssueEnrichmentLaneReceipt(result?: unknown, failure?: unknown): IssueEnrichmentLaneReceipt {
+  return classifyIssueEnrichmentReceipt(result === undefined ? { kind: "thrown", error: failure } : { kind: "result", result });
+}

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyIssueEnrichmentReceipt,
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS,
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP,
+  type IssueEnrichmentReceiptInput
+} from "../src/issue-enrichment-receipt.js";
+
+const summary = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
+);
+const result = (overrides: Record<string, unknown> = {}) => ({
+  ok: true,
+  dryRun: false,
+  status: { state: "ready", blockers: [] },
+  summary: summary(),
+  ...overrides
+});
+const classify = (value: unknown): ReturnType<typeof classifyIssueEnrichmentReceipt> =>
+  classifyIssueEnrichmentReceipt(value as IssueEnrichmentReceiptInput);
+
+describe("issue-enrichment receipt precedence", () => {
+  it.each([
+    ["thrown raw sentinel", { kind: "thrown", error: new Error("ghp_fake_token issue_enrichment_model_runtime_required") }, "cycle_failed", "issue_enrichment_model_runtime_required"],
+    ["lease overrides disabled", { kind: "result", result: result({ summary: summary({ workerSkipped: 1 }), status: { state: "disabled", blockers: [] } }) }, "lease_skipped", "worker_lease_held"],
+    ["disabled", { kind: "result", result: result({ status: { state: "disabled", blockers: [] }, summary: summary({ issuesSeen: 5 }) }) }, "disabled", undefined],
+    ["dry-run ignored blocker does not mask read failure", { kind: "result", result: result({ dryRun: true, ok: false, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] }, summary: summary({ readFailures: 1 }) }) }, "result_not_ok", "read_failure"],
+    ["mixed ignored and effective blocker", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "github_app_issues_permission_required"] } }) }, "blocked", "github_app_issues_permission_required"],
+    ["effective blocker after scan evidence", { kind: "result", result: result({ ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] }, summary: summary({ issuesSeen: 1 }) }) }, "result_not_ok", "unknown_failure"],
+    ["positive completed", { kind: "result", result: result({ summary: summary({ wouldEnrich: 1 }) }) }, "completed", undefined],
+    ["all-zero no candidates", { kind: "result", result: result() }, "no_candidates", undefined],
+    ["oversized valid values cap", { kind: "result", result: result({ summary: summary({ wouldEnrich: Number.MAX_SAFE_INTEGER }) }) }, "completed", undefined]
+  ])("classifies %s", (_name, input, code, reason) => {
+    const receipt = classify(input);
+    expect(receipt).toMatchObject({ code, ...(reason ? { reason } : {}) });
+    if (code === "lease_skipped") expect(receipt.counts.workerSkipped).toBe(1);
+    if (code === "disabled") expect(Object.values(receipt.counts).every((count) => count === 0)).toBe(true);
+    if (_name === "oversized valid values cap") expect(receipt.counts.wouldEnrich).toBe(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP);
+  });
+
+  it.each([
+    ["missing", (() => { const value = summary(); delete value.failed; return value; })()],
+    ["negative", summary({ failed: -1 })], ["NaN", summary({ failed: Number.NaN })],
+    ["fractional", summary({ failed: 1.5 })], ["string", summary({ failed: "1" })],
+    ["null", null], ["array", []]
+  ])("malformed %s overrides worker lease", (_name, malformed) => {
+    const receipt = classify({ kind: "result", result: result({ summary: malformed }) });
+    expect(receipt).toMatchObject({ ok: false, code: "malformed_summary", reason: "malformed_summary" });
+    expect(Object.values(receipt.counts).every((count) => count === 0)).toBe(true);
+  });
+
+  it("emits only the bounded sanitized receipt shape", () => {
+    const receipt = classify({ kind: "thrown", error: new Error("customer body https://example.test ghp_secret") });
+    expect(receipt).not.toHaveProperty("error");
+    expect(receipt).not.toHaveProperty("result");
+    expect(receipt).not.toHaveProperty("status");
+    expect(receipt).not.toHaveProperty("blockers");
+    expect(JSON.stringify(receipt)).not.toContain("ghp_secret");
+    expect(JSON.stringify(receipt)).not.toContain("example.test");
+  });
+});

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildIssueEnrichmentLaneReceipt,
   classifyIssueEnrichmentReceipt,
   ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS,
   ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP,
@@ -21,7 +22,7 @@ const classify = (value: unknown): ReturnType<typeof classifyIssueEnrichmentRece
 
 describe("issue-enrichment receipt precedence", () => {
   it.each([
-    ["thrown raw sentinel", { kind: "thrown", error: new Error("ghp_fake_token issue_enrichment_model_runtime_required") }, "cycle_failed", "issue_enrichment_model_runtime_required"],
+    ["thrown raw sentinel", { kind: "thrown", error: new Error("issue_enrichment_model_runtime_required; ghp_fake_token") }, "cycle_failed", "issue_enrichment_model_runtime_required"],
     ["lease overrides disabled", { kind: "result", result: result({ summary: summary({ workerSkipped: 1 }), status: { state: "disabled", blockers: [] } }) }, "lease_skipped", "worker_lease_held"],
     ["disabled", { kind: "result", result: result({ status: { state: "disabled", blockers: [] }, summary: summary({ issuesSeen: 5 }) }) }, "disabled", undefined],
     ["dry-run ignored blocker does not mask read failure", { kind: "result", result: result({ dryRun: true, ok: false, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] }, summary: summary({ readFailures: 1 }) }) }, "result_not_ok", "read_failure"],
@@ -57,5 +58,13 @@ describe("issue-enrichment receipt precedence", () => {
     expect(receipt).not.toHaveProperty("blockers");
     expect(JSON.stringify(receipt)).not.toContain("ghp_secret");
     expect(JSON.stringify(receipt)).not.toContain("example.test");
+  });
+
+  it("hardens hostile compatibility, messages, codes, and blocker arrays", () => {
+    expect(buildIssueEnrichmentLaneReceipt(undefined)).toMatchObject({ code: "malformed_summary" });
+    const hostile = summary(); let reads = 0; Object.defineProperty(hostile, "failed", { get: () => ++reads === 1 ? 0 : -1 }); expect(classify({ kind: "result", result: result({ summary: hostile }) }).code).toBe("no_candidates");
+    expect(classify({ kind: "thrown", error: "owner/issue_enrichment_model_runtime_required" }).reason).toBe("unknown_failure");
+    const error = new Error(); Object.defineProperty(error, "message", { value: 42 }); expect(classify({ kind: "thrown", error }).reason).toBe("unknown_failure");
+    const blockers: unknown[] = []; blockers.length = 2_000_000_000; expect(classify({ kind: "result", result: result({ ok: false, status: { state: "blocked", blockers } }) }).reason).toBe("unknown_failure");
   });
 });


### PR DESCRIPTION
Closes #994

## Summary
- add a pure discriminated thrown/result receipt classifier with the required precedence
- validate and cap all 18 summary counts
- add sanitized table fixtures for malformed, lease, disabled, failure, blocked, completed, no-candidate, and cap cases

## Validation
- PATH=/opt/homebrew/bin:$PATH npm exec -- vitest run tests/issue-enrichment-receipt.test.ts (17 passed)
- PATH=/opt/homebrew/bin:$PATH npm exec -- tsc --noEmit -p tsconfig.build.json
- PATH=/opt/homebrew/bin:$PATH npm run build
- git diff --cached --check

## Proof boundary
This is a pure source/test candidate only. It does not wire daemon logging, persistence, runtime, release, or customer behavior. Passing proves deterministic sanitized classification only.