### PR TITLE
fix(desktop): resolve trusted worker at action time

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift
@@ -7,8 +7,8 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
     private let localBotExecutionContextProvider:
         @Sendable () -> [DesktopLocalBotExecutionContext]
     private let defaultWorkingDirectory: URL?
-    private let trustedBundledWorker:
-        DesktopLocalBotExecutionContext?
+    private let trustedBundledWorkerProvider:
+        @Sendable () -> DesktopLocalBotExecutionContext?
     private let trustedProcessValidator:
         @Sendable (Int32) -> Bool
 
@@ -19,8 +19,8 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
             (@Sendable () -> [DesktopLocalBotExecutionContext])? = nil,
         defaultWorkingDirectory: URL? =
             NeonDiffCLIResolver.defaultWorkingDirectory(),
-        trustedBundledWorker:
-            DesktopLocalBotExecutionContext? = nil,
+        trustedBundledWorkerProvider:
+            (@Sendable () -> DesktopLocalBotExecutionContext?)? = nil,
         trustedProcessValidator:
             @escaping @Sendable (Int32) -> Bool = { _ in false }
     ) {
@@ -28,7 +28,7 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
         self.localBotExecutionContextProvider =
             localBotExecutionContextProvider ?? { localBotExecutionContexts }
         self.defaultWorkingDirectory = defaultWorkingDirectory
-        self.trustedBundledWorker = trustedBundledWorker
+        self.trustedBundledWorkerProvider = trustedBundledWorkerProvider ?? { nil }
         self.trustedProcessValidator = trustedProcessValidator
     }
 
@@ -56,6 +56,7 @@ struct FoundationDesktopCLIExecutor: DesktopCLIExecuting {
         }
         let trustedContext: DesktopLocalBotExecutionContext?
         if requiresTrustedWorker {
+            let trustedBundledWorker = trustedBundledWorkerProvider()
             guard let trustedBundledWorker else {
                 throw NeonDiffCLIError.launchFailed(
                     "The signed bundled NeonDiff worker is unavailable"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -9,12 +9,13 @@ struct FoundationKeychainWorkerLaunchAgentManager:
     private let appExecutableURL: URL
     private let homeDirectory: URL
     private let trustedBundledWorker:
-        DesktopLocalBotExecutionContext
+        @Sendable () -> DesktopLocalBotExecutionContext?
 
     init(
         appExecutableURL: URL,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        trustedBundledWorker: DesktopLocalBotExecutionContext
+        trustedBundledWorker:
+            @escaping @Sendable () -> DesktopLocalBotExecutionContext?
     ) {
         self.appExecutableURL = appExecutableURL.standardizedFileURL
         self.homeDirectory = homeDirectory.standardizedFileURL
@@ -25,7 +26,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
         request: DesktopKeychainWorkerLaunchAgentRequest,
         preservedRepositoryCount: Int
     ) async throws -> String {
-        try validate(request)
+        let trustedBundledWorker = try validate(request)
         guard let sealedWorkerPath = trustedBundledWorker.executablePath else {
             throw WorkerLaunchAgentRuntimeError.invalidCoordinates
         }
@@ -42,7 +43,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
         request: DesktopKeychainWorkerLaunchAgentRequest
     ) async throws -> String {
         try await Task.detached {
-            try validate(request)
+            _ = try validate(request)
             let data =
                 try DesktopKeychainWorkerLaunchAgentContract.propertyListData(
                     request: request,
@@ -111,8 +112,9 @@ struct FoundationKeychainWorkerLaunchAgentManager:
 
     private func validate(
         _ request: DesktopKeychainWorkerLaunchAgentRequest
-    ) throws {
-        guard isSafeAppExecutable(appExecutableURL),
+    ) throws -> DesktopLocalBotExecutionContext {
+        guard let trustedBundledWorker = trustedBundledWorker(),
+              isSafeAppExecutable(appExecutableURL),
               isSafeConfig(URL(filePath: request.configPath)),
               trustedBundledWorker.executablePath
                 == "/Applications/NeonDiff.app/Contents/Helpers/NeonDiffWorker",
@@ -121,6 +123,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
         else {
             throw WorkerLaunchAgentRuntimeError.invalidCoordinates
         }
+        return trustedBundledWorker
     }
 
     private func isSafeAppExecutable(_ url: URL) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -80,12 +80,13 @@ enum NeonDiffDesktopCompositionRoot {
             }
         let keychainWorkerLaunchAgentManager:
             any DesktopKeychainWorkerLaunchAgentManaging
-        if let appExecutableURL = Bundle.main.executableURL,
-           let trustedBundledWorker {
+        if let appExecutableURL = Bundle.main.executableURL {
             keychainWorkerLaunchAgentManager =
                 FoundationKeychainWorkerLaunchAgentManager(
                     appExecutableURL: appExecutableURL,
-                    trustedBundledWorker: trustedBundledWorker
+                    trustedBundledWorker: {
+                        FoundationTrustedBundledWorker.executionContext()
+                    }
                 )
         } else {
             keychainWorkerLaunchAgentManager =
@@ -100,7 +101,9 @@ enum NeonDiffDesktopCompositionRoot {
                 localBotExecutionContextProvider:
                     localBotExecutionContextProvider,
                 defaultWorkingDirectory: cliWorkingDirectory,
-                trustedBundledWorker: trustedBundledWorker,
+                trustedBundledWorkerProvider: {
+                    FoundationTrustedBundledWorker.executionContext()
+                },
                 trustedProcessValidator: {
                     FoundationTrustedBundledWorker
                         .runningProcessIsTrusted($0)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -212,6 +212,68 @@ import Testing
         }
     }
 
+    @Test func credentialBearingCLIResolvesTheTrustedWorkerAtActionTime() throws {
+        let source = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot().appendingPathComponent(
+                "Sources/NeonDiffDesktop/Adapters/FoundationDesktopCLIExecutor.swift"
+            )
+        )
+
+        #expect(source.contains(
+            "private let trustedBundledWorkerProvider:\n        @Sendable () -> DesktopLocalBotExecutionContext?"
+        ))
+        #expect(source.contains(
+            "trustedBundledWorkerProvider:\n            (@Sendable () -> DesktopLocalBotExecutionContext?)? = nil"
+        ))
+        #expect(source.contains(
+            "let trustedBundledWorker = trustedBundledWorkerProvider()"
+        ))
+        #expect(!source.contains(
+            "private let trustedBundledWorker:\n        DesktopLocalBotExecutionContext?"
+        ))
+        #expect(!source.contains("trustedBundledWorker: trustedBundledWorker"))
+    }
+
+    @Test func launchAgentManagerResolvesTheTrustedWorkerForEachAction() throws {
+        let source = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot().appendingPathComponent(
+                "Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift"
+            )
+        )
+
+        #expect(source.contains(
+            "private let trustedBundledWorker:\n        @Sendable () -> DesktopLocalBotExecutionContext?"
+        ))
+        #expect(source.contains(
+            "trustedBundledWorker:\n            @escaping @Sendable () -> DesktopLocalBotExecutionContext?"
+        ))
+        #expect(source.contains(
+            "guard let trustedBundledWorker = trustedBundledWorker(),"
+        ))
+        #expect(!source.contains(
+            "private let trustedBundledWorker:\n        DesktopLocalBotExecutionContext"
+        ))
+    }
+
+    @Test func compositionRootDoesNotGateTheManagerOnLaunchTimeWorkerPresence() throws {
+        let source = try sourceBoundaryText(
+            at: sourceBoundaryPackageRoot().appendingPathComponent(
+                "Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift"
+            )
+        )
+
+        #expect(source.contains("trustedBundledWorkerProvider: {"))
+        #expect(source.contains(
+            "trustedBundledWorker: {\n                        FoundationTrustedBundledWorker.executionContext()"
+        ))
+        #expect(!source.contains(
+            "if let appExecutableURL = Bundle.main.executableURL,\n           let trustedBundledWorker"
+        ))
+        #expect(!source.contains(
+            "FoundationKeychainWorkerLaunchAgentManager(\n                    appExecutableURL: appExecutableURL,\n                    trustedBundledWorker: trustedBundledWorker"
+        ))
+    }
+
     @Test func updaterUsesSignedFeedAndRevalidatesEntitlementBeforeEachCheck() throws {
         let updaterSource = sourceBoundaryPackageRoot()
             .appendingPathComponent("Sources/NeonDiffDesktop/Support/NeonUpdateController.swift")


### PR DESCRIPTION
Closes #1023

## Summary
- resolve the signed bundled worker from an action-time provider for credential-bearing CLI calls
- resolve the current worker again during LaunchAgent preview/install validation
- keep manager construction and existing-bot resolver behavior unchanged outside this boundary

## Validation
- `swift build --product NeonDiffDesktop` (pass)
- `git diff --check` (pass)
- focused Swift source-boundary assertions compile; local test binary link is blocked by missing Testing framework symbols

## Scope and proof boundary
- exact base: `7bb1902c5ba463ae2d2acb7347d069290eae2038`
- candidate: `4de60a1`
- 99 changed lines; no docs, model refresh, Keychain, runtime, release, or customer mutations
- source-level action-time resolution only; does not prove packaged or installed runtime behavior