### PR TITLE
Wire canonical severe verification into advisory worker

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
 import {
@@ -53,6 +54,7 @@ import {
   resolveRepoProfile
 } from "./repo-policy.js";
 import { applyDeterministicReviewGate, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
+import { buildFindingFingerprint } from "./findings.js";
 import {
   buildReviewEnsembleLeafPrompt,
   buildReviewEnsemblePlan,
@@ -126,12 +128,20 @@ import {
   isZCodeSchemaFailureError,
   mergeReviewModelSummaries,
   reviewPromptForbiddenFragments,
+  runZCodeRawJson,
   runZCodeReview,
   type ReviewModelSummary,
   type ZCodeReviewResult
 } from "./zcode.js";
-import { runCodexReview } from "./codex-runtime.js";
+import { runCodexReview, runCodexStructuredOutput } from "./codex-runtime.js";
 import { runSelfConsistencyRecheck, type SelfConsistencySecondDrawResult } from "./self-consistency.js";
+import { collectSevereVerificationEvidence, MAX_MODULES } from "./severe-verification-evidence.js";
+import {
+  buildSevereVerificationTransport, parseSevereVerificationTransport, severeVerificationTransportFailure,
+  type SevereVerificationTransportInput
+} from "./severe-verification-transport.js";
+import { canonicalizeSevereVerificationReceipt } from "./severe-verification-receipt-canonical.js";
+import type { SevereVerificationCode } from "./severe-verification-receipt-schema.js";
 import type { DeterministicReviewGateResult } from "./review-gate.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
 import type { DroppedFinding, Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
@@ -2068,10 +2078,15 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     try {
       selfConsistency = await applySelfConsistencyRecheck({
         config,
+        github,
+        repo,
+        pull,
+        findings: gatedFindings,
         gate,
         files: reviewFiles,
         worktreePath: worktree.path,
-        evidenceDir
+        evidenceDir,
+        assertProviderConfigCurrent: assertApprovedProviderConfigCurrent
       });
     } finally {
       startShadowLeaves?.();
@@ -3907,10 +3922,15 @@ function providerCooldownJitterMs(
 
 async function applySelfConsistencyRecheck(input: {
   config: BotConfig;
+  github: GitHubApi;
+  repo: string;
+  pull: PullRequestSummary;
+  findings: Finding[];
   gate: DeterministicReviewGateResult;
   files: PullFilePatch[];
   worktreePath: string;
   evidenceDir: string;
+  assertProviderConfigCurrent?: () => void;
 }): Promise<{ comments: DeterministicReviewGateResult["comments"]; event: DeterministicReviewGateResult["event"]; runtimeNote?: string }> {
   const selfConsistencyConfig = input.config.reviewGate?.selfConsistency;
   if (!selfConsistencyConfig?.enabled) {
@@ -3923,6 +3943,7 @@ async function applySelfConsistencyRecheck(input: {
     comments: input.gate.comments,
     files: input.files,
     config: selfConsistencyConfig,
+    reviewContext: { repo: input.repo, pullNumber: input.pull.number, baseSha: input.pull.base.sha, headSha: input.pull.head.sha },
     ...(input.config.reviewGate?.requestChangesConfidenceFloors
       ? { requestChangesConfidenceFloors: input.config.reviewGate.requestChangesConfidenceFloors }
       : {}),
@@ -3930,36 +3951,48 @@ async function applySelfConsistencyRecheck(input: {
       ? { categoryPrecisionFloors: input.config.reviewGate.categoryPrecisionFloors }
       : {}),
     secondDraw: async ({ comment, hunk }) => {
-      const prompt = buildSelfConsistencyPrompt(comment, hunk);
-      const draw = backend.useCodex
-        ? await runConfiguredReview({
-            config: input.config,
-            worktreePath: input.worktreePath,
-            prompt,
-            evidenceDir: join(
-              input.evidenceDir,
-              "self-consistency-codex",
-              createHash("sha256")
-                .update(comment.path)
-                .update("\0")
-                .update(String(comment.line))
-                .update("\0")
-                .update(comment.title)
-                .digest("hex")
-                .slice(0, 16)
-            )
-          })
-        : await runZCodeReview({
-            cwd: input.worktreePath,
-            prompt,
-            cliPath: input.config.zcode.cliPath,
-            appConfigPath: input.config.zcode.appConfigPath,
-            model: input.config.zcode.model,
-            ...(providerId ? { providerId } : {}),
-            timeoutMs: input.config.zcode.timeoutMs,
-            retryMaxRetries: input.config.zcode.retryMaxRetries
-          });
-      return parseSelfConsistencyVerdict(draw.rawResponse);
+      const context = { repo: input.repo, pullNumber: input.pull.number, baseSha: input.pull.base.sha, headSha: input.pull.head.sha };
+      const original = input.findings.find((finding) => buildFindingFingerprint(finding) === comment.fingerprint);
+      if (!original) return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, "identity_mismatch");
+      const finding: SevereVerificationTransportInput["finding"] = {
+        path: original.path, line: original.line, severity: original.severity as "P0" | "P1", title: original.title, body: original.body,
+        ...(original.category ? { category: original.category } : {}), ...(original.why_this_matters ? { why_this_matters: original.why_this_matters } : {}),
+        fingerprint: comment.fingerprint
+      };
+      try {
+        input.assertProviderConfigCurrent?.();
+        const livePull = await input.github.getPull(input.repo, input.pull.number);
+        if (detectStalePullHead({ expected: input.pull, live: livePull, phase: "before_review" })) {
+          return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, "stale_head");
+        }
+        const evidence = await collectSevereVerificationEvidence({
+          ...context,
+          worktreePath: input.worktreePath,
+          expectedHeadSha: context.headSha,
+          findingPath: comment.path,
+          changedHunk: hunk,
+          relevantModulePaths: [...new Set(input.files.map((file) => file.filename).filter((path) => path !== comment.path))].sort().slice(0, MAX_MODULES)
+        });
+        const contents = evidence.files.map((file) => ({ ...file, content: readFileSync(join(input.worktreePath, file.path), "utf8") }));
+        const transportInput: SevereVerificationTransportInput = { ...context, finding, changedHunk: hunk, evidence, files: contents };
+        const messages = buildSevereVerificationTransport(transportInput);
+        input.assertProviderConfigCurrent?.();
+        const rawResponse = backend.useCodex
+          ? await runSevereCodexRawJson(input.config, input.worktreePath, JSON.stringify(messages))
+          : await runZCodeRawJson({
+              cwd: input.worktreePath,
+              prompt: JSON.stringify(messages),
+              cliPath: input.config.zcode.cliPath,
+              appConfigPath: input.config.zcode.appConfigPath,
+              model: input.config.zcode.model,
+              ...(providerId ? { providerId } : {}),
+              timeoutMs: input.config.zcode.timeoutMs,
+              retryMaxRetries: input.config.zcode.retryMaxRetries
+            });
+        return parseSevereVerificationTransport(rawResponse, transportInput);
+      } catch (error) {
+        return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, severeVerificationFailureCode(error));
+      }
     }
   });
 
@@ -3972,13 +4005,48 @@ async function applySelfConsistencyRecheck(input: {
   });
 
   const agreed = result.verdicts.filter((verdict) => verdict.agreed === true).length;
-  const refuted = result.verdicts.filter((verdict) => verdict.refuted === true).length;
-  const failed = result.verdicts.filter((verdict) => verdict.error !== undefined).length;
+  const capped = result.verdicts.filter((verdict) => verdict.error === "severe_verifier_cap_exceeded").length;
+  const redrawn = result.verdicts.length - capped;
+  const suppressed = result.verdicts.filter((verdict) => verdict.refuted === true && verdict.error !== "severe_verifier_cap_exceeded").length;
+  const failed = result.verdicts.filter((verdict) => verdict.error !== undefined && verdict.error !== "severe_verifier_cap_exceeded").length;
   const runtimeNote = result.verdicts.length
-    ? `Self-consistency re-check (#303): ${result.verdicts.length} P0/P1 finding(s) re-drawn — ${agreed} agreed, ${refuted} refuted (downgraded/ineligible), ${failed} second-draw failure(s) left untouched.`
+    ? `Self-consistency re-check (#303): ${redrawn} actual P0/P1 redraw(s) — ${agreed} retained, ${suppressed} suppressed (${failed} failure(s)), ${capped} capped candidate(s). Suppression is fail-closed and is not a provider refutation.`
     : undefined;
 
   return { comments: result.comments, event: result.event, ...(runtimeNote ? { runtimeNote } : {}) };
+}
+
+function severeVerificationFailureCode(error: unknown): SevereVerificationCode {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("not_read")) return "not_read";
+  return severeVerificationTransportFailure(error);
+}
+
+function severeVerificationFailureReceipt(
+  context: { repo: string; pullNumber: number; baseSha: string; headSha: string }, path: string, findingFingerprint: string, code: SevereVerificationCode
+) {
+  const state = code === "timeout" ? "timeout" : code === "unavailable" ? "unavailable" : code === "provider_unavailable" ? "failed"
+    : code === "stale_head" || code === "identity_mismatch" ? "stale_head"
+      : code === "incomplete" || code === "not_read" || code === "evidence_incomplete" || code === "cap_exceeded" ? "incomplete" : "malformed";
+  return canonicalizeSevereVerificationReceipt(JSON.stringify({
+    schemaVersion: "severe-verifier-v1", ...context, findingFingerprint, state,
+    disposition: "suppress", reasonCode: code, evidence: { files: [], omitted: [{ path, code }], complete: false }
+  }));
+}
+
+async function runSevereCodexRawJson(config: BotConfig, cwd: string, prompt: string): Promise<string> {
+  const runtime = config.codexRuntime!;
+  const scratch = mkdtempSync(join(tmpdir(), "neondiff-severe-verifier-"));
+  try {
+    const result = await runCodexStructuredOutput<unknown>({
+      cwd, prompt, cliPath: runtime.cliPath, model: runtime.model, reasoningEffort: runtime.reasoningEffort,
+      evidenceDir: scratch, timeoutMs: runtime.timeoutMs, maxOutputBytes: runtime.maxOutputBytes,
+      artifactPrefix: "severe-verifier", schema: { type: "object" }, parse: (value) => value
+    });
+    return result.rawResponse;
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
 }
 
 export function resolveSelfConsistencyBackend(

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -407,6 +407,14 @@ export async function runZCodeReview(input: {
   );
 }
 
+export async function runZCodeRawJson(input: { cwd: string; prompt: string; cliPath: string; appConfigPath: string; model: string; providerId?: string; timeoutMs?: number; retryMaxRetries?: number }): Promise<string> {
+  const zcodeEnv = resolveZCodeProviderEnv({ appConfigPath: input.appConfigPath, model: input.model, providerId: input.providerId });
+  const result = await withTemporaryZCodeReviewPolicy(input.cwd, undefined, () => runZCodeProcess(process.execPath, [input.cliPath, "--cwd", input.cwd, "--mode", "plan", "--json", "--no-browser", "--prompt", input.prompt], { env: buildZCodeRuntimeEnv({ baseEnv: process.env, providerEnv: zcodeEnv, retryMaxRetries: input.retryMaxRetries ?? 0 }), maxBuffer: 20 * 1024 * 1024, timeout: input.timeoutMs ?? 180_000 }));
+  const stdout = redactSecrets(result.stdout.replaceAll(zcodeEnv.ZCODE_API_KEY, "[redacted-secret]")); const stderr = redactSecrets(result.stderr.replaceAll(zcodeEnv.ZCODE_API_KEY, "[redacted-secret]"));
+  if (result.error) throw enrichZCodeProcessError({ error: new Error(`ZCode failed before completion: ${result.error.message}`), originalError: result.error, signal: result.signal, status: result.status });
+  if (result.status !== 0) throw new Error(`ZCode failed with status ${result.status}: ${stderr || stdout.slice(0, 1000)}`); return extractZCodeResponse(stdout);
+}
+
 function buildStrictJsonRetryPrompt(originalPrompt: string): string {
   return [
     "Your previous review output was rejected because it was not valid JSON.",

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +8,7 @@ import type { BotConfig } from "../src/config.js";
 import type { GitHubApi } from "../src/github.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { Finding, PullRequestSummary } from "../src/types.js";
+import { buildFindingFingerprint } from "../src/findings.js";
 import { testLicenseAdmission } from "./helpers/license-admission.js";
 
 const zcodePrompts = vi.hoisted((): string[] => []);
@@ -15,6 +18,8 @@ const zcodeFailuresByPath = vi.hoisted(() => new Map<string, string>());
 const zcodeDelaysByPath = vi.hoisted(() => new Map<string, number>());
 const zcodeBarriersByPath = vi.hoisted(() => new Map<string, Promise<void>>());
 const zcodeFirstFailuresByPath = vi.hoisted(() => new Map<string, { message: string; beforeThrow?: () => void }>());
+const severeRawResponse = vi.hoisted(() => ({ value: "" }));
+const severeCurrentWorktree = vi.hoisted(() => ({ enabled: false }));
 const createdReviews = vi.hoisted((): Array<{
   repo: string;
   pullNumber: number;
@@ -36,7 +41,7 @@ vi.mock("../src/git.js", async (importOriginal) => {
   return {
     ...actual,
     preparePullWorktree: vi.fn((input: { workRoot: string; expectedHeadSha: string }) => {
-      const path = join(input.workRoot, "mock-worktree");
+      const path = severeCurrentWorktree.enabled ? process.cwd() : join(input.workRoot, "mock-worktree");
       mkdirSync(path, { recursive: true });
       return { path, headSha: input.expectedHeadSha };
     }),
@@ -73,7 +78,8 @@ vi.mock("../src/zcode.js", async (importOriginal) => {
         attempts: 1,
         degradedRecovery: false
       };
-    })
+    }),
+    runZCodeRawJson: vi.fn(async ({ prompt }: { prompt: string }) => (zcodePrompts.push(prompt), severeRawResponse.value))
   };
 });
 
@@ -165,6 +171,8 @@ describe("worker context budget preflight", () => {
     zcodeDelaysByPath.clear();
     zcodeBarriersByPath.clear();
     zcodeFirstFailuresByPath.clear();
+    severeRawResponse.value = "";
+    severeCurrentWorktree.enabled = false;
     createdReviews.length = 0;
     walkthroughBuildEvents.length = 0;
     delete reviewPostControl.error;
@@ -650,10 +658,11 @@ describe("worker context budget preflight", () => {
     const config = minimalConfig(root);
     config.reviewEnsemble = { enabled: true, mode: "shadow" };
     config.reviewGate = { maxInlineComments: 25, selfConsistency: { enabled: true } };
+    severeCurrentWorktree.enabled = true;
     const state = new ReviewStateStore(config.statePath);
-    const pull = pullSummary(426, "4".repeat(40));
-    const files = [pullFile("src/a.ts", 200)];
-    zcodeFindingsByPath.set("src/a.ts", [p1Finding("src/a.ts", "Canonical blocking finding")]);
+    const pull = pullSummary(426, execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim());
+    const files = [pullFile("src/severe-verification-evidence.ts", 200)];
+    zcodeFindingsByPath.set("src/severe-verification-evidence.ts", [p1Finding("src/severe-verification-evidence.ts", "Canonical blocking finding")]);
 
     const result = await reviewPull({
       config,
@@ -666,10 +675,40 @@ describe("worker context budget preflight", () => {
     });
 
     expect(result).toBe("reviewed");
-    const selfConsistencyIndex = zcodePrompts.findIndex((prompt) => prompt.includes("re-checking a SINGLE prior"));
+    const selfConsistencyIndex = zcodePrompts.findIndex((prompt) => prompt.includes("severe-verifier-input-v1"));
     const firstShadowIndex = zcodePrompts.findIndex((prompt) => prompt.includes("State and lifecycle review"));
     expect(selfConsistencyIndex).toBeGreaterThan(0);
     expect(firstShadowIndex).toBeGreaterThan(selfConsistencyIndex);
+    state.close();
+  });
+
+  it("binds severe verification to original finding fields after public normalization", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-severe-worker-original-finding-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    severeCurrentWorktree.enabled = true;
+    config.reviewGate = { maxInlineComments: 25, selfConsistency: { enabled: true } };
+    const state = new ReviewStateStore(config.statePath);
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    const pull = pullSummary(430, head);
+    const file = pullFile("src/severe-verification-evidence.ts", 40);
+    const original: Finding = { ...p1Finding(file.filename, "Proof gap with 95% confidence"), body: "The confidence is 95%; inspect this exact proof gap.", category: "proof_gap" };
+    zcodeFindingsByPath.set(file.filename, [original]);
+    const hunkHash = createHash("sha256").update(file.patch, "utf8").digest("hex");
+    const fileBytes = readFileSync(join(process.cwd(), file.filename));
+    const fileHash = createHash("sha256").update(fileBytes).digest("hex");
+    severeRawResponse.value = JSON.stringify({
+      schemaVersion: "severe-verifier-v1", repo: "electricsheephq/WorldOS", pullNumber: pull.number,
+      baseSha: pull.base.sha, headSha: head, findingFingerprint: buildFindingFingerprint(original),
+      state: "confirmed", disposition: "retain", confidence: 0.8,
+      evidence: { changedHunk: { sha256: hunkHash, bytes: Buffer.byteLength(file.patch), complete: true },
+        files: [{ path: file.filename, kind: "whole_file", sha256: fileHash, bytes: fileBytes.length, complete: true }], omitted: [], complete: true }
+    });
+    const result = await reviewPull({ config, github: githubForPull(pull, [file]), state, repo: "electricsheephq/WorldOS", pull, dryRun: false, useZCode: true });
+    expect(result).toBe("reviewed");
+    const transport = JSON.parse(JSON.parse(zcodePrompts.find((prompt) => prompt.includes("severe-verifier-input-v1"))!)[1].content);
+    expect(transport.finding).toMatchObject({ category: "proof_gap", title: original.title, body: original.body });
+    expect(createdReviews[0]?.comments).toHaveLength(1);
     state.close();
   });
 


### PR DESCRIPTION
Closes #1043.

This clean successor starts from public `main` at `b3a313a9cd81811217c9118105304b029870032e`. It preserves the rejected local-only candidate `e2b6b54194e4dd0b73c503a2a062d5b9b169dfd7` as evidence and fixes its verified original-finding fingerprint blocker by rebuilding from the accepted base; no failed-candidate commit is in this branch.

## What changed

- wires the accepted exact-head severe evidence collector, canonical transport/parser, and publication decision into the existing advisory worker self-consistency path
- carries the original pre-normalization finding only inside the in-memory verifier call, so its canonical fingerprint remains bound even when the public category or confidence text is normalized
- binds repo, PR, base/head, finding fingerprint, changed hunk, bounded whole-file/module bytes, hashes, and completeness before a verifier response can retain a P0/P1
- rechecks live PR head and approved provider configuration before the severe draw, then relies on the existing exact-head checks and `(repo, PR, head)` claim/post path before publication
- converts every stale, unavailable, timeout, malformed, incomplete, cap, evidence-read, identity, and provider failure into a canonical suppressing receipt
- keeps Codex raw output in a removed temporary directory and adds a no-evidence ZCode JSON path, so only redacted canonical verdicts enter durable review evidence
- preserves disabled/P2/P3 no-call behavior, dry-before-live admission, same-head duplicate suppression, explicit retryable-row policy, and advisory-only GitHub behavior
- changes no database, schema, queue, managed-App, runtime configuration, worker identity, customer data, billing, feed, artifact, or release surface

## Proof

- exact candidate: `63f86e3fe2ec4c346b4365d917298af0b13f82e5`
- exact scope: three files, 157 insertions plus 42 deletions, exactly 199 changed lines
- root focused run: 13 files, 134/134 tests pass under `/opt/homebrew/bin/node`
- candidate focused runs: worker context 62/62; severe/evidence/receipt/self-consistency/ZCode 73/73
- the prior `proof_gap` to public `auth` normalization plus confidence-text sanitization counterexample now reaches canonical transport with the original finding fields and retains a valid receipt
- production TypeScript build and diff hygiene pass; worktree is clean
- blind acceptance checker: PASS, confidence 97
- blind adversarial checker: PASS, confidence 97 after replaying the prior blocker and variant attacks
- GitNexus `detect_changes` was run before commit; its registry is 181 commits stale, so direct exact-source inspection is the authoritative impact bound

## Merge barrier

No merge until terminal exact-head CI, zero unresolved review conversations, unchanged head, and a final live metadata/readback check. The two required blind semantic checks already PASS at confidence 97 on this exact commit. Any new verified blocker exceeds the frozen 199-line source envelope and requires split/rebuild, not another patch.

Passing proves source/test worker integration only. It does not prove live provider calls, GitHub publication, installed runtime, customer behavior, signing, release, or GA readiness.
