### PR TITLE
fix(issue-enrichment): settle admitted source lazily

### DIFF
--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1362,6 +1362,7 @@ export async function runIssueEnrichmentCycle(input: {
       repo.deferred = repoItems.filter((item) => item.action === "deferred").length;
     }
     Object.assign(summary, summarizeScan(scan.repos));
+    scan.recommendedActions = buildScanRecommendedActions(status, summary);
 
     if (!input.dryRun && input.advanceWatermarks !== false) {
       for (const repo of scanned.repos) {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -33,6 +33,9 @@ import { isAuthenticProductionLicenseAdmission, type ProductionLicenseAdmission 
 import { prepareBranchWorktree, type PreparedWorktree } from "./git.js";
 import { getProtectedCheckoutRoots } from "./path-safety.js";
 import { writeSecureFileSync } from "./temp-files.js";
+import { snapshotIssueEnrichmentAdmission } from "./issue-enrichment-admission-snapshot.js";
+import { classifyIssueEnrichmentAdmission } from "./issue-enrichment-admission-decision.js";
+import { createIssueEnrichmentAdmissionLedger } from "./issue-enrichment-admission-ledger.js";
 
 export interface IssueEnrichmentConfig {
   enabled: boolean;
@@ -329,7 +332,7 @@ export type IssueEnrichmentScanReason =
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
   | "global_max_comments_per_cycle"
-  | "burst_threshold_exceeded";
+  | "burst_threshold_exceeded" | "persisted_defer_active" | "repository_blocked";
 
 export function shouldDeferPreservationPreviewToPromotion(reason: IssueEnrichmentScanReason): boolean {
   return reason === "preservation_only_upstream_intake";
@@ -356,6 +359,7 @@ export interface IssueEnrichmentScanItem {
   state: string;
   action: IssueEnrichmentScanAction;
   reason: IssueEnrichmentScanReason;
+  intendedAction?: "would_enrich" | "would_comment";
   url?: string;
   nextEligibleAt?: string;
 }
@@ -925,21 +929,6 @@ export async function runIssueEnrichmentCycle(input: {
     if (shouldCollectModelEvidence) {
       if (!input.config.workRoot) throw new Error("issue_enrichment_model_runtime_paths_required");
       if (!input.github.getRepo) throw new Error("issue_enrichment_repository_metadata_required");
-      for (const repo of reposToScan) {
-        const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
-        if (!policy.allowed) continue;
-        const metadata = await input.github.getRepo(repo);
-        const defaultBranch = metadata.default_branch?.trim();
-        if (!defaultBranch) throw new Error(`issue_enrichment_default_branch_missing: ${repo}`);
-        sourceSnapshots.set(repo.toLowerCase(), await prepareBranchWorktree({
-          repo,
-          branch: defaultBranch,
-          ...(metadata.clone_url ? { repoUrl: metadata.clone_url } : {}),
-          workRoot: input.config.workRoot,
-          protectedCheckoutRoots: getProtectedCheckoutRoots()
-        }));
-        defaultBranches.set(repo.toLowerCase(), defaultBranch);
-      }
     }
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
@@ -995,16 +984,6 @@ export async function runIssueEnrichmentCycle(input: {
       plannedAnalysisInputHashByIssue.set(key, analysisInputHash);
       return analysisInputHash;
     };
-    const shouldCountItem = (item: IssueEnrichmentScanItem) => {
-      if (input.force === true) return true;
-      const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
-      const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
-      const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      const analysisInputHash = issue && shouldCompareIssueEnrichmentAnalysisInputHash(existing)
-        ? plannedAnalysisInputHashForItem(item)
-        : undefined;
-      return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, analysisInputHash, item.action));
-    };
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
           config: input.config,
@@ -1021,15 +1000,6 @@ export async function runIssueEnrichmentCycle(input: {
                 });
                 prepared.push(promotion.issue);
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
-                if (shouldCollectModelEvidence) {
-                  issueEvidenceContextByIssue.set(issueKey(repo, issue.number), await buildIssueEvidenceContext({
-                    repo,
-                    issue: promotion.issue,
-                    github: input.github,
-                    defaultBranch: defaultBranches.get(repo.toLowerCase()) ?? "unknown",
-                    headSha: sourceSnapshots.get(repo.toLowerCase())?.headSha ?? "0".repeat(40)
-                  }));
-                }
                 if (promotion.evidence) {
                   promotionEvidenceByIssue.set(issueKey(repo, issue.number), promotion.evidence);
                 }
@@ -1045,7 +1015,7 @@ export async function runIssueEnrichmentCycle(input: {
           canPostAsApp: input.github.canPostAsApp(),
           checkedAt,
           applyGlobalCaps: false,
-          shouldCountItem
+          shouldCountItem: () => false
         })
       : {
           ok: true,
@@ -1057,13 +1027,6 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
-    applyGlobalIssueEnrichmentCaps({
-      items: scanned.items,
-      repoScans: scanned.repos,
-      config,
-      checkedAt,
-      shouldCountItem
-    });
     const combinedRepos = [...baselineRepos, ...scanned.repos];
     const combinedSummary = summarizeScan(combinedRepos);
     const scan: IssueEnrichmentScanResult = {
@@ -1072,6 +1035,23 @@ export async function runIssueEnrichmentCycle(input: {
       repos: combinedRepos,
       recommendedActions: buildScanRecommendedActions(status, combinedSummary)
     };
+    const admissionItems = scan.items.map((item) => ({ ...item, issueUpdatedAt: canonicalIssueUpdatedAt(issuesByKey.get(issueKey(item.repo, item.issueNumber)), checkedAt) }));
+    const admissionSnapshot = snapshotIssueEnrichmentAdmission({
+      allowlist: reposToScan,
+      items: admissionItems,
+      records: input.force === true ? [] : admissionItems.flatMap((item) => {
+        const record = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber); return record ? [{ ...record }] : [];
+      }),
+      checkedAt,
+      limits: {
+        globalMaxIssuesPerCycle: config.globalMaxIssuesPerCycle, globalMaxCommentsPerCycle: config.globalMaxCommentsPerCycle,
+        repos: Object.fromEntries(reposToScan.map((repo) => {
+          const throttle = resolveIssueEnrichmentRepoPolicy(config, repo).throttle;
+          return [repo, { maxIssuesPerCycle: throttle.maxIssuesPerCycle, maxCommentsPerCycle: throttle.maxCommentsPerCycle, maxIssuesPerBurst: throttle.maxIssuesPerBurst }];
+        }))
+      }
+    });
+    const admissionLedger = createIssueEnrichmentAdmissionLedger(admissionSnapshot, classifyIssueEnrichmentAdmission(admissionSnapshot));
     const summary = {
       ...scan.summary,
       posted: 0,
@@ -1082,11 +1062,48 @@ export async function runIssueEnrichmentCycle(input: {
       failed: 0
     };
     const items: IssueEnrichmentCycleResult["items"] = [];
+    const settled = new Set<string>();
 
-    for (const item of scan.items) {
+    for (const item of scan.items.filter((candidate) => candidate.action === "skipped")) {
+      const issueUpdatedAt = canonicalIssueUpdatedAt(issuesByKey.get(issueKey(item.repo, item.issueNumber)), checkedAt);
+      if (!input.dryRun) input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "skipped", reason: item.reason, now: new Date(checkedAt) });
+      if (!input.dryRun) summary.skippedRecorded += 1;
+      items.push({ ...item, ...(!input.dryRun ? { recordStatus: "skipped" as const } : {}) });
+    }
+
+    while (true) {
+      const admitted = admissionLedger.next();
+      if (!admitted) break;
+      const item = scan.items.find((candidate) => candidate.repo.toLowerCase() === admitted.candidate.repo.toLowerCase() && candidate.issueNumber === admitted.candidate.issueNumber)!;
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
+      if (shouldCollectModelEvidence && issue) {
+        const repoKey = item.repo.toLowerCase(), wasPrepared = sourceSnapshots.has(repoKey);
+        try {
+          if (!wasPrepared) {
+            const metadata = await input.github.getRepo!(item.repo), defaultBranch = metadata.default_branch?.trim();
+            if (!defaultBranch) throw new Error(`issue_enrichment_default_branch_missing: ${item.repo}`);
+            sourceSnapshots.set(repoKey, await prepareBranchWorktree({
+              repo: item.repo, branch: defaultBranch,
+              ...(metadata.clone_url ? { repoUrl: metadata.clone_url } : {}),
+              workRoot: input.config.workRoot!, protectedCheckoutRoots: getProtectedCheckoutRoots()
+            }));
+            defaultBranches.set(repoKey, defaultBranch);
+          }
+          issueEvidenceContextByIssue.set(issueKey(item.repo, item.issueNumber), await buildIssueEvidenceContext({
+            repo: item.repo, issue, github: input.github, defaultBranch: defaultBranches.get(repoKey)!, headSha: sourceSnapshots.get(repoKey)!.headSha
+          }));
+        } catch (error) {
+          const message = redactSecrets(error instanceof Error ? error.message : String(error));
+          if (!wasPrepared && !sourceSnapshots.has(repoKey)) admissionLedger.blockRepo(item.repo);
+          else admissionLedger.release(admitted.candidate);
+          input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "failed", reason: "source_or_evidence_failed", error: message, now: new Date(checkedAt) });
+          summary.failed += 1; settled.add(admitted.candidate.key);
+          items.push({ ...item, recordStatus: "failed", error: message });
+          continue;
+        }
+      }
       const analysisInputHash = shouldCompareIssueEnrichmentAnalysisInputHash(existing) ||
         shouldBackfillIssueEnrichmentAnalysisInputHash(existing, issueUpdatedAt, item.action)
         ? plannedAnalysisInputHashForItem(item)
@@ -1112,10 +1129,13 @@ export async function runIssueEnrichmentCycle(input: {
           });
         }
         summary.alreadyProcessed += 1;
+        admissionLedger.release(admitted.candidate);
+        settled.add(admitted.candidate.key);
         items.push({ ...item, skippedExisting: true, recordStatus: existing.status });
         continue;
       }
       if (input.dryRun) {
+        settled.add(admitted.candidate.key);
         items.push({ ...item });
         continue;
       }
@@ -1161,6 +1181,7 @@ export async function runIssueEnrichmentCycle(input: {
           now: new Date(checkedAt)
         });
         summary.dryRunRecorded += 1;
+        settled.add(admitted.candidate.key);
         items.push({ ...item, recordStatus: "dry_run" });
         continue;
       }
@@ -1259,6 +1280,8 @@ export async function runIssueEnrichmentCycle(input: {
             now: new Date(checkedAt)
           });
           summary.alreadyProcessed += 1;
+          admissionLedger.release(admitted.candidate);
+          settled.add(admitted.candidate.key);
           items.push({
             ...item,
             skippedExisting: true,
@@ -1288,6 +1311,7 @@ export async function runIssueEnrichmentCycle(input: {
           now: new Date(checkedAt)
         });
         summary.posted += 1;
+        settled.add(admitted.candidate.key);
         items.push({ ...item, recordStatus: "posted", ...(commentUrl ? { commentUrl } : {}) });
       } catch (error) {
         const message = redactSecrets(error instanceof Error ? error.message : String(error));
@@ -1302,9 +1326,42 @@ export async function runIssueEnrichmentCycle(input: {
           now: new Date(checkedAt)
         });
         summary.failed += 1;
+        admissionLedger.release(admitted.candidate);
+        settled.add(admitted.candidate.key);
         items.push({ ...item, recordStatus: "failed", error: message });
       }
     }
+
+    for (const decision of admissionLedger.snapshot()) {
+      if (settled.has(decision.candidate.key) || decision.reason === "released" || decision.reason === "eligible") continue;
+      const item = scan.items.find((candidate) => candidate.repo.toLowerCase() === decision.candidate.repo.toLowerCase() && candidate.issueNumber === decision.candidate.issueNumber)!;
+      const issueUpdatedAt = canonicalIssueUpdatedAt(issuesByKey.get(issueKey(item.repo, item.issueNumber)), checkedAt), existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
+      if (decision.reason === "already_recorded") {
+        summary.alreadyProcessed += 1; items.push({ ...item, skippedExisting: true, ...(existing ? { recordStatus: existing.status } : {}) }); continue;
+      }
+      if (decision.reason === "repository_blocked") {
+        const error = "issue_enrichment_repository_unavailable";
+        if (!input.dryRun) input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "failed", reason: "source_or_evidence_failed", error, now: new Date(checkedAt) });
+        if (!input.dryRun) summary.failed += 1; items.push({ ...item, ...(!input.dryRun ? { recordStatus: "failed" as const, error } : {}) }); continue;
+      }
+      const policy = resolveIssueEnrichmentRepoPolicy(config, item.repo), deferredReason = decision.reason === "held" ? "persisted_defer_active" : decision.reason;
+      const deferredUntil = decision.candidate.record?.nextEligibleAt ?? decision.candidate.nextEligibleAt ??
+        (decision.reason.startsWith("global_") ? globalNextEligibleAt({ checkedAt, config, throttle: policy.throttle }) : nextEligibleAt({ checkedAt, throttle: policy.throttle }));
+      const deferredItem = { ...item, action: "deferred" as const, intendedAction: decision.intendedAction, reason: deferredReason as IssueEnrichmentScanReason, nextEligibleAt: deferredUntil };
+      if (!input.dryRun) input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "deferred", reason: deferredReason, nextEligibleAt: deferredUntil, now: new Date(checkedAt) });
+      if (!input.dryRun) summary.deferredRecorded += 1; items.push({ ...deferredItem, ...(!input.dryRun ? { recordStatus: "deferred" as const } : {}) });
+    }
+
+    for (const repo of scanned.repos) {
+      if (!repo.allowed || !repo.ok) continue;
+      const repoItems = items.filter((item) => item.repo === repo.repo);
+      repo.eligible = repoItems.filter((item) => item.action !== "skipped" && !item.skippedExisting).length;
+      repo.skipped = repoItems.filter((item) => item.action === "skipped").length;
+      repo.wouldEnrich = repoItems.filter((item) => (item.action === "would_enrich" || item.action === "would_comment") && !item.skippedExisting).length;
+      repo.wouldComment = repoItems.filter((item) => item.action === "would_comment" && !item.skippedExisting).length;
+      repo.deferred = repoItems.filter((item) => item.action === "deferred").length;
+    }
+    Object.assign(summary, summarizeScan(scan.repos));
 
     if (!input.dryRun && input.advanceWatermarks !== false) {
       for (const repo of scanned.repos) {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -875,7 +875,7 @@ export async function runIssueEnrichmentCycle(input: {
     const baselineRepos: IssueEnrichmentRepoScan[] = [];
     const reposToScan: string[] = [];
     const sinceByRepo: Record<string, string> = {};
-    const candidateRepos = input.repo ? [input.repo] : config.allowlist;
+    const candidateRepos = [...new Map((input.repo ? [input.repo] : config.allowlist).map((repo) => [repo.toLowerCase(), repo])).values()];
     const canUseActivationWatermark = input.includeExisting !== true && input.since === undefined;
     for (const repo of candidateRepos) {
       const policy = resolveIssueEnrichmentRepoPolicy(config, repo);

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -2724,7 +2724,7 @@ describe("sticky enrichment comments", () => {
           maxCommentsPerCycle: 1,
           cooldownMs: 3_600_000,
           burstWindowMs: 3_600_000,
-          maxIssuesPerBurst: 6,
+          maxIssuesPerBurst: 10,
           lookbackMs: 600_000,
           processExistingOpenIssuesOnActivation: false,
           repos: {
@@ -2733,7 +2733,7 @@ describe("sticky enrichment comments", () => {
               maxCommentsPerCycle: 1,
               cooldownMs: 3_600_000,
               burstWindowMs: 3_600_000,
-              maxIssuesPerBurst: 6,
+              maxIssuesPerBurst: 10,
               lookbackMs: 600_000,
               processExistingOpenIssuesOnActivation: false
             }
@@ -2959,6 +2959,9 @@ describe("sticky enrichment comments", () => {
           issueNumber: 41,
           issueUpdatedAt: "2026-07-03T02:00:00.000Z",
           status: "posted",
+          reason: "legacy_receipt",
+          error: "retained diagnostic",
+          nextEligibleAt: "2026-07-03T03:00:00.000Z",
           commentUrl: "https://github.test/comment/1",
           now: new Date("2026-07-03T02:05:30.000Z")
         });
@@ -3015,6 +3018,9 @@ describe("sticky enrichment comments", () => {
           status: "posted",
           issueUpdatedAt: "2026-07-03T02:00:00.000Z",
           commentUrl: "https://github.test/comment/1",
+          reason: "legacy_receipt",
+          error: "retained diagnostic",
+          nextEligibleAt: "2026-07-03T03:00:00.000Z",
           analysisInputHash: firstRecord?.analysisInputHash
         });
         expect(backfilledRecord?.bodyHash).toBeUndefined();

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -2305,6 +2305,7 @@ describe("sticky enrichment comments", () => {
         });
 
         expect(first.summary).toMatchObject({ dryRunRecorded: 2, deferredRecorded: 2, alreadyProcessed: 0 });
+        expect(first.recommendedActions.join("\n")).toContain("inspect deferred issue-enrichment rows");
         expect(second.summary).toMatchObject({ dryRunRecorded: 2, deferredRecorded: 0, alreadyProcessed: 2 });
         expect(state.getIssueEnrichmentRecord("owner/issue-repo", 1)).toMatchObject({ status: "dry_run" });
         expect(state.getIssueEnrichmentRecord("owner/issue-repo", 2)).toMatchObject({ status: "dry_run" });

--- a/tests/issue-enrichment-lazy-settlement.test.ts
+++ b/tests/issue-enrichment-lazy-settlement.test.ts
@@ -9,7 +9,7 @@ const config = (allowlist: string[]) => ({ workRoot: "/tmp/work", evidenceDir: "
   enabled: true, postIssueComment: true, allowlist, allowedLabels: [], allowedReviewers: [], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, globalMaxIssuesPerCycle: 1, globalMaxCommentsPerCycle: 1, maxActiveRuns: 1, leaseTtlMs: 60_000, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 1, lookbackMs: 60_000, processExistingOpenIssuesOnActivation: true,
   repos: Object.fromEntries(allowlist.map((repo) => [repo, { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 1, lookbackMs: 60_000 }]))
 } });
-const state = () => ({ getIssueEnrichmentRecord: () => undefined, recordIssueEnrichment: (value: unknown) => value as never, getIssueEnrichmentRepoWatermark: () => undefined, recordIssueEnrichmentRepoWatermark: (value: unknown) => value as never, tryAcquireIssueEnrichmentRunLease: () => ({ leaseId: "fixture" }), releaseIssueEnrichmentRunLease: () => undefined });
+const state = () => ({ getIssueEnrichmentRecord: () => undefined, recordIssueEnrichment: (value: unknown) => value as never, getIssueEnrichmentRepoWatermark: () => undefined, recordIssueEnrichmentRepoWatermark: (value: unknown) => value as never, tryAcquireIssueEnrichmentRunLease: () => ({ leaseId: "fixture", expiresAt: "2026-08-26T10:01:00.000Z", ownerPid: 1 }), releaseIssueEnrichmentRunLease: () => undefined });
 const issue = (number: number) => ({ number, title: `Issue ${number}`, state: "open", updated_at: "2026-08-26T09:00:00.000Z", body: "Acceptance criteria and owner present." });
 const admission = await createTestLicenseAdmission({ operation: "issue_enrichment" });
 

--- a/tests/issue-enrichment-lazy-settlement.test.ts
+++ b/tests/issue-enrichment-lazy-settlement.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLicenseAdmission } from "./helpers/license-admission.js";
+const { prepareBranchWorktree, runIssueAnalysis } = vi.hoisted(() => ({ prepareBranchWorktree: vi.fn(), runIssueAnalysis: vi.fn(async () => ({ analysis: { classification: "needs-repro", priority: "P3", priorityState: "provisional", confidence: "needs-repro", repositoryImpact: "fixture", currentMainApplicability: "fixture", verifiedFacts: [], reproductionOrInvariantGap: "fixture", relatedWork: [], migrationDisposition: "needs-repro", nextGate: "fixture", limitations: [], labelProposals: [] } })) }));
+vi.mock("../src/git.js", async (original) => ({ ...await original<typeof import("../src/git.js")>(), prepareBranchWorktree }));
+vi.mock("../src/issue-analysis.js", async (original) => ({ ...await original<typeof import("../src/issue-analysis.js")>(), runIssueAnalysis }));
+import { runIssueEnrichmentCycle } from "../src/issue-enrichment.js";
+
+const config = (allowlist: string[]) => ({ workRoot: "/tmp/work", evidenceDir: "/tmp/evidence", codexRuntime: { enabled: true, cliPath: "/usr/bin/false", model: "fixture", reasoningEffort: "low" as const, timeoutMs: 1, maxOutputBytes: 1 }, issueEnrichment: {
+  enabled: true, postIssueComment: true, allowlist, allowedLabels: [], allowedReviewers: [], maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, globalMaxIssuesPerCycle: 1, globalMaxCommentsPerCycle: 1, maxActiveRuns: 1, leaseTtlMs: 60_000, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 1, lookbackMs: 60_000, processExistingOpenIssuesOnActivation: true,
+  repos: Object.fromEntries(allowlist.map((repo) => [repo, { maxIssuesPerCycle: 1, maxCommentsPerCycle: 1, cooldownMs: 60_000, burstWindowMs: 60_000, maxIssuesPerBurst: 1, lookbackMs: 60_000 }]))
+} });
+const state = () => ({ getIssueEnrichmentRecord: () => undefined, recordIssueEnrichment: (value: unknown) => value as never, getIssueEnrichmentRepoWatermark: () => undefined, recordIssueEnrichmentRepoWatermark: (value: unknown) => value as never, tryAcquireIssueEnrichmentRunLease: () => ({ leaseId: "fixture" }), releaseIssueEnrichmentRunLease: () => undefined });
+const issue = (number: number) => ({ number, title: `Issue ${number}`, state: "open", updated_at: "2026-08-26T09:00:00.000Z", body: "Acceptance criteria and owner present." });
+const admission = await createTestLicenseAdmission({ operation: "issue_enrichment" });
+
+describe("issue-enrichment lazy source settlement", () => {
+  beforeEach(() => vi.clearAllMocks());
+  it("does not prepare source for an empty repository scan", async () => {
+    prepareBranchWorktree.mockResolvedValue({ path: "/tmp/unused", headSha: "a".repeat(40) });
+    const result = await runIssueEnrichmentCycle({ config: config(["owner/empty"]), state: state(), github: { getRepo: async () => ({ default_branch: "main" }), listIssuesForEnrichment: async () => [], canPostAsApp: () => true, upsertIssueComment: async () => { throw new Error("must not post"); } }, dryRun: false, includeExisting: true, checkedAt: "2026-08-26T10:00:00.000Z", licenseAdmission: admission });
+    expect(result.summary).toMatchObject({ issuesSeen: 0, posted: 0, failed: 0 }); expect(prepareBranchWorktree).not.toHaveBeenCalled();
+  });
+  it("releases preparation failures and backfills a healthy repository", async () => {
+    const repos = ["owner/fail-a", "owner/fail-b", "owner/healthy"], posted: number[] = [];
+    prepareBranchWorktree.mockImplementation(async ({ repo }: { repo: string }) => { if (repo.includes("fail")) throw new Error("fixture prepare failure"); return { path: "/tmp/healthy", headSha: "a".repeat(40) }; });
+    const result = await runIssueEnrichmentCycle({ config: config(repos), state: state(), github: { getRepo: async () => ({ default_branch: "main" }), listIssuesForEnrichment: async (repo) => [issue(repos.indexOf(repo) + 1)], getIssueOrPull: async (_repo, number) => issue(number), canPostAsApp: () => true, upsertIssueComment: async ({ issueNumber }) => { posted.push(issueNumber); return { action: "created" as const, id: issueNumber }; } }, dryRun: false, includeExisting: true, checkedAt: "2026-08-26T10:00:00.000Z", licenseAdmission: admission });
+    expect(result.summary).toMatchObject({ posted: 1, failed: 2, deferredRecorded: 0 }); expect(posted).toEqual([3]); expect(prepareBranchWorktree).toHaveBeenCalledTimes(3);
+  });
+  it("releases one evidence failure and reuses the prepared repo for backfill", async () => {
+    const configured = config(["owner/repo"]); configured.issueEnrichment.maxIssuesPerBurst = 2; configured.issueEnrichment.repos["owner/repo"].maxIssuesPerBurst = 2; let evidenceReads = 0;
+    prepareBranchWorktree.mockResolvedValue({ path: "/tmp/repo", headSha: "a".repeat(40) });
+    const result = await runIssueEnrichmentCycle({ config: configured, state: state(), github: { getRepo: async () => ({ default_branch: "main" }), listIssuesForEnrichment: async () => [issue(1), issue(2)], listIssueCommentsForEnrichment: async () => { if (evidenceReads++ === 0) throw new Error("fixture evidence failure"); return Object.assign([], { items: [], rawCount: 0, truncated: false, overflow: false }); }, getIssueOrPull: async (_repo, number) => issue(number), canPostAsApp: () => true, upsertIssueComment: async ({ issueNumber }) => ({ action: "created" as const, id: issueNumber }) }, dryRun: false, includeExisting: true, checkedAt: "2026-08-26T10:00:00.000Z", licenseAdmission: admission });
+    expect(result.summary).toMatchObject({ posted: 1, failed: 1 }); expect(prepareBranchWorktree).toHaveBeenCalledTimes(1); expect(result.items.find(({ issueNumber }) => issueNumber === 2)?.recordStatus).toBe("posted");
+  });
+});

--- a/tests/issue-enrichment-lazy-settlement.test.ts
+++ b/tests/issue-enrichment-lazy-settlement.test.ts
@@ -20,6 +20,9 @@ describe("issue-enrichment lazy source settlement", () => {
     const result = await runIssueEnrichmentCycle({ config: config(["owner/empty"]), state: state(), github: { getRepo: async () => ({ default_branch: "main" }), listIssuesForEnrichment: async () => [], canPostAsApp: () => true, upsertIssueComment: async () => { throw new Error("must not post"); } }, dryRun: false, includeExisting: true, checkedAt: "2026-08-26T10:00:00.000Z", licenseAdmission: admission });
     expect(result.summary).toMatchObject({ issuesSeen: 0, posted: 0, failed: 0 }); expect(prepareBranchWorktree).not.toHaveBeenCalled();
   });
+  it("scans case-insensitive duplicate allowlist entries once", async () => {
+    const listIssuesForEnrichment = vi.fn(async () => []); const result = await runIssueEnrichmentCycle({ config: config(["Owner/Repo", "owner/repo"]), state: state(), github: { getRepo: async () => ({ default_branch: "main" }), listIssuesForEnrichment, canPostAsApp: () => true, upsertIssueComment: async () => { throw new Error("must not post"); } }, dryRun: false, includeExisting: true, checkedAt: "2026-08-26T10:00:00.000Z", licenseAdmission: admission }); expect(result.summary.issuesSeen).toBe(0); expect(listIssuesForEnrichment).toHaveBeenCalledTimes(1); expect(prepareBranchWorktree).not.toHaveBeenCalled();
+  });
   it("releases preparation failures and backfills a healthy repository", async () => {
     const repos = ["owner/fail-a", "owner/fail-b", "owner/healthy"], posted: number[] = [];
     prepareBranchWorktree.mockImplementation(async ({ repo }: { repo: string }) => { if (repo.includes("fail")) throw new Error("fixture prepare failure"); return { path: "/tmp/healthy", headSha: "a".repeat(40) }; });


### PR DESCRIPTION
## Outcome

The live model-backed issue-enrichment cycle now lists issue metadata first, prepares source only for a ledger-admitted repository, builds evidence per admitted item, and releases failed or unchanged reservations so healthy work can backfill deterministically.

Closes #997

Parent: #971

## Changes

- Route current scan candidates through the accepted immutable admission snapshot, classifier, and ledger from #996/#1013.
- Move repository checkout and evidence collection behind admission.
- Treat repository preparation failure as repo-scoped for the cycle; treat evidence/analysis/post failure as item-scoped and release its reservation.
- Backfill legacy posted records from the real admitted identity while preserving retained fields.
- Emit remaining work as deferred with its original intended action, and advance watermarks only after truthful terminal completion.

## Local proof

- Expected negative: unchanged main prepared an empty repository once before admission.
- Focused Vitest: 112/112 passed across enrichment, admission snapshot/decision/ledger, evidence, and lazy-settlement fixtures.
- TypeScript build configuration with `--noEmit`: passed.
- `git diff --check`: passed.
- Exact head: `70f2305a8d93141c1dff567b5b5559a0d53c34df`
- Exact base: `8b54c63338ca07ce1240c137ec08a8c54c8cfe3a`
- Exact base-to-head non-generated delta: 197 changed lines across three files, within #997's 200-line signal.
- Targeted review delta 1 rebuilds operator recommendations from the settled ledger summary and adds the focused assertion.
- Targeted review delta 2 completes the typed lease fixture used by the lazy-settlement tests.
- Targeted review delta 3 deduplicates case-insensitive repository entries before scan/snapshot construction and proves one metadata scan with zero empty-scan source preparation.

## Risk and proof boundary

The changed risk lane is issue-enrichment scheduling, cap accounting, source/evidence preparation, record settlement, and watermark truth. This PR does not change schemas, public APIs, services, runtime configuration, billing, release artifacts, or the installed NeonDiff beta.

Local fixtures prove source behavior only. All three review conversations are terminal with zero unresolved. Exact-head CI and targeted release-risk/acceptance/adversarial follow-ups for `70f2305a8d93141c1dff567b5b5559a0d53c34df`, merge, live enrichment progress, release readiness, and customer readiness remain gated.
