### PR TITLE
Clarify held PR lane in native setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,13 +198,14 @@ by the existing API-backed activation, and the signed app path—never a key
 value or key-file path. The headless app re-derives that device ID from its
 Keychain identity and rejects a mismatched plist before releasing credentials.
 Review and daemon readiness remain separate gates. The LaunchAgent's background
-PR review lane remains held: daemon liveness may cover the independently
-admitted issue-enrichment lane, but it never authorizes a PR post. Live PR
-posting uses only the exact scoped `review-pr` dry review plus explicit
-same-head confirmation; the matching approval is consumed atomically. The
-immutable published prerelease and clean-Mac artifact proof remain distribution
-gates. Unsigned development builds still require an executable global or
-checksum-managed worker before native first run
+PR review lane remains held: the daemon may run the independently admitted
+issue-enrichment lane, but a heartbeat proves service liveness only and never
+authorizes a PR post. Issue-enrichment success requires lane-specific result
+evidence. Live PR posting uses only the exact scoped `review-pr` dry review plus
+explicit same-head confirmation; the matching approval is consumed atomically.
+The immutable published prerelease and clean-Mac artifact proof remain
+distribution gates. Unsigned development builds still require an executable
+global or checksum-managed worker before native first run
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected

--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ Review and daemon readiness remain separate gates. The LaunchAgent's background
 PR review lane remains held: the daemon may run the independently admitted
 issue-enrichment lane, but a heartbeat proves service liveness only and never
 authorizes a PR post. Issue-enrichment success requires lane-specific result
-evidence. Live PR posting uses only the exact scoped `review-pr` dry review plus
-explicit same-head confirmation; the matching approval is consumed atomically.
+evidence. Native live PR posting uses only the exact scoped `review-pr` dry
+review plus explicit same-head confirmation; the matching approval is consumed
+atomically.
 The immutable published prerelease and clean-Mac artifact proof remain
 distribution gates. Unsigned development builds still require an executable
 global or checksum-managed worker before native first run

--- a/README.md
+++ b/README.md
@@ -197,7 +197,11 @@ public App ID, config path, launchd label, the non-secret broker device ID used
 by the existing API-backed activation, and the signed app path—never a key
 value or key-file path. The headless app re-derives that device ID from its
 Keychain identity and rejects a mismatched plist before releasing credentials.
-Review and daemon readiness remain separate gates. The
+Review and daemon readiness remain separate gates. The LaunchAgent's background
+PR review lane remains held: daemon liveness may cover the independently
+admitted issue-enrichment lane, but it never authorizes a PR post. Live PR
+posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation; the matching approval is consumed atomically. The
 immutable published prerelease and clean-Mac artifact proof remain distribution
 gates. Unsigned development builds still require an executable global or
 checksum-managed worker before native first run

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -106,7 +106,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
                 }
                 throw error
             }
-            return "Installed and started the Keychain-backed local review worker without placing its private key in the LaunchAgent."
+            return "Installed and started the Keychain-backed background worker with its PR review lane held. Live PR posts still require an exact scoped dry review and same-head confirmation."
         }.value
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -290,13 +290,15 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             : "repositories"
 
         return """
-        Ready to install and start the secret-free local review worker.
+        Ready to install and start the secret-free background worker.
         LaunchAgent: \(plistPath)
         Program: \(appExecutableURL.standardizedFileURL.path)
         ProgramArguments: \(redactedArguments)
         Sealed worker: \(sealedWorkerPath)
         EnvironmentVariables: none
         Launch policy: RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua; stdout=/dev/null; stderr=/dev/null.
+        Background PR review lane: held.
+        Live PR posting: exact scoped review-pr dry review plus explicit same-head confirmation only.
         Credentials: Keychain-only at runtime; no secret values in the plist, arguments, or environment.
         Repository allowlist: preserved unchanged (\(preservedRepositoryCount) configured \(repositoryLabel)); no config write.
         Mutation: write only the selected user LaunchAgent, then restart that exact service.

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -174,7 +174,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set)
         var isKeychainWorkerLaunchAgentOperationInProgress = false
     @Published package private(set) var keychainWorkerLaunchAgentStatus =
-        "Install and start the local review worker when setup is ready."
+        "Install and start the background worker when setup is ready. Its PR review lane remains held."
     package var localWorkerExecutionContextProvider:
         (@MainActor () -> [DesktopLocalBotExecutionContext])?
     @Published package var logText = "No logs loaded."
@@ -2634,7 +2634,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let manager = dependencies.keychainWorkerLaunchAgentManager
         isKeychainWorkerLaunchAgentOperationInProgress = true
         keychainWorkerLaunchAgentStatus =
-            "Installing and starting the secret-free local review worker…"
+            "Installing the secret-free background worker with its PR review lane held…"
         Task { [weak self] in
             do {
                 let status = try await manager.installAndStart(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -105,7 +105,7 @@ import NeonDiffDesktopCore
         #expect(parsed == request)
     }
 
-    @Test func sealedWorkerDaemonRunsLiveAfterExplicitNativeInstall() throws {
+    @Test func sealedWorkerDaemonRunsWithHeldPRLaneAfterExplicitNativeInstall() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
         )
@@ -237,6 +237,10 @@ import NeonDiffDesktopCore
             "RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua"
         ))
         #expect(preview.contains("stdout=/dev/null; stderr=/dev/null"))
+        #expect(preview.contains("Background PR review lane: held"))
+        #expect(preview.contains(
+            "Live PR posting: exact scoped review-pr dry review plus explicit same-head confirmation only."
+        ))
         #expect(preview.contains(
             "Repository allowlist: preserved unchanged (53 configured repositories)"
         ))

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -362,13 +362,15 @@ unsafe app/config/worker path, unavailable Keychain item, device mismatch, or
 launchd failure fails closed. Do not replace this with a `security -w` wrapper,
 export the key to disk, or weaken its Keychain access control.
 
-The installed LaunchAgent's background PR review lane remains held. Its daemon
-heartbeat is service and independently admitted issue-enrichment liveness only;
-it never authorizes a PR review or post. Live PR posting uses only the exact
-scoped `review-pr` dry review plus explicit same-head confirmation, and that
-matching approval is consumed atomically. **Install & Start** and
-**Start/Restart** therefore manage the background service; they do not bypass
-the separate **Run Dry Review** and **Post Live Review** controls.
+The installed LaunchAgent's background PR review lane remains held. A heartbeat
+proves service liveness only; issue-enrichment success requires lane-specific
+result evidence. The independently admitted issue-enrichment lane may run, but
+neither its admission nor the daemon heartbeat authorizes a PR review or post.
+Live PR posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation, and that matching approval is consumed atomically.
+**Install & Start** and **Start/Restart** therefore manage the background
+service; they do not bypass the separate **Run Dry Review** and **Post Live
+Review** controls.
 
 After Checkout displays the one-shot NeonDiff Activation Key, return to the
 native **License** pane, paste the key, and choose **Continue with this key**,

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -366,8 +366,9 @@ The installed LaunchAgent's background PR review lane remains held. A heartbeat
 proves service liveness only; issue-enrichment success requires lane-specific
 result evidence. The independently admitted issue-enrichment lane may run, but
 neither its admission nor the daemon heartbeat authorizes a PR review or post.
-Live PR posting uses only the exact scoped `review-pr` dry review plus explicit
-same-head confirmation, and that matching approval is consumed atomically.
+Native live PR posting uses only the exact scoped `review-pr` dry review plus
+explicit same-head confirmation, and that matching approval is consumed
+atomically.
 **Install & Start** and **Start/Restart** therefore manage the background
 service; they do not bypass the separate **Run Dry Review** and **Post Live
 Review** controls.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -362,6 +362,14 @@ unsafe app/config/worker path, unavailable Keychain item, device mismatch, or
 launchd failure fails closed. Do not replace this with a `security -w` wrapper,
 export the key to disk, or weaken its Keychain access control.
 
+The installed LaunchAgent's background PR review lane remains held. Its daemon
+heartbeat is service and independently admitted issue-enrichment liveness only;
+it never authorizes a PR review or post. Live PR posting uses only the exact
+scoped `review-pr` dry review plus explicit same-head confirmation, and that
+matching approval is consumed atomically. **Install & Start** and
+**Start/Restart** therefore manage the background service; they do not bypass
+the separate **Run Dry Review** and **Post Live Review** controls.
+
 After Checkout displays the one-shot NeonDiff Activation Key, return to the
 native **License** pane, paste the key, and choose **Continue with this key**,
 then **Activate**. **Buy an Activation Key** opens the public pricing page but
@@ -665,7 +673,9 @@ a filesystem security boundary. The automatically selected exact standard
 LaunchAgent path does not require that override; explicitly supplied paths
 outside the package root still do.
 
-Live `review-pr` posting is intentionally harder than dry-run inspection. Use
+Starting this raw daemon does not enable background PR review: that lane remains
+held while its independently admitted issue-enrichment work may run. Live
+`review-pr` posting is intentionally harder than dry-run inspection. Use
 `--dry-run true` for normal local checks. A live scoped PR review requires
 `--dry-run false --confirm true` after the target repo, PR, head SHA, and config
 path are approved by the relevant issue.

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -180,9 +180,9 @@ supplies the accepted runtime bytes.
 The BYO Mac LaunchAgent's background PR review lane remains held. Its heartbeat
 proves service liveness only; issue-enrichment success requires lane-specific
 result evidence. The independently admitted issue-enrichment lane may run, but
-neither its admission nor the heartbeat authorizes a PR review or post. Live PR
-posting uses only the exact scoped `review-pr` dry review plus explicit same-head
-confirmation; the matching approval is consumed atomically, and
+neither its admission nor the heartbeat authorizes a PR review or post. Native
+live PR posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation; the matching approval is consumed atomically, and
 install/start/restart cannot create it.
 
 The tested promotion and rollback implementation is not yet established for

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -178,10 +178,12 @@ proof. A checked-out tree, local build, or mutable channel pointer never
 supplies the accepted runtime bytes.
 
 The BYO Mac LaunchAgent's background PR review lane remains held. Its heartbeat
-may prove service and independently admitted issue-enrichment liveness, but it
-never authorizes a PR review or post. Live PR posting uses only the exact scoped
-`review-pr` dry review plus explicit same-head confirmation; the matching
-approval is consumed atomically, and install/start/restart cannot create it.
+proves service liveness only; issue-enrichment success requires lane-specific
+result evidence. The independently admitted issue-enrichment lane may run, but
+neither its admission nor the heartbeat authorizes a PR review or post. Live PR
+posting uses only the exact scoped `review-pr` dry review plus explicit same-head
+confirmation; the matching approval is consumed atomically, and
+install/start/restart cannot create it.
 
 The tested promotion and rollback implementation is not yet established for
 this contract. Its absence is an active Mac GA release blocker, not an implied

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -177,6 +177,12 @@ dry-before-live checks are required gates, but they are not installed-runtime
 proof. A checked-out tree, local build, or mutable channel pointer never
 supplies the accepted runtime bytes.
 
+The BYO Mac LaunchAgent's background PR review lane remains held. Its heartbeat
+may prove service and independently admitted issue-enrichment liveness, but it
+never authorizes a PR review or post. Live PR posting uses only the exact scoped
+`review-pr` dry review plus explicit same-head confirmation; the matching
+approval is consumed atomically, and install/start/restart cannot create it.
+
 The tested promotion and rollback implementation is not yet established for
 this contract. Its absence is an active Mac GA release blocker, not an implied
 manual step. The later manifest and release-candidate canary successors are

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -224,6 +224,12 @@ returned head SHA, and requires explicit confirmation before a live post pinned
 to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
+For the signed BYO Mac LaunchAgent, the background PR review lane remains held.
+Its heartbeat is service and independently admitted issue-enrichment liveness,
+not review authority. Live PR posting uses only the exact scoped `review-pr`
+dry review plus explicit same-head confirmation; installing, starting, or
+restarting the background service cannot manufacture that approval.
+
 If this matched local worker reports **Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle
 named in the same immutable GitHub prerelease and release manifest as the app.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -228,9 +228,9 @@ For the signed BYO Mac LaunchAgent, the background PR review lane remains held.
 A heartbeat proves service liveness only; issue-enrichment success requires
 lane-specific result evidence. The independently admitted issue-enrichment lane
 may run, but neither its admission nor the heartbeat supplies review authority.
-Live PR posting uses only the exact scoped `review-pr` dry review plus explicit
-same-head confirmation; installing, starting, or restarting the background
-service cannot manufacture that approval.
+Native live PR posting uses only the exact scoped `review-pr` dry review plus
+explicit same-head confirmation; installing, starting, or restarting the
+background service cannot manufacture that approval.
 
 If this matched local worker reports **Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -225,10 +225,12 @@ to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
 For the signed BYO Mac LaunchAgent, the background PR review lane remains held.
-Its heartbeat is service and independently admitted issue-enrichment liveness,
-not review authority. Live PR posting uses only the exact scoped `review-pr`
-dry review plus explicit same-head confirmation; installing, starting, or
-restarting the background service cannot manufacture that approval.
+A heartbeat proves service liveness only; issue-enrichment success requires
+lane-specific result evidence. The independently admitted issue-enrichment lane
+may run, but neither its admission nor the heartbeat supplies review authority.
+Live PR posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation; installing, starting, or restarting the background
+service cannot manufacture that approval.
 
 If this matched local worker reports **Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -15,8 +15,18 @@ Recommended first review proof:
 cd /path/to/neondiff
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
-npm run run-once -- --config /absolute/path/to/config.local.json --dry-run true --repo owner/repo --pr 123
+npm run cli -- review-pr \
+  --config /absolute/path/to/config.local.json \
+  --repo owner/repo \
+  --pr 123 \
+  --expected-config-revision <verified-config-revision> \
+  --dry-run true \
+  --zcode true
 ```
+
+Use the exact `configRevision` from the successful provider verification. The
+returned exact head and this scoped dry receipt are prerequisites for the
+separate same-head live confirmation.
 
 After the GitHub App is installed, use app credentials and keep `--dry-run true` for the first observation window:
 

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -2,7 +2,13 @@
 
 Launchd should stay disabled until GitHub App installation is complete and a real ZCode dry-run succeeds without rate limiting.
 
-Recommended first live command:
+For the BYO Mac path, the LaunchAgent's background PR review lane remains held,
+including when the daemon runs with `--dry-run false`. That live daemon mode may
+run the independently admitted issue-enrichment lane, but its heartbeat never
+authorizes PR work. Live PR posting uses only the exact scoped `review-pr` dry
+review plus explicit same-head confirmation.
+
+Recommended first review proof:
 
 ```bash
 cd /path/to/neondiff
@@ -41,7 +47,9 @@ Minimum LaunchAgent environment block:
 </dict>
 ```
 
-Only switch to `--dry-run false` after:
+Switch the long-running daemon to `--dry-run false` only for its independently
+governed issue-enrichment work; the background PR review lane stays held. Before
+that transition:
 
 - current-head duplicate reruns post nothing,
 - review-plan JSON contains only valid current-diff lines,

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -6,8 +6,9 @@ For the BYO Mac path, the LaunchAgent's background PR review lane remains held,
 including when the daemon runs with `--dry-run false`. That live daemon mode may
 run the independently admitted issue-enrichment lane. A heartbeat proves service
 liveness only; issue-enrichment success requires lane-specific result evidence.
-Neither its admission nor the heartbeat authorizes PR work. Live PR posting uses
-only the exact scoped `review-pr` dry review plus explicit same-head confirmation.
+Neither its admission nor the heartbeat authorizes PR work. Native live PR
+posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation.
 
 Recommended first review proof:
 

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -4,9 +4,10 @@ Launchd should stay disabled until GitHub App installation is complete and a rea
 
 For the BYO Mac path, the LaunchAgent's background PR review lane remains held,
 including when the daemon runs with `--dry-run false`. That live daemon mode may
-run the independently admitted issue-enrichment lane, but its heartbeat never
-authorizes PR work. Live PR posting uses only the exact scoped `review-pr` dry
-review plus explicit same-head confirmation.
+run the independently admitted issue-enrichment lane. A heartbeat proves service
+liveness only; issue-enrichment success requires lane-specific result evidence.
+Neither its admission nor the heartbeat authorizes PR work. Live PR posting uses
+only the exact scoped `review-pr` dry review plus explicit same-head confirmation.
 
 Recommended first review proof:
 

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -134,7 +134,7 @@ describe("NeonDiff public community funnel", () => {
       const normalized = text.replace(/\s+/g, " ");
       expect(normalized).toMatch(/background PR review lane (?:is|remains) held/i);
       expect(normalized).toMatch(
-        /live PR posting.*exact scoped `?review-pr`?.*dry review.*explicit same-head confirmation/i
+        /native live PR posting.*exact scoped `?review-pr`?.*dry review.*explicit same-head confirmation/i
       );
       expect(normalized).toMatch(/heartbeat proves service liveness only/i);
       expect(normalized).toMatch(

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -141,6 +141,13 @@ describe("NeonDiff public community funnel", () => {
         /issue-enrichment success requires lane-specific/i
       );
     }
+
+    const launchd = read("docs/launchd.md");
+    expect(launchd).toContain("npm run cli -- review-pr");
+    expect(launchd).toContain(
+      "--expected-config-revision <verified-config-revision>"
+    );
+    expect(launchd).not.toContain("npm run run-once");
   });
 
   it("license boundary surfaces are canonical and avoid open-source claims", () => {

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -136,6 +136,10 @@ describe("NeonDiff public community funnel", () => {
       expect(normalized).toMatch(
         /live PR posting.*exact scoped `?review-pr`?.*dry review.*explicit same-head confirmation/i
       );
+      expect(normalized).toMatch(/heartbeat proves service liveness only/i);
+      expect(normalized).toMatch(
+        /issue-enrichment success requires lane-specific/i
+      );
     }
   });
 

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -121,6 +121,24 @@ describe("NeonDiff public community funnel", () => {
     }
   });
 
+  it("public Mac setup names the held background PR lane and exact live authority", () => {
+    const surfaces = [
+      read("README.md"),
+      read("docs/SETUP.md"),
+      read("docs/github-app-setup.md"),
+      read("docs/architecture/mac-ga-release-contract.md"),
+      read("docs/launchd.md")
+    ];
+
+    for (const text of surfaces) {
+      const normalized = text.replace(/\s+/g, " ");
+      expect(normalized).toMatch(/background PR review lane (?:is|remains) held/i);
+      expect(normalized).toMatch(
+        /live PR posting.*exact scoped `?review-pr`?.*dry review.*explicit same-head confirmation/i
+      );
+    }
+  });
+
   it("license boundary surfaces are canonical and avoid open-source claims", () => {
     const license = read("LICENSE.md");
     const boundary = read("docs/license-boundary.md");


### PR DESCRIPTION
## Outcome

Complete the source-only Mac GA dry-before-live gate by making every native and
repository setup surface describe the accepted authority split:

- the LaunchAgent background PR-review lane is held;
- daemon heartbeat proves service liveness only, while issue-enrichment success
  requires lane-specific result evidence;
- a native UI live PR post requires the exact scoped `review-pr` dry review
  plus explicit same-head confirmation; and
- install, start, restart, or heartbeat cannot create posting authority.

## Cumulative issue acceptance

This small reconciliation delta sits on the already-merged source controls:

- PR #983 pins exact `{repo, pull_number, head_sha, config revision}` approval,
  atomic one-shot consumption, replay rejection, and stale/mismatched failure;
- PR #1097 holds the raw daemon PR lane while preserving independently admitted
  issue enrichment; and
- PR #1099 prevents daemon heartbeat/readiness from implying PR-post authority.

This PR updates native status/preview copy, README and setup contracts, and one
failing-first public-surface fixture. It does not introduce a new scheduler,
state store, service, schema, permission, CLI flag, or runtime mutation.

## Exact-head focused proof

Candidate: `f8ff8df622a679194e68479db6ea0bcbe9445d22`

- public community funnel: 11/11
- Desktop LaunchAgent contract: 20/20
- exact scoped Desktop review seam: 1/1
- daemon/state/worker focused tests: 159/159
- source TypeScript compile: pass
- diff hygiene: pass

Review delta 1 classified heartbeat-overclaim feedback as
`MERGE_BLOCKING / FIXED NOW`. A failing-first fixture reproduced the wording
gap; the corrected contract now states that heartbeat proves service liveness
only and issue-enrichment success requires lane-specific result evidence. The
affected public-surface suite passes 11/11 on the corrected head. All native
and TypeScript source files are byte-unchanged from the initially validated
head.

Review delta 2 classified the stale `run-once` LaunchAgent proof as
`MERGE_BLOCKING / FIXED NOW`. A failing-first fixture reproduced that it could
not create the exact scoped approval. The guide now uses
`npm run cli -- review-pr`, pins the verified config revision, and retains dry
mode; the affected suite passes 11/11. Only `docs/launchd.md` and its public
surface fixture changed from the previously reviewed head.

Review delta 3 classified the unqualified exclusivity claim as
`MERGE_BLOCKING / FIXED NOW`. The repository still supports a separately
documented operator `run-once --dry-run false` path, so the five-surface
contract now scopes exact dry-to-live exclusivity to native posting. Its
failing-first fixture passes 11/11. This was the third and final governed source
correction for this PR; any new verified blocker uses the recorded split/park
fallback rather than a fourth in-place patch.

Authoritative full CI and exact-head independent reviews remain required before
merge.

## Safety and proof boundary

No installed app, LaunchAgent, worker, config, DB, lease, Keychain, customer,
billing, feed, artifact, release, or website deployment state was changed.
Merging proves only the source contract and focused/remote test scope. It does
not prove packaged Desktop behavior, a provider call or GitHub post, installed
runtime behavior, website publication, release, or customer readiness.

Closes #965
