### PR TITLE
feat(issue-enrichment): normalize immutable admission candidates

### DIFF
--- a/src/issue-enrichment-admission-normalization.ts
+++ b/src/issue-enrichment-admission-normalization.ts
@@ -46,7 +46,12 @@ export function normalizeIssueEnrichmentCandidates(input: IssueEnrichmentNormali
   if (input.fallbackIntendedAction !== undefined && !isAction(input.fallbackIntendedAction)) {
     throw new Error("issue_enrichment_normalization_invalid_fallbackIntendedAction");
   }
-  const byKey = new Map(records.map((record) => [`${record.repo}#${record.issueNumber}`, record]));
+  const byKey = new Map<string, IssueEnrichmentNormalizationRecord>();
+  for (const record of records) {
+    const key = `${record.repo}#${record.issueNumber}`;
+    if (byKey.has(key)) throw new Error(`issue_enrichment_normalization_duplicate_record:${key}`);
+    byKey.set(key, record);
+  }
   const candidates: IssueEnrichmentNormalizationCandidate[] = [];
   const seen = new Set<string>();
   for (const repo of allowlist) for (const item of items) {
@@ -87,6 +92,7 @@ function parseTimestamp(value: string | undefined): string | undefined {
 }
 function deepFreeze<T>(value: T): T {
   if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    if (!Array.isArray(value) && Object.getPrototypeOf(value) !== Object.prototype) throw new Error("issue_enrichment_normalization_non_plain_value");
     for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
     Object.freeze(value);
   }

--- a/src/issue-enrichment-admission-normalization.ts
+++ b/src/issue-enrichment-admission-normalization.ts
@@ -1,0 +1,94 @@
+export type IssueEnrichmentNormalizationAction = "would_enrich" | "would_comment";
+export type IssueEnrichmentNormalizationScanAction = IssueEnrichmentNormalizationAction | "deferred" | "skipped";
+export type IssueEnrichmentNormalizationStatus = "dry_run" | "posted" | "skipped" | "deferred" | "failed";
+export type IssueEnrichmentNormalizationReason = "pending" | "held" | "already_recorded";
+
+export interface IssueEnrichmentNormalizationScanItem {
+  repo: string; issueNumber: number; state: string; action: IssueEnrichmentNormalizationScanAction;
+  intendedAction?: IssueEnrichmentNormalizationAction; issueUpdatedAt?: string; nextEligibleAt?: string; url?: string;
+}
+export interface IssueEnrichmentNormalizationRecord {
+  repo: string; issueNumber: number; status: IssueEnrichmentNormalizationStatus;
+  issueUpdatedAt?: string; bodyHash?: string; analysisInputHash?: string; nextEligibleAt?: string;
+  [key: string]: unknown;
+}
+export interface IssueEnrichmentNormalizationLimits {
+  readonly globalMaxIssuesPerCycle?: number; readonly globalMaxCommentsPerCycle?: number;
+  readonly repos: Readonly<Record<string, Readonly<Record<string, number>>>>;
+  readonly [key: string]: unknown;
+}
+export interface IssueEnrichmentNormalizationInput {
+  allowlist: readonly string[]; items: readonly IssueEnrichmentNormalizationScanItem[];
+  records?: readonly IssueEnrichmentNormalizationRecord[]; checkedAt: string;
+  fallbackIntendedAction?: IssueEnrichmentNormalizationAction; limits: IssueEnrichmentNormalizationLimits;
+}
+export interface IssueEnrichmentNormalizationCandidate {
+  key: string; repo: string; issueNumber: number; state: string;
+  action: IssueEnrichmentNormalizationScanAction; intendedAction: IssueEnrichmentNormalizationAction;
+  issueUpdatedAt?: string; nextEligibleAt?: string; identityKnown: boolean;
+  sourceDependent: boolean; pending: boolean; reason: IssueEnrichmentNormalizationReason;
+  scanItem: Readonly<IssueEnrichmentNormalizationScanItem>;
+  record?: Readonly<IssueEnrichmentNormalizationRecord>; limits: IssueEnrichmentNormalizationLimits;
+}
+export interface IssueEnrichmentNormalizationResult {
+  allowlist: readonly string[]; items: readonly IssueEnrichmentNormalizationScanItem[];
+  records: readonly IssueEnrichmentNormalizationRecord[]; limits: IssueEnrichmentNormalizationLimits;
+  candidates: readonly IssueEnrichmentNormalizationCandidate[];
+}
+
+export function normalizeIssueEnrichmentCandidates(input: IssueEnrichmentNormalizationInput): IssueEnrichmentNormalizationResult {
+  const checkedAt = parseTimestamp(input.checkedAt);
+  if (checkedAt === undefined) throw new Error("issue_enrichment_normalization_invalid_checkedAt");
+  const allowlist = deepFreeze(structuredClone(input.allowlist));
+  const items = deepFreeze(structuredClone(input.items));
+  const records = deepFreeze(structuredClone(input.records ?? []));
+  const limits = deepFreeze(structuredClone(input.limits));
+  if (input.fallbackIntendedAction !== undefined && !isAction(input.fallbackIntendedAction)) {
+    throw new Error("issue_enrichment_normalization_invalid_fallbackIntendedAction");
+  }
+  const byKey = new Map(records.map((record) => [`${record.repo}#${record.issueNumber}`, record]));
+  const candidates: IssueEnrichmentNormalizationCandidate[] = [];
+  const seen = new Set<string>();
+  for (const repo of allowlist) for (const item of items) {
+    if (item.repo !== repo || item.action === "skipped") continue;
+    const key = `${repo}#${item.issueNumber}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const record = byKey.get(key);
+    const intendedAction = item.intendedAction ?? (item.action === "deferred" ? input.fallbackIntendedAction : item.action);
+    if (!intendedAction || !isAction(intendedAction)) throw new Error(`issue_enrichment_normalization_missing_intent:${key}`);
+    const issueUpdatedAt = item.issueUpdatedAt === undefined ? undefined : parseTimestamp(item.issueUpdatedAt);
+    const recordUpdatedAt = parseTimestamp(record?.issueUpdatedAt);
+    const nextEligibleAt = item.nextEligibleAt === undefined ? parseTimestamp(record?.nextEligibleAt) : parseTimestamp(item.nextEligibleAt);
+    const held = (item.action === "deferred" || record?.status === "deferred") && nextEligibleAt !== undefined && Date.parse(nextEligibleAt) > Date.parse(checkedAt);
+    const knownSame = issueUpdatedAt !== undefined && recordUpdatedAt !== undefined && issueUpdatedAt === recordUpdatedAt;
+    const alreadyRecorded = record?.status === "dry_run" && intendedAction === "would_enrich" && knownSame;
+    const candidate = {
+      key, repo, issueNumber: item.issueNumber, state: item.state, action: item.action, intendedAction,
+      ...(issueUpdatedAt ? { issueUpdatedAt } : {}), ...(nextEligibleAt ? { nextEligibleAt } : {}),
+      identityKnown: issueUpdatedAt !== undefined, sourceDependent: record?.status === "posted",
+      pending: !held && !alreadyRecorded, reason: held ? "held" : alreadyRecorded ? "already_recorded" : "pending",
+      scanItem: deepFreeze(structuredClone(item)), ...(record ? { record: deepFreeze(structuredClone(record)) } : {}), limits
+    } satisfies IssueEnrichmentNormalizationCandidate;
+    candidates.push(deepFreeze(candidate));
+  }
+  return deepFreeze({ allowlist, items, records, limits, candidates });
+}
+
+export const normalizeIssueEnrichmentAdmission = normalizeIssueEnrichmentCandidates;
+
+function isAction(value: unknown): value is IssueEnrichmentNormalizationAction {
+  return value === "would_enrich" || value === "would_comment";
+}
+function parseTimestamp(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
+}
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/tests/issue-enrichment-admission-normalization.test.ts
+++ b/tests/issue-enrichment-admission-normalization.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { normalizeIssueEnrichmentCandidates, type IssueEnrichmentNormalizationInput as Input } from "../src/issue-enrichment-admission-normalization.js";
+
+const checkedAt = "2026-08-24T00:00:00.000Z";
+const limits = { globalMaxIssuesPerCycle: 3, repos: { "a/repo": { maxIssuesPerCycle: 2 } } };
+const item = (repo: string, issueNumber: number, action: "would_enrich" | "would_comment" = "would_enrich") => ({
+  repo, issueNumber, state: "open", action, issueUpdatedAt: "2026-08-23T00:00:00Z"
+});
+const input = (items: Input["items"], extra: Partial<Input> = {}): Input => ({
+  allowlist: ["a/repo", "b/repo"], items, checkedAt, fallbackIntendedAction: "would_enrich", limits, ...extra
+});
+
+describe("issue-enrichment admission normalization", () => {
+  it("keeps a frozen, allowlist/issue ordered unique candidate snapshot", () => {
+    const source = input([item("b/repo", 2), item("a/repo", 2), item("a/repo", 2), { ...item("a/repo", 3), action: "skipped" }], {
+      records: [{ repo: "a/repo", issueNumber: 2, status: "skipped" }]
+    });
+    const normalized = normalizeIssueEnrichmentCandidates(source);
+    expect(normalized.candidates.map((candidate) => candidate.key)).toEqual(["a/repo#2", "b/repo#2"]);
+    expect(Object.isFrozen(normalized.candidates[0])).toBe(true);
+    source.items[0]!.issueNumber = 99;
+    (source.allowlist as string[])[0] = "other/repo";
+    source.records![0]!.status = "posted";
+    (source.limits.repos as any)["a/repo"].maxIssuesPerCycle = 0;
+    expect(normalized.candidates[1]!.key).toBe("b/repo#2");
+    expect(normalized.allowlist[0]).toBe("a/repo");
+    expect(normalized.records[0]!.status).toBe("skipped");
+    expect(normalized.candidates[0]!.limits.repos["a/repo"].maxIssuesPerCycle).toBe(2);
+  });
+
+  it.each([
+    ["explicit", { action: "deferred", intendedAction: "would_comment" }, "would_comment"],
+    ["legacy", { action: "deferred" }, "would_comment"]
+  ] as const)("retains %s deferred intent", (_name, patch, expected) => {
+    const normalized = normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), ...patch }], { fallbackIntendedAction: expected }));
+    expect(normalized.candidates[0]!.intendedAction).toBe(expected);
+    expect(normalized.candidates[0]!.pending).toBe(true);
+  });
+
+  it("rejects a legacy deferred row without an explicit current-cycle fallback", () => {
+    expect(() => normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), action: "deferred" }], { fallbackIntendedAction: undefined }))).toThrow(/fallbackIntendedAction/);
+  });
+
+  it("keeps unknown timestamps unknown and applies deadline-only fallback", () => {
+    const unknown = normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), issueUpdatedAt: "bad" }], {
+      records: [{ repo: "a/repo", issueNumber: 1, status: "dry_run", issueUpdatedAt: "2026-08-23T00:00:00Z" }]
+    })).candidates[0]!;
+    expect(unknown.issueUpdatedAt).toBeUndefined();
+    expect(unknown.pending).toBe(true);
+    const future = normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), action: "deferred", nextEligibleAt: "2026-08-25T00:00:00Z" }])).candidates[0]!;
+    expect(future.pending).toBe(false);
+    expect(normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), action: "deferred", nextEligibleAt: checkedAt }])).candidates[0]!.pending).toBe(true);
+  });
+
+  it("keeps skipped records, dry-run-to-live, and posted rows pending", () => {
+    const records = [
+      { repo: "a/repo", issueNumber: 1, status: "skipped", issueUpdatedAt: "2026-08-23T00:00:00Z" },
+      { repo: "a/repo", issueNumber: 2, status: "dry_run", issueUpdatedAt: "2026-08-23T00:00:00Z" },
+      { repo: "a/repo", issueNumber: 3, status: "posted", analysisInputHash: "a".repeat(64) }
+    ] as const;
+    const normalized = normalizeIssueEnrichmentCandidates(input([item("a/repo", 1), item("a/repo", 2, "would_comment"), item("a/repo", 3)], { records }));
+    expect(normalized.candidates.map((candidate) => [candidate.pending, candidate.sourceDependent])).toEqual([[true, false], [true, false], [true, true]]);
+  });
+
+  it("may classify only known unchanged dry-run enrichment as already recorded", () => {
+    const candidate = normalizeIssueEnrichmentCandidates(input([item("a/repo", 1)], {
+      records: [{ repo: "a/repo", issueNumber: 1, status: "dry_run", issueUpdatedAt: "2026-08-23T00:00:00Z" }]
+    })).candidates[0]!;
+    expect(candidate.reason).toBe("already_recorded");
+    expect(candidate.pending).toBe(false);
+  });
+});

--- a/tests/issue-enrichment-admission-normalization.test.ts
+++ b/tests/issue-enrichment-admission-normalization.test.ts
@@ -38,7 +38,19 @@ describe("issue-enrichment admission normalization", () => {
   });
 
   it("rejects a legacy deferred row without an explicit current-cycle fallback", () => {
-    expect(() => normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), action: "deferred" }], { fallbackIntendedAction: undefined }))).toThrow(/fallbackIntendedAction/);
+    expect(() => normalizeIssueEnrichmentCandidates(input([{ ...item("a/repo", 1), action: "deferred" }], { fallbackIntendedAction: undefined }))).toThrow("issue_enrichment_normalization_missing_intent:a/repo#1");
+  });
+
+  it("rejects duplicate persisted records independently of input order", () => {
+    const records = [{ repo: "a/repo", issueNumber: 1, status: "dry_run" }, { repo: "a/repo", issueNumber: 1, status: "posted" }] as const;
+    for (const ordered of [records, [...records].reverse()]) expect(() => normalizeIssueEnrichmentCandidates(input([item("a/repo", 1)], { records: ordered }))).toThrow("issue_enrichment_normalization_duplicate_record:a/repo#1");
+  });
+
+  it("rejects mutable non-plain extension values", () => {
+    for (const extension of [new Map([["x", 1]]), new Date(0)]) {
+      const record = { repo: "a/repo", issueNumber: 1, status: "posted", extension } as any;
+      expect(() => normalizeIssueEnrichmentCandidates(input([item("a/repo", 1)], { records: [record] }))).toThrow("issue_enrichment_normalization_non_plain_value");
+    }
   });
 
   it("keeps unknown timestamps unknown and applies deadline-only fallback", () => {


### PR DESCRIPTION
Closes #1012

## Summary
- add a pure immutable candidate normalizer with stable allowlist/issue ordering and logical-key dedupe
- preserve explicit/deferred intent, require the explicit current-cycle fallback for legacy deferred rows, and classify conservative pending/source-dependent state
- keep unknown issue timestamps unknown; hold future deadlines; reopen due/no-deadline deferred and skipped rows
- add focused table tests for mutation isolation, timestamps, dry-run/live transitions, posted rows, empty/skipped input, and ordering

## Proof
- base: 7bb1902c5ba463ae2d2acb7347d069290eae2038
- candidate: d3c53f734e76b45c1867bae71e11a885bb33f655
- patch SHA-256 (git show HEAD): 7063a5a78042738cc357f4171c6f67fb438aaa2a28b059e8dc726dec0d69a125
- 166 added non-generated lines in the two owned files
- strict source TypeScript check: pass
- manual runtime assertions: pass
- git diff --check: pass
- focused Vitest: blocked by host Rollup optional-native binary code-signature mismatch (not source/test failure)
- GitNexus detect_changes: no changes detected; indexed checkout is stale at e41e9c9 and does not cover this exact 7bb1902c base/new files

Passing proves immutable normalization and conservative idempotency classification only. It does not prove cap enforcement, source/evidence correctness, live enrichment, persistence, runtime, release, or customer readiness. No #997 integration, schema/persistence, runtime, or customer mutation is included.