### PR TITLE
Gate severe publication on canonical receipts

### DIFF
--- a/src/self-consistency.ts
+++ b/src/self-consistency.ts
@@ -1,6 +1,10 @@
 import { decideReviewEvent } from "./findings.js";
 import { isRequestChangesEligible, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import { canonicalizeSevereVerificationReceipt, type CanonicalSevereVerificationReceipt } from "./severe-verification-receipt-canonical.js";
+import type { SevereVerificationReceipt } from "./severe-verification-receipt-schema.js";
 import type { PullFilePatch, ReviewComment, ReviewEvent, Severity } from "./types.js";
+
+export type { SevereVerificationReceipt } from "./severe-verification-receipt-schema.js";
 
 export interface SelfConsistencyRecheckConfig {
   enabled: boolean;
@@ -14,9 +18,19 @@ export interface SelfConsistencySecondDrawInput {
   hunk: string;
 }
 
-export interface SelfConsistencySecondDrawResult {
-  verified: boolean;
-  confidence: number;
+export interface SelfConsistencyReviewContext {
+  repo: string;
+  pullNumber: number;
+  baseSha: string;
+  headSha: string;
+  findingFingerprint?: string;
+}
+
+/** The injected runner must return the canonical result produced by transport parsing. */
+export type SelfConsistencySecondDrawResult = unknown;
+
+interface SelfConsistencyCanonicalResult extends CanonicalSevereVerificationReceipt {
+  receipt: SevereVerificationReceipt;
 }
 
 export interface SelfConsistencyVerdict {
@@ -28,6 +42,7 @@ export interface SelfConsistencyVerdict {
   secondConfidence?: number;
   agreed?: boolean;
   refuted?: boolean;
+  receipt?: SevereVerificationReceipt;
   error?: string;
 }
 
@@ -37,17 +52,18 @@ const DEFAULT_MAX_FINDINGS = 5;
 /**
  * Opt-in P0/P1 self-consistency re-check (#303). For each gate-accepted comment at a configured
  * severity (post-dedup, pre-event-decision; capped by maxFindingsPerReview in the ranked order the
- * gate already produced), issue ONE bounded second draw asking verify/refute + confidence. The merge
- * is strictly QUIETER-ONLY: agreement keeps the original confidence (never raised); refutation sets
- * confidence to min(original, second) AND strips REQUEST_CHANGES eligibility for that comment. Any
- * second-draw failure leaves the comment untouched (never blocks/drops the review). The event is then
- * re-derived from the comments that retain eligibility. Disabled ⇒ no second draw, byte-identical
- * output. The second-draw runner is injected so callers pick the provider and tests stay hermetic.
+ * gate already produced), issue ONE bounded second draw. Only a canonical, complete, confirmed and
+ * retained receipt bound to the current review context keeps a severe comment. Every invalid,
+ * failed, stale, incomplete, refuted, or capped result suppresses that severe comment. Advisory
+ * P2/P3 comments are never sent to the verifier and remain available. Disabled ⇒ no second draw,
+ * byte-identical output. The second-draw runner is injected so callers pick the provider and tests
+ * stay hermetic.
  */
 export async function runSelfConsistencyRecheck(input: {
   comments: ReviewComment[];
   files: PullFilePatch[];
   config: SelfConsistencyRecheckConfig;
+  reviewContext?: SelfConsistencyReviewContext;
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
   categoryPrecisionFloors?: CategoryPrecisionFloors;
   secondDraw: (input: SelfConsistencySecondDrawInput) => SelfConsistencySecondDrawResult | Promise<SelfConsistencySecondDrawResult>;
@@ -63,18 +79,15 @@ export async function runSelfConsistencyRecheck(input: {
   const severities = new Set<Severity>(input.config.severities ?? DEFAULT_SEVERITIES);
   const maxFindings = input.config.maxFindingsPerReview ?? DEFAULT_MAX_FINDINGS;
   const verdicts: SelfConsistencyVerdict[] = [];
-  const refutedKeys = new Set<string>();
   let rechecked = 0;
 
   // input.comments is already in the gate's ranked (highest-confidence-first) order.
   const comments: ReviewComment[] = [];
   for (const comment of input.comments) {
-    if (rechecked >= maxFindings || !severities.has(comment.severity)) {
+    if (!severities.has(comment.severity)) {
       comments.push(comment);
       continue;
     }
-    rechecked += 1;
-
     const base: SelfConsistencyVerdict = {
       path: comment.path,
       line: comment.line,
@@ -82,41 +95,79 @@ export async function runSelfConsistencyRecheck(input: {
       title: comment.title,
       originalConfidence: comment.confidence
     };
+    if (rechecked >= maxFindings) {
+      verdicts.push({ ...base, error: "severe_verifier_cap_exceeded", refuted: true });
+      continue;
+    }
+    rechecked += 1;
 
     let draw: SelfConsistencySecondDrawResult;
     try {
       draw = await input.secondDraw({ comment, hunk: extractHunk(comment, input.files) });
-    } catch (error) {
-      // Failure posture: keep the finding untouched; the re-check can only make output quieter.
-      verdicts.push({ ...base, error: error instanceof Error ? error.message : String(error) });
-      comments.push(comment);
+    } catch {
+      verdicts.push({ ...base, error: "severe_verifier_unavailable", refuted: true });
       continue;
     }
 
-    if (draw.verified) {
+    const canonical = parseCanonicalResult(draw);
+    if (!canonical) {
+      verdicts.push({ ...base, error: "severe_verifier_receipt_invalid", refuted: true });
+      continue;
+    }
+    const receipt = canonical.receipt;
+    if (retainsSevereFinding(receipt, comment, input.reviewContext)) {
       // Agreement: never raise confidence; keep the original.
-      verdicts.push({ ...base, secondConfidence: draw.confidence, agreed: true, refuted: false });
+      verdicts.push({ ...base, ...(receipt.confidence === undefined ? {} : { secondConfidence: receipt.confidence }), agreed: true, refuted: false, receipt });
       comments.push(comment);
       continue;
     }
 
-    // Refutation: quieter-only — lower confidence and strip REQUEST_CHANGES eligibility.
-    verdicts.push({ ...base, secondConfidence: draw.confidence, agreed: false, refuted: true });
-    refutedKeys.add(commentKey(comment));
-    comments.push({ ...comment, confidence: Math.min(comment.confidence, draw.confidence) });
+    // Any non-retained receipt is quieter-only: suppress the severe publication.
+    verdicts.push({ ...base, ...(receipt.confidence === undefined ? {} : { secondConfidence: receipt.confidence }), agreed: false, refuted: true, receipt });
   }
 
-  // Re-derive the event: a refuted comment still POSTS but no longer counts toward REQUEST_CHANGES.
-  const eligibleComments = comments.filter((comment) => !refutedKeys.has(commentKey(comment)));
-  const event = eligibleComments.some((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors))
-    ? "REQUEST_CHANGES"
-    : "COMMENT";
+  // Re-derive the event from only comments that remain publishable after the gate.
+  const event = comments.some((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors))
+    ? "REQUEST_CHANGES" : "COMMENT";
 
   return { comments, event, verdicts };
 }
 
-function commentKey(comment: Pick<ReviewComment, "path" | "line" | "title">): string {
-  return `${comment.path}${comment.line}${comment.title}`;
+function parseCanonicalResult(value: unknown): SelfConsistencyCanonicalResult | undefined {
+  if (!isRecord(value)) return undefined;
+  const keys = Object.keys(value).sort();
+  if (keys.length !== 3 || keys[0] !== "canonicalJson" || keys[1] !== "digest" || keys[2] !== "receipt") return undefined;
+  if (typeof value.canonicalJson !== "string" || typeof value.digest !== "string" || !isRecord(value.receipt)) return undefined;
+  try {
+    const canonical = canonicalizeSevereVerificationReceipt(value.canonicalJson);
+    return canonical.canonicalJson === value.canonicalJson && canonical.digest === value.digest && sameJsonData(canonical.receipt, value.receipt)
+      ? canonical
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function retainsSevereFinding(receipt: SevereVerificationReceipt, comment: ReviewComment, context: SelfConsistencyReviewContext | undefined): boolean {
+  if (!context || receipt.state !== "confirmed" || receipt.disposition !== "retain") return false;
+  if (context.findingFingerprint !== undefined && context.findingFingerprint !== comment.fingerprint) return false;
+  return receipt.repo === context.repo && receipt.pullNumber === context.pullNumber && receipt.baseSha === context.baseSha && receipt.headSha === context.headSha && receipt.findingFingerprint === comment.fingerprint && hasCompleteEvidence(receipt, comment.path);
+}
+
+function hasCompleteEvidence(receipt: SevereVerificationReceipt, findingPath: string): boolean {
+  return receipt.evidence.complete && receipt.evidence.changedHunk?.complete === true && receipt.evidence.omitted.length === 0 && receipt.evidence.files.length > 0 && receipt.evidence.files.every((file) => file.complete) && receipt.evidence.files.some((file) => file.kind === "whole_file" && file.path === findingPath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sameJsonData(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (Array.isArray(left) || Array.isArray(right)) return Array.isArray(left) && Array.isArray(right) && left.length === right.length && left.every((value, index) => sameJsonData(value, right[index]));
+  if (!isRecord(left) || !isRecord(right)) return false;
+  const leftKeys = Object.keys(left).sort(), rightKeys = Object.keys(right).sort();
+  return leftKeys.length === rightKeys.length && leftKeys.every((key, index) => key === rightKeys[index] && sameJsonData(left[key], right[key]));
 }
 
 /**

--- a/src/self-consistency.ts
+++ b/src/self-consistency.ts
@@ -23,7 +23,6 @@ export interface SelfConsistencyReviewContext {
   pullNumber: number;
   baseSha: string;
   headSha: string;
-  findingFingerprint?: string;
 }
 
 /** The injected runner must return the canonical result produced by transport parsing. */
@@ -150,7 +149,6 @@ function parseCanonicalResult(value: unknown): SelfConsistencyCanonicalResult | 
 
 function retainsSevereFinding(receipt: SevereVerificationReceipt, comment: ReviewComment, context: SelfConsistencyReviewContext | undefined): boolean {
   if (!context || receipt.state !== "confirmed" || receipt.disposition !== "retain") return false;
-  if (context.findingFingerprint !== undefined && context.findingFingerprint !== comment.fingerprint) return false;
   return receipt.repo === context.repo && receipt.pullNumber === context.pullNumber && receipt.baseSha === context.baseSha && receipt.headSha === context.headSha && receipt.findingFingerprint === comment.fingerprint && hasCompleteEvidence(receipt, comment.path);
 }
 

--- a/tests/self-consistency.test.ts
+++ b/tests/self-consistency.test.ts
@@ -177,8 +177,9 @@ describe("self-consistency re-check (#303)", () => {
   });
 
   it("retains #204, suppresses false-severe #225, and leaves clean #209 advisory", async () => {
-    const secondDraw = vi.fn(({ comment: finding }: { comment: ReviewComment }) => receipt(finding.title.includes("225") ? "refuted" : "confirmed"));
-    const result = await runSelfConsistencyRecheck({ comments: [comment({ severity: "P1", line: 2, title: "#225 false severe", confidence: 0.9 }), comment({ severity: "P1", line: 3, title: "#204 confirmed severe", confidence: 0.9 }), comment({ severity: "P2", line: 4, title: "#209 clean", category: "runtime_correctness", confidence: 0.9 })], files, config: { enabled: true }, reviewContext, secondDraw });
+    const legacyContext = { ...reviewContext, findingFingerprint: `finding:${"0".repeat(64)}` };
+    const secondDraw = vi.fn(({ comment: finding }: { comment: ReviewComment }) => { const draw = receipt(finding.title.includes("225") ? "refuted" : "confirmed"); return canonicalizeSevereVerificationReceipt(JSON.stringify({ ...draw.receipt, findingFingerprint: finding.fingerprint })); });
+    const result = await runSelfConsistencyRecheck({ comments: [comment({ severity: "P1", line: 2, title: "#225 false severe", confidence: 0.9 }), comment({ severity: "P1", line: 3, title: "#204 confirmed severe", confidence: 0.9, fingerprint: `finding:${"1".repeat(64)}` }), comment({ severity: "P2", line: 4, title: "#209 clean", category: "runtime_correctness", confidence: 0.9 })], files, config: { enabled: true }, reviewContext: legacyContext, secondDraw });
     expect(result.comments.map(({ title }) => title)).toEqual(["#204 confirmed severe", "#209 clean"]);
     expect(secondDraw).toHaveBeenCalledTimes(2);
     expect(result.event).toBe("REQUEST_CHANGES");

--- a/tests/self-consistency.test.ts
+++ b/tests/self-consistency.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { runSelfConsistencyRecheck } from "../src/self-consistency.js";
+import { canonicalizeSevereVerificationReceipt } from "../src/severe-verification-receipt-canonical.js";
+import { runSelfConsistencyRecheck, type SelfConsistencyReviewContext } from "../src/self-consistency.js";
+import type { SevereVerificationReceipt, SevereVerificationState } from "../src/severe-verification-receipt-schema.js";
 import type { PullFilePatch, ReviewComment } from "../src/types.js";
 
 function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severity" | "line" | "title" | "confidence">): ReviewComment {
@@ -16,6 +18,23 @@ function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severi
 const files: PullFilePatch[] = [
   { filename: "src/save.ts", patch: "@@ -1,2 +1,3 @@\n export function save() {\n+  overwriteAllData();\n }" }
 ];
+
+const reviewContext: SelfConsistencyReviewContext = { repo: "owner/repo", pullNumber: 1, baseSha: "b".repeat(40), headSha: "a".repeat(40) };
+const failureReason: Record<Exclude<SevereVerificationState, "confirmed">, SevereVerificationReceipt["reasonCode"]> = {
+  refuted: "refuted", failed: "provider_unavailable", malformed: "malformed", timeout: "timeout", unavailable: "unavailable", stale_head: "stale_head", incomplete: "incomplete"
+};
+function receipt(state: SevereVerificationState, confidence = 0.8) {
+  const confirmed = state === "confirmed";
+  const complete = confirmed || state === "refuted";
+  const value: SevereVerificationReceipt = {
+    schemaVersion: "severe-verifier-v1", ...reviewContext, findingFingerprint: `finding:${"0".repeat(64)}`, state,
+    disposition: confirmed ? "retain" : "suppress", ...(confirmed ? { confidence } : { reasonCode: failureReason[state] }),
+    evidence: complete
+      ? { changedHunk: { sha256: "e".repeat(64), bytes: 1, complete: true }, files: [{ path: "src/save.ts", kind: "whole_file", sha256: "f".repeat(64), bytes: 1, complete: true }], omitted: [], complete: true }
+      : { files: [], omitted: [{ path: "src/save.ts", code: failureReason[state]! }], complete: false }
+  };
+  return canonicalizeSevereVerificationReceipt(JSON.stringify(value));
+}
 
 describe("self-consistency re-check (#303)", () => {
   it("is a no-op with zero second-draw calls when disabled (byte-identical)", async () => {
@@ -41,7 +60,8 @@ describe("self-consistency re-check (#303)", () => {
       comments,
       files,
       config: { enabled: true, severities: ["P0", "P1"], maxFindingsPerReview: 5 },
-      secondDraw: () => ({ verified: true, confidence: 0.7 })
+      reviewContext,
+      secondDraw: () => receipt("confirmed", 0.7)
     });
 
     expect(result.comments[0]?.confidence).toBe(0.9); // never raised, kept on agreement
@@ -49,18 +69,18 @@ describe("self-consistency re-check (#303)", () => {
     expect(result.verdicts).toEqual([expect.objectContaining({ agreed: true, originalConfidence: 0.9, secondConfidence: 0.7 })]);
   });
 
-  it("downgrades confidence and removes REQUEST_CHANGES eligibility on refutation", async () => {
+  it("suppresses the severe publication on refutation", async () => {
     const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
     const result = await runSelfConsistencyRecheck({
       comments,
       files,
       config: { enabled: true, severities: ["P0", "P1"], maxFindingsPerReview: 5 },
-      secondDraw: () => ({ verified: false, confidence: 0.2 })
+      reviewContext,
+      secondDraw: () => receipt("refuted", 0.2)
     });
 
-    expect(result.comments[0]?.confidence).toBe(0.2); // min(0.9, 0.2)
-    expect(result.comments).toHaveLength(1); // still POSTS as a comment
-    expect(result.event).toBe("COMMENT"); // lost eligibility ⇒ quieter
+    expect(result.comments).toHaveLength(0);
+    expect(result.event).toBe("COMMENT");
     expect(result.verdicts).toEqual([expect.objectContaining({ agreed: false, refuted: true })]);
   });
 
@@ -69,7 +89,8 @@ describe("self-consistency re-check (#303)", () => {
       comments: [comment({ severity: "P1", line: 2, title: "Concern", confidence: 0.4 })],
       files,
       config: { enabled: true, maxFindingsPerReview: 5 },
-      secondDraw: () => ({ verified: true, confidence: 0.99 })
+      reviewContext,
+      secondDraw: () => receipt("confirmed", 0.99)
     });
     expect(result.comments[0]?.confidence).toBe(0.4);
   });
@@ -83,20 +104,23 @@ describe("self-consistency re-check (#303)", () => {
       comments,
       files,
       config: { enabled: true, severities: ["P0"], maxFindingsPerReview: 5 },
+      reviewContext,
       secondDraw: (input) => {
         seen.push(input.comment.title);
-        return { verified: true, confidence: 0.8 };
+        return receipt("confirmed");
       }
     });
 
     expect(seen).toHaveLength(5);
     // Ranked order = the comment order the gate already produced (highest-confidence first).
     expect(seen).toEqual(["Finding 0", "Finding 1", "Finding 2", "Finding 3", "Finding 4"]);
-    expect(result.verdicts).toHaveLength(5);
+    expect(result.comments).toHaveLength(5);
+    expect(result.verdicts).toHaveLength(6);
+    expect(result.verdicts[5]?.error).toBe("severe_verifier_cap_exceeded");
   });
 
   it("only re-checks findings at configured severities (default P0/P1)", async () => {
-    const secondDraw = vi.fn(() => ({ verified: true, confidence: 0.8 }));
+    const secondDraw = vi.fn(() => receipt("confirmed"));
     await runSelfConsistencyRecheck({
       comments: [
         comment({ severity: "P0", line: 2, title: "high", confidence: 0.9 }),
@@ -104,25 +128,27 @@ describe("self-consistency re-check (#303)", () => {
       ],
       files,
       config: { enabled: true, maxFindingsPerReview: 5 },
+      reviewContext,
       secondDraw
     });
     expect(secondDraw).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves a finding untouched when the second draw fails (quieter-only, never blocks)", async () => {
+  it("suppresses a finding when the second draw fails without failing the review", async () => {
     const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
     const result = await runSelfConsistencyRecheck({
       comments,
       files,
       config: { enabled: true, maxFindingsPerReview: 5 },
+      reviewContext,
       secondDraw: () => {
         throw new Error("provider exploded");
       }
     });
 
-    expect(result.comments[0]?.confidence).toBe(0.9);
-    expect(result.event).toBe("REQUEST_CHANGES");
-    expect(result.verdicts).toEqual([expect.objectContaining({ error: expect.stringContaining("provider exploded") })]);
+    expect(result.comments).toHaveLength(0);
+    expect(result.event).toBe("COMMENT");
+    expect(result.verdicts).toEqual([expect.objectContaining({ error: "severe_verifier_unavailable", refuted: true })]);
   });
 
   it("awaits asynchronous second draws sequentially in ranked order", async () => {
@@ -136,16 +162,39 @@ describe("self-consistency re-check (#303)", () => {
       comments,
       files,
       config: { enabled: true, maxFindingsPerReview: 5 },
+      reviewContext,
       secondDraw: async ({ comment: finding }) => {
         events.push(`start:${finding.title}`);
         await new Promise((resolve) => setTimeout(resolve, 5));
         events.push(`finish:${finding.title}`);
-        return { verified: true, confidence: 0.7 };
+        return receipt("confirmed", 0.7);
       }
     });
 
     expect(events).toEqual(["start:first", "finish:first", "start:second", "finish:second"]);
     expect(result.verdicts).toHaveLength(2);
     expect(result.event).toBe("REQUEST_CHANGES");
+  });
+
+  it("retains #204, suppresses false-severe #225, and leaves clean #209 advisory", async () => {
+    const secondDraw = vi.fn(({ comment: finding }: { comment: ReviewComment }) => receipt(finding.title.includes("225") ? "refuted" : "confirmed"));
+    const result = await runSelfConsistencyRecheck({ comments: [comment({ severity: "P1", line: 2, title: "#225 false severe", confidence: 0.9 }), comment({ severity: "P1", line: 3, title: "#204 confirmed severe", confidence: 0.9 }), comment({ severity: "P2", line: 4, title: "#209 clean", category: "runtime_correctness", confidence: 0.9 })], files, config: { enabled: true }, reviewContext, secondDraw });
+    expect(result.comments.map(({ title }) => title)).toEqual(["#204 confirmed severe", "#209 clean"]);
+    expect(secondDraw).toHaveBeenCalledTimes(2);
+    expect(result.event).toBe("REQUEST_CHANGES");
+  });
+
+  it("suppresses every terminal failure state and rejects legacy, mismatched, and incomplete receipts", async () => {
+    for (const state of ["refuted", "failed", "malformed", "timeout", "unavailable", "stale_head", "incomplete"] as const) {
+      const result = await runSelfConsistencyRecheck({ comments: [comment({ severity: "P1", line: 2, title: state, confidence: 0.9 })], files, config: { enabled: true }, reviewContext, secondDraw: () => receipt(state) });
+      expect(result.comments, state).toEqual([]);
+    }
+    const complete = receipt("confirmed");
+    const incomplete = canonicalizeSevereVerificationReceipt(JSON.stringify({ ...complete.receipt, evidence: { ...complete.receipt.evidence, changedHunk: undefined } }));
+    const mismatched = canonicalizeSevereVerificationReceipt(JSON.stringify({ ...complete.receipt, headSha: "c".repeat(40) }));
+    for (const draw of [{ verified: true, confidence: 1 }, incomplete, mismatched]) {
+      const result = await runSelfConsistencyRecheck({ comments: [comment({ severity: "P1", line: 2, title: "invalid", confidence: 0.9 })], files, config: { enabled: true }, reviewContext, secondDraw: () => draw });
+      expect(result.comments).toEqual([]);
+    }
   });
 });


### PR DESCRIPTION
Closes #1042.

Supersedes closed stale PR #818. This clean successor starts from live `main` at `e106faed93c57343f7ab1dd5dae0c53f9afad4a3` and reuses the accepted canonical receipt seam rather than the legacy private parser.

## What changed

- requires the injected severe recheck to return the exact canonical `{ receipt, canonicalJson, digest }` envelope produced by the accepted parser/transport seam
- re-canonicalizes the envelope and rejects byte, digest, or receipt-object mismatches
- binds repo, PR, base/head, and finding fingerprint to the current review context
- retains a P0/P1 only for canonical `confirmed` + `retain` with complete changed-hunk evidence, no omissions, and complete whole-file evidence for the finding path
- suppresses every refuted, failed, malformed, unavailable, timeout, stale-head, incomplete, capped, legacy, mismatched, or invalid severe candidate
- recomputes the review event from only remaining publishable comments, so an unverified P0/P1 cannot produce `REQUEST_CHANGES`
- preserves disabled byte-identical/no-call behavior, ranked call caps, sequential ordering, confirmed-confidence non-escalation, and P2/P3 advisory/no-call behavior
- adds no provider selection/call, evidence collection, worker wiring, live post, database/schema/queue, runtime, customer, or release change

The existing legacy worker caller is intentionally not wired here: while enabled it cannot retain a severe result through this pure gate until #1043 supplies the accepted canonical review context and envelope. That is the required fail-closed posture, not live integration proof.

## Proof

- 8 focused self-consistency, receipt/parser/canonicalizer, collector, and transport test files pass: 55/55 tests
- frozen #225 false-severe, #204 confirmed-severe, and #209 advisory fixtures pass
- all canonical terminal failure states, legacy envelope, context mismatch, incomplete evidence, ranking/cap, event recomputation, disabled mode, and P2/P3 no-call fixtures pass
- production TypeScript `tsc -p tsconfig.build.json --noEmit` passes
- diff hygiene passes and worktree is clean
- exact candidate: `b00cc54ab34e64102cee30786fdd807ed3dc434c`
- scope: exactly two files, 146 insertions / 46 deletions, 192 changed non-generated lines, under #1042's 199-line ceiling

## Merge barrier

No merge until terminal exact-head CI, zero unresolved review conversations, and two fresh blind checker PASS verdicts at confidence >=95. Passing proves only the pure severe publication decision. It does not prove provider behavior, worker integration, GitHub posting, runtime, release, or customer readiness.
