### PR TITLE
fix: collect exact-head severe verification evidence

### DIFF
--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -83,10 +83,10 @@ async function inspectFile(root: string, path: string, kind: "whole_file" | "mod
       cursor = join(cursor, part);
       if ((await lstat(cursor)).isSymbolicLink()) throw new Error("not_file");
     }
-    const stats = await lstat(candidate);
+    const stats = await lstat(actual);
     if (!stats.isFile() || stats.isSymbolicLink()) throw new Error("not_file");
     if (stats.size > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" as const } };
-    const data = await readFile(candidate);
+    const data = await readFile(actual);
     if (data.length > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" as const } };
     try { decoder.decode(data); } catch { return { omission: { path, code: "evidence_incomplete" as const } }; }
     return { file: { path, kind, sha256: hash(data), bytes: data.length, complete: true } };

--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { isAbsolute, join, resolve, sep } from "node:path";
+import type { SevereVerificationCode, SevereVerificationEvidenceFile } from "./severe-verification-receipt-schema.js";
+
+export const MAX_EVIDENCE_BYTES = 65_536;
+export const MAX_MODULES = 16;
+const decoder = new TextDecoder("utf-8", { fatal: true });
+type OmissionCode = SevereVerificationCode;
+
+export interface SevereVerificationEvidenceInput {
+  expectedHeadSha: string;
+  worktreePath: string;
+  findingPath: string;
+  changedHunk: string | Uint8Array;
+  relevantModulePaths: readonly string[];
+}
+export interface ChangedHunkMetadata { sha256: string; bytes: number; complete: boolean; code?: OmissionCode; }
+export interface SevereVerificationEvidenceResult {
+  changedHunk: ChangedHunkMetadata;
+  files: SevereVerificationEvidenceFile[];
+  omitted: { path: string; code: OmissionCode }[];
+  complete: boolean;
+}
+
+/** Collect exact-head, bounded, metadata-only evidence. This module has no worker/provider call sites. */
+export async function collectSevereVerificationEvidence(input: SevereVerificationEvidenceInput): Promise<SevereVerificationEvidenceResult> {
+  verifyHead(input.expectedHeadSha, input.worktreePath);
+  const root = await realpath(input.worktreePath).catch(() => { throw new Error("head_unavailable"); });
+  const finding = safePath(input.findingPath);
+  if (!Array.isArray(input.relevantModulePaths) || input.relevantModulePaths.length === 0 || input.relevantModulePaths.length > MAX_MODULES) {
+    throw new Error("module_list");
+  }
+  const modules = input.relevantModulePaths.map(safePath);
+  if (new Set(modules).size !== modules.length || modules.includes(finding)) throw new Error("module_list");
+  const changedHunk = hunkMetadata(input.changedHunk);
+  const files: SevereVerificationEvidenceFile[] = [];
+  const omitted: { path: string; code: OmissionCode }[] = [];
+  const add = async (path: string, kind: "whole_file" | "module") => {
+    const result = await inspectFile(root, path, kind);
+    if (result.file) files.push(result.file); else omitted.push(result.omission);
+  };
+  await add(finding, "whole_file");
+  for (const path of [...modules].sort(compareText)) await add(path, "module");
+  return { changedHunk, files, omitted, complete: changedHunk.complete && !omitted.length && files.length === modules.length + 1 };
+}
+
+function verifyHead(expected: string, worktree: string): void {
+  if (!/^[a-f0-9]{40}$/.test(expected) || typeof worktree !== "string" || !isAbsolute(worktree)) throw new Error("invalid_head");
+  let actual: string;
+  try { actual = execFileSync("git", ["rev-parse", "HEAD"], { cwd: worktree, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim(); }
+  catch { throw new Error("head_unavailable"); }
+  if (actual !== expected) throw new Error("stale_head");
+}
+
+function safePath(value: string): string {
+  if (typeof value !== "string" || !value || value.length > 4096 || isAbsolute(value) || /^[A-Za-z]:/.test(value)
+    || value.includes("\\") || value.includes("//") || /[\u0000-\u001f\u007f-\u009f]/.test(value)
+    || [...value].some((char) => { const code = char.codePointAt(0)!; return code >= 0xd800 && code <= 0xdfff; })
+    || value.split("/").some((part) => !part || part === "." || part === "..")) throw new Error("unsafe_path");
+  return value;
+}
+
+async function inspectFile(root: string, path: string, kind: "whole_file" | "module") {
+  try {
+    const candidate = resolve(root, path);
+    const actual = await realpath(candidate);
+    if (actual !== root && !actual.startsWith(`${root}${sep}`)) throw new Error("out_of_root");
+    let cursor = root;
+    for (const part of path.split("/")) {
+      cursor = join(cursor, part);
+      if ((await lstat(cursor)).isSymbolicLink()) throw new Error("not_file");
+    }
+    const stats = await lstat(candidate);
+    if (!stats.isFile() || stats.isSymbolicLink()) throw new Error("not_file");
+    if (stats.size > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" as const } };
+    const data = await readFile(candidate);
+    if (data.length > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" as const } };
+    try { decoder.decode(data); } catch { return { omission: { path, code: "evidence_incomplete" as const } }; }
+    return { file: { path, kind, sha256: hash(data), bytes: data.length, complete: true } };
+  } catch (error) {
+    if (error instanceof Error && ["out_of_root", "not_file", "unsafe_path"].includes(error.message)) throw error;
+    return { omission: { path, code: "not_read" as const } };
+  }
+}
+
+function hunkMetadata(value: string | Uint8Array): ChangedHunkMetadata {
+  if (typeof value !== "string" && !(value instanceof Uint8Array)) throw new Error("hunk_invalid");
+  const data = typeof value === "string" ? Buffer.from(value, "utf8") : Buffer.from(value);
+  const metadata: ChangedHunkMetadata = { sha256: hash(data), bytes: data.length, complete: data.length > 0 && data.length <= MAX_EVIDENCE_BYTES };
+  if (!data.length) return { ...metadata, complete: false, code: "not_read" };
+  if (data.length > MAX_EVIDENCE_BYTES) return { ...metadata, complete: false, code: "cap_exceeded" };
+  try { decoder.decode(data); } catch { return { ...metadata, complete: false, code: "evidence_incomplete" }; }
+  return metadata;
+}
+
+function hash(data: Uint8Array): string { return createHash("sha256").update(data).digest("hex"); }
+function compareText(a: string, b: string): number { return a < b ? -1 : a > b ? 1 : 0; }

--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -10,6 +10,9 @@ const decoder = new TextDecoder("utf-8", { fatal: true });
 type OmissionCode = SevereVerificationCode;
 
 export interface SevereVerificationEvidenceInput {
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
   expectedHeadSha: string;
   worktreePath: string;
   findingPath: string;
@@ -26,6 +29,7 @@ export interface SevereVerificationEvidenceResult {
 
 /** Collect exact-head, bounded, metadata-only evidence. This module has no worker/provider call sites. */
 export async function collectSevereVerificationEvidence(input: SevereVerificationEvidenceInput): Promise<SevereVerificationEvidenceResult> {
+  verifyIdentity(input);
   verifyHead(input.expectedHeadSha, input.worktreePath);
   const root = await realpath(input.worktreePath).catch(() => { throw new Error("head_unavailable"); });
   const finding = safePath(input.findingPath);
@@ -44,6 +48,13 @@ export async function collectSevereVerificationEvidence(input: SevereVerificatio
   await add(finding, "whole_file");
   for (const path of [...modules].sort(compareText)) await add(path, "module");
   return { changedHunk, files, omitted, complete: changedHunk.complete && !omitted.length && files.length === modules.length + 1 };
+}
+
+function verifyIdentity(input: SevereVerificationEvidenceInput): void {
+  const repo = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9_.-]{1,100}$/;
+  if (!repo.test(input.repo) || !Number.isSafeInteger(input.pullNumber) || input.pullNumber < 1 || !/^[a-f0-9]{40}$/.test(input.baseSha)) {
+    throw new Error("invalid_identity");
+  }
 }
 
 function verifyHead(expected: string, worktree: string): void {

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -11,6 +11,7 @@ const finding = "src/π space.ts";
 const moduleA = "lib/alpha.ts";
 const moduleB = "lib/β.ts";
 const input = (relevantModulePaths: readonly string[], changedHunk: string | Uint8Array = "@@ -1 +1 @@\n+changed") => ({
+  repo: "owner/repo", pullNumber: 1040, baseSha: "b".repeat(40),
   expectedHeadSha: head, worktreePath: root, findingPath: finding, changedHunk, relevantModulePaths
 });
 
@@ -54,6 +55,7 @@ describe("exact-head severe evidence collection", () => {
     expect(capped.changedHunk).toMatchObject({ complete: false, code: "cap_exceeded" });
     await expect(collectSevereVerificationEvidence({ ...input([moduleA]), expectedHeadSha: "a".repeat(40), worktreePath: fixture }))
       .rejects.toThrow("stale_head");
+    await expect(collectSevereVerificationEvidence({ ...input([moduleA]), pullNumber: 0 })).rejects.toThrow("invalid_identity");
   });
 
   it("rejects unsafe paths, symlinks, directories, duplicate finding modules, and unbounded lists", async () => {

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { collectSevereVerificationEvidence, MAX_EVIDENCE_BYTES, MAX_MODULES } from "../src/severe-verification-evidence.js";
+
+const root = process.cwd();
+let fixture = "";
+let head = "";
+const finding = "src/π space.ts";
+const moduleA = "lib/alpha.ts";
+const moduleB = "lib/β.ts";
+const input = (relevantModulePaths: readonly string[], changedHunk: string | Uint8Array = "@@ -1 +1 @@\n+changed") => ({
+  expectedHeadSha: head, worktreePath: root, findingPath: finding, changedHunk, relevantModulePaths
+});
+
+beforeAll(async () => {
+  fixture = await mkdtemp(join(root, ".severe-evidence-"));
+  await mkdir(join(fixture, "src"));
+  await mkdir(join(fixture, "lib"));
+  await writeFile(join(fixture, finding), "const π = 'finding';\n");
+  await writeFile(join(fixture, moduleA), "export const alpha = true;\n");
+  await writeFile(join(fixture, moduleB), "export const beta = true;\n");
+  await writeFile(join(fixture, "bad.bin"), Buffer.from([0xff, 0xfe]));
+  await writeFile(join(fixture, "big.bin"), Buffer.alloc(MAX_EVIDENCE_BYTES + 1, 65));
+  head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+});
+afterAll(async () => { await rm(fixture, { recursive: true, force: true }); });
+
+describe("exact-head severe evidence collection", () => {
+  it("returns deterministic metadata for the hunk, finding, and explicit modules", async () => {
+    const modules = [moduleB, moduleA];
+    const result = await collectSevereVerificationEvidence({ ...input(modules), worktreePath: fixture });
+    expect(result.complete).toBe(true);
+    expect(result.changedHunk).toMatchObject({ bytes: 20, complete: true });
+    expect(result.files.map((item) => [item.path, item.kind])).toEqual([
+      [finding, "whole_file"], [moduleA, "module"], [moduleB, "module"]
+    ]);
+    expect(result.files.every((item) => /^[a-f0-9]{64}$/.test(item.sha256) && item.complete)).toBe(true);
+    expect(result.omitted).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain("const π");
+    expect(JSON.stringify(result)).not.toContain("+changed");
+    expect(modules).toEqual([moduleB, moduleA]);
+    const repeated = await collectSevereVerificationEvidence({ ...input([moduleA, moduleB]), worktreePath: fixture });
+    expect(repeated).toEqual(result);
+  });
+
+  it("accepts UTF-8 bytes and fails closed on a stale head before reads", async () => {
+    const bytes = new TextEncoder().encode("@@ bytes");
+    expect((await collectSevereVerificationEvidence({ ...input([moduleA], bytes), worktreePath: fixture })).complete).toBe(true);
+    const invalid = await collectSevereVerificationEvidence({ ...input([moduleA], new Uint8Array([0xff])), worktreePath: fixture });
+    expect(invalid.changedHunk).toMatchObject({ complete: false, code: "evidence_incomplete" });
+    const capped = await collectSevereVerificationEvidence({ ...input([moduleA], new Uint8Array(MAX_EVIDENCE_BYTES + 1)), worktreePath: fixture });
+    expect(capped.changedHunk).toMatchObject({ complete: false, code: "cap_exceeded" });
+    await expect(collectSevereVerificationEvidence({ ...input([moduleA]), expectedHeadSha: "a".repeat(40), worktreePath: fixture }))
+      .rejects.toThrow("stale_head");
+  });
+
+  it("rejects unsafe paths, symlinks, directories, duplicate finding modules, and unbounded lists", async () => {
+    await symlink(join(fixture, finding), join(fixture, "link.ts"));
+    for (const path of ["/etc/passwd", "../outside.ts", "C:/outside.ts", "a\\b.ts", "a\u0000b.ts", "a\ud800b.ts", "src", "link.ts", finding]) {
+      await expect(collectSevereVerificationEvidence({ ...input([path]), worktreePath: fixture })).rejects.toThrow();
+    }
+    await expect(collectSevereVerificationEvidence({ ...input(Array(MAX_MODULES + 1).fill(moduleA)), worktreePath: fixture }))
+      .rejects.toThrow("module_list");
+  });
+
+  it("records invalid UTF-8, missing, and capped artifacts as explicit omissions", async () => {
+    const result = await collectSevereVerificationEvidence({ ...input(["missing.ts", "bad.bin", "big.bin"]), worktreePath: fixture });
+    expect(result.complete).toBe(false);
+    expect(result.files.map((item) => item.path)).toEqual([finding]);
+    expect(result.omitted).toEqual([
+      { path: "bad.bin", code: "evidence_incomplete" },
+      { path: "big.bin", code: "cap_exceeded" },
+      { path: "missing.ts", code: "not_read" }
+    ]);
+  });
+});


### PR DESCRIPTION
## Outcome

Collect bounded, metadata-only changed-hunk, whole-file, and explicit relevant-module evidence only from the expected pull-request head.

Closes #1040.

## What changed

- Validates exact repo, pull request, base, and head identity before evidence reads.
- Reads only the named finding file and an explicit bounded module set; no repository scan.
- Rejects unsafe paths, symlinks, non-files, invalid UTF-8, oversize inputs, and stale heads.
- Emits only repository-relative path, evidence kind, SHA-256, byte count, completeness, and explicit omission metadata.

## Proof

- `36/36` focused severe-verification tests passed across the collector, receipt schema, parsers, and canonical serializer.
- `tsc -p tsconfig.build.json --noEmit` passed under Node `v26.7.0`.
- `git diff --check` passed.
- Scope: 2 files, 190 non-generated added lines, below the 199-line issue limit.

## Proof boundary

This proves exact-head local evidence collection and metadata behavior only. It does not wire provider transport, publication, the worker, runtime, customers, or release paths.
