### PR TITLE
Mac GA: authenticate exact-ZIP app tree proof

### DIFF
--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -1,15 +1,56 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { chmodSync, closeSync, constants, createWriteStream, fstatSync, mkdirSync, mkdtempSync, openSync, readSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, posix, resolve } from "node:path";
 import { PassThrough, Readable, Transform, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createInflateRaw, crc32 } from "node:zlib";
+import { walkDescriptorTree } from "../shared/safe-fs.mjs";
 
 const MAX_BYTES = 512 * 1024 * 1024, MAX_RECORDS = 20_000, MAX_METADATA = 16 * 1024 * 1024, MAX_NODES = 20_000;
 const EOCD = 0x06054b50, LOCAL = 0x04034b50, CENTRAL = 0x02014b50, DATA_DESCRIPTOR = 0x08074b50, ZIP64 = "ZIP64 archive unsupported";
 const UTF8 = new TextDecoder("utf-8", { fatal: true }), ALLOWED_FLAGS = 0x080e, TYPE_MASK = 0o170000, PATH_OVERRIDE_FIELDS = new Set([0x0008, 0x7075]);
 const fail = (message) => { throw new Error(message); };
+const SHA1 = /^[a-f0-9]{40}$/, SHA256 = /^[a-f0-9]{64}$/, TREE_KIND = "neondiff.desktop.extracted-tree-proof-v1";
+const TREE_FIELDS = ["schemaVersion", "kind", "verified", "algorithm", "sourceSHA", "artifactSHA256", "artifactByteLength", "treeSHA256", "records", "bundleMarkers", "appleDouble"];
+const authenticatedTreeProofs = new WeakSet();
+const PLIST_PARSER = String.raw`
+import json, plistlib, sys, xml.etree.ElementTree as ET
+raw = sys.stdin.buffer.read(1048577)
+if len(raw) > 1048576 or raw.startswith(b"bplist00") or b"<!DOCTYPE" in raw or b"<!ENTITY" in raw:
+    raise ValueError("unsupported plist")
+root = ET.fromstring(raw)
+if root.tag != "plist" or len(root) != 1 or root[0].tag != "dict":
+    raise ValueError("invalid plist root")
+def unique(node):
+    if node.tag == "dict":
+        children = list(node)
+        if len(children) % 2:
+            raise ValueError("invalid plist dictionary")
+        seen = set()
+        for index in range(0, len(children), 2):
+            key, value = children[index], children[index + 1]
+            if key.tag != "key" or (key.text or "") in seen:
+                raise ValueError("duplicate or invalid plist key")
+            seen.add(key.text or "")
+            unique(value)
+    elif node.tag == "array":
+        for value in node:
+            unique(value)
+unique(root[0])
+value = plistlib.loads(raw)
+required = ("CFBundleIdentifier", "CFBundleShortVersionString", "CFBundleVersion")
+if not isinstance(value, dict):
+    raise ValueError("invalid plist dictionary")
+result = {}
+for key in required:
+    item = value.get(key)
+    if not isinstance(item, str) or not item or len(item.encode("utf-8")) > 128:
+        raise ValueError("invalid plist marker")
+    result[key] = item
+sys.stdout.write(json.dumps(result, separators=(",", ":")))
+`;
 function artifactBytes(descriptor) {
   const before = fstatSync(descriptor);
   if (!before.isFile() || before.size > MAX_BYTES) fail("artifact bytes exceed bound");
@@ -210,3 +251,66 @@ export async function withMaterializedClassicZipApp(artifactPath, consumer) {
     rmSync(root, { recursive: true, force: true });
   }
 }
+
+function proofText(value, label) {
+  if (typeof value !== "string" || !value || /[\\\u0000-\u001f\u007f]/.test(value) || value.startsWith("/") || value.split("/").some((part) => !part || part === "." || part === "..")) fail(`${label} is malformed`);
+  for (let index = 0; index < value.length; index += 1) { const code = value.charCodeAt(index); if (code >= 0xd800 && code <= 0xdfff) { if (code > 0xdbff || index + 1 >= value.length || value.charCodeAt(index + 1) < 0xdc00 || value.charCodeAt(index + 1) > 0xdfff) fail(`${label} is malformed`); index += 1; } }
+  return value;
+}
+function proofTarget(value) {
+  if (typeof value !== "string" || !value || /[\\\u0000-\u001f\u007f]/.test(value)) fail("symlink target is malformed");
+  for (let index = 0; index < value.length; index += 1) { const code = value.charCodeAt(index); if (code >= 0xd800 && code <= 0xdfff) { if (code > 0xdbff || index + 1 >= value.length || value.charCodeAt(index + 1) < 0xdc00 || value.charCodeAt(index + 1) > 0xdfff) fail("symlink target is malformed"); index += 1; } }
+  return value;
+}
+function proofPathIdentity(path) {
+  return path.split("/").map((part) => { const normalized = part.normalize("NFKC"), lower = normalized.toLowerCase(); if (lower.toUpperCase().toLowerCase() !== lower) fail("unsupported caseless tree path"); return lower.normalize("NFKC"); }).join("/");
+}
+function treeDigest(records) {
+  const digest = createHash("sha256");
+  for (const record of records) { for (const part of record) { digest.update(String(part), "utf8"); digest.update("\0"); } digest.update("\n"); }
+  return digest.digest("hex");
+}
+function appTree(appPath) {
+  const records = [], directories = new Set([""]), identities = new Map(); let aggregate = 0, infoPlist;
+  walkDescriptorTree(appPath, (entry) => {
+    if (records.length >= MAX_NODES) fail("tree record bound exceeded");
+    const path = proofText(entry.relativePath, "tree path"), identity = proofPathIdentity(path), collision = identities.get(identity);
+    if (collision && collision !== path) fail("tree path collision"); identities.set(identity, path);
+    const slash = path.lastIndexOf("/"), parent = slash < 0 ? "" : path.slice(0, slash);
+    if (!directories.has(parent)) fail("tree parent topology is invalid");
+    if (entry.type === "directory") { directories.add(path); records.push(["dir", path]); return; }
+    if (entry.type === "symlink") {
+      const target = proofTarget(entry.target), destination = posix.normalize(posix.join(posix.dirname(path), target));
+      if (posix.isAbsolute(target) || destination === ".." || destination.startsWith("../")) fail("symlink target escapes app root");
+      records.push(["link", path, target]); return;
+    }
+    if (!Buffer.isBuffer(entry.data) || !Number.isSafeInteger(entry.stat.size) || entry.stat.size !== entry.data.length || (aggregate += entry.data.length) > MAX_BYTES) fail("tree file bytes are invalid");
+    const fileSHA = createHash("sha256").update(entry.data).digest("hex"); if (!SHA256.test(fileSHA)) fail("tree file digest is invalid");
+    records.push(["file", path, (entry.stat.mode & 0o111) === 0 ? "-" : "x", entry.stat.size, fileSHA]);
+    if (path === "Contents/Info.plist") { if (infoPlist) fail("desktop Info.plist is duplicated"); infoPlist = entry.data; }
+  });
+  if (!infoPlist) fail("desktop Info.plist is missing");
+  return { records, infoPlist };
+}
+function plistMarkers(bytes) {
+  const parsed = spawnSync("/usr/bin/python3", ["-I", "-c", PLIST_PARSER], { input: bytes, encoding: "utf8", maxBuffer: 4096 }); let value;
+  try { if (parsed.status !== 0) fail("desktop Info.plist is malformed"); value = JSON.parse(parsed.stdout); } catch { fail("desktop Info.plist is malformed"); }
+  const bundleID = value.CFBundleIdentifier, version = value.CFBundleShortVersionString, build = value.CFBundleVersion;
+  if (bundleID !== "com.electricsheephq.NeonDiffDesktop" || !/^1\.1\.0(?:-(?:beta|rc)\.[1-9][0-9]{0,15})?$/.test(version) || !/^[0-9]{1,32}$/.test(build)) fail("bundle markers are not canonical");
+  return { appPath: "NeonDiff.app", bundleID, version, build };
+}
+function deepFreeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { for (const child of Object.values(value)) deepFreeze(child); Object.freeze(value); } return value; }
+
+export async function buildExtractedAppTreeProof(artifactPath, sourceSHA) {
+  if (typeof artifactPath !== "string" || !artifactPath) fail("artifact path is malformed");
+  if (typeof sourceSHA !== "string" || !SHA1.test(sourceSHA)) fail("source SHA is malformed");
+  return withMaterializedClassicZipApp(artifactPath, (appPath, graph) => {
+    const { records, infoPlist } = appTree(appPath), proof = { schemaVersion: 1, kind: TREE_KIND, verified: true, algorithm: "sha256-tree-v1", sourceSHA, artifactSHA256: graph.artifactSHA256, artifactByteLength: graph.artifactByteLength, treeSHA256: treeDigest(records), records, bundleMarkers: plistMarkers(infoPlist), appleDouble: { policy: "artifact-bound-excluded-from-tree-v1", entryCount: graph.records.filter((record) => typeof record.sidecarTarget === "string").length } };
+    authenticatedTreeProofs.add(proof); return deepFreeze(proof);
+  });
+}
+export function serializeExtractedAppTreeProof(proof) {
+  if (!authenticatedTreeProofs.has(proof)) fail("proof was not produced by the extracted-tree producer");
+  return `${JSON.stringify(Object.fromEntries(TREE_FIELDS.map((field) => [field, proof[field]])))}\n`;
+}
+export function extractedAppTreeProofDigest(proof) { return createHash("sha256").update(serializeExtractedAppTreeProof(proof), "utf8").digest("hex"); }

--- a/scripts/shared/safe-fs.mjs
+++ b/scripts/shared/safe-fs.mjs
@@ -10,7 +10,7 @@ export function walkDescriptorTree(root, visitor) {
   try {
     output = execFileSync(
       "/usr/bin/python3",
-      [helper, "--root", resolve(root)],
+      ["-I", helper, "--root", resolve(root)],
       { encoding: "utf8", maxBuffer: maximumOutputBytes }
     );
   } catch (error) {

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { crc32, deflateRawSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildClassicZipMetadataGraph, guardClassicZipArchive, withMaterializedClassicZipApp } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
+import { buildClassicZipMetadataGraph, buildExtractedAppTreeProof, extractedAppTreeProofDigest, guardClassicZipArchive, serializeExtractedAppTreeProof, withMaterializedClassicZipApp } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
 
 type Entry = { name: string; localName?: string; localOffset?: number; localExtra?: Buffer; type?: "file" | "directory" | "symlink"; data?: string | Buffer; trailing?: Buffer; flags?: number; method?: number; expanded?: number; crc?: number; descriptor?: boolean; extra?: number | Buffer; comment?: number; mode?: number };
 const roots: string[] = [];
@@ -26,6 +26,7 @@ function classicZip(entries: Entry[]) {
 }
 function unicodePathExtra(headerName: string, alternateName: string) { const alternate = Buffer.from(alternateName), field = Buffer.alloc(9 + alternate.length); u16(field, 0, 0x7075); u16(field, 2, 5 + alternate.length); field[4] = 1; u32(field, 5, crc32(Buffer.from(headerName))); alternate.copy(field, 9); return field; }
 function fixture(entries: Entry[]) { const root = mkdtempSync(join(tmpdir(), "neondiff-zip-")); roots.push(root); const artifact = join(root, "NeonDiff.zip"); writeFileSync(artifact, classicZip(entries)); return { root, artifact }; }
+function plist(version = "1.1.0-rc.9", extra = "") { return `<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.electricsheephq.NeonDiffDesktop</string><key>CFBundleShortVersionString</key><string>${version}</string><key>CFBundleVersion</key><string>11091</string>${extra}</dict></plist>`; }
 function eocdPatch(artifact: string, field: number, value: number) { const bytes = readFileSync(artifact); u32(bytes, bytes.length - 22 + field, value); writeFileSync(artifact, bytes); }
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 
@@ -150,5 +151,42 @@ describe("graph-authoritative ZIP materialization", () => {
     const value = fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Locked/", type: "directory", mode: 0o040000 }, { name: "NeonDiff.app/Locked/file", data: "bytes" }]); let materializedRoot = "";
     await expect(withMaterializedClassicZipApp(value.artifact, (appPath) => { materializedRoot = dirname(appPath); expect(statSync(join(appPath, "Locked")).mode & 0o777).toBe(0); return "clean"; })).resolves.toBe("clean");
     expect(existsSync(materializedRoot)).toBe(false);
+  });
+});
+
+describe("authenticated exact-ZIP app tree and plist proof", () => {
+  const sourceSHA = "0123456789abcdef0123456789abcdef01234567";
+  function proofFixture(version = "1.1.0-rc.9", extra = "", info: string | Buffer = plist(version, extra)) {
+    return fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Contents/Info.plist", data: info }, { name: "NeonDiff.app/Contents/MacOS/NeonDiffDesktop", data: "desktop", mode: 0o100755 }, { name: "NeonDiff.app/Contents/Resources/Current", type: "symlink", data: "../MacOS/NeonDiffDesktop" }, { name: "__MACOSX/NeonDiff.app/Contents/._Info.plist", data: "appledouble" }]);
+  }
+  it("derives one frozen canonical proof and binds explicit AppleDouble exclusion", async () => {
+    for (const version of ["1.1.0", "1.1.0-beta.87", "1.1.0-rc.9"]) {
+      const value = proofFixture(version), proof = await buildExtractedAppTreeProof(value.artifact, sourceSHA);
+      let canonicalTree: any;
+      await withMaterializedClassicZipApp(value.artifact, (appPath) => { canonicalTree = JSON.parse(execFileSync(process.execPath, [join(process.cwd(), "scripts/hash-desktop-bundle-tree.mjs"), appPath], { encoding: "utf8" })); });
+      expect(proof).toMatchObject({ schemaVersion: 1, kind: "neondiff.desktop.extracted-tree-proof-v1", verified: true, algorithm: "sha256-tree-v1", sourceSHA, treeSHA256: canonicalTree.sha256, bundleMarkers: { appPath: "NeonDiff.app", bundleID: "com.electricsheephq.NeonDiffDesktop", version, build: "11091" }, appleDouble: { policy: "artifact-bound-excluded-from-tree-v1", entryCount: 1 } });
+      expect(proof.artifactSHA256).toBe(createHash("sha256").update(readFileSync(value.artifact)).digest("hex")); expect(proof.records).toHaveLength(canonicalTree.entryCount);
+      expect(Object.isFrozen(proof) && Object.isFrozen(proof.records) && Object.isFrozen(proof.records[0]) && Object.isFrozen(proof.bundleMarkers) && Object.isFrozen(proof.appleDouble)).toBe(true);
+      expect(serializeExtractedAppTreeProof(proof)).toMatch(/\n$/); expect(extractedAppTreeProofDigest(proof)).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+  it("fails closed on ambiguous plist bytes and invalid bundle markers", async () => {
+    const invalid = [
+      proofFixture("1.1.0", "<key>CFBundleName</key><string>A</string><key>CFBundleName</key><string>B</string>"),
+      proofFixture("1.1.0", "", Buffer.from("bplist00hostile")),
+      proofFixture("1.2.0"),
+      proofFixture("1.1.0", "", plist("1.1.0").replace("com.electricsheephq.NeonDiffDesktop", "com.example.Wrong")),
+      proofFixture("1.1.0", "", plist("1.1.0").replace("11091", "not-a-build"))
+    ];
+    for (const value of invalid) await expect(buildExtractedAppTreeProof(value.artifact, sourceSHA)).rejects.toThrow(/plist|marker/i);
+  });
+  it("accepts primitive authority only and rejects forged proof serialization without proxy reads", async () => {
+    const value = proofFixture(), proof = await buildExtractedAppTreeProof(value.artifact, sourceSHA); let proxyRead = false;
+    await expect(buildExtractedAppTreeProof(new Proxy({}, { get() { proxyRead = true; throw new Error("trap"); } }) as any, sourceSHA)).rejects.toThrow("artifact path"); expect(proxyRead).toBe(false);
+    expect(() => serializeExtractedAppTreeProof({ ...proof } as any)).toThrow("not produced");
+    expect(() => serializeExtractedAppTreeProof(new Proxy(proof, { get() { proxyRead = true; throw new Error("trap"); } }) as any)).toThrow("not produced"); expect(proxyRead).toBe(false);
+    const shadow = proofFixture(), previousPythonPath = process.env.PYTHONPATH; writeFileSync(join(shadow.root, "json.py"), "raise RuntimeError('shadow')"); writeFileSync(join(shadow.root, "plistlib.py"), "raise RuntimeError('shadow')");
+    try { process.env.PYTHONPATH = shadow.root; await expect(buildExtractedAppTreeProof(shadow.artifact, sourceSHA)).resolves.toMatchObject({ verified: true }); } finally { if (previousPythonPath === undefined) delete process.env.PYTHONPATH; else process.env.PYTHONPATH = previousPythonPath; }
+    await expect(buildExtractedAppTreeProof(fixture([{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Contents/Info.plist", data: plist() }, { name: "NeonDiff.app/Foo/a" }, { name: "NeonDiff.app/Ｆｏｏ/b" }]).artifact, sourceSHA)).rejects.toThrow("tree path collision");
   });
 });


### PR DESCRIPTION
Closes #1076

## What changed

- Added a primitive-input-only producer that derives an authenticated, recursively frozen extracted-app tree/plist proof from the exact A1/A2/A3 classic-ZIP authority.
- Reused descriptor-safe traversal and existing `sha256-tree-v1` record framing; the proof digest matches the repository's established bundle-tree command on the same materialized app.
- Added strict XML-only plist marker parsing through absolute `/usr/bin/python3 -I`: duplicate any-key dictionaries, binary plists, wrong bundle/version/build markers, ambient `PYTHONPATH`, and malformed bytes fail closed.
- Added producer-owned proof authentication and fixed-field/order/newline serialization so forged, spread, or Proxy-wrapped proof objects are rejected before field reads.
- Added NFKC/caseless path-collision checks while preserving valid confined relative symlinks.
- Bound and counted AppleDouble sidecars under the explicit `artifact-bound-excluded-from-tree-v1` policy. Canonical extraction/signature equivalence remains a release gate in #1020; this PR does not claim it.

## Reuse and scope

- Reuse disposition: `COMPOSE` over merged A1/A2/A3 plus `scripts/shared/safe-fs.mjs` and the existing tree-hash semantics.
- No new ZIP/plist dependency, generic extractor, direct-record API, service, queue, storage layer, caller proof DTO, or runtime path.
- Exact scope: 3 files, 144 insertions / 2 deletions / 146 changed lines.

## Validation

- Failing-first: inherited A1/A2/A3 14/14 passed; the three new tests failed only because the proof producer was absent.
- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/desktop-extracted-app-tree-proof.test.ts tests/safe-file-read.test.ts tests/desktop-bundle-tree-hash.test.ts tests/desktop-info-plist.test.ts` — 26/26 passed.
- `/opt/homebrew/bin/node --check scripts/lib/desktop-extracted-app-tree-proof.mjs` — passed.
- `git diff --check` — passed.
- Node `v26.7.0`, exact lock installed with `npm ci`.

## Agent and safety disclosure

Codex authored this change under issue #1076. No app install, signing, tag, release, feed, updater, LaunchAgent/helper/config/database/Keychain, provider, billing, customer, or live-runtime mutation occurred. No secret, raw customer data, config value, raw database row, or credential was read into this PR.

## Proof boundary

Passing proves only exact source/test delivery for an authenticated immutable ordinary app-tree and strict XML-plist proof derived from one accepted classic-ZIP artifact. It does not prove canonical AppleDouble/xattr application, signing/notarization/Gatekeeper, accepted packet #1020, update/rollback #1021, installed runtime, customer use, release, or GA readiness.
