### PR TITLE
Mac GA: retain accepted packet evidence immutably

### DIFF
--- a/.github/workflows/desktop-accepted-release-packet.yml
+++ b/.github/workflows/desktop-accepted-release-packet.yml
@@ -14,6 +14,10 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+    outputs:
+      artifact_source_sha: ${{ steps.release.outputs.artifact_source_sha }}
+      packet_name: ${{ steps.packet.outputs.packet_name }}
+      bundle_name: ${{ steps.packet.outputs.bundle_name }}
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-15
     timeout-minutes: 30
@@ -144,6 +148,7 @@ jobs:
             printf 'packet_root=%s\n' "$PACKET_ROOT"
             printf 'artifact_path=%s\n' "$ARTIFACT_PATH"
             printf 'predicate_path=%s\n' "$PREDICATE_PATH"
+            printf 'artifact_source_sha=%s\n' "$SOURCE_SHA"
           } >> "$GITHUB_OUTPUT"
 
       - name: Attest exact signed artifact source binding
@@ -179,6 +184,8 @@ jobs:
           {
             printf 'packet_path=%s\n' "$PACKET_PATH"
             printf 'bundle_path=%s\n' "$BUNDLE_PATH"
+            printf 'packet_name=%s\n' "$PACKET_NAME"
+            printf 'bundle_name=%s\n' "$BUNDLE_NAME"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload source-bound packet evidence
@@ -190,3 +197,113 @@ jobs:
             ${{ steps.packet.outputs.bundle_path }}
           if-no-files-found: error
           retention-days: 30
+
+  retain-accepted-packet:
+    name: Retain exact accepted packet in immutable release
+    needs: promote-stable-artifact
+    permissions:
+      contents: write
+      attestations: read
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      REPOSITORY: electricsheephq/evaos-code-review-bot-neondiff
+      REPOSITORY_OWNER: electricsheephq
+      REPOSITORY_NAME: evaos-code-review-bot-neondiff
+      SOURCE_REF: refs/heads/main
+      SIGNER_WORKFLOW: electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/desktop-accepted-release-packet.yml
+      EVIDENCE_TAG: neondiff-accepted-packet-v1.1.0
+      EVIDENCE_RELEASE_NAME: NeonDiff accepted packet evidence v1.1.0
+      ARTIFACT_SOURCE_SHA: ${{ needs.promote-stable-artifact.outputs.artifact_source_sha }}
+      PACKET_NAME: ${{ needs.promote-stable-artifact.outputs.packet_name }}
+      BUNDLE_NAME: ${{ needs.promote-stable-artifact.outputs.bundle_name }}
+    steps:
+      - name: Checkout exact retention verifier
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 26
+
+      - name: Download current-run accepted evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: desktop-source-bound-packet-v1.1.0-${{ github.sha }}
+          path: ${{ runner.temp }}/desktop-source-bound-packet
+
+      - name: Publish once and reload exact immutable evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          umask 077
+          test "$GITHUB_ACTIONS" = "true"
+          test "$RUNNER_ENVIRONMENT" = "github-hosted"
+          test "$GITHUB_REPOSITORY" = "$REPOSITORY"
+          test "$GITHUB_REF" = "$SOURCE_REF"
+          test "$GITHUB_WORKFLOW_REF" = "$SIGNER_WORKFLOW@$SOURCE_REF"
+          [[ "$GITHUB_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$GITHUB_SHA" = "$(git rev-parse HEAD)"
+          [[ "$ARTIFACT_SOURCE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$PACKET_NAME" =~ ^[a-f0-9]{64}\.packet\.json$ ]]
+          [[ "$BUNDLE_NAME" =~ ^[a-f0-9]{64}\.artifact-source-attestation\.json$ ]]
+
+          TRANSIT_ROOT="$RUNNER_TEMP/desktop-source-bound-packet"
+          PACKET_PATH="$TRANSIT_ROOT/$PACKET_NAME"
+          BUNDLE_PATH="$TRANSIT_ROOT/$BUNDLE_NAME"
+          test -f "$PACKET_PATH"
+          test -f "$BUNDLE_PATH"
+
+          METADATA_ROOT="$RUNNER_TEMP/desktop-accepted-evidence-metadata"
+          RETRIEVED_ROOT="$RUNNER_TEMP/desktop-accepted-evidence-retrieved"
+          mkdir -p "$METADATA_ROOT" "$RETRIEVED_ROOT"
+          PRESENCE_PATH="$METADATA_ROOT/presence.json"
+          # GraphQL variables must remain literal for gh.
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -f query='query($owner:String!,$name:String!,$tag:String!,$ref:String!){repository(owner:$owner,name:$name){release(tagName:$tag){tagName isDraft isPrerelease} ref(qualifiedName:$ref){target{oid}}}}' \
+            -f owner="$REPOSITORY_OWNER" \
+            -f name="$REPOSITORY_NAME" \
+            -f tag="$EVIDENCE_TAG" \
+            -f ref="refs/tags/$EVIDENCE_TAG" > "$PRESENCE_PATH"
+          PRESENCE_STATE="$(jq -er 'if (.data.repository.release == null and .data.repository.ref == null) then "absent" elif (.data.repository.release != null and .data.repository.ref != null) then "present" else "partial" end' "$PRESENCE_PATH")"
+          case "$PRESENCE_STATE" in
+            absent)
+              gh release create "$EVIDENCE_TAG" "$PACKET_PATH" "$BUNDLE_PATH" \
+                --repo "$REPOSITORY" \
+                --target "$ARTIFACT_SOURCE_SHA" \
+                --title "$EVIDENCE_RELEASE_NAME" \
+                --notes "Immutable retained evidence for the accepted NeonDiff Desktop 1.1.0 packet. This is evidence, not a product release." \
+                --prerelease \
+                --latest=false
+              ;;
+            present) ;;
+            *)
+              echo "evidence release/tag state is partial; destructive replacement is forbidden" >&2
+              exit 1
+              ;;
+          esac
+
+          gh api "repos/$REPOSITORY/releases/tags/$EVIDENCE_TAG" > "$METADATA_ROOT/release.json"
+          gh api "repos/$REPOSITORY/git/ref/tags/$EVIDENCE_TAG" > "$METADATA_ROOT/tag-ref.json"
+          gh release download "$EVIDENCE_TAG" \
+            --repo "$REPOSITORY" \
+            --dir "$RETRIEVED_ROOT" \
+            --pattern "$PACKET_NAME" \
+            --pattern "$BUNDLE_NAME"
+          RETENTION_RESULT="$(node scripts/verify-desktop-accepted-evidence-release.mjs \
+            --packet "$RETRIEVED_ROOT/$PACKET_NAME" \
+            --bundle "$RETRIEVED_ROOT/$BUNDLE_NAME" \
+            --release "$METADATA_ROOT/release.json" \
+            --tag-ref "$METADATA_ROOT/tag-ref.json")"
+          test "$(jq -er '.retained' <<< "$RETENTION_RESULT")" = "true"
+          test "$(jq -er '.artifactSourceSHA' <<< "$RETENTION_RESULT")" = "$ARTIFACT_SOURCE_SHA"
+          test "$(jq -er '.packetFileName' <<< "$RETENTION_RESULT")" = "$PACKET_NAME"
+          test "$(jq -er '.artifactAttestationBundleFileName' <<< "$RETENTION_RESULT")" = "$BUNDLE_NAME"
+          printf '%s\n' "$RETENTION_RESULT"

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -120,6 +120,31 @@ that archive into fresh staging, computes the tree identity, and rejects any
 mismatch, unavailable/changed reference, untrusted location, or changed config.
 It contains references to secrets rather than secret values.
 
+For Desktop `1.1.0`, the canonical retained-evidence location is the immutable,
+evidence-only GitHub prerelease/tag
+`neondiff-accepted-packet-v1.1.0`. It is not the product release and is excluded
+from latest-release selection. It targets the packet's exact artifact source
+commit and contains exactly two assets: the content-addressed accepted packet
+and its content-addressed verified artifact-source-attestation bundle. The
+30-day Actions artifact is transit and convenience evidence only; expiry cannot
+remove the canonical pair.
+
+The producer job keeps read, OIDC, and attestation-write authority. Only its
+dependent retention job receives release-content write and attestation-read
+authority. That job may create the fixed evidence release once or verify an
+already exact immutable release. It must download the published assets into a
+fresh directory and re-prove the fixed repository, tag, commit, workflow,
+packet/bundle names, digests, sizes, and GitHub release attestation. A partial or
+mismatched release/tag fails closed; automation never overwrites, deletes, or
+rotates retained evidence.
+
+No workflow has retained-evidence deletion authority. Exceptional deletion is
+a separately reviewed repository-administrator action. GitHub permanently
+retires an immutable release tag after deletion, so any approved successor uses
+a new fixed identity and records why the prior evidence became unavailable.
+This authority does not permit deleting the stable product release, changing
+feed bytes, or replacing accepted packet bytes.
+
 ## Gates and single implementation path
 
 Mac promotion requires one tested implementation path owning preflight,

--- a/scripts/lib/desktop-accepted-evidence-release.mjs
+++ b/scripts/lib/desktop-accepted-evidence-release.mjs
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { closeSync, constants, fstatSync, openSync, readFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+
+export const DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY = "electricsheephq/evaos-code-review-bot-neondiff";
+export const DESKTOP_ACCEPTED_EVIDENCE_TAG = "neondiff-accepted-packet-v1.1.0";
+export const DESKTOP_ACCEPTED_EVIDENCE_RELEASE_NAME = "NeonDiff accepted packet evidence v1.1.0";
+
+const SIGNER_WORKFLOW = `${DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY}/.github/workflows/desktop-accepted-release-packet.yml`;
+const SOURCE_REF = "refs/heads/main";
+const STABLE_TAG = "v1.1.0";
+const TEAM_ID = "TC6MS3T6NN";
+const PACKET_KIND = "neondiff.desktop.accepted-release-packet-v3";
+const CLAIM_CLASS = "neondiff.desktop.artifact-source-promotion.v1";
+const PREDICATE_TYPE = "https://neondiff.com/attestations/desktop-artifact-source-promotion/v1";
+const SHA1 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const ARTIFACT_NAME = /^NeonDiff-1\.1\.0-build[0-9]+-macOS\.zip$/;
+const MAX_PACKET_BYTES = 1024 * 1024;
+const MAX_BUNDLE_BYTES = 4 * 1024 * 1024;
+const MAX_METADATA_BYTES = 1024 * 1024;
+const INPUT_FIELDS = ["packetPath", "bundlePath", "releasePath", "tagRefPath"];
+const PACKET_FIELDS = ["schemaVersion", "kind", "verified", "channel", "version", "build", "tag", "sourceSHA", "artifactSourceSHA", "tagObjectSHA", "artifactURL", "artifactName", "artifactByteLength", "artifactSHA256", "treeSHA256", "feedSHA256", "feedEntry", "enclosureProofSHA256", "releaseContract", "productionContract", "npmReleaseClass"];
+const PREDICATE_FIELDS = ["schemaVersion", "claimClass", "repository", "signerWorkflow", "workflowSourceRef", "workflowSourceSHA", "releaseTag", "artifactSourceSHA", "developerIDTeamID"];
+const STRICT_JSON = String.raw`
+import json,sys
+def pairs(values):
+    result = {}
+    for key,value in values:
+        if key in result: raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+value = json.loads(sys.stdin.buffer.read(), object_pairs_hook=pairs)
+sys.stdout.write(json.dumps(value, separators=(",", ":")))
+`;
+
+function fail(message) { throw new Error(message); }
+function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+function sameFile(left, right) { return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode && left.size === right.size && left.mtimeNs === right.mtimeNs && left.ctimeNs === right.ctimeNs; }
+function exactObject(value, fields, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).length !== fields.length || fields.some((field) => !Object.hasOwn(value, field))) fail(`${label} is not canonical`);
+}
+function boundedBytes(input, label, maximum) {
+  if (typeof input !== "string" || !input) fail(`${label} path is invalid`);
+  const path = resolve(input); let descriptor;
+  try {
+    descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const before = fstatSync(descriptor, { bigint: true });
+    if (!before.isFile() || before.size < 1n || before.size > BigInt(maximum)) fail(`${label} must be a bounded regular file`);
+    const bytes = readFileSync(descriptor), after = fstatSync(descriptor, { bigint: true });
+    if (!after.isFile() || !sameFile(before, after) || BigInt(bytes.length) !== before.size) fail(`${label} changed during read`);
+    return { path, bytes, digest: sha256(bytes) };
+  } catch (error) {
+    if (error?.code === "ELOOP") fail(`${label} must not be symlinked`);
+    throw error;
+  } finally { if (descriptor !== undefined) closeSync(descriptor); }
+}
+function strictJSON(bytes, label) {
+  const result = spawnSync("/usr/bin/python3", ["-I", "-c", STRICT_JSON], { input: bytes, encoding: "utf8", maxBuffer: MAX_BUNDLE_BYTES });
+  try { if (result.error || result.signal || result.status !== 0) fail(`${label} is malformed`); return JSON.parse(result.stdout); } catch { fail(`${label} is malformed`); }
+}
+function canonicalContext() {
+  const workflowSHA = process.env.GITHUB_SHA;
+  if (process.env.GITHUB_ACTIONS !== "true" || process.env.GITHUB_REPOSITORY !== DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY || process.env.GITHUB_REF !== SOURCE_REF || !SHA1.test(workflowSHA ?? "") || process.env.GITHUB_WORKFLOW_REF !== `${SIGNER_WORKFLOW}@${SOURCE_REF}` || process.env.RUNNER_ENVIRONMENT !== "github-hosted") fail("canonical GitHub-hosted workflow identity is required");
+  return { workflowSHA };
+}
+function exactPacket(path) {
+  const evidence = boundedBytes(path, "accepted packet", MAX_PACKET_BYTES), packet = strictJSON(evidence.bytes, "accepted packet"); exactObject(packet, PACKET_FIELDS, "accepted packet");
+  if (packet.schemaVersion !== 3 || packet.kind !== PACKET_KIND || packet.verified !== true || packet.channel !== "stable" || packet.version !== "1.1.0" || packet.tag !== STABLE_TAG || !/^[1-9][0-9]*$/.test(packet.build ?? "") || !SHA1.test(packet.sourceSHA ?? "") || packet.artifactSourceSHA !== packet.sourceSHA || !SHA1.test(packet.tagObjectSHA ?? "") || packet.tagObjectSHA === packet.sourceSHA || !ARTIFACT_NAME.test(packet.artifactName ?? "") || !Number.isSafeInteger(packet.artifactByteLength) || packet.artifactByteLength < 1 || !SHA256.test(packet.artifactSHA256 ?? "") || !SHA256.test(packet.treeSHA256 ?? "") || !SHA256.test(packet.feedSHA256 ?? "") || !SHA256.test(packet.enclosureProofSHA256 ?? "") || packet.releaseContract !== "paid-mac-ga-byo-v1" || !packet.feedEntry || typeof packet.feedEntry !== "object" || Array.isArray(packet.feedEntry)) fail("accepted packet identity is not canonical");
+  const artifactURL = `https://github.com/${DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY}/releases/download/${STABLE_TAG}/${packet.artifactName}`;
+  if (packet.artifactURL !== artifactURL || packet.feedEntry.url !== artifactURL || basename(evidence.path) !== `${evidence.digest}.packet.json`) fail("accepted packet content address is not canonical");
+  return { ...evidence, packet, name: basename(evidence.path) };
+}
+function exactBundle(path, packet, workflowSHA) {
+  const evidence = boundedBytes(path, "artifact-source attestation bundle", MAX_BUNDLE_BYTES);
+  if (basename(evidence.path) !== `${evidence.digest}.artifact-source-attestation.json`) fail("artifact-source attestation content address is not canonical");
+  const bundle = strictJSON(evidence.bytes, "artifact-source attestation bundle"), payload = bundle?.dsseEnvelope?.payload, signatures = bundle?.dsseEnvelope?.signatures;
+  if (bundle?.mediaType !== "application/vnd.dev.sigstore.bundle.v0.3+json" || !bundle.verificationMaterial || typeof bundle.verificationMaterial !== "object" || Object.keys(bundle.verificationMaterial).length < 1 || bundle?.dsseEnvelope?.payloadType !== "application/vnd.in-toto+json" || typeof payload !== "string" || !payload || !Array.isArray(signatures) || signatures.length < 1 || signatures.some((value) => typeof value?.sig !== "string" || !value.sig || Buffer.from(value.sig, "base64").toString("base64") !== value.sig)) fail("artifact-source attestation bundle is malformed");
+  const decoded = Buffer.from(payload, "base64"); if (!decoded.length || decoded.toString("base64") !== payload) fail("artifact-source attestation bundle is malformed");
+  const statement = strictJSON(decoded, "artifact-source attestation statement"), subject = statement?.subject, predicate = statement?.predicate;
+  exactObject(statement, ["_type", "subject", "predicateType", "predicate"], "artifact-source attestation statement"); exactObject(predicate, PREDICATE_FIELDS, "artifact-source attestation predicate");
+  if (statement._type !== "https://in-toto.io/Statement/v1" || statement.predicateType !== PREDICATE_TYPE || !Array.isArray(subject) || subject.length !== 1 || subject[0]?.name !== packet.artifactName || subject[0]?.digest?.sha256 !== packet.artifactSHA256 || Object.keys(subject[0] ?? {}).length !== 2 || Object.keys(subject[0]?.digest ?? {}).length !== 1) fail("artifact-source attestation subject is not canonical");
+  const expected = { schemaVersion: 1, claimClass: CLAIM_CLASS, repository: DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY, signerWorkflow: SIGNER_WORKFLOW, workflowSourceRef: SOURCE_REF, workflowSourceSHA: workflowSHA, releaseTag: STABLE_TAG, artifactSourceSHA: packet.sourceSHA, developerIDTeamID: TEAM_ID };
+  if (PREDICATE_FIELDS.some((field) => predicate[field] !== expected[field])) fail("artifact-source attestation predicate is not canonical");
+  return { ...evidence, name: basename(evidence.path) };
+}
+function exactRelease(releasePath, tagRefPath, packet, retained) {
+  const release = strictJSON(boundedBytes(releasePath, "evidence release metadata", MAX_METADATA_BYTES).bytes, "evidence release metadata"), tagRef = strictJSON(boundedBytes(tagRefPath, "evidence tag metadata", MAX_METADATA_BYTES).bytes, "evidence tag metadata");
+  if (tagRef?.ref !== `refs/tags/${DESKTOP_ACCEPTED_EVIDENCE_TAG}` || tagRef?.object?.type !== "commit" || tagRef?.object?.sha !== packet.sourceSHA) fail("evidence tag is not bound to the artifact source");
+  if (release?.tag_name !== DESKTOP_ACCEPTED_EVIDENCE_TAG || release?.name !== DESKTOP_ACCEPTED_EVIDENCE_RELEASE_NAME || release?.draft !== false || release?.prerelease !== true || release?.immutable !== true || release?.target_commitish !== packet.sourceSHA || release?.html_url !== `https://github.com/${DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY}/releases/tag/${DESKTOP_ACCEPTED_EVIDENCE_TAG}` || !Array.isArray(release.assets) || release.assets.length !== retained.length) fail("immutable evidence release metadata is required");
+  for (const evidence of retained) {
+    const matches = release.assets.filter((asset) => asset?.name === evidence.name), url = `https://github.com/${DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY}/releases/download/${DESKTOP_ACCEPTED_EVIDENCE_TAG}/${evidence.name}`;
+    if (matches.length !== 1 || matches[0]?.digest !== `sha256:${evidence.digest}` || matches[0]?.size !== evidence.bytes.length || matches[0]?.browser_download_url !== url) fail("evidence release asset identity mismatch");
+  }
+}
+function githubVerify(path) {
+  const calls = [["release", "verify", DESKTOP_ACCEPTED_EVIDENCE_TAG, "--repo", DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY, "--format", "json"], ["release", "verify-asset", DESKTOP_ACCEPTED_EVIDENCE_TAG, path.packet, "--repo", DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY, "--format", "json"], ["release", "verify-asset", DESKTOP_ACCEPTED_EVIDENCE_TAG, path.bundle, "--repo", DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY, "--format", "json"]];
+  for (const args of calls) { const result = spawnSync("gh", args, { encoding: "utf8", env: { ...process.env, GH_PAGER: "cat", PAGER: "cat", NO_COLOR: "1" }, maxBuffer: MAX_BUNDLE_BYTES, timeout: 30_000 }); if (result.error || result.signal || result.status !== 0) fail("GitHub immutable release verification failed"); try { strictJSON(Buffer.from(result.stdout), "GitHub release verification result"); } catch { fail("GitHub immutable release verification failed"); } }
+}
+
+export function verifyRetainedDesktopAcceptedEvidence(input) {
+  exactObject(input, INPUT_FIELDS, "retained evidence input"); for (const field of INPUT_FIELDS) if (typeof input[field] !== "string" || !input[field]) fail("retained evidence input is not canonical");
+  const context = canonicalContext(), packet = exactPacket(input.packetPath), bundle = exactBundle(input.bundlePath, packet.packet, context.workflowSHA);
+  if (dirname(packet.path) !== dirname(bundle.path)) fail("retained evidence files must share one release download directory");
+  exactRelease(input.releasePath, input.tagRefPath, packet.packet, [packet, bundle]); githubVerify({ packet: packet.path, bundle: bundle.path });
+  return Object.freeze({ retained: true, repository: DESKTOP_ACCEPTED_EVIDENCE_REPOSITORY, releaseTag: DESKTOP_ACCEPTED_EVIDENCE_TAG, artifactSourceSHA: packet.packet.sourceSHA, workflowSourceSHA: context.workflowSHA, packetSHA256: packet.digest, packetFileName: packet.name, artifactAttestationBundleSHA256: bundle.digest, artifactAttestationBundleFileName: bundle.name });
+}

--- a/scripts/lib/desktop-accepted-evidence-release.mjs
+++ b/scripts/lib/desktop-accepted-evidence-release.mjs
@@ -45,7 +45,7 @@ function boundedBytes(input, label, maximum) {
   if (typeof input !== "string" || !input) fail(`${label} path is invalid`);
   const path = resolve(input); let descriptor;
   try {
-    descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    descriptor = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0));
     const before = fstatSync(descriptor, { bigint: true });
     if (!before.isFile() || before.size < 1n || before.size > BigInt(maximum)) fail(`${label} must be a bounded regular file`);
     const bytes = readFileSync(descriptor), after = fstatSync(descriptor, { bigint: true });

--- a/scripts/verify-desktop-accepted-evidence-release.mjs
+++ b/scripts/verify-desktop-accepted-evidence-release.mjs
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+import { verifyRetainedDesktopAcceptedEvidence } from "./lib/desktop-accepted-evidence-release.mjs";
+
+const NAMES = ["packet", "bundle", "release", "tag-ref"];
+function fail(message) { throw new Error(message); }
+function parseArguments(values) {
+  if (values.length !== NAMES.length * 2) fail("exact retained evidence arguments are required");
+  const parsed = Object.create(null);
+  for (let index = 0; index < values.length; index += 2) {
+    const flag = values[index], value = values[index + 1], name = typeof flag === "string" && flag.startsWith("--") ? flag.slice(2) : "";
+    if (!NAMES.includes(name) || Object.hasOwn(parsed, name) || typeof value !== "string" || !value) fail("retained evidence arguments are invalid"); parsed[name] = resolve(value);
+  }
+  return parsed;
+}
+try {
+  const values = parseArguments(process.argv.slice(2)), receipt = verifyRetainedDesktopAcceptedEvidence({ packetPath: values.packet, bundlePath: values.bundle, releasePath: values.release, tagRefPath: values["tag-ref"] });
+  process.stdout.write(`${JSON.stringify(receipt)}\n`);
+} catch { process.stderr.write("retained accepted evidence verification failed\n"); process.exitCode = 1; }

--- a/tests/desktop-accepted-evidence-release.test.ts
+++ b/tests/desktop-accepted-evidence-release.test.ts
@@ -145,6 +145,7 @@ process.stdout.write("{}\\n");
   ], {
     cwd: process.cwd(),
     encoding: "utf8",
+    timeout: 1500,
     env: {
       ...process.env,
       PATH: `${root}:${process.env.PATH}`,
@@ -195,6 +196,11 @@ describe("retained accepted Desktop evidence", () => {
     const packetLink = join(linkedRoot, linked.packetName);
     symlinkSync(linked.packetPath, packetLink);
     expect(linked.run({ packet: packetLink }).status).not.toBe(0);
+
+    const fifo = fixture(), fifoPath = join(fifo.root, fifo.packetName);
+    expect(spawnSync("mkfifo", [fifoPath]).status).toBe(0);
+    const fifoResult = fifo.run({ packet: fifoPath });
+    expect(fifoResult.error).toBeUndefined(); expect(fifoResult.status).not.toBe(0);
 
     const oversized = fixture(); truncateSync(oversized.bundlePath, 4 * 1024 * 1024 + 1);
     expect(oversized.run().status).not.toBe(0);

--- a/tests/desktop-accepted-evidence-release.test.ts
+++ b/tests/desktop-accepted-evidence-release.test.ts
@@ -1,0 +1,223 @@
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [];
+const repository = "electricsheephq/evaos-code-review-bot-neondiff";
+const workflow = `${repository}/.github/workflows/desktop-accepted-release-packet.yml`;
+const sourceRef = "refs/heads/main";
+const evidenceTag = "neondiff-accepted-packet-v1.1.0";
+const evidenceReleaseName = "NeonDiff accepted packet evidence v1.1.0";
+const sourceSHA = "1".repeat(40);
+const workflowSHA = "2".repeat(40);
+const tagObjectSHA = "3".repeat(40);
+const artifactSHA256 = "4".repeat(64);
+
+function sha256(bytes: Buffer) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-retained-evidence-"));
+  roots.push(root);
+  const releaseDownload = join(root, "release-download");
+  const actionsArtifact = join(root, "expired-actions-artifact");
+  mkdirSync(releaseDownload);
+
+  const artifactName = "NeonDiff-1.1.0-build11091-macOS.zip";
+  const packet = {
+    schemaVersion: 3,
+    kind: "neondiff.desktop.accepted-release-packet-v3",
+    verified: true,
+    channel: "stable",
+    version: "1.1.0",
+    build: "11091",
+    tag: "v1.1.0",
+    sourceSHA,
+    artifactSourceSHA: sourceSHA,
+    tagObjectSHA,
+    artifactURL: `https://github.com/${repository}/releases/download/v1.1.0/${artifactName}`,
+    artifactName,
+    artifactByteLength: 4096,
+    artifactSHA256,
+    treeSHA256: "5".repeat(64),
+    feedSHA256: "6".repeat(64),
+    feedEntry: {
+      url: `https://github.com/${repository}/releases/download/v1.1.0/${artifactName}`,
+      length: 4096,
+      type: "application/octet-stream",
+      version: "1.1.0",
+      build: "11091",
+      shortVersionString: "1.1.0",
+      minimumSystemVersion: "13.0",
+      channel: "stable",
+      edSignature: "fixture"
+    },
+    enclosureProofSHA256: "7".repeat(64),
+    releaseContract: "paid-mac-ga-byo-v1",
+    productionContract: { contract: "paid-mac-beta-byo-v1", byoGitHubEnabled: true, managedGitHubBrokerEnabledPresent: false, githubBrokerOriginPresent: false },
+    npmReleaseClass: "desktop-only"
+  };
+  const packetBytes = Buffer.from(`${JSON.stringify(packet)}\n`);
+  const packetSHA256 = sha256(packetBytes);
+  const packetName = `${packetSHA256}.packet.json`;
+  const packetPath = join(releaseDownload, packetName);
+  writeFileSync(packetPath, packetBytes);
+
+  const predicate = {
+    schemaVersion: 1,
+    claimClass: "neondiff.desktop.artifact-source-promotion.v1",
+    repository,
+    signerWorkflow: workflow,
+    workflowSourceRef: sourceRef,
+    workflowSourceSHA: workflowSHA,
+    releaseTag: "v1.1.0",
+    artifactSourceSHA: sourceSHA,
+    developerIDTeamID: "TC6MS3T6NN"
+  };
+  const statement = {
+    _type: "https://in-toto.io/Statement/v1",
+    subject: [{ name: artifactName, digest: { sha256: artifactSHA256 } }],
+    predicateType: "https://neondiff.com/attestations/desktop-artifact-source-promotion/v1",
+    predicate
+  };
+  const bundle = {
+    mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+    verificationMaterial: { tlogEntries: [{}] },
+    dsseEnvelope: {
+      payload: Buffer.from(JSON.stringify(statement)).toString("base64"),
+      payloadType: "application/vnd.in-toto+json",
+      signatures: [{ sig: Buffer.alloc(64, 1).toString("base64") }]
+    }
+  };
+  const bundleBytes = Buffer.from(JSON.stringify(bundle));
+  const bundleSHA256 = sha256(bundleBytes);
+  const bundleName = `${bundleSHA256}.artifact-source-attestation.json`;
+  const bundlePath = join(releaseDownload, bundleName);
+  writeFileSync(bundlePath, bundleBytes);
+
+  const releasePath = join(root, "release.json");
+  writeFileSync(releasePath, JSON.stringify({
+    tag_name: evidenceTag,
+    name: evidenceReleaseName,
+    draft: false,
+    prerelease: true,
+    immutable: true,
+    target_commitish: sourceSHA,
+    html_url: `https://github.com/${repository}/releases/tag/${evidenceTag}`,
+    assets: [
+      { name: packetName, size: packetBytes.length, digest: `sha256:${packetSHA256}`, browser_download_url: `https://github.com/${repository}/releases/download/${evidenceTag}/${packetName}` },
+      { name: bundleName, size: bundleBytes.length, digest: `sha256:${bundleSHA256}`, browser_download_url: `https://github.com/${repository}/releases/download/${evidenceTag}/${bundleName}` }
+    ]
+  }));
+  const tagRefPath = join(root, "tag-ref.json");
+  writeFileSync(tagRefPath, JSON.stringify({ ref: `refs/tags/${evidenceTag}`, object: { type: "commit", sha: sourceSHA } }));
+
+  const capturePath = join(root, "gh-calls.jsonl");
+  const fakeGh = join(root, "gh");
+  writeFileSync(fakeGh, `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+appendFileSync(process.env.CAPTURE_PATH, JSON.stringify(process.argv.slice(2)) + "\\n");
+if (process.env.FAKE_GH_FAIL === process.argv.slice(2, 5).join(" ")) process.exit(1);
+process.stdout.write("{}\\n");
+`);
+  chmodSync(fakeGh, 0o755);
+
+  const run = (paths: Record<string, string> = {}, env: Record<string, string> = {}) => spawnSync(process.execPath, [
+    "scripts/verify-desktop-accepted-evidence-release.mjs",
+    "--packet", paths.packet ?? packetPath,
+    "--bundle", paths.bundle ?? bundlePath,
+    "--release", paths.release ?? releasePath,
+    "--tag-ref", paths.tagRef ?? tagRefPath
+  ], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${root}:${process.env.PATH}`,
+      CAPTURE_PATH: capturePath,
+      GITHUB_ACTIONS: "true",
+      GITHUB_REPOSITORY: repository,
+      GITHUB_REF: sourceRef,
+      GITHUB_SHA: workflowSHA,
+      GITHUB_WORKFLOW_REF: `${workflow}@${sourceRef}`,
+      RUNNER_ENVIRONMENT: "github-hosted",
+      ...env
+    }
+  });
+  return { actionsArtifact, bundleName, bundlePath, bundleSHA256, capturePath, packetName, packetPath, packetSHA256, releasePath, root, run };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("retained accepted Desktop evidence", () => {
+  it("reloads and verifies the exact immutable-release pair after the Actions artifact expires", () => {
+    const value = fixture();
+    expect(existsSync(value.actionsArtifact)).toBe(false);
+    const result = value.run();
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      retained: true,
+      repository,
+      releaseTag: evidenceTag,
+      artifactSourceSHA: sourceSHA,
+      workflowSourceSHA: workflowSHA,
+      packetSHA256: value.packetSHA256,
+      packetFileName: value.packetName,
+      artifactAttestationBundleSHA256: value.bundleSHA256,
+      artifactAttestationBundleFileName: value.bundleName
+    });
+    const calls = readFileSync(value.capturePath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(calls).toEqual([
+      ["release", "verify", evidenceTag, "--repo", repository, "--format", "json"],
+      ["release", "verify-asset", evidenceTag, expect.stringMatching(new RegExp(`${value.packetName}$`)), "--repo", repository, "--format", "json"],
+      ["release", "verify-asset", evidenceTag, expect.stringMatching(new RegExp(`${value.bundleName}$`)), "--repo", repository, "--format", "json"]
+    ]);
+  });
+
+  it("fails closed for unsafe bytes, mutable identity, duplicates, and failed GitHub verification", () => {
+    const linked = fixture(), linkedRoot = join(linked.root, "linked-download"); mkdirSync(linkedRoot);
+    const packetLink = join(linkedRoot, linked.packetName);
+    symlinkSync(linked.packetPath, packetLink);
+    expect(linked.run({ packet: packetLink }).status).not.toBe(0);
+
+    const oversized = fixture(); truncateSync(oversized.bundlePath, 4 * 1024 * 1024 + 1);
+    expect(oversized.run().status).not.toBe(0);
+
+    const duplicate = fixture(), duplicateRelease = JSON.parse(readFileSync(duplicate.releasePath, "utf8"));
+    duplicateRelease.assets.push({ ...duplicateRelease.assets[0], digest: `sha256:${"9".repeat(64)}` });
+    writeFileSync(duplicate.releasePath, JSON.stringify(duplicateRelease));
+    expect(duplicate.run().status).not.toBe(0);
+
+    const wrongTarget = fixture(), wrongRelease = JSON.parse(readFileSync(wrongTarget.releasePath, "utf8"));
+    wrongRelease.target_commitish = "8".repeat(40); writeFileSync(wrongTarget.releasePath, JSON.stringify(wrongRelease));
+    expect(wrongTarget.run().status).not.toBe(0);
+    expect(fixture().run({}, { GITHUB_REPOSITORY: "attacker/example" }).status).not.toBe(0);
+    expect(fixture().run({}, { FAKE_GH_FAIL: `release verify ${evidenceTag}` }).status).not.toBe(0);
+  });
+
+  it("keeps creation separate from signing and forbids automated replacement or deletion", () => {
+    const workflowSource = readFileSync(".github/workflows/desktop-accepted-release-packet.yml", "utf8");
+    expect(workflowSource).toContain("  promote-stable-artifact:\n    name: Verify source binding and build accepted packet\n    permissions:\n      contents: read\n      id-token: write\n      attestations: write");
+    expect(workflowSource).toContain("  retain-accepted-packet:\n    name: Retain exact accepted packet in immutable release\n    needs: promote-stable-artifact\n    permissions:\n      contents: write\n      attestations: read");
+    expect(workflowSource).toContain("actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0");
+    expect(workflowSource).toContain("gh release create \"$EVIDENCE_TAG\"");
+    expect(workflowSource).toContain("--prerelease"); expect(workflowSource).toContain("--latest=false");
+    expect(workflowSource).not.toMatch(/gh release delete|gh api[^\n]*-X DELETE/);
+  });
+});


### PR DESCRIPTION
## Outcome

Retain the exact accepted Desktop `1.1.0` packet and its verified
artifact-source-attestation bundle beyond the 30-day Actions artifact lifetime,
without adding a storage service or weakening the producer job's authority.

## Implementation

- Reuses GitHub immutable Releases through one fixed evidence-only prerelease
  tag: `neondiff-accepted-packet-v1.1.0`, excluded from latest selection and
  targeted at the packet's exact artifact source commit.
- Keeps the existing producer at `contents: read`, `id-token: write`, and
  `attestations: write`. A dependent job alone receives `contents: write` and
  `attestations: read`.
- Creates the evidence release only when both the release and tag are absent;
  reruns verify an already exact release. Partial or mismatched state fails
  closed and automation never deletes or replaces evidence.
- Reloads the two published assets into a fresh directory and verifies bounded
  no-follow files, content-addressed names, exact packet/bundle pairing, fixed
  repository/tag/source/workflow identities, immutable REST metadata, release
  asset digests/sizes/URLs, and GitHub release/asset attestations.
- Documents exceptional deletion/rotation as a separately reviewed
  repository-admin action that permanently retires the immutable tag.

## Validation

- Failing-first expiry fixture: Actions artifact absent, exact immutable-release
  download required.
- 30 focused tests passed across retained evidence, accepted packet generation,
  and artifact-source attestation.
- `actionlint` passed for the changed workflow.
- Both new Node modules passed syntax checks.
- Exact-lock Node 26 build passed.
- Repository secret scan and staged diff checks passed.
- Initial adversarial FIFO finding: `MERGE_BLOCKING / FIXED NOW`. The bounded
  reader now opens with `O_NONBLOCK` before rejecting non-regular files, and a
  timed FIFO regression proves an ordinary failure instead of a blocked read.
- Scope: 5 files, 497 insertions; no runtime, customer, billing, updater,
  rollback, feed, or product-release mutation.

## Proof boundary

Passing proves durable retrieval and exact pairing of accepted packet and
attestation evidence only. It does not prove the promoted artifact,
publication, updater/rollback, installed runtime, customer journey, RC, or GA
readiness.

Closes #1087
