### PR TITLE
Mac GA: attest accepted release packets from protected main

### DIFF
--- a/.github/workflows/desktop-accepted-release-packet.yml
+++ b/.github/workflows/desktop-accepted-release-packet.yml
@@ -1,0 +1,174 @@
+name: Desktop accepted release packet
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: desktop-accepted-release-packet-v1.1.0
+  cancel-in-progress: false
+
+jobs:
+  attest-stable-packet:
+    name: Build and attest stable packet
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      RELEASE_TAG: v1.1.0
+      REPOSITORY: electricsheephq/evaos-code-review-bot-neondiff
+      STABLE_FEED_URL: https://www.neondiff.com/updates/stable/appcast.xml
+    steps:
+      - name: Checkout protected main
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Install exact dependencies
+        run: npm ci
+
+      - name: Build accepted stable packet
+        id: packet
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          umask 077
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_SHA" = "$(git rev-parse HEAD)"
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+          PACKET_ROOT="$RUNNER_TEMP/desktop-accepted-release-packet"
+          DECLARATION_DIRECTORY="$PACKET_ROOT/declarations"
+          EXTRACT_DIRECTORY="$PACKET_ROOT/extracted"
+          mkdir -p "$DECLARATION_DIRECTORY" "$EXTRACT_DIRECTORY"
+
+          gh api "repos/$REPOSITORY/git/ref/tags/$RELEASE_TAG" > "$PACKET_ROOT/tag-ref.json"
+          TAG_OBJECT_SHA="$(jq -er '.object.sha' "$PACKET_ROOT/tag-ref.json")"
+          gh api "repos/$REPOSITORY/git/tags/$TAG_OBJECT_SHA" > "$PACKET_ROOT/tag-object.json"
+          gh api "repos/$REPOSITORY/releases/tags/$RELEASE_TAG" > "$PACKET_ROOT/release.json"
+          SOURCE_SHA="$(jq -er '.object.sha' "$PACKET_ROOT/tag-object.json")"
+          test "$TAG_OBJECT_SHA" = "$(git rev-parse "${RELEASE_TAG}^{tag}")"
+          test "$SOURCE_SHA" = "$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          git merge-base --is-ancestor "$SOURCE_SHA" "$GITHUB_SHA"
+
+          ASSET_FILTER='[.assets[] | select(.name | test("^NeonDiff-1\\.1\\.0-build[0-9]+-macOS\\.zip$"))]'
+          test "$(jq "$ASSET_FILTER | length" "$PACKET_ROOT/release.json")" = "1"
+          ARTIFACT_NAME="$(jq -er "$ASSET_FILTER | .[0].name" "$PACKET_ROOT/release.json")"
+          ASSET_API_URL="$(jq -er "$ASSET_FILTER | .[0].url" "$PACKET_ROOT/release.json")"
+          ARTIFACT_PATH="$PACKET_ROOT/$ARTIFACT_NAME"
+          gh api -H "Accept: application/octet-stream" "$ASSET_API_URL" > "$ARTIFACT_PATH"
+
+          node --input-type=module - "$ARTIFACT_PATH" <<'NODE'
+          import { guardClassicZipArchive } from "./scripts/lib/desktop-extracted-app-tree-proof.mjs";
+          guardClassicZipArchive({ artifactPath: process.argv[2] });
+          NODE
+          ditto -x -k "$ARTIFACT_PATH" "$EXTRACT_DIRECTORY"
+          APP_PATH="$EXTRACT_DIRECTORY/NeonDiff.app"
+          INFO_PLIST="$APP_PATH/Contents/Info.plist"
+          test -d "$APP_PATH"
+          test -f "$INFO_PLIST"
+          codesign --verify --deep --strict "$APP_PATH"
+          codesign -d --verbose=4 "$APP_PATH" 2> "$PACKET_ROOT/codesign-metadata.txt"
+          grep -q '^Authority=Developer ID Application:' "$PACKET_ROOT/codesign-metadata.txt"
+          grep -q 'TeamIdentifier=TC6MS3T6NN' "$PACKET_ROOT/codesign-metadata.txt"
+          xcrun stapler validate "$APP_PATH"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
+
+          BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$INFO_PLIST")"
+          VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+          BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+          FEED_URL="$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$INFO_PLIST")"
+          SPARKLE_PUBLIC_KEY="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$INFO_PLIST")"
+          test "$BUNDLE_ID" = "com.electricsheephq.NeonDiffDesktop"
+          test "$VERSION" = "1.1.0"
+          test "$FEED_URL" = "$STABLE_FEED_URL"
+          test "$ARTIFACT_NAME" = "NeonDiff-1.1.0-build${BUILD}-macOS.zip"
+          ACCEPTED_PUBLIC_KEY="$PACKET_ROOT/accepted-sparkle-public-key.txt"
+          printf '%s' "$SPARKLE_PUBLIC_KEY" > "$ACCEPTED_PUBLIC_KEY"
+          node - "$ACCEPTED_PUBLIC_KEY" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const value = readFileSync(process.argv[2], "utf8"), decoded = Buffer.from(value, "base64");
+          if (decoded.length !== 32 || decoded.toString("base64") !== value) process.exit(1);
+          NODE
+
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 --max-time 60 "$STABLE_FEED_URL" > "$PACKET_ROOT/appcast.xml"
+          jq -n \
+            --arg build "$BUILD" \
+            --arg artifact "$ARTIFACT_NAME" \
+            --arg feed "$STABLE_FEED_URL" \
+            '{schemaVersion:1,product:"neondiff-desktop",version:"1.1.0",tag:"v1.1.0",channel:"stable",sequence:null,build:$build,predecessor:null,contract:"paid-mac-ga-byo-v1",distribution:{bundleId:"com.electricsheephq.NeonDiffDesktop",appPath:"NeonDiff.app",artifactName:$artifact,releaseClass:"desktop-only",origins:{github:"https://github.com/electricsheephq/evaos-code-review-bot-neondiff",site:"https://www.neondiff.com",feed:$feed}}}' \
+            > "$DECLARATION_DIRECTORY/v1.1.0.json"
+          jq -n \
+            '{schemaVersion:1,status:"retained",declarationDirectory:"declarations",declarationPaths:["v1.1.0.json"],currentPath:"v1.1.0.json"}' \
+            > "$PACKET_ROOT/index.json"
+
+          BUILD_RESULT="$(node scripts/build-desktop-accepted-release-packet.mjs \
+            --index "$PACKET_ROOT/index.json" \
+            --artifact "$ARTIFACT_PATH" \
+            --feed "$PACKET_ROOT/appcast.xml" \
+            --tag-ref "$PACKET_ROOT/tag-ref.json" \
+            --tag-object "$PACKET_ROOT/tag-object.json" \
+            --release "$PACKET_ROOT/release.json" \
+            --accepted-public-key "$ACCEPTED_PUBLIC_KEY" \
+            --output "$PACKET_ROOT/packet.pending.json")"
+          PACKET_SHA256="$(jq -er '.packetSHA256 | select(test("^[a-f0-9]{64}$"))' <<< "$BUILD_RESULT")"
+          PACKET_NAME="$(jq -er '.packetFileName' <<< "$BUILD_RESULT")"
+          test "$PACKET_NAME" = "$PACKET_SHA256.packet.json"
+          PACKET_PATH="$PACKET_ROOT/$PACKET_NAME"
+          test ! -e "$PACKET_PATH"
+          mv "$PACKET_ROOT/packet.pending.json" "$PACKET_PATH"
+          test "$PACKET_SHA256" = "$(shasum -a 256 "$PACKET_PATH" | awk '{print $1}')"
+          {
+            printf 'packet_path=%s\n' "$PACKET_PATH"
+            printf 'packet_name=%s\n' "$PACKET_NAME"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest exact accepted packet
+        id: attest
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: ${{ steps.packet.outputs.packet_path }}
+
+      - name: Retain content-addressed attestation bundle
+        id: bundle
+        env:
+          BUNDLE_SOURCE: ${{ steps.attest.outputs.bundle-path }}
+          EXPECTED_PACKET_NAME: ${{ steps.packet.outputs.packet_name }}
+          PACKET_DIRECTORY: ${{ runner.temp }}/desktop-accepted-release-packet
+        run: |
+          set -euo pipefail
+          BUNDLE_RESULT="$(node scripts/retain-desktop-packet-attestation.mjs \
+            --bundle "$BUNDLE_SOURCE" \
+            --packet-name "$EXPECTED_PACKET_NAME" \
+            --output-directory "$PACKET_DIRECTORY")"
+          BUNDLE_SHA256="$(jq -er '.bundleSHA256 | select(test("^[a-f0-9]{64}$"))' <<< "$BUNDLE_RESULT")"
+          BUNDLE_NAME="$(jq -er '.bundleFileName' <<< "$BUNDLE_RESULT")"
+          test "$BUNDLE_NAME" = "$BUNDLE_SHA256.attestation.json"
+          BUNDLE_PATH="$PACKET_DIRECTORY/$BUNDLE_NAME"
+          test "$BUNDLE_SHA256" = "$(shasum -a 256 "$BUNDLE_PATH" | awk '{print $1}')"
+          {
+            printf 'bundle_path=%s\n' "$BUNDLE_PATH"
+            printf 'bundle_name=%s\n' "$BUNDLE_NAME"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload packet and retained attestation
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: desktop-accepted-packet-v1.1.0-${{ github.sha }}
+          path: |
+            ${{ steps.packet.outputs.packet_path }}
+            ${{ steps.bundle.outputs.bundle_path }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/desktop-accepted-release-packet.yml
+++ b/.github/workflows/desktop-accepted-release-packet.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     env:
+      # SHA-256 of SUPublicEDKey from immutable, notarized beta.87 artifact a90f77f5a1dbebd52de2fa19c37bf10d465fc58f7ad622dd12c289accde368a1.
+      EXPECTED_SPARKLE_PUBLIC_KEY_SHA256: 550933d363765a39fb62610776e4b73fbedfe678cd43b667a4e606eae9028e31
       RELEASE_TAG: v1.1.0
       REPOSITORY: electricsheephq/evaos-code-review-bot-neondiff
       STABLE_FEED_URL: https://www.neondiff.com/updates/stable/appcast.xml
@@ -102,6 +104,8 @@ jobs:
           const value = readFileSync(process.argv[2], "utf8"), decoded = Buffer.from(value, "base64");
           if (decoded.length !== 32 || decoded.toString("base64") !== value) process.exit(1);
           NODE
+          SPARKLE_PUBLIC_KEY_SHA256="$(shasum -a 256 "$ACCEPTED_PUBLIC_KEY" | awk '{print $1}')"
+          test "$SPARKLE_PUBLIC_KEY_SHA256" = "$EXPECTED_SPARKLE_PUBLIC_KEY_SHA256"
 
           curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 --max-time 60 "$STABLE_FEED_URL" > "$PACKET_ROOT/appcast.xml"
           jq -n \
@@ -145,13 +149,13 @@ jobs:
         id: bundle
         env:
           BUNDLE_SOURCE: ${{ steps.attest.outputs.bundle-path }}
-          EXPECTED_PACKET_NAME: ${{ steps.packet.outputs.packet_name }}
+          PACKET_SOURCE: ${{ steps.packet.outputs.packet_path }}
           PACKET_DIRECTORY: ${{ runner.temp }}/desktop-accepted-release-packet
         run: |
           set -euo pipefail
           BUNDLE_RESULT="$(node scripts/retain-desktop-packet-attestation.mjs \
             --bundle "$BUNDLE_SOURCE" \
-            --packet-name "$EXPECTED_PACKET_NAME" \
+            --packet "$PACKET_SOURCE" \
             --output-directory "$PACKET_DIRECTORY")"
           BUNDLE_SHA256="$(jq -er '.bundleSHA256 | select(test("^[a-f0-9]{64}$"))' <<< "$BUNDLE_RESULT")"
           BUNDLE_NAME="$(jq -er '.bundleFileName' <<< "$BUNDLE_RESULT")"

--- a/scripts/build-desktop-accepted-release-packet.mjs
+++ b/scripts/build-desktop-accepted-release-packet.mjs
@@ -1,0 +1,58 @@
+import { closeSync, constants, fstatSync, fsyncSync, openSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  acceptedDesktopReleasePacketDigest,
+  buildAcceptedDesktopReleasePacket,
+  serializeAcceptedDesktopReleasePacket
+} from "./lib/desktop-accepted-release-packet.mjs";
+
+const NAMES = ["index", "artifact", "feed", "tag-ref", "tag-object", "release", "accepted-public-key", "output"];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArguments(values) {
+  if (values.length !== NAMES.length * 2) fail("exact packet builder arguments are required");
+  const parsed = Object.create(null);
+  for (let index = 0; index < values.length; index += 2) {
+    const flag = values[index], value = values[index + 1];
+    if (typeof flag !== "string" || !flag.startsWith("--") || !NAMES.includes(flag.slice(2)) || Object.hasOwn(parsed, flag.slice(2)) || typeof value !== "string" || value.length === 0) fail("packet builder arguments are invalid");
+    parsed[flag.slice(2)] = resolve(value);
+  }
+  if (NAMES.some((name) => !Object.hasOwn(parsed, name))) fail("packet builder arguments are incomplete");
+  return parsed;
+}
+
+async function main() {
+  const values = parseArguments(process.argv.slice(2));
+  const packet = await buildAcceptedDesktopReleasePacket(values.index, values.artifact, values.feed, values["tag-ref"], values["tag-object"], values.release, values["accepted-public-key"]);
+  const serialized = serializeAcceptedDesktopReleasePacket(packet);
+  const packetSHA256 = acceptedDesktopReleasePacketDigest(packet);
+  const bytes = Buffer.from(serialized, "utf8");
+  let descriptor, created = false;
+  try {
+    descriptor = openSync(values.output, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), 0o600);
+    created = true;
+    writeFileSync(descriptor, bytes);
+    fsyncSync(descriptor);
+    const stored = fstatSync(descriptor);
+    if (!stored.isFile() || stored.size !== bytes.length) fail("packet output was not written exactly");
+    closeSync(descriptor);
+    descriptor = undefined;
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    if (created) {
+      try { unlinkSync(values.output); } catch { /* best-effort cleanup of this invocation's new file */ }
+    }
+    throw error;
+  }
+  process.stdout.write(`${JSON.stringify({ packetSHA256, packetFileName: `${packetSHA256}.packet.json` })}\n`);
+}
+
+try {
+  await main();
+} catch {
+  process.stderr.write("accepted release packet build failed\n");
+  process.exitCode = 1;
+}

--- a/scripts/retain-desktop-packet-attestation.mjs
+++ b/scripts/retain-desktop-packet-attestation.mjs
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { closeSync, constants, fstatSync, fsyncSync, openSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const MAX_BUNDLE_BYTES = 4 * 1024 * 1024;
+const PACKET_NAME = /^([a-f0-9]{64})\.packet\.json$/;
+const NAMES = ["bundle", "packet-name", "output-directory"];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArguments(values) {
+  if (values.length !== NAMES.length * 2) fail("exact bundle retention arguments are required");
+  const parsed = Object.create(null);
+  for (let index = 0; index < values.length; index += 2) {
+    const flag = values[index], value = values[index + 1];
+    if (typeof flag !== "string" || !flag.startsWith("--") || !NAMES.includes(flag.slice(2)) || Object.hasOwn(parsed, flag.slice(2)) || typeof value !== "string" || value.length === 0) fail("bundle retention arguments are invalid");
+    parsed[flag.slice(2)] = value;
+  }
+  if (NAMES.some((name) => !Object.hasOwn(parsed, name))) fail("bundle retention arguments are incomplete");
+  return parsed;
+}
+
+function boundedBundle(input) {
+  let descriptor;
+  try {
+    descriptor = openSync(resolve(input), constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const before = fstatSync(descriptor);
+    if (!before.isFile() || before.size < 1 || before.size > MAX_BUNDLE_BYTES) fail("bundle must be a bounded regular file");
+    const bytes = readFileSync(descriptor), after = fstatSync(descriptor);
+    if (!after.isFile() || before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || bytes.length !== before.size) fail("bundle changed during read");
+    return bytes;
+  } catch (error) {
+    if (error?.code === "ELOOP") fail("bundle must not be symlinked");
+    throw error;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function exactStatement(bytes, packetName) {
+  let bundle, statement;
+  try {
+    bundle = JSON.parse(bytes.toString("utf8"));
+    const payload = bundle?.dsseEnvelope?.payload;
+    if (typeof payload !== "string" || payload.length === 0) fail("bundle payload is missing");
+    const decoded = Buffer.from(payload, "base64");
+    if (decoded.toString("base64") !== payload) fail("bundle payload is not canonical base64");
+    statement = JSON.parse(decoded.toString("utf8"));
+  } catch {
+    fail("bundle is malformed");
+  }
+  const packetDigest = packetName.match(PACKET_NAME)?.[1], subjects = statement?.subject;
+  if (bundle?.mediaType !== "application/vnd.dev.sigstore.bundle.v0.3+json" || typeof bundle?.verificationMaterial !== "object" || bundle.verificationMaterial === null || bundle?.dsseEnvelope?.payloadType !== "application/vnd.in-toto+json" || !Array.isArray(bundle?.dsseEnvelope?.signatures) || bundle.dsseEnvelope.signatures.length < 1 || bundle.dsseEnvelope.signatures.some((item) => typeof item?.sig !== "string" || item.sig.length === 0) || statement?._type !== "https://in-toto.io/Statement/v1" || statement?.predicateType !== "https://slsa.dev/provenance/v1" || !packetDigest || !Array.isArray(subjects) || subjects.length !== 1 || subjects[0]?.name !== packetName || subjects[0]?.digest?.sha256 !== packetDigest) fail("bundle does not attest the exact packet");
+}
+
+function main() {
+  const values = parseArguments(process.argv.slice(2)), packetName = values["packet-name"], bytes = boundedBundle(values.bundle);
+  exactStatement(bytes, packetName);
+  const directory = resolve(values["output-directory"]), bundleSHA256 = createHash("sha256").update(bytes).digest("hex"), bundleFileName = `${bundleSHA256}.attestation.json`, outputPath = resolve(directory, bundleFileName);
+  let directoryDescriptor, outputDescriptor, created = false;
+  try {
+    directoryDescriptor = openSync(directory, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0) | (constants.O_NOFOLLOW ?? 0));
+    if (!fstatSync(directoryDescriptor).isDirectory()) fail("output directory is not a directory");
+    outputDescriptor = openSync(outputPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), 0o600);
+    created = true;
+    writeFileSync(outputDescriptor, bytes);
+    fsyncSync(outputDescriptor);
+    const stored = fstatSync(outputDescriptor);
+    if (!stored.isFile() || stored.size !== bytes.length) fail("retained bundle was not written exactly");
+    closeSync(outputDescriptor);
+    outputDescriptor = undefined;
+  } catch (error) {
+    if (outputDescriptor !== undefined) closeSync(outputDescriptor);
+    if (created) {
+      try { unlinkSync(outputPath); } catch { /* best-effort cleanup of this invocation's new file */ }
+    }
+    throw error;
+  } finally {
+    if (directoryDescriptor !== undefined) closeSync(directoryDescriptor);
+  }
+  process.stdout.write(`${JSON.stringify({ bundleSHA256, bundleFileName })}\n`);
+}
+
+try {
+  main();
+} catch {
+  process.stderr.write("attestation bundle retention failed\n");
+  process.exitCode = 1;
+}

--- a/scripts/retain-desktop-packet-attestation.mjs
+++ b/scripts/retain-desktop-packet-attestation.mjs
@@ -1,10 +1,16 @@
 import { createHash } from "node:crypto";
-import { closeSync, constants, fstatSync, fsyncSync, openSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { closeSync, constants, fstatSync, fsyncSync, mkdtempSync, openSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
 
-const MAX_BUNDLE_BYTES = 4 * 1024 * 1024;
+const REPOSITORY = "electricsheephq/evaos-code-review-bot-neondiff";
+const SIGNER_WORKFLOW = `${REPOSITORY}/.github/workflows/desktop-accepted-release-packet.yml`;
+const SOURCE_REF = "refs/heads/main";
+const PREDICATE_TYPE = "https://slsa.dev/provenance/v1";
+const MAX_INPUT_BYTES = 4 * 1024 * 1024;
 const PACKET_NAME = /^([a-f0-9]{64})\.packet\.json$/;
-const NAMES = ["bundle", "packet-name", "output-directory"];
+const NAMES = ["bundle", "packet", "output-directory"];
 
 function fail(message) {
   throw new Error(message);
@@ -22,24 +28,31 @@ function parseArguments(values) {
   return parsed;
 }
 
-function boundedBundle(input) {
+function boundedBytes(input, label) {
+  const path = resolve(input);
   let descriptor;
   try {
-    descriptor = openSync(resolve(input), constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
     const before = fstatSync(descriptor);
-    if (!before.isFile() || before.size < 1 || before.size > MAX_BUNDLE_BYTES) fail("bundle must be a bounded regular file");
+    if (!before.isFile() || before.size < 1 || before.size > MAX_INPUT_BYTES) fail(`${label} must be a bounded regular file`);
     const bytes = readFileSync(descriptor), after = fstatSync(descriptor);
-    if (!after.isFile() || before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || bytes.length !== before.size) fail("bundle changed during read");
-    return bytes;
+    if (!after.isFile() || before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || bytes.length !== before.size) fail(`${label} changed during read`);
+    return { path, bytes };
   } catch (error) {
-    if (error?.code === "ELOOP") fail("bundle must not be symlinked");
+    if (error?.code === "ELOOP") fail(`${label} must not be symlinked`);
     throw error;
   } finally {
     if (descriptor !== undefined) closeSync(descriptor);
   }
 }
 
-function exactStatement(bytes, packetName) {
+function exactPacket(input) {
+  const value = boundedBytes(input, "packet"), digest = createHash("sha256").update(value.bytes).digest("hex"), name = basename(value.path);
+  if (name !== `${digest}.packet.json`) fail("packet filename is not content-addressed");
+  return { ...value, digest, name };
+}
+
+function exactStatement(bytes, packetName, packetDigest) {
   let bundle, statement;
   try {
     bundle = JSON.parse(bytes.toString("utf8"));
@@ -51,24 +64,67 @@ function exactStatement(bytes, packetName) {
   } catch {
     fail("bundle is malformed");
   }
-  const packetDigest = packetName.match(PACKET_NAME)?.[1], subjects = statement?.subject;
-  if (bundle?.mediaType !== "application/vnd.dev.sigstore.bundle.v0.3+json" || typeof bundle?.verificationMaterial !== "object" || bundle.verificationMaterial === null || bundle?.dsseEnvelope?.payloadType !== "application/vnd.in-toto+json" || !Array.isArray(bundle?.dsseEnvelope?.signatures) || bundle.dsseEnvelope.signatures.length < 1 || bundle.dsseEnvelope.signatures.some((item) => typeof item?.sig !== "string" || item.sig.length === 0) || statement?._type !== "https://in-toto.io/Statement/v1" || statement?.predicateType !== "https://slsa.dev/provenance/v1" || !packetDigest || !Array.isArray(subjects) || subjects.length !== 1 || subjects[0]?.name !== packetName || subjects[0]?.digest?.sha256 !== packetDigest) fail("bundle does not attest the exact packet");
+  const subjects = statement?.subject, signatures = bundle?.dsseEnvelope?.signatures;
+  if (!PACKET_NAME.test(packetName) || bundle?.mediaType !== "application/vnd.dev.sigstore.bundle.v0.3+json" || typeof bundle?.verificationMaterial !== "object" || bundle.verificationMaterial === null || Object.keys(bundle.verificationMaterial).length < 1 || bundle?.dsseEnvelope?.payloadType !== "application/vnd.in-toto+json" || !Array.isArray(signatures) || signatures.length < 1 || signatures.some((item) => { if (typeof item?.sig !== "string" || item.sig.length === 0) return true; const decoded = Buffer.from(item.sig, "base64"); return decoded.length === 0 || decoded.toString("base64") !== item.sig; }) || statement?._type !== "https://in-toto.io/Statement/v1" || statement?.predicateType !== PREDICATE_TYPE || !Array.isArray(subjects) || subjects.length !== 1 || subjects[0]?.name !== packetName || subjects[0]?.digest?.sha256 !== packetDigest) fail("bundle does not attest the exact packet");
+}
+
+function writePrivate(path, bytes) {
+  let descriptor;
+  try {
+    descriptor = openSync(path, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), 0o600);
+    writeFileSync(descriptor, bytes);
+    fsyncSync(descriptor);
+    const stored = fstatSync(descriptor);
+    if (!stored.isFile() || stored.size !== bytes.length) fail("private verification input was not written exactly");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function cryptographicallyVerify(packet, bundle) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-bundle-verification-")), packetPath = join(root, packet.name), bundlePath = join(root, "attestation.json");
+  let result;
+  try {
+    writePrivate(packetPath, packet.bytes);
+    writePrivate(bundlePath, bundle.bytes);
+    result = spawnSync("gh", [
+      "attestation", "verify", packetPath,
+      "--bundle", bundlePath,
+      "--repo", REPOSITORY,
+      "--signer-workflow", SIGNER_WORKFLOW,
+      "--source-ref", SOURCE_REF,
+      "--deny-self-hosted-runners",
+      "--format", "json"
+    ], {
+      encoding: "utf8",
+      env: { ...process.env, GH_PAGER: "cat", PAGER: "cat", NO_COLOR: "1" },
+      maxBuffer: MAX_INPUT_BYTES,
+      timeout: 30_000
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+  if (result.error || result.signal || result.status !== 0) fail("canonical bundle verification failed");
+  let verification;
+  try { verification = JSON.parse(result.stdout); } catch { fail("canonical bundle verification failed"); }
+  if (!Array.isArray(verification) || !verification.some((entry) => { const statement = entry?.verificationResult?.statement; return statement?.predicateType === PREDICATE_TYPE && Array.isArray(statement.subject) && statement.subject.some((subject) => subject?.name === packet.name && subject?.digest?.sha256 === packet.digest); })) fail("canonical bundle verification failed");
 }
 
 function main() {
-  const values = parseArguments(process.argv.slice(2)), packetName = values["packet-name"], bytes = boundedBundle(values.bundle);
-  exactStatement(bytes, packetName);
-  const directory = resolve(values["output-directory"]), bundleSHA256 = createHash("sha256").update(bytes).digest("hex"), bundleFileName = `${bundleSHA256}.attestation.json`, outputPath = resolve(directory, bundleFileName);
+  const values = parseArguments(process.argv.slice(2)), packet = exactPacket(values.packet), bundle = boundedBytes(values.bundle, "bundle");
+  exactStatement(bundle.bytes, packet.name, packet.digest);
+  cryptographicallyVerify(packet, bundle);
+  const directory = resolve(values["output-directory"]), bundleSHA256 = createHash("sha256").update(bundle.bytes).digest("hex"), bundleFileName = `${bundleSHA256}.attestation.json`, outputPath = resolve(directory, bundleFileName);
   let directoryDescriptor, outputDescriptor, created = false;
   try {
     directoryDescriptor = openSync(directory, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0) | (constants.O_NOFOLLOW ?? 0));
     if (!fstatSync(directoryDescriptor).isDirectory()) fail("output directory is not a directory");
     outputDescriptor = openSync(outputPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), 0o600);
     created = true;
-    writeFileSync(outputDescriptor, bytes);
+    writeFileSync(outputDescriptor, bundle.bytes);
     fsyncSync(outputDescriptor);
     const stored = fstatSync(outputDescriptor);
-    if (!stored.isFile() || stored.size !== bytes.length) fail("retained bundle was not written exactly");
+    if (!stored.isFile() || stored.size !== bundle.bytes.length) fail("retained bundle was not written exactly");
     closeSync(outputDescriptor);
     outputDescriptor = undefined;
   } catch (error) {

--- a/scripts/verify-desktop-packet-attestation.mjs
+++ b/scripts/verify-desktop-packet-attestation.mjs
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { closeSync, constants, fstatSync, fsyncSync, mkdtempSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const REPOSITORY = "electricsheephq/evaos-code-review-bot-neondiff";
+const SIGNER_WORKFLOW = `${REPOSITORY}/.github/workflows/desktop-accepted-release-packet.yml`;
+const SOURCE_REF = "refs/heads/main";
+const PREDICATE_TYPE = "https://slsa.dev/provenance/v1";
+const MAX_PACKET_BYTES = 4 * 1024 * 1024;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function exactPacketBytes(input) {
+  if (typeof input !== "string" || input.length === 0) fail("one packet path is required");
+  const packetPath = resolve(input);
+  let descriptor;
+  try {
+    descriptor = openSync(packetPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const before = fstatSync(descriptor);
+    if (!before.isFile() || before.size < 1 || before.size > MAX_PACKET_BYTES) fail("packet must be a bounded regular file");
+    const bytes = readFileSync(descriptor);
+    const after = fstatSync(descriptor);
+    if (!after.isFile() || before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || bytes.length !== before.size) fail("packet changed during read");
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    if (!SHA256.test(digest) || basename(packetPath) !== `${digest}.packet.json`) fail("packet filename is not content-addressed");
+    return { packetPath, bytes, digest };
+  } catch (error) {
+    if (error?.code === "ELOOP") fail("packet must not be symlinked");
+    throw error;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function privatePacketCopy(packetName, bytes) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-packet-verification-")), packetPath = join(root, packetName);
+  let descriptor;
+  try {
+    descriptor = openSync(packetPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), 0o600);
+    writeFileSync(descriptor, bytes);
+    fsyncSync(descriptor);
+    const stored = fstatSync(descriptor);
+    if (!stored.isFile() || stored.size !== bytes.length) fail("private packet copy was not written exactly");
+    closeSync(descriptor);
+    descriptor = undefined;
+    return { root, packetPath };
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function hasExactSubject(value, packetName, digest) {
+  if (!Array.isArray(value) || value.length < 1) return false;
+  return value.some((entry) => {
+    const statement = entry?.verificationResult?.statement;
+    return statement?.predicateType === PREDICATE_TYPE && Array.isArray(statement.subject) && statement.subject.some((subject) => subject?.name === packetName && subject?.digest?.sha256 === digest);
+  });
+}
+
+function main() {
+  const values = process.argv.slice(2);
+  if (values.length !== 2 || values[0] !== "--packet") fail("usage: verify-desktop-packet-attestation --packet PATH");
+  const { packetPath, bytes, digest } = exactPacketBytes(values[1]);
+  const packetName = basename(packetPath);
+  const stable = privatePacketCopy(packetName, bytes);
+  let result;
+  try {
+    result = spawnSync("gh", [
+      "attestation", "verify", stable.packetPath,
+      "--repo", REPOSITORY,
+      "--signer-workflow", SIGNER_WORKFLOW,
+      "--source-ref", SOURCE_REF,
+      "--deny-self-hosted-runners",
+      "--format", "json"
+    ], {
+      encoding: "utf8",
+      env: { ...process.env, GH_PAGER: "cat", PAGER: "cat", NO_COLOR: "1" },
+      maxBuffer: MAX_PACKET_BYTES,
+      timeout: 30_000
+    });
+  } finally {
+    rmSync(stable.root, { recursive: true, force: true });
+  }
+  if (result.error || result.signal || result.status !== 0) fail("canonical packet attestation verification failed");
+  let verification;
+  try {
+    verification = JSON.parse(result.stdout);
+  } catch {
+    fail("canonical packet attestation verification failed");
+  }
+  if (!hasExactSubject(verification, packetName, digest)) fail("canonical packet attestation verification failed");
+  process.stdout.write(`${JSON.stringify({ verified: true, packetSHA256: digest, repository: REPOSITORY, signerWorkflow: SIGNER_WORKFLOW, sourceRef: SOURCE_REF })}\n`);
+}
+
+try {
+  main();
+} catch {
+  process.stderr.write("canonical packet attestation verification failed\n");
+  process.exitCode = 1;
+}

--- a/tests/desktop-packet-attestation.test.ts
+++ b/tests/desktop-packet-attestation.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, constants, existsSync, fstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -38,6 +38,15 @@ process.stdout.write(JSON.stringify([{ verificationResult: { statement: { predic
   return { root, output, packetName, packet, bundle, bytes, capture, run };
 }
 
+function storedFile(path: string) {
+  const descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const before = fstatSync(descriptor), bytes = readFileSync(descriptor), after = fstatSync(descriptor);
+    if (!before.isFile() || before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || bytes.length !== before.size) throw new Error("stored file changed during read");
+    return { bytes, mode: before.mode & 0o777 };
+  } finally { closeSync(descriptor); }
+}
+
 describe("trusted Desktop accepted-packet attestation", () => {
   it("verifies one exact content-addressed packet under fixed canonical identity", () => {
     const value = fixture(), result = value.run(); expect(result.status).toBe(0); expect(JSON.parse(result.stdout)).toEqual({ verified: true, packetSHA256: value.packetSHA256, repository, signerWorkflow, sourceRef });
@@ -57,9 +66,9 @@ describe("trusted Desktop accepted-packet attestation", () => {
 
   it("retains one bounded content-addressed bundle bound to the exact packet", () => {
     const value = bundleFixture(), result = value.run(); expect(result.status).toBe(0); const receipt = JSON.parse(result.stdout), expectedDigest = createHash("sha256").update(value.bytes).digest("hex"), target = join(value.output, `${expectedDigest}.attestation.json`);
-    expect(receipt).toEqual({ bundleSHA256: expectedDigest, bundleFileName: `${expectedDigest}.attestation.json` }); expect(readFileSync(target)).toEqual(value.bytes); expect(statSync(target).mode & 0o777).toBe(0o600);
+    const stored = storedFile(target); expect(receipt).toEqual({ bundleSHA256: expectedDigest, bundleFileName: `${expectedDigest}.attestation.json` }); expect(stored.bytes).toEqual(value.bytes); expect(stored.mode).toBe(0o600);
     const args = JSON.parse(readFileSync(value.capture, "utf8")); expect(args.slice(0, 2)).toEqual(["attestation", "verify"]); expect(basename(args[2])).toBe(value.packetName); expect(args[2]).not.toBe(value.packet); expect(args[3]).toBe("--bundle"); expect(args[4]).not.toBe(value.bundle); expect(args.slice(5)).toEqual(["--repo", repository, "--signer-workflow", signerWorkflow, "--source-ref", sourceRef, "--deny-self-hosted-runners", "--format", "json"]);
-    expect(bundleFixture().run("fail").status).not.toBe(0); expect(value.run().status).not.toBe(0); expect(readFileSync(target)).toEqual(value.bytes);
+    expect(bundleFixture().run("fail").status).not.toBe(0); expect(value.run().status).not.toBe(0); expect(storedFile(target).bytes).toEqual(value.bytes);
     expect(bundleFixture("malformed").run().status).not.toBe(0); expect(bundleFixture("wrong-subject").run().status).not.toBe(0);
     const linked = bundleFixture(), alias = join(linked.root, "alias.json"); symlinkSync(linked.bundle, alias); expect(linked.run("success", ["--bundle", alias, "--packet", linked.packet, "--output-directory", linked.output]).status).not.toBe(0);
     const alternate = bundleFixture(); expect(alternate.run("success", ["--bundle", alternate.bundle, "--packet", alternate.packet, "--output-directory", alternate.output, "--repo", "attacker/example"]).status).not.toBe(0);

--- a/tests/desktop-packet-attestation.test.ts
+++ b/tests/desktop-packet-attestation.test.ts
@@ -24,11 +24,18 @@ process.stdout.write(JSON.stringify([{ verificationResult: { statement: { predic
 }
 
 function bundleFixture(mode: "valid" | "wrong-subject" | "malformed" = "valid") {
-  const root = mkdtempSync(join(tmpdir(), "neondiff-packet-bundle-")); roots.push(root); const output = join(root, "retained"); mkdirSync(output);
-  const packetSHA256 = "a".repeat(64), packetName = `${packetSHA256}.packet.json`, statement = { _type: "https://in-toto.io/Statement/v1", predicateType: "https://slsa.dev/provenance/v1", subject: [{ name: packetName, digest: { sha256: mode === "wrong-subject" ? "b".repeat(64) : packetSHA256 } }], predicate: {} };
-  const bundle = join(root, "attestation.json"), bytes = mode === "malformed" ? Buffer.from("{") : Buffer.from(`${JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json", verificationMaterial: {}, dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement)).toString("base64"), payloadType: "application/vnd.in-toto+json", signatures: [{ sig: "synthetic" }] } })}\n`); writeFileSync(bundle, bytes);
-  const run = (args = ["--bundle", bundle, "--packet-name", packetName, "--output-directory", output]) => spawnSync(process.execPath, [retainer, ...args], { cwd: process.cwd(), encoding: "utf8" });
-  return { root, output, packetName, bundle, bytes, run };
+  const root = mkdtempSync(join(tmpdir(), "neondiff-packet-bundle-")); roots.push(root); const output = join(root, "retained"), capture = join(root, "args.json"); mkdirSync(output);
+  const packetBytes = Buffer.from('{"kind":"synthetic-accepted-packet"}\n'), packetSHA256 = createHash("sha256").update(packetBytes).digest("hex"), packetName = `${packetSHA256}.packet.json`, packet = join(root, packetName), statement = { _type: "https://in-toto.io/Statement/v1", predicateType: "https://slsa.dev/provenance/v1", subject: [{ name: packetName, digest: { sha256: mode === "wrong-subject" ? "b".repeat(64) : packetSHA256 } }], predicate: {} };
+  const bundle = join(root, "attestation.json"), bytes = mode === "malformed" ? Buffer.from("{") : Buffer.from(`${JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json", verificationMaterial: { tlogEntries: [{}] }, dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement)).toString("base64"), payloadType: "application/vnd.in-toto+json", signatures: [{ sig: Buffer.alloc(64, 1).toString("base64") }] } })}\n`); writeFileSync(packet, packetBytes); writeFileSync(bundle, bytes);
+  writeFileSync(join(root, "gh"), `#!/usr/bin/env node
+const { createHash } = require("node:crypto"), { readFileSync, writeFileSync } = require("node:fs"), { basename } = require("node:path");
+const args = process.argv.slice(2), packet = args[2]; writeFileSync(process.env.CAPTURE_PATH, JSON.stringify(args));
+if (process.env.FAKE_GH_MODE === "fail") { process.stderr.write("invalid bundle signature"); process.exit(1); }
+const digest = createHash("sha256").update(readFileSync(packet)).digest("hex");
+process.stdout.write(JSON.stringify([{ verificationResult: { statement: { predicateType: "https://slsa.dev/provenance/v1", subject: [{ name: basename(packet), digest: { sha256: digest } }] } } }]));
+`); chmodSync(join(root, "gh"), 0o755);
+  const run = (ghMode = "success", args = ["--bundle", bundle, "--packet", packet, "--output-directory", output]) => spawnSync(process.execPath, [retainer, ...args], { cwd: process.cwd(), encoding: "utf8", env: { ...process.env, PATH: `${root}:${process.env.PATH}`, CAPTURE_PATH: capture, FAKE_GH_MODE: ghMode } });
+  return { root, output, packetName, packet, bundle, bytes, capture, run };
 }
 
 describe("trusted Desktop accepted-packet attestation", () => {
@@ -51,9 +58,11 @@ describe("trusted Desktop accepted-packet attestation", () => {
   it("retains one bounded content-addressed bundle bound to the exact packet", () => {
     const value = bundleFixture(), result = value.run(); expect(result.status).toBe(0); const receipt = JSON.parse(result.stdout), expectedDigest = createHash("sha256").update(value.bytes).digest("hex"), target = join(value.output, `${expectedDigest}.attestation.json`);
     expect(receipt).toEqual({ bundleSHA256: expectedDigest, bundleFileName: `${expectedDigest}.attestation.json` }); expect(readFileSync(target)).toEqual(value.bytes); expect(statSync(target).mode & 0o777).toBe(0o600);
+    const args = JSON.parse(readFileSync(value.capture, "utf8")); expect(args.slice(0, 2)).toEqual(["attestation", "verify"]); expect(basename(args[2])).toBe(value.packetName); expect(args[2]).not.toBe(value.packet); expect(args[3]).toBe("--bundle"); expect(args[4]).not.toBe(value.bundle); expect(args.slice(5)).toEqual(["--repo", repository, "--signer-workflow", signerWorkflow, "--source-ref", sourceRef, "--deny-self-hosted-runners", "--format", "json"]);
+    expect(bundleFixture().run("fail").status).not.toBe(0); expect(value.run().status).not.toBe(0); expect(readFileSync(target)).toEqual(value.bytes);
     expect(bundleFixture("malformed").run().status).not.toBe(0); expect(bundleFixture("wrong-subject").run().status).not.toBe(0);
-    const linked = bundleFixture(), alias = join(linked.root, "alias.json"); symlinkSync(linked.bundle, alias); expect(linked.run(["--bundle", alias, "--packet-name", linked.packetName, "--output-directory", linked.output]).status).not.toBe(0);
-    const alternate = bundleFixture(); expect(alternate.run(["--bundle", alternate.bundle, "--packet-name", alternate.packetName, "--output-directory", alternate.output, "--repo", "attacker/example"]).status).not.toBe(0);
+    const linked = bundleFixture(), alias = join(linked.root, "alias.json"); symlinkSync(linked.bundle, alias); expect(linked.run("success", ["--bundle", alias, "--packet", linked.packet, "--output-directory", linked.output]).status).not.toBe(0);
+    const alternate = bundleFixture(); expect(alternate.run("success", ["--bundle", alternate.bundle, "--packet", alternate.packet, "--output-directory", alternate.output, "--repo", "attacker/example"]).status).not.toBe(0);
   });
 
   it("keeps the canonical builder and attester on protected main with no authority inputs", () => {
@@ -61,6 +70,7 @@ describe("trusted Desktop accepted-packet attestation", () => {
     expect(workflow).toMatch(/workflow_dispatch:\s*\n/); expect(workflow).not.toMatch(/workflow_dispatch:\s*\n\s+inputs:/); expect(workflow).toMatch(/contents:\s*read[\s\S]*id-token:\s*write[\s\S]*attestations:\s*write/);
     expect(workflow).toContain("github.ref == 'refs/heads/main'"); expect(workflow).toContain("runs-on: macos-15"); expect(workflow).not.toContain("self-hosted"); expect(workflow).toContain('RELEASE_TAG: v1.1.0'); expect(workflow).toContain('test "$GITHUB_SHA" = "$(git rev-parse HEAD)"');
     expect(workflow).toContain("TeamIdentifier=TC6MS3T6NN"); expect(workflow).toMatch(/codesign --verify/); expect(workflow).toMatch(/stapler validate/); expect(workflow).toMatch(/spctl --assess/); expect(workflow).toContain("build-desktop-accepted-release-packet.mjs");
+    expect(workflow).toContain("EXPECTED_SPARKLE_PUBLIC_KEY_SHA256: 550933d363765a39fb62610776e4b73fbedfe678cd43b667a4e606eae9028e31"); expect(workflow).toContain('test "$SPARKLE_PUBLIC_KEY_SHA256" = "$EXPECTED_SPARKLE_PUBLIC_KEY_SHA256"');
     expect(workflow).toContain("actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3"); expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4");
     expect(workflow).toContain("steps.attest.outputs.bundle-path"); expect(workflow).toContain("retain-desktop-packet-attestation.mjs");
     expect(producer).toContain("buildAcceptedDesktopReleasePacket"); expect(producer).toContain("serializeAcceptedDesktopReleasePacket"); expect(producer).toContain("acceptedDesktopReleasePacketDigest"); expect(producer).toMatch(/O_EXCL/); expect(producer).not.toMatch(/private.?key|token|secret/i);

--- a/tests/desktop-packet-attestation.test.ts
+++ b/tests/desktop-packet-attestation.test.ts
@@ -1,0 +1,68 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [], verifier = "scripts/verify-desktop-packet-attestation.mjs", retainer = "scripts/retain-desktop-packet-attestation.mjs", builder = "scripts/build-desktop-accepted-release-packet.mjs", workflowPath = ".github/workflows/desktop-accepted-release-packet.yml";
+const repository = "electricsheephq/evaos-code-review-bot-neondiff", signerWorkflow = `${repository}/${workflowPath}`, sourceRef = "refs/heads/main";
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-packet-attestation-")); roots.push(root); const bytes = Buffer.from('{"kind":"synthetic-accepted-packet"}\n'), packetSHA256 = createHash("sha256").update(bytes).digest("hex"), packet = join(root, `${packetSHA256}.packet.json`), bin = join(root, "bin"), capture = join(root, "args.json");
+  writeFileSync(packet, bytes); writeFileSync(join(root, "gh"), `#!/usr/bin/env node
+const { createHash } = require("node:crypto"), { readFileSync, writeFileSync } = require("node:fs"), { basename } = require("node:path");
+const args = process.argv.slice(2), packet = args[2]; writeFileSync(process.env.CAPTURE_PATH, JSON.stringify(args));
+if (process.env.FAKE_GH_MODE === "fail") { process.stderr.write("no canonical attestation"); process.exit(1); }
+if (process.env.FAKE_GH_MODE === "malformed") { process.stdout.write("{"); process.exit(0); }
+const actual = createHash("sha256").update(readFileSync(packet)).digest("hex"), digest = process.env.FAKE_GH_MODE === "wrong-subject" ? "0".repeat(64) : actual;
+process.stdout.write(JSON.stringify([{ verificationResult: { statement: { predicateType: "https://slsa.dev/provenance/v1", subject: [{ name: basename(packet), digest: { sha256: digest } }] } } }]));
+`); chmodSync(join(root, "gh"), 0o755); symlinkSync(join(root, "gh"), bin);
+  const run = (mode = "success", args = ["--packet", packet]) => spawnSync(process.execPath, [verifier, ...args], { cwd: process.cwd(), encoding: "utf8", env: { ...process.env, PATH: `${root}:${process.env.PATH}`, CAPTURE_PATH: capture, FAKE_GH_MODE: mode } });
+  return { root, packet, packetSHA256, capture, run };
+}
+
+function bundleFixture(mode: "valid" | "wrong-subject" | "malformed" = "valid") {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-packet-bundle-")); roots.push(root); const output = join(root, "retained"); mkdirSync(output);
+  const packetSHA256 = "a".repeat(64), packetName = `${packetSHA256}.packet.json`, statement = { _type: "https://in-toto.io/Statement/v1", predicateType: "https://slsa.dev/provenance/v1", subject: [{ name: packetName, digest: { sha256: mode === "wrong-subject" ? "b".repeat(64) : packetSHA256 } }], predicate: {} };
+  const bundle = join(root, "attestation.json"), bytes = mode === "malformed" ? Buffer.from("{") : Buffer.from(`${JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json", verificationMaterial: {}, dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement)).toString("base64"), payloadType: "application/vnd.in-toto+json", signatures: [{ sig: "synthetic" }] } })}\n`); writeFileSync(bundle, bytes);
+  const run = (args = ["--bundle", bundle, "--packet-name", packetName, "--output-directory", output]) => spawnSync(process.execPath, [retainer, ...args], { cwd: process.cwd(), encoding: "utf8" });
+  return { root, output, packetName, bundle, bytes, run };
+}
+
+describe("trusted Desktop accepted-packet attestation", () => {
+  it("verifies one exact content-addressed packet under fixed canonical identity", () => {
+    const value = fixture(), result = value.run(); expect(result.status).toBe(0); expect(JSON.parse(result.stdout)).toEqual({ verified: true, packetSHA256: value.packetSHA256, repository, signerWorkflow, sourceRef });
+    const args = JSON.parse(readFileSync(value.capture, "utf8")); expect(args.slice(0, 2)).toEqual(["attestation", "verify"]); expect(basename(args[2])).toBe(basename(value.packet)); expect(args[2]).not.toBe(value.packet);
+    expect(args.slice(3)).toEqual(["--repo", repository, "--signer-workflow", signerWorkflow, "--source-ref", sourceRef, "--deny-self-hosted-runners", "--format", "json"]);
+    expect(result.stdout).not.toContain(value.packet); expect(result.stdout).not.toMatch(/attestation|certificate|signature|path/i);
+  });
+
+  it("rejects missing authority, wrong subjects, alternate CLI identity, and unsafe packet paths", () => {
+    const missing = fixture(); expect(missing.run("fail").status).not.toBe(0);
+    const malformed = fixture(); expect(malformed.run("malformed").status).not.toBe(0);
+    const wrong = fixture(); expect(wrong.run("wrong-subject").status).not.toBe(0);
+    const alternate = fixture(); expect(alternate.run("success", ["--packet", alternate.packet, "--repo", "attacker/example"]).status).not.toBe(0);
+    const unaddressed = fixture(), renamed = join(unaddressed.root, "packet.json"); writeFileSync(renamed, readFileSync(unaddressed.packet)); expect(unaddressed.run("success", ["--packet", renamed]).status).not.toBe(0);
+    const linked = fixture(), alias = join(linked.root, basename(linked.packet).replace(".packet.json", ".alias.packet.json")); symlinkSync(linked.packet, alias); expect(linked.run("success", ["--packet", alias]).status).not.toBe(0); expect(existsSync(linked.capture)).toBe(false);
+  });
+
+  it("retains one bounded content-addressed bundle bound to the exact packet", () => {
+    const value = bundleFixture(), result = value.run(); expect(result.status).toBe(0); const receipt = JSON.parse(result.stdout), expectedDigest = createHash("sha256").update(value.bytes).digest("hex"), target = join(value.output, `${expectedDigest}.attestation.json`);
+    expect(receipt).toEqual({ bundleSHA256: expectedDigest, bundleFileName: `${expectedDigest}.attestation.json` }); expect(readFileSync(target)).toEqual(value.bytes); expect(statSync(target).mode & 0o777).toBe(0o600);
+    expect(bundleFixture("malformed").run().status).not.toBe(0); expect(bundleFixture("wrong-subject").run().status).not.toBe(0);
+    const linked = bundleFixture(), alias = join(linked.root, "alias.json"); symlinkSync(linked.bundle, alias); expect(linked.run(["--bundle", alias, "--packet-name", linked.packetName, "--output-directory", linked.output]).status).not.toBe(0);
+    const alternate = bundleFixture(); expect(alternate.run(["--bundle", alternate.bundle, "--packet-name", alternate.packetName, "--output-directory", alternate.output, "--repo", "attacker/example"]).status).not.toBe(0);
+  });
+
+  it("keeps the canonical builder and attester on protected main with no authority inputs", () => {
+    const workflow = readFileSync(workflowPath, "utf8"), producer = readFileSync(builder, "utf8");
+    expect(workflow).toMatch(/workflow_dispatch:\s*\n/); expect(workflow).not.toMatch(/workflow_dispatch:\s*\n\s+inputs:/); expect(workflow).toMatch(/contents:\s*read[\s\S]*id-token:\s*write[\s\S]*attestations:\s*write/);
+    expect(workflow).toContain("github.ref == 'refs/heads/main'"); expect(workflow).toContain("runs-on: macos-15"); expect(workflow).not.toContain("self-hosted"); expect(workflow).toContain('RELEASE_TAG: v1.1.0'); expect(workflow).toContain('test "$GITHUB_SHA" = "$(git rev-parse HEAD)"');
+    expect(workflow).toContain("TeamIdentifier=TC6MS3T6NN"); expect(workflow).toMatch(/codesign --verify/); expect(workflow).toMatch(/stapler validate/); expect(workflow).toMatch(/spctl --assess/); expect(workflow).toContain("build-desktop-accepted-release-packet.mjs");
+    expect(workflow).toContain("actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3"); expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4");
+    expect(workflow).toContain("steps.attest.outputs.bundle-path"); expect(workflow).toContain("retain-desktop-packet-attestation.mjs");
+    expect(producer).toContain("buildAcceptedDesktopReleasePacket"); expect(producer).toContain("serializeAcceptedDesktopReleasePacket"); expect(producer).toContain("acceptedDesktopReleasePacketDigest"); expect(producer).toMatch(/O_EXCL/); expect(producer).not.toMatch(/private.?key|token|secret/i);
+  });
+});


### PR DESCRIPTION
## Outcome

Adds the protected-main authority boundary required before rebuilding #1021: exact accepted Desktop packet bytes can be generated and attested only by the inputless canonical repository workflow, then verified against fixed repository, signer-workflow, source-ref, runner, predicate, and subject-digest policy.

## Change

- adds an inputless `macos-15` workflow with only `contents: read`, `id-token: write`, and `attestations: write`
- derives the fixed `v1.1.0` release, annotated tag, Apple identity, stapling/Gatekeeper result, Sparkle feed/key, declaration, artifact tree, enclosure proof, and npm release class before packet production
- attests only the exact content-addressed packet with the repository's pinned GitHub attestation action
- validates and retains the action's bounded Sigstore bundle under its own digest
- verifies a private exact-byte packet copy with fixed canonical `gh attestation verify` identity flags and redacted output
- rejects alternate CLI identity, malformed/wrong-subject attestations, non-addressed or symlinked packets/bundles, and existing output collisions

## Focused proof

- `28/28` packet, artifact-tree, and declaration tests passed under Node 26
- all three new CLI syntax checks passed
- Actionlint passed
- exact-lock `npm run build` and postbuild passed
- staged `git diff --check` passed
- staged secret scan passed across 928 tracked files

## Proof boundary

This is exact source/test/workflow-contract proof only. The workflow has not produced the future immutable `v1.1.0` packet or attestation, and this does not prove #1021 consumer transition rules, actual update/rollback/re-update, publication, installed runtime, customer, RC, release, or GA readiness.

Closes #1083
