### PR TITLE
feat(issue-event): add strict pagination state machine (#990)

### DIFF
--- a/src/issue-event-pagination.ts
+++ b/src/issue-event-pagination.ts
@@ -1,0 +1,140 @@
+export type IssueEventTerminal = "short_page" | "bounded_tail" | "event_history_unbounded";
+
+export interface IssueEventPage<T> {
+  page: number;
+  items: T[];
+  link?: string | null;
+  linkHeader?: string | null;
+}
+
+export interface IssueEventPaginationReceipt<T> {
+  items: T[];
+  rawCount: number;
+  uniqueCount: number;
+  duplicateCount: number;
+  pagesRead: number;
+  lastPage?: number;
+  terminal: IssueEventTerminal;
+  truncated: boolean;
+  overflow: boolean;
+}
+
+interface Relations {
+  first?: number;
+  prev?: number;
+  next?: number;
+  last?: number;
+}
+
+interface ReadPage<T> {
+  page: IssueEventPage<T>;
+  relations?: Relations;
+  present: boolean;
+}
+
+const PAGE_SIZE = 100;
+const MAX_ITEMS = 200;
+const RELATIONS = new Set(["first", "prev", "next", "last"]);
+
+export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
+  readPage: (page: number) => Promise<IssueEventPage<T>>;
+  apiOrigin: string;
+  issueEventsPath: string;
+}): Promise<IssueEventPaginationReceipt<T>> {
+  const latest = new Map<string, T>();
+  let anonymous = 0, rawCount = 0, pagesRead = 0, lastPage: number | undefined;
+  const add = (items: T[]) => {
+    rawCount += items.length;
+    for (const event of items) {
+      const value = event?.id;
+      const known = (typeof value === "number" && Number.isSafeInteger(value)) || (typeof value === "string" && Boolean(value.trim()));
+      const id = known ? `id:${String(value)}` : `anonymous:${anonymous++}`;
+      latest.delete(id);
+      latest.set(id, event);
+    }
+  };
+  const receipt = (terminal: IssueEventTerminal): IssueEventPaginationReceipt<T> => {
+    const items = [...latest.values()];
+    const uniqueCount = items.length;
+    const overflow = terminal === "event_history_unbounded";
+    return {
+      items: items.slice(-MAX_ITEMS), rawCount, uniqueCount, duplicateCount: rawCount - uniqueCount,
+      pagesRead, ...(lastPage === undefined ? {} : { lastPage }), terminal,
+      truncated: overflow || uniqueCount > MAX_ITEMS, overflow
+    };
+  };
+  const read = async (requested: number): Promise<ReadPage<T>> => {
+    const page = await input.readPage(requested);
+    if (!Number.isSafeInteger(page.page) || page.page !== requested || !Array.isArray(page.items)) throw new Error("invalid issue-event page");
+    pagesRead += 1; add(page.items);
+    const rawLink = page.link ?? page.linkHeader;
+    const present = rawLink !== undefined && rawLink !== null;
+    const relations = present ? parseRelations(rawLink!, input.apiOrigin, input.issueEventsPath) : undefined;
+    return { page, relations, present };
+  };
+  const fail = () => receipt("event_history_unbounded");
+  const readSafe = async (page: number) => {
+    try { return await read(page); } catch { return undefined; }
+  };
+  const chain = (relations: Relations | undefined, page: number, last: number) => Boolean(
+    relations && relations.last === last && (relations.first === undefined || relations.first === 1) &&
+    (page === 1 ? relations.prev === undefined && (last === 1 ? relations.next === undefined : relations.next === 2)
+      : relations.prev === page - 1 && (page === last ? relations.next === undefined : relations.next === page + 1))
+  );
+  const terminalLinks = (relations: Relations | undefined, page: number, last: number) => Boolean(
+    relations && relations.last === last && (relations.first === undefined || relations.first === 1) &&
+    relations.prev === undefined && relations.next === undefined
+  );
+  const tail = async (existing: number, first: ReadPage<T>): Promise<IssueEventPaginationReceipt<T>> => {
+    if (!first.relations?.last || first.relations.last < existing || !chain(first.relations, existing, lastPage!)) return fail();
+    const start = Math.max(1, lastPage! - 4);
+    for (let page = Math.max(existing + 1, start); page <= lastPage!; page += 1) {
+      const next = await readSafe(page);
+      if (!next || !next.present || !chain(next.relations, page, lastPage!) || (page < lastPage! && next.page.items.length < PAGE_SIZE)) return fail();
+    }
+    return receipt("bounded_tail");
+  };
+
+  const first = await readSafe(1);
+  if (!first) return fail();
+  if (first.page.items.length < PAGE_SIZE) {
+    if (first.present && (!first.relations || !terminalLinks(first.relations, 1, 1))) return fail();
+    lastPage = 1; return receipt("short_page");
+  }
+  if (first.present) {
+    if (!first.relations?.last || first.relations.last < 1) return fail();
+    lastPage = first.relations.last;
+    if (lastPage === 1) return chain(first.relations, 1, 1) ? receipt("short_page") : fail();
+    return tail(1, first);
+  }
+  const second = await readSafe(2);
+  if (!second) return fail();
+  if (second.page.items.length < PAGE_SIZE) {
+    const terminalLast = second.page.items.length ? 2 : 1;
+    if (second.present && (!second.relations || !terminalLinks(second.relations, 2, terminalLast))) return fail();
+    lastPage = terminalLast; return receipt("short_page");
+  }
+  if (!second.present || !second.relations?.last || second.relations.last < 2) return fail();
+  lastPage = second.relations.last;
+  return tail(2, second);
+}
+
+function parseRelations(value: string, origin: string, path: string): Relations | undefined {
+  const result: Relations = {}, seen = new Set<string>();
+  if (!value.trim()) return undefined;
+  for (const part of value.split(",")) {
+    const match = /^\s*<([^<>]+)>\s*;\s*rel\s*=\s*(?:"([^"]+)"|'([^']+)'|([^;\s]+))\s*$/.exec(part);
+    if (!match) return undefined;
+    let url: URL;
+    try { url = new URL(match[1]!); } catch { return undefined; }
+    const pageValues = [...url.searchParams.entries()].filter(([key]) => key.toLowerCase() === "page").map(([, page]) => page);
+    if (url.origin !== origin || url.username || url.password || url.pathname !== path || url.hash || pageValues.length !== 1) return undefined;
+    const page = pageValues[0]!;
+    if (!/^[1-9]\d*$/.test(page) || !Number.isSafeInteger(Number(page))) return undefined;
+    for (const name of (match[2] ?? match[3] ?? match[4]!).toLowerCase().split(/\s+/)) {
+      if (!RELATIONS.has(name) || seen.has(name)) return undefined;
+      seen.add(name); result[name as keyof Relations] = Number(page);
+    }
+  }
+  return seen.size ? result : undefined;
+}

--- a/tests/issue-event-pagination.test.ts
+++ b/tests/issue-event-pagination.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { readIssueEventHistory, type IssueEventPage } from "../src/issue-event-pagination.js";
+
+type Event = { id: number; value?: string };
+const origin = "https://api.github.com", path = "/repos/o/r/issues/7/events";
+const events = (start: number, count = 100): Event[] => Array.from({ length: count }, (_, i) => ({ id: start + i }));
+const url = (rel: string, page: string | number, suffix = "") => `<${origin}${path}?page=${page}${suffix}>; rel="${rel}"`;
+const chain = (page: number, last: number, prev: number | null | undefined = page > 1 ? page - 1 : undefined, next: number | null | undefined = page < last ? page + 1 : undefined) =>
+  [prev == null ? "" : url("prev", prev), next == null ? "" : url("next", next), url("last", last)].filter(Boolean).join(", ");
+const run = async (pages: Record<number, IssueEventPage<Event>>) => readIssueEventHistory({ apiOrigin: origin, issueEventsPath: path, readPage: async (page) => pages[page] ?? { page, items: [] } });
+
+describe("strict issue-event pagination state machine", () => {
+  it("handles short history, exact-100 probe, nonempty page 2, and full/no-Link overflow", async () => {
+    expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page");
+    const exact = await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } });
+    expect(exact).toMatchObject({ rawCount: 100, pagesRead: 2, lastPage: 1, terminal: "short_page", overflow: false });
+    const two = await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(101, 3) } });
+    expect(two).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "short_page" });
+    expect((await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(101) } })).terminal).toBe("event_history_unbounded");
+  });
+
+  it("validates a five-page tail, overlap, newest duplicate, and newest-200 receipt", async () => {
+    const pages: Record<number, IssueEventPage<Event>> = { 1: { page: 1, items: events(1), link: chain(1, 5) } };
+    for (let page = 2; page <= 5; page += 1) pages[page] = { page, items: page === 5 ? [{ id: 400, value: "newest" }, ...events(401, 49)] : events(page === 2 ? 101 : page === 3 ? 201 : 301), link: chain(page, 5) };
+    const result = await run(pages);
+    expect(result).toMatchObject({ rawCount: 450, uniqueCount: 449, duplicateCount: 1, pagesRead: 5, lastPage: 5, terminal: "bounded_tail", truncated: true, overflow: false });
+    expect(result.items).toHaveLength(200); expect(result.items.find((event) => event.id === 400)?.value).toBe("newest");
+  });
+
+  it("fails closed for hostile links and contradictory chains", async () => {
+    const hostile = [`<${origin}${path}?page=2>; rel="next", <${origin}${path}?page=3>; rel="next"`, `<${origin}${path}?page=2>; rel="next"`, `<https://evil.test/x?page=2>; rel="next"`, `<${origin}/wrong?page=2>; rel="next"`, `<${origin}${path}?page=2&page=2>; rel="next"`, `<${origin}${path}?page=0>; rel="next"`, `<${origin}${path}?page=no>; rel="next"`, `<${origin}${path}?page=2; rel="next"`, `<${origin}${path}?page=2>; rel="bogus"`];
+    for (const link of hostile) expect((await run({ 1: { page: 1, items: events(1), link } })).terminal).toBe("event_history_unbounded");
+    const bad = (page: number, link: string, items = events(page * 100 + 1)) => run({ 1: { page: 1, items: events(1), link: chain(1, 5) }, 4: { page: 4, items, link }, 2: { page: 2, items: events(101), link: chain(2, 5) }, 3: { page: 3, items: events(201), link: chain(3, 5) }, 5: { page: 5, items: events(401, 2), link: chain(5, 5) } });
+    for (const [page, link, items] of [[4, chain(4, 4), events(301)], [4, chain(4, 6, 3, 5), events(301)], [4, chain(4, 5, 2, 5), events(301)], [4, chain(4, 5, 3, null), events(301)], [4, chain(4, 5, 3, 5), events(301, 1)], [5, chain(5, 5, 3), events(401, 2)] ] as const) expect((await bad(page, link, items)).terminal).toBe("event_history_unbounded");
+    expect((await run({ 1: { page: 1, items: events(1), link: `${url("next", 2)}, ${url("last", 1)}` } })).terminal).toBe("event_history_unbounded");
+  });
+});


### PR DESCRIPTION
Closes #990

## Summary
- Add a pure issue-event page reader and bounded receipt; no API, enrichment, runtime, DB, release, or customer wiring.
- Validate every present Link header against the exact configured origin/path, strict page relations, immutable last page, and contiguous tail.
- Probe exactly one page after a full page 1 without Link; deduplicate known IDs with newest occurrence retained and return the newest 200 events.
- Add focused short-history, exact-100, bounded-tail, hostile-link, contradiction, overlap, duplicate, and newest-200 fixtures.

## Proof
- Base: c234391ffc98ae1bcb051991e997b0207789c1ce
- Candidate: d73b9fd0899ebc67c2e90e04ea15cae2e3cb0975
- Scope: 177 added non-generated lines in two new files.
- Passing: direct TypeScript compile of the module; runtime smoke for exact-100 probe, bounded tail, dedupe/newest retention, hostile links, and contradictory chains; git diff --check.
- Vitest focused run is currently blocked by the checkout environment’s invalid/missing platform-native optional bindings; no dependency files were changed.

## Proof boundary
This source-only candidate proves deterministic pagination and receipt behavior only. It does not prove #991 API/enrichment wiring, live GitHub reads, runtime, release, or customer readiness. Authored by an agent; merge and review remain maintainer gates.