### PR TITLE
Fix severe verifier immutable blob content

### DIFF
--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -55,7 +55,7 @@ export function readSevereVerificationEvidenceContents(
   const expected = new Map<string, "whole_file" | "module">();
   expected.set(finding, "whole_file");
   for (const path of modules) expected.set(path, "module");
-  if (!evidence || !Array.isArray(evidence.files)) throw new Error("evidence_incomplete");
+  if (!evidence || evidence.complete !== true || !Array.isArray(evidence.files)) throw new Error("evidence_incomplete");
   const fileCount = evidence.files.length;
   if (!Number.isSafeInteger(fileCount) || fileCount > MAX_MODULES + 1) throw new Error("evidence_incomplete");
   const seen = new Set<string>(), contents: SevereVerificationEvidenceContent[] = [];
@@ -68,6 +68,7 @@ export function readSevereVerificationEvidenceContents(
     if (result.file.sha256 !== metadata.sha256 || result.file.bytes !== metadata.bytes || result.file.complete !== true || metadata.complete !== true) throw new Error("evidence_incomplete");
     contents.push({ path: metadata.path, kind: metadata.kind, content: contentDecoder.decode(result.data) });
   }
+  if (seen.size !== expected.size) throw new Error("evidence_incomplete");
   return contents.sort((a, b) => compareText(a.path, b.path) || compareText(a.kind, b.kind));
 }
 

--- a/src/severe-verification-evidence.ts
+++ b/src/severe-verification-evidence.ts
@@ -6,6 +6,7 @@ import type { SevereVerificationCode, SevereVerificationEvidenceFile } from "./s
 export const MAX_EVIDENCE_BYTES = 65_536;
 export const MAX_MODULES = 16;
 const decoder = new TextDecoder("utf-8", { fatal: true });
+const contentDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
 const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
 const typedArrayBuffer = Object.getOwnPropertyDescriptor(typedArrayPrototype, "buffer")!.get!;
 const typedArrayByteOffset = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteOffset")!.get!;
@@ -22,19 +23,16 @@ export interface SevereVerificationEvidenceResult {
   changedHunk: ChangedHunkMetadata; files: SevereVerificationEvidenceFile[];
   omitted: { path: string; code: OmissionCode }[]; complete: boolean;
 }
+export interface SevereVerificationEvidenceContent { path: string; kind: "whole_file" | "module"; content: string; }
 type TreeEntry = { mode: string; type: string; object: string; bytes: number };
+type InspectedFile = { file: SevereVerificationEvidenceFile; data: Buffer };
 
 /** Exact-head, bounded, metadata-only evidence; source bytes come only from immutable Git blobs. */
 export async function collectSevereVerificationEvidence(input: SevereVerificationEvidenceInput): Promise<SevereVerificationEvidenceResult> {
   verifyIdentity(input);
   const gitDir = verifyHead(input.expectedHeadSha, input.worktreePath);
   const finding = safePath(input.findingPath);
-  if (!Array.isArray(input.relevantModulePaths)) throw new Error("module_list");
-  const moduleCount = input.relevantModulePaths.length;
-  if (!Number.isSafeInteger(moduleCount) || moduleCount > MAX_MODULES) throw new Error("module_list");
-  const modules: string[] = [];
-  for (let index = 0; index < moduleCount; index += 1) modules.push(safePath(input.relevantModulePaths[index]));
-  if (new Set(modules).size !== modules.length || modules.includes(finding)) throw new Error("module_list");
+  const modules = normalizeModules(input.relevantModulePaths, finding);
   const changedHunk = hunkMetadata(input.changedHunk);
   const files: SevereVerificationEvidenceFile[] = [], omitted: { path: string; code: OmissionCode }[] = [];
   const add = (path: string, kind: "whole_file" | "module") => {
@@ -44,6 +42,33 @@ export async function collectSevereVerificationEvidence(input: SevereVerificatio
   add(finding, "whole_file");
   for (const path of [...modules].sort(compareText)) add(path, "module");
   return { changedHunk, files, omitted, complete: changedHunk.complete && !omitted.length && files.length === modules.length + 1 };
+}
+
+/** Read the exact blob bytes represented by metadata without consulting filtered worktree files. */
+export function readSevereVerificationEvidenceContents(
+  input: SevereVerificationEvidenceInput, evidence: SevereVerificationEvidenceResult
+): SevereVerificationEvidenceContent[] {
+  verifyIdentity(input);
+  const gitDir = verifyHead(input.expectedHeadSha, input.worktreePath);
+  const finding = safePath(input.findingPath);
+  const modules = normalizeModules(input.relevantModulePaths, finding);
+  const expected = new Map<string, "whole_file" | "module">();
+  expected.set(finding, "whole_file");
+  for (const path of modules) expected.set(path, "module");
+  if (!evidence || !Array.isArray(evidence.files)) throw new Error("evidence_incomplete");
+  const fileCount = evidence.files.length;
+  if (!Number.isSafeInteger(fileCount) || fileCount > MAX_MODULES + 1) throw new Error("evidence_incomplete");
+  const seen = new Set<string>(), contents: SevereVerificationEvidenceContent[] = [];
+  for (let index = 0; index < fileCount; index += 1) {
+    const metadata = evidence.files[index];
+    if (!metadata || !safePath(metadata.path) || (metadata.kind !== "whole_file" && metadata.kind !== "module") || seen.has(metadata.path) || expected.get(metadata.path) !== metadata.kind) throw new Error("evidence_incomplete");
+    seen.add(metadata.path);
+    const result = inspectFile(gitDir, input.expectedHeadSha, metadata.path, metadata.kind);
+    if (!("file" in result)) throw new Error(result.omission.code);
+    if (result.file.sha256 !== metadata.sha256 || result.file.bytes !== metadata.bytes || result.file.complete !== true || metadata.complete !== true) throw new Error("evidence_incomplete");
+    contents.push({ path: metadata.path, kind: metadata.kind, content: contentDecoder.decode(result.data) });
+  }
+  return contents.sort((a, b) => compareText(a.path, b.path) || compareText(a.kind, b.kind));
 }
 
 function verifyIdentity(input: SevereVerificationEvidenceInput): void {
@@ -69,7 +94,7 @@ function safePath(value: string): string {
 }
 
 function inspectFile(gitDir: string, head: string, path: string, kind: "whole_file" | "module"):
-  { file: SevereVerificationEvidenceFile } | { omission: { path: string; code: OmissionCode } } {
+  InspectedFile | { omission: { path: string; code: OmissionCode } } {
   let entry: TreeEntry | undefined;
   try { entry = treeEntry(gitDir, head, path); } catch { return { omission: { path, code: "not_read" } }; }
   if (!entry) return { omission: { path, code: "not_read" } };
@@ -81,7 +106,15 @@ function inspectFile(gitDir: string, head: string, path: string, kind: "whole_fi
   catch { return { omission: { path, code: "not_read" } }; }
   if (data.length > MAX_EVIDENCE_BYTES) return { omission: { path, code: "cap_exceeded" } };
   try { decoder.decode(data); } catch { return { omission: { path, code: "evidence_incomplete" } }; }
-  return { file: { path, kind, sha256: hash(data), bytes: data.length, complete: true } };
+  return { file: { path, kind, sha256: hash(data), bytes: data.length, complete: true }, data };
+}
+
+function normalizeModules(paths: readonly string[], finding: string): string[] {
+  if (!Array.isArray(paths) || !Number.isSafeInteger(paths.length) || paths.length > MAX_MODULES) throw new Error("module_list");
+  const modules: string[] = [];
+  for (let index = 0; index < paths.length; index += 1) modules.push(safePath(paths[index]));
+  if (new Set(modules).size !== modules.length || modules.includes(finding)) throw new Error("module_list");
+  return modules;
 }
 
 function treeEntry(gitDir: string, head: string, path: string): TreeEntry | undefined {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
@@ -135,7 +135,7 @@ import {
 } from "./zcode.js";
 import { runCodexReview, runCodexStructuredOutput } from "./codex-runtime.js";
 import { runSelfConsistencyRecheck, type SelfConsistencySecondDrawResult } from "./self-consistency.js";
-import { collectSevereVerificationEvidence } from "./severe-verification-evidence.js";
+import { collectSevereVerificationEvidence, readSevereVerificationEvidenceContents } from "./severe-verification-evidence.js";
 import {
   buildSevereVerificationTransport, parseSevereVerificationTransport, severeVerificationTransportFailure,
   type SevereVerificationTransportInput
@@ -3959,13 +3959,14 @@ async function applySelfConsistencyRecheck(input: {
         ...(original.category ? { category: original.category } : {}), ...(original.why_this_matters ? { why_this_matters: original.why_this_matters } : {}),
         fingerprint: comment.fingerprint
       };
+      let evidence: Awaited<ReturnType<typeof collectSevereVerificationEvidence>> | undefined;
       try {
         input.assertProviderConfigCurrent?.();
         const livePull = await input.github.getPull(input.repo, input.pull.number);
         if (detectStalePullHead({ expected: input.pull, live: livePull, phase: "before_review" })) {
           return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, "stale_head");
         }
-        const evidence = await collectSevereVerificationEvidence({
+        evidence = await collectSevereVerificationEvidence({
           ...context,
           worktreePath: input.worktreePath,
           expectedHeadSha: context.headSha,
@@ -3973,7 +3974,14 @@ async function applySelfConsistencyRecheck(input: {
           changedHunk: hunk,
           relevantModulePaths: []
         });
-        const contents = evidence.files.map((file) => ({ ...file, content: readFileSync(join(input.worktreePath, file.path), "utf8") }));
+        const contents = readSevereVerificationEvidenceContents({
+          ...context,
+          worktreePath: input.worktreePath,
+          expectedHeadSha: context.headSha,
+          findingPath: comment.path,
+          changedHunk: hunk,
+          relevantModulePaths: []
+        }, evidence);
         const transportInput: SevereVerificationTransportInput = { ...context, finding, changedHunk: hunk, evidence, files: contents };
         const messages = buildSevereVerificationTransport(transportInput);
         input.assertProviderConfigCurrent?.();
@@ -3992,7 +4000,8 @@ async function applySelfConsistencyRecheck(input: {
         return parseSevereVerificationTransport(rawResponse, transportInput);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, message.includes("not_read") ? "not_read" : severeVerificationTransportFailure(error));
+        const code = message.includes("not_read") ? "not_read" : severeVerificationTransportFailure(error);
+        return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, code, evidence?.omitted.length ? evidence : undefined);
       }
     }
   });
@@ -4018,14 +4027,16 @@ async function applySelfConsistencyRecheck(input: {
 }
 
 function severeVerificationFailureReceipt(
-  context: { repo: string; pullNumber: number; baseSha: string; headSha: string }, path: string, findingFingerprint: string, code: SevereVerificationCode
+  context: { repo: string; pullNumber: number; baseSha: string; headSha: string }, path: string, findingFingerprint: string, code: SevereVerificationCode,
+  evidence?: Pick<Awaited<ReturnType<typeof collectSevereVerificationEvidence>>, "files" | "omitted">
 ) {
   const state = code === "timeout" ? "timeout" : code === "unavailable" ? "unavailable" : code === "provider_unavailable" ? "failed"
     : code === "stale_head" || code === "identity_mismatch" ? "stale_head"
       : code === "incomplete" || code === "not_read" || code === "evidence_incomplete" || code === "cap_exceeded" ? "incomplete" : "malformed";
+  const failureEvidence = evidence ?? { files: [], omitted: [{ path, code }] };
   return canonicalizeSevereVerificationReceipt(JSON.stringify({
     schemaVersion: "severe-verifier-v1", ...context, findingFingerprint, state,
-    disposition: "suppress", reasonCode: code, evidence: { files: [], omitted: [{ path, code }], complete: false }
+    disposition: "suppress", reasonCode: code, evidence: { ...failureEvidence, complete: false }
   }));
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4000,8 +4000,13 @@ async function applySelfConsistencyRecheck(input: {
         return parseSevereVerificationTransport(rawResponse, transportInput);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        const code = message.includes("not_read") ? "not_read" : severeVerificationTransportFailure(error);
-        return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, code, evidence?.omitted.length ? evidence : undefined);
+        const evidenceCode = evidence?.complete === false
+          ? evidence.changedHunk.complete === false && evidence.changedHunk.code
+            ? evidence.changedHunk.code
+            : evidence.omitted.length === 1 ? evidence.omitted[0].code : undefined
+          : undefined;
+        const code = evidenceCode ?? (message.includes("not_read") ? "not_read" : severeVerificationTransportFailure(error));
+        return severeVerificationFailureReceipt(context, comment.path, comment.fingerprint, code, evidence);
       }
     }
   });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4033,7 +4033,7 @@ function severeVerificationFailureReceipt(
   const state = code === "timeout" ? "timeout" : code === "unavailable" ? "unavailable" : code === "provider_unavailable" ? "failed"
     : code === "stale_head" || code === "identity_mismatch" ? "stale_head"
       : code === "incomplete" || code === "not_read" || code === "evidence_incomplete" || code === "cap_exceeded" ? "incomplete" : "malformed";
-  const failureEvidence = evidence ?? { files: [], omitted: [{ path, code }] };
+  const failureEvidence = evidence ? { files: evidence.files, omitted: evidence.omitted } : { files: [], omitted: [{ path, code }] };
   return canonicalizeSevereVerificationReceipt(JSON.stringify({
     schemaVersion: "severe-verifier-v1", ...context, findingFingerprint, state,
     disposition: "suppress", reasonCode: code, evidence: { ...failureEvidence, complete: false }

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -81,6 +81,8 @@ describe("exact-head severe evidence collection", () => {
 
   it("records missing, invalid UTF-8, and capped blobs as omissions", async () => {
     const result = await collectSevereVerificationEvidence(input(["missing.ts", "bad.bin", "big.bin"])); expect(result.complete).toBe(false); expect(result.files.map((item) => item.path)).toEqual([finding]); expect(result.omitted).toEqual([{ path: "bad.bin", code: "evidence_incomplete" }, { path: "big.bin", code: "cap_exceeded" }, { path: "missing.ts", code: "not_read" }]);
+    expect(() => readSevereVerificationEvidenceContents(input(["missing.ts", "bad.bin", "big.bin"]), result)).toThrow("evidence_incomplete");
+    expect(() => readSevereVerificationEvidenceContents(input([moduleA]), { ...result, complete: true, omitted: [] })).toThrow("evidence_incomplete");
   });
 
   it("does not lazily fetch missing partial-clone blobs", async () => {

--- a/tests/severe-verification-evidence.test.ts
+++ b/tests/severe-verification-evidence.test.ts
@@ -2,9 +2,11 @@ import { execFileSync } from "node:child_process";
 import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { collectSevereVerificationEvidence, MAX_EVIDENCE_BYTES, MAX_MODULES } from "../src/severe-verification-evidence.js";
+import { buildFindingFingerprint } from "../src/findings.js";
+import { buildSevereVerificationTransport } from "../src/severe-verification-transport.js";
+import { collectSevereVerificationEvidence, MAX_EVIDENCE_BYTES, MAX_MODULES, readSevereVerificationEvidenceContents } from "../src/severe-verification-evidence.js";
 
-const root = process.cwd(), finding = "src/π space.ts", moduleA = "lib/alpha.ts", moduleB = "lib/β.ts";
+const root = process.cwd(), finding = "src/π space.ts", moduleA = "lib/alpha.ts", moduleB = "lib/β.ts", bomFile = "lib/bom.ts";
 let fixture = "", head = "";
 const git = (args: string[]) => execFileSync("git", args, { cwd: fixture, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
 const input = (relevantModulePaths: readonly string[], changedHunk: string | Uint8Array = "@@ -1 +1 @@\n+changed") => ({
@@ -14,7 +16,7 @@ const input = (relevantModulePaths: readonly string[], changedHunk: string | Uin
 
 beforeAll(async () => {
   fixture = await mkdtemp(join(root, ".severe-evidence-")); await mkdir(join(fixture, "src")); await mkdir(join(fixture, "lib"));
-  await writeFile(join(fixture, finding), "const π = 'finding';\n"); await writeFile(join(fixture, moduleA), "export const alpha = true;\n"); await writeFile(join(fixture, moduleB), "export const beta = true;\n");
+  await writeFile(join(fixture, finding), "const π = 'finding';\n"); await writeFile(join(fixture, moduleA), "export const alpha = true;\n"); await writeFile(join(fixture, moduleB), "export const beta = true;\n"); await writeFile(join(fixture, bomFile), Buffer.from([0xef, 0xbb, 0xbf, 0x65, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x20, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x20, 0x62, 0x6f, 0x6d, 0x20, 0x3d, 0x20, 0x74, 0x72, 0x75, 0x65, 0x3b, 0x0a]));
   await writeFile(join(fixture, "bad.bin"), Buffer.from([0xff, 0xfe])); await writeFile(join(fixture, "big.bin"), Buffer.alloc(MAX_EVIDENCE_BYTES + 1, 65)); await symlink("src/π space.ts", join(fixture, "link.ts"));
   execFileSync("git", ["init", "--quiet"], { cwd: fixture }); git(["config", "user.email", "test@example.invalid"]); git(["config", "user.name", "NeonDiff test"]); git(["add", "."]); git(["commit", "--quiet", "-m", "fixture"]); head = git(["rev-parse", "HEAD"]);
 });
@@ -25,6 +27,29 @@ describe("exact-head severe evidence collection", () => {
     const result = await collectSevereVerificationEvidence(input([moduleB, moduleA]));
     expect(result.complete).toBe(true); expect(result.files.map((item) => [item.path, item.kind])).toEqual([[finding, "whole_file"], [moduleA, "module"], [moduleB, "module"]]); expect(result.omitted).toEqual([]); expect(JSON.stringify(result)).not.toContain("const π");
     const digest = result.files[0].sha256; await writeFile(join(fixture, finding), "tampered\n"); expect((await collectSevereVerificationEvidence(input([moduleA, moduleB]))).files[0].sha256).toBe(digest);
+  });
+
+  it("transports immutable blob content when the filtered worktree differs", async () => {
+    const evidence = await collectSevereVerificationEvidence(input([]));
+    await writeFile(join(fixture, finding), "tampered transport content\n");
+    const findingFields = { path: finding, line: 1, severity: "P1" as const, title: "Immutable verifier input", body: "Use the exact committed blob.", category: "security_boundary" as const, why_this_matters: "The verifier must not trust the filtered worktree." };
+    const messages = buildSevereVerificationTransport({
+      repo: "owner/repo", pullNumber: 1040, baseSha: "b".repeat(40), headSha: head,
+      finding: { ...findingFields, fingerprint: buildFindingFingerprint(findingFields) }, changedHunk: "@@ -1 +1 @@\n+changed",
+      evidence, files: readSevereVerificationEvidenceContents(input([]), evidence)
+    });
+    const payload = JSON.parse(messages[1].content);
+    expect(payload.data.files[0].content).toBe("const π = 'finding';\n");
+    expect(payload.data.files[0].content).not.toContain("tampered transport content");
+  });
+
+  it("preserves UTF-8 BOM bytes when decoding immutable content", async () => {
+    const evidence = await collectSevereVerificationEvidence(input([bomFile]));
+    const contents = readSevereVerificationEvidenceContents(input([bomFile]), evidence);
+    const bom = contents.find((file) => file.path === bomFile);
+    expect(bom?.content.codePointAt(0)).toBe(0xfeff);
+    expect(Buffer.from(bom?.content ?? "", "utf8").subarray(0, 3)).toEqual(Buffer.from([0xef, 0xbb, 0xbf]));
+    expect(bom?.content).toContain("export const bom = true;");
   });
 
   it("accepts an explicit empty module set", async () => {

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -20,6 +20,7 @@ const zcodeBarriersByPath = vi.hoisted(() => new Map<string, Promise<void>>());
 const zcodeFirstFailuresByPath = vi.hoisted(() => new Map<string, { message: string; beforeThrow?: () => void }>());
 const severeRawResponse = vi.hoisted(() => ({ value: "" }));
 const severeCurrentWorktree = vi.hoisted(() => ({ enabled: false }));
+const severeWorktreePath = vi.hoisted(() => ({ value: "" }));
 const createdReviews = vi.hoisted((): Array<{
   repo: string;
   pullNumber: number;
@@ -41,7 +42,7 @@ vi.mock("../src/git.js", async (importOriginal) => {
   return {
     ...actual,
     preparePullWorktree: vi.fn((input: { workRoot: string; expectedHeadSha: string }) => {
-      const path = severeCurrentWorktree.enabled ? process.cwd() : join(input.workRoot, "mock-worktree");
+      const path = severeWorktreePath.value || (severeCurrentWorktree.enabled ? process.cwd() : join(input.workRoot, "mock-worktree"));
       mkdirSync(path, { recursive: true });
       return { path, headSha: input.expectedHeadSha };
     }),
@@ -173,6 +174,7 @@ describe("worker context budget preflight", () => {
     zcodeFirstFailuresByPath.clear();
     severeRawResponse.value = "";
     severeCurrentWorktree.enabled = false;
+    severeWorktreePath.value = "";
     createdReviews.length = 0;
     walkthroughBuildEvents.length = 0;
     delete reviewPostControl.error;
@@ -709,6 +711,51 @@ describe("worker context budget preflight", () => {
     const transport = JSON.parse(JSON.parse(zcodePrompts.find((prompt) => prompt.includes("severe-verifier-input-v1"))!)[1].content);
     expect(transport.finding).toMatchObject({ category: "proof_gap", title: original.title, body: original.body });
     expect(createdReviews[0]?.comments).toHaveLength(1);
+    state.close();
+  });
+
+  it("suppresses oversized immutable evidence without throwing a malformed receipt", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-severe-worker-oversized-evidence-"));
+    roots.push(root);
+    const fixture = join(root, "worktree");
+    mkdirSync(join(fixture, "src"), { recursive: true });
+    const filename = "src/oversized.ts";
+    const blob = `${"x".repeat(65_536)}\n`;
+    writeFileSync(join(fixture, filename), blob);
+    execFileSync("git", ["init", "--quiet"], { cwd: fixture });
+    execFileSync("git", ["config", "user.email", "test@example.invalid"], { cwd: fixture });
+    execFileSync("git", ["config", "user.name", "NeonDiff test"], { cwd: fixture });
+    execFileSync("git", ["add", "."], { cwd: fixture });
+    execFileSync("git", ["commit", "--quiet", "-m", "oversized"], { cwd: fixture });
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: fixture, encoding: "utf8" }).trim();
+    const patch = `@@ -1 +1 @@\n+${"x".repeat(65_530)}`;
+    const file = { filename, patch, status: "modified", additions: 1, deletions: 0, changes: 1 };
+    severeCurrentWorktree.enabled = true;
+    severeWorktreePath.value = fixture;
+    const config = minimalConfig(root);
+    config.reviewGate = { maxInlineComments: 25, selfConsistency: { enabled: true } };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(431, head);
+    zcodeFindingsByPath.set(filename, [p1Finding(filename, "Oversized severe candidate")]);
+
+    const result = await reviewPull({ config, github: githubForPull(pull, [file]), state, repo: "electricsheephq/WorldOS", pull, dryRun: false, useZCode: true });
+
+    const evidenceDir = join(root, "evidence", localDateFolder(), "electricsheephq__WorldOS", `pr-${pull.number}`, head);
+    expect(result).toBe("reviewed");
+    expect(createdReviews[0]?.comments).toHaveLength(0);
+    expect(zcodePrompts.some((prompt) => prompt.includes("severe-verifier-input-v1"))).toBe(false);
+    const selfConsistency = JSON.parse(readFileSync(join(evidenceDir, "self-consistency.json"), "utf8"));
+    expect(selfConsistency.verdicts[0]).toMatchObject({
+      path: filename,
+      refuted: true,
+      receipt: {
+        state: "incomplete",
+        disposition: "suppress",
+        reasonCode: "cap_exceeded",
+        evidence: { files: [], omitted: [{ path: filename, code: "cap_exceeded" }], complete: false }
+      }
+    });
+    expect(JSON.stringify(selfConsistency)).not.toContain(blob);
     state.close();
   });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -711,6 +711,17 @@ describe("worker context budget preflight", () => {
     const transport = JSON.parse(JSON.parse(zcodePrompts.find((prompt) => prompt.includes("severe-verifier-input-v1"))!)[1].content);
     expect(transport.finding).toMatchObject({ category: "proof_gap", title: original.title, body: original.body });
     expect(createdReviews[0]?.comments).toHaveLength(1);
+
+    severeRawResponse.value = "";
+    const failedPull = pullSummary(432, head);
+    expect(await reviewPull({ config, github: githubForPull(failedPull, [file]), state, repo: "electricsheephq/WorldOS", pull: failedPull, dryRun: false, useZCode: true })).toBe("reviewed");
+    const failedEvidenceDir = join(root, "evidence", localDateFolder(), "electricsheephq__WorldOS", `pr-${failedPull.number}`, head);
+    const failedSelfConsistency = JSON.parse(readFileSync(join(failedEvidenceDir, "self-consistency.json"), "utf8"));
+    expect(failedSelfConsistency.verdicts[0].receipt.evidence).toMatchObject({
+      files: [{ path: file.filename, kind: "whole_file", sha256: fileHash, bytes: fileBytes.length, complete: true }],
+      omitted: [],
+      complete: false
+    });
     state.close();
   });
 
@@ -728,7 +739,7 @@ describe("worker context budget preflight", () => {
     execFileSync("git", ["add", "."], { cwd: fixture });
     execFileSync("git", ["commit", "--quiet", "-m", "oversized"], { cwd: fixture });
     const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: fixture, encoding: "utf8" }).trim();
-    const patch = `@@ -1 +1 @@\n+${"x".repeat(65_530)}`;
+    const patch = "@@ -1 +1 @@\n+x";
     const file = { filename, patch, status: "modified", additions: 1, deletions: 0, changes: 1 };
     severeCurrentWorktree.enabled = true;
     severeWorktreePath.value = fixture;

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -695,7 +695,7 @@ describe("worker context budget preflight", () => {
     const original: Finding = { ...p1Finding(file.filename, "Proof gap with 95% confidence"), body: "The confidence is 95%; inspect this exact proof gap.", category: "proof_gap" };
     zcodeFindingsByPath.set(file.filename, [original]);
     const hunkHash = createHash("sha256").update(file.patch, "utf8").digest("hex");
-    const fileBytes = readFileSync(join(process.cwd(), file.filename));
+    const fileBytes = execFileSync("git", ["show", `${head}:${file.filename}`]);
     const fileHash = createHash("sha256").update(fileBytes).digest("hex");
     severeRawResponse.value = JSON.stringify({
       schemaVersion: "severe-verifier-v1", repo: "electricsheephq/WorldOS", pullNumber: pull.number,


### PR DESCRIPTION
Closes #1069

## Outcome

Source severe-verifier whole-file/module content from the exact expected-head Git blobs used for evidence metadata. The worker no longer reconstructs verifier content with a filtered-worktree `readFileSync`.

## Implementation

- re-read only the explicitly selected finding file and relevant modules from exact-head regular Git blobs with replacement refs and lazy fetching disabled
- verify the second read's SHA-256, byte count, mode/path, UTF-8, per-file, module-count, and aggregate transport constraints against canonical metadata before provider execution
- preserve UTF-8 BOM bytes so provider content re-encodes to the exact blob bytes
- keep the worker default finding-file-only with `relevantModulePaths: []`; arbitrary changed files are not selected
- persist only metadata/canonical receipts; raw source stays in the ephemeral provider payload
- reject incomplete or partial expected evidence before content reaches the provider
- preserve collected file metadata and named omission evidence across provider/parser failures while stripping invalid hunk/runtime-only collector fields from failure receipts

## Exact candidate

- base: `5a7fceaf785b3eeb461720c3912cb5726f986b4f`
- head: `330c6e41b0b872835d80412a5219e822a63774a3`
- scope: four files, 155 insertions / 20 deletions, 175 cumulative changed lines

## Deterministic evidence

- failing-first targeted delta: 3 expected failures reproduced, then 73/73 affected tests passed
- pinned Node 26 severe evidence/transport/parser/canonicalization/self-consistency/worker suites: 121/121 passed
- current delta `git diff --check`: passed
- prior-head acceptance/adversarial checker passes and CI do not cover this head; exact-head CI and both blind checker reruns are required before merge
- worktree: clean

## Safety and proof boundary

No live provider call, GitHub review post, installed-app/worker/LaunchAgent/config/DB/Keychain mutation, customer data, billing, signing, feed, artifact, or release action occurred. Passing this PR proves source/test behavior only; it does not prove live provider, runtime, customer, RC, release, or GA readiness.
