### PR TITLE
Mac GA: enforce canonical UTF-8 appcast parsing

### DIFF
--- a/scripts/lib/desktop-raw-appcast.mjs
+++ b/scripts/lib/desktop-raw-appcast.mjs
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+
+const MAX_INPUT = 4 * 1024 * 1024;
+const PARSER = String.raw`
+import json,sys,xml.etree.ElementTree as ET
+text = sys.stdin.buffer.read().decode("utf-8")
+root = ET.fromstring(text)
+channels = [node for node in root if node.tag == "channel"]
+if root.tag != "rss" or len(channels) != 1: raise ValueError("invalid feed")
+channel = channels[0]; links = [node.text or "" for node in channel if node.tag == "link"]
+if len(links) != 1: raise ValueError("invalid feed link")
+ns = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"; expected = {"url","length","type",ns+"version",ns+"shortVersionString",ns+"minimumSystemVersion",ns+"edSignature"}; entries = []
+for item in [node for node in channel if node.tag == "item"]:
+    enclosures = [node for node in item if node.tag == "enclosure"]; minimum = [node.text or "" for node in item if node.tag == ns+"minimumSystemVersion"]; rings = [node.text or "" for node in item if node.tag == ns+"channel"]
+    if len(enclosures) != 1 or set(enclosures[0].attrib) != expected or len(minimum) != 1 or len(rings) > 1: raise ValueError("invalid feed item")
+    value = enclosures[0].attrib
+    if value[ns+"minimumSystemVersion"] != minimum[0]: raise ValueError("minimum version mismatch")
+    entries.append({"url":value["url"],"length":value["length"],"type":value["type"],"version":value[ns+"shortVersionString"],"build":value[ns+"version"],"shortVersionString":value[ns+"shortVersionString"],"minimumSystemVersion":minimum[0],"channel":rings[0] if rings else "stable","edSignature":value[ns+"edSignature"]})
+sys.stdout.write(json.dumps({"link":links[0],"entries":entries}, separators=(",", ":")))
+`;
+
+const fail = (message) => { throw new Error(message); };
+function deepFreeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function canonicalUTF8(input) {
+  if (!(input instanceof Uint8Array)) fail("raw appcast must be bytes");
+  const raw = Buffer.from(input);
+  if (raw.length === 0 || raw.length > MAX_INPUT) fail("raw appcast is not bounded");
+  let text;
+  try { text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(raw); }
+  catch { fail("raw appcast is not canonical UTF-8"); }
+  if (text.charCodeAt(0) === 0xfeff || text.includes("\0") || !Buffer.from(text, "utf8").equals(raw)) fail("raw appcast is not canonical UTF-8");
+  const declaration = text.match(/^<\?xml\s+([\s\S]*?)\?>/i), encoding = declaration?.[1].match(/\bencoding\s*=\s*(["'])([^"']+)\1/i)?.[2];
+  if (encoding && !/^utf-8$/i.test(encoding)) fail("raw appcast declares a non-UTF-8 encoding");
+  if (/<!(?:doctype|entity)\b/i.test(text)) fail("raw appcast DTD is unsupported");
+  return raw;
+}
+
+export function parseRawDesktopAppcast(input) {
+  const raw = canonicalUTF8(input), result = spawnSync("/usr/bin/python3", ["-I", "-c", PARSER], { input: raw, encoding: "utf8", maxBuffer: MAX_INPUT, timeout: 5_000 });
+  try { if (result.status !== 0) fail("raw appcast is malformed"); return deepFreeze(JSON.parse(result.stdout)); }
+  catch { fail("raw appcast is malformed"); }
+}

--- a/scripts/lib/desktop-raw-appcast.mjs
+++ b/scripts/lib/desktop-raw-appcast.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 
 const MAX_INPUT = 4 * 1024 * 1024;
+const INTRINSIC_BYTE_LENGTH = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(Uint8Array.prototype), "byteLength").get;
 const PARSER = String.raw`
 import json,sys,xml.etree.ElementTree as ET
 text = sys.stdin.buffer.read().decode("utf-8")
@@ -30,7 +31,8 @@ function deepFreeze(value) {
 
 function canonicalUTF8(input) {
   if (!(input instanceof Uint8Array)) fail("raw appcast must be bytes");
-  if (input.byteLength === 0 || input.byteLength > MAX_INPUT) fail("raw appcast is not bounded");
+  const byteLength = Reflect.apply(INTRINSIC_BYTE_LENGTH, input, []);
+  if (byteLength === 0 || byteLength > MAX_INPUT) fail("raw appcast is not bounded");
   const raw = Buffer.from(input);
   let text;
   try { text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(raw); }

--- a/scripts/lib/desktop-raw-appcast.mjs
+++ b/scripts/lib/desktop-raw-appcast.mjs
@@ -30,8 +30,8 @@ function deepFreeze(value) {
 
 function canonicalUTF8(input) {
   if (!(input instanceof Uint8Array)) fail("raw appcast must be bytes");
+  if (input.byteLength === 0 || input.byteLength > MAX_INPUT) fail("raw appcast is not bounded");
   const raw = Buffer.from(input);
-  if (raw.length === 0 || raw.length > MAX_INPUT) fail("raw appcast is not bounded");
   let text;
   try { text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(raw); }
   catch { fail("raw appcast is not canonical UTF-8"); }

--- a/tests/desktop-raw-appcast.test.ts
+++ b/tests/desktop-raw-appcast.test.ts
@@ -31,7 +31,6 @@ describe("canonical raw Desktop appcast", () => {
   it.each([
     ["primitive text", feed],
     ["empty bytes", Buffer.alloc(0)],
-    ["oversized bytes", Buffer.alloc(4 * 1024 * 1024 + 1)],
     ["malformed UTF-8", Buffer.from([0xc3, 0x28])],
     ["UTF-8 BOM", Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(feed)])],
     ["declared alternate encoding", Buffer.from(feed.replace("UTF-8", "UTF-16"))],
@@ -43,6 +42,14 @@ describe("canonical raw Desktop appcast", () => {
     ["case-folded DTD/entity", Buffer.from(hostile.toLowerCase())]
   ])("rejects %s before XML acceptance", (_label, raw) => {
     expect(() => parseRawDesktopAppcast(raw as Uint8Array)).toThrow();
+  });
+
+  it("rejects oversized input before copying it", () => {
+    const oversized = new Uint8Array(4 * 1024 * 1024 + 1), originalFrom = Buffer.from;
+    let error;
+    try { Buffer.from = (() => { throw new Error("oversized input was copied"); }) as typeof Buffer.from; try { parseRawDesktopAppcast(oversized); } catch (caught) { error = caught; } }
+    finally { Buffer.from = originalFrom; }
+    expect(error).toMatchObject({ message: "raw appcast is not bounded" });
   });
 
   it.each([

--- a/tests/desktop-raw-appcast.test.ts
+++ b/tests/desktop-raw-appcast.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { parseRawDesktopAppcast } from "../scripts/lib/desktop-raw-appcast.mjs";
+
+const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel>
+<link>https://www.neondiff.com/appcast.xml</link><item>
+<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion><sparkle:channel>stable</sparkle:channel>
+<enclosure url="https://example.test/NeonDiff.zip" length="42" type="application/octet-stream" sparkle:version="11000" sparkle:shortVersionString="1.1.0" sparkle:minimumSystemVersion="14.0" sparkle:edSignature="signature"/>
+</item></channel></rss>`;
+const hostile = `<?xml version="1.0"?><!DOCTYPE rss [<!ENTITY x "hostile">]><rss><channel><link>&x;</link></channel></rss>`;
+const originalPythonPath = process.env.PYTHONPATH;
+
+function encoded(text: string, width: 2 | 4, littleEndian: boolean) {
+  const bom = width === 2 ? Buffer.from(littleEndian ? [0xff, 0xfe] : [0xfe, 0xff]) : Buffer.from(littleEndian ? [0xff, 0xfe, 0x00, 0x00] : [0x00, 0x00, 0xfe, 0xff]);
+  const body = Buffer.alloc(text.length * width);
+  for (let index = 0; index < text.length; index += 1) littleEndian ? body[width === 2 ? "writeUInt16LE" : "writeUInt32LE"](text.charCodeAt(index), index * width) : body[width === 2 ? "writeUInt16BE" : "writeUInt32BE"](text.charCodeAt(index), index * width);
+  return Buffer.concat([bom, body]);
+}
+
+afterEach(() => { if (originalPythonPath === undefined) delete process.env.PYTHONPATH; else process.env.PYTHONPATH = originalPythonPath; });
+
+describe("canonical raw Desktop appcast", () => {
+  it("parses one strict canonical UTF-8 feed and freezes its bounded output", () => {
+    const parsed = parseRawDesktopAppcast(Buffer.from(feed, "utf8"));
+    expect(parsed).toMatchObject({ link: "https://www.neondiff.com/appcast.xml", entries: [{ version: "1.1.0", build: "11000", minimumSystemVersion: "14.0", channel: "stable" }] });
+    expect(Object.isFrozen(parsed)).toBe(true);
+    expect(Object.isFrozen(parsed.entries)).toBe(true);
+    expect(Object.isFrozen(parsed.entries[0])).toBe(true);
+  });
+
+  it.each([
+    ["primitive text", feed],
+    ["empty bytes", Buffer.alloc(0)],
+    ["oversized bytes", Buffer.alloc(4 * 1024 * 1024 + 1)],
+    ["malformed UTF-8", Buffer.from([0xc3, 0x28])],
+    ["UTF-8 BOM", Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(feed)])],
+    ["declared alternate encoding", Buffer.from(feed.replace("UTF-8", "UTF-16"))],
+    ["UTF-16LE DTD", encoded(hostile, 2, true)],
+    ["UTF-16BE DTD", encoded(hostile, 2, false)],
+    ["UTF-32LE DTD", encoded(hostile, 4, true)],
+    ["UTF-32BE DTD", encoded(hostile, 4, false)],
+    ["UTF-8 DTD/entity", Buffer.from(hostile)],
+    ["case-folded DTD/entity", Buffer.from(hostile.toLowerCase())]
+  ])("rejects %s before XML acceptance", (_label, raw) => {
+    expect(() => parseRawDesktopAppcast(raw as Uint8Array)).toThrow();
+  });
+
+  it.each([
+    ["malformed XML", feed.slice(0, -8)],
+    ["duplicate channel", feed.replace("</rss>", "<channel><link>x</link></channel></rss>")],
+    ["extra enclosure attribute", feed.replace("<enclosure ", "<enclosure extra=\"x\" ")],
+    ["minimum-version drift", feed.replace("<sparkle:minimumSystemVersion>14.0", "<sparkle:minimumSystemVersion>13.0")]
+  ])("rejects %s", (_label, xml) => expect(() => parseRawDesktopAppcast(Buffer.from(xml))).toThrow());
+
+  it("isolates the Python parser from ambient module paths", () => {
+    process.env.PYTHONPATH = "/path/that/must/not/control/parsing";
+    expect(parseRawDesktopAppcast(new Uint8Array(Buffer.from(feed))).entries).toHaveLength(1);
+  });
+});

--- a/tests/desktop-raw-appcast.test.ts
+++ b/tests/desktop-raw-appcast.test.ts
@@ -44,8 +44,9 @@ describe("canonical raw Desktop appcast", () => {
     expect(() => parseRawDesktopAppcast(raw as Uint8Array)).toThrow();
   });
 
-  it("rejects oversized input before copying it", () => {
+  it("rejects oversized input before copying even when byteLength is shadowed", () => {
     const oversized = new Uint8Array(4 * 1024 * 1024 + 1), originalFrom = Buffer.from;
+    Object.defineProperty(oversized, "byteLength", { value: 1 });
     let error;
     try { Buffer.from = (() => { throw new Error("oversized input was copied"); }) as typeof Buffer.from; try { parseRawDesktopAppcast(oversized); } catch (caught) { error = caught; } }
     finally { Buffer.from = originalFrom; }


### PR DESCRIPTION
Closes #1079. Prerequisite for #1020.

## Outcome

Add one bounded raw-appcast parser that accepts only canonical UTF-8 bytes and rejects DTD/entity declarations before isolated XML parsing. This closes the UTF-16 entity-expansion bypass reproduced on superseded packet candidate PR #1078.

## Change

- Require a `Buffer`/`Uint8Array`, nonempty input, and the existing 4 MiB cap.
- Fatal-decode UTF-8, require exact byte round-trip, and reject BOM, NUL-bearing alternate encodings, and non-UTF-8 XML declarations.
- Reject DTD/entity declarations case-insensitively on decoded canonical text before XML parsing.
- Reuse #1078's isolated `/usr/bin/python3 -I` `ElementTree` topology/attribute parser with bounded time/output.
- Recursively freeze the bounded parsed result.

## Evidence

- Accepted base: `2edf449e126b6d9359fb25ea2c6861fda2f0e095`.
- Candidate head: `04c3a2d43ceecddd20dc35b81f83379a38c82011`.
- Failing first: focused test could not import the absent parser module.
- Focused: `18/18` in `tests/desktop-raw-appcast.test.ts`.
- Exact-lock Node 26 build: pass.
- `git diff --cached --check`: pass before commit.
- Scope: two new files, 108 insertions, no deletions.

The focused matrix covers canonical UTF-8, malformed UTF-8, UTF-8 BOM, UTF-16LE/BE, UTF-32LE/BE, alternate encoding declarations, DTD/entity declarations, malformed XML/topology/attributes, size/type bounds, recursive freezing, and ambient-Python isolation.

## Safety and proof boundary

Agent-authored. No feed/network/filesystem operation, release publication, signing, install/update/rollback, runtime, billing, entitlement, secret, customer-data, or customer mutation occurred.

Passing proves only bounded canonical-UTF-8 appcast parsing from supplied raw bytes with DTD/entity declarations rejected before XML parsing. It does not prove feed authenticity/publication, accepted-release packet correctness, signing, updater, runtime, customer, release, or GA readiness.
