### PR TITLE
docs: make release evidence packets portable

### DIFF
--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -2,11 +2,14 @@
 
 This document covers the buildable appcast generation lane for NeonDiff Desktop.
 It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
+Sparkle 2 is the selected production updater, but #116 and #610 Mac GA artifact gates remain open.
 
 ## Channels
 
-- `beta`: early desktop builds for opted-in testers.
-- `stable`: signed release builds after the Mac release runbook has passed.
+- `beta`: early or signed candidate builds for opted-in testers; fixture output
+  is not a public or GA release.
+- `stable`: future signed release builds only after #116 and #610 signed-feed,
+  immutable-artifact, install, and rollback proof has passed.
 - Rollback is represented by a stable feed whose newest marker pins the channel
   latest to an earlier stable version via `rollback_to`; the generated appcast
   excludes the superseded newer build so Sparkle cannot select it.
@@ -16,11 +19,24 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 Generate a local appcast from a committed fixture:
 
 ```sh
+: "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
+RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$(date +%F)/$RUN_ID"
+mkdir -p "$(dirname "$RUN_DIR")"
+mkdir "$RUN_DIR"
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
+  --output "$RUN_DIR/appcast.xml" \
   --dry-run
 ```
+
+The output root is operator-owned, absolute, and external to the checkout; use
+a fresh `<date>/<run-id>/` directory for every packet. `mkdir` must fail on
+reuse. This command does not read credentials or private-key paths.
 
 Dry-run mode never signs, uploads, notarizes, or fabricates a real signature.
 The `sparkle:edSignature` attribute appears only when the manifest explicitly
@@ -44,8 +60,10 @@ The appcast core models these update outcomes for fixtures and release evidence:
 
 These statuses back both dry-run planning and the native updater UI. The source
 maps real Sparkle no-update, network/feed, signature/validation, cancellation,
-and generic failures into distinct customer states. A hosted signed appcast and
-installed-app run are still required before claiming runtime proof.
+and generic failures into distinct customer states. The current generator does
+not reject invalid or missing `rollback_to`; release validation must catch it
+before publishing. A hosted signed appcast and installed-app run are still
+required before claiming runtime or GA proof.
 
 ## Fixtures
 

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -24,10 +24,10 @@ case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be
 test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
-RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
-RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$(date +%F)/$RUN_ID"
+RELEASE_DATE="$(date +%F)"; RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$RELEASE_DATE/$RUN_ID"
 mkdir -p "$(dirname "$RUN_DIR")"
-mkdir "$RUN_DIR"
+mkdir "$RUN_DIR" || exit
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
   --output "$RUN_DIR/appcast.xml" \

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -25,9 +25,14 @@ test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root f
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 RELEASE_DATE="$(date +%F)"; RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
-RUN_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$RELEASE_DATE/$RUN_ID"
-mkdir -p "$(dirname "$RUN_DIR")"
-mkdir "$RUN_DIR" || exit
+PACKET_ROOT="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop"
+test -e "$PACKET_ROOT" || mkdir "$PACKET_ROOT" || exit 2
+PACKET_ROOT="$(cd "$PACKET_ROOT" && pwd -P)"; case "$PACKET_ROOT/" in "$REPO_ROOT/"*) echo "evidence packet root must be outside the checkout" >&2; exit 2 ;; esac
+RUN_PARENT="$PACKET_ROOT/$RELEASE_DATE"
+test -e "$RUN_PARENT" || mkdir "$RUN_PARENT" || exit 2
+RUN_PARENT="$(cd "$RUN_PARENT" && pwd -P)"; case "$RUN_PARENT/" in "$REPO_ROOT/"*) echo "evidence packet parent must be outside the checkout" >&2; exit 2 ;; esac
+RUN_DIR="$RUN_PARENT/$RUN_ID"
+mkdir "$RUN_DIR" || exit 2
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
   --output "$RUN_DIR/appcast.xml" \

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -132,9 +132,14 @@ test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root f
 NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 RELEASE_DATE="$(date +%F)"; RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
-RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$RELEASE_DATE/$RUN_ID"
-mkdir -p "$(dirname "$RELEASE_EVIDENCE_DIR")"
-mkdir "$RELEASE_EVIDENCE_DIR" || exit
+RELEASE_PACKET_ROOT="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop"
+test -e "$RELEASE_PACKET_ROOT" || mkdir "$RELEASE_PACKET_ROOT" || exit 2
+RELEASE_PACKET_ROOT="$(cd "$RELEASE_PACKET_ROOT" && pwd -P)"; case "$RELEASE_PACKET_ROOT/" in "$REPO_ROOT/"*) echo "evidence packet root must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_EVIDENCE_PARENT="$RELEASE_PACKET_ROOT/$RELEASE_DATE"
+test -e "$RELEASE_EVIDENCE_PARENT" || mkdir "$RELEASE_EVIDENCE_PARENT" || exit 2
+RELEASE_EVIDENCE_PARENT="$(cd "$RELEASE_EVIDENCE_PARENT" && pwd -P)"; case "$RELEASE_EVIDENCE_PARENT/" in "$REPO_ROOT/"*) echo "evidence packet parent must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_EVIDENCE_DIR="$RELEASE_EVIDENCE_PARENT/$RUN_ID"
+mkdir "$RELEASE_EVIDENCE_DIR" || exit 2
 ```
 
 ```sh

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -8,6 +8,8 @@ Apple/Sparkle inputs are available.
 Proof boundary: this document closes the #322 documentation lane only. It does
 not prove a signed artifact exists, does not submit anything to Apple, does not
 publish an appcast, and does not make the desktop update channel GA-ready.
+Sparkle 2 remains selected while #116 is open. #610 also requires immutable artifact/feed identity,
+signed hosted-feed, installed update, state-preserving rollback, and re-update evidence before Mac GA.
 Parent issue #116 owns the signed auto-update channel, #323 owns appcast
 fixtures/dry-run generation, #324 owns credential naming/custody, #325 owns the
 desktop onboarding wizard, #327 owns production license-service deployment, and
@@ -119,10 +121,26 @@ the wrong source SHA, or carries unrelated local changes. Do not sign whatever
 
 Before building, run the read-only credential doctor:
 
+Set the external evidence root once for this run. The source checkout default is
+`$HOME/.neondiff/evidence`; CI or another operator may set a different root.
+Keep historical packets immutable and never place secrets in the root or repo:
+
+```sh
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_DATE="$(date +%F)"; RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$RELEASE_DATE/$RUN_ID"
+mkdir -p "$(dirname "$RELEASE_EVIDENCE_DIR")"
+mkdir "$RELEASE_EVIDENCE_DIR"
+```
+
 ```sh
 apps/neondiff-desktop/script/preflight-credentials.sh
 apps/neondiff-desktop/script/preflight-credentials.sh --json \
-  > /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/credential-preflight.json
+  > "$RELEASE_EVIDENCE_DIR/credential-preflight.json"
 ```
 
 The doctor reports presence only. It does not sign, notarize, upload, fetch
@@ -145,7 +163,7 @@ Required owner/Codex inputs for a real signing run:
 - Sparkle public key as `NEONDIFF_SPARKLE_PUBLIC_ED_KEY`.
 - Sparkle feed URL as `NEONDIFF_SPARKLE_FEED_URL`.
 - Appcast hosting destination and rollback destination.
-- Evidence packet directory under `/Users/m1/Codex/evidence/`.
+- Evidence packet directory under `$NEONDIFF_EVIDENCE_ROOT/`.
 
 ## Build The Release App
 
@@ -230,7 +248,7 @@ the notarization paths documented in #324.
 ```sh
 cd apps/neondiff-desktop
 APP="dist/NeonDiff.app"
-ZIP="/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/NeonDiff.zip"
+ZIP="$RELEASE_EVIDENCE_DIR/NeonDiff.zip"
 
 ditto -c -k --keepParent "$APP" "$ZIP"
 shasum -a 256 "$ZIP"
@@ -282,8 +300,8 @@ fabricate a real Sparkle signature.
 
 ```sh
 apps/neondiff-desktop/script/generate-appcast.sh \
-  --fixture apps/neondiff-desktop/fixtures/appcast/beta.json \
-  --output /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/neondiff-beta-appcast.xml \
+  --fixture fixtures/appcast/beta.json \
+  --output "$RELEASE_EVIDENCE_DIR/appcast.xml" \
   --dry-run
 ```
 
@@ -323,7 +341,7 @@ License boundary:
 Create a public-safe packet under:
 
 ```text
-/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/
+$RELEASE_EVIDENCE_DIR/
 ```
 
 Minimum files:

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -134,7 +134,7 @@ case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be o
 RELEASE_DATE="$(date +%F)"; RUN_ID="replace-with-unique-run-id"; case "$RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
 RELEASE_EVIDENCE_DIR="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop/$RELEASE_DATE/$RUN_ID"
 mkdir -p "$(dirname "$RELEASE_EVIDENCE_DIR")"
-mkdir "$RELEASE_EVIDENCE_DIR"
+mkdir "$RELEASE_EVIDENCE_DIR" || exit
 ```
 
 ```sh

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -6,7 +6,7 @@ contains the real Sparkle controller and release-build configuration gate. No
 hosted appcast, signed update, installed update, rollback, or public release is
 proven by source alone.
 
-## Current Implementation — 2026-07-28
+## Current Implementation — reconciled against `8de8840` (2026-08-24)
 
 - The native SwiftUI executable uses the existing Sparkle 2 dependency and
   standard updater UI in
@@ -41,33 +41,44 @@ proof only. #116 remains open for real public-key/feed identity, EdDSA-signed
 appcast, exact signed/notarized installed update, state-preserving rollback and
 re-update, immutable release assets, and live customer evidence.
 
+Sparkle 2 is the selected updater for the native SwiftUI path while #116 is
+open. The #610 Mac GA boundary is stricter: the current public release manifest
+does not include a signed native Desktop artifact, so fixtures or an unsigned
+bundle cannot establish release, installed-update, rollback, or GA readiness.
+
 ## Durable Plan Contract
 
-- Goal: define the desktop auto-update channel contract for NeonDiff Desktop so
-  future implementation can choose Sparkle, Tauri updater, or an equivalent
-  signed updater without weakening release governance or license boundaries.
-- Resume identity: repo `electricsheephq/evaos-code-review-bot`, branch
+Set `NEONDIFF_EVIDENCE_ROOT` to an absolute external directory outside the checkout for
+local packets (the source default is `$HOME/.neondiff/evidence`). Do not put
+credentials, private keys, or customer data in that directory. Historical
+release/evidence packets are immutable and are not rewritten by this plan.
+
+- Goal: define the desktop auto-update channel contract for NeonDiff Desktop
+  using the selected Sparkle 2 path without weakening release governance or
+  license boundaries.
+- Resume identity: repo `electricsheephq/evaos-code-review-bot-neondiff`, branch
   `codex/116-desktop-autoupdate-plan`, base
-  `1e28bf8ee0bfe42d0a7f3cc47ed76508497efe96`, issue
-  https://github.com/electricsheephq/evaos-code-review-bot/issues/116, parent
-  tracker https://github.com/electricsheephq/evaos-code-review-bot/issues/103.
+  `8de8840282657ffe457c78132ad0a31328695f68`, issue
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116,
+  parent tracker
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103.
 - Tracking / source of truth: GitHub issues and PRs own implementation truth;
   `docs/release-governance.md`, `docs/license-boundary.md`, and
   `docs/public-release-manifest.json` own current release and license wording;
   Notion/Company OS remains architecture and evidence routing; no live runtime
   or roadmap state is changed by this document.
-- Scope / non-goals: no updater implementation, no Sparkle or Tauri dependency
-  selection, no signing/notarization setup, no private key material, no appcast
-  publication, no installer distribution, no license API implementation, no
-  launchd/runtime change, and no claim that desktop auto-update is shipped.
+- Scope / non-goals: no updater implementation, signing/notarization setup,
+  private key material, appcast publication, installer distribution, license API
+  implementation, launchd/runtime change, or claim that desktop auto-update is
+  shipped.
 - Current state: NeonDiff is a source-available beta; desktop update channels
-  are marked `post_1_0` and non-required in `docs/public-release-manifest.json`;
-  `docs/neondiff-desktop.md` describes a development-only unsigned desktop
-  scaffold; issue #111 owns license activation and issue #114 owns the legacy
-  desktop shell audit.
-- Exact next action: after desktop shell choice and license activation design
-  are settled, create an implementation issue or PR that wires a signed local or
-  static update-manifest dry run before any public appcast or artifact channel.
+  remain `post_1_0` and non-required in `docs/public-release-manifest.json`.
+  The native source has a Sparkle 2 controller and Release configuration gate,
+  but source/unsigned-bundle proof is not signed-feed or installed-update proof.
+  Issue #111 owns license activation and #610 owns the Mac GA artifact boundary.
+- Exact next action: implement and test the single promotion, containment, and
+  rollback path required by `docs/architecture/mac-ga-release-contract.md`;
+  only then run owner-gated #116/#322/#323 evidence from an exact candidate.
 - Critical invariants: every downloaded gated artifact must be entitlement
   checked before download, signature verified before install, tied to a channel
   manifest, rollbackable to a last-known-good release, and backed by public-safe
@@ -95,10 +106,10 @@ re-update, immutable release assets, and live customer evidence.
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/<run-id>/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/<run-id>/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -115,7 +126,7 @@ re-update, immutable release assets, and live customer evidence.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop-auto-update/<date>/<run-id>/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -123,11 +134,12 @@ re-update, immutable release assets, and live customer evidence.
 The desktop channel should be explicit in update metadata rather than inferred
 from branch names, app names, or runtime config.
 
-- `beta`: pre-stable desktop channel for signed test artifacts and release
-  candidates. Beta may be license-gated and must remain rollbackable.
-- `stable`: future channel for public-ready signed artifacts after beta evidence
-  proves update checks, entitlement behavior, signature failure handling, and
-  rollback.
+- `beta`: pre-stable desktop channel for fixture or signed candidate artifacts.
+  Beta may be license-gated and must remain rollbackable; beta evidence never
+  implies a public or GA release.
+- `stable`: future channel for public-ready signed artifacts only after #116
+  and the #610 immutable artifact/feed/install/rollback gates pass. Stable must
+  not alias the beta feed.
 - `disabled`: server-side or static-manifest state that makes the desktop report
   a clear no-update or channel-disabled result without attempting a download.
 - `rollback`: pointer to the last-known-good signed version. Rollback metadata
@@ -192,16 +204,16 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$NEONDIFF_EVIDENCE_ROOT/`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.
 
 ## Tracking
 
-- Parent roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
-- Release governance: https://github.com/electricsheephq/evaos-code-review-bot/issues/112
-- License activation: https://github.com/electricsheephq/evaos-code-review-bot/issues/111
-- Desktop shell audit: https://github.com/electricsheephq/evaos-code-review-bot/issues/114
-- Desktop app MVP: https://github.com/electricsheephq/evaos-code-review-bot/issues/115
-- This plan: https://github.com/electricsheephq/evaos-code-review-bot/issues/116
+- Parent roadmap: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103
+- Release governance: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/112
+- License activation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111
+- Desktop shell audit: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/114
+- Desktop app MVP: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/115
+- This plan: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116


### PR DESCRIPTION
Closes #1045.

## Scope

- updates only the three release-facing docs owned by #1045
- replaces machine-specific evidence paths with a canonical external root
- captures one executable release date and validates one portable run ID
- reserves the exact packet directory before output so reuse fails closed
- makes the appcast fixture package-relative and output name match promotion
- reconciles Sparkle 2, #116/#610, beta/stable, rollback, credential, and proof boundaries

## Identity and envelope

- base: `8de8840282657ffe457c78132ad0a31328695f68`
- head: `7c91b8e0ea63a904914064dbc757278b74c09b2a`
- files: 3
- changed lines: 148 (103 additions, 45 deletions)
- architecture: #1045 under parent #1016 and milestone 11

## Focused proof

- `git diff --check`
- `npm run check:public-claims`
- `npm run check:secrets`
- `npm run check:desktop-fixture-boundary -- apps/neondiff-desktop/fixtures/appcast/beta.json`
- fixed-path/stale-source scan: no matches
- relative, traversal, direct-checkout, root-symlink, and intermediate-parent-symlink paths rejected; external root accepted
- fresh packet reservation succeeded; reuse failed before downstream output and preserved the existing packet
- exact documented generator command produced an 816-byte `appcast.xml`

## Proof boundary

This proves only the documentation and runnable local packet examples. It does not sign, notarize, host, install, update, roll back, publish, or mutate app, worker, configuration, credentials, customer, billing, feed, or release state.
