### PR TITLE
feat(review): canonicalize severe verifier receipts

### DIFF
--- a/src/severe-verification-receipt-canonical.ts
+++ b/src/severe-verification-receipt-canonical.ts
@@ -8,6 +8,8 @@ import type {
   SevereVerificationReceipt
 } from "./severe-verification-receipt-schema.js";
 
+const intrinsicStringify = JSON.stringify;
+
 export interface CanonicalSevereVerificationReceipt {
   receipt: SevereVerificationReceipt;
   canonicalJson: string;
@@ -71,9 +73,9 @@ function compareText(a: string, b: string): number {
 }
 
 function serializeReceipt(receipt: SevereVerificationReceipt): string {
-  const quote = (value: string): string => JSON.stringify(value);
+  const quote = (value: string): string => intrinsicStringify(value);
   let output = `{"schemaVersion":${quote(receipt.schemaVersion)},"repo":${quote(receipt.repo)},"pullNumber":${receipt.pullNumber},"baseSha":${quote(receipt.baseSha)},"headSha":${quote(receipt.headSha)},"findingFingerprint":${quote(receipt.findingFingerprint)},"state":${quote(receipt.state)},"disposition":${quote(receipt.disposition)}`;
-  if (receipt.confidence !== undefined) output += `,"confidence":${JSON.stringify(receipt.confidence)}`;
+  if (receipt.confidence !== undefined) output += `,"confidence":${intrinsicStringify(receipt.confidence)}`;
   if (receipt.reasonCode !== undefined) output += `,"reasonCode":${quote(receipt.reasonCode)}`;
   output += `,"evidence":{"files":[`;
   for (let index = 0; index < receipt.evidence.files.length; index += 1) {

--- a/src/severe-verification-receipt-canonical.ts
+++ b/src/severe-verification-receipt-canonical.ts
@@ -1,0 +1,60 @@
+import { createHash } from "node:crypto";
+import { parseSevereVerificationReceipt } from "./severe-verification-receipt-parser-c.js";
+import type {
+  SevereVerificationEvidenceFile,
+  SevereVerificationEvidenceOmission,
+  SevereVerificationReceipt
+} from "./severe-verification-receipt-schema.js";
+
+export interface CanonicalSevereVerificationReceipt {
+  receipt: SevereVerificationReceipt;
+  canonicalJson: string;
+  digest: string;
+}
+
+/** Revalidate, order, and hash a metadata-only severe-verification receipt. */
+export function canonicalizeSevereVerificationReceipt(input: unknown): CanonicalSevereVerificationReceipt {
+  const parsed = parseSevereVerificationReceipt(input);
+  const files = parsed.evidence.files.map(copyFile).sort(compareFiles);
+  const omitted = parsed.evidence.omitted.map(copyOmission).sort(compareOmissions);
+  const receipt: SevereVerificationReceipt = {
+    schemaVersion: parsed.schemaVersion,
+    repo: parsed.repo,
+    pullNumber: parsed.pullNumber,
+    baseSha: parsed.baseSha,
+    headSha: parsed.headSha,
+    findingFingerprint: parsed.findingFingerprint,
+    state: parsed.state,
+    disposition: parsed.disposition,
+    ...(parsed.confidence === undefined ? {} : { confidence: parsed.confidence }),
+    ...(parsed.reasonCode === undefined ? {} : { reasonCode: parsed.reasonCode }),
+    evidence: { files, omitted, complete: parsed.evidence.complete }
+  };
+  const canonicalJson = JSON.stringify(receipt);
+  return {
+    receipt,
+    canonicalJson,
+    digest: createHash("sha256").update(canonicalJson, "utf8").digest("hex")
+  };
+}
+
+function copyFile(file: SevereVerificationEvidenceFile): SevereVerificationEvidenceFile {
+  return { path: file.path, kind: file.kind, sha256: file.sha256, bytes: file.bytes, complete: file.complete };
+}
+
+function copyOmission(item: SevereVerificationEvidenceOmission): SevereVerificationEvidenceOmission {
+  return { path: item.path, code: item.code };
+}
+
+function compareFiles(a: SevereVerificationEvidenceFile, b: SevereVerificationEvidenceFile): number {
+  return compareText(a.path, b.path) || compareText(a.kind, b.kind) || compareText(a.sha256, b.sha256)
+    || a.bytes - b.bytes || Number(a.complete) - Number(b.complete);
+}
+
+function compareOmissions(a: SevereVerificationEvidenceOmission, b: SevereVerificationEvidenceOmission): number {
+  return compareText(a.path, b.path) || compareText(a.code, b.code);
+}
+
+function compareText(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/src/severe-verification-receipt-canonical.ts
+++ b/src/severe-verification-receipt-canonical.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import type { SerializedSevereVerificationInput } from "./severe-verification-receipt-parser-a.js";
+import { parseSevereVerificationReceiptJson } from "./severe-verification-receipt-parser-b.js";
 import { parseSevereVerificationReceipt } from "./severe-verification-receipt-parser-c.js";
 import type {
   SevereVerificationEvidenceFile,
@@ -13,8 +15,8 @@ export interface CanonicalSevereVerificationReceipt {
 }
 
 /** Revalidate, order, and hash a metadata-only severe-verification receipt. */
-export function canonicalizeSevereVerificationReceipt(input: unknown): CanonicalSevereVerificationReceipt {
-  const parsed = parseSevereVerificationReceipt(input);
+export function canonicalizeSevereVerificationReceipt(input: SerializedSevereVerificationInput): CanonicalSevereVerificationReceipt {
+  const parsed = parseSevereVerificationReceipt(parseSevereVerificationReceiptJson(input));
   const files = parsed.evidence.files.map(copyFile).sort(compareFiles);
   const omitted = parsed.evidence.omitted.map(copyOmission).sort(compareOmissions);
   const receipt: SevereVerificationReceipt = {
@@ -30,7 +32,7 @@ export function canonicalizeSevereVerificationReceipt(input: unknown): Canonical
     ...(parsed.reasonCode === undefined ? {} : { reasonCode: parsed.reasonCode }),
     evidence: { files, omitted, complete: parsed.evidence.complete }
   };
-  const canonicalJson = JSON.stringify(receipt);
+  const canonicalJson = serializeReceipt(receipt);
   return {
     receipt,
     canonicalJson,
@@ -56,5 +58,34 @@ function compareOmissions(a: SevereVerificationEvidenceOmission, b: SevereVerifi
 }
 
 function compareText(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
+  let left = 0;
+  let right = 0;
+  while (left < a.length && right < b.length) {
+    const aCode = a.codePointAt(left)!;
+    const bCode = b.codePointAt(right)!;
+    if (aCode !== bCode) return aCode < bCode ? -1 : 1;
+    left += aCode > 0xffff ? 2 : 1;
+    right += bCode > 0xffff ? 2 : 1;
+  }
+  return a.length - b.length;
+}
+
+function serializeReceipt(receipt: SevereVerificationReceipt): string {
+  const quote = (value: string): string => JSON.stringify(value);
+  let output = `{"schemaVersion":${quote(receipt.schemaVersion)},"repo":${quote(receipt.repo)},"pullNumber":${receipt.pullNumber},"baseSha":${quote(receipt.baseSha)},"headSha":${quote(receipt.headSha)},"findingFingerprint":${quote(receipt.findingFingerprint)},"state":${quote(receipt.state)},"disposition":${quote(receipt.disposition)}`;
+  if (receipt.confidence !== undefined) output += `,"confidence":${JSON.stringify(receipt.confidence)}`;
+  if (receipt.reasonCode !== undefined) output += `,"reasonCode":${quote(receipt.reasonCode)}`;
+  output += `,"evidence":{"files":[`;
+  for (let index = 0; index < receipt.evidence.files.length; index += 1) {
+    if (index > 0) output += ",";
+    const file = receipt.evidence.files[index];
+    output += `{"path":${quote(file.path)},"kind":${quote(file.kind)},"sha256":${quote(file.sha256)},"bytes":${file.bytes},"complete":${file.complete}}`;
+  }
+  output += `],"omitted":[`;
+  for (let index = 0; index < receipt.evidence.omitted.length; index += 1) {
+    if (index > 0) output += ",";
+    const item = receipt.evidence.omitted[index];
+    output += `{"path":${quote(item.path)},"code":${quote(item.code)}}`;
+  }
+  return `${output}],"complete":${receipt.evidence.complete}}}`;
 }

--- a/tests/severe-verification-receipt-canonical.test.ts
+++ b/tests/severe-verification-receipt-canonical.test.ts
@@ -24,6 +24,7 @@ const receipt = (): SevereVerificationReceipt => ({
     complete: false
   }
 });
+const serialized = (value: unknown) => JSON.stringify(value);
 
 describe("severe verification receipt canonicalization", () => {
   it("sorts evidence sets and produces stable canonical bytes and digest", () => {
@@ -32,12 +33,13 @@ describe("severe verification receipt canonicalization", () => {
     reordered.evidence.files.reverse();
     reordered.evidence.omitted.reverse();
 
-    const a = canonicalizeSevereVerificationReceipt(first);
-    const b = canonicalizeSevereVerificationReceipt(reordered);
+    const a = canonicalizeSevereVerificationReceipt(serialized(first));
+    const b = canonicalizeSevereVerificationReceipt(new TextEncoder().encode(serialized(reordered)));
 
     expect(a.canonicalJson).toBe(b.canonicalJson);
     expect(a.digest).toBe(b.digest);
     expect(a.digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.parse(a.canonicalJson)).toEqual(a.receipt);
     expect(a.receipt.evidence.files.map((item) => item.path)).toEqual(["src/a.ts", "src/z.ts"]);
     expect(a.receipt.evidence.omitted.map((item) => item.path)).toEqual(["src/b.ts", "src/y.ts"]);
     expect(first.evidence.files.map((item) => item.path)).toEqual(["src/z.ts", "src/a.ts"]);
@@ -48,20 +50,42 @@ describe("severe verification receipt canonicalization", () => {
     const changed = receipt();
     changed.headSha = "e".repeat(40);
 
-    expect(canonicalizeSevereVerificationReceipt(first).digest)
-      .not.toBe(canonicalizeSevereVerificationReceipt(changed).digest);
+    expect(canonicalizeSevereVerificationReceipt(serialized(first)).digest)
+      .not.toBe(canonicalizeSevereVerificationReceipt(serialized(changed)).digest);
   });
 
-  it("revalidates input and rejects non-schema or caller-owned hostile data", () => {
+  it("requires serialized input and rejects caller-owned hostile data without traps", () => {
     const extra = { ...receipt(), extra: true };
-    expect(() => canonicalizeSevereVerificationReceipt(extra)).toThrow("schema_invalid");
+    expect(() => canonicalizeSevereVerificationReceipt(serialized(extra))).toThrow("schema_invalid");
 
     let touched = false;
     const hostile = new Proxy(receipt(), {
       ownKeys() { touched = true; throw new Error("trap"); },
       get() { touched = true; throw new Error("trap"); }
     });
-    expect(() => canonicalizeSevereVerificationReceipt(hostile)).toThrow("schema_invalid");
+    expect(() => canonicalizeSevereVerificationReceipt(hostile as unknown as string)).toThrow("serialized_input");
     expect(touched).toBe(false);
+  });
+
+  it("does not invoke inherited serialization hooks", () => {
+    let touched = false;
+    const input = serialized(receipt());
+    const previous = Object.getOwnPropertyDescriptor(Object.prototype, "toJSON");
+    Object.defineProperty(Object.prototype, "toJSON", { configurable: true, get() { touched = true; throw new Error("trap"); } });
+    try {
+      expect(canonicalizeSevereVerificationReceipt(input).digest).toMatch(/^[a-f0-9]{64}$/);
+      expect(touched).toBe(false);
+    } finally {
+      if (previous) Object.defineProperty(Object.prototype, "toJSON", previous);
+      else delete (Object.prototype as { toJSON?: unknown }).toJSON;
+    }
+  });
+
+  it("orders valid Unicode paths by scalar code point", () => {
+    const value = receipt();
+    value.evidence.files[0].path = "src/😀.ts";
+    value.evidence.files[1].path = "src/.ts";
+    expect(canonicalizeSevereVerificationReceipt(serialized(value)).receipt.evidence.files.map((item) => item.path))
+      .toEqual(["src/.ts", "src/😀.ts"]);
   });
 });

--- a/tests/severe-verification-receipt-canonical.test.ts
+++ b/tests/severe-verification-receipt-canonical.test.ts
@@ -88,4 +88,17 @@ describe("severe verification receipt canonicalization", () => {
     expect(canonicalizeSevereVerificationReceipt(serialized(value)).receipt.evidence.files.map((item) => item.path))
       .toEqual(["src/.ts", "src/😀.ts"]);
   });
+
+  it("uses the captured primitive JSON encoder", () => {
+    const input = serialized(receipt());
+    const previous = JSON.stringify;
+    let touched = 0;
+    JSON.stringify = (() => { touched += 1; return "\"evil\""; }) as typeof JSON.stringify;
+    try {
+      expect(canonicalizeSevereVerificationReceipt(input).canonicalJson).not.toContain("evil");
+      expect(touched).toBe(0);
+    } finally {
+      JSON.stringify = previous;
+    }
+  });
 });

--- a/tests/severe-verification-receipt-canonical.test.ts
+++ b/tests/severe-verification-receipt-canonical.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeSevereVerificationReceipt } from "../src/severe-verification-receipt-canonical.js";
+import type { SevereVerificationReceipt } from "../src/severe-verification-receipt-schema.js";
+
+const receipt = (): SevereVerificationReceipt => ({
+  schemaVersion: "severe-verifier-v1",
+  repo: "owner/repo",
+  pullNumber: 7,
+  baseSha: "b".repeat(40),
+  headSha: "a".repeat(40),
+  findingFingerprint: `finding:${"f".repeat(64)}`,
+  state: "incomplete",
+  disposition: "suppress",
+  reasonCode: "not_read",
+  evidence: {
+    files: [
+      { path: "src/z.ts", kind: "module", sha256: "d".repeat(64), bytes: 20, complete: false },
+      { path: "src/a.ts", kind: "whole_file", sha256: "c".repeat(64), bytes: 10, complete: false }
+    ],
+    omitted: [
+      { path: "src/y.ts", code: "cap_exceeded" },
+      { path: "src/b.ts", code: "not_read" }
+    ],
+    complete: false
+  }
+});
+
+describe("severe verification receipt canonicalization", () => {
+  it("sorts evidence sets and produces stable canonical bytes and digest", () => {
+    const first = receipt();
+    const reordered = receipt();
+    reordered.evidence.files.reverse();
+    reordered.evidence.omitted.reverse();
+
+    const a = canonicalizeSevereVerificationReceipt(first);
+    const b = canonicalizeSevereVerificationReceipt(reordered);
+
+    expect(a.canonicalJson).toBe(b.canonicalJson);
+    expect(a.digest).toBe(b.digest);
+    expect(a.digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(a.receipt.evidence.files.map((item) => item.path)).toEqual(["src/a.ts", "src/z.ts"]);
+    expect(a.receipt.evidence.omitted.map((item) => item.path)).toEqual(["src/b.ts", "src/y.ts"]);
+    expect(first.evidence.files.map((item) => item.path)).toEqual(["src/z.ts", "src/a.ts"]);
+  });
+
+  it("changes the digest when receipt semantics change", () => {
+    const first = receipt();
+    const changed = receipt();
+    changed.headSha = "e".repeat(40);
+
+    expect(canonicalizeSevereVerificationReceipt(first).digest)
+      .not.toBe(canonicalizeSevereVerificationReceipt(changed).digest);
+  });
+
+  it("revalidates input and rejects non-schema or caller-owned hostile data", () => {
+    const extra = { ...receipt(), extra: true };
+    expect(() => canonicalizeSevereVerificationReceipt(extra)).toThrow("schema_invalid");
+
+    let touched = false;
+    const hostile = new Proxy(receipt(), {
+      ownKeys() { touched = true; throw new Error("trap"); },
+      get() { touched = true; throw new Error("trap"); }
+    });
+    expect(() => canonicalizeSevereVerificationReceipt(hostile)).toThrow("schema_invalid");
+    expect(touched).toBe(false);
+  });
+});


### PR DESCRIPTION
## Outcome

Canonicalize validated severe-verification receipt metadata into deterministic JSON and bind it to a SHA-256 digest. Equivalent file/omission set order produces identical bytes and digest; receipt semantic changes change the digest.

Closes #865
Related: #807

## Scope

- add one production-inert canonicalizer that accepts only serialized string/byte input through Parser A -> B -> C/schema
- sort bounded evidence-file and omission sets with locale-independent code-point ordering
- copy fields into an explicit canonical property order, serialize without object hooks, and hash the resulting UTF-8 JSON
- add deterministic order, semantic-change, schema-rejection, hostile-proxy, inherited-hook, Unicode scalar-order, and round-trip fixtures

Exact base/head: `53039a3b07d750b388836e1ba3b7735ab5ae7357` -> `282e9220e2ce9aeb8064cee5a907b382fdcecd2b`

Changed non-generated lines: 197 across two new files.

## Validation

- red test: focused Vitest initially failed because the canonicalizer module did not exist
- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/severe-verification-receipt-schema.test.ts tests/severe-verification-receipt-parser-a.test.ts tests/severe-verification-receipt-parser-b.test.ts tests/severe-verification-receipt-parser-c.test.ts tests/severe-verification-receipt-canonical.test.ts` — 32/32 pass
- `/opt/homebrew/bin/node node_modules/typescript/bin/tsc -p tsconfig.build.json --noEmit` — pass
- production build preparation plus `tsc -p tsconfig.build.json` — pass
- `git diff --cached --check` before commit — pass

The default repository-wide `tsc --noEmit` includes existing unrelated test-typing failures and is not claimed as a passing gate; the production build configuration passes.

## Safety and proof boundary

Agent-authored. The bounded review deltas enforce the serialized boundary, prevent inherited `toJSON` execution, implement actual Unicode code-point ordering, and capture the primitive JSON encoder so a hostile global override cannot corrupt canonical bytes/digest. This PR adds no provider call, evidence collector, worker/publication wiring, database/schema/queue, GitHub post, runtime/config/customer mutation, or release action. It proves only deterministic canonical receipt bytes/digest after Parser A -> B -> C/schema. Exact-head CI, zero unresolved threads, and final targeted adversarial recheck remain required before merge.
