### PR TITLE
fix(issue-enrichment): share canonical repo policy

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ import {
   type IssueEnrichmentConfig,
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
+import { canonicalIssueEnrichmentRepository } from "./issue-enrichment-repository-policy.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
 import { requireActiveProductionLicense, type ProductionLicenseAdmission } from "./license-admission.js";
 import { resolveProductionLicensePolicy } from "./license-production-policy.js";
@@ -1345,7 +1346,7 @@ async function main(): Promise<void> {
     });
     await withRuntimeGitHubCredentials(runtimeCredentials, async () => {
     if (!args.repo) throw new Error("--repo is required for issue-enrichment-run");
-    const repo = parseSingleArg(args.repo, "--repo");
+    const requestedRepo = parseSingleArg(args.repo, "--repo");
     const issueNumbers = parseIssueNumberArgs(args.issue);
     const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
     const confirm = args.confirm === undefined ? false : parseBooleanArg(args.confirm, "--confirm");
@@ -1363,6 +1364,7 @@ async function main(): Promise<void> {
     if (!dryRun && !issueConfig.postIssueComment) {
       throw new Error("issue-enrichment-run live posting requires issueEnrichment.postIssueComment true");
     }
+    const repo = canonicalIssueEnrichmentRepository(issueConfig, requestedRepo).repo;
     const policy = resolveIssueEnrichmentRepoPolicy(issueConfig, repo);
     if (!policy.allowed) throw new Error(`Repo ${repo} is skipped by issue-enrichment policy: ${policy.reason}`);
     const licenseAdmission = await requireActiveProductionLicense({

--- a/src/issue-enrichment-repository-policy.ts
+++ b/src/issue-enrichment-repository-policy.ts
@@ -10,14 +10,19 @@ export function canonicalIssueEnrichmentRepositories(
   config: IssueEnrichmentConfig,
   repositories: readonly string[] = config.allowlist
 ): CanonicalIssueEnrichmentRepository[] {
-  const groups = new Map<string, string[]>();
-  for (const repo of repositories) {
-    const key = repo.toLowerCase();
-    const aliases = groups.get(key);
-    if (aliases) aliases.push(repo);
-    else groups.set(key, [repo]);
-  }
-  return [...groups].map(([key, aliases]) => {
+  const group = (values: readonly string[]): Map<string, string[]> => {
+    const groups = new Map<string, string[]>();
+    for (const repo of values) {
+      const key = repo.toLowerCase();
+      const aliases = groups.get(key);
+      if (aliases) aliases.push(repo);
+      else groups.set(key, [repo]);
+    }
+    return groups;
+  };
+  const configured = group(config.allowlist);
+  return [...group(repositories)].map(([key, requestedAliases]) => {
+    const aliases = configured.get(key) ?? requestedAliases;
     const repo = [...aliases].sort()[0]!;
     const exact = config.repos?.[repo];
     const fallback = Object.entries(config.repos ?? {})

--- a/src/issue-enrichment-repository-policy.ts
+++ b/src/issue-enrichment-repository-policy.ts
@@ -1,0 +1,35 @@
+import type { IssueEnrichmentConfig, IssueEnrichmentRepoOverride } from "./issue-enrichment.js";
+
+export interface CanonicalIssueEnrichmentRepository {
+  key: string;
+  repo: string;
+  override?: IssueEnrichmentRepoOverride;
+}
+
+export function canonicalIssueEnrichmentRepositories(
+  config: IssueEnrichmentConfig,
+  repositories: readonly string[] = config.allowlist
+): CanonicalIssueEnrichmentRepository[] {
+  const groups = new Map<string, string[]>();
+  for (const repo of repositories) {
+    const key = repo.toLowerCase();
+    const aliases = groups.get(key);
+    if (aliases) aliases.push(repo);
+    else groups.set(key, [repo]);
+  }
+  return [...groups].map(([key, aliases]) => {
+    const repo = [...aliases].sort()[0]!;
+    const exact = config.repos?.[repo];
+    const fallback = Object.entries(config.repos ?? {})
+      .filter(([candidate]) => candidate.toLowerCase() === key)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)[0]?.[1];
+    return { key, repo, ...(exact ?? fallback ? { override: exact ?? fallback } : {}) };
+  });
+}
+
+export function canonicalIssueEnrichmentRepository(
+  config: IssueEnrichmentConfig,
+  repo: string
+): CanonicalIssueEnrichmentRepository {
+  return canonicalIssueEnrichmentRepositories(config, [repo])[0]!;
+}

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -33,6 +33,7 @@ import { isAuthenticProductionLicenseAdmission, type ProductionLicenseAdmission 
 import { prepareBranchWorktree, type PreparedWorktree } from "./git.js";
 import { getProtectedCheckoutRoots } from "./path-safety.js";
 import { writeSecureFileSync } from "./temp-files.js";
+import { canonicalIssueEnrichmentRepositories, canonicalIssueEnrichmentRepository } from "./issue-enrichment-repository-policy.js";
 
 export interface IssueEnrichmentConfig {
   enabled: boolean;
@@ -597,11 +598,9 @@ const LIVE_REPO_THRESHOLD_FIELDS = [
 ] satisfies Array<keyof IssueEnrichmentRepoOverride>;
 
 function reposMissingLiveIssueEnrichmentThresholds(config: IssueEnrichmentConfig): string[] {
-  return config.allowlist.filter((repo) => {
-    const override = config.repos?.[repo];
-    if (override?.enabled === false) return false;
-    return override === undefined ||
-      LIVE_REPO_THRESHOLD_FIELDS.some((field) => override[field] === undefined);
+  return canonicalIssueEnrichmentRepositories(config).flatMap(({ repo, override }) => {
+    if (override?.enabled === false) return [];
+    return override === undefined || LIVE_REPO_THRESHOLD_FIELDS.some((field) => override[field] === undefined) ? [repo] : [];
   });
 }
 
@@ -631,7 +630,7 @@ export async function collectIssueEnrichmentScan(input: {
     canPostAsApp: input.canPostAsApp ?? false,
     checkedAt
   });
-  const repos = input.repo ? [input.repo] : input.repos ?? config.allowlist;
+  const repos = canonicalIssueEnrichmentRepositories(config, input.repo ? [input.repo] : input.repos ?? config.allowlist).map(({ repo }) => repo);
   const repoScans: IssueEnrichmentRepoScan[] = [];
   const items: IssueEnrichmentScanItem[] = [];
 
@@ -871,7 +870,7 @@ export async function runIssueEnrichmentCycle(input: {
     const baselineRepos: IssueEnrichmentRepoScan[] = [];
     const reposToScan: string[] = [];
     const sinceByRepo: Record<string, string> = {};
-    const candidateRepos = input.repo ? [input.repo] : config.allowlist;
+    const candidateRepos = canonicalIssueEnrichmentRepositories(config, input.repo ? [input.repo] : config.allowlist).map(({ repo }) => repo);
     const canUseActivationWatermark = input.includeExisting !== true && input.since === undefined;
     for (const repo of candidateRepos) {
       const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
@@ -1343,7 +1342,7 @@ export function resolveIssueEnrichmentRepoPolicy(
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
 } {
-  const override = config.repos?.[repo];
+  const override = canonicalIssueEnrichmentRepository(config, repo).override;
   const throttle = {
     maxIssuesPerCycle: override?.maxIssuesPerCycle ?? config.maxIssuesPerCycle,
     maxCommentsPerCycle: override?.maxCommentsPerCycle ?? config.maxCommentsPerCycle,
@@ -1365,7 +1364,7 @@ export function resolveIssueEnrichmentRepoPolicy(
     suggestedReviewers: [...(override?.suggestedReviewers ?? [])],
     labelAliases: { ...(override?.labelAliases ?? {}) }
   };
-  if (!config.allowlist.includes(repo)) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle, suggestions, repoPolicy };
+  if (!config.allowlist.some((allowed) => allowed.toLowerCase() === repo.toLowerCase())) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle, suggestions, repoPolicy };
   if (override?.enabled === false) return { allowed: false, reason: "issue_enrichment_repo_disabled", throttle, suggestions, repoPolicy };
   return { allowed: true, throttle, suggestions, repoPolicy };
 }

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1015,7 +1015,7 @@ export async function runIssueEnrichmentCycle(input: {
                 const promotion = await evaluateIssuePromotion({
                   repo,
                   issue,
-                  override: config.repos?.[repo],
+                  override: canonicalIssueEnrichmentRepository(config, repo).override,
                   github: input.github
                 });
                 prepared.push(promotion.issue);

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -696,7 +696,7 @@ describe("build-enrichment-comment issue CLI", () => {
         "--config",
         configPath,
         "--repo",
-        "owner/issue-repo",
+        "Owner/Issue-Repo",
         "--issue",
         "17",
         "--issue",

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -941,7 +941,7 @@ describe("sticky enrichment comments", () => {
         issueEnrichment: {
           enabled: true,
           postIssueComment: true,
-          allowlist: ["electricsheephq/lcm-x"],
+          allowlist: ["Electricsheephq/lcm-x", "electricsheephq/lcm-x"],
           maxIssuesPerCycle: 1,
           maxCommentsPerCycle: 1,
           processExistingOpenIssuesOnActivation: true,

--- a/tests/issue-enrichment-repository-policy.test.ts
+++ b/tests/issue-enrichment-repository-policy.test.ts
@@ -56,6 +56,10 @@ describe("issue-enrichment canonical repository policy", () => {
       { "Owner/Repo": exact, "owner/repo": alias }
     ))[0]?.override).toBe(exact);
     expect(canonicalIssueEnrichmentRepositories(config(
+      ["owner/repo", "Owner/Repo"],
+      { "Owner/Repo": exact, "owner/repo": alias }
+    ), ["owner/repo"])[0]).toMatchObject({ repo: "Owner/Repo", override: exact });
+    expect(canonicalIssueEnrichmentRepositories(config(
       ["Owner/Repo", "owner/repo"],
       { "owner/repo": alias }
     ))[0]?.override).toBe(alias);

--- a/tests/issue-enrichment-repository-policy.test.ts
+++ b/tests/issue-enrichment-repository-policy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIssueEnrichmentStatus,
+  resolveIssueEnrichmentRepoPolicy,
+  type IssueEnrichmentConfig,
+  type IssueEnrichmentRepoOverride
+} from "../src/issue-enrichment.js";
+import { canonicalIssueEnrichmentRepositories } from "../src/issue-enrichment-repository-policy.js";
+
+const thresholds = (overrides: IssueEnrichmentRepoOverride = {}): IssueEnrichmentRepoOverride => ({
+  maxIssuesPerCycle: 1,
+  maxCommentsPerCycle: 1,
+  cooldownMs: 60_000,
+  burstWindowMs: 60_000,
+  maxIssuesPerBurst: 1,
+  lookbackMs: 60_000,
+  ...overrides
+});
+
+const config = (allowlist: string[], repos: Record<string, IssueEnrichmentRepoOverride>): IssueEnrichmentConfig => ({
+  enabled: true,
+  postIssueComment: true,
+  allowlist,
+  allowedLabels: [],
+  allowedReviewers: [],
+  maxIssuesPerCycle: 1,
+  maxCommentsPerCycle: 1,
+  globalMaxIssuesPerCycle: 1,
+  globalMaxCommentsPerCycle: 1,
+  maxActiveRuns: 1,
+  leaseTtlMs: 60_000,
+  cooldownMs: 60_000,
+  burstWindowMs: 60_000,
+  maxIssuesPerBurst: 1,
+  lookbackMs: 60_000,
+  processExistingOpenIssuesOnActivation: true,
+  repos
+});
+
+describe("issue-enrichment canonical repository policy", () => {
+  it("preserves distinct order and chooses a stable casefolded representative", () => {
+    const value = config(["z/repo", "Owner/Repo", "a/repo", "owner/repo"], {});
+    expect(canonicalIssueEnrichmentRepositories(value).map(({ key, repo }) => ({ key, repo }))).toEqual([
+      { key: "z/repo", repo: "z/repo" },
+      { key: "owner/repo", repo: "Owner/Repo" },
+      { key: "a/repo", repo: "a/repo" }
+    ]);
+    expect(canonicalIssueEnrichmentRepositories(config(["owner/repo", "Owner/Repo"], {}))[0]?.repo).toBe("Owner/Repo");
+  });
+
+  it("uses exact representative overrides before stable casefolded fallback", () => {
+    const exact = thresholds({ maxIssuesPerCycle: 2 });
+    const alias = thresholds({ maxIssuesPerCycle: 7 });
+    expect(canonicalIssueEnrichmentRepositories(config(
+      ["owner/repo", "Owner/Repo"],
+      { "Owner/Repo": exact, "owner/repo": alias }
+    ))[0]?.override).toBe(exact);
+    expect(canonicalIssueEnrichmentRepositories(config(
+      ["Owner/Repo", "owner/repo"],
+      { "owner/repo": alias }
+    ))[0]?.override).toBe(alias);
+  });
+
+  it("aligns disabled and missing-threshold policy with live preflight", () => {
+    const disabled = config(["Owner/Repo", "owner/repo"], { "owner/repo": { enabled: false } });
+    expect(buildIssueEnrichmentStatus({
+      config: { issueEnrichment: disabled, codexRuntime: { enabled: true } },
+      canPostAsApp: true,
+      modelAnalysisAvailable: true
+    })).toMatchObject({ ok: true, state: "ready", liveThresholdsMissingRepos: [] });
+    const missing = config(["Owner/Repo", "owner/repo"], { "owner/repo": { maxIssuesPerCycle: 1 } });
+    expect(buildIssueEnrichmentStatus({
+      config: { issueEnrichment: missing, codexRuntime: { enabled: true } },
+      canPostAsApp: true,
+      modelAnalysisAvailable: true
+    }).liveThresholdsMissingRepos).toEqual(["Owner/Repo"]);
+  });
+
+  it("keeps live preflight aligned with the stable runtime representative", () => {
+    const value = config(
+      ["Owner/Repo", "owner/repo"],
+      { "Owner/Repo": thresholds(), "owner/repo": { maxIssuesPerCycle: 9 } }
+    );
+    expect(resolveIssueEnrichmentRepoPolicy(value, "Owner/Repo").allowed).toBe(true);
+    expect(buildIssueEnrichmentStatus({
+      config: { issueEnrichment: value, codexRuntime: { enabled: true } },
+      canPostAsApp: true,
+      modelAnalysisAvailable: true
+    })).toMatchObject({ ok: true, state: "ready", liveThresholdsMissingRepos: [] });
+  });
+});


### PR DESCRIPTION
## Outcome

Issue-enrichment live preflight, scan ordering, cycle ordering, and runtime policy now consume one canonical repository-policy view, preventing case-variant aliases from disagreeing on identity, enabled state, thresholds, or overrides.

Closes #1120

Parent: #971

Blocks: #997

## Changes

- Add one pure internal canonical repository-policy view.
- Preserve first-seen order for distinct repositories while selecting a stable representative for case variants.
- Give an exact representative override precedence, with a deterministic case-insensitive fallback.
- Use the shared view for live-threshold preflight, scan repository lists, cycle repository lists, runtime policy resolution, and case-insensitive allowlist admission.
- Resolve explicit/subset repository inputs against the full configured alias group while preserving the requested distinct-key order.
- Add focused table fixtures for order, reversed variants, exact precedence, alias fallback, disabled aliases, complete-versus-partial conflicts, and missing thresholds.
- Targeted correction 1 proves explicit `owner/repo` selects the same `Owner/Repo` representative and exact override as the full preflight view.
- Targeted correction 2 routes promotion-maintainer checks through the canonical override and changes the existing active-continuation fixture to keep its maintainer allowlist only on the fallback alias.
- Targeted correction 3 canonicalizes the selected CLI `--repo` argument before GitHub access, policy, persistent state, and cycle adapter use; the existing CLI dry-run fixture now supplies a case-variant argument.

## Proof

- Expected negative on unchanged main: runtime accepted the stable complete representative while live preflight blocked on the partial alias.
- Focused repository-policy, enrichment, and selected-run CLI suites: `106/106 PASS`.
- TypeScript build configuration with `--noEmit`: `PASS`.
- `git diff --check`: `PASS`.
- Exact base: `8b54c63338ca07ce1240c137ec08a8c54c8cfe3a`.
- Exact head: `11c75243ed95e4c298d6824f09c7b3a4d9f64f03`.
- Exact delta: `162` non-generated changed lines across six files, below the raised 400-line integration envelope.

## Risk and proof boundary

The changed risk lane is internal issue-enrichment repository identity, policy selection, threshold preflight, and scan/cycle ordering. No schema, public API, source preparation, evidence, analyzer, posting contract, state persistence, watermark, runtime configuration, billing, release artifact, or installed beta is changed.

This proves source and deterministic fixtures only. Exact-head CI, independent semantic review, blind acceptance/adversarial checks, zero unresolved conversations, merge, #997 integration, live enrichment progress, release readiness, and customer readiness remain gated.
