### PR TITLE
feat(issue-enrichment): classify admission decisions

### DIFF
--- a/src/issue-enrichment-admission-decision.ts
+++ b/src/issue-enrichment-admission-decision.ts
@@ -1,0 +1,52 @@
+import type { IssueEnrichmentAdmissionCandidate, IssueEnrichmentAdmissionSnapshot } from "./issue-enrichment-admission-snapshot.js";
+
+export type IssueEnrichmentAdmissionDecisionState = "pending" | "held" | "already_recorded" | "source_dependent";
+export type IssueEnrichmentAdmissionDecisionReason =
+  | "no_record" | "record_failed" | "record_skipped"
+  | "persisted_defer_active" | "persisted_defer_identity_unknown_or_changed" | "persisted_defer_due_or_unknown"
+  | "dry_run_equal_identity" | "dry_run_identity_unknown_or_changed" | "dry_run_requires_live"
+  | "posted_requires_source_comparison" | "current_defer_active" | "current_defer_due_or_unknown" | "current_scan_skipped";
+
+export interface IssueEnrichmentAdmissionDecision {
+  key: string;
+  state: IssueEnrichmentAdmissionDecisionState;
+  reason: IssueEnrichmentAdmissionDecisionReason;
+  candidate: Readonly<IssueEnrichmentAdmissionCandidate>;
+}
+
+export function classifyIssueEnrichmentAdmission(snapshot: Readonly<IssueEnrichmentAdmissionSnapshot>): readonly Readonly<IssueEnrichmentAdmissionDecision>[] {
+  if (!snapshot || !Object.isFrozen(snapshot) || !Array.isArray(snapshot.candidates) || !Object.isFrozen(snapshot.candidates)) fail("invalid_snapshot");
+  return Object.freeze(snapshot.candidates.map((candidate) => {
+    if (!candidate || !Object.isFrozen(candidate)) fail("invalid_candidate");
+    return classify(candidate, snapshot.checkedAt);
+  }));
+}
+
+function classify(candidate: Readonly<IssueEnrichmentAdmissionCandidate>, checkedAt: string): Readonly<IssueEnrichmentAdmissionDecision> {
+  if (candidate.action === "deferred") return decision(candidate, future(candidate.nextEligibleAt, checkedAt) ? "held" : "pending", future(candidate.nextEligibleAt, checkedAt) ? "current_defer_active" : "current_defer_due_or_unknown");
+  if (candidate.action === "skipped") return decision(candidate, "pending", "current_scan_skipped");
+  const record = candidate.record;
+  if (!record) return decision(candidate, "pending", "no_record");
+  if (record.status === "failed") return decision(candidate, "pending", "record_failed");
+  if (record.status === "skipped") return decision(candidate, "pending", "record_skipped");
+  if (record.status === "posted") return decision(candidate, "source_dependent", "posted_requires_source_comparison");
+  const sameKnownIdentity = typeof candidate.issueUpdatedAt === "string" && typeof record.issueUpdatedAt === "string" && candidate.issueUpdatedAt === record.issueUpdatedAt;
+  if (record.status === "deferred") {
+    if (!sameKnownIdentity) return decision(candidate, "pending", "persisted_defer_identity_unknown_or_changed");
+    return decision(candidate, future(record.nextEligibleAt, checkedAt) ? "held" : "pending", future(record.nextEligibleAt, checkedAt) ? "persisted_defer_active" : "persisted_defer_due_or_unknown");
+  }
+  if (candidate.action === "would_comment") return decision(candidate, "pending", "dry_run_requires_live");
+  return decision(candidate, sameKnownIdentity ? "already_recorded" : "pending", sameKnownIdentity ? "dry_run_equal_identity" : "dry_run_identity_unknown_or_changed");
+}
+
+function future(value: unknown, checkedAt: unknown): boolean {
+  if (typeof value !== "string" || typeof checkedAt !== "string") return false;
+  const deadline = Date.parse(value), now = Date.parse(checkedAt);
+  return Number.isFinite(deadline) && Number.isFinite(now) && deadline > now;
+}
+
+function decision(candidate: Readonly<IssueEnrichmentAdmissionCandidate>, state: IssueEnrichmentAdmissionDecisionState, reason: IssueEnrichmentAdmissionDecisionReason): Readonly<IssueEnrichmentAdmissionDecision> {
+  return Object.freeze(Object.assign(Object.create(null), { key: candidate.key, state, reason, candidate }));
+}
+
+function fail(reason: string): never { throw new Error(`issue_enrichment_admission_decision_${reason}`); }

--- a/tests/issue-enrichment-admission-decision.test.ts
+++ b/tests/issue-enrichment-admission-decision.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { classifyIssueEnrichmentAdmission } from "../src/issue-enrichment-admission-decision.js";
+import { snapshotIssueEnrichmentAdmission, type IssueEnrichmentAdmissionInput as Input } from "../src/issue-enrichment-admission-snapshot.js";
+
+const checkedAt = "2026-08-26T00:00:00Z", issueUpdatedAt = "2026-08-25T00:00:00Z";
+const snapshot = (action: Input["items"][number]["action"], record?: Input["records"] extends readonly (infer Record)[] | undefined ? Record : never, itemExtra: Record<string, unknown> = {}) => snapshotIssueEnrichmentAdmission({
+  allowlist: ["a/repo"], checkedAt, limits: {},
+  items: [{ repo: "a/repo", issueNumber: 1, state: "open", action, issueUpdatedAt, ...itemExtra }],
+  ...(record ? { records: [{ repo: "a/repo", issueNumber: 1, ...record }] as Input["records"] } : {})
+});
+
+describe("issue-enrichment admission decisions", () => {
+  it.each([
+    ["no record", snapshot("would_enrich"), "pending", "no_record"],
+    ["failed", snapshot("would_enrich", { status: "failed", issueUpdatedAt }), "pending", "record_failed"],
+    ["skipped", snapshot("would_enrich", { status: "skipped", issueUpdatedAt }), "pending", "record_skipped"],
+    ["future persisted defer, equal identity", snapshot("would_enrich", { status: "deferred", issueUpdatedAt, nextEligibleAt: "2026-08-27T00:00:00Z" }), "held", "persisted_defer_active"],
+    ["future persisted defer, changed identity", snapshot("would_enrich", { status: "deferred", issueUpdatedAt: "2026-08-24T00:00:00Z", nextEligibleAt: "2026-08-27T00:00:00Z" }), "pending", "persisted_defer_identity_unknown_or_changed"],
+    ["future persisted defer, unknown identity", snapshot("would_enrich", { status: "deferred", nextEligibleAt: "2026-08-27T00:00:00Z" }, { issueUpdatedAt: undefined }), "pending", "persisted_defer_identity_unknown_or_changed"],
+    ["due persisted defer", snapshot("would_enrich", { status: "deferred", issueUpdatedAt, nextEligibleAt: checkedAt }), "pending", "persisted_defer_due_or_unknown"],
+    ["dry run enrich, equal identity", snapshot("would_enrich", { status: "dry_run", issueUpdatedAt }), "already_recorded", "dry_run_equal_identity"],
+    ["dry run enrich, changed identity", snapshot("would_enrich", { status: "dry_run", issueUpdatedAt: "2026-08-24T00:00:00Z" }), "pending", "dry_run_identity_unknown_or_changed"],
+    ["dry run to live comment", snapshot("would_comment", { status: "dry_run", issueUpdatedAt }), "pending", "dry_run_requires_live"],
+    ["posted always needs source comparison", snapshot("would_enrich", { status: "posted", issueUpdatedAt, analysisInputHash: "a".repeat(64) }), "source_dependent", "posted_requires_source_comparison"],
+    ["future current defer", snapshot("deferred", undefined, { intendedAction: "would_enrich", nextEligibleAt: "2026-08-27T00:00:00Z" }), "held", "current_defer_active"],
+    ["due current defer", snapshot("deferred", undefined, { intendedAction: "would_enrich", nextEligibleAt: checkedAt }), "pending", "current_defer_due_or_unknown"],
+    ["current skipped", snapshot("skipped"), "pending", "current_scan_skipped"]
+  ] as const)("classifies %s conservatively", (_name, input, state, reason) => {
+    expect(classifyIssueEnrichmentAdmission(input)).toMatchObject([{ key: "a/repo#1", state, reason }]);
+  });
+
+  it("is deterministic and freezes decisions without changing candidate order", () => {
+    const input = snapshotIssueEnrichmentAdmission({ allowlist: ["b/repo", "a/repo"], checkedAt, limits: {}, items: [
+      { repo: "a/repo", issueNumber: 1, state: "open", action: "would_enrich", issueUpdatedAt },
+      { repo: "b/repo", issueNumber: 2, state: "open", action: "would_enrich", issueUpdatedAt }
+    ] });
+    const decisions = classifyIssueEnrichmentAdmission(input);
+    expect(decisions.map(({ key }) => key)).toEqual(["b/repo#2", "a/repo#1"]);
+    expect(Object.isFrozen(decisions)).toBe(true); expect(decisions.every(Object.isFrozen)).toBe(true);
+    expect(() => classifyIssueEnrichmentAdmission(null as any)).toThrow(/invalid_snapshot/);
+  });
+});


### PR DESCRIPTION
Closes #1026

## Summary

- add one pure classifier over accepted immutable #1025 snapshots
- classify candidates conservatively as `pending`, `held`, `already_recorded`, or `source_dependent`
- hold future deferrals only with the required identity/deadline evidence, keep dry-run-to-live and skipped/failed states pending, and require prepared-source comparison for every posted row
- return frozen deterministic decisions without persistence, caps, source preparation, integration, runtime, or public-contract changes

## Exact identity and scope

- base: `181215422a4a566a655ccfd099f3391346a75255`
- head: `0cf998b414d72ad30cc86b62087df6d2aeabc364`
- changed files: 2
- non-generated change: 94 additions
- source corrections used: 0/3

## Failing-first and local proof

Before source creation, the focused table fixture returned `EXPECTED_NEGATIVE` because `src/issue-enrichment-admission-decision.ts` did not exist.

Corrected proof:

- focused Vitest: 15/15 pass
- TypeScript `tsc -p tsconfig.build.json --noEmit`: pass
- `git diff --check`: pass
- exact-lock `npm ci`: pass; existing audit/install-script notices were not auto-fixed or broadened into this gate

The table covers no record, failed/skipped records, equal/changed/unknown identity, future/due/no deferred deadline, dry-run enrich versus live comment, every posted row regardless of stored hash, current deferred/skipped items, deterministic allowlist order, frozen outputs, and explicit invalid-snapshot rejection.

## Required merge barrier

Authoritative exact-head `Build, test, and package`, terminal finding dispositions, zero unresolved conversations, one selected independent semantic review, and blind acceptance/adversarial `PASS` verdicts at 95 or above are required before merge.

Passing proves only pure conservative idempotency decisions over accepted immutable snapshots at this exact head. It does not prove reservation/caps, source/evidence comparison, integration, live enrichment, runtime, release, or customer readiness.
