### PR TITLE
fix(desktop): refresh native worker verification state

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -7,8 +7,8 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
     private let localBotExecutionContextProvider:
         @Sendable () -> [DesktopLocalBotExecutionContext]
     private let defaultWorkingDirectory: URL?
-    private let trustedBundledWorker:
-        DesktopLocalBotExecutionContext?
+    private let trustedBundledWorkerProvider:
+        @Sendable () -> DesktopLocalBotExecutionContext?
     private let trustedProcessValidator:
         @Sendable (Int32) -> Bool
 
@@ -19,8 +19,8 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
             (@Sendable () -> [DesktopLocalBotExecutionContext])? = nil,
         defaultWorkingDirectory: URL? =
             NeonDiffCLIResolver.defaultWorkingDirectory(),
-        trustedBundledWorker:
-            DesktopLocalBotExecutionContext? = nil,
+        trustedBundledWorkerProvider:
+            (@Sendable () -> DesktopLocalBotExecutionContext?)? = nil,
         trustedProcessValidator:
             @escaping @Sendable (Int32) -> Bool = { _ in false }
     ) {
@@ -28,7 +28,7 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
         self.localBotExecutionContextProvider =
             localBotExecutionContextProvider ?? { localBotExecutionContexts }
         self.defaultWorkingDirectory = defaultWorkingDirectory
-        self.trustedBundledWorker = trustedBundledWorker
+        self.trustedBundledWorkerProvider = trustedBundledWorkerProvider ?? { nil }
         self.trustedProcessValidator = trustedProcessValidator
     }
 
@@ -56,6 +56,7 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
         }
         let trustedContext: DesktopLocalBotExecutionContext?
         if requiresTrustedWorker {
+            let trustedBundledWorker = trustedBundledWorkerProvider()
             guard let trustedBundledWorker else {
                 throw NeonDiffCLIError.launchFailed(
                     "The signed bundled NeonDiff worker is unavailable"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -9,12 +9,13 @@ struct FoundationKeychainWorkerLaunchAgentManager:
     private let appExecutableURL: URL
     private let homeDirectory: URL
     private let trustedBundledWorker:
-        DesktopLocalBotExecutionContext
+        @Sendable () -> DesktopLocalBotExecutionContext?
 
     init(
         appExecutableURL: URL,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        trustedBundledWorker: DesktopLocalBotExecutionContext
+        trustedBundledWorker:
+            @escaping @Sendable () -> DesktopLocalBotExecutionContext?
     ) {
         self.appExecutableURL = appExecutableURL.standardizedFileURL
         self.homeDirectory = homeDirectory.standardizedFileURL
@@ -25,7 +26,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
         request: DesktopKeychainWorkerLaunchAgentRequest,
         preservedRepositoryCount: Int
     ) async throws -> String {
-        try validate(request)
+        let trustedBundledWorker = try validate(request)
         guard let sealedWorkerPath = trustedBundledWorker.executablePath else {
             throw WorkerLaunchAgentRuntimeError.invalidCoordinates
         }
@@ -41,8 +42,8 @@ struct FoundationKeychainWorkerLaunchAgentManager:
     func installAndStart(
         request: DesktopKeychainWorkerLaunchAgentRequest
     ) async throws -> String {
-        try await Task.detached {
-            try validate(request)
+        _ = try validate(request)
+        return try await Task.detached {
             let data =
                 try DesktopKeychainWorkerLaunchAgentContract.propertyListData(
                     request: request,
@@ -111,8 +112,9 @@ struct FoundationKeychainWorkerLaunchAgentManager:
 
     private func validate(
         _ request: DesktopKeychainWorkerLaunchAgentRequest
-    ) throws {
-        guard isSafeAppExecutable(appExecutableURL),
+    ) throws -> DesktopLocalBotExecutionContext {
+        guard let trustedBundledWorker = trustedBundledWorker(),
+              isSafeAppExecutable(appExecutableURL),
               isSafeConfig(URL(filePath: request.configPath)),
               trustedBundledWorker.executablePath
                 == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
@@ -121,6 +123,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
         else {
             throw WorkerLaunchAgentRuntimeError.invalidCoordinates
         }
+        return trustedBundledWorker
     }
 
     private func isSafeAppExecutable(_ url: URL) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/LaunchAgentLocalBotConfigurationDiscovery.swift
@@ -12,7 +12,8 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
 
     static func discoverSnapshot(
         label: String = defaultLabel,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        trustedBundledWorker: DesktopLocalBotExecutionContext? = nil
     ) -> Snapshot {
         let launchAgentURL = fileManager.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
@@ -60,7 +61,8 @@ enum LaunchAgentLocalBotConfigurationDiscovery {
            ),
            let appID = Int64(request.appID),
            let sealedContext =
-                FoundationTrustedBundledWorker.executionContext() {
+                trustedBundledWorker
+                    ?? FoundationTrustedBundledWorker.executionContext() {
             return Snapshot(
                 configurations: [
                     DesktopLocalBotConfiguration(

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -92,12 +92,13 @@ enum NeonDiffDesktopCompositionRoot {
             }
         let keychainWorkerLaunchAgentManager:
             any DesktopKeychainWorkerLaunchAgentManaging
-        if let appExecutableURL = Bundle.main.executableURL,
-           let trustedBundledWorker {
+        if let appExecutableURL = Bundle.main.executableURL {
             keychainWorkerLaunchAgentManager =
                 FoundationKeychainWorkerLaunchAgentManager(
                     appExecutableURL: appExecutableURL,
-                    trustedBundledWorker: trustedBundledWorker
+                    trustedBundledWorker: {
+                        FoundationTrustedBundledWorker.executionContext()
+                    }
                 )
         } else {
             keychainWorkerLaunchAgentManager =

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -35,11 +35,14 @@ enum NeonDiffDesktopCompositionRoot {
         if productionBoundary.managedGitHubBrokerOrigin != nil, githubBroker == nil {
             productionBoundary = .quarantined
         }
+        let discoveryProductionBoundary = productionBoundary
         let cliWorkingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
-        let localBotSnapshot =
-            LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot()
         let trustedBundledWorker =
             FoundationTrustedBundledWorker.executionContext()
+        let localBotSnapshot =
+            LaunchAgentLocalBotConfigurationDiscovery.discoverSnapshot(
+                trustedBundledWorker: trustedBundledWorker
+            )
         let nativeVerificationCapability =
             DesktopNativeVerificationCapability.resolve(
                 productionBoundary: productionBoundary,
@@ -63,18 +66,27 @@ enum NeonDiffDesktopCompositionRoot {
         let localBotDiscoveryProvider:
             @Sendable (String) -> DesktopLocalBotDiscoverySnapshot = {
                 label in
+                let trustedBundledWorker =
+                    FoundationTrustedBundledWorker.executionContext()
                 let snapshot =
                     LaunchAgentLocalBotConfigurationDiscovery
-                        .discoverSnapshot(label: label)
+                        .discoverSnapshot(
+                            label: label,
+                            trustedBundledWorker: trustedBundledWorker
+                        )
                 return DesktopLocalBotDiscoverySnapshot(
                     configurations: snapshot.configurations,
                     executionContexts:
                         snapshot.executionContexts
                         + (
-                            FoundationTrustedBundledWorker
-                                .executionContext()
+                            trustedBundledWorker
                                 .map { [$0] }
                             ?? []
+                        ),
+                    nativeVerificationCapability:
+                        DesktopNativeVerificationCapability.resolve(
+                            productionBoundary: discoveryProductionBoundary,
+                            trustedBundledWorker: trustedBundledWorker
                         )
                 )
             }
@@ -100,7 +112,9 @@ enum NeonDiffDesktopCompositionRoot {
                 localBotExecutionContextProvider:
                     localBotExecutionContextProvider,
                 defaultWorkingDirectory: cliWorkingDirectory,
-                trustedBundledWorker: trustedBundledWorker,
+                trustedBundledWorkerProvider: {
+                    FoundationTrustedBundledWorker.executionContext()
+                },
                 trustedProcessValidator: {
                     FoundationTrustedBundledWorker
                         .runningProcessIsTrusted($0)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -565,13 +565,16 @@ package struct UnavailableDesktopKeychainWorkerLaunchAgentManager:
 package struct DesktopLocalBotDiscoverySnapshot: Sendable {
     package let configurations: [DesktopLocalBotConfiguration]
     package let executionContexts: [DesktopLocalBotExecutionContext]
+    package let nativeVerificationCapability: DesktopNativeVerificationCapability
 
     package init(
         configurations: [DesktopLocalBotConfiguration],
-        executionContexts: [DesktopLocalBotExecutionContext]
+        executionContexts: [DesktopLocalBotExecutionContext],
+        nativeVerificationCapability: DesktopNativeVerificationCapability = .unavailable
     ) {
         self.configurations = configurations
         self.executionContexts = executionContexts
+        self.nativeVerificationCapability = nativeVerificationCapability
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -170,6 +170,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         [DesktopLocalBotConfiguration] = []
     @Published package private(set) var currentLocalBotExecutionConfigPaths:
         [String] = []
+    @Published package private(set) var newAppNativeVerificationAvailable = false
     @Published package private(set)
         var isKeychainWorkerLaunchAgentOperationInProgress = false
     @Published package private(set) var keychainWorkerLaunchAgentStatus =
@@ -592,10 +593,6 @@ package final class NeonDiffDesktopModel: ObservableObject {
             && dependencies.productionBoundary.managedGitHubBrokerOrigin == nil
     }
 
-    package var newAppNativeVerificationAvailable: Bool {
-        dependencies.newAppNativeVerificationAvailable
-    }
-
     package var byoGitHubAppIdStored: Bool {
         storedBYOGitHubAppId != nil
     }
@@ -793,6 +790,8 @@ package final class NeonDiffDesktopModel: ObservableObject {
     package init(dependencies: DesktopAppDependencies, activationLicenseClient: (any ActivationLicenseClienting)? = nil) {
         self.dependencies = dependencies
         self.activationLicenseClientOverride = activationLicenseClient
+        self.newAppNativeVerificationAvailable =
+            dependencies.newAppNativeVerificationAvailable
         self.currentLocalWorkerExecutionContexts =
             dependencies.localBotExecutionContexts
         self.currentLocalBotConfigurations =
@@ -2706,11 +2705,18 @@ package final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         let snapshot = provider(launchdLabel)
+        let wasAvailable = newAppNativeVerificationAvailable
         currentLocalBotConfigurations = snapshot.configurations
         currentLocalWorkerExecutionContexts = snapshot.executionContexts
         currentLocalBotExecutionConfigPaths = snapshot.executionContexts
             .map(\.configPath)
             .filter { !$0.isEmpty }
+        newAppNativeVerificationAvailable =
+            snapshot.nativeVerificationCapability.newAppNativeVerificationAvailable
+        if wasAvailable && !newAppNativeVerificationAvailable {
+            byoGitHubCredentialRevision &+= 1
+            invalidateBYOGitHubVerificationContext()
+        }
     }
 
     private var runtimeCredentialsForReviewRequired: Bool {
@@ -3831,6 +3837,9 @@ package final class NeonDiffDesktopModel: ObservableObject {
             lastError = "Retry account verification before verifying GitHub App setup."
             byoGitHubCredentialStatus = lastError ?? "Account check required"
             return
+        }
+        if source == .keychainStdin {
+            refreshLocalBotDiscovery()
         }
         guard source != .keychainStdin || newAppNativeVerificationAvailable else {
             lastError = "Native new-App verification is unavailable in this signed build."

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -2713,7 +2713,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             .filter { !$0.isEmpty }
         newAppNativeVerificationAvailable =
             snapshot.nativeVerificationCapability.newAppNativeVerificationAvailable
-        if wasAvailable && !newAppNativeVerificationAvailable {
+        if wasAvailable && !newAppNativeVerificationAvailable && !existingLocalAgentAccessAvailable {
             byoGitHubCredentialRevision &+= 1
             invalidateBYOGitHubVerificationContext()
         }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/BYOGitHubAppCredentialOnboardingTests.swift
@@ -3,6 +3,14 @@ import Testing
 @testable import NeonDiffDesktopAppCore
 import NeonDiffDesktopCore
 
+private final class DiscoverySnapshotBox: @unchecked Sendable {
+    var snapshot: DesktopLocalBotDiscoverySnapshot
+
+    init(_ snapshot: DesktopLocalBotDiscoverySnapshot) {
+        self.snapshot = snapshot
+    }
+}
+
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
 struct BYOGitHubAppCredentialOnboardingTests {
@@ -125,6 +133,83 @@ struct BYOGitHubAppCredentialOnboardingTests {
         fixture.model.refreshStatus()
 
         #expect(fixture.model.localWorkerCLIAvailable)
+    }
+
+    @Test func refreshStatusPublishesMissingWorkerBeforeOneDaemonRead() async {
+        let snapshots = DiscoverySnapshotBox(discoverySnapshot(.testAvailable))
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [
+                .success(doctorResult(
+                    readChecks: doctorReadCheck(repo: "acme/demo")
+                )),
+                .success(CLIRunResult(
+                    exitCode: 0,
+                    stdout: #"{"ok":true,"command":"daemon status","state":"running"}"#,
+                    stderr: ""
+                ))
+            ],
+            preferenceStrings: [
+                "neondiff.cliPath": "neondiff",
+                "neondiff.configPath":
+                    "/Users/test/Library/Application Support/NeonDiffDesktop/Accounts/account/Bots/new/config.local.json"
+            ],
+            localBotDiscoveryProvider: { _ in snapshots.snapshot },
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.repos = [RepoMonitor(name: "acme/demo", enabled: true)]
+        fixture.model.pendingBYOGitHubAppId = "123456"
+        fixture.model.pendingBYOGitHubAppPrivateKey = fixturePrivateKey
+        fixture.model.storeBYOGitHubAppCredentials()
+        fixture.model.verifyBYOGitHubAppCredentials()
+        #expect(fixture.model.localWorkerCLIAvailable)
+        await waitForBYOVerification(fixture)
+        #expect(fixture.model.byoGitHubCredentialsVerified)
+
+        snapshots.snapshot = discoverySnapshot(.unavailable)
+        fixture.model.refreshStatus()
+        await fixture.cli.waitUntilCallCount(2)
+
+        #expect(!fixture.model.newAppNativeVerificationAvailable)
+        #expect(!fixture.model.byoGitHubCredentialsVerified)
+        #expect(fixture.model.currentLocalWorkerExecutionContexts.isEmpty)
+        #expect(fixture.cli.calls.count == 2)
+        #expect(fixture.cli.calls[1].arguments.prefix(2) == ["daemon", "status"])
+    }
+
+    @Test func refreshStatusPublishesNewWorkerBeforeOneDaemonRead() async {
+        let snapshots = DiscoverySnapshotBox(discoverySnapshot(.unavailable))
+        let fixture = ModelDependencyFixture(
+            cliOutcomes: [.success(CLIRunResult(
+                exitCode: 0,
+                stdout: #"{"ok":true,"command":"daemon status","state":"running"}"#,
+                stderr: ""
+            ))],
+            localBotDiscoveryProvider: { _ in snapshots.snapshot },
+            productionBoundary: exactB0Boundary,
+            nativeVerificationCapability: .unavailable
+        )
+        snapshots.snapshot = discoverySnapshot(.testAvailable)
+
+        fixture.model.refreshStatus()
+        await fixture.cli.waitUntilCallCount(1)
+
+        #expect(fixture.model.newAppNativeVerificationAvailable)
+        #expect(fixture.model.currentLocalWorkerExecutionContexts.count == 1)
+        #expect(fixture.cli.calls.count == 1)
+    }
+
+    @Test func newAppVerificationRefreshesAndRefusesRemovedWorkerBeforeCLI() {
+        let snapshots = DiscoverySnapshotBox(discoverySnapshot(.unavailable))
+        let fixture = ModelDependencyFixture(
+            preferenceStrings: ["neondiff.cliPath": "neondiff"],
+            localBotDiscoveryProvider: { _ in snapshots.snapshot },
+            productionBoundary: exactB0Boundary
+        )
+        fixture.model.verifyBYOGitHubAppCredentials()
+
+        #expect(!fixture.model.newAppNativeVerificationAvailable)
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.model.lastError?.contains("unavailable") == true)
     }
 
     @Test func cleanInstallInitializationUsesNonDestructiveCLIInit() async {
@@ -778,6 +863,23 @@ private func doctorReadCheck(
         #","skippedByPolicy":"\#($0)""#
     } ?? ""
     return #"{"repo":"\#(repo)","ok":\#(ok),"visibility_result":"public","installation_id_present":true,"app_can_read_metadata":true,"app_can_read_pull_requests":true\#(skippedField)}"#
+}
+
+private func discoverySnapshot(
+    _ capability: DesktopNativeVerificationCapability
+) -> DesktopLocalBotDiscoverySnapshot {
+    DesktopLocalBotDiscoverySnapshot(
+        configurations: [],
+        executionContexts: capability.newAppNativeVerificationAvailable
+            ? [DesktopLocalBotExecutionContext(
+                configPath: "",
+                executablePath:
+                    "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
+                environmentOverrides: [:]
+            )]
+            : [],
+        nativeVerificationCapability: capability
+    )
 }
 
 private let exactB0Boundary = DesktopProductionBoundary.resolve(infoDictionary: [

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ExistingLocalBotReconciliationTests.swift
@@ -789,7 +789,8 @@ import NeonDiffDesktopCore
             preferenceStrings: [
                 "neondiff.cliPath": "/usr/bin/true"
             ],
-            productionBoundary: .testAccountLink
+            productionBoundary: .testAccountLink,
+            nativeVerificationCapability: .unavailable
         )
         fixture.model.pendingBYOGitHubAppId = "4184532"
         fixture.model.pendingBYOGitHubAppPrivateKey =

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -254,6 +254,8 @@ struct ModelDependencyFixture {
         localBotConfigurations: [DesktopLocalBotConfiguration] = [],
         localBotExecutionContexts: [DesktopLocalBotExecutionContext] = [],
         localBotExecutionConfigPaths: [String] = [],
+        localBotDiscoveryProvider:
+            (@Sendable (String) -> DesktopLocalBotDiscoverySnapshot)? = nil,
         productionBoundary: DesktopProductionBoundary = .testVerified,
         nativeVerificationCapability: DesktopNativeVerificationCapability = .testAvailable,
         localWorkerUpdateGuideURL: URL = DesktopReleaseRouting.localWorkerUpdateGuideURL(
@@ -297,7 +299,8 @@ struct ModelDependencyFixture {
             localWorkerUpdateGuideURL: localWorkerUpdateGuideURL,
             localBotConfigurations: localBotConfigurations,
             localBotExecutionContexts: localBotExecutionContexts,
-            localBotExecutionConfigPaths: localBotExecutionConfigPaths
+            localBotExecutionConfigPaths: localBotExecutionConfigPaths,
+            localBotDiscoveryProvider: localBotDiscoveryProvider
         ), activationLicenseClient: activationLicenseClient)
     }
 


### PR DESCRIPTION
Closes #993

## Summary
- resolve the trusted bundled worker from a current provider at credential-bearing invocation time
- resolve the LaunchAgent manager's worker at preview/install action time, so a helper appearing after launch works without an app restart
- carry one refresh snapshot's worker capability into the published model gate before the read-only daemon status call
- clear new-App verification proof when the trusted helper disappears while preserving proof for an unchanged existing local-agent route
- keep existing-bot verification independent of the new-App capability gate

## Deterministic proof
- Base: `7bb1902c5ba463ae2d2acb7347d069290eae2038` (#998)
- Head: `934f59e12f0182dad65e96c228f27d27ccd76303`
- Patch SHA-256: `9850c85b84e57e43e08e45793cef33659a8237d4aaa5f31af3ddd9093cdde9d4`
- Changed lines: 199 total (169 added, 30 removed)
- `git diff --check`: pass
- `swift build --package-path apps/neondiff-desktop`: pass
- BYOGitHubAppCredentialOnboardingTests: 28 passed
- ExistingLocalBotReconciliationTests: 49 passed
- ManagedGitHubOnboardingTests: 24 passed
- Exact-head Build/test/package and Swift Desktop Gate: pass

## Documentation dependency

Milestone-11 issue #1009 owns the repository-mandated coordinated updates to `README.md`, `docs/SETUP.md`, `docs/github-app-setup.md`, and website onboarding. This source PR does not claim first-run documentation, packaged artifact, clean-Mac, release, or customer readiness; those claims remain release-blocked until #1009 and the later packaged acceptance gates pass.

Proof boundary: source-level refresh/action gating and focused Swift behavior only. This does not prove signed artifact identity, installed runtime, clean-Mac onboarding, release, or customer readiness.
