### PR TITLE
feat(runtime): report bounded daemon progress safely

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -134,7 +134,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   }));
 
   const issueEnrichmentPromise = input.issueEnrichmentEnabled === true
-    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr })
+    ? runIssueEnrichmentLane({ input, admissions, stdout, stderr, recordHeartbeat, heartbeatRunId })
     : Promise.resolve();
 
   try {
@@ -143,6 +143,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       ...(admissions ? { licenseAdmission: admissions.reviewDiscovery } : {})
     });
+    recordHeartbeat("daemon_cycle_progress", undefined, heartbeatRunId);
     try {
       if (schedulerEnabled) {
         stdout(formatDaemonLog({
@@ -196,7 +197,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       error: message
     }));
-    recordHeartbeat("daemon_cycle_failed", message, heartbeatRunId);
+    recordHeartbeat("daemon_cycle_failed", "daemon_cycle_failed", heartbeatRunId);
     return { ok: false, failureKind: "runtime_failure", error: message };
   }
 }
@@ -271,6 +272,8 @@ async function runIssueEnrichmentLane(input: {
   admissions: DaemonCycleAdmissions | void;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
+  recordHeartbeat: (event: DaemonHeartbeatEvent, error?: string, runId?: string) => void;
+  heartbeatRunId: string;
 }): Promise<void> {
   const issueEnrichmentCycleImpl = input.input.issueEnrichmentCycleImpl ?? runIssueEnrichmentCycleFromConfig;
   input.stdout(formatDaemonLog({
@@ -284,6 +287,7 @@ async function runIssueEnrichmentLane(input: {
       dryRun: input.input.dryRun,
       ...(input.admissions ? { licenseAdmission: input.admissions.issueEnrichment } : {})
     });
+    input.recordHeartbeat("daemon_cycle_progress", undefined, input.heartbeatRunId);
     input.stdout(formatDaemonLog({
       event: "daemon_issue_enrichment",
       phase: "complete",
@@ -293,6 +297,7 @@ async function runIssueEnrichmentLane(input: {
     }));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    input.recordHeartbeat("daemon_cycle_progress", "issue_enrichment_failed", input.heartbeatRunId);
     input.stderr(formatDaemonLog({
       event: "daemon_issue_enrichment_failed",
       level: "error",

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -840,6 +840,12 @@ export function filterBotProcessRows(
 }
 
 export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string {
+  const heartbeat = inventory.release.heartbeat;
+  const heartbeatClocks = heartbeat.status === "active" || heartbeat.activeAgeMs !== undefined
+    ? ` totalAgeMs=${heartbeat.activeTotalAgeMs ?? "unknown"}` +
+      ` progressAgeMs=${heartbeat.activeProgressAgeMs ?? "unknown"}` +
+      ` livenessAgeMs=${heartbeat.activeAgeMs ?? "unknown"}`
+    : heartbeat.ageMs !== undefined ? ` ageMs=${heartbeat.ageMs}` : "";
   const lines = [
     `runtime: ${inventory.classification} (${inventory.ok ? "ok" : "blocked"})`,
     `checkedAt: ${inventory.checkedAt}`,
@@ -847,8 +853,11 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
       (inventory.release.launchd.pid ? ` pid=${inventory.release.launchd.pid}` : "") +
       (inventory.release.launchd.configPath ? ` config=${inventory.release.launchd.configPath}` : ""),
     `heartbeat: ${inventory.summary.heartbeatStatus}` +
-      (inventory.release.heartbeat.cycle !== undefined ? ` cycle=${inventory.release.heartbeat.cycle}` : "") +
-      (inventory.release.heartbeat.ageMs !== undefined ? ` ageMs=${inventory.release.heartbeat.ageMs}` : ""),
+      (heartbeat.cycle !== undefined ? ` cycle=${heartbeat.cycle}` : "") +
+      (heartbeat.event ? ` event=${heartbeat.event}` : "") +
+      (heartbeat.error ? ` error=${heartbeat.error}` : "") +
+      heartbeatClocks +
+      (heartbeat.completedAt ? ` completedAt=${heartbeat.completedAt}` : ""),
     `repo: ${inventory.release.repo.branch}@${inventory.release.repo.head}` +
       (inventory.release.repo.dirtyFiles.length > 0 ? ` dirty=${inventory.release.repo.dirtyFiles.length}` : " clean"),
     `queue: active=${inventory.summary.activeQueueJobs} queued=${inventory.summary.queuedJobs}` +

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -6,7 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { containsSecretLikeText } from "./secrets.js";
-import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
+import { normalizeDaemonHeartbeatError, parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
 import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
 import type { ReviewQueueJobRecord } from "./state.js";
@@ -104,10 +104,16 @@ export interface ReleaseHeartbeatStatus {
   ageMs?: number;
   cycle?: number;
   event?: string;
+  error?: string;
   dryRun?: boolean;
   activeCycle?: number;
+  activeRunId?: string;
   activeStartedAt?: string;
+  activeLastProgressAt?: string;
+  activeProgressAgeMs?: number;
+  activeTotalAgeMs?: number;
   activeAgeMs?: number;
+  completedAt?: string;
 }
 
 export interface ReleaseStatusInput {
@@ -2987,11 +2993,16 @@ function readHeartbeatStatus(
       (db.prepare("pragma table_info(daemon_heartbeat)").all() as unknown as Array<{ name: string }>)
         .map((column) => column.name)
     );
+    const errorSelect = columns.has("error") ? "error" : "null as error";
     const startedCycleSelect = columns.has("started_cycle") ? "started_cycle" : "null as started_cycle";
     const startedAtSelect = columns.has("started_at") ? "started_at" : "null as started_at";
+    const runIdSelect = columns.has("run_id") ? "run_id" : "null as run_id";
+    const progressAtSelect = columns.has("last_progress_at") ? "last_progress_at" : "null as last_progress_at";
+    const completedAtSelect = columns.has("completed_at") ? "completed_at" : "null as completed_at";
     const row = db
       .prepare(
-        `select cycle, event, dry_run, recorded_at, ${startedCycleSelect}, ${startedAtSelect}
+        `select cycle, event, dry_run, recorded_at, ${errorSelect}, ${startedCycleSelect}, ${startedAtSelect},
+                ${runIdSelect}, ${progressAtSelect}, ${completedAtSelect}
          from daemon_heartbeat
          where id = 1
          limit 1`
@@ -2999,54 +3010,81 @@ function readHeartbeatStatus(
       .get() as {
         cycle: number | null;
         event: string | null;
+        error: string | null;
         dry_run: number | null;
         recorded_at: string | null;
         started_cycle: number | null;
         started_at: string | null;
+        run_id: string | null;
+        last_progress_at: string | null;
+        completed_at: string | null;
       } | undefined;
     if (!row) return { status: "missing", maxAgeMs };
 
     const latestTime = row.recorded_at ? Date.parse(row.recorded_at) : NaN;
     const activeStartedTime = row.started_at ? Date.parse(row.started_at) : NaN;
-    const hasActiveCycle =
-      Number.isFinite(activeStartedTime) &&
-      (!Number.isFinite(latestTime) || activeStartedTime > latestTime);
-    if (hasActiveCycle) {
-      const activeAgeMs = Math.max(0, now.getTime() - activeStartedTime);
+    const progressTime = row.last_progress_at ? Date.parse(row.last_progress_at) : NaN;
+    const completedTime = row.completed_at ? Date.parse(row.completed_at) : NaN;
+    const terminalEvent = row.event === "daemon_cycle_complete" || row.event === "daemon_cycle_failed";
+    const fallbackTerminal = terminalEvent && row.completed_at === null;
+    const effectiveCompletedTime = Number.isFinite(completedTime) ? completedTime : fallbackTerminal ? latestTime : NaN;
+    const completedAt = Number.isFinite(completedTime)
+      ? row.completed_at!
+      : fallbackTerminal && Number.isFinite(latestTime) ? row.recorded_at! : undefined;
+    const nowMs = now.getTime();
+    const validLatest = row.recorded_at === null || Number.isFinite(latestTime) && latestTime <= nowMs;
+    const validStart = Number.isFinite(activeStartedTime) && activeStartedTime <= nowMs && (row.recorded_at === null || !Number.isFinite(latestTime) || latestTime >= activeStartedTime);
+    const validProgress = row.last_progress_at !== null && Number.isFinite(progressTime) && validStart &&
+      progressTime >= activeStartedTime && progressTime <= nowMs && Number.isFinite(latestTime) && latestTime >= progressTime;
+    const invalidProgress = row.last_progress_at !== null && !validProgress;
+    const invalidCompletion = ((row.completed_at !== null || terminalEvent) &&
+      (!Number.isFinite(effectiveCompletedTime) || effectiveCompletedTime > nowMs ||
+        (row.started_at !== null && !validStart) || (validStart && effectiveCompletedTime < activeStartedTime) ||
+        (validProgress && effectiveCompletedTime < progressTime) ||
+        (Number.isFinite(latestTime) && effectiveCompletedTime > latestTime) || invalidProgress)) ||
+      (completedAt !== undefined && !terminalEvent);
+    const error = normalizeDaemonHeartbeatError(row.event, row.error);
+    const common = {
+      maxAgeMs,
+      ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
+      ...(Number.isFinite(latestTime) ? { ageMs: Math.max(0, nowMs - latestTime) } : {}),
+      ...(row.cycle !== null ? { cycle: row.cycle } : {}),
+      ...(row.event ? { event: row.event } : {}),
+      ...(error ? { error } : {}),
+      dryRun: row.dry_run === 1
+    };
+    if (!completedAt && !invalidCompletion && !invalidProgress && validStart && validLatest) {
+      const livenessTime = validProgress ? progressTime : activeStartedTime;
+      const activeAgeMs = Math.max(0, nowMs - livenessTime);
       return {
         status: activeAgeMs <= activeMaxAgeMs ? "active" : "stale",
-        maxAgeMs,
         activeMaxAgeMs,
-        ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
-        ...(Number.isFinite(latestTime) ? { ageMs: Math.max(0, now.getTime() - latestTime) } : {}),
-        ...(row.cycle !== null ? { cycle: row.cycle } : {}),
-        ...(row.event ? { event: row.event } : {}),
-        dryRun: row.dry_run === 1,
+        ...common,
         ...(row.started_cycle !== null ? { activeCycle: row.started_cycle } : {}),
+        ...(row.run_id ? { activeRunId: row.run_id } : {}),
         ...(row.started_at ? { activeStartedAt: row.started_at } : {}),
+        ...(validProgress && row.last_progress_at ? { activeLastProgressAt: row.last_progress_at } : {}),
+        ...(validProgress ? { activeProgressAgeMs: Math.max(0, nowMs - progressTime) } : {}),
+        activeTotalAgeMs: Math.max(0, nowMs - activeStartedTime),
         activeAgeMs
       };
     }
 
-    if (!Number.isFinite(latestTime)) {
+    const validTerminal = terminalEvent && !invalidCompletion && !invalidProgress && validLatest && Number.isFinite(latestTime);
+    if (!completedAt && !Number.isFinite(latestTime)) {
       return {
         status: "stale",
-        maxAgeMs,
-        ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
-        ...(row.cycle !== null ? { cycle: row.cycle } : {}),
-        ...(row.event ? { event: row.event } : {}),
-        dryRun: row.dry_run === 1
+        ...common,
+        ...(row.started_cycle !== null ? { activeCycle: row.started_cycle } : {}),
+        ...(row.run_id ? { activeRunId: row.run_id } : {}),
+        ...(row.started_at ? { activeStartedAt: row.started_at } : {}),
+        ...(completedAt ? { completedAt } : {})
       };
     }
-    const ageMs = Math.max(0, now.getTime() - latestTime);
     return {
-      status: ageMs <= maxAgeMs ? "fresh" : "stale",
-      maxAgeMs,
-      ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
-      ageMs,
-      ...(row.cycle !== null ? { cycle: row.cycle } : {}),
-      ...(row.event ? { event: row.event } : {}),
-      dryRun: row.dry_run === 1
+      status: validTerminal && nowMs - latestTime <= maxAgeMs ? "fresh" : "stale",
+      ...common,
+      ...(completedAt ? { completedAt } : {})
     };
   } finally {
     db.close();
@@ -3055,19 +3093,35 @@ function readHeartbeatStatus(
 
 function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
   if (heartbeat.status === "missing") return `missing heartbeat row; max age ${heartbeat.maxAgeMs}ms`;
+  const errorSuffix = heartbeat.error ? `; error ${heartbeat.error}` : "";
   if (heartbeat.status === "active") {
     const activeAge = heartbeat.activeAgeMs === undefined ? "unknown" : `${heartbeat.activeAgeMs}ms`;
+    if (heartbeat.activeTotalAgeMs === undefined && heartbeat.activeProgressAgeMs === undefined) {
+      return (
+        `active; active age ${activeAge}; max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
+        `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
+        `last cycle ${heartbeat.cycle ?? "unknown"}${errorSuffix}`
+      );
+    }
+    const totalAge = heartbeat.activeTotalAgeMs === undefined ? "unknown" : `${heartbeat.activeTotalAgeMs}ms`;
+    const progressAge = heartbeat.activeProgressAgeMs === undefined ? "unknown" : `${heartbeat.activeProgressAgeMs}ms`;
     return (
-      `active; active age ${activeAge}; max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
+      `active; total age ${totalAge}; progress age ${progressAge}; liveness age ${activeAge}; ` +
+      `max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
       `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
-      `last cycle ${heartbeat.cycle ?? "unknown"}`
+      `last cycle ${heartbeat.cycle ?? "unknown"}${errorSuffix}`
     );
   }
   const age = heartbeat.ageMs === undefined ? "unknown" : `${heartbeat.ageMs}ms`;
   const activeSuffix = heartbeat.activeAgeMs === undefined
     ? ""
-    : `; active age ${heartbeat.activeAgeMs}ms; active max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; active cycle ${heartbeat.activeCycle ?? "unknown"}`;
-  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}`;
+    : heartbeat.activeTotalAgeMs === undefined && heartbeat.activeProgressAgeMs === undefined
+      ? `; active age ${heartbeat.activeAgeMs}ms; active max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; active cycle ${heartbeat.activeCycle ?? "unknown"}`
+      : `; total age ${heartbeat.activeTotalAgeMs === undefined ? "unknown" : `${heartbeat.activeTotalAgeMs}ms`}; ` +
+        `progress age ${heartbeat.activeProgressAgeMs === undefined ? "unknown" : `${heartbeat.activeProgressAgeMs}ms`}; ` +
+        `liveness age ${heartbeat.activeAgeMs}ms`;
+  const completedSuffix = heartbeat.completedAt ? `; completed at ${heartbeat.completedAt}` : "";
+  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}${completedSuffix}${errorSuffix}`;
 }
 
 interface ChangelogHeadStatus {

--- a/src/state.ts
+++ b/src/state.ts
@@ -340,6 +340,18 @@ export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecor
 }
 
 export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete" | "daemon_cycle_failed";
+export type DaemonHeartbeatFailureCode = "issue_enrichment_failed" | "daemon_cycle_failed";
+
+export function normalizeDaemonHeartbeatError(
+  event: DaemonHeartbeatEvent | string | null | undefined,
+  error: unknown
+): DaemonHeartbeatFailureCode | undefined {
+  if (error === "issue_enrichment_failed") return "issue_enrichment_failed";
+  if (error === "daemon_cycle_failed") return "daemon_cycle_failed";
+  return event === "daemon_cycle_failed" && typeof error === "string" && error.length > 0
+    ? "daemon_cycle_failed"
+    : undefined;
+}
 
 export interface DaemonHeartbeatRecord {
   cycle: number;
@@ -3312,6 +3324,7 @@ export class ReviewStateStore {
 
   recordDaemonHeartbeat(record: DaemonHeartbeatRecord): void {
     const recordedAt = (record.recordedAt ?? new Date()).toISOString();
+    const error = normalizeDaemonHeartbeatError(record.event, record.error);
     if (record.event === "daemon_cycle_start") {
       const runId = record.runId ?? null;
       const current = this.db.prepare(
@@ -3336,10 +3349,10 @@ export class ReviewStateStore {
     if (record.event === "daemon_cycle_progress") {
       this.db.prepare(
         `update daemon_heartbeat set
-           cycle = ?, event = ?, dry_run = ?, recorded_at = ?, error = null, last_progress_at = ?
+           cycle = ?, event = ?, dry_run = ?, recorded_at = ?, error = coalesce(?, error), last_progress_at = ?
          where id = 1 and run_id is ? and completed_at is null and started_at is not null
            and ? >= started_at and (last_progress_at is null or last_progress_at < ?)`
-      ).run(record.cycle, record.event, record.dryRun ? 1 : 0, recordedAt, recordedAt,
+      ).run(record.cycle, record.event, record.dryRun ? 1 : 0, recordedAt, error ?? null, recordedAt,
         record.runId ?? null, recordedAt, recordedAt);
       return;
     }
@@ -3351,7 +3364,7 @@ export class ReviewStateStore {
          values (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          on conflict(id) do update set
            cycle = excluded.cycle, event = excluded.event, dry_run = excluded.dry_run,
-           recorded_at = excluded.recorded_at, error = excluded.error,
+           recorded_at = excluded.recorded_at, error = coalesce(excluded.error, daemon_heartbeat.error),
            completed_at = excluded.completed_at
          where daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
            and excluded.completed_at >= daemon_heartbeat.started_at
@@ -3363,7 +3376,7 @@ export class ReviewStateStore {
         record.event,
         record.dryRun ? 1 : 0,
         recordedAt,
-        record.error ? redactSecrets(record.error) : null,
+        error ?? null,
         record.cycle,
         recordedAt,
         record.runId ?? null,
@@ -4643,12 +4656,13 @@ function readableQueueText(value: unknown): string {
 }
 
 function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRecord {
+  const error = normalizeDaemonHeartbeatError(row.event, row.error);
   return {
     cycle: row.cycle!,
     event: row.event!,
     dryRun: row.dry_run === 1,
     recordedAt: row.recorded_at!,
-    ...(row.error ? { error: row.error } : {}),
+    ...(error ? { error } : {}),
     ...(row.started_cycle !== null ? { startedCycle: row.started_cycle } : {}),
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.run_id ? { runId: row.run_id } : {}),

--- a/src/state.ts
+++ b/src/state.ts
@@ -342,10 +342,7 @@ export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecor
 export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete" | "daemon_cycle_failed";
 export type DaemonHeartbeatFailureCode = "issue_enrichment_failed" | "daemon_cycle_failed";
 
-export function normalizeDaemonHeartbeatError(
-  event: DaemonHeartbeatEvent | string | null | undefined,
-  error: unknown
-): DaemonHeartbeatFailureCode | undefined {
+export function normalizeDaemonHeartbeatError(event: DaemonHeartbeatEvent | string | null | undefined, error: unknown): DaemonHeartbeatFailureCode | undefined {
   if (error === "issue_enrichment_failed") return "issue_enrichment_failed";
   if (error === "daemon_cycle_failed") return "daemon_cycle_failed";
   return event === "daemon_cycle_failed" && typeof error === "string" && error.length > 0
@@ -3350,8 +3347,9 @@ export class ReviewStateStore {
       this.db.prepare(
         `update daemon_heartbeat set
            cycle = ?, event = ?, dry_run = ?, recorded_at = ?, error = coalesce(?, error), last_progress_at = ?
-         where id = 1 and run_id is ? and completed_at is null and started_at is not null
-           and ? >= started_at and (last_progress_at is null or last_progress_at < ?)`
+         where id = 1 and (event is null or event not in ('daemon_cycle_complete', 'daemon_cycle_failed'))
+           and run_id is ? and completed_at is null and started_at is not null
+           and ? >= started_at and (last_progress_at is null or last_progress_at <= ?)`
       ).run(record.cycle, record.event, record.dryRun ? 1 : 0, recordedAt, error ?? null, recordedAt,
         record.runId ?? null, recordedAt, recordedAt);
       return;
@@ -3366,7 +3364,7 @@ export class ReviewStateStore {
            cycle = excluded.cycle, event = excluded.event, dry_run = excluded.dry_run,
            recorded_at = excluded.recorded_at, error = coalesce(excluded.error, daemon_heartbeat.error),
            completed_at = excluded.completed_at
-         where daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
+         where (daemon_heartbeat.event is null or daemon_heartbeat.event not in ('daemon_cycle_complete', 'daemon_cycle_failed')) and daemon_heartbeat.run_id is excluded.run_id and daemon_heartbeat.completed_at is null
            and excluded.completed_at >= daemon_heartbeat.started_at
            and (daemon_heartbeat.last_progress_at is null
              or excluded.completed_at >= daemon_heartbeat.last_progress_at)`

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -335,7 +335,7 @@ describe("daemon cycle resilience", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(heartbeats.map(({ event }) => event)).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
+    expect(heartbeats.map(({ event }) => event)).toEqual(["daemon_cycle_start", "daemon_cycle_progress", "daemon_cycle_complete"]);
     expect(new Set(heartbeats.map(({ runId }) => runId)).size).toBe(1);
     expect(heartbeats[0]?.runId).toMatch(/^[0-9a-f-]{36}$/);
   });
@@ -482,7 +482,7 @@ describe("daemon cycle resilience", () => {
     expect(result).toMatchObject({ failureKind: "runtime_failure" });
     expect(heartbeats).toEqual([
       { event: "daemon_cycle_start" },
-      { event: "daemon_cycle_failed", error: "second timeout" }
+      { event: "daemon_cycle_failed", error: "daemon_cycle_failed" }
     ]);
     expect(new Set(runIds).size).toBe(1);
   });
@@ -618,6 +618,7 @@ describe("daemon cycle resilience", () => {
 
   it("keeps the daemon cycle healthy when issue enrichment fails", async () => {
     const stderr: string[] = [];
+    const heartbeats: Array<{ event: string; error?: string }> = [];
 
     const result = await runDaemonCycle({
       cycle: 10,
@@ -632,7 +633,7 @@ describe("daemon cycle resilience", () => {
       issueEnrichmentCycleImpl: async () => {
         throw new Error("issue enrichment failed with ghp_fake_token");
       },
-      recordHeartbeatImpl: () => undefined,
+      recordHeartbeatImpl: (event, error) => heartbeats.push({ event, ...(error ? { error } : {}) }),
       stdout: () => undefined,
       stderr: (line) => stderr.push(line)
     });
@@ -647,6 +648,7 @@ describe("daemon cycle resilience", () => {
     });
     expect(failure.error).toContain("issue enrichment failed");
     expect(failure.error).not.toContain("ghp_fake_token");
+    expect(heartbeats).toContainEqual({ event: "daemon_cycle_progress", error: "issue_enrichment_failed" });
   });
 });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6969,6 +6969,10 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
       detail: "active; active age 60000ms; max 420000ms; started cycle 6; last event daemon_cycle_complete; last cycle 5"
     });
   });
+  it("projects legacy heartbeat failures safely and fails future clocks closed", () => { const root = mkdtempSync(join(tmpdir(), "release-status-safe-heartbeat-")); roots.push(root); const dbPath = join(root, "state.sqlite"); const db = new DatabaseSync(dbPath); db.exec("create table processed_reviews (repo text, pull_number integer, head_sha text, status text, error text, created_at text); create table daemon_heartbeat (id integer primary key, cycle integer, event text, dry_run integer, recorded_at text, error text, started_cycle integer, started_at text, run_id text, last_progress_at text, completed_at text)"); db.prepare("insert into daemon_heartbeat values (1,?,?,?,?,?,?,?,?,?,?)").run(7, "daemon_cycle_failed", 0, "2026-07-01T00:09:00.000Z", "review failed for customer_repo owner/private-repo PR-42", 7, "2026-07-01T00:00:00.000Z", "run-7", null, null); db.close();
+    const collect = (at = "2026-07-01T00:10:00.000Z") => collectReleaseStatus({ cwd: repoRoot, statePath: dbPath, configPath: join(root, "missing.json"), launchdLabel: "worker", now: new Date(at) }); const status = collect();
+    expect(status.heartbeat).toMatchObject({ status: "fresh", error: "daemon_cycle_failed", completedAt: "2026-07-01T00:09:00.000Z" }); expect(JSON.stringify(status)).not.toContain("owner/private-repo");
+    const future = new DatabaseSync(dbPath); future.prepare("update daemon_heartbeat set recorded_at=?").run("2026-07-01T00:11:00.000Z"); future.close(); expect(collect().heartbeat.status).toBe("stale"); });
 });
 
 function freshHeartbeat() {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1788,12 +1788,12 @@ describe("review state store", () => {
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
 
-    const record = (event: "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete", runId: string, at: string) =>
-      store.recordDaemonHeartbeat({ cycle: 1, event, dryRun: false, runId, recordedAt: new Date(at) });
+    const record = (event: "daemon_cycle_start" | "daemon_cycle_progress" | "daemon_cycle_complete", runId: string, at: string, error?: string) =>
+      store.recordDaemonHeartbeat({ cycle: 1, event, dryRun: false, runId, recordedAt: new Date(at), ...(error ? { error } : {}) });
     record("daemon_cycle_start", "run-a", "2026-07-01T00:00:00.000Z");
     record("daemon_cycle_start", "run-a", "2026-07-01T00:00:05.000Z");
-    record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:00.000Z");
-    record("daemon_cycle_progress", "run-a", "2026-07-01T00:00:30.000Z");
+    record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:00.000Z", "issue_enrichment_failed");
+    record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:30.000Z");
     record("daemon_cycle_progress", "run-b", "2026-07-01T00:02:00.000Z");
     record("daemon_cycle_complete", "run-a", "2026-07-01T00:03:00.000Z");
 
@@ -1801,11 +1801,12 @@ describe("review state store", () => {
       cycle: 1,
       event: "daemon_cycle_complete",
       dryRun: false,
+      error: "issue_enrichment_failed",
       recordedAt: "2026-07-01T00:03:00.000Z",
       startedCycle: 1,
       startedAt: "2026-07-01T00:00:00.000Z",
       runId: "run-a",
-      lastProgressAt: "2026-07-01T00:01:00.000Z",
+      lastProgressAt: "2026-07-01T00:01:30.000Z",
       completedAt: "2026-07-01T00:03:00.000Z"
     });
     record("daemon_cycle_start", "run-b", "2026-07-01T01:00:00.000Z");
@@ -1880,8 +1881,11 @@ describe("review state store", () => {
     expect(store.getDaemonHeartbeat()).toMatchObject({
       cycle: 2,
       event: "daemon_cycle_failed",
-      error: "request failed with [redacted-secret]"
+      error: "daemon_cycle_failed"
     });
+    const raw = new DatabaseSync(join(root, "state.sqlite"), { readOnly: true });
+    expect(raw.prepare("select error from daemon_heartbeat where id = 1").get()).toEqual({ error: "daemon_cycle_failed" });
+    raw.close();
     store.close();
   });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1792,8 +1792,8 @@ describe("review state store", () => {
       store.recordDaemonHeartbeat({ cycle: 1, event, dryRun: false, runId, recordedAt: new Date(at), ...(error ? { error } : {}) });
     record("daemon_cycle_start", "run-a", "2026-07-01T00:00:00.000Z");
     record("daemon_cycle_start", "run-a", "2026-07-01T00:00:05.000Z");
+    record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:00.000Z");
     record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:00.000Z", "issue_enrichment_failed");
-    record("daemon_cycle_progress", "run-a", "2026-07-01T00:01:30.000Z");
     record("daemon_cycle_progress", "run-b", "2026-07-01T00:02:00.000Z");
     record("daemon_cycle_complete", "run-a", "2026-07-01T00:03:00.000Z");
 
@@ -1806,7 +1806,7 @@ describe("review state store", () => {
       startedCycle: 1,
       startedAt: "2026-07-01T00:00:00.000Z",
       runId: "run-a",
-      lastProgressAt: "2026-07-01T00:01:30.000Z",
+      lastProgressAt: "2026-07-01T00:01:00.000Z",
       completedAt: "2026-07-01T00:03:00.000Z"
     });
     record("daemon_cycle_start", "run-b", "2026-07-01T01:00:00.000Z");
@@ -1840,7 +1840,7 @@ describe("review state store", () => {
         startedAt: "2026-07-01T00:00:00.000Z",
         completedAt: "2026-07-01T00:04:00.000Z"
       });
-      expect(store.getDaemonHeartbeat()?.lastProgressAt).toBeUndefined();
+      store.recordDaemonHeartbeat({ cycle: 4, event: "daemon_cycle_progress", dryRun: false, recordedAt: new Date("2026-07-01T00:05:00.000Z") }); store.recordDaemonHeartbeat({ cycle: 4, event: "daemon_cycle_complete", dryRun: false, recordedAt: new Date("2026-07-01T00:06:00.000Z") }); expect(store.getDaemonHeartbeat()).toMatchObject({ event: "daemon_cycle_failed", recordedAt: "2026-07-01T00:04:00.000Z", completedAt: "2026-07-01T00:04:00.000Z" }); expect(store.getDaemonHeartbeat()?.lastProgressAt).toBeUndefined();
       store.close();
     }
     const rollbackReader = new DatabaseSync(statePath, { readOnly: true });
@@ -1883,9 +1883,7 @@ describe("review state store", () => {
       event: "daemon_cycle_failed",
       error: "daemon_cycle_failed"
     });
-    const raw = new DatabaseSync(join(root, "state.sqlite"), { readOnly: true });
-    expect(raw.prepare("select error from daemon_heartbeat where id = 1").get()).toEqual({ error: "daemon_cycle_failed" });
-    raw.close();
+    const raw = new DatabaseSync(join(root, "state.sqlite"), { readOnly: true }); expect(raw.prepare("select error from daemon_heartbeat where id = 1").get()).toEqual({ error: "daemon_cycle_failed" }); raw.close();
     store.close();
   });
 


### PR DESCRIPTION
Closes #1034.

## Observable outcome

The daemon emits bounded progress under one per-cycle run identity, while release and operator status distinguish active liveness from total run age and terminal history without contradicting the persisted #910 contract or exposing diagnostic payload as release classification.

This clean replacement supersedes closed, unmerged PR #1053 after its final adversarial review reproduced raw repository/customer text in heartbeat status.

## Scope

- emit `daemon_cycle_progress` after the review lane and after the independently started issue-enrichment lane, using the same per-cycle run ID
- classify attempted issue-enrichment and terminal daemon failures with finite code-owned markers while keeping detailed prose in existing redacted logs only
- normalize both new persistence and legacy-row projection so arbitrary failure text never reaches heartbeat state, JSON, release gate detail, or human operator output
- read optional progress columns with legacy-schema fallback and keep active progress age, total age, and terminal completion separate
- preserve prior fields and fail closed on malformed, future, wrong-run, out-of-order, or stale progress/completion state

## Identity and envelope

- base: `01d071b6cadfd9dfa7b26e3c83cd3c99015c3f14`
- exact head: `ef0878c54408ae523fe91e0d8ba381a8599f8979`
- changed files: `src/daemon.ts`, `src/operator-cli.ts`, `src/release-status.ts`, `src/state.ts`, and three focused test files
- changed lines: 141 insertions, 49 deletions, 190 cumulative non-generated lines; ceiling 190
- no DB migration/schema redesign, dependency, scheduler/provider change, live worker/config/DB mutation, watermark/lease edit, or failed-row retry

## Focused proof

- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test -- tests/state.test.ts tests/daemon-loop.test.ts tests/operator-cli.test.ts tests/release-status.test.ts` — 257/257 passed
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build` — passed
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run check:public-claims` — passed
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run check:secrets` — passed, 913 tracked files
- `git diff --check` — passed
- compiled classification probe — new raw diagnostic text is stored as `daemon_cycle_failed`; a simulated legacy raw row also projects as `daemon_cycle_failed`; raw repository/customer text is absent from JSON, release gate detail, and human output: `/Users/m1/Codex/evidence/neondiff/2026-08-23/mac-ga-1.1.0/pr-1034-rebuild-classification-probe.mjs`

The single coherent review delta also proves that an `issue_enrichment_failed` marker is retained when two truthful progress events share the same millisecond, and that no-run-ID progress or terminal conflict updates cannot rewrite a migrated terminal row whose additive completion column is null. Standalone terminal inserts remain compatible. Cumulative scope remains exactly 190 lines.

The locked dependency install and tests require the repository's supported Homebrew Node 26; the app-bundled Node 24 is below the package engine floor and macOS rejects its native Rollup module.

## Live read-only context

The installed beta.87 worker remains exactly one wrapper/helper pair, but its cycle 44 exceeded the installed 420-second active threshold while issue-enrichment watermarks remained stalled. That checkpoint motivates this source gate; this PR does not install or adopt the change.

## Proof boundary

Passing proves source event emission, fixed non-leaking classification, legacy-compatible status reads, deterministic focused tests, and presentation consistency only. It does not prove installed worker health, useful enrichment progress, release readiness, or customer readiness. Installed validation remains a separate signed-candidate rollback-safe gate.
