### PR TITLE
Clarify held PR lane in native setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,16 @@ public App ID, config path, launchd label, the non-secret broker device ID used
 by the existing API-backed activation, and the signed app path—never a key
 value or key-file path. The headless app re-derives that device ID from its
 Keychain identity and rejects a mismatched plist before releasing credentials.
-Review and daemon readiness remain separate gates. The
-immutable published prerelease and clean-Mac artifact proof remain distribution
-gates. Unsigned development builds still require an executable global or
-checksum-managed worker before native first run
+Review and daemon readiness remain separate gates. The LaunchAgent's background
+PR review lane remains held: the daemon may run the independently admitted
+issue-enrichment lane, but a heartbeat proves service liveness only and never
+authorizes a PR post. Issue-enrichment success requires lane-specific result
+evidence. Native live PR posting uses only the exact scoped `review-pr` dry
+review plus explicit same-head confirmation; the matching approval is consumed
+atomically.
+The immutable published prerelease and clean-Mac artifact proof remain
+distribution gates. Unsigned development builds still require an executable
+global or checksum-managed worker before native first run
 exposes **Initialize Local Config** (non-destructive; never force-overwrites),
 **Add Repository**, **Apply Repository**, and **Verify App Access** without a
 terminal or operator config edit. **Apply Repository** writes both the selected

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/FoundationKeychainWorkerLaunchAgentManager.swift
@@ -106,7 +106,7 @@ struct FoundationKeychainWorkerLaunchAgentManager:
                 }
                 throw error
             }
-            return "Installed and started the Keychain-backed local review worker without placing its private key in the LaunchAgent."
+            return "Installed and started the Keychain-backed background worker with its PR review lane held. Live PR posts still require an exact scoped dry review and same-head confirmation."
         }.value
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/DesktopKeychainWorkerLaunchAgent.swift
@@ -290,13 +290,15 @@ package enum DesktopKeychainWorkerLaunchAgentContract {
             : "repositories"
 
         return """
-        Ready to install and start the secret-free local review worker.
+        Ready to install and start the secret-free background worker.
         LaunchAgent: \(plistPath)
         Program: \(appExecutableURL.standardizedFileURL.path)
         ProgramArguments: \(redactedArguments)
         Sealed worker: \(sealedWorkerPath)
         EnvironmentVariables: none
         Launch policy: RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua; stdout=/dev/null; stderr=/dev/null.
+        Background PR review lane: held.
+        Live PR posting: exact scoped review-pr dry review plus explicit same-head confirmation only.
         Credentials: Keychain-only at runtime; no secret values in the plist, arguments, or environment.
         Repository allowlist: preserved unchanged (\(preservedRepositoryCount) configured \(repositoryLabel)); no config write.
         Mutation: write only the selected user LaunchAgent, then restart that exact service.

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -174,7 +174,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package private(set)
         var isKeychainWorkerLaunchAgentOperationInProgress = false
     @Published package private(set) var keychainWorkerLaunchAgentStatus =
-        "Install and start the local review worker when setup is ready."
+        "Install and start the background worker when setup is ready. Its PR review lane remains held."
     package var localWorkerExecutionContextProvider:
         (@MainActor () -> [DesktopLocalBotExecutionContext])?
     @Published package var logText = "No logs loaded."
@@ -2634,7 +2634,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         let manager = dependencies.keychainWorkerLaunchAgentManager
         isKeychainWorkerLaunchAgentOperationInProgress = true
         keychainWorkerLaunchAgentStatus =
-            "Installing and starting the secret-free local review worker…"
+            "Installing the secret-free background worker with its PR review lane held…"
         Task { [weak self] in
             do {
                 let status = try await manager.installAndStart(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -105,7 +105,7 @@ import NeonDiffDesktopCore
         #expect(parsed == request)
     }
 
-    @Test func sealedWorkerDaemonRunsLiveAfterExplicitNativeInstall() throws {
+    @Test func sealedWorkerDaemonRunsWithHeldPRLaneAfterExplicitNativeInstall() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
         )
@@ -237,6 +237,10 @@ import NeonDiffDesktopCore
             "RunAtLoad=true; KeepAlive=true; ProcessType=Background; Session=Aqua"
         ))
         #expect(preview.contains("stdout=/dev/null; stderr=/dev/null"))
+        #expect(preview.contains("Background PR review lane: held"))
+        #expect(preview.contains(
+            "Live PR posting: exact scoped review-pr dry review plus explicit same-head confirmation only."
+        ))
         #expect(preview.contains(
             "Repository allowlist: preserved unchanged (53 configured repositories)"
         ))

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/DesktopKeychainWorkerLaunchAgentTests.swift
@@ -105,7 +105,7 @@ import NeonDiffDesktopCore
         #expect(parsed == request)
     }
 
-    @Test func sealedWorkerDaemonRunsWithHeldPRLaneAfterExplicitNativeInstall() throws {
+    @Test func sealedWorkerDaemonArgumentsAreLiveAndSecretFree() throws {
         let config = home.appending(
             path: "Library/Application Support/NeonDiffDesktop/Accounts/account-1/Bots/bot-1/config.local.json"
         )

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -362,6 +362,17 @@ unsafe app/config/worker path, unavailable Keychain item, device mismatch, or
 launchd failure fails closed. Do not replace this with a `security -w` wrapper,
 export the key to disk, or weaken its Keychain access control.
 
+The installed LaunchAgent's background PR review lane remains held. A heartbeat
+proves service liveness only; issue-enrichment success requires lane-specific
+result evidence. The independently admitted issue-enrichment lane may run, but
+neither its admission nor the daemon heartbeat authorizes a PR review or post.
+Native live PR posting uses only the exact scoped `review-pr` dry review plus
+explicit same-head confirmation, and that matching approval is consumed
+atomically.
+**Install & Start** and **Start/Restart** therefore manage the background
+service; they do not bypass the separate **Run Dry Review** and **Post Live
+Review** controls.
+
 After Checkout displays the one-shot NeonDiff Activation Key, return to the
 native **License** pane, paste the key, and choose **Continue with this key**,
 then **Activate**. **Buy an Activation Key** opens the public pricing page but
@@ -665,7 +676,9 @@ a filesystem security boundary. The automatically selected exact standard
 LaunchAgent path does not require that override; explicitly supplied paths
 outside the package root still do.
 
-Live `review-pr` posting is intentionally harder than dry-run inspection. Use
+Starting this raw daemon does not enable background PR review: that lane remains
+held while its independently admitted issue-enrichment work may run. Live
+`review-pr` posting is intentionally harder than dry-run inspection. Use
 `--dry-run true` for normal local checks. A live scoped PR review requires
 `--dry-run false --confirm true` after the target repo, PR, head SHA, and config
 path are approved by the relevant issue.

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -177,6 +177,14 @@ dry-before-live checks are required gates, but they are not installed-runtime
 proof. A checked-out tree, local build, or mutable channel pointer never
 supplies the accepted runtime bytes.
 
+The BYO Mac LaunchAgent's background PR review lane remains held. Its heartbeat
+proves service liveness only; issue-enrichment success requires lane-specific
+result evidence. The independently admitted issue-enrichment lane may run, but
+neither its admission nor the heartbeat authorizes a PR review or post. Native
+live PR posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation; the matching approval is consumed atomically, and
+install/start/restart cannot create it.
+
 The tested promotion and rollback implementation is not yet established for
 this contract. Its absence is an active Mac GA release blocker, not an implied
 manual step. The later manifest and release-candidate canary successors are

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -224,6 +224,14 @@ returned head SHA, and requires explicit confirmation before a live post pinned
 to both. Any transport failure revokes approval and requires a new dry review.
 Daemon-wide start stays blocked for a multi-repository worker.
 
+For the signed BYO Mac LaunchAgent, the background PR review lane remains held.
+A heartbeat proves service liveness only; issue-enrichment success requires
+lane-specific result evidence. The independently admitted issue-enrichment lane
+may run, but neither its admission nor the heartbeat supplies review authority.
+Native live PR posting uses only the exact scoped `review-pr` dry review plus
+explicit same-head confirmation; installing, starting, or restarting the
+background service cannot manufacture that approval.
+
 If this matched local worker reports **Worker update required**, choose
 **Install / Update Local Worker** and use only the checksum-bound B0 bundle
 named in the same immutable GitHub prerelease and release manifest as the app.

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -2,14 +2,32 @@
 
 Launchd should stay disabled until GitHub App installation is complete and a real ZCode dry-run succeeds without rate limiting.
 
-Recommended first live command:
+For the BYO Mac path, the LaunchAgent's background PR review lane remains held,
+including when the daemon runs with `--dry-run false`. That live daemon mode may
+run the independently admitted issue-enrichment lane. A heartbeat proves service
+liveness only; issue-enrichment success requires lane-specific result evidence.
+Neither its admission nor the heartbeat authorizes PR work. Native live PR
+posting uses only the exact scoped `review-pr` dry review plus explicit
+same-head confirmation.
+
+Recommended first review proof:
 
 ```bash
 cd /path/to/neondiff
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
-npm run run-once -- --config /absolute/path/to/config.local.json --dry-run true --repo owner/repo --pr 123
+npm run cli -- review-pr \
+  --config /absolute/path/to/config.local.json \
+  --repo owner/repo \
+  --pr 123 \
+  --expected-config-revision <verified-config-revision> \
+  --dry-run true \
+  --zcode true
 ```
+
+Use the exact `configRevision` from the successful provider verification. The
+returned exact head and this scoped dry receipt are prerequisites for the
+separate same-head live confirmation.
 
 After the GitHub App is installed, use app credentials and keep `--dry-run true` for the first observation window:
 
@@ -41,7 +59,12 @@ Minimum LaunchAgent environment block:
 </dict>
 ```
 
-Only switch to `--dry-run false` after:
+Switch the long-running daemon to `--dry-run false` only after its independently
+governed issue-enrichment work and configured maintenance side effects are both
+approved; the background PR review lane stays held. Non-dry daemon operation
+can also perform review-worktree cleanup when `worktreeCleanup.enabled` is
+`true`. Disable `worktreeCleanup` if issue enrichment must be the sole live
+operation. Before that transition:
 
 - current-head duplicate reruns post nothing,
 - review-plan JSON contains only valid current-diff lines,

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -121,6 +121,43 @@ describe("NeonDiff public community funnel", () => {
     }
   });
 
+  it("public Mac setup names the held background PR lane and exact live authority", () => {
+    const surfaces = [
+      read("README.md"),
+      read("docs/SETUP.md"),
+      read("docs/github-app-setup.md"),
+      read("docs/architecture/mac-ga-release-contract.md"),
+      read("docs/launchd.md")
+    ];
+
+    for (const text of surfaces) {
+      const normalized = text.replace(/\s+/g, " ");
+      expect(normalized).toMatch(/background PR review lane (?:is|remains) held/i);
+      expect(normalized).toMatch(
+        /native live PR posting.*exact scoped `?review-pr`?.*dry review.*explicit same-head confirmation/i
+      );
+      expect(normalized).toMatch(/heartbeat proves service liveness only/i);
+      expect(normalized).toMatch(
+        /issue-enrichment success requires lane-specific/i
+      );
+    }
+
+    const launchd = read("docs/launchd.md");
+    expect(launchd).toContain("npm run cli -- review-pr");
+    expect(launchd).toContain(
+      "--expected-config-revision <verified-config-revision>"
+    );
+    expect(launchd).not.toContain("npm run run-once");
+    const normalizedLaunchd = launchd.replace(/\s+/g, " ");
+    expect(normalizedLaunchd).toMatch(
+      /non-dry daemon operation.*review-worktree cleanup/i
+    );
+    expect(launchd).toContain("worktreeCleanup.enabled");
+    expect(normalizedLaunchd).toMatch(
+      /disable .*worktreeCleanup.*issue enrichment.*sole live operation/i
+    );
+  });
+
   it("license boundary surfaces are canonical and avoid open-source claims", () => {
     const license = read("LICENSE.md");
     const boundary = read("docs/license-boundary.md");


### PR DESCRIPTION
## Outcome

Complete the source-only native Mac dry-before-live contract with one rebuilt
candidate:

- the LaunchAgent background PR-review lane remains held;
- install/start/restart and heartbeat cannot authorize a native PR post;
- native posting requires the exact scoped `review-pr` dry review plus explicit
  same-head confirmation and atomic approval consumption;
- heartbeat proves service liveness only, while issue-enrichment success needs
  lane-specific evidence; and
- non-dry raw-daemon operation also discloses configured review-worktree cleanup
  and the `worktreeCleanup.enabled` control.

## Rebuild provenance

PR #1100 closed unmerged after its governed `3/3` correction budget exposed the
cleanup-disclosure blocker. This replacement starts from protected main
`5aafa46d392e7ac3f309dcc323b0a3f5a7d7d113`, imports the accepted source without
its commits, and fixes that terminal blocker before the replacement's first and
only commit.

The cumulative implementation remains anchored by merged controls:

- PR #983: exact target/config-revision approval, atomic one-shot consumption,
  replay rejection, and stale/mismatch failure;
- PR #1097: held raw-daemon PR lane with separately admitted issue enrichment;
- PR #1099: truthful readiness that cannot infer PR authority from heartbeat.

No scheduler, state store, service, schema, permission, dependency, or runtime
behavior was added by this replacement.

## Exact-head focused proof

Candidate: `3c17f3a7ae7b8b668ad2d934727e43f424cb692a`

- public community funnel: 11/11
- Desktop LaunchAgent contract: 20/20
- exact scoped Desktop review seam: 1/1
- daemon/state/worker focused tests: 159/159
- source TypeScript compile: pass
- cumulative diff hygiene: pass

The cleanup disclosure fixture failed 1/11 before correction and passes 11/11
on this candidate. Authoritative remote CI, exact-head independent release-risk
review, and blind acceptance/adversarial verdicts remain required before merge.

## Safety and proof boundary

No installed app, LaunchAgent, worker, config, DB, lease, Keychain, customer,
billing, feed, artifact, release, or website deployment state was changed.
Merge proves only source and named test/CI scope. It does not prove packaged
Desktop behavior, a provider call or GitHub post, installed-runtime behavior,
website publication, release, or customer readiness.

Closes #965
