### PR TITLE
feat: add exception-safe issue-enrichment receipt snapshot

### DIFF
--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -2,11 +2,11 @@ import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG, type Issue
 export const ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP = 1_000_000;
 export const ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT = 32;
 export const ISSUE_ENRICHMENT_RECEIPT_MESSAGE_LIMIT = 256;
-export const ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS = [
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS = Object.freeze([
   "reposScanned", "reposSkipped", "readFailures", "issuesSeen", "eligible", "skipped", "wouldEnrich",
   "wouldComment", "deferred", "baselinedRepos", "truncatedRepos", "workerSkipped", "posted", "dryRunRecorded",
   "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
-] as const;
+] as const);
 export type IssueEnrichmentReceiptCounts = { readonly [K in typeof ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS[number]]: number };
 export type IssueEnrichmentReceiptReason = IssueEnrichmentBlocker | "unknown_failure";
 export type IssueEnrichmentReceiptInput = { kind: "result"; result: unknown } | { kind: "thrown"; error: unknown };
@@ -59,9 +59,9 @@ function snapshotSummary(value: unknown): Readonly<{ valid: false }> | Readonly<
 }
 function snapshotBlockers(value: unknown): IssueEnrichmentBlockersSnapshot {
   try {
-    if (!Array.isArray(value)) return frozen({ readable: false, complete: false, reasons: [] });
+    if (!Array.isArray(value)) return frozen({ readable: false, complete: false, reasons: frozen([]) });
     const length = (value as unknown[]).length;
-    if (!Number.isSafeInteger(length) || length < 0) return frozen({ readable: false, complete: false, reasons: [] });
+    if (!Number.isSafeInteger(length) || length < 0) return frozen({ readable: false, complete: false, reasons: frozen([]) });
     const reasons: IssueEnrichmentBlocker[] = [];
     let readable = true;
     let complete = length <= ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT;
@@ -69,12 +69,12 @@ function snapshotBlockers(value: unknown): IssueEnrichmentBlockersSnapshot {
       try {
         const present = Object.prototype.hasOwnProperty.call(value, index);
         const blocker = (value as unknown[])[index];
-        if (!present || blocker === undefined) complete = false;
-        else if (typeof blocker === "string" && BLOCKERS.has(blocker as IssueEnrichmentBlocker)) reasons.push(blocker as IssueEnrichmentBlocker);
+        if (!present || typeof blocker !== "string" || !BLOCKERS.has(blocker as IssueEnrichmentBlocker)) complete = false;
+        else reasons.push(blocker as IssueEnrichmentBlocker);
       } catch { readable = false; complete = false; }
     }
     return frozen({ readable, complete, reasons: frozen(reasons) });
-  } catch { return frozen({ readable: false, complete: false, reasons: [] }); }
+  } catch { return frozen({ readable: false, complete: false, reasons: frozen([]) }); }
 }
 function snapshotThrown(error: unknown): IssueEnrichmentReceiptSnapshot {
   let message: unknown;
@@ -115,6 +115,7 @@ export function snapshotIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInpu
     try { error = (input as { kind: "thrown"; error: unknown }).error; } catch { /* fail closed */ }
     return snapshotThrown(error);
   }
+  if (kind !== "result") return frozen({ kind: "thrown", reason: "unknown_failure" });
   let result: unknown;
   try { result = (input as { kind: "result"; result: unknown }).result; } catch { /* malformed result */ }
   return snapshotResult(result);

--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -1,0 +1,121 @@
+import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentBlocker } from "./issue-enrichment.js";
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP = 1_000_000;
+export const ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT = 32;
+export const ISSUE_ENRICHMENT_RECEIPT_MESSAGE_LIMIT = 256;
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS = [
+  "reposScanned", "reposSkipped", "readFailures", "issuesSeen", "eligible", "skipped", "wouldEnrich",
+  "wouldComment", "deferred", "baselinedRepos", "truncatedRepos", "workerSkipped", "posted", "dryRunRecorded",
+  "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
+] as const;
+export type IssueEnrichmentReceiptCounts = { readonly [K in typeof ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS[number]]: number };
+export type IssueEnrichmentReceiptReason = IssueEnrichmentBlocker | "unknown_failure";
+export type IssueEnrichmentReceiptInput = { kind: "result"; result: unknown } | { kind: "thrown"; error: unknown };
+export type IssueEnrichmentReceiptSnapshot = Readonly<{ kind: "thrown"; reason: IssueEnrichmentReceiptReason }> | Readonly<{
+  kind: "result"; summary: Readonly<{ valid: false }> | Readonly<{ valid: true; counts: IssueEnrichmentReceiptCounts }>;
+  status: IssueEnrichmentStatusSnapshot; dryRun: IssueEnrichmentFlagSnapshot; ok: IssueEnrichmentFlagSnapshot;
+}>;
+export interface IssueEnrichmentStatusSnapshot {
+  readonly readable: boolean;
+  readonly state: "disabled" | "blocked" | "other" | "unreadable";
+  readonly blockers: IssueEnrichmentBlockersSnapshot;
+}
+export interface IssueEnrichmentBlockersSnapshot {
+  readonly readable: boolean;
+  readonly complete: boolean;
+  readonly reasons: readonly IssueEnrichmentBlocker[];
+}
+export type IssueEnrichmentFlagSnapshot = "true" | "false" | "unreadable";
+const enabledConfig = {
+  ...DEFAULT_ISSUE_ENRICHMENT_CONFIG, enabled: true, postIssueComment: true, allowlist: ["owner/repo"]
+};
+const BLOCKERS = new Set<IssueEnrichmentBlocker>([
+  ...buildIssueEnrichmentStatus({ config: { issueEnrichment: DEFAULT_ISSUE_ENRICHMENT_CONFIG }, canPostAsApp: false }).blockers,
+  ...buildIssueEnrichmentStatus({ config: { issueEnrichment: enabledConfig }, canPostAsApp: false, modelAnalysisAvailable: false }).blockers,
+  ...buildIssueEnrichmentStatus({ config: { issueEnrichment: enabledConfig }, canPostAsApp: true, modelAnalysisAvailable: true,
+    issueReadChecks: [{ repo: "owner/repo", ok: false }] }).blockers
+]);
+type RecordValue = Record<string, unknown>;
+type Read = { ok: boolean; value?: unknown };
+const isRecord = (value: unknown): value is RecordValue => {
+  try { return typeof value === "object" && value !== null && !Array.isArray(value); } catch { return false; }
+};
+const read = (value: RecordValue | undefined, key: string): Read => {
+  if (!value) return { ok: false };
+  try { return { ok: true, value: value[key] }; } catch { return { ok: false }; }
+};
+const frozen = <T extends object>(value: T): Readonly<T> => Object.freeze(value);
+function snapshotSummary(value: unknown): Readonly<{ valid: false }> | Readonly<{ valid: true; counts: IssueEnrichmentReceiptCounts }> {
+  if (!isRecord(value)) return frozen({ valid: false });
+  const counts = {} as { -readonly [K in typeof ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS[number]]: number };
+  let valid = true;
+  for (const key of ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS) {
+    try {
+      const count = value[key];
+      if (typeof count !== "number" || !Number.isFinite(count) || !Number.isInteger(count) || count < 0) valid = false;
+      else counts[key] = Math.min(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP, count);
+    } catch { valid = false; }
+  }
+  return valid ? frozen({ valid: true, counts: frozen(counts) }) : frozen({ valid: false });
+}
+function snapshotBlockers(value: unknown): IssueEnrichmentBlockersSnapshot {
+  try {
+    if (!Array.isArray(value)) return frozen({ readable: false, complete: false, reasons: [] });
+    const length = (value as unknown[]).length;
+    if (!Number.isSafeInteger(length) || length < 0) return frozen({ readable: false, complete: false, reasons: [] });
+    const reasons: IssueEnrichmentBlocker[] = [];
+    let readable = true;
+    let complete = length <= ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT;
+    for (let index = 0; index < Math.min(length, ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT); index += 1) {
+      try {
+        const present = Object.prototype.hasOwnProperty.call(value, index);
+        const blocker = (value as unknown[])[index];
+        if (!present || blocker === undefined) complete = false;
+        else if (typeof blocker === "string" && BLOCKERS.has(blocker as IssueEnrichmentBlocker)) reasons.push(blocker as IssueEnrichmentBlocker);
+      } catch { readable = false; complete = false; }
+    }
+    return frozen({ readable, complete, reasons: frozen(reasons) });
+  } catch { return frozen({ readable: false, complete: false, reasons: [] }); }
+}
+function snapshotThrown(error: unknown): IssueEnrichmentReceiptSnapshot {
+  let message: unknown;
+  try { message = typeof error === "string" ? error : read(isRecord(error) ? error : undefined, "message").value; } catch { /* fail closed */ }
+  if (typeof message === "string") {
+    const prefix = message.slice(0, ISSUE_ENRICHMENT_RECEIPT_MESSAGE_LIMIT).trim();
+    for (const blocker of BLOCKERS) {
+      const next = prefix[blocker.length];
+      if (prefix === blocker || (prefix.startsWith(blocker) && !/[A-Za-z0-9_]/.test(next ?? ""))) {
+        return frozen({ kind: "thrown", reason: blocker });
+      }
+    }
+  }
+  return frozen({ kind: "thrown", reason: "unknown_failure" });
+}
+function snapshotResult(result: unknown): IssueEnrichmentReceiptSnapshot {
+  const root = isRecord(result) ? result : undefined;
+  const summary = read(root, "summary");
+  const status = read(root, "status");
+  const dryRun = read(root, "dryRun");
+  const ok = read(root, "ok");
+  const statusValue = status.ok && isRecord(status.value) ? status.value : undefined;
+  const state = read(statusValue, "state");
+  const blockers = read(statusValue, "blockers");
+  const statusSnapshot: IssueEnrichmentStatusSnapshot = frozen({
+    readable: Boolean(statusValue && state.ok && (state.value === "disabled" || state.value === "blocked" || state.value === "ready" || state.value === "dry_run_only")),
+    state: !state.ok || typeof state.value !== "string" ? "unreadable" : state.value === "disabled" ? "disabled" : state.value === "blocked" ? "blocked" : state.value === "ready" || state.value === "dry_run_only" ? "other" : "unreadable",
+    blockers: snapshotBlockers(blockers.ok ? blockers.value : undefined)
+  });
+  const flag = (value: Read): IssueEnrichmentFlagSnapshot => value.ok && value.value === true ? "true" : value.ok && value.value === false ? "false" : "unreadable";
+  return frozen({ kind: "result", summary: snapshotSummary(summary.ok ? summary.value : undefined), status: statusSnapshot, dryRun: flag(dryRun), ok: flag(ok) });
+}
+export function snapshotIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentReceiptSnapshot {
+  let kind: unknown;
+  try { kind = (input as unknown as RecordValue).kind; } catch { return frozen({ kind: "thrown", reason: "unknown_failure" }); }
+  if (kind === "thrown") {
+    let error: unknown;
+    try { error = (input as { kind: "thrown"; error: unknown }).error; } catch { /* fail closed */ }
+    return snapshotThrown(error);
+  }
+  let result: unknown;
+  try { result = (input as { kind: "result"; result: unknown }).result; } catch { /* malformed result */ }
+  return snapshotResult(result);
+}

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -4,12 +4,8 @@ import {
   snapshotIssueEnrichmentReceipt,
   type IssueEnrichmentReceiptSnapshot
 } from "../src/issue-enrichment-receipt-snapshot.js";
-const summary = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
-  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
-);
-const result = (overrides: Record<string, unknown> = {}) => ({
-  summary: summary(), status: { state: "ready", blockers: [] }, dryRun: false, ok: true, ...overrides
-});
+const summary = (overrides: Record<string, unknown> = {}) => Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0]));
+const result = (overrides: Record<string, unknown> = {}) => ({ summary: summary(), status: { state: "ready", blockers: [] }, dryRun: false, ok: true, ...overrides });
 const snap = (input: unknown): IssueEnrichmentReceiptSnapshot =>
   snapshotIssueEnrichmentReceipt(input as never);
 describe("issue-enrichment hostile receipt snapshot", () => {
@@ -19,6 +15,7 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     expect(value.kind).toBe("result");
     expect(value.summary.valid).toBe(false);
     expect(value.status).toMatchObject({ readable: false, state: "unreadable" });
+    expect(Object.isFrozen(value.status.blockers.reasons)).toBe(true);
     expect(JSON.stringify(value)).not.toContain("proxy");
     const hostile = result(); for (const key of ["summary", "status", "dryRun", "ok"]) Object.defineProperty(hostile, key, { get: () => { throw new Error("hostile"); } });
     expect(snap({ kind: "result", result: hostile })).toMatchObject({ summary: { valid: false }, dryRun: "unreadable", ok: "unreadable" });
@@ -61,6 +58,7 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     const value = snap({ kind: "result", result: result({ status: { state: "blocked", blockers } }) });
     expect(reads).toBe(32);
     expect(value.status.blockers).toMatchObject({ readable: true, complete: false });
+    expect(snap({ kind: "result", result: result({ status: { state: "blocked", blockers: ["future_blocker", 1] } }) }).status.blockers.complete).toBe(false);
     const revoked = Proxy.revocable([], {}); revoked.revoke();
     expect(snap({ kind: "result", result: result({ status: { state: "blocked", blockers: revoked.proxy } }) })
       .status.blockers).toMatchObject({ readable: false, complete: false, reasons: [] });
@@ -73,5 +71,7 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     expect(snap({ kind: "thrown", error: `${" ".repeat(300)}${token}` })).toMatchObject({ reason: "unknown_failure" });
     const error = {}; Object.defineProperty(error, "message", { get: () => { throw new Error("revoked"); } });
     expect(snap({ kind: "thrown", error })).toMatchObject({ reason: "unknown_failure" });
+    expect(snap({ kind: "oops", result: result() })).toMatchObject({ kind: "thrown", reason: "unknown_failure" });
+    expect(Object.isFrozen(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS)).toBe(true);
   });
 });

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS,
+  snapshotIssueEnrichmentReceipt,
+  type IssueEnrichmentReceiptSnapshot
+} from "../src/issue-enrichment-receipt-snapshot.js";
+const summary = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
+);
+const result = (overrides: Record<string, unknown> = {}) => ({
+  summary: summary(), status: { state: "ready", blockers: [] }, dryRun: false, ok: true, ...overrides
+});
+const snap = (input: unknown): IssueEnrichmentReceiptSnapshot =>
+  snapshotIssueEnrichmentReceipt(input as never);
+describe("issue-enrichment hostile receipt snapshot", () => {
+  it("never throws for a revoked result and returns only markers", () => {
+    const revoked = Proxy.revocable({}, {}); revoked.revoke();
+    const value = snap({ kind: "result", result: revoked.proxy });
+    expect(value.kind).toBe("result");
+    expect(value.summary.valid).toBe(false);
+    expect(value.status).toMatchObject({ readable: false, state: "unreadable" });
+    expect(JSON.stringify(value)).not.toContain("proxy");
+    const hostile = result(); for (const key of ["summary", "status", "dryRun", "ok"]) Object.defineProperty(hostile, key, { get: () => { throw new Error("hostile"); } });
+    expect(snap({ kind: "result", result: hostile })).toMatchObject({ summary: { valid: false }, dryRun: "unreadable", ok: "unreadable" });
+  });
+  it("reads roots and all 18 counts at most once, then freezes values", () => {
+    const reads = new Map<string, number>();
+    const count = (key: string, value: unknown) => ({ get: () => {
+      reads.set(key, (reads.get(key) ?? 0) + 1); return value;
+    }});
+    const counts = {}; Object.defineProperties(counts, Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, count(key, 1)])));
+    const source = result({ summary: counts });
+    for (const key of ["summary", "status", "dryRun", "ok"]) {
+      const value = (source as Record<string, unknown>)[key];
+      Object.defineProperty(source, key, { configurable: true, get: () => {
+        reads.set(key, (reads.get(key) ?? 0) + 1); return value;
+      }});
+    }
+    const value = snap({ kind: "result", result: source });
+    expect([...reads.values()].every((read) => read === 1)).toBe(true);
+    expect(value.summary.valid && value.summary.counts.failed).toBe(1);
+    Object.defineProperty(source, "summary", { configurable: true, value: summary({ failed: 99 }) });
+    expect(value.summary.valid && value.summary.counts.failed).toBe(1);
+    expect(Object.isFrozen(value)).toBe(true);
+  });
+  it.each([
+    ["missing", (() => { const value = summary(); delete value.failed; return value; })()],
+    ["negative", summary({ failed: -1 })], ["NaN", summary({ failed: Number.NaN })],
+    ["fractional", summary({ failed: 1.5 })], ["string", summary({ failed: "1" })],
+    ["null", null], ["array", []]
+  ])("fails the whole summary for %s", (_name, malformed) => {
+    const value = snap({ kind: "result", result: result({ summary: malformed }) });
+    expect(value.summary).toEqual({ valid: false });
+  });
+  it("caps blocker traversal and records sparse or revoked input", () => {
+    const blockers: unknown[] = []; blockers.length = 2_000_000_000;
+    let reads = 0;
+    for (let index = 0; index < 40; index += 1) Object.defineProperty(blockers, String(index), {
+      configurable: true, get: () => { reads += 1; return "github_app_issues_permission_required"; }
+    });
+    const value = snap({ kind: "result", result: result({ status: { state: "blocked", blockers } }) });
+    expect(reads).toBe(32);
+    expect(value.status.blockers).toMatchObject({ readable: true, complete: false });
+    const revoked = Proxy.revocable([], {}); revoked.revoke();
+    expect(snap({ kind: "result", result: result({ status: { state: "blocked", blockers: revoked.proxy } }) })
+      .status.blockers).toMatchObject({ readable: false, complete: false, reasons: [] });
+  });
+  it("keeps only an exact bounded leading blocker token from errors", () => {
+    const token = "issue_enrichment_model_runtime_required";
+    expect(snap({ kind: "thrown", error: new Error(`${token}: ${"x".repeat(10_000)}`) }))
+      .toMatchObject({ kind: "thrown", reason: token });
+    expect(snap({ kind: "thrown", error: `context ${token}` })).toMatchObject({ reason: "unknown_failure" });
+    expect(snap({ kind: "thrown", error: `${" ".repeat(300)}${token}` })).toMatchObject({ reason: "unknown_failure" });
+    const error = {}; Object.defineProperty(error, "message", { get: () => { throw new Error("revoked"); } });
+    expect(snap({ kind: "thrown", error })).toMatchObject({ reason: "unknown_failure" });
+  });
+});


### PR DESCRIPTION
Closes #1010

## Summary
- add an explicit discriminated hostile-input snapshot boundary for issue-enrichment results/errors
- read root fields and all 18 summary counts once, fail closed, freeze plain snapshots, cap valid counts
- bound blocker traversal to 32 entries and thrown-message inspection to a 256-character prefix
- source recognized blocker tokens from the existing issue-enrichment definitions; retain no raw producer values

## Validation
- focused Vitest: 11 passed
- targeted TypeScript strict check: passed
- git diff --cached --check: passed
- 197 added non-generated lines across the two scoped files

## Proof boundary
This source/test candidate proves only the exception-safe bounded snapshot boundary. It does not wire receipt classification, daemon/log serialization, persistence, runtime, release, or customer behavior. Agent-authored candidate; merge and independent review remain root-owned gates.