### PR TITLE
docs: unify portable release evidence

### DIFF
--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -5,8 +5,10 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 
 ## Channels
 
-- `beta`: early desktop builds for opted-in testers.
-- `stable`: signed release builds after the Mac release runbook has passed.
+- `beta`: early or signed candidate builds for opted-in testers; fixture output
+  is not a public or GA release.
+- `stable`: future signed release builds only after #116 and #610 signed-feed,
+  immutable-artifact, install, and rollback proof has passed.
 - Rollback is represented by a stable feed whose newest marker pins the channel
   latest to an earlier stable version via `rollback_to`; the generated appcast
   excludes the superseded newer build so Sparkle cannot select it.
@@ -16,11 +18,32 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 Generate a local appcast from a committed fixture:
 
 ```sh
-apps/neondiff-desktop/script/generate-appcast.sh \
+: "${NEONDIFF_EVIDENCE_ROOT:?set an external evidence root outside this checkout}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence root" >&2; exit 2; }
+REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)" || { echo "cannot canonicalize checkout root" >&2; exit 2; }
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_DATE="$(date +%F)" || { echo "cannot capture release date" >&2; exit 2; }; case "$RELEASE_DATE" in [0123456789][0123456789][0123456789][0123456789]-[0123456789][0123456789]-[0123456789][0123456789]) ;; *) echo "RELEASE_DATE must use YYYY-MM-DD" >&2; exit 2 ;; esac; : "${RUN_ID:?set a unique portable RUN_ID}"; case "$RUN_ID" in ""|"."|".."|*[!0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+PACKET_ROOT="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop"
+test -e "$PACKET_ROOT" || mkdir "$PACKET_ROOT" || exit 2
+PACKET_ROOT="$(cd "$PACKET_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence packet root" >&2; exit 2; }
+case "$PACKET_ROOT/" in "$NEONDIFF_EVIDENCE_ROOT/"*) ;; *) echo "evidence packet root escaped evidence root" >&2; exit 2 ;; esac
+case "$PACKET_ROOT/" in "$REPO_ROOT/"*) echo "evidence packet root must be outside the checkout" >&2; exit 2 ;; esac
+RUN_PARENT="$PACKET_ROOT/$RELEASE_DATE"
+test -e "$RUN_PARENT" || mkdir "$RUN_PARENT" || exit 2
+RUN_PARENT="$(cd "$RUN_PARENT" && pwd -P)" || { echo "cannot canonicalize evidence packet parent" >&2; exit 2; }
+case "$RUN_PARENT/" in "$PACKET_ROOT/"*) ;; *) echo "evidence packet parent escaped packet root" >&2; exit 2 ;; esac
+case "$RUN_PARENT/" in "$REPO_ROOT/"*) echo "evidence packet parent must be outside the checkout" >&2; exit 2 ;; esac
+RUN_DIR="$RUN_PARENT/$RUN_ID"
+mkdir "$RUN_DIR" || exit 2
+"$REPO_ROOT/apps/neondiff-desktop/script/generate-appcast.sh" \
   --fixture fixtures/appcast/beta.json \
-  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
+  --output "$RUN_DIR/appcast.xml" \
   --dry-run
 ```
+
+Use the captured external `$RELEASE_DATE/$RUN_ID/` directory for every packet; `mkdir` must fail on reuse. This command does not read credentials or private-key paths.
 
 Dry-run mode never signs, uploads, notarizes, or fabricates a real signature.
 The `sparkle:edSignature` attribute appears only when the manifest explicitly
@@ -44,8 +67,10 @@ The appcast core models these update outcomes for fixtures and release evidence:
 
 These statuses back both dry-run planning and the native updater UI. The source
 maps real Sparkle no-update, network/feed, signature/validation, cancellation,
-and generic failures into distinct customer states. A hosted signed appcast and
-installed-app run are still required before claiming runtime proof.
+and generic failures into distinct customer states. The current generator does
+not reject invalid or missing `rollback_to`; release validation must catch it
+before publishing. A hosted signed appcast and installed-app run are still
+required before claiming runtime or GA proof.
 
 ## Fixtures
 

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -131,24 +131,24 @@ NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)" || { echo "ca
 REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)" || { echo "cannot canonicalize checkout root" >&2; exit 2; }
 case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
 RELEASE_DATE="$(date +%F)" || { echo "cannot capture release date" >&2; exit 2; }; case "$RELEASE_DATE" in [0123456789][0123456789][0123456789][0123456789]-[0123456789][0123456789]-[0123456789][0123456789]) ;; *) echo "RELEASE_DATE must use YYYY-MM-DD" >&2; exit 2 ;; esac; : "${RUN_ID:?set a unique portable RUN_ID}"; case "$RUN_ID" in ""|"."|".."|*[!0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
-RELEASE_PACKET_ROOT="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop"
-test -e "$RELEASE_PACKET_ROOT" || mkdir "$RELEASE_PACKET_ROOT" || exit 2
-RELEASE_PACKET_ROOT="$(cd "$RELEASE_PACKET_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence packet root" >&2; exit 2; }
-case "$RELEASE_PACKET_ROOT/" in "$NEONDIFF_EVIDENCE_ROOT/"*) ;; *) echo "evidence packet root escaped evidence root" >&2; exit 2 ;; esac
-case "$RELEASE_PACKET_ROOT/" in "$REPO_ROOT/"*) echo "evidence packet root must be outside the checkout" >&2; exit 2 ;; esac
-RELEASE_EVIDENCE_PARENT="$RELEASE_PACKET_ROOT/$RELEASE_DATE"
-test -e "$RELEASE_EVIDENCE_PARENT" || mkdir "$RELEASE_EVIDENCE_PARENT" || exit 2
-RELEASE_EVIDENCE_PARENT="$(cd "$RELEASE_EVIDENCE_PARENT" && pwd -P)" || { echo "cannot canonicalize evidence packet parent" >&2; exit 2; }
-case "$RELEASE_EVIDENCE_PARENT/" in "$RELEASE_PACKET_ROOT/"*) ;; *) echo "evidence packet parent escaped packet root" >&2; exit 2 ;; esac
-case "$RELEASE_EVIDENCE_PARENT/" in "$REPO_ROOT/"*) echo "evidence packet parent must be outside the checkout" >&2; exit 2 ;; esac
-RELEASE_EVIDENCE_DIR="$RELEASE_EVIDENCE_PARENT/$RUN_ID"
-mkdir "$RELEASE_EVIDENCE_DIR" || exit 2; cd "$REPO_ROOT" || exit 2
+PACKET_ROOT="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop"
+test -e "$PACKET_ROOT" || mkdir "$PACKET_ROOT" || exit 2
+PACKET_ROOT="$(cd "$PACKET_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence packet root" >&2; exit 2; }
+case "$PACKET_ROOT/" in "$NEONDIFF_EVIDENCE_ROOT/"*) ;; *) echo "evidence packet root escaped evidence root" >&2; exit 2 ;; esac
+case "$PACKET_ROOT/" in "$REPO_ROOT/"*) echo "evidence packet root must be outside the checkout" >&2; exit 2 ;; esac
+RUN_PARENT="$PACKET_ROOT/$RELEASE_DATE"
+test -e "$RUN_PARENT" || mkdir "$RUN_PARENT" || exit 2
+RUN_PARENT="$(cd "$RUN_PARENT" && pwd -P)" || { echo "cannot canonicalize evidence packet parent" >&2; exit 2; }
+case "$RUN_PARENT/" in "$PACKET_ROOT/"*) ;; *) echo "evidence packet parent escaped packet root" >&2; exit 2 ;; esac
+case "$RUN_PARENT/" in "$REPO_ROOT/"*) echo "evidence packet parent must be outside the checkout" >&2; exit 2 ;; esac
+RUN_DIR="$RUN_PARENT/$RUN_ID"
+mkdir "$RUN_DIR" || exit 2; cd "$REPO_ROOT" || exit 2
 ```
 
 ```sh
 apps/neondiff-desktop/script/preflight-credentials.sh
 apps/neondiff-desktop/script/preflight-credentials.sh --json \
-  > "$RELEASE_EVIDENCE_DIR/credential-preflight.json"
+  > "$RUN_DIR/credential-preflight.json"
 ```
 
 The doctor reports presence only. It does not sign, notarize, upload, fetch
@@ -257,7 +257,7 @@ the notarization paths documented in #324.
 ```sh
 cd "$REPO_ROOT/apps/neondiff-desktop"
 APP="dist/NeonDiff.app"
-ZIP="$RELEASE_EVIDENCE_DIR/NeonDiff.zip"
+ZIP="$RUN_DIR/NeonDiff.zip"
 
 ditto -c -k --keepParent "$APP" "$ZIP"
 shasum -a 256 "$ZIP"
@@ -310,7 +310,7 @@ fabricate a real Sparkle signature.
 ```sh
 "$REPO_ROOT/apps/neondiff-desktop/script/generate-appcast.sh" \
   --fixture fixtures/appcast/beta.json \
-  --output "$RELEASE_EVIDENCE_DIR/appcast.xml" \
+  --output "$RUN_DIR/appcast.xml" \
   --dry-run
 ```
 
@@ -350,7 +350,7 @@ License boundary:
 Create a public-safe packet under:
 
 ```text
-$RELEASE_EVIDENCE_DIR/
+$RUN_DIR/
 ```
 
 Minimum files:

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -308,7 +308,7 @@ model. The generator creates local XML only; it does not sign, upload, or
 fabricate a real Sparkle signature.
 
 ```sh
-script/generate-appcast.sh \
+"$REPO_ROOT/apps/neondiff-desktop/script/generate-appcast.sh" \
   --fixture fixtures/appcast/beta.json \
   --output "$RELEASE_EVIDENCE_DIR/appcast.xml" \
   --dry-run

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -119,10 +119,36 @@ the wrong source SHA, or carries unrelated local changes. Do not sign whatever
 
 Before building, run the read-only credential doctor:
 
+Set the external evidence root once for this run (default `$HOME/.neondiff/evidence`).
+Keep packets immutable and secret-free. Run every following `sh` block in this
+same shell; sections anchor to `$REPO_ROOT`. If state is lost, restart with a new `RUN_ID`:
+
+```sh
+export NEONDIFF_EVIDENCE_ROOT="${NEONDIFF_EVIDENCE_ROOT:-$HOME/.neondiff/evidence}"
+case "$NEONDIFF_EVIDENCE_ROOT" in /*) ;; *) echo "NEONDIFF_EVIDENCE_ROOT must be absolute" >&2; exit 2 ;; esac
+test -d "$NEONDIFF_EVIDENCE_ROOT" || { echo "create the external evidence root first" >&2; exit 2; }
+NEONDIFF_EVIDENCE_ROOT="$(cd "$NEONDIFF_EVIDENCE_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence root" >&2; exit 2; }
+REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)" || { echo "cannot canonicalize checkout root" >&2; exit 2; }
+case "$NEONDIFF_EVIDENCE_ROOT/" in "$REPO_ROOT/"*) echo "evidence root must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_DATE="$(date +%F)" || { echo "cannot capture release date" >&2; exit 2; }; case "$RELEASE_DATE" in [0123456789][0123456789][0123456789][0123456789]-[0123456789][0123456789]-[0123456789][0123456789]) ;; *) echo "RELEASE_DATE must use YYYY-MM-DD" >&2; exit 2 ;; esac; : "${RUN_ID:?set a unique portable RUN_ID}"; case "$RUN_ID" in ""|"."|".."|*[!0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._-]*) echo "RUN_ID must be a portable path segment" >&2; exit 2 ;; esac
+RELEASE_PACKET_ROOT="$NEONDIFF_EVIDENCE_ROOT/neondiff-desktop"
+test -e "$RELEASE_PACKET_ROOT" || mkdir "$RELEASE_PACKET_ROOT" || exit 2
+RELEASE_PACKET_ROOT="$(cd "$RELEASE_PACKET_ROOT" && pwd -P)" || { echo "cannot canonicalize evidence packet root" >&2; exit 2; }
+case "$RELEASE_PACKET_ROOT/" in "$NEONDIFF_EVIDENCE_ROOT/"*) ;; *) echo "evidence packet root escaped evidence root" >&2; exit 2 ;; esac
+case "$RELEASE_PACKET_ROOT/" in "$REPO_ROOT/"*) echo "evidence packet root must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_EVIDENCE_PARENT="$RELEASE_PACKET_ROOT/$RELEASE_DATE"
+test -e "$RELEASE_EVIDENCE_PARENT" || mkdir "$RELEASE_EVIDENCE_PARENT" || exit 2
+RELEASE_EVIDENCE_PARENT="$(cd "$RELEASE_EVIDENCE_PARENT" && pwd -P)" || { echo "cannot canonicalize evidence packet parent" >&2; exit 2; }
+case "$RELEASE_EVIDENCE_PARENT/" in "$RELEASE_PACKET_ROOT/"*) ;; *) echo "evidence packet parent escaped packet root" >&2; exit 2 ;; esac
+case "$RELEASE_EVIDENCE_PARENT/" in "$REPO_ROOT/"*) echo "evidence packet parent must be outside the checkout" >&2; exit 2 ;; esac
+RELEASE_EVIDENCE_DIR="$RELEASE_EVIDENCE_PARENT/$RUN_ID"
+mkdir "$RELEASE_EVIDENCE_DIR" || exit 2; cd "$REPO_ROOT" || exit 2
+```
+
 ```sh
 apps/neondiff-desktop/script/preflight-credentials.sh
 apps/neondiff-desktop/script/preflight-credentials.sh --json \
-  > /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/credential-preflight.json
+  > "$RELEASE_EVIDENCE_DIR/credential-preflight.json"
 ```
 
 The doctor reports presence only. It does not sign, notarize, upload, fetch
@@ -138,6 +164,7 @@ release blocker until the owner provides the notarization input and
 Required owner/Codex inputs for a real signing run:
 
 - Exact release source SHA, version, build number, and channel.
+- Unique portable `RUN_ID` for this immutable evidence packet.
 - Developer ID Application identity name, for example
   `Developer ID Application: <Team Name> (<TEAMID>)`.
 - Notarization path: either `NEONDIFF_NOTARY_KEYCHAIN_PROFILE` or the App Store
@@ -145,7 +172,7 @@ Required owner/Codex inputs for a real signing run:
 - Sparkle public key as `NEONDIFF_SPARKLE_PUBLIC_ED_KEY`.
 - Sparkle feed URL as `NEONDIFF_SPARKLE_FEED_URL`.
 - Appcast hosting destination and rollback destination.
-- Evidence packet directory under `/Users/m1/Codex/evidence/`.
+- Evidence packet directory under `$NEONDIFF_EVIDENCE_ROOT/`.
 
 ## Build The Release App
 
@@ -154,7 +181,7 @@ The bundle id is `com.electricsheephq.NeonDiffDesktop`; the minimum supported
 macOS version is 14.0.
 
 ```sh
-cd apps/neondiff-desktop
+cd "$REPO_ROOT/apps/neondiff-desktop"
 export NEONDIFF_DESKTOP_VERSION="<version>"
 export NEONDIFF_DESKTOP_BUILD="<build>"
 export NEONDIFF_SPARKLE_PUBLIC_ED_KEY="<owner-provided-public-key>"
@@ -190,7 +217,7 @@ framework when it exists, and finally the outer app. Do not use `--deep` to
 replace the already-reviewed nested signatures.
 
 ```sh
-cd apps/neondiff-desktop
+cd "$REPO_ROOT/apps/neondiff-desktop"
 IDENTITY="Developer ID Application: <Team Name> (<TEAMID>)"
 APP="dist/NeonDiff.app"
 SPARKLE_FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework"
@@ -228,9 +255,9 @@ Create a zip for Apple notarization with `ditto`, then submit it through one of
 the notarization paths documented in #324.
 
 ```sh
-cd apps/neondiff-desktop
+cd "$REPO_ROOT/apps/neondiff-desktop"
 APP="dist/NeonDiff.app"
-ZIP="/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/NeonDiff.zip"
+ZIP="$RELEASE_EVIDENCE_DIR/NeonDiff.zip"
 
 ditto -c -k --keepParent "$APP" "$ZIP"
 shasum -a 256 "$ZIP"
@@ -281,9 +308,9 @@ model. The generator creates local XML only; it does not sign, upload, or
 fabricate a real Sparkle signature.
 
 ```sh
-apps/neondiff-desktop/script/generate-appcast.sh \
-  --fixture apps/neondiff-desktop/fixtures/appcast/beta.json \
-  --output /Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/neondiff-beta-appcast.xml \
+script/generate-appcast.sh \
+  --fixture fixtures/appcast/beta.json \
+  --output "$RELEASE_EVIDENCE_DIR/appcast.xml" \
   --dry-run
 ```
 
@@ -323,7 +350,7 @@ License boundary:
 Create a public-safe packet under:
 
 ```text
-/Users/m1/Codex/evidence/neondiff-desktop/<date>/<version>/
+$RELEASE_EVIDENCE_DIR/
 ```
 
 Minimum files:

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -43,7 +43,7 @@ re-update, immutable release assets, and live customer evidence.
 
 ## Durable Plan Contract
 
-Use the initializer in `apps/neondiff-desktop/docs/appcast-channels.md` to set `NEONDIFF_EVIDENCE_ROOT`, `RELEASE_DATE`, `RUN_ID`, and reserved external immutable `RUN_DIR`; use that same `RUN_DIR` for every local packet path and never store secrets or customer data there.
+Use exactly one equivalent initializer in `apps/neondiff-desktop/docs/appcast-channels.md` or `apps/neondiff-desktop/docs/mac-release-runbook.md` to set `NEONDIFF_EVIDENCE_ROOT`, `RELEASE_DATE`, `RUN_ID`, and reserved external immutable `RUN_DIR`; never rerun it for the same ID, reuse that `RUN_DIR` for every local packet path, and never store secrets or customer data there.
 
 - Goal: define the desktop auto-update channel contract for NeonDiff Desktop using
   the selected Sparkle 2 path without weakening release governance or license boundaries.

--- a/docs/desktop-auto-update-channel.md
+++ b/docs/desktop-auto-update-channel.md
@@ -6,7 +6,7 @@ contains the real Sparkle controller and release-build configuration gate. No
 hosted appcast, signed update, installed update, rollback, or public release is
 proven by source alone.
 
-## Current Implementation — 2026-07-28
+## Current Implementation — reconciled against `8de8840` (2026-08-24)
 
 - The native SwiftUI executable uses the existing Sparkle 2 dependency and
   standard updater UI in
@@ -43,31 +43,33 @@ re-update, immutable release assets, and live customer evidence.
 
 ## Durable Plan Contract
 
-- Goal: define the desktop auto-update channel contract for NeonDiff Desktop so
-  future implementation can choose Sparkle, Tauri updater, or an equivalent
-  signed updater without weakening release governance or license boundaries.
-- Resume identity: repo `electricsheephq/evaos-code-review-bot`, branch
-  `codex/116-desktop-autoupdate-plan`, base
-  `1e28bf8ee0bfe42d0a7f3cc47ed76508497efe96`, issue
-  https://github.com/electricsheephq/evaos-code-review-bot/issues/116, parent
-  tracker https://github.com/electricsheephq/evaos-code-review-bot/issues/103.
+Use the initializer in `apps/neondiff-desktop/docs/appcast-channels.md` to set `NEONDIFF_EVIDENCE_ROOT`, `RELEASE_DATE`, `RUN_ID`, and reserved external immutable `RUN_DIR`; use that same `RUN_DIR` for every local packet path and never store secrets or customer data there.
+
+- Goal: define the desktop auto-update channel contract for NeonDiff Desktop using
+  the selected Sparkle 2 path without weakening release governance or license boundaries.
+- Resume identity: repo `electricsheephq/evaos-code-review-bot-neondiff`, branch
+  `main`, base
+  `8de8840282657ffe457c78132ad0a31328695f68`, issue
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116,
+  parent tracker
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103.
 - Tracking / source of truth: GitHub issues and PRs own implementation truth;
   `docs/release-governance.md`, `docs/license-boundary.md`, and
   `docs/public-release-manifest.json` own current release and license wording;
   Notion/Company OS remains architecture and evidence routing; no live runtime
   or roadmap state is changed by this document.
-- Scope / non-goals: no updater implementation, no Sparkle or Tauri dependency
-  selection, no signing/notarization setup, no private key material, no appcast
-  publication, no installer distribution, no license API implementation, no
-  launchd/runtime change, and no claim that desktop auto-update is shipped.
+- Scope / non-goals: no updater implementation, signing/notarization setup,
+  private key material, appcast publication, installer distribution, license API
+  implementation, launchd/runtime change, or claim that desktop auto-update is
+  shipped.
 - Current state: NeonDiff is a source-available beta; desktop update channels
-  are marked `post_1_0` and non-required in `docs/public-release-manifest.json`;
-  `docs/neondiff-desktop.md` describes a development-only unsigned desktop
-  scaffold; issue #111 owns license activation and issue #114 owns the legacy
-  desktop shell audit.
-- Exact next action: after desktop shell choice and license activation design
-  are settled, create an implementation issue or PR that wires a signed local or
-  static update-manifest dry run before any public appcast or artifact channel.
+  are represented by `signed-appcast-desktop-post-launch` with `requiredForV1: false`
+  in `docs/public-release-manifest.json`. The native source has a Sparkle 2
+  controller and Release configuration gate, but no signed-feed or installed-update proof.
+  Issue #111 owns license activation and #610 owns the Mac GA artifact boundary.
+- Exact next action: implement and test the single promotion, containment, and
+  rollback path required by `docs/architecture/mac-ga-release-contract.md`;
+  only then run owner-gated #116/#322/#323 evidence from an exact candidate.
 - Critical invariants: every downloaded gated artifact must be entitlement
   checked before download, signature verified before install, tied to a channel
   manifest, rollbackable to a last-known-good release, and backed by public-safe
@@ -87,18 +89,17 @@ re-update, immutable release assets, and live customer evidence.
   - Dataset/scenario refs: issue #116 acceptance criteria, issue #111 license
     activation contract, issue #114 desktop shell audit, issue #112 release
     governance, and `docs/public-release-manifest.json`.
-  - Baseline/comparison: current `post_1_0` deferred desktop channel in
-    `docs/public-release-manifest.json`.
+  - Baseline/comparison: current non-required `signed-appcast-desktop-post-launch` manifest stage.
   - Metrics and thresholds: update check distinguishes no-update,
     update-available, blocked-by-license, network-error, and signature-error;
     invalid signatures never install; gated artifacts never download without a
     valid entitlement when policy requires one; rollback target resolves to a
     signed last-known-good release.
   - Runner/CI location: future GitHub Actions plus local evidence packet under
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$RUN_DIR/`.
   - Failure owner: desktop/update implementation owner for future PRs.
   - Eval evidence path:
-    `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/`.
+    `$RUN_DIR/`.
   - Trace feedback target: issue #116, the implementation PR, release notes,
     and the public release manifest.
   - Eval proof boundary: proves only planning readiness until implementation
@@ -115,7 +116,7 @@ re-update, immutable release assets, and live customer evidence.
   rollback; update status cannot distinguish license, network, and signature
   failures; docs or release notes claim shipped updater before fixture evidence.
 - Evidence path / packet:
-  `/Volumes/LEXAR/Codex/evidence/neondiff-desktop-auto-update/<date>/` plus
+  `$RUN_DIR/` plus
   linked GitHub issue, PR, release, workflow run, and artifact identities.
 
 ## Channel Model
@@ -123,11 +124,12 @@ re-update, immutable release assets, and live customer evidence.
 The desktop channel should be explicit in update metadata rather than inferred
 from branch names, app names, or runtime config.
 
-- `beta`: pre-stable desktop channel for signed test artifacts and release
-  candidates. Beta may be license-gated and must remain rollbackable.
-- `stable`: future channel for public-ready signed artifacts after beta evidence
-  proves update checks, entitlement behavior, signature failure handling, and
-  rollback.
+- `beta`: pre-stable desktop channel for fixture or signed candidate artifacts.
+  Beta may be license-gated and must remain rollbackable; beta evidence never
+  implies a public or GA release.
+- `stable`: future channel for public-ready signed artifacts only after #116
+  and the #610 immutable artifact/feed/install/rollback gates pass. Stable must
+  not alias the beta feed.
 - `disabled`: server-side or static-manifest state that makes the desktop report
   a clear no-update or channel-disabled result without attempting a download.
 - `rollback`: pointer to the last-known-good signed version. Rollback metadata
@@ -192,16 +194,16 @@ channel, the release lane must provide evidence for:
 - rollback manifest fixture resolving to a signed last-known-good artifact
 - release notes naming source commit, version, artifact identity, and rollback
   target
-- public-safe evidence packet under `/Volumes/LEXAR/Codex/evidence/`
+- public-safe evidence packet under `$RUN_DIR/`
 
 Until those gates exist, `docs/public-release-manifest.json` should keep desktop
 updates non-required and explicitly linked to issue #116.
 
 ## Tracking
 
-- Parent roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
-- Release governance: https://github.com/electricsheephq/evaos-code-review-bot/issues/112
-- License activation: https://github.com/electricsheephq/evaos-code-review-bot/issues/111
-- Desktop shell audit: https://github.com/electricsheephq/evaos-code-review-bot/issues/114
-- Desktop app MVP: https://github.com/electricsheephq/evaos-code-review-bot/issues/115
-- This plan: https://github.com/electricsheephq/evaos-code-review-bot/issues/116
+- Parent roadmap: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103
+- Release governance: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/112
+- License activation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111
+- Desktop shell audit: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/114
+- Desktop app MVP: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/115
+- This plan: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116


### PR DESCRIPTION
Closes #1045. Supersedes closed, unmerged PRs #1047, #1049, #1050, and #1051 under their recorded split/rebuild fallbacks.

## Scope

- rebuilds the three release-facing docs from accepted main
- requires one pre-created canonical external evidence root, one validated ASCII date, and one explicit unique ASCII portable RUN_ID
- exclusively reserves one canonical RUN_DIR and reuses that exact variable and packet path across appcast, release, and auto-update evidence
- rejects direct and symlinked checkout paths, packet/date escapes, malformed or locale-dependent inputs, and run-directory reuse before output
- anchors standalone and release-runbook appcast generation, credential preflight, and every release section to canonical REPO_ROOT
- binds the durable plan to live main and exact signed-appcast-desktop-post-launch requiredForV1 false manifest state
- keeps the package-relative beta fixture and required appcast.xml dry-run contract
- preserves Sparkle 2, #116/#610 ownership, credential custody, rollback states, and proof boundaries

## Identity and envelope

- base: 8de8840282657ffe457c78132ad0a31328695f68
- head: 3f3fd5b732335df74df63c4160feb0d59a3c6890
- files: 3
- cumulative changed lines: 160 (107 additions, 53 deletions), ceiling 160
- coherent initial-review delta: two commits; canonical release appcast command plus one RUN_DIR namespace; cumulative scope unchanged
- architecture: #1045 under #1016 and milestone 11
- agent-authored: yes

## Focused proof

- git diff --check
- npm run check:public-claims
- npm run check:secrets: 913 tracked files
- desktop fixture boundary scan: beta fixture passes
- fixed workstation path, literal date placeholder, stale source/branch/manifest state, duplicate auto-update namespace, and legacy release packet variable scans: no matches
- deterministic containment, date-capture, run-ID, reuse, and no-downstream probes pass
- explicit ASCII date and RUN_ID allowlists reject non-ASCII inputs under C and en_US.UTF-8 locales
- standalone and release-runbook appcast commands use canonical REPO_ROOT; checkout-subdirectory probe produces an 816-byte appcast.xml
- runbook and auto-update surfaces use the same initialized RUN_DIR; exactly one initializer reserves it and must not be rerun for the same ID
- manifest stage and explicit RUN_ID handoff checks pass
- public-safe probe receipt: /Users/m1/Codex/evidence/neondiff/2026-08-23/mac-ga-1.1.0/pr-1045-v5-portable-probe.sh

## Rebuilt review history

- prior closed candidates proved canonicalization/symlink, shell-context, locale, stale-branch, packet-namespace, manifest-state, and explicit-input failures
- every verified blocker is folded into this candidate; none of the prior candidates merged
- live #610 remains the GA execution tracker; the false contrary ownership comment was resolved on #1051
- initial #1052 review found release appcast cwd dependence and a second RELEASE_EVIDENCE_DIR namespace; both are fixed in the one coherent review delta
- fresh exact-head CI, zero unresolved mandatory threads, and delta-only verdicts from the same two blind checkers are required before merge

## Safety and proof boundary

No app, worker, LaunchAgent, configuration, database, Keychain, feed, artifact, billing, customer, signing, notarization, install, update, rollback, or publication state was changed. Passing proves only the three documentation surfaces and runnable local packet examples; it does not prove signed bytes, hosted feeds, installed update/rollback, release, runtime, or customer readiness.