### PR TITLE
docs: make release and eval evidence paths portable

### DIFF
--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -2,8 +2,7 @@
 
 This document covers the buildable appcast generation lane for NeonDiff Desktop.
 It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
-Sparkle 2 is the selected production updater, but #116 and the #610 Mac GA
-artifact gates remain open.
+Sparkle 2 is the selected production updater, but #116 and #610 Mac GA artifact gates remain open.
 
 ## Channels
 
@@ -25,7 +24,7 @@ case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be
 test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
-RUN_ID="<caller-supplied-unique-run-id>"
+RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
 RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$(date +%F)/$RUN_ID"
 mkdir -p "$(dirname "$RUN_DIR")"
 mkdir "$RUN_DIR"

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -2,11 +2,15 @@
 
 This document covers the buildable appcast generation lane for NeonDiff Desktop.
 It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
+Sparkle 2 is the selected production updater, but #116 and the #610 Mac GA
+artifact gates remain open.
 
 ## Channels
 
-- `beta`: early desktop builds for opted-in testers.
-- `stable`: signed release builds after the Mac release runbook has passed.
+- `beta`: early or signed candidate builds for opted-in testers; fixture output
+  is not a public or GA release.
+- `stable`: future signed release builds only after #116 and #610 signed-feed,
+  immutable-artifact, install, and rollback proof has passed.
 - Rollback is represented by a stable feed whose newest marker pins the channel
   latest to an earlier stable version via `rollback_to`; the generated appcast
   excludes the superseded newer build so Sparkle cannot select it.
@@ -16,11 +20,16 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 Generate a local appcast from a committed fixture:
 
 ```sh
+: "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
+  --output "$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
   --dry-run
 ```
+
+The output root is operator-owned and external to the checkout; this command
+does not read credentials or private-key paths. Historical packets remain
+immutable.
 
 Dry-run mode never signs, uploads, notarizes, or fabricates a real signature.
 The `sparkle:edSignature` attribute appears only when the manifest explicitly
@@ -44,8 +53,10 @@ The appcast core models these update outcomes for fixtures and release evidence:
 
 These statuses back both dry-run planning and the native updater UI. The source
 maps real Sparkle no-update, network/feed, signature/validation, cancellation,
-and generic failures into distinct customer states. A hosted signed appcast and
-installed-app run are still required before claiming runtime proof.
+and generic failures into distinct customer states. Invalid or missing
+`rollback_to` is a release-gate failure, not proof of installed rollback. A
+hosted signed appcast and installed-app run are still required before claiming
+runtime or GA proof.
 
 ## Fixtures
 

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -22,6 +22,9 @@ Generate a local appcast from a committed fixture:
 ```sh
 : "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
 case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 RUN_ID="<caller-supplied-unique-run-id>"
 RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$(date +%F)/$RUN_ID"
 mkdir -p "$(dirname "$RUN_DIR")"

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -21,15 +21,20 @@ Generate a local appcast from a committed fixture:
 
 ```sh
 : "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+RUN_ID="<caller-supplied-unique-run-id>"
+RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$(date +%F)/$RUN_ID"
+mkdir -p "$(dirname "$RUN_DIR")"
+mkdir "$RUN_DIR"
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output "$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/neondiff-beta-appcast.xml" \
+  --output "$RUN_DIR/appcast.xml" \
   --dry-run
 ```
 
-The output root is operator-owned and external to the checkout; this command
-does not read credentials or private-key paths. Historical packets remain
-immutable.
+The output root is operator-owned, absolute, and external to the checkout; use
+a fresh `<date>/<run-id>/` directory for every packet. `mkdir` must fail on
+reuse. This command does not read credentials or private-key paths.
 
 Dry-run mode never signs, uploads, notarizes, or fabricates a real signature.
 The `sparkle:edSignature` attribute appears only when the manifest explicitly
@@ -53,10 +58,10 @@ The appcast core models these update outcomes for fixtures and release evidence:
 
 These statuses back both dry-run planning and the native updater UI. The source
 maps real Sparkle no-update, network/feed, signature/validation, cancellation,
-and generic failures into distinct customer states. Invalid or missing
-`rollback_to` is a release-gate failure, not proof of installed rollback. A
-hosted signed appcast and installed-app run are still required before claiming
-runtime or GA proof.
+and generic failures into distinct customer states. The current generator does
+not reject invalid or missing `rollback_to`; release validation must catch it
+before publishing. A hosted signed appcast and installed-app run are still
+required before claiming runtime or GA proof.
 
 ## Fixtures
 

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -8,9 +8,8 @@ Apple/Sparkle inputs are available.
 Proof boundary: this document closes the #322 documentation lane only. It does
 not prove a signed artifact exists, does not submit anything to Apple, does not
 publish an appcast, and does not make the desktop update channel GA-ready.
-Sparkle 2 remains the selected updater while #116 is open. #610 additionally
-requires immutable artifact/feed identity, signed hosted-feed evidence, an
-installed update, state-preserving rollback, and re-update before a Mac GA claim.
+Sparkle 2 remains selected while #116 is open. #610 also requires immutable artifact/feed identity,
+signed hosted-feed, installed update, state-preserving rollback, and re-update evidence before Mac GA.
 Parent issue #116 owns the signed auto-update channel, #323 owns appcast
 fixtures/dry-run generation, #324 owns credential naming/custody, #325 owns the
 desktop onboarding wizard, #327 owns production license-service deployment, and
@@ -132,7 +131,7 @@ case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be
 test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
-RUN_ID="<caller-supplied-unique-run-id>"
+RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
 RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/<date>/$RUN_ID"
 mkdir -p "$(dirname "$RELEASE_EVIDENCE_DIR")"
 mkdir "$RELEASE_EVIDENCE_DIR"
@@ -301,7 +300,7 @@ fabricate a real Sparkle signature.
 
 ```sh
 apps/neondiff-desktop/script/generate-appcast.sh \
-  --fixture apps/neondiff-desktop/fixtures/appcast/beta.json \
+  --fixture fixtures/appcast/beta.json \
   --output "$RELEASE_EVIDENCE_DIR/appcast.xml" \
   --dry-run
 ```

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -8,6 +8,9 @@ Apple/Sparkle inputs are available.
 Proof boundary: this document closes the #322 documentation lane only. It does
 not prove a signed artifact exists, does not submit anything to Apple, does not
 publish an appcast, and does not make the desktop update channel GA-ready.
+Sparkle 2 remains the selected updater while #116 is open. #610 additionally
+requires immutable artifact/feed identity, signed hosted-feed evidence, an
+installed update, state-preserving rollback, and re-update before a Mac GA claim.
 Parent issue #116 owns the signed auto-update channel, #323 owns appcast
 fixtures/dry-run generation, #324 owns credential naming/custody, #325 owns the
 desktop onboarding wizard, #327 owns production license-service deployment, and
@@ -119,10 +122,20 @@ the wrong source SHA, or carries unrelated local changes. Do not sign whatever
 
 Before building, run the read-only credential doctor:
 
+Set the external evidence root once for this run. The source checkout default is
+`$HOME/.neondiff/evidence`; CI or another operator may set a different root.
+Keep historical packets immutable and never place secrets in the root or repo:
+
+```sh
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
+RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/<date>/<version>"
+mkdir -p "$RELEASE_EVIDENCE_DIR"
+```
+
 ```sh
 apps/neondiff-desktop/script/preflight-credentials.sh
 apps/neondiff-desktop/script/preflight-credentials.sh --json \
-  > /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/credential-preflight.json
+  > "$RELEASE_EVIDENCE_DIR/credential-preflight.json"
 ```
 
 The doctor reports presence only. It does not sign, notarize, upload, fetch
@@ -145,7 +158,7 @@ Required owner/Codex inputs for a real signing run:
 - Sparkle public key as `NEONDIFF_SPARKLE_PUBLIC_ED_KEY`.
 - Sparkle feed URL as `NEONDIFF_SPARKLE_FEED_URL`.
 - Appcast hosting destination and rollback destination.
-- Evidence packet directory under `/Users/m1/Codex/evidence/`.
+- Evidence packet directory under `$NEONDIFF_EVIDENCE_ROOT/`.
 
 ## Build The Release App
 
@@ -230,7 +243,7 @@ the notarization paths documented in #324.
 ```sh
 cd apps/neondiff-desktop
 APP="dist/NeonDiff.app"
-ZIP="/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/NeonDiff.zip"
+ZIP="$RELEASE_EVIDENCE_DIR/NeonDiff.zip"
 
 ditto -c -k --keepParent "$APP" "$ZIP"
 shasum -a 256 "$ZIP"
@@ -283,7 +296,7 @@ fabricate a real Sparkle signature.
 ```sh
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture apps/neondiff-desktop/fixtures/appcast/beta.json \
-  --output /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/neondiff-beta-appcast.xml \
+  --output "$RELEASE_EVIDENCE_DIR/neondiff-beta-appcast.xml" \
   --dry-run
 ```
 
@@ -323,7 +336,7 @@ License boundary:
 Create a public-safe packet under:
 
 ```text
-/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/
+$RELEASE_EVIDENCE_DIR/
 ```
 
 Minimum files:

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -129,6 +129,9 @@ Keep historical packets immutable and never place secrets in the root or repo:
 ```sh
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
 case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 RUN_ID="<caller-supplied-unique-run-id>"
 RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/<date>/$RUN_ID"
 mkdir -p "$(dirname "$RELEASE_EVIDENCE_DIR")"

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -128,8 +128,11 @@ Keep historical packets immutable and never place secrets in the root or repo:
 
 ```sh
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
-RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/<date>/<version>"
-mkdir -p "$RELEASE_EVIDENCE_DIR"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+RUN_ID="<caller-supplied-unique-run-id>"
+RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/<date>/$RUN_ID"
+mkdir -p "$(dirname "$RELEASE_EVIDENCE_DIR")"
+mkdir "$RELEASE_EVIDENCE_DIR"
 ```
 
 ```sh
@@ -296,7 +299,7 @@ fabricate a real Sparkle signature.
 ```sh
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture apps/neondiff-desktop/fixtures/appcast/beta.json \
-  --output "$RELEASE_EVIDENCE_DIR/neondiff-beta-appcast.xml" \
+  --output "$RELEASE_EVIDENCE_DIR/appcast.xml" \
   --dry-run
 ```
 

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -48,7 +48,7 @@ bundle cannot establish release, installed-update, rollback, or GA readiness.
 
 ## Durable Plan Contract
 
-Set `NEONDIFF_EVIDENCE_ROOT` to an external directory outside the checkout for
+Set `NEONDIFF_EVIDENCE_ROOT` to an absolute external directory outside the checkout for
 local packets (the source default is `$HOME/.neondiff/evidence`). Do not put
 credentials, private keys, or customer data in that directory. Historical
 release/evidence packets are immutable and are not rewritten by this plan.
@@ -76,9 +76,9 @@ release/evidence packets are immutable and are not rewritten by this plan.
   The native source has a Sparkle 2 controller and Release configuration gate,
   but source/unsigned-bundle proof is not signed-feed or installed-update proof.
   Issue #111 owns license activation and #610 owns the Mac GA artifact boundary.
-- Exact next action: execute the owner-gated #116/#322/#323 release evidence
-  lane from an exact candidate once signing, notarization, hosting, entitlement,
-  and rollback inputs are available.
+- Exact next action: implement and test the single promotion, containment, and
+  rollback path required by `docs/architecture/mac-ga-release-contract.md`;
+  only then run owner-gated #116/#322/#323 evidence from an exact candidate.
 - Critical invariants: every downloaded gated artifact must be entitlement
   checked before download, signature verified before install, tied to a channel
   manifest, rollbackable to a last-known-good release, and backed by public-safe
@@ -106,10 +106,10 @@ release/evidence packets are immutable and are not rewritten by this plan.
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/<run-id>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/<run-id>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -126,7 +126,7 @@ release/evidence packets are immutable and are not rewritten by this plan.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/<run-id>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -58,7 +58,7 @@ release/evidence packets are immutable and are not rewritten by this plan.
   license boundaries.
 - Resume identity: repo `electricsheephq/evaos-code-review-bot-neondiff`, branch
   `codex/116-desktop-autoupdate-plan`, base
-  `1e4b54d1d14f35fb2b22464c474f74cf1fa20b35`, issue
+  `8de8840282657ffe457c78132ad0a31328695f68`, issue
   https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116,
   parent tracker
   https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103.

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -6,7 +6,7 @@ contains the real Sparkle controller and release-build configuration gate. No
 hosted appcast, signed update, installed update, rollback, or public release is
 proven by source alone.
 
-## Current Implementation — 2026-07-28
+## Current Implementation — source main `1e4b54d` (2026-08-24)
 
 - The native SwiftUI executable uses the existing Sparkle 2 dependency and
   standard updater UI in
@@ -41,33 +41,44 @@ proof only. #116 remains open for real public-key/feed identity, EdDSA-signed
 appcast, exact signed/notarized installed update, state-preserving rollback and
 re-update, immutable release assets, and live customer evidence.
 
+Sparkle 2 is the selected updater for the native SwiftUI path while #116 is
+open. The #610 Mac GA boundary is stricter: the current public release manifest
+does not include a signed native Desktop artifact, so fixtures or an unsigned
+bundle cannot establish release, installed-update, rollback, or GA readiness.
+
 ## Durable Plan Contract
 
-- Goal: define the desktop auto-update channel contract for NeonDiff Desktop so
-  future implementation can choose Sparkle, Tauri updater, or an equivalent
-  signed updater without weakening release governance or license boundaries.
-- Resume identity: repo `electricsheephq/evaos-code-review-bot`, branch
+Set `NEONDIFF_EVIDENCE_ROOT` to an external directory outside the checkout for
+local packets (the source default is `$HOME/.neondiff/evidence`). Do not put
+credentials, private keys, or customer data in that directory. Historical
+release/evidence packets are immutable and are not rewritten by this plan.
+
+- Goal: define the desktop auto-update channel contract for NeonDiff Desktop
+  using the selected Sparkle 2 path without weakening release governance or
+  license boundaries.
+- Resume identity: repo `electricsheephq/evaos-code-review-bot-neondiff`, branch
   `codex/116-desktop-autoupdate-plan`, base
-  `1e28bf8ee0bfe42d0a7f3cc47ed76508497efe96`, issue
-  https://github.com/electricsheephq/evaos-code-review-bot/issues/116, parent
-  tracker https://github.com/electricsheephq/evaos-code-review-bot/issues/103.
+  `1e4b54d1d14f35fb2b22464c474f74cf1fa20b35`, issue
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116,
+  parent tracker
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103.
 - Tracking / source of truth: GitHub issues and PRs own implementation truth;
   `docs/release-governance.md`, `docs/license-boundary.md`, and
   `docs/public-release-manifest.json` own current release and license wording;
   Notion/Company OS remains architecture and evidence routing; no live runtime
   or roadmap state is changed by this document.
-- Scope / non-goals: no updater implementation, no Sparkle or Tauri dependency
-  selection, no signing/notarization setup, no private key material, no appcast
-  publication, no installer distribution, no license API implementation, no
-  launchd/runtime change, and no claim that desktop auto-update is shipped.
+- Scope / non-goals: no updater implementation, signing/notarization setup,
+  private key material, appcast publication, installer distribution, license API
+  implementation, launchd/runtime change, or claim that desktop auto-update is
+  shipped.
 - Current state: NeonDiff is a source-available beta; desktop update channels
-  are marked `post_1_0` and non-required in `docs/public-release-manifest.json`;
-  `docs/neondiff-desktop.md` describes a development-only unsigned desktop
-  scaffold; issue #111 owns license activation and issue #114 owns the legacy
-  desktop shell audit.
-- Exact next action: after desktop shell choice and license activation design
-  are settled, create an implementation issue or PR that wires a signed local or
-  static update-manifest dry run before any public appcast or artifact channel.
+  remain `post_1_0` and non-required in `docs/public-release-manifest.json`.
+  The native source has a Sparkle 2 controller and Release configuration gate,
+  but source/unsigned-bundle proof is not signed-feed or installed-update proof.
+  Issue #111 owns license activation and #610 owns the Mac GA artifact boundary.
+- Exact next action: execute the owner-gated #116/#322/#323 release evidence
+  lane from an exact candidate once signing, notarization, hosting, entitlement,
+  and rollback inputs are available.
 - Critical invariants: every downloaded gated artifact must be entitlement
   checked before download, signature verified before install, tied to a channel
   manifest, rollbackable to a last-known-good release, and backed by public-safe
@@ -95,10 +106,10 @@ re-update, immutable release assets, and live customer evidence.
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -115,7 +126,7 @@ re-update, immutable release assets, and live customer evidence.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -123,11 +134,12 @@ re-update, immutable release assets, and live customer evidence.
 The desktop channel should be explicit in update metadata rather than inferred
 from branch names, app names, or runtime config.
 
-- `beta`: pre-stable desktop channel for signed test artifacts and release
-  candidates. Beta may be license-gated and must remain rollbackable.
-- `stable`: future channel for public-ready signed artifacts after beta evidence
-  proves update checks, entitlement behavior, signature failure handling, and
-  rollback.
+- `beta`: pre-stable desktop channel for fixture or signed candidate artifacts.
+  Beta may be license-gated and must remain rollbackable; beta evidence never
+  implies a public or GA release.
+- `stable`: future channel for public-ready signed artifacts only after #116
+  and the #610 immutable artifact/feed/install/rollback gates pass. Stable must
+  not alias the beta feed.
 - `disabled`: server-side or static-manifest state that makes the desktop report
   a clear no-update or channel-disabled result without attempting a download.
 - `rollback`: pointer to the last-known-good signed version. Rollback metadata
@@ -192,16 +204,16 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$NEONDIFF_EVIDENCE_ROOT/`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.
 
 ## Tracking
 
-- Parent roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
-- Release governance: https://github.com/electricsheephq/evaos-code-review-bot/issues/112
-- License activation: https://github.com/electricsheephq/evaos-code-review-bot/issues/111
-- Desktop shell audit: https://github.com/electricsheephq/evaos-code-review-bot/issues/114
-- Desktop app MVP: https://github.com/electricsheephq/evaos-code-review-bot/issues/115
-- This plan: https://github.com/electricsheephq/evaos-code-review-bot/issues/116
+- Parent roadmap: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103
+- Release governance: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/112
+- License activation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111
+- Desktop shell audit: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/114
+- Desktop app MVP: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/115
+- This plan: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -6,7 +6,7 @@ contains the real Sparkle controller and release-build configuration gate. No
 hosted appcast, signed update, installed update, rollback, or public release is
 proven by source alone.
 
-## Current Implementation — source main `1e4b54d` (2026-08-24)
+## Current Implementation — source main `8de8840` (2026-08-24)
 
 - The native SwiftUI executable uses the existing Sparkle 2 dependency and
   standard updater UI in

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -2,6 +2,16 @@
 
 The offline eval harness creates read-only comparison packets for the v0.2 CodeRabbit-class reviewer work. It does not call GitHub, post PR comments, mutate repos, or change launchd state.
 
+Use an external evidence root for every run. The source default is
+`$HOME/.neondiff/evidence`; set `NEONDIFF_EVIDENCE_ROOT` for CI or another
+operator-owned location outside this checkout. These packets are offline,
+advisory evidence only and must not be presented as hosted, runtime, or GA
+proof.
+
+```bash
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
+```
+
 Run it with a local scenario file:
 
 ```bash
@@ -13,7 +23,7 @@ Run the checked-in local suite fixtures:
 ```bash
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/local-suite"
 ```
 
 Run the paired sticky-vs-cold fixture:
@@ -21,7 +31,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -30,7 +40,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -38,7 +48,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -52,7 +62,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S)" \
   --dry-run true
 ```
 
@@ -65,10 +75,11 @@ The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.
 
-By default, packets are written under:
+By default, packets are written under the external root selected by
+`NEONDIFF_EVIDENCE_ROOT` (or `$HOME/.neondiff/evidence` when unset):
 
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/
+$NEONDIFF_EVIDENCE_ROOT/<date>/<run-id>/
 ```
 
 Use `--output-dir` for tests or scratch runs.

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -14,7 +14,7 @@ case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be
 test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
-EVAL_RUN_ID="<caller-supplied-unique-run-id>"
+EVAL_RUN_ID="replace-with-unique-run-id"; case "$EVAL_RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "EVAL_RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
 ```
 
 Run it with a local scenario file:
@@ -27,6 +27,7 @@ Run the checked-in local suite fixtures:
 
 ```bash
 EVAL_SUITE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/local-suite"
+mkdir -p "$(dirname "$EVAL_SUITE_ROOT")"
 mkdir "$EVAL_SUITE_ROOT"
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -14,7 +14,7 @@ case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be
 test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
-EVAL_RUN_ID="replace-with-unique-run-id"; case "$EVAL_RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "EVAL_RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+EVAL_DATE="$(date +%F)"; EVAL_RUN_ID="replace-with-unique-run-id"; case "$EVAL_RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "EVAL_RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
 ```
 
 Run it with a local scenario file:
@@ -26,7 +26,7 @@ npm run eval:offline -- --input /path/to/scenario.json
 Run the checked-in local suite fixtures:
 
 ```bash
-EVAL_SUITE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/local-suite"
+EVAL_SUITE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/local-suite"
 mkdir -p "$(dirname "$EVAL_SUITE_ROOT")"
 mkdir "$EVAL_SUITE_ROOT"
 npm run eval:suite -- \
@@ -39,7 +39,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/sticky-vs-cold-seeded-quality"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -48,7 +48,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/eval-gates/ab"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -56,7 +56,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/eval-gates/docs-drift"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -70,7 +70,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/review-lenses-eval-gate" \
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/review-lenses-eval-gate" \
   --dry-run true
 ```
 

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -10,6 +10,8 @@ proof.
 
 ```bash
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+EVAL_RUN_ID="<caller-supplied-unique-run-id>"
 ```
 
 Run it with a local scenario file:
@@ -23,7 +25,7 @@ Run the checked-in local suite fixtures:
 ```bash
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/local-suite"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/local-suite"
 ```
 
 Run the paired sticky-vs-cold fixture:
@@ -31,7 +33,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/sticky-vs-cold-seeded-quality"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -40,7 +42,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/eval-gates/ab"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -48,7 +50,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/eval-gates/docs-drift"
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -62,7 +64,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S)" \
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/review-lenses-eval-gate" \
   --dry-run true
 ```
 

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -11,6 +11,9 @@ proof.
 ```bash
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
 case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 EVAL_RUN_ID="<caller-supplied-unique-run-id>"
 ```
 
@@ -23,9 +26,11 @@ npm run eval:offline -- --input /path/to/scenario.json
 Run the checked-in local suite fixtures:
 
 ```bash
+EVAL_SUITE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/local-suite"
+mkdir "$EVAL_SUITE_ROOT"
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$(date +%F)/$EVAL_RUN_ID/local-suite"
+  --output-root "$EVAL_SUITE_ROOT"
 ```
 
 Run the paired sticky-vs-cold fixture:

--- a/docs/evals/gitnexus-readonly-adapter-eval-plan.md
+++ b/docs/evals/gitnexus-readonly-adapter-eval-plan.md
@@ -118,7 +118,7 @@ Regression caps:
 
 ## Evidence Packet
 
-Set `NEONDIFF_EVIDENCE_ROOT` to an operator- or CI-owned directory outside the
+Set `NEONDIFF_EVIDENCE_ROOT` to an operator- or CI-owned absolute directory outside the
 checkout before a local run. The CLI default is `$HOME/.neondiff/evidence`;
 CI may inject another external root. Historical packets are immutable evidence
 and must not be moved, rewritten, or used to infer a current release state.
@@ -127,7 +127,7 @@ For EVAOS operator-local runs, write eval evidence under the default scratch
 root:
 
 ```text
-$NEONDIFF_EVIDENCE_ROOT/<date>/gitnexus-readonly-adapter-<run-id>/
+$NEONDIFF_EVIDENCE_ROOT/<date>/<run-id>/gitnexus-readonly-adapter/
 ```
 
 Other operators and CI runners should configure an equivalent external evidence

--- a/docs/evals/gitnexus-readonly-adapter-eval-plan.md
+++ b/docs/evals/gitnexus-readonly-adapter-eval-plan.md
@@ -118,16 +118,21 @@ Regression caps:
 
 ## Evidence Packet
 
+Set `NEONDIFF_EVIDENCE_ROOT` to an operator- or CI-owned directory outside the
+checkout before a local run. The CLI default is `$HOME/.neondiff/evidence`;
+CI may inject another external root. Historical packets are immutable evidence
+and must not be moved, rewritten, or used to infer a current release state.
+
 For EVAOS operator-local runs, write eval evidence under the default scratch
 root:
 
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/gitnexus-readonly-adapter-<run-id>/
+$NEONDIFF_EVIDENCE_ROOT/<date>/gitnexus-readonly-adapter-<run-id>/
 ```
 
-Other operators and CI runners should configure an equivalent environment-local
-evidence root and preserve the same per-run packet shape. The Lexar path is the
-current EVAOS workstation default, not a portable hard requirement.
+Other operators and CI runners should configure an equivalent external evidence
+root and preserve the same per-run packet shape. This plan never grants hosted,
+runtime, release, or GA proof from an offline adapter packet.
 
 Each scenario should include:
 

--- a/docs/research/gitnexus-readonly-adapter.md
+++ b/docs/research/gitnexus-readonly-adapter.md
@@ -59,7 +59,7 @@ Current ZCode behavior is intentionally narrower than a tool-using agent:
   `buildGitNexusContextPromptSection`.
 
 The portable source-defaults slice now uses `NEONDIFF_EVIDENCE_ROOT` for
-explicit external evidence roots and falls back to `$HOME/.neondiff/evidence`.
+explicit absolute external evidence roots and falls back to `$HOME/.neondiff/evidence`.
 The adapter remains offline/shadow-only; no source or runtime change in this
 document promotes it.
 

--- a/docs/research/gitnexus-readonly-adapter.md
+++ b/docs/research/gitnexus-readonly-adapter.md
@@ -27,8 +27,8 @@ wrapper-owned designs.
 
 ## Current Source Behavior
 
-This research is based on local source inspection at `origin/main` commit
-`0f5be870ce303259f1ba6d7227b98704ecf5a81b`.
+This research is based on direct source inspection at the accepted current main
+commit `1e4b54d1d14f35fb2b22464c474f74cf1fa20b35`.
 
 Current GitNexus behavior is packet-only:
 
@@ -57,6 +57,11 @@ Current ZCode behavior is intentionally narrower than a tool-using agent:
 - Tool concurrency is capped at `1`.
 - ZCode receives GitNexus only as advisory prompt text through
   `buildGitNexusContextPromptSection`.
+
+The portable source-defaults slice now uses `NEONDIFF_EVIDENCE_ROOT` for
+explicit external evidence roots and falls back to `$HOME/.neondiff/evidence`.
+The adapter remains offline/shadow-only; no source or runtime change in this
+document promotes it.
 
 Release notes for the GitNexus packet feature preserve the same boundary:
 GitNexus context stayed disabled in live config by default, and the release did
@@ -239,7 +244,7 @@ The issue should require:
 - No raw ZCode GitNexus access.
 - No index writes.
 - Evidence packets under the configured eval evidence root. For EVAOS
-  operator-local runs, the current default is
-  `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/`; other environments should
-  configure an equivalent local/runner path.
+  operator-local runs, the current default is `$HOME/.neondiff/evidence`;
+  other environments should configure `NEONDIFF_EVIDENCE_ROOT` to an equivalent
+  external local/runner path. Historical packets remain immutable.
 - A promotion decision that can still choose packet-only.

--- a/docs/research/gitnexus-readonly-adapter.md
+++ b/docs/research/gitnexus-readonly-adapter.md
@@ -28,7 +28,7 @@ wrapper-owned designs.
 ## Current Source Behavior
 
 This research is based on direct source inspection at the accepted current main
-commit `1e4b54d1d14f35fb2b22464c474f74cf1fa20b35`.
+commit `8de8840282657ffe457c78132ad0a31328695f68`.
 
 Current GitNexus behavior is packet-only:
 


### PR DESCRIPTION
Closes #1016.

## Scope

- replaces the closed #1039 candidate with a clean, current-main branch
- removes stale machine-specific evidence paths from the updater, release, eval, and GitNexus docs
- gives each run a collision-resistant external evidence packet and makes reuse fail closed
- writes generated appcasts as `appcast.xml`, matching the promotion command
- rejects relative, missing, direct in-checkout, and symlinked-into-checkout evidence roots before output creation
- reserves the local eval-suite output directory before the suite can overwrite or mix a prior packet
- states the exact rollback limitation: `rollback_to` controls feed selection but is not proof of installed rollback

## Identity and envelope

- base: `8de8840282657ffe457c78132ad0a31328695f68`
- head: `c95c4ea487bf3f3678cc178ad89087b61fa16e68`
- changed surface: six documentation files, 199 added/deleted lines
- supersedes closed PR #1039 after its review budget was exhausted

## Focused proof

- `git diff --check 8de8840282657ffe457c78132ad0a31328695f68..HEAD`
- `npm run check:public-claims`
- `npm run check:secrets`
- `npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/fixtures/appcast/beta.json`
- fixed-path scan found no `/Volumes/LEXAR`, `/Users/m1`, `Lexar`, or stale `1e4b54d1d14f35fb2b22464c474f74cf1fa20b35` references in the six changed docs
- shell boundary probes: relative root rejected; missing root rejected; direct in-checkout root rejected; symlinked-into-checkout root rejected; existing external root accepted; packet-directory reuse rejected
- review delta: traversal-capable run IDs rejected, fresh eval parent created before exclusive reservation, and the appcast fixture resolves from the generator's working directory
- final targeted delta: one captured eval date is reused across the complete multi-command packet, preventing a midnight split

## Proof boundary

This is source/documentation proof only. It does not publish an appcast, sign or notarize bytes, install or update NeonDiff, exercise rollback, mutate the operating worker, or prove RC/GA/customer readiness.
