### PR TITLE
docs: make offline eval packets portable

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -12,23 +12,32 @@ proof.
 export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
 case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
 test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
-NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence root" >&2; exit 2; }
+REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)" || { echo "cannot canonicalize checkout root" >&2; exit 2; }
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 EVAL_DATE="$(date +%F)"; EVAL_RUN_ID="replace-with-unique-run-id"; case "$EVAL_RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "EVAL_RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+EVAL_DATE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE"; test -e "$EVAL_DATE_ROOT" || mkdir "$EVAL_DATE_ROOT" || exit 2
+EVAL_DATE_ROOT="$(cd "$EVAL_DATE_ROOT" && pwd -P)" || { echo "cannot canonicalize eval date root" >&2; exit 2; }
+case "$EVAL_DATE_ROOT/" in "$NEONDIFF_EVIDENCE_ROOT/"*) ;; *) echo "eval date root escaped evidence root" >&2; exit 2 ;; esac
+case "$EVAL_DATE_ROOT/" in "$REPO_ROOT/"*) echo "eval date root must be outside the checkout" >&2; exit 2 ;; esac
+EVAL_PACKET_ROOT="$EVAL_DATE_ROOT/$EVAL_RUN_ID"; mkdir "$EVAL_PACKET_ROOT" || exit 2
+EVAL_PACKET_ROOT="$(cd "$EVAL_PACKET_ROOT" && pwd -P)" || { echo "cannot canonicalize eval packet root" >&2; exit 2; }
+case "$EVAL_PACKET_ROOT/" in "$EVAL_DATE_ROOT/"*) ;; *) echo "eval packet root escaped date root" >&2; exit 2 ;; esac
+case "$EVAL_PACKET_ROOT/" in "$REPO_ROOT/"*) echo "eval packet root must be outside the checkout" >&2; exit 2 ;; esac
 ```
 
 Run it with a local scenario file:
 
 ```bash
-npm run eval:offline -- --input /path/to/scenario.json
+npm run eval:offline -- --input /path/to/scenario.json \
+  --output-dir "$EVAL_PACKET_ROOT/offline"
 ```
 
 Run the checked-in local suite fixtures:
 
 ```bash
-EVAL_SUITE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/local-suite"
-mkdir -p "$(dirname "$EVAL_SUITE_ROOT")"
-mkdir "$EVAL_SUITE_ROOT"
+EVAL_SUITE_ROOT="$EVAL_PACKET_ROOT/local-suite"
+mkdir "$EVAL_SUITE_ROOT" || exit 2
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
   --output-root "$EVAL_SUITE_ROOT"
@@ -39,7 +48,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/sticky-vs-cold-seeded-quality"
+  --output-root "$EVAL_PACKET_ROOT/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -48,7 +57,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/eval-gates/ab"
+  --output-root "$EVAL_PACKET_ROOT/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -56,7 +65,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/eval-gates/docs-drift"
+  --output-root "$EVAL_PACKET_ROOT/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -70,7 +79,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/review-lenses-eval-gate" \
+  --output-root "$EVAL_PACKET_ROOT/review-lenses-eval-gate" \
   --dry-run true
 ```
 
@@ -87,7 +96,7 @@ By default, packets are written under the external root selected by
 `NEONDIFF_EVIDENCE_ROOT` (or `$HOME/.neondiff/evidence` when unset):
 
 ```text
-$NEONDIFF_EVIDENCE_ROOT/<date>/<run-id>/
+$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/
 ```
 
 Use `--output-dir` for tests or scratch runs.

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -2,6 +2,21 @@
 
 The offline eval harness creates read-only comparison packets for the v0.2 CodeRabbit-class reviewer work. It does not call GitHub, post PR comments, mutate repos, or change launchd state.
 
+Use an external evidence root for every run. The source default is
+`$HOME/.neondiff/evidence`; set `NEONDIFF_EVIDENCE_ROOT` for CI or another
+operator-owned location outside this checkout. These packets are offline,
+advisory evidence only and must not be presented as hosted, runtime, or GA
+proof.
+
+```bash
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)"; REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
+EVAL_DATE="$(date +%F)"; EVAL_RUN_ID="replace-with-unique-run-id"; case "$EVAL_RUN_ID" in ""|"."|".."|*[!A-Za-z0-9._-]*) echo "EVAL_RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+```
+
 Run it with a local scenario file:
 
 ```bash
@@ -11,9 +26,12 @@ npm run eval:offline -- --input /path/to/scenario.json
 Run the checked-in local suite fixtures:
 
 ```bash
+EVAL_SUITE_ROOT="$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/local-suite"
+mkdir -p "$(dirname "$EVAL_SUITE_ROOT")"
+mkdir "$EVAL_SUITE_ROOT"
 npm run eval:suite -- \
   --input-dir tests/fixtures/eval-suite-scenarios \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
+  --output-root "$EVAL_SUITE_ROOT"
 ```
 
 Run the paired sticky-vs-cold fixture:
@@ -21,7 +39,7 @@ Run the paired sticky-vs-cold fixture:
 ```bash
 npm run eval:sticky-vs-cold -- \
   --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/sticky-vs-cold-seeded-quality"
 ```
 
 Run the repo-wiki context A/B gate with a fixture that contains baseline,
@@ -30,7 +48,7 @@ deterministic repo-wiki, and curated OpenWiki-derived findings:
 ```bash
 npx tsx src/cli.ts eval-repo-wiki-context-ab \
   --input /path/to/repo-wiki-context-ab.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/eval-gates/ab"
 ```
 
 Run the suggest-only OpenWiki docs-drift gate:
@@ -38,7 +56,7 @@ Run the suggest-only OpenWiki docs-drift gate:
 ```bash
 npx tsx src/cli.ts eval-openwiki-docs-drift \
   --input /path/to/docs-drift.json \
-  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/eval-gates/docs-drift"
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
@@ -52,7 +70,7 @@ Run the review-lenses dry-run comparison gate:
 ```bash
 npx tsx src/cli.ts review-lenses-eval \
   --input-dir tests/fixtures/review-lenses-eval \
-  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
+  --output-root "$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/review-lenses-eval-gate" \
   --dry-run true
 ```
 
@@ -65,10 +83,11 @@ The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.
 
-By default, packets are written under:
+By default, packets are written under the external root selected by
+`NEONDIFF_EVIDENCE_ROOT` (or `$HOME/.neondiff/evidence` when unset):
 
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/
+$NEONDIFF_EVIDENCE_ROOT/<date>/<run-id>/
 ```
 
 Use `--output-dir` for tests or scratch runs.

--- a/docs/evals/gitnexus-readonly-adapter-eval-plan.md
+++ b/docs/evals/gitnexus-readonly-adapter-eval-plan.md
@@ -118,16 +118,21 @@ Regression caps:
 
 ## Evidence Packet
 
+Set `NEONDIFF_EVIDENCE_ROOT` to an operator- or CI-owned absolute directory outside the
+checkout before a local run. The CLI default is `$HOME/.neondiff/evidence`;
+CI may inject another external root. Historical packets are immutable evidence
+and must not be moved, rewritten, or used to infer a current release state.
+
 For EVAOS operator-local runs, write eval evidence under the default scratch
 root:
 
 ```text
-/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/gitnexus-readonly-adapter-<run-id>/
+$NEONDIFF_EVIDENCE_ROOT/<date>/<run-id>/gitnexus-readonly-adapter/
 ```
 
-Other operators and CI runners should configure an equivalent environment-local
-evidence root and preserve the same per-run packet shape. The Lexar path is the
-current EVAOS workstation default, not a portable hard requirement.
+Other operators and CI runners should configure an equivalent external evidence
+root and preserve the same per-run packet shape. This plan never grants hosted,
+runtime, release, or GA proof from an offline adapter packet.
 
 Each scenario should include:
 

--- a/docs/evals/gitnexus-readonly-adapter-eval-plan.md
+++ b/docs/evals/gitnexus-readonly-adapter-eval-plan.md
@@ -127,7 +127,7 @@ For EVAOS operator-local runs, write eval evidence under the default scratch
 root:
 
 ```text
-$NEONDIFF_EVIDENCE_ROOT/<date>/<run-id>/gitnexus-readonly-adapter/
+$NEONDIFF_EVIDENCE_ROOT/$EVAL_DATE/$EVAL_RUN_ID/gitnexus-readonly-adapter/
 ```
 
 Other operators and CI runners should configure an equivalent external evidence

--- a/docs/research/gitnexus-readonly-adapter.md
+++ b/docs/research/gitnexus-readonly-adapter.md
@@ -27,8 +27,8 @@ wrapper-owned designs.
 
 ## Current Source Behavior
 
-This research is based on local source inspection at `origin/main` commit
-`0f5be870ce303259f1ba6d7227b98704ecf5a81b`.
+This research is based on direct source inspection at the accepted reconciliation
+base `8de8840282657ffe457c78132ad0a31328695f68`; recheck `origin/main` before reuse.
 
 Current GitNexus behavior is packet-only:
 
@@ -57,6 +57,11 @@ Current ZCode behavior is intentionally narrower than a tool-using agent:
 - Tool concurrency is capped at `1`.
 - ZCode receives GitNexus only as advisory prompt text through
   `buildGitNexusContextPromptSection`.
+
+The portable source-defaults slice now uses `NEONDIFF_EVIDENCE_ROOT` for
+explicit absolute external evidence roots and falls back to `$HOME/.neondiff/evidence`.
+The adapter remains offline/shadow-only; no source or runtime change in this
+document promotes it.
 
 Release notes for the GitNexus packet feature preserve the same boundary:
 GitNexus context stayed disabled in live config by default, and the release did
@@ -239,7 +244,7 @@ The issue should require:
 - No raw ZCode GitNexus access.
 - No index writes.
 - Evidence packets under the configured eval evidence root. For EVAOS
-  operator-local runs, the current default is
-  `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/`; other environments should
-  configure an equivalent local/runner path.
+  operator-local runs, the current default is `$HOME/.neondiff/evidence`;
+  other environments should configure `NEONDIFF_EVIDENCE_ROOT` to an equivalent
+  external local/runner path. Historical packets remain immutable.
 - A promotion decision that can still choose packet-only.


### PR DESCRIPTION
Closes #1046.

## Scope

- portable external evidence-root setup for offline eval packets
- one captured EVAL_DATE and safe EVAL_RUN_ID reused across a logical run
- exclusive packet-root and local-suite reservation so historical reuse fails before eval output
- explicit canonicalization failure and canonical date/packet containment under the declared evidence root
- eval:offline, suite, sticky/cold, OpenWiki, docs-drift, and review-lens output routed through the same packet root
- portable GitNexus adapter packet paths and immutable/offline proof boundaries
- current source authority framed as the accepted reconciliation base

## Identity and envelope

- rebased base: eddb6d4bb2c121392da420565dd23e80bf805bd0
- exact head: d61f8281b408b660436b7198e111aa0ee79a9c10
- changed files: exactly docs/eval-harness.md, docs/evals/gitnexus-readonly-adapter-eval-plan.md, and docs/research/gitnexus-readonly-adapter.md
- changed lines: 55 insertions, 17 deletions, 72 cumulative lines; ceiling 100
- agent-authored: yes

## Focused proof

- git diff --check
- npm run check:public-claims
- npm run check:secrets (913 tracked files)
- deterministic relative/missing/direct/root-link/date-file/date-link/packet-link/unsafe-ID/packet-reuse/local-suite-reuse probes passed with no downstream output
- eval:offline is explicitly routed under EVAL_PACKET_ROOT/offline
- public-safe probe receipt: /Users/m1/Codex/evidence/neondiff/2026-08-23/mac-ga-1.1.0/pr-1046-delta-portable-probe.sh

The probe could not execute the TypeScript eval command locally because this isolated worktree has no tsx executable; dependencies were not installed. Exact-head GitHub CI is the authoritative build/test/package gate. GitNexus is not indexed for this worktree, so direct exact source is the proof boundary and no GitNexus freshness claim is made.

## Remaining barrier

The branch has been rebased onto the merged portable release-doc base from PR #1052. Merge requires fresh exact-head CI, zero unresolved mandatory threads, and blind acceptance/adversarial PASS verdicts at 95 or above.

## Proof boundary

This is documentation/offline/advisory proof only. It does not prove hosted or runtime behavior, release/signing, installation/update, customer readiness, or live adapter enablement.
