### PR TITLE
Mac GA: rebuild canonical accepted Desktop release packet

### DIFF
--- a/scripts/lib/desktop-accepted-release-packet.mjs
+++ b/scripts/lib/desktop-accepted-release-packet.mjs
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { closeSync, constants, fstatSync, openSync, readFileSync } from "node:fs";
+import { basename, dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildExtractedAppTreeProof, guardClassicZipArchive } from "./desktop-extracted-app-tree-proof.mjs";
+import { buildFeedEnclosureProof, feedEnclosureProofDigest } from "./desktop-feed-enclosure-proof.mjs";
+import { classifyDesktopOnlyRelease } from "./desktop-only-release-policy.mjs";
+import { parseRawDesktopAppcast } from "./desktop-raw-appcast.mjs";
+
+const KIND = "neondiff.desktop.accepted-release-packet-v1", SHA1 = /^[a-f0-9]{40}$/, MAX_INPUT = 4 * 1024 * 1024;
+const FIELDS = ["schemaVersion", "kind", "verified", "channel", "version", "build", "tag", "sourceSHA", "tagObjectSHA", "artifactURL", "artifactName", "artifactByteLength", "artifactSHA256", "treeSHA256", "feedSHA256", "feedEntry", "enclosureProofSHA256", "npmReleaseClass"];
+const ENTRY_FIELDS = ["url", "length", "type", "version", "build", "shortVersionString", "minimumSystemVersion", "channel", "edSignature"], authenticatedPackets = new WeakSet(), validator = fileURLToPath(new URL("../validate-desktop-release-declaration.mjs", import.meta.url));
+const fail = (message) => { throw new Error(message); }, sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const STRICT_JSON = String.raw`
+import json,sys
+def pairs(values):
+    result = {}
+    for key,value in values:
+        if key in result: raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+value = json.loads(sys.stdin.buffer.read(), object_pairs_hook=pairs)
+sys.stdout.write(json.dumps(value, separators=(",", ":")))
+`;
+
+function boundedBytes(input, label) {
+  if (typeof input !== "string" || !input) fail(`${label} must be a primitive path`);
+  let descriptor;
+  try { descriptor = openSync(resolve(input), constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0)); const before = fstatSync(descriptor); if (!before.isFile() || before.size > MAX_INPUT) fail(`${label} is not a bounded regular file`); const raw = readFileSync(descriptor), after = fstatSync(descriptor); if (!after.isFile() || raw.length !== before.size || after.size !== before.size) fail(`${label} changed during read`); return raw; }
+  catch (error) { if (error?.code === "ELOOP") fail(`${label} must not be symlinked`); throw error; } finally { if (descriptor !== undefined) closeSync(descriptor); }
+}
+function parseIsolated(raw, script, label) { const result = spawnSync("/usr/bin/python3", ["-I", "-c", script], { input: raw, encoding: "utf8", maxBuffer: MAX_INPUT }); try { if (result.status !== 0) fail(`${label} is malformed`); return JSON.parse(result.stdout); } catch { fail(`${label} is malformed`); } }
+function strictJSON(raw, label) { return parseIsolated(raw, STRICT_JSON, label); }
+function currentDeclaration(indexPath) {
+  const indexRaw = boundedBytes(indexPath, "declaration index"), index = strictJSON(indexRaw, "declaration index");
+  if (index?.declarationDirectory !== "declarations" || typeof index.currentPath !== "string" || !/^v1\.1\.0(?:-(?:beta\.[1-9][0-9]{0,3}|rc\.[1-9][0-9]{0,15}))?\.json$/.test(index.currentPath)) fail("declaration index has no canonical current path");
+  const directory = resolve(dirname(resolve(indexPath)), "declarations"), declarationPath = resolve(directory, index.currentPath); if (relative(directory, declarationPath).startsWith("..")) fail("declaration path escapes index");
+  const declarationRaw = boundedBytes(declarationPath, "release declaration"), checked = spawnSync(process.execPath, [validator, "--index", resolve(indexPath)], { encoding: "utf8", maxBuffer: MAX_INPUT });
+  if (checked.status !== 0) fail((checked.stderr || "release declaration validation failed").trim());
+  if (!boundedBytes(indexPath, "declaration index").equals(indexRaw) || !boundedBytes(declarationPath, "release declaration").equals(declarationRaw)) fail("release declaration changed during validation");
+  return strictJSON(declarationRaw, "release declaration");
+}
+function metadata(tagRefPath, tagObjectPath, releasePath, declaration) {
+  const tagRef = strictJSON(boundedBytes(tagRefPath, "tag-ref metadata"), "tag-ref metadata"), tagObject = strictJSON(boundedBytes(tagObjectPath, "annotated-tag metadata"), "annotated-tag metadata"), release = strictJSON(boundedBytes(releasePath, "release metadata"), "release metadata"), tagObjectSHA = tagRef?.object?.sha, sourceSHA = tagObject?.object?.sha;
+  if (tagRef?.ref !== `refs/tags/${declaration.tag}` || tagRef?.object?.type !== "tag" || !SHA1.test(tagObjectSHA ?? "") || tagObject?.sha !== tagObjectSHA || tagObject?.tag !== declaration.tag || tagObject?.object?.type !== "commit" || !SHA1.test(sourceSHA ?? "") || sourceSHA === tagObjectSHA) fail("annotated tag metadata is not canonical");
+  if (release?.tag_name !== declaration.tag || release?.draft !== false || release?.prerelease !== false || release?.immutable !== true) fail("immutable stable release metadata is required");
+  const policy = classifyDesktopOnlyRelease(declaration.tag, tagObject.message, release.prerelease), assets = Array.isArray(release.assets) ? release.assets.filter((asset) => asset?.name === declaration.distribution.artifactName) : [];
+  if (assets.length !== 1) fail("one exact release asset is required"); return { tagObjectSHA, sourceSHA, asset: assets[0], policy };
+}
+function deepFreeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { for (const child of Object.values(value)) deepFreeze(child); Object.freeze(value); } return value; }
+
+export async function buildAcceptedDesktopReleasePacket(indexPath, artifactPath, feedPath, tagRefPath, tagObjectPath, releasePath, acceptedPublicKeyPath) {
+  for (const [value, label] of [[indexPath, "indexPath"], [artifactPath, "artifactPath"], [feedPath, "feedPath"], [tagRefPath, "tagRefPath"], [tagObjectPath, "tagObjectPath"], [releasePath, "releasePath"], [acceptedPublicKeyPath, "acceptedPublicKeyPath"]]) if (typeof value !== "string" || !value) fail(`${label} must be a primitive path`);
+  const declaration = currentDeclaration(indexPath); if (declaration.channel !== "stable" || declaration.version !== "1.1.0" || declaration.tag !== "v1.1.0" || declaration.sequence !== null || declaration.distribution.releaseClass !== "desktop-only") fail("current declaration is not the stable Desktop release");
+  const { tagObjectSHA, sourceSHA, asset, policy } = metadata(tagRefPath, tagObjectPath, releasePath, declaration), artifactName = declaration.distribution.artifactName, artifactURL = `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${declaration.tag}/${artifactName}`;
+  if (basename(resolve(artifactPath)) !== artifactName) fail("artifact path name is not canonical"); const guarded = guardClassicZipArchive({ artifactPath }), tree = await buildExtractedAppTreeProof(artifactPath, sourceSHA);
+  if (asset?.browser_download_url !== artifactURL || asset?.digest !== `sha256:${guarded.artifactSHA256}` || asset?.size !== guarded.artifactBytes.length || tree.artifactSHA256 !== guarded.artifactSHA256 || tree.artifactByteLength !== guarded.artifactBytes.length) fail("release artifact identity mismatch");
+  if (tree.bundleMarkers.appPath !== declaration.distribution.appPath || tree.bundleMarkers.bundleID !== declaration.distribution.bundleId || tree.bundleMarkers.version !== declaration.version || tree.bundleMarkers.build !== declaration.build || tree.bundleMarkers.feedURL !== declaration.distribution.origins.feed || tree.appleDouble.entryCount !== 0) fail(tree.appleDouble.entryCount ? "AppleDouble sidecars are unsupported by the accepted packet" : "extracted app identity mismatch");
+  const rawFeed = boundedBytes(feedPath, "raw appcast"), feed = parseRawDesktopAppcast(rawFeed), matches = Array.isArray(feed.entries) ? feed.entries.filter((entry) => entry?.url === artifactURL) : [];
+  if (feed.link !== declaration.distribution.origins.feed || matches.length !== 1) fail("raw appcast does not select one canonical enclosure"); const entry = matches[0], length = Number(entry.length);
+  if (Object.keys(entry).length !== ENTRY_FIELDS.length || ENTRY_FIELDS.some((field) => !Object.hasOwn(entry, field)) || !/^(?:0|[1-9][0-9]*)$/.test(entry.length) || !Number.isSafeInteger(length) || length !== guarded.artifactBytes.length || entry.type !== "application/octet-stream" || entry.version !== declaration.version || entry.shortVersionString !== declaration.version || entry.build !== declaration.build || entry.channel !== "stable" || entry.minimumSystemVersion !== tree.bundleMarkers.minimumSystemVersion) fail("selected appcast enclosure identity mismatch");
+  const acceptedPublicKey = boundedBytes(acceptedPublicKeyPath, "accepted Sparkle public key").toString("utf8"); if (acceptedPublicKey !== tree.bundleMarkers.publicKey) fail("artifact Sparkle public key does not match accepted release authority");
+  const enclosure = buildFeedEnclosureProof({ url: entry.url, version: entry.version, build: entry.build, shortVersionString: entry.shortVersionString, channel: entry.channel, artifactName, artifactSHA256: guarded.artifactSHA256, edSignature: entry.edSignature }, { acceptedPublicKey, signedContent: guarded.artifactBytes });
+  const packet = { schemaVersion: 1, kind: KIND, verified: true, channel: declaration.channel, version: declaration.version, build: declaration.build, tag: declaration.tag, sourceSHA, tagObjectSHA, artifactURL, artifactName, artifactByteLength: guarded.artifactBytes.length, artifactSHA256: guarded.artifactSHA256, treeSHA256: tree.treeSHA256, feedSHA256: sha256(rawFeed), feedEntry: Object.fromEntries(ENTRY_FIELDS.map((field) => [field, field === "length" ? length : entry[field]])), enclosureProofSHA256: feedEnclosureProofDigest(enclosure), npmReleaseClass: policy.releaseKind };
+  authenticatedPackets.add(packet); return deepFreeze(packet);
+}
+export function serializeAcceptedDesktopReleasePacket(packet) { if (!authenticatedPackets.has(packet)) fail("packet was not produced by the accepted release producer"); return `${JSON.stringify(Object.fromEntries(FIELDS.map((field) => [field, packet[field]])))}\n`; }
+export function acceptedDesktopReleasePacketDigest(packet) { return sha256(Buffer.from(serializeAcceptedDesktopReleasePacket(packet), "utf8")); }

--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -16,13 +16,17 @@ const SHA1 = /^[a-f0-9]{40}$/, SHA256 = /^[a-f0-9]{64}$/, TREE_KIND = "neondiff.
 const TREE_FIELDS = ["schemaVersion", "kind", "verified", "algorithm", "sourceSHA", "artifactSHA256", "artifactByteLength", "treeSHA256", "records", "bundleMarkers", "appleDouble"];
 const authenticatedTreeProofs = new WeakSet();
 const PLIST_PARSER = String.raw`
-import json, plistlib, sys, xml.etree.ElementTree as ET
+import json, plistlib, re, sys, xml.etree.ElementTree as ET
 raw = sys.stdin.buffer.read(1048577)
 if len(raw) > 1048576 or raw.startswith(b"bplist00"):
     raise ValueError("unsupported plist")
 try:
     text = raw.decode("utf-8")
 except UnicodeDecodeError:
+    raise ValueError("unsupported plist encoding")
+declaration = re.match(r"^\s*<\?xml\s+[^?]*\?>", text, re.IGNORECASE)
+encoding = re.search(r"\bencoding\s*=\s*(['\"])([^'\"]+)\1", declaration.group(0), re.IGNORECASE) if declaration else None
+if encoding and encoding.group(2).lower() != "utf-8":
     raise ValueError("unsupported plist encoding")
 doctype = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
 if text.startswith("\ufeff") or "\x00" in text or "<!ENTITY" in text or ("<!DOCTYPE" in text and (text.count("<!DOCTYPE") != 1 or text.count(doctype) != 1)):

--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -18,9 +18,16 @@ const authenticatedTreeProofs = new WeakSet();
 const PLIST_PARSER = String.raw`
 import json, plistlib, sys, xml.etree.ElementTree as ET
 raw = sys.stdin.buffer.read(1048577)
-if len(raw) > 1048576 or raw.startswith(b"bplist00") or b"<!DOCTYPE" in raw or b"<!ENTITY" in raw:
+if len(raw) > 1048576 or raw.startswith(b"bplist00"):
     raise ValueError("unsupported plist")
-root = ET.fromstring(raw)
+try:
+    text = raw.decode("utf-8")
+except UnicodeDecodeError:
+    raise ValueError("unsupported plist encoding")
+doctype = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+if text.startswith("\ufeff") or "\x00" in text or "<!ENTITY" in text or ("<!DOCTYPE" in text and (text.count("<!DOCTYPE") != 1 or text.count(doctype) != 1)):
+    raise ValueError("unsupported plist declaration")
+root = ET.fromstring(text)
 if root.tag != "plist" or len(root) != 1 or root[0].tag != "dict":
     raise ValueError("invalid plist root")
 def unique(node):

--- a/scripts/lib/desktop-extracted-app-tree-proof.mjs
+++ b/scripts/lib/desktop-extracted-app-tree-proof.mjs
@@ -40,7 +40,7 @@ def unique(node):
             unique(value)
 unique(root[0])
 value = plistlib.loads(raw)
-required = ("CFBundleIdentifier", "CFBundleShortVersionString", "CFBundleVersion")
+required = ("CFBundleIdentifier", "CFBundleShortVersionString", "CFBundleVersion", "LSMinimumSystemVersion", "SUFeedURL", "SUPublicEDKey")
 if not isinstance(value, dict):
     raise ValueError("invalid plist dictionary")
 result = {}
@@ -275,6 +275,7 @@ function appTree(appPath) {
   walkDescriptorTree(appPath, (entry) => {
     if (records.length >= MAX_NODES) fail("tree record bound exceeded");
     const path = proofText(entry.relativePath, "tree path"), identity = proofPathIdentity(path), collision = identities.get(identity);
+    if (path.split("/").some((part) => part.startsWith("._"))) fail("AppleDouble sidecars are unsupported inside the app tree");
     if (collision && collision !== path) fail("tree path collision"); identities.set(identity, path);
     const slash = path.lastIndexOf("/"), parent = slash < 0 ? "" : path.slice(0, slash);
     if (!directories.has(parent)) fail("tree parent topology is invalid");
@@ -295,9 +296,12 @@ function appTree(appPath) {
 function plistMarkers(bytes) {
   const parsed = spawnSync("/usr/bin/python3", ["-I", "-c", PLIST_PARSER], { input: bytes, encoding: "utf8", maxBuffer: 4096 }); let value;
   try { if (parsed.status !== 0) fail("desktop Info.plist is malformed"); value = JSON.parse(parsed.stdout); } catch { fail("desktop Info.plist is malformed"); }
-  const bundleID = value.CFBundleIdentifier, version = value.CFBundleShortVersionString, build = value.CFBundleVersion;
+  const bundleID = value.CFBundleIdentifier, version = value.CFBundleShortVersionString, build = value.CFBundleVersion, minimumSystemVersion = value.LSMinimumSystemVersion, feedURL = value.SUFeedURL, publicKey = value.SUPublicEDKey;
   if (bundleID !== "com.electricsheephq.NeonDiffDesktop" || !/^1\.1\.0(?:-(?:beta|rc)\.[1-9][0-9]{0,15})?$/.test(version) || !/^[0-9]{1,32}$/.test(build)) fail("bundle markers are not canonical");
-  return { appPath: "NeonDiff.app", bundleID, version, build };
+  const expectedFeed = version === "1.1.0" ? "https://www.neondiff.com/updates/stable/appcast.xml" : "https://www.neondiff.com/updates/beta/appcast.xml", decodedKey = Buffer.from(publicKey, "base64");
+  if (!/^\d+(?:\.\d+){1,2}$/.test(minimumSystemVersion)) fail("bundle minimum system version is not canonical");
+  if (feedURL !== expectedFeed || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(publicKey) || decodedKey.length !== 32 || decodedKey.toString("base64") !== publicKey) fail("bundle updater markers are not canonical");
+  return { appPath: "NeonDiff.app", bundleID, version, build, minimumSystemVersion, feedURL, publicKey };
 }
 function deepFreeze(value) { if (value && typeof value === "object" && !Object.isFrozen(value)) { for (const child of Object.values(value)) deepFreeze(child); Object.freeze(value); } return value; }
 

--- a/scripts/lib/desktop-only-release-policy.mjs
+++ b/scripts/lib/desktop-only-release-policy.mjs
@@ -1,0 +1,11 @@
+const RC_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:[1-9]\d*)$/;
+const FINAL_TAG = "v1.1.0";
+export const DESKTOP_ONLY_TAG_ANNOTATION = "NeonDiff-Release-Class: desktop-only";
+
+export function hasDesktopOnlyTagAnnotation(tag, annotation) {
+  return (RC_TAG.test(tag) || tag === FINAL_TAG) && typeof annotation === "string" && annotation.split("\n").filter((line) => line === DESKTOP_ONLY_TAG_ANNOTATION).length === 1;
+}
+export function classifyDesktopOnlyRelease(tag, annotation, prerelease) {
+  if (!hasDesktopOnlyTagAnnotation(tag, annotation) || RC_TAG.test(tag) !== (prerelease === true) || tag === FINAL_TAG !== (prerelease === false)) throw new Error("release is not covered by the Desktop-only npm policy");
+  return Object.freeze({ shouldPublish: false, npmTag: tag === FINAL_TAG ? "latest" : "beta", releaseKind: "desktop-only" });
+}

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -2,6 +2,7 @@
 
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { hasDesktopOnlyTagAnnotation } from "./lib/desktop-only-release-policy.mjs";
 
 const V104_PROVENANCE_RECOVERY = Object.freeze({
   package: "neondiff",
@@ -15,7 +16,6 @@ const V104_PROVENANCE_RECOVERY = Object.freeze({
 });
 const DESKTOP_ONLY_RC_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:[1-9]\d*)$/;
 const DESKTOP_ONLY_FINAL_TAG = "v1.1.0";
-const DESKTOP_ONLY_TAG_ANNOTATION = "NeonDiff-Release-Class: desktop-only";
 
 function fail(message) {
   console.error(message);
@@ -70,7 +70,7 @@ function isDesktopOnlyTag(tag) {
     const messageStart = rawTag.indexOf("\n\n");
     if (messageStart < 0) return false;
     const annotation = rawTag.slice(messageStart + 2);
-    return annotation.split("\n").filter((line) => line === DESKTOP_ONLY_TAG_ANNOTATION).length === 1;
+    return hasDesktopOnlyTagAnnotation(tag, annotation);
   } catch {
     return false;
   }

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, mkdirSync, mkdtempSync, readdirSync, readlinkSync, rmSync, statSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { crc32, deflateRawSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildClassicZipMetadataGraph, buildExtractedAppTreeProof, extractedAppTreeProofDigest, guardClassicZipArchive, serializeExtractedAppTreeProof, withMaterializedClassicZipApp } from "../scripts/lib/desktop-extracted-app-tree-proof.mjs";
+import { acceptedDesktopReleasePacketDigest, buildAcceptedDesktopReleasePacket, serializeAcceptedDesktopReleasePacket } from "../scripts/lib/desktop-accepted-release-packet.mjs";
 
 type Entry = { name: string; localName?: string; localOffset?: number; localExtra?: Buffer; type?: "file" | "directory" | "symlink"; data?: string | Buffer; trailing?: Buffer; flags?: number; method?: number; expanded?: number; crc?: number; descriptor?: boolean; extra?: number | Buffer; comment?: number; mode?: number };
 const roots: string[] = [];
@@ -26,7 +27,8 @@ function classicZip(entries: Entry[]) {
 }
 function unicodePathExtra(headerName: string, alternateName: string) { const alternate = Buffer.from(alternateName), field = Buffer.alloc(9 + alternate.length); u16(field, 0, 0x7075); u16(field, 2, 5 + alternate.length); field[4] = 1; u32(field, 5, crc32(Buffer.from(headerName))); alternate.copy(field, 9); return field; }
 function fixture(entries: Entry[]) { const root = mkdtempSync(join(tmpdir(), "neondiff-zip-")); roots.push(root); const artifact = join(root, "NeonDiff.zip"); writeFileSync(artifact, classicZip(entries)); return { root, artifact }; }
-function plist(version = "1.1.0-rc.9", extra = "") { return `<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.electricsheephq.NeonDiffDesktop</string><key>CFBundleShortVersionString</key><string>${version}</string><key>CFBundleVersion</key><string>11091</string>${extra}</dict></plist>`; }
+const stableFeed = "https://www.neondiff.com/updates/stable/appcast.xml", betaFeed = "https://www.neondiff.com/updates/beta/appcast.xml", defaultPublicKey = Buffer.alloc(32, 1).toString("base64");
+function plist(version = "1.1.0-rc.9", extra = "", publicKey = defaultPublicKey) { const feed = version === "1.1.0" ? stableFeed : betaFeed; return `<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.electricsheephq.NeonDiffDesktop</string><key>CFBundleShortVersionString</key><string>${version}</string><key>CFBundleVersion</key><string>11091</string><key>LSMinimumSystemVersion</key><string>14.0</string><key>SUFeedURL</key><string>${feed}</string><key>SUPublicEDKey</key><string>${publicKey}</string>${extra}</dict></plist>`; }
 function eocdPatch(artifact: string, field: number, value: number) { const bytes = readFileSync(artifact); u32(bytes, bytes.length - 22 + field, value); writeFileSync(artifact, bytes); }
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 
@@ -56,6 +58,49 @@ describe("raw bounded classic-ZIP archive guard", () => {
     expect(() => guardClassicZipArchive({ artifactPath: alias })).toThrow();
     const oversized = join(value.root, "oversized.zip"); writeFileSync(oversized, ""); truncateSync(oversized, 512 * 1024 * 1024 + 1);
     expect(() => guardClassicZipArchive({ artifactPath: oversized })).toThrow("artifact bytes exceed bound");
+  });
+});
+
+describe("canonical accepted Desktop release packet", () => {
+  const sourceSHA = "1".repeat(40), tagObjectSHA = "2".repeat(40), tag = "v1.1.0", version = "1.1.0", build = "11091", artifactName = `NeonDiff-${version}-build${build}-macOS.zip`;
+  function packetFixture(sidecar = false, inAppSidecar = false) {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-packet-")); roots.push(root);
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519"), acceptedPublicKey = Buffer.from(publicKey.export({ format: "der", type: "spki" })).subarray(-32).toString("base64"), artifactPath = join(root, artifactName);
+    const entries: Entry[] = [{ name: "NeonDiff.app/", type: "directory" }, { name: "NeonDiff.app/Contents/Info.plist", data: plist(version, "", acceptedPublicKey) }, { name: "NeonDiff.app/Contents/MacOS/NeonDiffDesktop", data: "desktop", mode: 0o100755 }]; if (sidecar) entries.push({ name: "__MACOSX/NeonDiff.app/Contents/._Info.plist", data: "appledouble" }); if (inAppSidecar) entries.push({ name: "NeonDiff.app/Contents/._Info.plist", data: Buffer.from([0x00, 0x05, 0x16, 0x07]) });
+    writeFileSync(artifactPath, classicZip(entries)); const artifact = readFileSync(artifactPath), artifactSHA256 = createHash("sha256").update(artifact).digest("hex"), url = `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/download/${tag}/${artifactName}`, edSignature = sign(null, artifact, privateKey).toString("base64"), declarationDirectory = join(root, "declarations"); mkdirSync(declarationDirectory);
+    const indexPath = join(root, "index.json"), feedPath = join(root, "appcast.xml"), tagRefPath = join(root, "tag-ref.json"), tagObjectPath = join(root, "tag-object.json"), releasePath = join(root, "release.json"), acceptedPublicKeyPath = join(root, "accepted-sparkle-public-key.txt"), declarationPath = join(declarationDirectory, `${tag}.json`);
+    const declaration = { schemaVersion: 1, product: "neondiff-desktop", version, tag, channel: "stable", sequence: null, build, predecessor: null, contract: "paid-mac-ga-byo-v1", distribution: { bundleId: "com.electricsheephq.NeonDiffDesktop", appPath: "NeonDiff.app", artifactName, releaseClass: "desktop-only", origins: { github: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff", site: "https://www.neondiff.com", feed: stableFeed } } };
+    const tagRef = { ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObjectSHA } }, tagObject = { sha: tagObjectSHA, tag, message: `NeonDiff ${version}\n\nNeonDiff-Release-Class: desktop-only\n`, object: { type: "commit", sha: sourceSHA } }, release = { tag_name: tag, draft: false, prerelease: false, immutable: true, assets: [{ name: artifactName, size: artifact.length, digest: `sha256:${artifactSHA256}`, browser_download_url: url }] };
+    writeFileSync(indexPath, JSON.stringify({ schemaVersion: 1, status: "retained", declarationDirectory: "declarations", declarationPaths: [`${tag}.json`], currentPath: `${tag}.json` })); writeFileSync(declarationPath, JSON.stringify(declaration)); writeFileSync(tagRefPath, JSON.stringify(tagRef)); writeFileSync(tagObjectPath, JSON.stringify(tagObject)); writeFileSync(releasePath, JSON.stringify(release)); writeFileSync(acceptedPublicKeyPath, acceptedPublicKey); writeFileSync(feedPath, `<?xml version="1.0"?><rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><title>NeonDiff Desktop stable</title><link>${stableFeed}</link><description>NeonDiff Desktop stable appcast</description><item><title>NeonDiff ${version}</title><pubDate>Sun, 24 Aug 2026 00:00:00 +0000</pubDate><sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion><enclosure url="${url}" length="${artifact.length}" type="application/octet-stream" sparkle:version="${build}" sparkle:shortVersionString="${version}" sparkle:minimumSystemVersion="14.0" sparkle:edSignature="${edSignature}" /></item></channel></rss>`);
+    return { paths: [indexPath, artifactPath, feedPath, tagRefPath, tagObjectPath, releasePath, acceptedPublicKeyPath] as const, indexPath, feedPath, tagRefPath, tagObjectPath, releasePath, acceptedPublicKeyPath, declarationPath, declaration, tagRef, tagObject, release };
+  }
+  it("derives one frozen exact-source/artifact/tree/feed/enclosure/npm packet", async () => {
+    const value = packetFixture(), packet = await buildAcceptedDesktopReleasePacket(...value.paths);
+    expect(packet).toMatchObject({ schemaVersion: 1, kind: "neondiff.desktop.accepted-release-packet-v1", channel: "stable", version, build, tag, sourceSHA, tagObjectSHA, artifactName, npmReleaseClass: "desktop-only" });
+    expect(packet.artifactSHA256).toMatch(/^[a-f0-9]{64}$/); expect(packet.treeSHA256).toMatch(/^[a-f0-9]{64}$/); expect(packet.feedSHA256).toMatch(/^[a-f0-9]{64}$/); expect(packet.enclosureProofSHA256).toMatch(/^[a-f0-9]{64}$/);
+    expect(Object.isFrozen(packet) && Object.isFrozen(packet.feedEntry)).toBe(true); expect(serializeAcceptedDesktopReleasePacket(packet)).toMatch(/\n$/); expect(acceptedDesktopReleasePacketDigest(packet)).toMatch(/^[a-f0-9]{64}$/);
+    let read = false; expect(() => serializeAcceptedDesktopReleasePacket({ ...packet } as any)).toThrow("not produced"); expect(() => serializeAcceptedDesktopReleasePacket(new Proxy(packet, { get() { read = true; throw new Error("trap"); } }) as any)).toThrow("not produced"); expect(read).toBe(false);
+  });
+  it("rejects cross-release, raw-feed, metadata, artifact, and caller substitutions", async () => {
+    const cases: Array<(value: ReturnType<typeof packetFixture>) => void> = [
+      (value) => writeFileSync(value.tagObjectPath, JSON.stringify({ ...value.tagObject, object: { type: "commit", sha: tagObjectSHA } })),
+      (value) => writeFileSync(value.releasePath, JSON.stringify({ ...value.release, tag_name: "v1.1.0-rc.1" })),
+      (value) => writeFileSync(value.releasePath, JSON.stringify({ ...value.release, assets: [{ ...value.release.assets[0], digest: `sha256:${"a".repeat(64)}` }] })),
+      (value) => writeFileSync(value.declarationPath, JSON.stringify({ ...value.declaration, build: "11092" })),
+      (value) => writeFileSync(value.feedPath, readFileSync(value.feedPath, "utf8").replace('sparkle:version="11091"', 'sparkle:version="11092"')),
+      (value) => { const raw = readFileSync(value.feedPath, "utf8"), item = raw.match(/<item>.*<\/item>/s)?.[0] ?? ""; writeFileSync(value.feedPath, raw.replace("</channel>", `${item}</channel>`)); },
+      (value) => writeFileSync(value.feedPath, '<!DOCTYPE rss [<!ENTITY x "hostile">]><rss>&x;</rss>'),
+      (value) => writeFileSync(value.feedPath, Buffer.from('<?xml version="1.0" encoding="UTF-16"?><rss/>', "utf16le")),
+      (value) => writeFileSync(value.tagRefPath, `{"ref":"refs/tags/v1.1.0","ref":"refs/tags/v1.1.0-rc.1","object":{"type":"tag","sha":"${tagObjectSHA}"}}`)
+    ];
+    for (const mutate of cases) { const value = packetFixture(); mutate(value); await expect(buildAcceptedDesktopReleasePacket(...value.paths)).rejects.toThrow(); }
+    await expect(buildAcceptedDesktopReleasePacket(...packetFixture(true).paths)).rejects.toThrow(/AppleDouble/i);
+    let read = false; const paths = packetFixture().paths; await expect(buildAcceptedDesktopReleasePacket(new Proxy({}, { get() { read = true; throw new Error("trap"); } }) as any, ...paths.slice(1))).rejects.toThrow("primitive"); expect(read).toBe(false);
+  });
+  it("rejects untrusted updater keys, bundle/feed OS drift, and in-app AppleDouble", async () => {
+    const wrongKey = packetFixture(); writeFileSync(wrongKey.acceptedPublicKeyPath, Buffer.alloc(32, 9).toString("base64")); await expect(buildAcceptedDesktopReleasePacket(...wrongKey.paths)).rejects.toThrow(/release authority/i);
+    const wrongMinimum = packetFixture(); writeFileSync(wrongMinimum.feedPath, readFileSync(wrongMinimum.feedPath, "utf8").replaceAll("14.0", "13.0")); await expect(buildAcceptedDesktopReleasePacket(...wrongMinimum.paths)).rejects.toThrow(/enclosure identity/i);
+    await expect(buildAcceptedDesktopReleasePacket(...packetFixture(false, true).paths)).rejects.toThrow(/AppleDouble/i);
   });
 });
 

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -221,6 +221,8 @@ describe("authenticated exact-ZIP app tree and plist proof", () => {
       proofFixture("1.1.0", "", Buffer.from("bplist00hostile")),
       proofFixture("1.1.0", "", plist("1.1.0").replace(plistDoctype, '<!DOCTYPE plist [<!ENTITY x "hostile">]>')),
       proofFixture("1.1.0", "", Buffer.from(plist("1.1.0"), "utf16le")),
+      proofFixture("1.1.0", "", plist("1.1.0").replace('encoding="UTF-8"', 'encoding="ISO-8859-1"')),
+      proofFixture("1.1.0", "", plist("1.1.0").replace('encoding="UTF-8"', 'encoding="windows-1252"')),
       proofFixture("1.2.0"),
       proofFixture("1.1.0", "", plist("1.1.0").replace("com.electricsheephq.NeonDiffDesktop", "com.example.Wrong")),
       proofFixture("1.1.0", "", plist("1.1.0").replace("11091", "not-a-build"))

--- a/tests/desktop-extracted-app-tree-proof.test.ts
+++ b/tests/desktop-extracted-app-tree-proof.test.ts
@@ -27,8 +27,8 @@ function classicZip(entries: Entry[]) {
 }
 function unicodePathExtra(headerName: string, alternateName: string) { const alternate = Buffer.from(alternateName), field = Buffer.alloc(9 + alternate.length); u16(field, 0, 0x7075); u16(field, 2, 5 + alternate.length); field[4] = 1; u32(field, 5, crc32(Buffer.from(headerName))); alternate.copy(field, 9); return field; }
 function fixture(entries: Entry[]) { const root = mkdtempSync(join(tmpdir(), "neondiff-zip-")); roots.push(root); const artifact = join(root, "NeonDiff.zip"); writeFileSync(artifact, classicZip(entries)); return { root, artifact }; }
-const stableFeed = "https://www.neondiff.com/updates/stable/appcast.xml", betaFeed = "https://www.neondiff.com/updates/beta/appcast.xml", defaultPublicKey = Buffer.alloc(32, 1).toString("base64");
-function plist(version = "1.1.0-rc.9", extra = "", publicKey = defaultPublicKey) { const feed = version === "1.1.0" ? stableFeed : betaFeed; return `<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.electricsheephq.NeonDiffDesktop</string><key>CFBundleShortVersionString</key><string>${version}</string><key>CFBundleVersion</key><string>11091</string><key>LSMinimumSystemVersion</key><string>14.0</string><key>SUFeedURL</key><string>${feed}</string><key>SUPublicEDKey</key><string>${publicKey}</string>${extra}</dict></plist>`; }
+const stableFeed = "https://www.neondiff.com/updates/stable/appcast.xml", betaFeed = "https://www.neondiff.com/updates/beta/appcast.xml", defaultPublicKey = Buffer.alloc(32, 1).toString("base64"), plistDoctype = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">';
+function plist(version = "1.1.0-rc.9", extra = "", publicKey = defaultPublicKey) { const feed = version === "1.1.0" ? stableFeed : betaFeed; return `<?xml version="1.0" encoding="UTF-8"?>${plistDoctype}<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.electricsheephq.NeonDiffDesktop</string><key>CFBundleShortVersionString</key><string>${version}</string><key>CFBundleVersion</key><string>11091</string><key>LSMinimumSystemVersion</key><string>14.0</string><key>SUFeedURL</key><string>${feed}</string><key>SUPublicEDKey</key><string>${publicKey}</string>${extra}</dict></plist>`; }
 function eocdPatch(artifact: string, field: number, value: number) { const bytes = readFileSync(artifact); u32(bytes, bytes.length - 22 + field, value); writeFileSync(artifact, bytes); }
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 
@@ -219,6 +219,8 @@ describe("authenticated exact-ZIP app tree and plist proof", () => {
     const invalid = [
       proofFixture("1.1.0", "<key>CFBundleName</key><string>A</string><key>CFBundleName</key><string>B</string>"),
       proofFixture("1.1.0", "", Buffer.from("bplist00hostile")),
+      proofFixture("1.1.0", "", plist("1.1.0").replace(plistDoctype, '<!DOCTYPE plist [<!ENTITY x "hostile">]>')),
+      proofFixture("1.1.0", "", Buffer.from(plist("1.1.0"), "utf16le")),
       proofFixture("1.2.0"),
       proofFixture("1.1.0", "", plist("1.1.0").replace("com.electricsheephq.NeonDiffDesktop", "com.example.Wrong")),
       proofFixture("1.1.0", "", plist("1.1.0").replace("11091", "not-a-build"))

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -52,7 +52,7 @@ describe("v1.0.4 npm provenance recovery workflow", () => {
     const candidateHead = "42db7c8ff7dba6ceac813238dcebfb54dc83851f";
     const policyScript = resolve("scripts/npm-release-policy.mjs");
     mkdirSync(join(root, "scripts"), { recursive: true });
-    mkdirSync(join(root, ".recovery-policy", "scripts"), { recursive: true });
+    mkdirSync(join(root, ".recovery-policy", "scripts", "lib"), { recursive: true });
     mkdirSync(join(root, "docs"), { recursive: true });
     mkdirSync(join(root, "evidence"), { recursive: true });
     mkdirSync(join(root, "neondiff-reviewed-pack"), { recursive: true });
@@ -79,6 +79,7 @@ describe("v1.0.4 npm provenance recovery workflow", () => {
       if (process.env.FAIL_STAGE === "readiness") process.exit(41);
     `);
     copyFileSync(policyScript, join(root, ".recovery-policy", "scripts", "npm-release-policy.mjs"));
+    copyFileSync(resolve("scripts/lib/desktop-only-release-policy.mjs"), join(root, ".recovery-policy", "scripts", "lib", "desktop-only-release-policy.mjs"));
     const provenanceVerifier = join(root, ".recovery-policy", "scripts", "verify-npm-provenance.mjs");
     writeFileSync(provenanceVerifier, `
       if (process.env.FAIL_STAGE === "provenance") process.exit(42);


### PR DESCRIPTION
## Outcome

Rebuilds #1020 cleanly from accepted `main` after the canonical appcast-parser prerequisite landed. The new producer derives one deterministic, recursively frozen public-safe Desktop accepted-release packet from bounded fetched metadata, exact ZIP bytes/tree, canonical raw appcast bytes, an independently accepted Sparkle public-key file, and the existing enclosure/npm policy producers.

This supersedes closed PR #1078. It imports the accepted `parseRawDesktopAppcast` from PR #1080 instead of embedding the rejected parser.

## Exact source and scope

- Base: `47a279d6be69e5fe718443ffb9ac990a23bd0f2a`
- Initial head: `dbcd677eda5df37a8099d41f0e7ea8891c40d3ae`
- Rehydration: `PASS`
- Reuse disposition: `COMPOSE`
- Scope: 6 files, 138 insertions, 8 deletions, 146 changed lines (issue cap: 200)

The candidate reuses the accepted declaration validator, canonical UTF-8 appcast parser, exact-ZIP authenticated tree/plist proof, Sparkle enclosure verifier, and shared Desktop-only npm tag policy. It rejects AppleDouble-bearing artifacts rather than introducing xattr/resource-fork decoding.

## Validation

- Failing first: focused packet suite failed at collection because `desktop-accepted-release-packet.mjs` was absent on accepted `main`.
- Focused Node 26 matrix: 81/81 passed across packet/tree, raw appcast, and npm recovery-policy tests.
- Canonical-parser consumer coverage includes UTF-16 feed rejection.
- Node 26 build passed.
- New/changed JavaScript syntax checks passed.
- `git diff --check` passed.

## Review and merge gate

Before merge: exact-head authoritative CI, one independent release/security semantic review, blind acceptance and adversarial checks each `PASS >=95`, terminal finding dispositions, zero unresolved conversations, exact base/head/scope readback, and the final merge barrier.

## Proof boundary

This PR can prove only deterministic source/test packet construction from verified inputs. It does not prove build provenance, signing/notarization/Gatekeeper, tag/release/asset/feed publication, website/download agreement, npm immutability, install/update/rollback, runtime, billing, entitlement, customer use, RC, release, or GA readiness.

Closes #1020
