### PR TITLE
feat(issue-event): add strict Link and page-envelope parser

### DIFF
--- a/src/issue-event-pagination-links.ts
+++ b/src/issue-event-pagination-links.ts
@@ -14,7 +14,7 @@ export function parseIssueEventLink(input: {
 }): IssueEventLinkResult {
   if (typeof input.currentPage !== "number") invalid("current page");
   const currentPage = positivePage(input.currentPage, "current page");
-  if (input.link === undefined) return { kind: "absent" };
+  if (input.link === undefined || input.link === null) return { kind: "absent" };
   if (typeof input.link !== "string" || input.link.trim() === "") invalid("Link header");
   const origin = configuredOrigin(input.apiOrigin);
   if (typeof input.issueEventsPath !== "string" || !input.issueEventsPath.startsWith("/")) invalid("event path");

--- a/src/issue-event-pagination-links.ts
+++ b/src/issue-event-pagination-links.ts
@@ -1,0 +1,120 @@
+export const ISSUE_EVENT_PAGE_SIZE = 100;
+export type IssueEventRelation = "first" | "prev" | "next" | "last";
+export type IssueEventRelations = Partial<Record<IssueEventRelation, number>>;
+
+export type IssueEventLinkResult =
+  | { kind: "absent" }
+  | { kind: "present"; relations: IssueEventRelations };
+
+export function parseIssueEventLink(input: {
+  link?: unknown;
+  apiOrigin: string;
+  issueEventsPath: string;
+  currentPage: unknown;
+}): IssueEventLinkResult {
+  if (typeof input.currentPage !== "number") invalid("current page");
+  const currentPage = positivePage(input.currentPage, "current page");
+  if (input.link === undefined) return { kind: "absent" };
+  if (typeof input.link !== "string" || input.link.trim() === "") invalid("Link header");
+  const origin = configuredOrigin(input.apiOrigin);
+  if (typeof input.issueEventsPath !== "string" || !input.issueEventsPath.startsWith("/")) invalid("event path");
+  const relations: IssueEventRelations = {};
+  const seen = new Set<IssueEventRelation>();
+  for (const part of input.link.split(",")) {
+    const match = /^\s*<([^<>]+)>\s*;\s*rel=(?:"([^"]+)"|([^\s;,]+))\s*$/.exec(part);
+    if (!match) invalid("Link member");
+    const target = parseTarget(match[1]!, origin, input.issueEventsPath);
+    const relationNames = (match[2] ?? match[3]!).split(/\s+/);
+    if (relationNames.length === 0 || relationNames.some((name) => !isRelation(name))) invalid("relation");
+    for (const name of relationNames) {
+      const relation = name as IssueEventRelation;
+      if (seen.has(relation)) invalid("duplicate relation");
+      seen.add(relation);
+      relations[relation] = target;
+    }
+  }
+  if (seen.size === 0) invalid("empty relations");
+  const { first, prev, next, last } = relations;
+  if (first !== undefined && first !== 1) invalid("first relation");
+  if (prev !== undefined && (currentPage === 1 || prev !== currentPage - 1)) invalid("prev relation");
+  if (next !== undefined && (currentPage === Number.MAX_SAFE_INTEGER || next !== currentPage + 1)) invalid("next relation");
+  if (last !== undefined && (last < currentPage || (last === currentPage && next !== undefined))) invalid("last relation");
+  return { kind: "present", relations };
+}
+
+export type IssueEventPageCardinality = "empty" | "short" | "full";
+export interface IssueEventPage<T> {
+  page: number;
+  items: T[];
+  cardinality: IssueEventPageCardinality;
+}
+
+export function parseIssueEventPage<T>(input: {
+  requestedPage: unknown;
+  returnedPage: unknown;
+  items: unknown;
+}): IssueEventPage<T> {
+  if (typeof input.requestedPage !== "number") invalid("requested page");
+  const page = positivePage(input.requestedPage, "requested page");
+  if (input.returnedPage !== page) invalid("returned page");
+  if (!Array.isArray(input.items) || input.items.length > ISSUE_EVENT_PAGE_SIZE) invalid("page items");
+  const items = input.items.slice() as T[];
+  return {
+    page,
+    items,
+    cardinality: items.length === 0 ? "empty" : items.length === ISSUE_EVENT_PAGE_SIZE ? "full" : "short"
+  };
+}
+
+function parseTarget(raw: string, origin: string, path: string): number {
+  if (/%(?![0-9a-f]{2})/i.test(raw)) invalid("URL escape");
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    invalid("URL");
+  }
+  if (url.origin !== origin || url.username || url.password || url.hash || url.pathname !== path) invalid("URL target");
+  const schemeEnd = raw.indexOf("://");
+  const pathStart = raw.indexOf("/", schemeEnd + 3);
+  const pathEnd = raw.search(/[?#]/);
+  const rawPath = raw.slice(pathStart < 0 ? raw.length : pathStart, pathEnd < 0 ? raw.length : pathEnd);
+  if (rawPath !== path) invalid("URL path");
+  const query = url.search.slice(1);
+  if (!query || query.startsWith("&") || query.endsWith("&") || query.includes("&&")) invalid("query");
+  if (query.split("&").some((part) => !part.includes("="))) invalid("query member");
+  const entries = [...url.searchParams.entries()];
+  const pages = entries.filter(([key]) => key === "page").map(([, value]) => value);
+  const perPages = entries.filter(([key]) => key === "per_page").map(([, value]) => value);
+  if (entries.some(([key]) => key !== "page" && key !== "per_page") || pages.length !== 1 || perPages.length > 1) {
+    invalid("query keys");
+  }
+  if (perPages.length === 1 && perPages[0] !== "100") invalid("per_page");
+  return positivePage(pages[0], "page");
+}
+
+function configuredOrigin(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    invalid("origin");
+  }
+  if (url.username || url.password || url.hash || url.search || url.pathname !== "/") invalid("origin");
+  return url.origin;
+}
+
+function positivePage(value: unknown, label: string): number {
+  if ((typeof value !== "number" && typeof value !== "string") || !/^[1-9]\d*$/.test(String(value))) invalid(label);
+  const page = Number(value);
+  if (!Number.isSafeInteger(page)) invalid(label);
+  return page;
+}
+
+function isRelation(value: string): value is IssueEventRelation {
+  return value === "first" || value === "prev" || value === "next" || value === "last";
+}
+
+function invalid(label: string): never {
+  throw new Error(`invalid issue-event ${label}`);
+}

--- a/tests/issue-event-pagination-links.test.ts
+++ b/tests/issue-event-pagination-links.test.ts
@@ -30,7 +30,7 @@ describe("strict issue-event Link parser", () => {
       `<${href("page=-1")}>; rel="next"`, `<${href("page=1.5")}>; rel="next"`,
       `<${href("page=9007199254740992")}>; rel="next"`, `<${href("page=2&per_page=200")}>; rel="next"`,
       `<${href("page=2&per_page=100&per_page=100")}>; rel="next"`, `<${href("page=2&extra=x")}>; rel="next"`,
-      `<${href("page=2")}>; rel="next"`, `<${href("page=2")}>; rel="Next"`,
+      `<${href("page=2")}>; rel="Next"`,
       `<${href("page=2")}>; rel="bogus"`, `<${href("page=2")}>; rel="next" junk`,
       `${link("next")}, ${link("next", "page=3")}`, `${link("next")}, ${link("prev", "page=0")}`
     ];

--- a/tests/issue-event-pagination-links.test.ts
+++ b/tests/issue-event-pagination-links.test.ts
@@ -15,6 +15,7 @@ const parse = (value: unknown, currentPage = 1) => parseIssueEventLink({
 describe("strict issue-event Link parser", () => {
   it("distinguishes absent Link from present-invalid and normalizes safe metadata", () => {
     expect(parse(undefined)).toEqual({ kind: "absent" });
+    expect(parse(null)).toEqual({ kind: "absent" });
     expect(parse(link("next", "page=2&per_page=100"))).toEqual({ kind: "present", relations: { next: 2 } });
     expect(() => parse("")).toThrow();
   });
@@ -33,7 +34,7 @@ describe("strict issue-event Link parser", () => {
       `<${href("page=2")}>; rel="bogus"`, `<${href("page=2")}>; rel="next" junk`,
       `${link("next")}, ${link("next", "page=3")}`, `${link("next")}, ${link("prev", "page=0")}`
     ];
-    for (const value of [null, ...bad]) expect(() => parse(value)).toThrow();
+    for (const value of bad) expect(() => parse(value)).toThrow();
   });
 
   it("rejects contradictory local relation metadata", () => {

--- a/tests/issue-event-pagination-links.test.ts
+++ b/tests/issue-event-pagination-links.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { parseIssueEventLink, parseIssueEventPage } from "../src/issue-event-pagination-links.js";
+
+const origin = "https://api.github.com";
+const path = "/repos/owner/repo/issues/7/events";
+const href = (query: string) => `${origin}${path}?${query}`;
+const link = (relation: string, query = "page=2") => `<${href(query)}>; rel="${relation}"`;
+const parse = (value: unknown, currentPage = 1) => parseIssueEventLink({
+  link: value,
+  apiOrigin: origin,
+  issueEventsPath: path,
+  currentPage
+});
+
+describe("strict issue-event Link parser", () => {
+  it("distinguishes absent Link from present-invalid and normalizes safe metadata", () => {
+    expect(parse(undefined)).toEqual({ kind: "absent" });
+    expect(parse(link("next", "page=2&per_page=100"))).toEqual({ kind: "present", relations: { next: 2 } });
+    expect(() => parse("")).toThrow();
+  });
+
+  it("rejects hostile origins, paths, credentials, hashes, queries, relations, and pages", () => {
+    const bad = [
+      `<https://evil.test/x?page=2>; rel="next"`, `<${origin}/wrong?page=2>; rel="next"`,
+      `<${origin}/repos/owner/repo/issues/7/events/../events?page=2>; rel="next"`,
+      `<https://user:pass@api.github.com${path}?page=2>; rel="next"`, `<${origin}${path}?page=2#bad>; rel="next"`,
+      `<${href("per_page=100")}>; rel="next"`, `<${href("page=2&page=2")}>; rel="next"`,
+      `<${href("page=2&Page=3")}>; rel="next"`, `<${href("page=0")}>; rel="next"`,
+      `<${href("page=-1")}>; rel="next"`, `<${href("page=1.5")}>; rel="next"`,
+      `<${href("page=9007199254740992")}>; rel="next"`, `<${href("page=2&per_page=200")}>; rel="next"`,
+      `<${href("page=2&per_page=100&per_page=100")}>; rel="next"`, `<${href("page=2&extra=x")}>; rel="next"`,
+      `<${href("page=2")}>; rel="next"`, `<${href("page=2")}>; rel="Next"`,
+      `<${href("page=2")}>; rel="bogus"`, `<${href("page=2")}>; rel="next" junk`,
+      `${link("next")}, ${link("next", "page=3")}`, `${link("next")}, ${link("prev", "page=0")}`
+    ];
+    for (const value of [null, ...bad]) expect(() => parse(value)).toThrow();
+  });
+
+  it("rejects contradictory local relation metadata", () => {
+    expect(() => parse(`${link("first", "page=2")}`)).toThrow();
+    expect(() => parse(`${link("prev", "page=2")}`, 4)).toThrow();
+    expect(() => parse(`${link("next", "page=6")}`, 4)).toThrow();
+    expect(() => parse(`${link("last", "page=3")}`, 4)).toThrow();
+    expect(() => parse(`${link("next", "page=5")}, ${link("last", "page=4")}`, 4)).toThrow();
+  });
+});
+
+describe("issue-event page envelope", () => {
+  it("truthfully classifies empty, short, and full pages", () => {
+    expect(parseIssueEventPage({ requestedPage: 1, returnedPage: 1, items: [] }).cardinality).toBe("empty");
+    expect(parseIssueEventPage({ requestedPage: 2, returnedPage: 2, items: [{}] }).cardinality).toBe("short");
+    expect(parseIssueEventPage({ requestedPage: 3, returnedPage: 3, items: Array(99) }).cardinality).toBe("short");
+    expect(parseIssueEventPage({ requestedPage: 4, returnedPage: 4, items: Array(100) }).cardinality).toBe("full");
+  });
+
+  it("rejects wrong-page, non-array, and overfull envelopes", () => {
+    expect(() => parseIssueEventPage({ requestedPage: 2, returnedPage: 1, items: [] })).toThrow();
+    expect(() => parseIssueEventPage({ requestedPage: 1, returnedPage: 1, items: {} })).toThrow();
+    expect(() => parseIssueEventPage({ requestedPage: 1, returnedPage: 1, items: Array(101) })).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1005

## Summary
- Add event-specific pure validation for issue-event Link metadata.
- Enforce exact origin/path, safe page, canonical per_page=100, unique known relations, and local relation consistency.
- Add one-shot page-envelope validation for requested-page identity, array items, and empty/short/full cardinality; overfull pages fail.
- Treat an omitted/null Link as absent while rejecting an empty present Link.

## Proof
- Exact base: 7bb1902c5ba463ae2d2acb7347d069290eae2038
- Candidate: 521ec6321d99b4d5d98588c2937496d35fb5ab02
- Scope: 182 added non-generated lines in two new files.
- Patch SHA-256: 1f549e292b1052e607f79e54e81d4032b1533259d23b6410b2511516ad3ccd8b
- Passing: focused TypeScript compile; `npm run build`; deterministic runtime smoke; `git diff --check`.
- Vitest collection is blocked by the checkout environment’s pre-existing missing/invalid platform-native Rollup binding; no dependency files changed.

## Boundaries
- No traversal, fetching, terminal classification, dedupe, receipts, GitHub adapter, enrichment, runtime, release, or customer state.
- Authored by an agent; merge and independent review remain maintainer gates.