### PR TITLE
Hold raw daemon PR review lane

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2500,6 +2500,7 @@ async function runRawDaemon(args: ParsedArgs): Promise<void> {
     const cycleResult = await runDaemonCycle({
       cycle,
       dryRun,
+      reviewLane: "held",
       pilotRepos: config.pilotRepos,
       monitoredRepos,
       canaryPulls: config.canaryPulls ?? [],

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -32,6 +32,7 @@ export function shouldExitDaemonAfterFailedCycle(result: DaemonCycleResult, runO
 export interface RunDaemonCycleOptions {
   cycle: number;
   dryRun: boolean;
+  reviewLane?: "active" | "held";
   configPath?: string;
   pilotRepos: string[];
   monitoredRepos: string[];
@@ -137,6 +138,25 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     ? runIssueEnrichmentLane({ input, admissions, stdout, stderr, recordHeartbeat, heartbeatRunId })
     : Promise.resolve();
 
+  if (input.reviewLane === "held") {
+    stdout(formatDaemonLog({
+      event: "daemon_review_lane_held",
+      cycle: input.cycle,
+      dryRun: input.dryRun,
+      reason: "scoped_review_required"
+    }));
+    await issueEnrichmentPromise;
+    const result = emptyRunOnceResult();
+    stdout(formatDaemonLog({
+      event: "daemon_cycle_complete",
+      cycle: input.cycle,
+      dryRun: input.dryRun,
+      result
+    }));
+    recordHeartbeat("daemon_cycle_complete", undefined, heartbeatRunId);
+    return { ok: true, result };
+  }
+
   try {
     const result = await runOnceImpl({
       configPath: input.configPath,
@@ -200,6 +220,30 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     recordHeartbeat("daemon_cycle_failed", "daemon_cycle_failed", heartbeatRunId);
     return { ok: false, failureKind: "runtime_failure", error: message };
   }
+}
+
+function emptyRunOnceResult(): RunOnceResult {
+  return {
+    reposScanned: 0,
+    pullsSeen: 0,
+    reviewed: 0,
+    failed: 0,
+    skippedDraft: 0,
+    skippedCanary: 0,
+    skippedPolicy: 0,
+    skippedLicenseGate: 0,
+    skippedCommandStop: 0,
+    skippedCommandExplain: 0,
+    skippedFinishingTouchDraft: 0,
+    commandReviewRequested: 0,
+    skippedProcessed: 0,
+    skippedCapacity: 0,
+    skippedContextBudget: 0,
+    skippedProviderCooldown: 0,
+    skippedStaleHead: 0,
+    baselinedExisting: 0,
+    policySkips: []
+  };
 }
 
 export function cleanupReviewWorktreesFromConfig(input: {

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -525,6 +525,86 @@ describe("daemon cycle resilience", () => {
         })
       })
     ]));
+  });
+
+  it("holds PR review work while preserving live issue enrichment", async () => {
+    const stdout: string[] = [];
+    const calls = { review: 0, retry: 0, enrichment: 0 };
+
+    const result = await runDaemonCycle({
+      cycle: 13,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewLane: "held",
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => {
+        calls.review += 1;
+        throw new Error("held PR review lane must not run");
+      },
+      retryProviderCooldownsImpl: async () => {
+        calls.retry += 1;
+        throw new Error("held PR retry lane must not run");
+      },
+      issueEnrichmentCycleImpl: async (options) => {
+        calls.enrichment += 1;
+        expect(options.dryRun).toBe(false);
+        return successfulIssueEnrichmentCycleResult();
+      },
+      recordHeartbeatImpl: () => undefined,
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      result: {
+        reposScanned: 0,
+        pullsSeen: 0,
+        reviewed: 0,
+        failed: 0,
+        skippedDraft: 0,
+        skippedCanary: 0,
+        skippedPolicy: 0,
+        skippedLicenseGate: 0,
+        skippedCommandStop: 0,
+        skippedCommandExplain: 0,
+        skippedFinishingTouchDraft: 0,
+        commandReviewRequested: 0,
+        skippedProcessed: 0,
+        skippedCapacity: 0,
+        skippedContextBudget: 0,
+        skippedProviderCooldown: 0,
+        skippedStaleHead: 0,
+        baselinedExisting: 0,
+        policySkips: []
+      }
+    });
+    expect(calls).toEqual({ review: 0, retry: 0, enrichment: 1 });
+    expect(stdout.map((line) => JSON.parse(line))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event: "daemon_review_lane_held",
+        cycle: 13,
+        dryRun: false,
+        reason: "scoped_review_required"
+      }),
+      expect.objectContaining({ event: "daemon_issue_enrichment", phase: "complete", cycle: 13 }),
+      expect.objectContaining({ event: "daemon_cycle_complete", cycle: 13 })
+    ]));
+  });
+
+  it("pins the raw daemon to the held PR lane without an argv override", () => {
+    const cliSource = readFileSync(join(process.cwd(), "src/cli.ts"), "utf8");
+    const start = cliSource.indexOf("async function runRawDaemon");
+    const end = cliSource.indexOf("\nasync function resolveCLIReviewRuntimeCredentials", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const rawDaemonSource = cliSource.slice(start, end);
+    expect(rawDaemonSource).toContain('reviewLane: "held"');
+    expect(rawDaemonSource).not.toMatch(/args\[(?:"|')review-lane(?:"|')\]/);
   });
 
   it("starts issue enrichment while the review batch is still unresolved", async () => {


### PR DESCRIPTION
## Outcome

Hold the raw daemon's broad pull-request review lane while preserving the independently admitted issue-enrichment lane. Exact scoped `review-pr` promotion remains the only live PR-post path.

Part of #965.

## Change

- add an internal `active | held` daemon review-lane selection, defaulting programmatic callers to the existing active behavior;
- pin `runRawDaemon` to `held` with no argv-selectable override;
- in held mode, skip PR discovery and provider-cooldown retry, emit an explicit held event, and return an all-zero PR result;
- preserve live issue enrichment and its existing admission, heartbeat, and error isolation;
- add red-to-green fixtures for held behavior and fixed raw-daemon routing.

## Validation

- red fixture reproduced the pre-change PR worker call and failed as `EXPECTED_NEGATIVE`;
- selected held fixtures: 2/2 passed;
- `tests/daemon-loop.test.ts`: 18/18 passed;
- TypeScript build typecheck with `tsc -p tsconfig.build.json --noEmit`: passed;
- `git diff --check`: passed.

## Scope and proof boundary

Three files, 126 insertions and 1 deletion. No schema, state, service, dependency, config flag, installed-runtime, customer, billing, or release mutation. This PR proves source behavior only after exact-head CI and independent review; issue #965 remains open for its remaining acceptance, and this PR does not prove Desktop routing, installed runtime behavior, release readiness, or customer readiness.
