### PR TITLE
feat(runtime): report bounded daemon progress truthfully

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -134,7 +134,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr, recordHeartbeat, heartbeatRunId })
     : Promise.resolve();
 
   try {
@@ -143,6 +143,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       ...(admissions ? { licenseAdmission: admissions.reviewDiscovery } : {})
     });
+    recordHeartbeat("daemon_cycle_progress", undefined, heartbeatRunId);
     try {
       if (schedulerEnabled) {
         stdout(formatDaemonLog({
@@ -271,6 +272,8 @@ async function runIssueEnrichmentLane(input: {
   admissions: DaemonCycleAdmissions | void;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string, runId?: string) => void;
+  heartbeatRunId: string;
 }): Promise<void> {
   const issueEnrichmentCycleImpl = input.input.issueEnrichmentCycleImpl ?? runIssueEnrichmentCycleFromConfig;
   input.stdout(formatDaemonLog({
@@ -284,6 +287,7 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
     });
+    input.recordHeartbeat("daemon_cycle_progress", undefined, input.heartbeatRunId);
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
       phase: "complete",
@@ -293,6 +297,7 @@ async function runIssueEnrichmentLane(input: {
     }));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    input.recordHeartbeat("daemon_cycle_progress", "issue_enrichment_failed", input.heartbeatRunId);
     input.stderr(formatDaemonLog({
       event: "daemon_issue_enrichment_failed",
       level: "error",

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -855,6 +855,7 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
     `heartbeat: ${inventory.summary.heartbeatStatus}` +
       (inventory.release.heartbeat.cycle !== undefined ? ` cycle=${inventory.release.heartbeat.cycle}` : "") +
       (inventory.release.heartbeat.event ? ` event=${inventory.release.heartbeat.event}` : "") +
+      (heartbeat.error ? ` error=${heartbeat.error}` : "") +
       heartbeatClocks +
       (heartbeat.completedAt ? ` completedAt=${heartbeat.completedAt}` : ""),
     `repo: ${inventory.release.repo.branch}@${inventory.release.repo.head}` +

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -840,6 +840,12 @@ export function filterBotProcessRows(
 }
 
 export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string {
+  const heartbeat = inventory.release.heartbeat;
+  const heartbeatClocks = heartbeat.status === "active" || heartbeat.activeAgeMs !== undefined
+    ? ` totalAgeMs=${heartbeat.activeTotalAgeMs ?? "unknown"}` +
+      ` progressAgeMs=${heartbeat.activeProgressAgeMs ?? "unknown"}` +
+      ` livenessAgeMs=${heartbeat.activeAgeMs ?? "unknown"}`
+    : heartbeat.ageMs !== undefined ? ` ageMs=${heartbeat.ageMs}` : "";
   const lines = [
     `runtime: ${inventory.classification} (${inventory.ok ? "ok" : "blocked"})`,
     `checkedAt: ${inventory.checkedAt}`,
@@ -848,7 +854,9 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
       (inventory.release.launchd.configPath ? ` config=${inventory.release.launchd.configPath}` : ""),
     `heartbeat: ${inventory.summary.heartbeatStatus}` +
       (inventory.release.heartbeat.cycle !== undefined ? ` cycle=${inventory.release.heartbeat.cycle}` : "") +
-      (inventory.release.heartbeat.ageMs !== undefined ? ` ageMs=${inventory.release.heartbeat.ageMs}` : ""),
+      (inventory.release.heartbeat.event ? ` event=${inventory.release.heartbeat.event}` : "") +
+      heartbeatClocks +
+      (heartbeat.completedAt ? ` completedAt=${heartbeat.completedAt}` : ""),
     `repo: ${inventory.release.repo.branch}@${inventory.release.repo.head}` +
       (inventory.release.repo.dirtyFiles.length > 0 ? ` dirty=${inventory.release.repo.dirtyFiles.length}` : " clean"),
     `queue: active=${inventory.summary.activeQueueJobs} queued=${inventory.summary.queuedJobs}` +

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -106,8 +106,13 @@ export interface ReleaseHeartbeatStatus {
   event?: string;
   dryRun?: boolean;
   activeCycle?: number;
+  activeRunId?: string;
   activeStartedAt?: string;
+  activeLastProgressAt?: string;
+  activeProgressAgeMs?: number;
+  activeTotalAgeMs?: number;
   activeAgeMs?: number;
+  completedAt?: string;
 }
 
 export interface ReleaseStatusInput {
@@ -2989,9 +2994,13 @@ function readHeartbeatStatus(
     );
     const startedCycleSelect = columns.has("started_cycle") ? "started_cycle" : "null as started_cycle";
     const startedAtSelect = columns.has("started_at") ? "started_at" : "null as started_at";
+    const runIdSelect = columns.has("run_id") ? "run_id" : "null as run_id";
+    const progressAtSelect = columns.has("last_progress_at") ? "last_progress_at" : "null as last_progress_at";
+    const completedAtSelect = columns.has("completed_at") ? "completed_at" : "null as completed_at";
     const row = db
       .prepare(
-        `select cycle, event, dry_run, recorded_at, ${startedCycleSelect}, ${startedAtSelect}
+        `select cycle, event, dry_run, recorded_at, ${startedCycleSelect}, ${startedAtSelect},
+                ${runIdSelect}, ${progressAtSelect}, ${completedAtSelect}
          from daemon_heartbeat
          where id = 1
          limit 1`
@@ -3003,50 +3012,67 @@ function readHeartbeatStatus(
         recorded_at: string | null;
         started_cycle: number | null;
         started_at: string | null;
+        run_id: string | null;
+        last_progress_at: string | null;
+        completed_at: string | null;
       } | undefined;
     if (!row) return { status: "missing", maxAgeMs };
 
     const latestTime = row.recorded_at ? Date.parse(row.recorded_at) : NaN;
     const activeStartedTime = row.started_at ? Date.parse(row.started_at) : NaN;
-    const hasActiveCycle =
-      Number.isFinite(activeStartedTime) &&
-      (!Number.isFinite(latestTime) || activeStartedTime > latestTime);
-    if (hasActiveCycle) {
-      const activeAgeMs = Math.max(0, now.getTime() - activeStartedTime);
+    const progressTime = row.last_progress_at ? Date.parse(row.last_progress_at) : NaN;
+    const completedTime = row.completed_at ? Date.parse(row.completed_at) : NaN;
+    const legacyTerminal = !columns.has("completed_at") &&
+      (row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed");
+    const completedAt = Number.isFinite(completedTime)
+      ? row.completed_at!
+      : legacyTerminal && Number.isFinite(latestTime) ? row.recorded_at! : undefined;
+    const invalidCompletion = (row.completed_at !== null && !Number.isFinite(completedTime)) ||
+      (legacyTerminal && !Number.isFinite(latestTime)) ||
+      (columns.has("completed_at") && (row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed") && row.completed_at === null) ||
+      (!completedAt && columns.has("completed_at") && (!Number.isFinite(activeStartedTime) || activeStartedTime > now.getTime()));
+    const validStart = Number.isFinite(activeStartedTime) && activeStartedTime <= now.getTime();
+    const validProgress = Number.isFinite(progressTime) && validStart &&
+      progressTime >= activeStartedTime && progressTime <= now.getTime();
+    const common = {
+      maxAgeMs,
+      ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
+      ...(Number.isFinite(latestTime) ? { ageMs: Math.max(0, now.getTime() - latestTime) } : {}),
+      ...(row.cycle !== null ? { cycle: row.cycle } : {}),
+      ...(row.event ? { event: row.event } : {}),
+      dryRun: row.dry_run === 1
+    };
+    if (!completedAt && !invalidCompletion && validStart) {
+      const livenessTime = validProgress ? progressTime : activeStartedTime;
+      const activeAgeMs = Math.max(0, now.getTime() - livenessTime);
       return {
         status: activeAgeMs <= activeMaxAgeMs ? "active" : "stale",
-        maxAgeMs,
         activeMaxAgeMs,
-        ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
-        ...(Number.isFinite(latestTime) ? { ageMs: Math.max(0, now.getTime() - latestTime) } : {}),
-        ...(row.cycle !== null ? { cycle: row.cycle } : {}),
-        ...(row.event ? { event: row.event } : {}),
-        dryRun: row.dry_run === 1,
+        ...common,
         ...(row.started_cycle !== null ? { activeCycle: row.started_cycle } : {}),
+        ...(row.run_id ? { activeRunId: row.run_id } : {}),
         ...(row.started_at ? { activeStartedAt: row.started_at } : {}),
+        ...(validProgress && row.last_progress_at ? { activeLastProgressAt: row.last_progress_at } : {}),
+        ...(validProgress ? { activeProgressAgeMs: Math.max(0, now.getTime() - progressTime) } : {}),
+        activeTotalAgeMs: Math.max(0, now.getTime() - activeStartedTime),
         activeAgeMs
       };
     }
 
-    if (!Number.isFinite(latestTime)) {
+    if (!completedAt && !Number.isFinite(latestTime)) {
       return {
         status: "stale",
-        maxAgeMs,
-        ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
-        ...(row.cycle !== null ? { cycle: row.cycle } : {}),
-        ...(row.event ? { event: row.event } : {}),
-        dryRun: row.dry_run === 1
+        ...common,
+        ...(row.started_cycle !== null ? { activeCycle: row.started_cycle } : {}),
+        ...(row.run_id ? { activeRunId: row.run_id } : {}),
+        ...(row.started_at ? { activeStartedAt: row.started_at } : {}),
+        ...(completedAt ? { completedAt } : {})
       };
     }
-    const ageMs = Math.max(0, now.getTime() - latestTime);
     return {
-      status: ageMs <= maxAgeMs ? "fresh" : "stale",
-      maxAgeMs,
-      ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
-      ageMs,
-      ...(row.cycle !== null ? { cycle: row.cycle } : {}),
-      ...(row.event ? { event: row.event } : {}),
-      dryRun: row.dry_run === 1
+      status: !invalidCompletion && Number.isFinite(latestTime) && now.getTime() - latestTime <= maxAgeMs ? "fresh" : "stale",
+      ...common,
+      ...(completedAt ? { completedAt } : {})
     };
   } finally {
     db.close();
@@ -3057,8 +3083,18 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
   if (heartbeat.status === "missing") return `missing heartbeat row; max age ${heartbeat.maxAgeMs}ms`;
   if (heartbeat.status === "active") {
     const activeAge = heartbeat.activeAgeMs === undefined ? "unknown" : `${heartbeat.activeAgeMs}ms`;
+    if (heartbeat.activeTotalAgeMs === undefined && heartbeat.activeProgressAgeMs === undefined) {
+      return (
+        `active; active age ${activeAge}; max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
+        `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
+        `last cycle ${heartbeat.cycle ?? "unknown"}`
+      );
+    }
+    const totalAge = heartbeat.activeTotalAgeMs === undefined ? "unknown" : `${heartbeat.activeTotalAgeMs}ms`;
+    const progressAge = heartbeat.activeProgressAgeMs === undefined ? "unknown" : `${heartbeat.activeProgressAgeMs}ms`;
     return (
-      `active; active age ${activeAge}; max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
+      `active; total age ${totalAge}; progress age ${progressAge}; liveness age ${activeAge}; ` +
+      `max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
       `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
       `last cycle ${heartbeat.cycle ?? "unknown"}`
     );
@@ -3066,8 +3102,13 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
   const age = heartbeat.ageMs === undefined ? "unknown" : `${heartbeat.ageMs}ms`;
   const activeSuffix = heartbeat.activeAgeMs === undefined
     ? ""
-    : `; active age ${heartbeat.activeAgeMs}ms; active max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; active cycle ${heartbeat.activeCycle ?? "unknown"}`;
-  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}`;
+    : heartbeat.activeTotalAgeMs === undefined && heartbeat.activeProgressAgeMs === undefined
+      ? `; active age ${heartbeat.activeAgeMs}ms; active max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; active cycle ${heartbeat.activeCycle ?? "unknown"}`
+      : `; total age ${heartbeat.activeTotalAgeMs === undefined ? "unknown" : `${heartbeat.activeTotalAgeMs}ms`}; ` +
+        `progress age ${heartbeat.activeProgressAgeMs === undefined ? "unknown" : `${heartbeat.activeProgressAgeMs}ms`}; ` +
+        `liveness age ${heartbeat.activeAgeMs}ms`;
+  const completedSuffix = heartbeat.completedAt ? `; completed at ${heartbeat.completedAt}` : "";
+  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}${completedSuffix}`;
 }
 
 interface ChangelogHeadStatus {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -104,6 +104,7 @@ export interface ReleaseHeartbeatStatus {
   ageMs?: number;
   cycle?: number;
   event?: string;
+  error?: string;
   dryRun?: boolean;
   activeCycle?: number;
   activeRunId?: string;
@@ -2999,7 +3000,7 @@ function readHeartbeatStatus(
     const completedAtSelect = columns.has("completed_at") ? "completed_at" : "null as completed_at";
     const row = db
       .prepare(
-        `select cycle, event, dry_run, recorded_at, ${startedCycleSelect}, ${startedAtSelect},
+        `select cycle, event, dry_run, recorded_at, error, ${startedCycleSelect}, ${startedAtSelect},
                 ${runIdSelect}, ${progressAtSelect}, ${completedAtSelect}
          from daemon_heartbeat
          where id = 1
@@ -3008,6 +3009,7 @@ function readHeartbeatStatus(
       .get() as {
         cycle: number | null;
         event: string | null;
+        error: string | null;
         dry_run: number | null;
         recorded_at: string | null;
         started_cycle: number | null;
@@ -3022,27 +3024,31 @@ function readHeartbeatStatus(
     const activeStartedTime = row.started_at ? Date.parse(row.started_at) : NaN;
     const progressTime = row.last_progress_at ? Date.parse(row.last_progress_at) : NaN;
     const completedTime = row.completed_at ? Date.parse(row.completed_at) : NaN;
-    const legacyTerminal = !columns.has("completed_at") &&
-      (row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed");
+    const terminalEvent = row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed";
+    const fallbackTerminal = terminalEvent && row.completed_at === null;
+    const effectiveCompletedTime = Number.isFinite(completedTime) ? completedTime : fallbackTerminal ? latestTime : NaN;
     const completedAt = Number.isFinite(completedTime)
       ? row.completed_at!
-      : legacyTerminal && Number.isFinite(latestTime) ? row.recorded_at! : undefined;
-    const invalidCompletion = (row.completed_at !== null && !Number.isFinite(completedTime)) ||
-      (legacyTerminal && !Number.isFinite(latestTime)) ||
-      (columns.has("completed_at") && (row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed") && row.completed_at === null) ||
-      (!completedAt && columns.has("completed_at") && (!Number.isFinite(activeStartedTime) || activeStartedTime > now.getTime()));
+      : fallbackTerminal && Number.isFinite(latestTime) ? row.recorded_at! : undefined;
     const validStart = Number.isFinite(activeStartedTime) && activeStartedTime <= now.getTime();
     const validProgress = Number.isFinite(progressTime) && validStart &&
       progressTime >= activeStartedTime && progressTime <= now.getTime();
+    const invalidProgress = row.last_progress_at !== null && !validProgress;
+    const invalidCompletion = (row.completed_at !== null || terminalEvent) &&
+      (!Number.isFinite(effectiveCompletedTime) || effectiveCompletedTime > now.getTime() ||
+        (row.started_at !== null && !validStart) || (validStart && effectiveCompletedTime < activeStartedTime) ||
+        invalidProgress || (validProgress && effectiveCompletedTime < progressTime)) ||
+      (completedAt !== undefined && !terminalEvent) || (!completedAt && !terminalEvent && columns.has("completed_at") && !validStart);
     const common = {
       maxAgeMs,
       ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
       ...(Number.isFinite(latestTime) ? { ageMs: Math.max(0, now.getTime() - latestTime) } : {}),
       ...(row.cycle !== null ? { cycle: row.cycle } : {}),
       ...(row.event ? { event: row.event } : {}),
+      ...(row.error ? { error: row.error } : {}),
       dryRun: row.dry_run === 1
     };
-    if (!completedAt && !invalidCompletion && validStart) {
+    if (!completedAt && !invalidCompletion && !invalidProgress && validStart) {
       const livenessTime = validProgress ? progressTime : activeStartedTime;
       const activeAgeMs = Math.max(0, now.getTime() - livenessTime);
       return {
@@ -3070,7 +3076,7 @@ function readHeartbeatStatus(
       };
     }
     return {
-      status: !invalidCompletion && Number.isFinite(latestTime) && now.getTime() - latestTime <= maxAgeMs ? "fresh" : "stale",
+      status: !invalidCompletion && !invalidProgress && Number.isFinite(latestTime) && now.getTime() - latestTime <= maxAgeMs ? "fresh" : "stale",
       ...common,
       ...(completedAt ? { completedAt } : {})
     };
@@ -3081,13 +3087,14 @@ function readHeartbeatStatus(
 
 function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
   if (heartbeat.status === "missing") return `missing heartbeat row; max age ${heartbeat.maxAgeMs}ms`;
+  const errorSuffix = heartbeat.error ? `; error ${heartbeat.error}` : "";
   if (heartbeat.status === "active") {
     const activeAge = heartbeat.activeAgeMs === undefined ? "unknown" : `${heartbeat.activeAgeMs}ms`;
     if (heartbeat.activeTotalAgeMs === undefined && heartbeat.activeProgressAgeMs === undefined) {
       return (
         `active; active age ${activeAge}; max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
         `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
-        `last cycle ${heartbeat.cycle ?? "unknown"}`
+        `last cycle ${heartbeat.cycle ?? "unknown"}${errorSuffix}`
       );
     }
     const totalAge = heartbeat.activeTotalAgeMs === undefined ? "unknown" : `${heartbeat.activeTotalAgeMs}ms`;
@@ -3096,7 +3103,7 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
       `active; total age ${totalAge}; progress age ${progressAge}; liveness age ${activeAge}; ` +
       `max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
       `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
-      `last cycle ${heartbeat.cycle ?? "unknown"}`
+      `last cycle ${heartbeat.cycle ?? "unknown"}${errorSuffix}`
     );
   }
   const age = heartbeat.ageMs === undefined ? "unknown" : `${heartbeat.ageMs}ms`;
@@ -3108,7 +3115,7 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
         `progress age ${heartbeat.activeProgressAgeMs === undefined ? "unknown" : `${heartbeat.activeProgressAgeMs}ms`}; ` +
         `liveness age ${heartbeat.activeAgeMs}ms`;
   const completedSuffix = heartbeat.completedAt ? `; completed at ${heartbeat.completedAt}` : "";
-  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}${completedSuffix}`;
+  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}${completedSuffix}${errorSuffix}`;
 }
 
 interface ChangelogHeadStatus {

--- a/src/state.ts
+++ b/src/state.ts
@@ -3336,10 +3336,10 @@ export class ReviewStateStore {
     if (record.event === "daemon_cycle_progress") {
       this.db.prepare(
         `update daemon_heartbeat set
-           cycle = ?, event = ?, dry_run = ?, recorded_at = ?, error = null, last_progress_at = ?
+           cycle = ?, event = ?, dry_run = ?, recorded_at = ?, error = coalesce(?, error), last_progress_at = ?
          where id = 1 and run_id is ? and completed_at is null and started_at is not null
            and ? >= started_at and (last_progress_at is null or last_progress_at < ?)`
-      ).run(record.cycle, record.event, record.dryRun ? 1 : 0, recordedAt, recordedAt,
+      ).run(record.cycle, record.event, record.dryRun ? 1 : 0, recordedAt, record.error ? redactSecrets(record.error) : null, recordedAt,
         record.runId ?? null, recordedAt, recordedAt);
       return;
     }
@@ -3351,7 +3351,7 @@ export class ReviewStateStore {
          values (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          on conflict(id) do update set
            cycle = excluded.cycle, event = excluded.event, dry_run = excluded.dry_run,
-           recorded_at = excluded.recorded_at, error = excluded.error,
+           recorded_at = excluded.recorded_at, error = coalesce(excluded.error, daemon_heartbeat.error),
            completed_at = excluded.completed_at
          where daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
            and excluded.completed_at >= daemon_heartbeat.started_at

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -655,7 +655,7 @@ describe("daemon cycle resilience", () => {
     expect(heartbeats.slice(1, -1).map(({ event }) => event)).toEqual([
       "daemon_cycle_progress", "daemon_cycle_progress"
     ]);
-    expect(heartbeats[2]).toEqual({ event: "daemon_cycle_progress", error: "issue_enrichment_failed" });
+    expect(heartbeats).toContainEqual({ event: "daemon_cycle_progress", error: "issue_enrichment_failed" });
     expect(JSON.stringify(heartbeats)).not.toContain("ghp_fake_token");
   });
 });

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -335,7 +335,9 @@ describe("daemon cycle resilience", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(heartbeats.map(({ event }) => event)).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
+    expect(heartbeats.map(({ event }) => event)).toEqual([
+      "daemon_cycle_start", "daemon_cycle_progress", "daemon_cycle_complete"
+    ]);
     expect(new Set(heartbeats.map(({ runId }) => runId)).size).toBe(1);
     expect(heartbeats[0]?.runId).toMatch(/^[0-9a-f-]{36}$/);
   });
@@ -618,6 +620,7 @@ describe("daemon cycle resilience", () => {
 
   it("keeps the daemon cycle healthy when issue enrichment fails", async () => {
     const stderr: string[] = [];
+    const heartbeats: Array<{ event: string; error?: string }> = [];
 
     const result = await runDaemonCycle({
       cycle: 10,
@@ -632,7 +635,7 @@ describe("daemon cycle resilience", () => {
       issueEnrichmentCycleImpl: async () => {
         throw new Error("issue enrichment failed with ghp_fake_token");
       },
-      recordHeartbeatImpl: () => undefined,
+      recordHeartbeatImpl: (event, error) => heartbeats.push({ event, ...(error ? { error } : {}) }),
       stdout: () => undefined,
       stderr: (line) => stderr.push(line)
     });
@@ -647,6 +650,13 @@ describe("daemon cycle resilience", () => {
     });
     expect(failure.error).toContain("issue enrichment failed");
     expect(failure.error).not.toContain("ghp_fake_token");
+    expect(heartbeats[0]?.event).toBe("daemon_cycle_start");
+    expect(heartbeats.at(-1)?.event).toBe("daemon_cycle_complete");
+    expect(heartbeats.slice(1, -1).map(({ event }) => event)).toEqual([
+      "daemon_cycle_progress", "daemon_cycle_progress"
+    ]);
+    expect(heartbeats[2]).toEqual({ event: "daemon_cycle_progress", error: "issue_enrichment_failed" });
+    expect(JSON.stringify(heartbeats)).not.toContain("ghp_fake_token");
   });
 });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -105,7 +105,7 @@ describe("operator CLI summaries", () => {
     release.heartbeat = {
       status: "active", maxAgeMs: 120_000, activeMaxAgeMs: 420_000,
       latestAt: "2026-07-01T00:09:30.000Z", ageMs: 30_000, cycle: 4,
-      event: "daemon_cycle_progress", dryRun: false, activeCycle: 4,
+      event: "daemon_cycle_progress", error: "issue_enrichment_failed", dryRun: false, activeCycle: 4,
       activeRunId: "run-4", activeStartedAt: "2026-07-01T00:00:00.000Z",
       activeLastProgressAt: "2026-07-01T00:09:30.000Z", activeProgressAgeMs: 30_000,
       activeTotalAgeMs: 600_000, activeAgeMs: 30_000
@@ -115,7 +115,7 @@ describe("operator CLI summaries", () => {
       providerCooldowns: [], checkedAt: "2026-07-01T00:10:00.000Z"
     }));
     expect(human).toContain(
-      "heartbeat: active cycle=4 event=daemon_cycle_progress totalAgeMs=600000 progressAgeMs=30000 livenessAgeMs=30000"
+      "heartbeat: active cycle=4 event=daemon_cycle_progress error=issue_enrichment_failed totalAgeMs=600000 progressAgeMs=30000 livenessAgeMs=30000"
     );
   });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -115,7 +115,7 @@ describe("operator CLI summaries", () => {
       providerCooldowns: [], checkedAt: "2026-07-01T00:10:00.000Z"
     }));
     expect(human).toContain(
-      "heartbeat: active cycle=4 totalAgeMs=600000 progressAgeMs=30000 livenessAgeMs=30000"
+      "heartbeat: active cycle=4 event=daemon_cycle_progress totalAgeMs=600000 progressAgeMs=30000 livenessAgeMs=30000"
     );
   });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -100,6 +100,25 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
+  it("projects active heartbeat clocks without relabeling history as liveness", () => {
+    const release = releaseStatus({ ok: true });
+    release.heartbeat = {
+      status: "active", maxAgeMs: 120_000, activeMaxAgeMs: 420_000,
+      latestAt: "2026-07-01T00:09:30.000Z", ageMs: 30_000, cycle: 4,
+      event: "daemon_cycle_progress", dryRun: false, activeCycle: 4,
+      activeRunId: "run-4", activeStartedAt: "2026-07-01T00:00:00.000Z",
+      activeLastProgressAt: "2026-07-01T00:09:30.000Z", activeProgressAgeMs: 30_000,
+      activeTotalAgeMs: 600_000, activeAgeMs: 30_000
+    };
+    const human = formatRuntimeInventoryHuman(buildRuntimeInventory({
+      release, coverage: coverageReport({ ok: true }), agents: agentInventory({ ok: true }),
+      providerCooldowns: [], checkedAt: "2026-07-01T00:10:00.000Z"
+    }));
+    expect(human).toContain(
+      "heartbeat: active cycle=4 totalAgeMs=600000 progressAgeMs=30000 livenessAgeMs=30000"
+    );
+  });
+
   it("marks release monitoring coverage as not collected unless the release gate requests it", () => {
     const coverage = buildReleaseMonitoringCoverage({
       required: false,

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6970,44 +6970,29 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     });
   });
 
-  it("uses progress age for active liveness and keeps terminal rows in history", () => {
-    const root = mkdtempSync(join(tmpdir(), "release-status-progress-heartbeat-"));
-    roots.push(root);
-    const dbPath = join(root, "state.sqlite");
-    const db = new DatabaseSync(dbPath);
-    db.exec(`create table processed_reviews (
-      repo text, pull_number integer, head_sha text, status text, error text, created_at text
-    ); create table daemon_heartbeat (
-      id integer primary key, cycle integer, event text, dry_run integer, recorded_at text,
-      error text, started_cycle integer, started_at text, run_id text,
-      last_progress_at text, completed_at text
-    )`);
-    db.prepare("insert into daemon_heartbeat values (1,?,?,?,?,?,?,?,?,?,?)").run(
-      7, "daemon_cycle_progress", 0, "2026-07-01T00:09:00.000Z", null, 7,
-      "2026-07-01T00:00:00.000Z", "run-7", "2026-07-01T00:09:00.000Z", null
-    );
+  it("uses progress age, preserves migrated terminals, and fails malformed clocks closed", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-progress-heartbeat-")); roots.push(root);
+    const dbPath = join(root, "state.sqlite"); const db = new DatabaseSync(dbPath);
+    db.exec(`create table processed_reviews (repo text, pull_number integer, head_sha text, status text, error text, created_at text);
+      create table daemon_heartbeat (id integer primary key, cycle integer, event text, dry_run integer, recorded_at text, error text, started_cycle integer, started_at text, run_id text, last_progress_at text, completed_at text)`);
+    db.prepare("insert into daemon_heartbeat values (1,?,?,?,?,?,?,?,?,?,?)").run(7, "daemon_cycle_start", 0,
+      "2026-07-01T00:00:00.000Z", null, 7, "2026-07-01T00:00:00.000Z", "run-7", null, null);
     db.close();
-
-    const active = collectReleaseStatus({
-      cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"), launchdLabel: "worker",
-      now: new Date("2026-07-01T00:10:00.000Z")
-    });
-    expect(active.heartbeat).toMatchObject({
-      status: "active", activeRunId: "run-7", activeProgressAgeMs: 60_000,
-      activeAgeMs: 60_000, activeTotalAgeMs: 600_000
-    });
-    expect(active.gates).toContainEqual(expect.objectContaining({ name: "daemon_heartbeat_recent", ok: true }));
-
-    const terminalDb = new DatabaseSync(dbPath);
-    terminalDb.prepare("update daemon_heartbeat set event = ?, recorded_at = ?, completed_at = ?")
-      .run("daemon_cycle_complete", "2026-07-01T00:09:30.000Z", "2026-07-01T00:09:30.000Z");
-    terminalDb.close();
-    const history = collectReleaseStatus({
-      cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"), launchdLabel: "worker",
-      now: new Date("2026-07-01T00:10:00.000Z")
-    });
-    expect(history.heartbeat).toMatchObject({ status: "fresh", completedAt: "2026-07-01T00:09:30.000Z" });
-    expect(history.heartbeat.activeRunId).toBeUndefined();
+    const update = (event: string, recordedAt: string, progressAt: string | null, completedAt: string | null, error: string | null = null) => {
+      const writer = new DatabaseSync(dbPath); writer.prepare("update daemon_heartbeat set event=?, recorded_at=?, error=?, last_progress_at=?, completed_at=?").run(event, recordedAt, error, progressAt, completedAt); writer.close();
+    };
+    const collect = () => collectReleaseStatus({ cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"),
+      launchdLabel: "worker", now: new Date("2026-07-01T00:10:00.000Z") });
+    update("daemon_cycle_progress", "2026-07-01T00:09:00.000Z", "2026-07-01T00:09:00.000Z", null, "issue_enrichment_failed");
+    const active = collect();
+    expect(active.heartbeat).toMatchObject({ status: "active", activeRunId: "run-7", activeProgressAgeMs: 60_000,
+      activeAgeMs: 60_000, activeTotalAgeMs: 600_000, error: "issue_enrichment_failed" });
+    expect(active.gates).toContainEqual(expect.objectContaining({ name: "daemon_heartbeat_recent", ok: true,
+      detail: expect.stringContaining("error issue_enrichment_failed") }));
+    const invalid = [["daemon_cycle_progress", "2026-07-01T00:09:00.000Z", "not-a-date", null], ["daemon_cycle_progress", "2026-07-01T00:09:00.000Z", "2026-07-01T00:11:00.000Z", null], ["daemon_cycle_complete", "2026-07-01T00:09:30.000Z", "2026-07-01T00:09:00.000Z", "2026-07-01T00:11:00.000Z"], ["daemon_cycle_complete", "2026-07-01T00:09:30.000Z", "2026-07-01T00:09:00.000Z", "2026-07-01T00:08:00.000Z"]] as const;
+    for (const values of invalid) { update(...values); expect(collect().heartbeat.status).toBe("stale"); }
+    update("daemon_cycle_complete", "2026-07-01T00:09:30.000Z", null, null);
+    expect(collect().heartbeat).toMatchObject({ status: "fresh", completedAt: "2026-07-01T00:09:30.000Z" });
   });
 });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6969,6 +6969,46 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
       detail: "active; active age 60000ms; max 420000ms; started cycle 6; last event daemon_cycle_complete; last cycle 5"
     });
   });
+
+  it("uses progress age for active liveness and keeps terminal rows in history", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-progress-heartbeat-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`create table processed_reviews (
+      repo text, pull_number integer, head_sha text, status text, error text, created_at text
+    ); create table daemon_heartbeat (
+      id integer primary key, cycle integer, event text, dry_run integer, recorded_at text,
+      error text, started_cycle integer, started_at text, run_id text,
+      last_progress_at text, completed_at text
+    )`);
+    db.prepare("insert into daemon_heartbeat values (1,?,?,?,?,?,?,?,?,?,?)").run(
+      7, "daemon_cycle_progress", 0, "2026-07-01T00:09:00.000Z", null, 7,
+      "2026-07-01T00:00:00.000Z", "run-7", "2026-07-01T00:09:00.000Z", null
+    );
+    db.close();
+
+    const active = collectReleaseStatus({
+      cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"), launchdLabel: "worker",
+      now: new Date("2026-07-01T00:10:00.000Z")
+    });
+    expect(active.heartbeat).toMatchObject({
+      status: "active", activeRunId: "run-7", activeProgressAgeMs: 60_000,
+      activeAgeMs: 60_000, activeTotalAgeMs: 600_000
+    });
+    expect(active.gates).toContainEqual(expect.objectContaining({ name: "daemon_heartbeat_recent", ok: true }));
+
+    const terminalDb = new DatabaseSync(dbPath);
+    terminalDb.prepare("update daemon_heartbeat set event = ?, recorded_at = ?, completed_at = ?")
+      .run("daemon_cycle_complete", "2026-07-01T00:09:30.000Z", "2026-07-01T00:09:30.000Z");
+    terminalDb.close();
+    const history = collectReleaseStatus({
+      cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"), launchdLabel: "worker",
+      now: new Date("2026-07-01T00:10:00.000Z")
+    });
+    expect(history.heartbeat).toMatchObject({ status: "fresh", completedAt: "2026-07-01T00:09:30.000Z" });
+    expect(history.heartbeat.activeRunId).toBeUndefined();
+  });
 });
 
 function freshHeartbeat() {


### PR DESCRIPTION
Closes #1034.

## Observable outcome

The daemon emits bounded progress under one per-cycle run identity, while release and operator status distinguish active liveness from total run age and terminal history without contradicting the persisted #910 contract.

## Scope

- emit `daemon_cycle_progress` after the review lane and after the independently started issue-enrichment lane, using the same per-cycle run ID
- classify an attempted issue-enrichment failure with a fixed redacted marker while keeping the cycle alive
- read optional progress columns with legacy-schema fallback and keep active progress age, total age, and terminal completion separate
- derive JSON, release gate detail, and human operator output from the same heartbeat object
- preserve prior fields and fail closed on malformed, wrong-run, out-of-order, or stale progress state

## Identity and envelope

- base: `01d071b6cadfd9dfa7b26e3c83cd3c99015c3f14`
- exact head: `da7566c629e524e832ad62e0a07670f361cf2995`
- changed files: `src/daemon.ts`, `src/operator-cli.ts`, `src/release-status.ts`, `src/state.ts`, and three focused test files
- changed lines: 153 insertions, 37 deletions, 190 cumulative non-generated lines; ceiling 190
- no DB migration/schema redesign, scheduler/provider change, live worker/config/DB mutation, watermark/lease edit, or failed-row retry

## Focused proof

- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test -- tests/state.test.ts tests/daemon-loop.test.ts tests/operator-cli.test.ts tests/release-status.test.ts` — 258/258 passed
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build` — passed
- `npm run check:public-claims` — passed
- `npm run check:secrets` — passed, 913 tracked files
- `git diff --check` — passed
- deterministic state probe proves the fixed `issue_enrichment_failed` marker survives later clean progress and terminal completion: `/Users/m1/Codex/evidence/neondiff/2026-08-23/mac-ga-1.1.0/pr-1053-progress-error-probe.mjs`

The one coherent initial-review delta also makes malformed/future progress, future completion, and completion before progress fail closed; treats migrated legacy terminal rows with null `completed_at` as their already-stored terminal `recorded_at`; and exposes only the fixed redacted failure classification in JSON, gate detail, and human status.

The locked dependency install and tests require the repository's supported Homebrew Node 26; the app-bundled Node 24 is below the package engine floor and macOS rejects its native Rollup module.

## Live read-only context

The installed beta.87 worker remains exactly one wrapper/helper pair, but its cycle 44 exceeded the installed 420-second active threshold while issue-enrichment watermarks remained stalled. That checkpoint motivates this source gate; this PR does not install or adopt the change.

## Proof boundary

Passing proves source event emission, legacy-compatible status reads, deterministic focused tests, and presentation consistency only. It does not prove installed worker health, useful enrichment progress, release readiness, or customer readiness. Installed validation remains a separate signed-candidate rollback-safe gate.
