### PR TITLE
fix: enforce intrinsic hunk evidence cap

### DIFF
--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -29,8 +29,11 @@ export async function collectSevereVerificationEvidence(input: SevereVerificatio
   verifyIdentity(input);
   const gitDir = verifyHead(input.expectedHeadSha, input.worktreePath);
   const finding = safePath(input.findingPath);
-  if (!Array.isArray(input.relevantModulePaths) || input.relevantModulePaths.length > MAX_MODULES) throw new Error("module_list");
-  const modules = input.relevantModulePaths.map(safePath);
+  if (!Array.isArray(input.relevantModulePaths)) throw new Error("module_list");
+  const moduleCount = input.relevantModulePaths.length;
+  if (!Number.isSafeInteger(moduleCount) || moduleCount > MAX_MODULES) throw new Error("module_list");
+  const modules: string[] = [];
+  for (let index = 0; index < moduleCount; index += 1) modules.push(safePath(input.relevantModulePaths[index]));
   if (new Set(modules).size !== modules.length || modules.includes(finding)) throw new Error("module_list");
   const changedHunk = hunkMetadata(input.changedHunk);
   const files: SevereVerificationEvidenceFile[] = [], omitted: { path: string; code: OmissionCode }[] = [];
@@ -71,7 +74,8 @@ function inspectFile(gitDir: string, head: string, path: string, kind: "whole_fi
   try { entry = treeEntry(gitDir, head, path); } catch { return { omission: { path, code: "not_read" } }; }
   if (!entry) return { omission: { path, code: "not_read" } };
   if (entry.type !== "blob" || (entry.mode !== "100644" && entry.mode !== "100755")) throw new Error("not_file");
-  if (!Number.isSafeInteger(entry.bytes) || entry.bytes > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" } };
+  if (!Number.isSafeInteger(entry.bytes) || entry.bytes < 0) return { omission: { path, code: "not_read" } };
+  if (entry.bytes > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" } };
   let data: Buffer;
   try { data = execFileSync("git", ["--git-dir", gitDir, "cat-file", "blob", entry.object], { env: gitEnvironment(), encoding: "buffer", maxBuffer: MAX_EVIDENCE_BYTES + 1, stdio: ["ignore", "pipe", "ignore"] }) as Buffer; }
   catch { return { omission: { path, code: "not_read" } }; }
@@ -116,4 +120,4 @@ function hunkMetadata(value: string | Uint8Array): ChangedHunkMetadata {
 
 function hash(data: Uint8Array): string { return createHash("sha256").update(data).digest("hex"); }
 function compareText(a: string, b: string): number { return a < b ? -1 : a > b ? 1 : 0; }
-function gitEnvironment(): NodeJS.ProcessEnv { const env: NodeJS.ProcessEnv = { ...process.env, GIT_NO_REPLACE_OBJECTS: "1" }; for (const key of REPOSITORY_ENV) delete env[key]; return env; }
+function gitEnvironment(): NodeJS.ProcessEnv { const env: NodeJS.ProcessEnv = { ...process.env, GIT_NO_REPLACE_OBJECTS: "1", GIT_NO_LAZY_FETCH: "1" }; for (const key of REPOSITORY_ENV) delete env[key]; return env; }

--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -1,0 +1,119 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { isAbsolute } from "node:path";
+import type { SevereVerificationCode, SevereVerificationEvidenceFile } from "./severe-verification-receipt-schema.js";
+
+export const MAX_EVIDENCE_BYTES = 65_536;
+export const MAX_MODULES = 16;
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const typedArrayBuffer = Object.getOwnPropertyDescriptor(typedArrayPrototype, "buffer")!.get!;
+const typedArrayByteOffset = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteOffset")!.get!;
+const typedArrayByteLength = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!.get!;
+const REPOSITORY_ENV = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR", "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_REPLACE_REF_BASE"] as const;
+type OmissionCode = SevereVerificationCode;
+
+export interface SevereVerificationEvidenceInput {
+  repo: string; pullNumber: number; baseSha: string; expectedHeadSha: string; worktreePath: string;
+  findingPath: string; changedHunk: string | Uint8Array; relevantModulePaths: readonly string[];
+}
+export interface ChangedHunkMetadata { sha256?: string; bytes: number; complete: boolean; code?: OmissionCode; }
+export interface SevereVerificationEvidenceResult {
+  changedHunk: ChangedHunkMetadata; files: SevereVerificationEvidenceFile[];
+  omitted: { path: string; code: OmissionCode }[]; complete: boolean;
+}
+type TreeEntry = { mode: string; type: string; object: string; bytes: number };
+
+/** Exact-head, bounded, metadata-only evidence; source bytes come only from immutable Git blobs. */
+export async function collectSevereVerificationEvidence(input: SevereVerificationEvidenceInput): Promise<SevereVerificationEvidenceResult> {
+  verifyIdentity(input);
+  const gitDir = verifyHead(input.expectedHeadSha, input.worktreePath);
+  const finding = safePath(input.findingPath);
+  if (!Array.isArray(input.relevantModulePaths) || input.relevantModulePaths.length > MAX_MODULES) throw new Error("module_list");
+  const modules = input.relevantModulePaths.map(safePath);
+  if (new Set(modules).size !== modules.length || modules.includes(finding)) throw new Error("module_list");
+  const changedHunk = hunkMetadata(input.changedHunk);
+  const files: SevereVerificationEvidenceFile[] = [], omitted: { path: string; code: OmissionCode }[] = [];
+  const add = (path: string, kind: "whole_file" | "module") => {
+    const result = inspectFile(gitDir, input.expectedHeadSha, path, kind);
+    if ("file" in result) files.push(result.file); else omitted.push(result.omission);
+  };
+  add(finding, "whole_file");
+  for (const path of [...modules].sort(compareText)) add(path, "module");
+  return { changedHunk, files, omitted, complete: changedHunk.complete && !omitted.length && files.length === modules.length + 1 };
+}
+
+function verifyIdentity(input: SevereVerificationEvidenceInput): void {
+  const repo = /^(?![^/]*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9_.-]{1,100}$/;
+  if (!input || typeof input !== "object" || !repo.test(input.repo) || !Number.isSafeInteger(input.pullNumber) || input.pullNumber < 1 || !/^[a-f0-9]{40}$/.test(input.baseSha)) throw new Error("invalid_identity");
+}
+
+function verifyHead(expected: string, worktree: string): string {
+  if (!/^[a-f0-9]{40}$/.test(expected) || typeof worktree !== "string" || !isAbsolute(worktree)) throw new Error("invalid_head");
+  let lines: string[];
+  try {
+    const output = execFileSync("git", ["rev-parse", "--path-format=absolute", "HEAD", "--git-dir"], { cwd: worktree, env: gitEnvironment(), encoding: "buffer", stdio: ["ignore", "pipe", "ignore"] }) as Buffer;
+    lines = output.toString("utf8").trimEnd().split("\n");
+  } catch { throw new Error("head_unavailable"); }
+  if (lines[0] !== expected) throw new Error("stale_head");
+  if (!lines[1] || !isAbsolute(lines[1])) throw new Error("head_unavailable");
+  return lines[1];
+}
+
+function safePath(value: string): string {
+  if (typeof value !== "string" || !value || value.length > 4096 || isAbsolute(value) || /^[A-Za-z]:/.test(value) || value.includes("\\") || value.includes("//") || /[\u0000-\u001f\u007f-\u009f]/.test(value) || [...value].some((char) => { const code = char.codePointAt(0)!; return code >= 0xd800 && code <= 0xdfff; }) || value.split("/").some((part) => !part || part === "." || part === "..")) throw new Error("unsafe_path");
+  return value;
+}
+
+function inspectFile(gitDir: string, head: string, path: string, kind: "whole_file" | "module"):
+  { file: SevereVerificationEvidenceFile } | { omission: { path: string; code: OmissionCode } } {
+  let entry: TreeEntry | undefined;
+  try { entry = treeEntry(gitDir, head, path); } catch { return { omission: { path, code: "not_read" } }; }
+  if (!entry) return { omission: { path, code: "not_read" } };
+  if (entry.type !== "blob" || (entry.mode !== "100644" && entry.mode !== "100755")) throw new Error("not_file");
+  if (!Number.isSafeInteger(entry.bytes) || entry.bytes > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" } };
+  let data: Buffer;
+  try { data = execFileSync("git", ["--git-dir", gitDir, "cat-file", "blob", entry.object], { env: gitEnvironment(), encoding: "buffer", maxBuffer: MAX_EVIDENCE_BYTES + 1, stdio: ["ignore", "pipe", "ignore"] }) as Buffer; }
+  catch { return { omission: { path, code: "not_read" } }; }
+  if (data.length > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" } };
+  try { decoder.decode(data); } catch { return { omission: { path, code: "evidence_incomplete" } }; }
+  return { file: { path, kind, sha256: hash(data), bytes: data.length, complete: true } };
+}
+
+function treeEntry(gitDir: string, head: string, path: string): TreeEntry | undefined {
+  const raw = execFileSync("git", ["--git-dir", gitDir, "ls-tree", "--full-tree", "-z", "-l", head, "--", `:(literal)${path}`], { env: gitEnvironment(), encoding: "buffer", maxBuffer: 16_384, stdio: ["ignore", "pipe", "ignore"] }) as Buffer;
+  if (!raw.length) return undefined;
+  const end = raw.indexOf(0), tab = raw.indexOf(9);
+  if (end < 1 || tab < 1 || end !== raw.length - 1 || tab > end) throw new Error("not_file");
+  const [mode, type, object, size] = raw.subarray(0, tab).toString("ascii").trim().split(/\s+/);
+  const actualPath = decoder.decode(raw.subarray(tab + 1, end));
+  if (actualPath !== path || !/^[a-f0-9]{40}$/.test(object)) throw new Error("not_file");
+  return { mode, type, object, bytes: Number(size) };
+}
+
+function hunkMetadata(value: string | Uint8Array): ChangedHunkMetadata {
+  if (typeof value !== "string" && !(value instanceof Uint8Array)) throw new Error("hunk_invalid");
+  let bytes: number, data: Buffer;
+  if (typeof value === "string") {
+    bytes = Buffer.byteLength(value, "utf8");
+    if (bytes > MAX_EVIDENCE_BYTES) return { bytes, complete: false, code: "cap_exceeded" };
+    if ([...value].some((char) => { const code = char.codePointAt(0)!; return code >= 0xd800 && code <= 0xdfff; })) return { bytes, complete: false, code: "evidence_incomplete" };
+    data = Buffer.from(value, "utf8");
+  } else {
+    try { bytes = Reflect.apply(typedArrayByteLength, value, []) as number; } catch { throw new Error("hunk_invalid"); }
+    if (bytes > MAX_EVIDENCE_BYTES) return { bytes, complete: false, code: "cap_exceeded" };
+    try {
+      const buffer = Reflect.apply(typedArrayBuffer, value, []) as ArrayBufferLike;
+      const offset = Reflect.apply(typedArrayByteOffset, value, []) as number;
+      data = Buffer.from(new Uint8Array(buffer, offset, bytes));
+    } catch { throw new Error("hunk_invalid"); }
+  }
+  const metadata: ChangedHunkMetadata = { sha256: hash(data), bytes, complete: bytes > 0 };
+  if (!bytes) return { ...metadata, code: "not_read" };
+  try { decoder.decode(data); } catch { return { ...metadata, complete: false, code: "evidence_incomplete" }; }
+  return metadata;
+}
+
+function hash(data: Uint8Array): string { return createHash("sha256").update(data).digest("hex"); }
+function compareText(a: string, b: string): number { return a < b ? -1 : a > b ? 1 : 0; }
+function gitEnvironment(): NodeJS.ProcessEnv { const env: NodeJS.ProcessEnv = { ...process.env, GIT_NO_REPLACE_OBJECTS: "1" }; for (const key of REPOSITORY_ENV) delete env[key]; return env; }

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { collectSevereVerificationEvidence, MAX_EVIDENCE_BYTES, MAX_MODULES } from "../src/severe-verification-evidence.js";
+
+const root = process.cwd(), finding = "src/π space.ts", moduleA = "lib/alpha.ts", moduleB = "lib/β.ts";
+let fixture = "", head = "";
+const git = (args: string[]) => execFileSync("git", args, { cwd: fixture, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+const input = (relevantModulePaths: readonly string[], changedHunk: string | Uint8Array = "@@ -1 +1 @@\n+changed") => ({
+  repo: "owner/repo", pullNumber: 1040, baseSha: "b".repeat(40), expectedHeadSha: head, worktreePath: fixture,
+  findingPath: finding, changedHunk, relevantModulePaths
+});
+
+beforeAll(async () => {
+  fixture = await mkdtemp(join(root, ".severe-evidence-")); await mkdir(join(fixture, "src")); await mkdir(join(fixture, "lib"));
+  await writeFile(join(fixture, finding), "const π = 'finding';\n"); await writeFile(join(fixture, moduleA), "export const alpha = true;\n"); await writeFile(join(fixture, moduleB), "export const beta = true;\n");
+  await writeFile(join(fixture, "bad.bin"), Buffer.from([0xff, 0xfe])); await writeFile(join(fixture, "big.bin"), Buffer.alloc(MAX_EVIDENCE_BYTES + 1, 65)); await symlink("src/π space.ts", join(fixture, "link.ts"));
+  execFileSync("git", ["init", "--quiet"], { cwd: fixture }); git(["config", "user.email", "test@example.invalid"]); git(["config", "user.name", "NeonDiff test"]); git(["add", "."]); git(["commit", "--quiet", "-m", "fixture"]); head = git(["rev-parse", "HEAD"]);
+});
+afterAll(async () => { await rm(fixture, { recursive: true, force: true }); });
+
+describe("exact-head severe evidence collection", () => {
+  it("is deterministic, metadata-only, multi-file, and immutable", async () => {
+    const result = await collectSevereVerificationEvidence(input([moduleB, moduleA]));
+    expect(result.complete).toBe(true); expect(result.files.map((item) => [item.path, item.kind])).toEqual([[finding, "whole_file"], [moduleA, "module"], [moduleB, "module"]]); expect(result.omitted).toEqual([]); expect(JSON.stringify(result)).not.toContain("const π");
+    const digest = result.files[0].sha256; await writeFile(join(fixture, finding), "tampered\n"); expect((await collectSevereVerificationEvidence(input([moduleA, moduleB]))).files[0].sha256).toBe(digest);
+  });
+
+  it("accepts an explicit empty module set", async () => {
+    const result = await collectSevereVerificationEvidence(input([])); expect(result.complete).toBe(true); expect(result.files.map((item) => item.kind)).toEqual(["whole_file"]);
+  });
+
+  it("rejects stale identity and caps hunks using intrinsic bytes before hashing", async () => {
+    const disguised = new Uint8Array(MAX_EVIDENCE_BYTES + 1); Object.defineProperty(disguised, "byteLength", { value: 1 });
+    const stringCap = await collectSevereVerificationEvidence(input([], "a".repeat(MAX_EVIDENCE_BYTES + 1))); const byteCap = await collectSevereVerificationEvidence(input([], disguised));
+    expect(stringCap.changedHunk).toEqual({ bytes: MAX_EVIDENCE_BYTES + 1, complete: false, code: "cap_exceeded" }); expect(byteCap.changedHunk).toEqual(stringCap.changedHunk);
+    expect((await collectSevereVerificationEvidence(input([], new Uint8Array([0xff])))).changedHunk).toMatchObject({ complete: false, code: "evidence_incomplete" }); expect((await collectSevereVerificationEvidence(input([], "\ud800"))).changedHunk).toEqual({ bytes: 3, complete: false, code: "evidence_incomplete" });
+    await expect(collectSevereVerificationEvidence({ ...input([]), expectedHeadSha: "a".repeat(40) })).rejects.toThrow("stale_head"); await expect(collectSevereVerificationEvidence({ ...input([]), pullNumber: 0 })).rejects.toThrow("invalid_identity");
+  });
+
+  it("ignores inherited repository selectors and replacement objects", async () => {
+    const foreign = await mkdtemp(join(root, ".severe-foreign-")); execFileSync("git", ["init", "--quiet"], { cwd: foreign }); const prior = process.env.GIT_DIR;
+    try { process.env.GIT_DIR = join(foreign, ".git"); expect((await collectSevereVerificationEvidence(input([]))).complete).toBe(true); }
+    finally { if (prior === undefined) delete process.env.GIT_DIR; else process.env.GIT_DIR = prior; await rm(foreign, { recursive: true, force: true }); }
+    const expected = (await collectSevereVerificationEvidence(input([]))).files[0].sha256; git(["add", finding]); const replacement = git(["commit-tree", git(["write-tree"]), "-m", "replacement"]); git(["replace", head, replacement]); const priorBase = process.env.GIT_REPLACE_REF_BASE, priorNoReplace = process.env.GIT_NO_REPLACE_OBJECTS;
+    try { process.env.GIT_REPLACE_REF_BASE = "refs/replace"; process.env.GIT_NO_REPLACE_OBJECTS = "0"; expect((await collectSevereVerificationEvidence(input([]))).files[0].sha256).toBe(expected); }
+    finally { if (priorBase === undefined) delete process.env.GIT_REPLACE_REF_BASE; else process.env.GIT_REPLACE_REF_BASE = priorBase; if (priorNoReplace === undefined) delete process.env.GIT_NO_REPLACE_OBJECTS; else process.env.GIT_NO_REPLACE_OBJECTS = priorNoReplace; git(["replace", "-d", head]); }
+  });
+
+  it("rejects unsafe paths, non-files, duplicates, and unbounded lists", async () => {
+    for (const path of ["/etc/passwd", "../outside.ts", "C:/outside.ts", "a\\b.ts", "a\u0000b.ts", "a\ud800b.ts", "src", "link.ts", finding]) await expect(collectSevereVerificationEvidence(input([path]))).rejects.toThrow();
+    await expect(collectSevereVerificationEvidence(input(Array(MAX_MODULES + 1).fill(moduleA)))).rejects.toThrow("module_list");
+  });
+
+  it("records missing, invalid UTF-8, and capped blobs as omissions", async () => {
+    const result = await collectSevereVerificationEvidence(input(["missing.ts", "bad.bin", "big.bin"])); expect(result.complete).toBe(false); expect(result.files.map((item) => item.path)).toEqual([finding]); expect(result.omitted).toEqual([{ path: "bad.bin", code: "evidence_incomplete" }, { path: "big.bin", code: "cap_exceeded" }, { path: "missing.ts", code: "not_read" }]);
+  });
+});

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -29,6 +29,7 @@ describe("exact-head severe evidence collection", () => {
 
   it("accepts an explicit empty module set", async () => {
     const result = await collectSevereVerificationEvidence(input([])); expect(result.complete).toBe(true); expect(result.files.map((item) => item.kind)).toEqual(["whole_file"]);
+    const overridden = [moduleA]; Object.defineProperty(overridden, "map", { value: () => Array(MAX_MODULES + 1).fill(moduleA) }); expect((await collectSevereVerificationEvidence(input(overridden))).files.map((item) => item.path)).toEqual([finding, moduleA]);
   });
 
   it("rejects stale identity and caps hunks using intrinsic bytes before hashing", async () => {
@@ -55,5 +56,12 @@ describe("exact-head severe evidence collection", () => {
 
   it("records missing, invalid UTF-8, and capped blobs as omissions", async () => {
     const result = await collectSevereVerificationEvidence(input(["missing.ts", "bad.bin", "big.bin"])); expect(result.complete).toBe(false); expect(result.files.map((item) => item.path)).toEqual([finding]); expect(result.omitted).toEqual([{ path: "bad.bin", code: "evidence_incomplete" }, { path: "big.bin", code: "cap_exceeded" }, { path: "missing.ts", code: "not_read" }]);
+  });
+
+  it("does not lazily fetch missing partial-clone blobs", async () => {
+    const partial = await mkdtemp(join(root, ".severe-partial-"));
+    try { git(["config", "uploadpack.allowFilter", "true"]); execFileSync("git", ["clone", "--quiet", "--filter=blob:none", "--no-checkout", `file://${fixture}`, partial]); const partialHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: partial, encoding: "utf8" }).trim();
+      const result = await collectSevereVerificationEvidence({ ...input([]), expectedHeadSha: partialHead, worktreePath: partial }); expect(result.files).toEqual([]); expect(result.omitted).toEqual([{ path: finding, code: "not_read" }]);
+    } finally { await rm(partial, { recursive: true, force: true }); }
   });
 });


### PR DESCRIPTION
## Outcome

Collect bounded, metadata-only changed-hunk, whole-file, and explicit relevant-module evidence from the exact expected pull-request head.

Closes #1040.

## Clean successor

This is the clean successor to closed, unmerged PRs #1057, #1058, and #1059. It incorporates every verified predecessor blocker from the start:

- reads literal regular-file entries and immutable blobs from the expected Git commit; no mutable worktree evidence read
- sanitizes inherited Git repository/object selectors and disables replacement objects for every Git invocation
- accepts an explicit empty relevant-module set for whole-file-only findings
- obtains typed-array byte length, backing buffer, and byte offset from intrinsic getters, enforcing the hunk cap before copying or hashing even when own properties are spoofed
- copies module paths through a fixed bounded indexed loop, ignoring overridable array methods
- disables Git lazy fetching so missing partial-clone blobs become explicit omissions without network retrieval

## Behavior

- Validates repo, pull request, base, expected head, worktree, paths, and bounded module input.
- Rejects unsafe paths, symlink/non-file entries, invalid UTF-8, oversize artifacts, stale heads, duplicate modules, and unbounded lists.
- Emits only path, evidence kind, SHA-256, byte count, completeness, and explicit omission metadata; never raw evidence content.

## Proof

- `39/39` focused severe-verification tests passed across the collector, receipt schema, parsers, and canonical serializer under Node `v26.7.0`.
- The exact #1059 regression covers a `Uint8Array(65537)` with own `byteLength = 1` and proves `{bytes:65537, complete:false, code:"cap_exceeded"}` with no digest.
- Fixtures cover later worktree mutation, inherited foreign `GIT_DIR`, replacement commits, empty/nonempty module sets, Unicode, caps, omissions, and exact/stale heads.
- `tsc -p tsconfig.build.json --noEmit` passed.
- `git diff --cached --check` passed before commit.
- Scope: exactly 2 files / 190 non-generated added lines, below the 199-line issue limit.

## Proof boundary

This proves exact-head local evidence collection and metadata behavior only. The caller-supplied hunk is accepted and fingerprinted here; ordered issue #1041 owns binding it and the evidence metadata to review identity and canonical digest. This PR does not wire provider transport, publication, worker, runtime, customers, or release paths.
