### PR TITLE
feat(issue-enrichment): add immutable admission ledger

### DIFF
--- a/src/issue-enrichment-admission.ts
+++ b/src/issue-enrichment-admission.ts
@@ -1,13 +1,13 @@
 export type IssueEnrichmentAdmissionAction = "would_enrich" | "would_comment";
 export type IssueEnrichmentAdmissionProjection = IssueEnrichmentAdmissionAction | "deferred";
-export type IssueEnrichmentAdmissionReason = "eligible" | "already_recorded" | "released" | "repository_blocked" | "repo_max_issues_per_cycle" | "repo_max_comments_per_cycle" | "burst_threshold_exceeded" | "global_max_issues_per_cycle" | "global_max_comments_per_cycle";
+export type IssueEnrichmentAdmissionReason = "eligible" | "already_recorded" | "cooldown" | "released" | "repository_blocked" | "repo_max_issues_per_cycle" | "repo_max_comments_per_cycle" | "burst_threshold_exceeded" | "global_max_issues_per_cycle" | "global_max_comments_per_cycle";
 
-export interface IssueEnrichmentAdmissionScanItem { readonly repo: string; readonly issueNumber: number; readonly state: string; readonly action: IssueEnrichmentAdmissionAction | "skipped" | "deferred"; readonly issueUpdatedAt?: string; readonly url?: string; }
-export interface IssueEnrichmentAdmissionRecord { readonly repo: string; readonly issueNumber: number; readonly issueUpdatedAt?: string; readonly analysisInputHash?: string; readonly status: "dry_run" | "posted" | "deferred" | "failed" | "skipped"; }
+export interface IssueEnrichmentAdmissionScanItem { readonly repo: string; readonly issueNumber: number; readonly state: string; readonly action: IssueEnrichmentAdmissionAction | "skipped" | "deferred"; readonly intendedAction?: IssueEnrichmentAdmissionAction; readonly issueUpdatedAt?: string; readonly nextEligibleAt?: string; readonly url?: string; }
+export interface IssueEnrichmentAdmissionRecord { readonly repo: string; readonly issueNumber: number; readonly issueUpdatedAt?: string; readonly analysisInputHash?: string; readonly nextEligibleAt?: string; readonly status: "dry_run" | "posted" | "deferred" | "failed" | "skipped"; }
 export interface IssueEnrichmentAdmissionRepoLimits { readonly maxIssuesPerCycle: number; readonly maxCommentsPerCycle: number; readonly maxIssuesPerBurst: number; }
 export interface IssueEnrichmentAdmissionLimits { readonly globalMaxIssuesPerCycle: number; readonly globalMaxCommentsPerCycle: number; readonly repos: Readonly<Record<string, IssueEnrichmentAdmissionRepoLimits>>; }
 export interface IssueEnrichmentAdmissionInput { readonly allowlist: readonly string[]; readonly items: readonly IssueEnrichmentAdmissionScanItem[]; readonly records?: readonly IssueEnrichmentAdmissionRecord[]; readonly limits: IssueEnrichmentAdmissionLimits; readonly checkedAt: string; }
-export interface IssueEnrichmentAdmissionCandidate { readonly key: string; readonly repo: string; readonly issueNumber: number; readonly state: string; readonly issueUpdatedAt: string; readonly record?: IssueEnrichmentAdmissionRecord; readonly intendedAction: IssueEnrichmentAdmissionAction; readonly sourceDependent: boolean; readonly pending: boolean; readonly scanItem: Readonly<IssueEnrichmentAdmissionScanItem>; }
+export interface IssueEnrichmentAdmissionCandidate { readonly key: string; readonly repo: string; readonly issueNumber: number; readonly state: string; readonly issueUpdatedAt: string; readonly nextEligibleAt?: string; readonly cooldownActive: boolean; readonly record?: IssueEnrichmentAdmissionRecord; readonly intendedAction: IssueEnrichmentAdmissionAction; readonly sourceDependent: boolean; readonly pending: boolean; readonly scanItem: Readonly<IssueEnrichmentAdmissionScanItem>; }
 export interface IssueEnrichmentAdmissionDecision { readonly candidate: IssueEnrichmentAdmissionCandidate; readonly outputAction: IssueEnrichmentAdmissionProjection; readonly reason: IssueEnrichmentAdmissionReason; }
 export interface IssueEnrichmentAdmissionLedger { readonly candidates: readonly IssueEnrichmentAdmissionCandidate[]; next(): IssueEnrichmentAdmissionDecision | undefined; snapshot(): readonly IssueEnrichmentAdmissionDecision[]; release(candidate: IssueEnrichmentAdmissionCandidate): void; blockRepo(repo: string): void; }
 export interface IssueEnrichmentAdmission { readonly candidates: readonly IssueEnrichmentAdmissionCandidate[]; readonly ledger: IssueEnrichmentAdmissionLedger; }
@@ -19,13 +19,18 @@ export function createIssueEnrichmentAdmission(input: IssueEnrichmentAdmissionIn
   const records = new Map((input.records ?? []).map((record) => [`${record.repo}#${record.issueNumber}`, record]));
   const candidates: IssueEnrichmentAdmissionCandidate[] = [];
   for (const repo of input.allowlist) for (const item of input.items) {
-    if (item.repo !== repo || item.action === "skipped" || item.action === "deferred") continue;
+    if (item.repo !== repo || item.action === "skipped") continue;
     const key = `${repo}#${item.issueNumber}`;
     if (candidates.some((candidate) => candidate.key === key)) continue;
-    const record = records.get(key), intendedAction = item.action;
-    const pending = record?.status !== "skipped" && !(record?.status === "dry_run" && intendedAction === "would_enrich");
+    const record = records.get(key), intendedAction = item.action === "deferred" ? item.intendedAction : item.action;
+    if (!intendedAction) continue;
+    const issueUpdatedAt = canonicalDate(item.issueUpdatedAt ?? record?.issueUpdatedAt, input.checkedAt);
+    const nextEligibleAt = item.nextEligibleAt ?? record?.nextEligibleAt;
+    const cooldownActive = Boolean(nextEligibleAt && Date.parse(nextEligibleAt) > Date.parse(input.checkedAt));
+    const unchangedDryRun = record?.status === "dry_run" && intendedAction === "would_enrich" && canonicalDate(record.issueUpdatedAt, input.checkedAt) === issueUpdatedAt;
+    const pending = record?.status !== "skipped" && !cooldownActive && !unchangedDryRun;
     candidates.push(Object.freeze({ key, repo, issueNumber: item.issueNumber, state: item.state,
-      issueUpdatedAt: canonicalDate(item.issueUpdatedAt ?? record?.issueUpdatedAt, input.checkedAt),
+      issueUpdatedAt, ...(nextEligibleAt ? { nextEligibleAt } : {}), cooldownActive,
       ...(record ? { record: Object.freeze({ ...record }) } : {}), intendedAction,
       sourceDependent: record?.status === "posted", pending, scanItem: Object.freeze({ ...item }) }));
   }
@@ -34,6 +39,9 @@ export function createIssueEnrichmentAdmission(input: IssueEnrichmentAdmissionIn
 
 function makeLedger(candidates: readonly IssueEnrichmentAdmissionCandidate[], limits: IssueEnrichmentAdmissionLimits): IssueEnrichmentAdmissionLedger {
   const active = new Set<string>(), released = new Set<string>(), blocked = new Set<string>();
+  const burstCounts = new Map<string, number>();
+  for (const candidate of candidates) if (candidate.pending) burstCounts.set(candidate.repo, (burstCounts.get(candidate.repo) ?? 0) + 1);
+  const burstBlocked = new Set(candidates.filter((candidate) => candidate.pending && burstCounts.get(candidate.repo)! > (limits.repos[candidate.repo]?.maxIssuesPerBurst ?? 0)).map((candidate) => candidate.key));
   const usage = (): Usage => {
     const current: Usage = { repos: new Map(), globalIssues: 0, globalComments: 0 };
     for (const candidate of candidates) if (active.has(candidate.key)) add(current, candidate);
@@ -41,6 +49,7 @@ function makeLedger(candidates: readonly IssueEnrichmentAdmissionCandidate[], li
   };
   const reason = (candidate: IssueEnrichmentAdmissionCandidate, current: Usage): IssueEnrichmentAdmissionReason | undefined => {
     if (blocked.has(candidate.repo)) return "repository_blocked";
+    if (burstBlocked.has(candidate.key)) return "burst_threshold_exceeded";
     const cap = limits.repos[candidate.repo], repo = current.repos.get(candidate.repo) ?? { issues: 0, comments: 0, burst: 0 };
     if (!cap || repo.issues >= cap.maxIssuesPerCycle) return "repo_max_issues_per_cycle";
     if (candidate.intendedAction === "would_comment" && repo.comments >= cap.maxCommentsPerCycle) return "repo_max_comments_per_cycle";
@@ -49,7 +58,7 @@ function makeLedger(candidates: readonly IssueEnrichmentAdmissionCandidate[], li
     if (candidate.intendedAction === "would_comment" && current.globalComments >= limits.globalMaxCommentsPerCycle) return "global_max_comments_per_cycle";
   };
   const decide = (candidate: IssueEnrichmentAdmissionCandidate, current: Usage): IssueEnrichmentAdmissionDecision => {
-    if (!candidate.pending) return { candidate, outputAction: "deferred", reason: "already_recorded" };
+    if (!candidate.pending) return { candidate, outputAction: "deferred", reason: candidate.cooldownActive ? "cooldown" : "already_recorded" };
     if (released.has(candidate.key)) return { candidate, outputAction: "deferred", reason: "released" };
     if (active.has(candidate.key)) return { candidate, outputAction: candidate.intendedAction, reason: "eligible" };
     const blockedReason = reason(candidate, current);

--- a/src/issue-enrichment-admission.ts
+++ b/src/issue-enrichment-admission.ts
@@ -1,0 +1,88 @@
+export type IssueEnrichmentAdmissionAction = "would_enrich" | "would_comment";
+export type IssueEnrichmentAdmissionProjection = IssueEnrichmentAdmissionAction | "deferred";
+export type IssueEnrichmentAdmissionReason = "eligible" | "already_recorded" | "released" | "repository_blocked" | "repo_max_issues_per_cycle" | "repo_max_comments_per_cycle" | "burst_threshold_exceeded" | "global_max_issues_per_cycle" | "global_max_comments_per_cycle";
+
+export interface IssueEnrichmentAdmissionScanItem { readonly repo: string; readonly issueNumber: number; readonly state: string; readonly action: IssueEnrichmentAdmissionAction | "skipped" | "deferred"; readonly issueUpdatedAt?: string; readonly url?: string; }
+export interface IssueEnrichmentAdmissionRecord { readonly repo: string; readonly issueNumber: number; readonly issueUpdatedAt?: string; readonly analysisInputHash?: string; readonly status: "dry_run" | "posted" | "deferred" | "failed" | "skipped"; }
+export interface IssueEnrichmentAdmissionRepoLimits { readonly maxIssuesPerCycle: number; readonly maxCommentsPerCycle: number; readonly maxIssuesPerBurst: number; }
+export interface IssueEnrichmentAdmissionLimits { readonly globalMaxIssuesPerCycle: number; readonly globalMaxCommentsPerCycle: number; readonly repos: Readonly<Record<string, IssueEnrichmentAdmissionRepoLimits>>; }
+export interface IssueEnrichmentAdmissionInput { readonly allowlist: readonly string[]; readonly items: readonly IssueEnrichmentAdmissionScanItem[]; readonly records?: readonly IssueEnrichmentAdmissionRecord[]; readonly limits: IssueEnrichmentAdmissionLimits; readonly checkedAt: string; }
+export interface IssueEnrichmentAdmissionCandidate { readonly key: string; readonly repo: string; readonly issueNumber: number; readonly state: string; readonly issueUpdatedAt: string; readonly record?: IssueEnrichmentAdmissionRecord; readonly intendedAction: IssueEnrichmentAdmissionAction; readonly sourceDependent: boolean; readonly pending: boolean; readonly scanItem: Readonly<IssueEnrichmentAdmissionScanItem>; }
+export interface IssueEnrichmentAdmissionDecision { readonly candidate: IssueEnrichmentAdmissionCandidate; readonly outputAction: IssueEnrichmentAdmissionProjection; readonly reason: IssueEnrichmentAdmissionReason; }
+export interface IssueEnrichmentAdmissionLedger { readonly candidates: readonly IssueEnrichmentAdmissionCandidate[]; next(): IssueEnrichmentAdmissionDecision | undefined; snapshot(): readonly IssueEnrichmentAdmissionDecision[]; release(candidate: IssueEnrichmentAdmissionCandidate): void; blockRepo(repo: string): void; }
+export interface IssueEnrichmentAdmission { readonly candidates: readonly IssueEnrichmentAdmissionCandidate[]; readonly ledger: IssueEnrichmentAdmissionLedger; }
+
+type RepoUsage = { issues: number; comments: number; burst: number };
+type Usage = { repos: Map<string, RepoUsage>; globalIssues: number; globalComments: number };
+
+export function createIssueEnrichmentAdmission(input: IssueEnrichmentAdmissionInput): IssueEnrichmentAdmission {
+  const records = new Map((input.records ?? []).map((record) => [`${record.repo}#${record.issueNumber}`, record]));
+  const candidates: IssueEnrichmentAdmissionCandidate[] = [];
+  for (const repo of input.allowlist) for (const item of input.items) {
+    if (item.repo !== repo || item.action === "skipped" || item.action === "deferred") continue;
+    const key = `${repo}#${item.issueNumber}`;
+    if (candidates.some((candidate) => candidate.key === key)) continue;
+    const record = records.get(key), intendedAction = item.action;
+    const pending = record?.status !== "skipped" && !(record?.status === "dry_run" && intendedAction === "would_enrich");
+    candidates.push(Object.freeze({ key, repo, issueNumber: item.issueNumber, state: item.state,
+      issueUpdatedAt: canonicalDate(item.issueUpdatedAt ?? record?.issueUpdatedAt, input.checkedAt),
+      ...(record ? { record: Object.freeze({ ...record }) } : {}), intendedAction,
+      sourceDependent: record?.status === "posted", pending, scanItem: Object.freeze({ ...item }) }));
+  }
+  return { candidates: Object.freeze(candidates), ledger: makeLedger(candidates, input.limits) };
+}
+
+function makeLedger(candidates: readonly IssueEnrichmentAdmissionCandidate[], limits: IssueEnrichmentAdmissionLimits): IssueEnrichmentAdmissionLedger {
+  const active = new Set<string>(), released = new Set<string>(), blocked = new Set<string>();
+  const usage = (): Usage => {
+    const current: Usage = { repos: new Map(), globalIssues: 0, globalComments: 0 };
+    for (const candidate of candidates) if (active.has(candidate.key)) add(current, candidate);
+    return current;
+  };
+  const reason = (candidate: IssueEnrichmentAdmissionCandidate, current: Usage): IssueEnrichmentAdmissionReason | undefined => {
+    if (blocked.has(candidate.repo)) return "repository_blocked";
+    const cap = limits.repos[candidate.repo], repo = current.repos.get(candidate.repo) ?? { issues: 0, comments: 0, burst: 0 };
+    if (!cap || repo.issues >= cap.maxIssuesPerCycle) return "repo_max_issues_per_cycle";
+    if (candidate.intendedAction === "would_comment" && repo.comments >= cap.maxCommentsPerCycle) return "repo_max_comments_per_cycle";
+    if (repo.burst >= cap.maxIssuesPerBurst) return "burst_threshold_exceeded";
+    if (current.globalIssues >= limits.globalMaxIssuesPerCycle) return "global_max_issues_per_cycle";
+    if (candidate.intendedAction === "would_comment" && current.globalComments >= limits.globalMaxCommentsPerCycle) return "global_max_comments_per_cycle";
+  };
+  const decide = (candidate: IssueEnrichmentAdmissionCandidate, current: Usage): IssueEnrichmentAdmissionDecision => {
+    if (!candidate.pending) return { candidate, outputAction: "deferred", reason: "already_recorded" };
+    if (released.has(candidate.key)) return { candidate, outputAction: "deferred", reason: "released" };
+    if (active.has(candidate.key)) return { candidate, outputAction: candidate.intendedAction, reason: "eligible" };
+    const blockedReason = reason(candidate, current);
+    return blockedReason ? { candidate, outputAction: "deferred", reason: blockedReason } : { candidate, outputAction: candidate.intendedAction, reason: "eligible" };
+  };
+  return { candidates,
+    next() {
+      const current = usage();
+      for (const candidate of candidates) if (candidate.pending && !released.has(candidate.key) && !active.has(candidate.key) && !reason(candidate, current)) {
+        active.add(candidate.key); return { candidate, outputAction: candidate.intendedAction, reason: "eligible" };
+      }
+    },
+    snapshot() {
+      const current = usage(), projected: IssueEnrichmentAdmissionDecision[] = [];
+      for (const candidate of candidates) {
+        const item = decide(candidate, current); projected.push(item);
+        if (item.outputAction !== "deferred" && !active.has(candidate.key)) add(current, candidate);
+      }
+      return projected;
+    },
+    release(candidate) { active.delete(candidate.key); released.add(candidate.key); },
+    blockRepo(repo) { blocked.add(repo); for (const candidate of candidates) if (candidate.repo === repo && active.delete(candidate.key)) released.add(candidate.key); }
+  };
+}
+
+function add(current: Usage, candidate: IssueEnrichmentAdmissionCandidate): void {
+  const repo = current.repos.get(candidate.repo) ?? { issues: 0, comments: 0, burst: 0 };
+  repo.issues += 1; repo.burst += 1;
+  if (candidate.intendedAction === "would_comment") { repo.comments += 1; current.globalComments += 1; }
+  current.repos.set(candidate.repo, repo); current.globalIssues += 1;
+}
+
+function canonicalDate(value: string | undefined, fallback: string): string {
+  const parsed = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+}

--- a/tests/issue-enrichment-admission.test.ts
+++ b/tests/issue-enrichment-admission.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createIssueEnrichmentAdmission, type IssueEnrichmentAdmissionInput } from "../src/issue-enrichment-admission.js";
+
+const checkedAt = "2026-08-24T00:00:00.000Z";
+const limits = (overrides: Partial<IssueEnrichmentAdmissionInput["limits"]> = {}): IssueEnrichmentAdmissionInput["limits"] => ({
+  globalMaxIssuesPerCycle: 3, globalMaxCommentsPerCycle: 2, repos: {
+    "a/repo": { maxIssuesPerCycle: 2, maxCommentsPerCycle: 1, maxIssuesPerBurst: 2 },
+    "b/repo": { maxIssuesPerCycle: 2, maxCommentsPerCycle: 2, maxIssuesPerBurst: 2 }
+  }, ...overrides
+});
+const item = (repo: string, issueNumber: number, action: "would_enrich" | "would_comment" = "would_comment") => ({ repo, issueNumber, state: "open", action, issueUpdatedAt: "2026-08-23T00:00:00Z" } as const);
+const input = (items: IssueEnrichmentAdmissionInput["items"], extra: Partial<IssueEnrichmentAdmissionInput> = {}): IssueEnrichmentAdmissionInput => ({ allowlist: ["a/repo", "b/repo"], items, checkedAt, limits: limits(), ...extra });
+
+describe("issue enrichment admission ledger", () => {
+  it.each([
+    ["repo and global caps", [item("a/repo", 1), item("a/repo", 2), item("b/repo", 3)], ["a/repo#1", "b/repo#3"]],
+    ["burst cap", [item("a/repo", 1, "would_enrich"), item("a/repo", 2, "would_enrich"), item("a/repo", 3, "would_enrich")], ["a/repo#1", "a/repo#2"]]
+  ])("admits stable candidates under %s", (_name, items, expected) => {
+    const admission = createIssueEnrichmentAdmission(input(items as IssueEnrichmentAdmissionInput["items"]));
+    expect(admission.candidates.map((candidate) => candidate.key)).toEqual((items as readonly { repo: string; issueNumber: number }[]).map((entry) => `${entry.repo}#${entry.issueNumber}`));
+    expect([admission.ledger.next()?.candidate.key, admission.ledger.next()?.candidate.key]).toEqual(expected);
+  });
+
+  it("keeps intent immutable, carries records, and makes live comments pending", () => {
+    const admission = createIssueEnrichmentAdmission(input([item("a/repo", 1), item("a/repo", 2), item("b/repo", 3)], {
+      records: [
+        { repo: "a/repo", issueNumber: 1, status: "posted", analysisInputHash: "a" },
+        { repo: "a/repo", issueNumber: 2, status: "dry_run" },
+        { repo: "b/repo", issueNumber: 3, status: "posted" }
+      ]
+    }));
+    expect(admission.candidates.map((candidate) => [candidate.sourceDependent, candidate.pending, candidate.record?.analysisInputHash])).toEqual([[true, true, "a"], [false, true, undefined], [true, true, undefined]]);
+    const original = admission.candidates[0]!.scanItem;
+    admission.ledger.next();
+    expect(original.action).toBe("would_comment");
+  });
+
+  it("reports burst projection independently of repository issue caps", () => {
+    const admission = createIssueEnrichmentAdmission(input([item("a/repo", 1, "would_enrich"), item("a/repo", 2, "would_enrich")], {
+      limits: limits({ repos: { ...limits().repos, "a/repo": { maxIssuesPerCycle: 2, maxCommentsPerCycle: 1, maxIssuesPerBurst: 1 } } })
+    }));
+    expect(admission.ledger.snapshot()[1]).toMatchObject({ outputAction: "deferred", reason: "burst_threshold_exceeded" });
+  });
+
+  it("releases reservations and blocks repos without starving siblings", () => {
+    const admission = createIssueEnrichmentAdmission(input([item("a/repo", 1), item("b/repo", 1), item("a/repo", 2)], { limits: limits({ globalMaxIssuesPerCycle: 1 }) }));
+    const first = admission.ledger.next()!;
+    expect(first.candidate.key).toBe("a/repo#1");
+    admission.ledger.release(first.candidate);
+    admission.ledger.blockRepo("a/repo");
+    expect(admission.ledger.next()!.candidate.key).toBe("b/repo#1");
+    expect(admission.ledger.snapshot().find((decision) => decision.candidate.key === "a/repo#2")?.reason).toBe("repository_blocked");
+  });
+
+  it("projects deferred output without changing empty or skipped inputs", () => {
+    const skipped = item("a/repo", 1);
+    const admission = createIssueEnrichmentAdmission(input([{ ...skipped, action: "skipped" }]));
+    expect(admission.candidates).toHaveLength(0);
+    expect(admission.ledger.snapshot()).toEqual([]);
+  });
+});

--- a/tests/issue-enrichment-admission.test.ts
+++ b/tests/issue-enrichment-admission.test.ts
@@ -14,7 +14,7 @@ const input = (items: IssueEnrichmentAdmissionInput["items"], extra: Partial<Iss
 describe("issue enrichment admission ledger", () => {
   it.each([
     ["repo and global caps", [item("a/repo", 1), item("a/repo", 2), item("b/repo", 3)], ["a/repo#1", "b/repo#3"]],
-    ["burst cap", [item("a/repo", 1, "would_enrich"), item("a/repo", 2, "would_enrich"), item("a/repo", 3, "would_enrich")], ["a/repo#1", "a/repo#2"]]
+    ["burst cap", [item("a/repo", 1, "would_enrich"), item("a/repo", 2, "would_enrich"), item("a/repo", 3, "would_enrich")], [undefined, undefined]]
   ])("admits stable candidates under %s", (_name, items, expected) => {
     const admission = createIssueEnrichmentAdmission(input(items as IssueEnrichmentAdmissionInput["items"]));
     expect(admission.candidates.map((candidate) => candidate.key)).toEqual((items as readonly { repo: string; issueNumber: number }[]).map((entry) => `${entry.repo}#${entry.issueNumber}`));
@@ -25,7 +25,7 @@ describe("issue enrichment admission ledger", () => {
     const admission = createIssueEnrichmentAdmission(input([item("a/repo", 1), item("a/repo", 2), item("b/repo", 3)], {
       records: [
         { repo: "a/repo", issueNumber: 1, status: "posted", analysisInputHash: "a" },
-        { repo: "a/repo", issueNumber: 2, status: "dry_run" },
+        { repo: "a/repo", issueNumber: 2, status: "dry_run", issueUpdatedAt: "2026-08-22T00:00:00Z" },
         { repo: "b/repo", issueNumber: 3, status: "posted" }
       ]
     }));
@@ -40,6 +40,13 @@ describe("issue enrichment admission ledger", () => {
       limits: limits({ repos: { ...limits().repos, "a/repo": { maxIssuesPerCycle: 2, maxCommentsPerCycle: 1, maxIssuesPerBurst: 1 } } })
     }));
     expect(admission.ledger.snapshot()[1]).toMatchObject({ outputAction: "deferred", reason: "burst_threshold_exceeded" });
+  });
+
+  it("holds deferred rows until nextEligibleAt", () => {
+    const deferred = { ...item("a/repo", 9), action: "deferred" as const, intendedAction: "would_comment" as const, nextEligibleAt: "2026-08-25T00:00:00Z" };
+    const future = input([deferred], { records: [{ repo: "a/repo", issueNumber: 9, status: "deferred", nextEligibleAt: "2026-08-25T00:00:00Z" }] });
+    expect(createIssueEnrichmentAdmission(future).ledger.next()).toBeUndefined();
+    expect(createIssueEnrichmentAdmission({ ...future, checkedAt: "2026-08-25T00:00:00Z" }).ledger.next()?.candidate.key).toBe("a/repo#9");
   });
 
   it("releases reservations and blocks repos without starving siblings", () => {


### PR DESCRIPTION
Closes #996

## Summary
- add a pure immutable issue-enrichment admission ledger
- preserve intendedAction separately from deferred output projection
- provisionally enforce per-repo, burst, and global issue/comment caps with release and blocked-repo fairness
- add compact table-focused fixtures for cap, record/hash, dry-run/live, order, release, block, and empty cases

## Proof
- base: c234391ffc98ae1bcb051991e997b0207789c1ce
- focused TypeScript check: pass
- repository build: pass
- git diff --check: pass
- manual runtime assertions: pass
- Vitest focused execution: blocked by host Rollup optional native binary code-signature mismatch (not source/test failure)
- 149 added non-generated lines; no source/evidence/analyzer/GitHub/state/runtime calls

Passing proves deterministic pure admission/cap accounting only. It does not prove source preparation, evidence generation, live enrichment, persistence, worker/runtime behavior, release readiness, or customer readiness.