### PR TITLE
Mac GA: materialize accepted ZIP graph safely

### DIFF
--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
-import { closeSync, constants, fstatSync, openSync, readSync } from "node:fs";
-import { resolve } from "node:path";
+import { chmodSync, closeSync, constants, createWriteStream, fstatSync, mkdirSync, mkdtempSync, openSync, readSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix, resolve } from "node:path";
+import { PassThrough, Readable, Transform, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createInflateRaw, crc32 } from "node:zlib";
 
 const MAX_BYTES = 512 * 1024 * 1024, MAX_RECORDS = 20_000, MAX_METADATA = 16 * 1024 * 1024, MAX_NODES = 20_000;
 const EOCD = 0x06054b50, LOCAL = 0x04034b50, CENTRAL = 0x02014b50, DATA_DESCRIPTOR = 0x08074b50, ZIP64 = "ZIP64 archive unsupported";
@@ -109,9 +113,8 @@ function parseMetadataRecords(guarded) {
   return records;
 }
 
-export function buildClassicZipMetadataGraph(artifactPath) {
-  if (typeof artifactPath !== "string" || !artifactPath) fail("artifact path is required");
-  const guarded = guardClassicZipArchive({ artifactPath }), nodes = new Map(), folded = new Map(); let expandedBytes = 0;
+function buildClassicZipMetadataGraphFromGuarded(guarded) {
+  const nodes = new Map(), folded = new Map(); let expandedBytes = 0;
   for (const entry of parseMetadataRecords(guarded)) {
     if (entry.type !== "directory" && (expandedBytes += entry.uncompressedSize) > MAX_BYTES) fail("expanded byte bound exceeded");
     let path = "", identity = "";
@@ -139,4 +142,57 @@ export function buildClassicZipMetadataGraph(artifactPath) {
   }
   const records = [...nodes.values()].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0).map(({ parts: _parts, rangeEnd: _rangeEnd, ...record }) => Object.freeze(record));
   return Object.freeze({ kind: "neondiff.desktop.classic-zip-metadata-graph-v1", artifactSHA256: guarded.artifactSHA256, artifactByteLength: guarded.artifactBytes.length, expandedByteLength: expandedBytes, records: Object.freeze(records) });
+}
+
+export function buildClassicZipMetadataGraph(artifactPath) {
+  if (typeof artifactPath !== "string" || !artifactPath) fail("artifact path is required");
+  return buildClassicZipMetadataGraphFromGuarded(guardClassicZipArchive({ artifactPath }));
+}
+
+function materializedPath(root, path) {
+  const destination = resolve(root, path);
+  if (!destination.startsWith(`${root}/`)) fail("unsafe materialized path");
+  return destination;
+}
+async function pipeVerifiedEntry(guarded, record, destination, aggregate) {
+  let actual = 0, checksum = 0;
+  const end = record.dataOffset + record.compressedSize, source = Readable.from((function* () { for (let offset = record.dataOffset; offset < end; offset += 64 * 1024) yield guarded.artifactBytes.subarray(offset, Math.min(end, offset + 64 * 1024)); })());
+  const verifier = new Transform({ transform(chunk, _encoding, callback) {
+    actual += chunk.length; aggregate.value += chunk.length;
+    if (actual > record.uncompressedSize) return callback(new Error("expanded entry size mismatch"));
+    if (aggregate.value > MAX_BYTES) return callback(new Error("expanded byte bound exceeded"));
+    checksum = crc32(chunk, checksum); callback(null, chunk);
+  } });
+  await pipeline(source, record.compressionMethod === 8 ? createInflateRaw() : new PassThrough(), verifier, destination);
+  if (actual !== record.uncompressedSize) fail("expanded entry size mismatch");
+  if ((checksum >>> 0) !== record.crc32) fail("CRC-32 mismatch");
+}
+
+export async function withMaterializedClassicZipApp(artifactPath, consumer) {
+  if (typeof artifactPath !== "string" || !artifactPath || typeof consumer !== "function") fail("materialization inputs are malformed");
+  const guarded = guardClassicZipArchive({ artifactPath }), graph = buildClassicZipMetadataGraphFromGuarded(guarded), byPath = new Map(graph.records.map((record) => [record.path, record]));
+  if (graph.records.some((record) => record.mode & 0o7000)) fail("special permission bits unsupported");
+  const root = mkdtempSync(join(tmpdir(), "neondiff-materialized-")), directories = graph.records.filter((record) => record.type === "directory"), aggregate = { value: 0 };
+  chmodSync(root, 0o700);
+  try {
+    for (const record of directories) mkdirSync(materializedPath(root, record.path), { mode: 0o700 });
+    for (const record of graph.records.filter((candidate) => candidate.type === "file")) {
+      const destination = materializedPath(root, record.path);
+      await pipeVerifiedEntry(guarded, record, createWriteStream(destination, { flags: constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW, mode: 0o600 }), aggregate);
+      chmodSync(destination, record.mode & 0o777);
+    }
+    for (const record of graph.records.filter((candidate) => candidate.type === "symlink")) {
+      if (record.uncompressedSize > 4096) fail("symlink target too large");
+      const chunks = []; await pipeVerifiedEntry(guarded, record, new Writable({ write(chunk, _encoding, callback) { chunks.push(Buffer.from(chunk)); callback(); } }), aggregate);
+      const bytes = Buffer.concat(chunks); let target;
+      try { target = UTF8.decode(bytes); } catch { fail("unsafe symlink target"); }
+      if (!target || bytes.includes(0) || !Buffer.from(target, "utf8").equals(bytes) || posix.isAbsolute(target)) fail("unsafe symlink target");
+      const targetPath = posix.normalize(posix.join(posix.dirname(record.path), target));
+      if (targetPath !== "NeonDiff.app" && !targetPath.startsWith("NeonDiff.app/")) fail("unsafe symlink target");
+      if (!byPath.has(targetPath)) fail("missing symlink target");
+      symlinkSync(target, materializedPath(root, record.path));
+    }
+    for (const record of [...directories].reverse()) chmodSync(materializedPath(root, record.path), record.mode & 0o777);
+    return await consumer(materializedPath(root, "NeonDiff.app"), graph);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 }

--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -163,9 +163,20 @@ async function pipeVerifiedEntry(guarded, record, destination, aggregate) {
     if (aggregate.value > MAX_BYTES) return callback(new Error("expanded byte bound exceeded"));
     checksum = crc32(chunk, checksum); callback(null, chunk);
   } });
-  await pipeline(source, record.compressionMethod === 8 ? createInflateRaw() : new PassThrough(), verifier, destination);
+  await pipeline(source, record.compressionMethod === 8 ? createInflateRaw({ rejectGarbageAfterEnd: true }) : new PassThrough(), verifier, destination);
   if (actual !== record.uncompressedSize) fail("expanded entry size mismatch");
   if ((checksum >>> 0) !== record.crc32) fail("CRC-32 mismatch");
+}
+function verifyGraphSymlink(path, target, byPath, linkTargets) {
+  let candidate = posix.normalize(posix.join(posix.dirname(path), target)); const seen = new Set();
+  while (true) {
+    if (candidate !== "NeonDiff.app" && !candidate.startsWith("NeonDiff.app/")) fail("unsafe symlink target");
+    const parts = candidate.split("/"); let link = null, suffix = [];
+    for (let index = 1; index <= parts.length; index += 1) { const prefix = parts.slice(0, index).join("/"); if (linkTargets.has(prefix)) { link = prefix; suffix = parts.slice(index); break; } }
+    if (!link) { if (!byPath.has(candidate)) fail("missing symlink target"); return; }
+    if (seen.has(link)) fail("symlink cycle"); seen.add(link);
+    candidate = posix.normalize(posix.join(posix.dirname(link), linkTargets.get(link), ...suffix));
+  }
 }
 
 export async function withMaterializedClassicZipApp(artifactPath, consumer) {
@@ -181,18 +192,21 @@ export async function withMaterializedClassicZipApp(artifactPath, consumer) {
       await pipeVerifiedEntry(guarded, record, createWriteStream(destination, { flags: constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW, mode: 0o600 }), aggregate);
       chmodSync(destination, record.mode & 0o777);
     }
-    for (const record of graph.records.filter((candidate) => candidate.type === "symlink")) {
+    const symlinks = graph.records.filter((candidate) => candidate.type === "symlink"), linkTargets = new Map();
+    for (const record of symlinks) {
       if (record.uncompressedSize > 4096) fail("symlink target too large");
       const chunks = []; await pipeVerifiedEntry(guarded, record, new Writable({ write(chunk, _encoding, callback) { chunks.push(Buffer.from(chunk)); callback(); } }), aggregate);
       const bytes = Buffer.concat(chunks); let target;
       try { target = UTF8.decode(bytes); } catch { fail("unsafe symlink target"); }
       if (!target || bytes.includes(0) || !Buffer.from(target, "utf8").equals(bytes) || posix.isAbsolute(target)) fail("unsafe symlink target");
-      const targetPath = posix.normalize(posix.join(posix.dirname(record.path), target));
-      if (targetPath !== "NeonDiff.app" && !targetPath.startsWith("NeonDiff.app/")) fail("unsafe symlink target");
-      if (!byPath.has(targetPath)) fail("missing symlink target");
-      symlinkSync(target, materializedPath(root, record.path));
+      linkTargets.set(record.path, target);
     }
+    for (const record of symlinks) verifyGraphSymlink(record.path, linkTargets.get(record.path), byPath, linkTargets);
+    for (const record of symlinks) symlinkSync(linkTargets.get(record.path), materializedPath(root, record.path));
     for (const record of [...directories].reverse()) chmodSync(materializedPath(root, record.path), record.mode & 0o777);
     return await consumer(materializedPath(root, "NeonDiff.app"), graph);
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    for (const record of directories) { try { chmodSync(materializedPath(root, record.path), 0o700); } catch {} }
+    rmSync(root, { recursive: true, force: true });
+  }
 }

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -1,23 +1,24 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, mkdirSync, mkdtempSync, readdirSync, readlinkSync, rmSync, statSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { crc32 } from "node:zlib";
+import { dirname, join } from "node:path";
+import { crc32, deflateRawSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildClassicZipMetadataGraph, guardClassicZipArchive } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
+import { buildClassicZipMetadataGraph, guardClassicZipArchive, withMaterializedClassicZipApp } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
 
-type Entry = { name: string; localName?: string; localOffset?: number; localExtra?: Buffer; type?: "file" | "directory" | "symlink"; data?: string; flags?: number; method?: number; expanded?: number; extra?: number | Buffer; comment?: number; mode?: number };
+type Entry = { name: string; localName?: string; localOffset?: number; localExtra?: Buffer; type?: "file" | "directory" | "symlink"; data?: string | Buffer; flags?: number; method?: number; expanded?: number; crc?: number; descriptor?: boolean; extra?: number | Buffer; comment?: number; mode?: number };
 const roots: string[] = [];
 const u16 = (b: Buffer, p: number, n: number) => b.writeUInt16LE(n, p);
 const u32 = (b: Buffer, p: number, n: number) => b.writeUInt32LE(n, p);
 function classicZip(entries: Entry[]) {
   const locals: Buffer[] = [], central: Buffer[] = []; let offset = 0;
   for (const entry of entries) {
-    const name = Buffer.from(entry.name), localName = Buffer.from(entry.localName ?? entry.name), data = Buffer.from(entry.data ?? ""), localExtra = entry.localExtra ?? Buffer.alloc(0), extra = Buffer.isBuffer(entry.extra) ? entry.extra : Buffer.alloc(entry.extra ?? 0), comment = Buffer.alloc(entry.comment ?? 0), flags = entry.flags ?? 0x800, method = entry.method ?? 0, expanded = entry.expanded ?? data.length;
+    const name = Buffer.from(entry.name), localName = Buffer.from(entry.localName ?? entry.name), payload = Buffer.from(entry.data ?? ""), localExtra = entry.localExtra ?? Buffer.alloc(0), extra = Buffer.isBuffer(entry.extra) ? entry.extra : Buffer.alloc(entry.extra ?? 0), comment = Buffer.alloc(entry.comment ?? 0), flags = entry.flags ?? 0x800, method = entry.method ?? 0, data = method === 8 ? deflateRawSync(payload) : payload, expanded = entry.expanded ?? payload.length, checksum = entry.crc ?? crc32(payload), hasDescriptor = Boolean(flags & 0x8), descriptor = hasDescriptor && entry.descriptor !== false ? Buffer.alloc(16) : Buffer.alloc(0);
     const type = entry.type ?? (entry.name.endsWith("/") ? "directory" : "file"), mode = entry.mode ?? ({ file: 0o100644, directory: 0o040755, symlink: 0o120777 })[type];
-    const local = Buffer.alloc(30 + localName.length + localExtra.length + data.length); u32(local, 0, 0x04034b50); u16(local, 4, 20); u16(local, 6, flags); u16(local, 8, method); u32(local, 18, data.length); u32(local, 22, expanded); u16(local, 26, localName.length); u16(local, 28, localExtra.length); localName.copy(local, 30); localExtra.copy(local, 30 + localName.length); data.copy(local, 30 + localName.length + localExtra.length); locals.push(local);
-    const record = Buffer.alloc(46 + name.length + extra.length + comment.length); u32(record, 0, 0x02014b50); u16(record, 4, (3 << 8) | 20); u16(record, 6, 20); u16(record, 8, flags); u16(record, 10, method); u32(record, 20, data.length); u32(record, 24, expanded); u16(record, 28, name.length); u16(record, 30, extra.length); u16(record, 32, comment.length); u32(record, 38, (mode << 16) >>> 0); u32(record, 42, entry.localOffset ?? offset); name.copy(record, 46); extra.copy(record, 46 + name.length); comment.copy(record, 46 + name.length + extra.length); central.push(record);
+    if (descriptor.length) { u32(descriptor, 0, 0x08074b50); u32(descriptor, 4, checksum); u32(descriptor, 8, data.length); u32(descriptor, 12, expanded); }
+    const local = Buffer.alloc(30 + localName.length + localExtra.length + data.length + descriptor.length); u32(local, 0, 0x04034b50); u16(local, 4, 20); u16(local, 6, flags); u16(local, 8, method); u32(local, 14, hasDescriptor ? 0 : checksum); u32(local, 18, hasDescriptor ? 0 : data.length); u32(local, 22, hasDescriptor ? 0 : expanded); u16(local, 26, localName.length); u16(local, 28, localExtra.length); localName.copy(local, 30); localExtra.copy(local, 30 + localName.length); data.copy(local, 30 + localName.length + localExtra.length); descriptor.copy(local, 30 + localName.length + localExtra.length + data.length); locals.push(local);
+    const record = Buffer.alloc(46 + name.length + extra.length + comment.length); u32(record, 0, 0x02014b50); u16(record, 4, (3 << 8) | 20); u16(record, 6, 20); u16(record, 8, flags); u16(record, 10, method); u32(record, 16, checksum); u32(record, 20, data.length); u32(record, 24, expanded); u16(record, 28, name.length); u16(record, 30, extra.length); u16(record, 32, comment.length); u32(record, 38, (mode << 16) >>> 0); u32(record, 42, entry.localOffset ?? offset); name.copy(record, 46); extra.copy(record, 46 + name.length); comment.copy(record, 46 + name.length + extra.length); central.push(record);
     offset += local.length;
   }
   const directory = Buffer.concat(central), eocd = Buffer.alloc(22); u32(eocd, 0, 0x06054b50); u16(eocd, 8, entries.length); u16(eocd, 10, entries.length); u32(eocd, 12, directory.length); u32(eocd, 16, offset);
@@ -80,7 +81,7 @@ describe("bounded classic-ZIP metadata graph", () => {
   it("rejects central/local drift, encryption, unsupported types, and contradictory directories", () => {
     expect(() => buildClassicZipMetadataGraph(fixture([{ name: "NeonDiff.app/a", localName: "NeonDiff.app/b" }]).artifact)).toThrow("local/central metadata mismatch");
     expect(() => buildClassicZipMetadataGraph(fixture([{ name: "NeonDiff.app/a", flags: 0x801 }]).artifact)).toThrow("encrypted or unsupported ZIP flags");
-    expect(() => buildClassicZipMetadataGraph(fixture([{ name: "NeonDiff.app/a", flags: 0x808 }]).artifact)).toThrow("data descriptor mismatch");
+    expect(() => buildClassicZipMetadataGraph(fixture([{ name: "NeonDiff.app/a", flags: 0x808, descriptor: false }]).artifact)).toThrow("data descriptor mismatch");
     const headerName = "NeonDiff.app/safe", override = unicodePathExtra(headerName, "../escape");
     expect(() => buildClassicZipMetadataGraph(fixture([{ name: headerName, extra: override }]).artifact)).toThrow("path-overriding ZIP extra field");
     expect(() => buildClassicZipMetadataGraph(fixture([{ name: headerName, localExtra: override }]).artifact)).toThrow("path-overriding ZIP extra field");
@@ -100,10 +101,47 @@ describe("bounded classic-ZIP metadata graph", () => {
     const wide = Array.from({ length: 10000 }, (_, index) => ({ name: `NeonDiff.app/d${index}/f` }));
     expect(() => buildClassicZipMetadataGraph(fixture(wide).artifact)).toThrow("metadata node bound exceeded");
   });
-  it.skipIf(process.platform !== "darwin")("accepts the canonical ditto keep-parent archive shape", () => {
+  it.skipIf(process.platform !== "darwin")("accepts the canonical ditto keep-parent archive shape", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-ditto-")), app = join(root, "NeonDiff.app"), archive = join(root, "NeonDiff.zip"); roots.push(root);
     mkdirSync(join(app, "Contents", "MacOS"), { recursive: true }); writeFileSync(join(app, "Contents", "MacOS", "NeonDiff"), "binary"); symlinkSync("MacOS", join(app, "Contents", "Current"));
     execFileSync("/usr/bin/ditto", ["-c", "-k", "--sequesterRsrc", "--keepParent", app, archive]);
     const graph = buildClassicZipMetadataGraph(archive); expect(buildClassicZipMetadataGraph(archive)).toEqual(graph); expect(graph.records.some((record) => record.type === "symlink")).toBe(true);
+    await withMaterializedClassicZipApp(archive, (appPath) => { expect(readFileSync(join(appPath, "Contents", "MacOS", "NeonDiff"), "utf8")).toBe("binary"); expect(readlinkSync(join(appPath, "Contents", "Current"))).toBe("MacOS"); });
+  });
+});
+
+describe("graph-authoritative ZIP materialization", () => {
+  it("materializes stored/deflated bytes, modes, and symlinks before one bounded consumer", async () => {
+    const value = fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Contents/Info.plist", data: "plist" }, { name: "NeonDiff.app/Contents/MacOS/NeonDiff", data: "binary", method: 8, flags: 0x808, mode: 0o100755 }, { name: "NeonDiff.app/Contents/Current", type: "symlink", data: "MacOS" }, { name: "__MACOSX/NeonDiff.app/Contents/._Info.plist", data: "appledouble", method: 8 }]); let materializedRoot = "";
+    const result = await withMaterializedClassicZipApp(value.artifact, async (appPath, graph) => {
+      materializedRoot = dirname(appPath); writeFileSync(value.artifact, "changed after snapshot");
+      expect(readFileSync(join(appPath, "Contents", "Info.plist"), "utf8")).toBe("plist"); expect(readFileSync(join(appPath, "Contents", "MacOS", "NeonDiff"), "utf8")).toBe("binary"); expect(readFileSync(join(materializedRoot, "__MACOSX", "NeonDiff.app", "Contents", "._Info.plist"), "utf8")).toBe("appledouble");
+      expect(statSync(join(appPath, "Contents", "MacOS", "NeonDiff")).mode & 0o777).toBe(0o755); expect(readlinkSync(join(appPath, "Contents", "Current"))).toBe("MacOS"); expect(Object.isFrozen(graph)).toBe(true); return "accepted";
+    });
+    expect(result).toBe("accepted"); expect(existsSync(materializedRoot)).toBe(false);
+  });
+  it("fails before the consumer on CRC, size, special-mode, and symlink invariant violations", async () => {
+    const cases: [Entry[], string][] = [
+      [[{ name: "NeonDiff.app/a", data: "bytes", crc: 0 }], "CRC-32 mismatch"],
+      [[{ name: "NeonDiff.app/a", data: "expands", method: 8, expanded: 1 }], "expanded entry size mismatch"],
+      [[{ name: "NeonDiff.app/a", mode: 0o104755 }], "special permission bits unsupported"],
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: "" }], "unsafe symlink target"],
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: "bad\0target" }], "unsafe symlink target"],
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: "/tmp" }], "unsafe symlink target"],
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: Buffer.alloc(4097, 97) }], "symlink target too large"],
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: "../../escape" }], "unsafe symlink target"],
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: "missing" }], "missing symlink target"]
+    ];
+    for (const [entries, message] of cases) {
+      const value = fixture(entries), before = readdirSync(value.root).sort(), previous = process.env.TMPDIR; let called = false; process.env.TMPDIR = value.root;
+      try { await expect(withMaterializedClassicZipApp(value.artifact, () => { called = true; })).rejects.toThrow(message); } finally { if (previous === undefined) delete process.env.TMPDIR; else process.env.TMPDIR = previous; }
+      expect(called).toBe(false); expect(readdirSync(value.root).sort()).toEqual(before);
+    }
+  });
+  it("ignores unreferenced local headers and removes its private root after callback failure", async () => {
+    const value = fixture([{ name: "NeonDiff.app/a", data: "safe" }]), original = readFileSync(value.artifact), central = original.readUInt32LE(original.length - 6), hiddenArchive = classicZip([{ name: "../escape", data: "hostile" }]), hidden = hiddenArchive.subarray(0, hiddenArchive.readUInt32LE(hiddenArchive.length - 6)), bytes = Buffer.concat([hidden, original]);
+    u32(bytes, hidden.length + central + 42, original.readUInt32LE(central + 42) + hidden.length); u32(bytes, bytes.length - 6, central + hidden.length); writeFileSync(value.artifact, bytes); let materializedRoot = "";
+    await expect(withMaterializedClassicZipApp(value.artifact, (appPath) => { materializedRoot = dirname(appPath); expect(readFileSync(join(appPath, "a"), "utf8")).toBe("safe"); expect(existsSync(join(materializedRoot, "escape"))).toBe(false); throw new Error("consumer failed"); })).rejects.toThrow("consumer failed");
+    expect(materializedRoot).not.toBe(""); expect(existsSync(materializedRoot)).toBe(false);
   });
 });

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -7,14 +7,14 @@ import { crc32, deflateRawSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildClassicZipMetadataGraph, guardClassicZipArchive, withMaterializedClassicZipApp } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
 
-type Entry = { name: string; localName?: string; localOffset?: number; localExtra?: Buffer; type?: "file" | "directory" | "symlink"; data?: string | Buffer; flags?: number; method?: number; expanded?: number; crc?: number; descriptor?: boolean; extra?: number | Buffer; comment?: number; mode?: number };
+type Entry = { name: string; localName?: string; localOffset?: number; localExtra?: Buffer; type?: "file" | "directory" | "symlink"; data?: string | Buffer; trailing?: Buffer; flags?: number; method?: number; expanded?: number; crc?: number; descriptor?: boolean; extra?: number | Buffer; comment?: number; mode?: number };
 const roots: string[] = [];
 const u16 = (b: Buffer, p: number, n: number) => b.writeUInt16LE(n, p);
 const u32 = (b: Buffer, p: number, n: number) => b.writeUInt32LE(n, p);
 function classicZip(entries: Entry[]) {
   const locals: Buffer[] = [], central: Buffer[] = []; let offset = 0;
   for (const entry of entries) {
-    const name = Buffer.from(entry.name), localName = Buffer.from(entry.localName ?? entry.name), payload = Buffer.from(entry.data ?? ""), localExtra = entry.localExtra ?? Buffer.alloc(0), extra = Buffer.isBuffer(entry.extra) ? entry.extra : Buffer.alloc(entry.extra ?? 0), comment = Buffer.alloc(entry.comment ?? 0), flags = entry.flags ?? 0x800, method = entry.method ?? 0, data = method === 8 ? deflateRawSync(payload) : payload, expanded = entry.expanded ?? payload.length, checksum = entry.crc ?? crc32(payload), hasDescriptor = Boolean(flags & 0x8), descriptor = hasDescriptor && entry.descriptor !== false ? Buffer.alloc(16) : Buffer.alloc(0);
+    const name = Buffer.from(entry.name), localName = Buffer.from(entry.localName ?? entry.name), payload = Buffer.from(entry.data ?? ""), localExtra = entry.localExtra ?? Buffer.alloc(0), extra = Buffer.isBuffer(entry.extra) ? entry.extra : Buffer.alloc(entry.extra ?? 0), comment = Buffer.alloc(entry.comment ?? 0), flags = entry.flags ?? 0x800, method = entry.method ?? 0, encoded = method === 8 ? deflateRawSync(payload) : payload, data = entry.trailing ? Buffer.concat([encoded, entry.trailing]) : encoded, expanded = entry.expanded ?? payload.length, checksum = entry.crc ?? crc32(payload), hasDescriptor = Boolean(flags & 0x8), descriptor = hasDescriptor && entry.descriptor !== false ? Buffer.alloc(16) : Buffer.alloc(0);
     const type = entry.type ?? (entry.name.endsWith("/") ? "directory" : "file"), mode = entry.mode ?? ({ file: 0o100644, directory: 0o040755, symlink: 0o120777 })[type];
     if (descriptor.length) { u32(descriptor, 0, 0x08074b50); u32(descriptor, 4, checksum); u32(descriptor, 8, data.length); u32(descriptor, 12, expanded); }
     const local = Buffer.alloc(30 + localName.length + localExtra.length + data.length + descriptor.length); u32(local, 0, 0x04034b50); u16(local, 4, 20); u16(local, 6, flags); u16(local, 8, method); u32(local, 14, hasDescriptor ? 0 : checksum); u32(local, 18, hasDescriptor ? 0 : data.length); u32(local, 22, hasDescriptor ? 0 : expanded); u16(local, 26, localName.length); u16(local, 28, localExtra.length); localName.copy(local, 30); localExtra.copy(local, 30 + localName.length); data.copy(local, 30 + localName.length + localExtra.length); descriptor.copy(local, 30 + localName.length + localExtra.length + data.length); locals.push(local);
@@ -112,25 +112,27 @@ describe("bounded classic-ZIP metadata graph", () => {
 
 describe("graph-authoritative ZIP materialization", () => {
   it("materializes stored/deflated bytes, modes, and symlinks before one bounded consumer", async () => {
-    const value = fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Contents/Info.plist", data: "plist" }, { name: "NeonDiff.app/Contents/MacOS/NeonDiff", data: "binary", method: 8, flags: 0x808, mode: 0o100755 }, { name: "NeonDiff.app/Contents/Current", type: "symlink", data: "MacOS" }, { name: "__MACOSX/NeonDiff.app/Contents/._Info.plist", data: "appledouble", method: 8 }]); let materializedRoot = "";
+    const value = fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Contents/Info.plist", data: "plist" }, { name: "NeonDiff.app/Contents/MacOS/NeonDiff", data: "binary", method: 8, flags: 0x808, mode: 0o100755 }, { name: "NeonDiff.app/Contents/Current", type: "symlink", data: "MacOS" }, { name: "NeonDiff.app/Contents/Frameworks/Fixture.framework/Versions/A/Fixture", data: "framework" }, { name: "NeonDiff.app/Contents/Frameworks/Fixture.framework/Versions/Current", type: "symlink", data: "A" }, { name: "NeonDiff.app/Contents/Frameworks/Fixture.framework/Fixture", type: "symlink", data: "Versions/Current/Fixture" }, { name: "__MACOSX/NeonDiff.app/Contents/._Info.plist", data: "appledouble", method: 8 }]); let materializedRoot = "";
     const result = await withMaterializedClassicZipApp(value.artifact, async (appPath, graph) => {
       materializedRoot = dirname(appPath); writeFileSync(value.artifact, "changed after snapshot");
       expect(readFileSync(join(appPath, "Contents", "Info.plist"), "utf8")).toBe("plist"); expect(readFileSync(join(appPath, "Contents", "MacOS", "NeonDiff"), "utf8")).toBe("binary"); expect(readFileSync(join(materializedRoot, "__MACOSX", "NeonDiff.app", "Contents", "._Info.plist"), "utf8")).toBe("appledouble");
-      expect(statSync(join(appPath, "Contents", "MacOS", "NeonDiff")).mode & 0o777).toBe(0o755); expect(readlinkSync(join(appPath, "Contents", "Current"))).toBe("MacOS"); expect(Object.isFrozen(graph)).toBe(true); return "accepted";
+      expect(statSync(join(appPath, "Contents", "MacOS", "NeonDiff")).mode & 0o777).toBe(0o755); expect(readlinkSync(join(appPath, "Contents", "Current"))).toBe("MacOS"); expect(readFileSync(join(appPath, "Contents", "Frameworks", "Fixture.framework", "Fixture"), "utf8")).toBe("framework"); expect(Object.isFrozen(graph)).toBe(true); return "accepted";
     });
     expect(result).toBe("accepted"); expect(existsSync(materializedRoot)).toBe(false);
   });
   it("fails before the consumer on CRC, size, special-mode, and symlink invariant violations", async () => {
-    const cases: [Entry[], string][] = [
+    const cases: [Entry[], string | RegExp][] = [
       [[{ name: "NeonDiff.app/a", data: "bytes", crc: 0 }], "CRC-32 mismatch"],
       [[{ name: "NeonDiff.app/a", data: "expands", method: 8, expanded: 1 }], "expanded entry size mismatch"],
+      [[{ name: "NeonDiff.app/a", data: "bytes", method: 8, trailing: Buffer.from("garbage") }], /trailing|garbage/i],
       [[{ name: "NeonDiff.app/a", mode: 0o104755 }], "special permission bits unsupported"],
       [[{ name: "NeonDiff.app/link", type: "symlink", data: "" }], "unsafe symlink target"],
       [[{ name: "NeonDiff.app/link", type: "symlink", data: "bad\0target" }], "unsafe symlink target"],
       [[{ name: "NeonDiff.app/link", type: "symlink", data: "/tmp" }], "unsafe symlink target"],
       [[{ name: "NeonDiff.app/link", type: "symlink", data: Buffer.alloc(4097, 97) }], "symlink target too large"],
       [[{ name: "NeonDiff.app/link", type: "symlink", data: "../../escape" }], "unsafe symlink target"],
-      [[{ name: "NeonDiff.app/link", type: "symlink", data: "missing" }], "missing symlink target"]
+      [[{ name: "NeonDiff.app/link", type: "symlink", data: "missing" }], "missing symlink target"],
+      [[{ name: "NeonDiff.app/a", type: "symlink", data: "b" }, { name: "NeonDiff.app/b", type: "symlink", data: "a" }], "symlink cycle"]
     ];
     for (const [entries, message] of cases) {
       const value = fixture(entries), before = readdirSync(value.root).sort(), previous = process.env.TMPDIR; let called = false; process.env.TMPDIR = value.root;
@@ -143,5 +145,10 @@ describe("graph-authoritative ZIP materialization", () => {
     u32(bytes, hidden.length + central + 42, original.readUInt32LE(central + 42) + hidden.length); u32(bytes, bytes.length - 6, central + hidden.length); writeFileSync(value.artifact, bytes); let materializedRoot = "";
     await expect(withMaterializedClassicZipApp(value.artifact, (appPath) => { materializedRoot = dirname(appPath); expect(readFileSync(join(appPath, "a"), "utf8")).toBe("safe"); expect(existsSync(join(materializedRoot, "escape"))).toBe(false); throw new Error("consumer failed"); })).rejects.toThrow("consumer failed");
     expect(materializedRoot).not.toBe(""); expect(existsSync(materializedRoot)).toBe(false);
+  });
+  it("restores owner directory access before removing accepted restrictive modes", async () => {
+    const value = fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Locked/", type: "directory", mode: 0o040000 }, { name: "NeonDiff.app/Locked/file", data: "bytes" }]); let materializedRoot = "";
+    await expect(withMaterializedClassicZipApp(value.artifact, (appPath) => { materializedRoot = dirname(appPath); expect(statSync(join(appPath, "Locked")).mode & 0o777).toBe(0); return "clean"; })).resolves.toBe("clean");
+    expect(existsSync(materializedRoot)).toBe(false);
   });
 });


### PR DESCRIPTION
## Outcome

Materialize exactly the A1/A2-accepted classic-ZIP graph from one immutable byte snapshot into a private temporary root, expose `NeonDiff.app` only after every selected byte/type/mode/symlink validates, and remove the root after the bounded consumer completes or fails.

Closes #1074

## Exact source

- Base: `cfe997ef4854be83b060f82affdb2d5c009ed6cf`
- Head: `ded55dd1d61e09ff17be10c6c6460c7936c90ac9`
- Scope: `scripts/lib/desktop-extracted-app-tree-proof.mjs` and `tests/desktop-extracted-app-tree-proof.test.ts`
- Delta: 130 insertions, 15 deletions; 145 cumulative changed lines

## Design

- Reuses the merged A1 archive guard and A2 normalized metadata graph from the same in-memory byte snapshot.
- Streams only graph-selected stored/raw-DEFLATE ranges through actual expanded-size, aggregate-size, and CRC-32 verification.
- Creates a private mode-0700 root, accepted directories first, files with `O_EXCL | O_NOFOLLOW`, then confined graph-backed symlinks; ordinary accepted modes apply only after verified writes.
- Keeps accepted AppleDouble sidecars inside the private sibling namespace and passes only the completed app path plus frozen graph to the consumer.
- Cleans the complete root in `finally`, including validation and consumer failure.
- Never scans unreferenced local headers and invokes no generic extractor or helper process.

## Failing-first and validation

- First valid focused run: 10 passed, 3 failed because the materializer API was absent.
- Review-delta failing-first run: 11/14 passed; framework-link, trailing-DEFLATE, and restrictive-mode cleanup failures reproduced.
- Node 26.7.0 focused Vitest: 14/14 passed.
- Canonical macOS `ditto` framework-chain probe: passed.
- Node 26.7.0 source syntax check: passed.
- `git diff --check`: passed.
- Authoritative full build/test/package remains GitHub CI.

Tests cover stored/raw-DEFLATE data, complete compressed-input consumption, valid data descriptors, AppleDouble sidecars, executable and restrictive directory modes, canonical macOS `ditto --sequesterRsrc --keepParent`, standard framework symlink chains, CRC and declared-size mismatch, raw-DEFLATE expansion past declared size, special modes, NUL/absolute/empty/oversized/escaping/missing/cyclic symlink targets, a hostile unreferenced local header, pre-consumer cleanup, consumer-failure cleanup, and artifact mutation after the accepted snapshot.

## Safety and proof boundary

This is agent-authored. No package, schema, service, queue, release, runtime, LaunchAgent, config, database, Keychain, provider, customer, billing, website, artifact, or updater mutation occurred.

Accepted tradeoff: this A3 gate does not claim protection from an external hostile process running as the same local UID. Such a process can mechanically substitute a descendant inside the randomized mode-0700 root, but it already has direct write/chmod authority over the proposed outside target; no archive-controlled code or callback runs before materialization completes. Portable descriptor-relative `openat`-style mutation would require a separate native threat-model expansion beyond this bounded Node-only gate.

Passing proves only bounded graph-authoritative temporary materialization of classic-ZIP app bytes, ordinary modes, and symlink payloads. It does not prove T1v4b authenticated tree/plist evidence, accepted packet #1020, updater/rollback #1021, signing/notarization/Gatekeeper, release, installed runtime, customer use, or GA readiness.

Required merge barrier: exact-head remote CI; one independent archive/materialization-risk review; blind acceptance and adversarial PASS at confidence 95 or above; terminal finding dispositions; zero unresolved conversations; exact base/head/scope readback.
