### PR TITLE
fix(issue-enrichment): preserve durable repo identity

### DIFF
--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -256,6 +256,13 @@ launch entitlement remain distinct evidence domains. Issue enrichment is
 reported separately from review execution and Desktop health. Codex runtime
 state is reported separately from customer outcome.
 
+Issue-enrichment policy aliases resolve through one deterministic casefolded
+view, while the casefolded repository key is the durable identity for records,
+watermarks, and sticky-comment markers. Existing mixed-case records and issue
+markers remain readable without rewriting the database. Adding or reordering a
+case alias therefore cannot create another state identity or another sticky
+comment for the same repository and issue.
+
 Distribution/updater evidence identifies the signed artifact, enclosure
 signature, exact feed/key identity, appcast digest, ring, entitlement, and
 rollback target. `beta` is rollback-capable. Before `stable`, the packet must

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ import {
   type IssueEnrichmentConfig,
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
+import { canonicalIssueEnrichmentRepository } from "./issue-enrichment-repository-policy.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
 import { requireActiveProductionLicense, type ProductionLicenseAdmission } from "./license-admission.js";
 import { resolveProductionLicensePolicy } from "./license-production-policy.js";
@@ -1345,7 +1346,7 @@ async function main(): Promise<void> {
     });
     await withRuntimeGitHubCredentials(runtimeCredentials, async () => {
     if (!args.repo) throw new Error("--repo is required for issue-enrichment-run");
-    const repo = parseSingleArg(args.repo, "--repo");
+    const requestedRepo = parseSingleArg(args.repo, "--repo");
     const issueNumbers = parseIssueNumberArgs(args.issue);
     const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
     const confirm = args.confirm === undefined ? false : parseBooleanArg(args.confirm, "--confirm");
@@ -1363,6 +1364,7 @@ async function main(): Promise<void> {
     if (!dryRun && !issueConfig.postIssueComment) {
       throw new Error("issue-enrichment-run live posting requires issueEnrichment.postIssueComment true");
     }
+    const repo = canonicalIssueEnrichmentRepository(issueConfig, requestedRepo).repo;
     const policy = resolveIssueEnrichmentRepoPolicy(issueConfig, repo);
     if (!policy.allowed) throw new Error(`Repo ${repo} is skipped by issue-enrichment policy: ${policy.reason}`);
     const licenseAdmission = await requireActiveProductionLicense({

--- a/src/github.ts
+++ b/src/github.ts
@@ -606,7 +606,12 @@ export class GitHubApi {
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
       );
-      const existing = comments.find((comment) => comment.body?.includes(marker) && this.isBotAuthoredComment(comment));
+      const issueMarker = marker.includes(" issue=");
+      const normalizedMarker = issueMarker ? marker.toLowerCase() : marker;
+      const existing = comments.find((comment) => {
+        const body = issueMarker ? comment.body?.toLowerCase() : comment.body;
+        return body?.includes(normalizedMarker) && this.isBotAuthoredComment(comment);
+      });
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }

--- a/src/issue-enrichment-repository-policy.ts
+++ b/src/issue-enrichment-repository-policy.ts
@@ -1,0 +1,32 @@
+import type { IssueEnrichmentConfig, IssueEnrichmentRepoOverride } from "./issue-enrichment.js";
+
+export interface CanonicalIssueEnrichmentRepository {
+  key: string;
+  repo: string;
+  override?: IssueEnrichmentRepoOverride;
+}
+
+export function canonicalIssueEnrichmentRepositories(
+  config: IssueEnrichmentConfig,
+  repositories: readonly string[] = config.allowlist
+): CanonicalIssueEnrichmentRepository[] {
+  const keys = new Map<string, string>();
+  for (const repo of repositories) {
+    const key = repo.toLowerCase();
+    if (!keys.has(key)) keys.set(key, key);
+  }
+  return [...keys].map(([key, repo]) => {
+    const exact = config.repos?.[repo];
+    const fallback = Object.entries(config.repos ?? {})
+      .filter(([candidate]) => candidate.toLowerCase() === key)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)[0]?.[1];
+    return { key, repo, ...(exact ?? fallback ? { override: exact ?? fallback } : {}) };
+  });
+}
+
+export function canonicalIssueEnrichmentRepository(
+  config: IssueEnrichmentConfig,
+  repo: string
+): CanonicalIssueEnrichmentRepository {
+  return canonicalIssueEnrichmentRepositories(config, [repo])[0]!;
+}

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -33,6 +33,7 @@ import { isAuthenticProductionLicenseAdmission, type ProductionLicenseAdmission 
 import { prepareBranchWorktree, type PreparedWorktree } from "./git.js";
 import { getProtectedCheckoutRoots } from "./path-safety.js";
 import { writeSecureFileSync } from "./temp-files.js";
+import { canonicalIssueEnrichmentRepositories, canonicalIssueEnrichmentRepository } from "./issue-enrichment-repository-policy.js";
 
 export interface IssueEnrichmentConfig {
   enabled: boolean;
@@ -597,11 +598,9 @@ const LIVE_REPO_THRESHOLD_FIELDS = [
 ] satisfies Array<keyof IssueEnrichmentRepoOverride>;
 
 function reposMissingLiveIssueEnrichmentThresholds(config: IssueEnrichmentConfig): string[] {
-  return config.allowlist.filter((repo) => {
-    const override = config.repos?.[repo];
-    if (override?.enabled === false) return false;
-    return override === undefined ||
-      LIVE_REPO_THRESHOLD_FIELDS.some((field) => override[field] === undefined);
+  return canonicalIssueEnrichmentRepositories(config).flatMap(({ repo, override }) => {
+    if (override?.enabled === false) return [];
+    return override === undefined || LIVE_REPO_THRESHOLD_FIELDS.some((field) => override[field] === undefined) ? [repo] : [];
   });
 }
 
@@ -631,7 +630,7 @@ export async function collectIssueEnrichmentScan(input: {
     canPostAsApp: input.canPostAsApp ?? false,
     checkedAt
   });
-  const repos = input.repo ? [input.repo] : input.repos ?? config.allowlist;
+  const repos = canonicalIssueEnrichmentRepositories(config, input.repo ? [input.repo] : input.repos ?? config.allowlist).map(({ repo }) => repo);
   const repoScans: IssueEnrichmentRepoScan[] = [];
   const items: IssueEnrichmentScanItem[] = [];
 
@@ -871,7 +870,7 @@ export async function runIssueEnrichmentCycle(input: {
     const baselineRepos: IssueEnrichmentRepoScan[] = [];
     const reposToScan: string[] = [];
     const sinceByRepo: Record<string, string> = {};
-    const candidateRepos = input.repo ? [input.repo] : config.allowlist;
+    const candidateRepos = canonicalIssueEnrichmentRepositories(config, input.repo ? [input.repo] : config.allowlist).map(({ repo }) => repo);
     const canUseActivationWatermark = input.includeExisting !== true && input.since === undefined;
     for (const repo of candidateRepos) {
       const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
@@ -1016,7 +1015,7 @@ export async function runIssueEnrichmentCycle(input: {
                 const promotion = await evaluateIssuePromotion({
                   repo,
                   issue,
-                  override: config.repos?.[repo],
+                  override: canonicalIssueEnrichmentRepository(config, repo).override,
                   github: input.github
                 });
                 prepared.push(promotion.issue);
@@ -1343,7 +1342,7 @@ export function resolveIssueEnrichmentRepoPolicy(
   suggestions: IssueEnrichmentSuggestionPolicy;
   repoPolicy: IssueEnrichmentRepoPolicy;
 } {
-  const override = config.repos?.[repo];
+  const override = canonicalIssueEnrichmentRepository(config, repo).override;
   const throttle = {
     maxIssuesPerCycle: override?.maxIssuesPerCycle ?? config.maxIssuesPerCycle,
     maxCommentsPerCycle: override?.maxCommentsPerCycle ?? config.maxCommentsPerCycle,
@@ -1365,7 +1364,7 @@ export function resolveIssueEnrichmentRepoPolicy(
     suggestedReviewers: [...(override?.suggestedReviewers ?? [])],
     labelAliases: { ...(override?.labelAliases ?? {}) }
   };
-  if (!config.allowlist.includes(repo)) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle, suggestions, repoPolicy };
+  if (!config.allowlist.some((allowed) => allowed.toLowerCase() === repo.toLowerCase())) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle, suggestions, repoPolicy };
   if (override?.enabled === false) return { allowed: false, reason: "issue_enrichment_repo_disabled", throttle, suggestions, repoPolicy };
   return { allowed: true, throttle, suggestions, repoPolicy };
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1352,6 +1352,7 @@ export class ReviewStateStore {
   recordIssueEnrichment(input: RecordIssueEnrichmentInput): IssueEnrichmentRecord {
     validateIssueEnrichmentInput(input);
     const existing = this.getIssueEnrichmentRecord(input.repo, input.issueNumber);
+    const repo = existing?.repo ?? input.repo;
     const nowIso = (input.now ?? new Date()).toISOString();
     const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
     const bodyHash = input.bodyHash ? input.bodyHash.trim().toLowerCase() : undefined;
@@ -1377,7 +1378,7 @@ export class ReviewStateStore {
            updated_at = excluded.updated_at`
       )
       .run(
-        input.repo,
+        repo,
         input.issueNumber,
         input.issueUpdatedAt ?? null,
         bodyHash ?? null,
@@ -1400,7 +1401,7 @@ export class ReviewStateStore {
         `select repo, issue_number, issue_updated_at, body_hash, analysis_input_hash, status, reason, comment_url, error,
                 next_eligible_at, created_at, updated_at
          from issue_enrichment_records
-         where repo = ? and issue_number = ?
+         where repo = ? collate nocase and issue_number = ?
          limit 1`
       )
       .get(repo, issueNumber) as IssueEnrichmentRecordRow | undefined;
@@ -1422,7 +1423,7 @@ export class ReviewStateStore {
     const predicates: string[] = [];
     const params: Array<string | number> = [];
     if (input.repo) {
-      predicates.push("repo = ?");
+      predicates.push("repo = ? collate nocase");
       params.push(input.repo);
     }
     if (statuses?.length) {
@@ -1448,6 +1449,7 @@ export class ReviewStateStore {
   recordIssueEnrichmentRepoWatermark(input: RecordIssueEnrichmentRepoWatermarkInput): IssueEnrichmentRepoWatermark {
     validateIssueEnrichmentRepoWatermarkInput(input);
     const existing = this.getIssueEnrichmentRepoWatermark(input.repo);
+    const repo = existing?.repo ?? input.repo;
     const nowIso = (input.now ?? new Date()).toISOString();
     this.db
       .prepare(
@@ -1459,7 +1461,7 @@ export class ReviewStateStore {
            updated_at = excluded.updated_at`
       )
       .run(
-        input.repo,
+        repo,
         existing?.activatedAt ?? input.activatedAt,
         input.lastCheckedAt,
         existing?.createdAt ?? nowIso,
@@ -1474,7 +1476,7 @@ export class ReviewStateStore {
       .prepare(
         `select repo, activated_at, last_checked_at, created_at, updated_at
          from issue_enrichment_repo_watermarks
-         where repo = ?
+         where repo = ? collate nocase
          limit 1`
       )
       .get(repo) as IssueEnrichmentRepoWatermarkRow | undefined;

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -696,7 +696,7 @@ describe("build-enrichment-comment issue CLI", () => {
         "--config",
         configPath,
         "--repo",
-        "owner/issue-repo",
+        "Owner/Issue-Repo",
         "--issue",
         "17",
         "--issue",

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -863,7 +863,7 @@ describe("sticky enrichment comments", () => {
         issueEnrichment: {
           enabled: true,
           postIssueComment: true,
-          allowlist: ["electricsheephq/lcm-x"],
+          allowlist: ["Electricsheephq/lcm-x", "electricsheephq/lcm-x"],
           maxIssuesPerCycle: 1,
           maxCommentsPerCycle: 1,
           processExistingOpenIssuesOnActivation: true,
@@ -3039,6 +3039,95 @@ describe("sticky enrichment comments", () => {
         expect(changedRecord?.bodyHash).toBe(firstRecord?.bodyHash);
         expect(changedRecord?.analysisInputHash).not.toBe(firstRecord?.analysisInputHash);
         expect(posts[1]!.body).toContain(`hash=${changedRecord?.bodyHash}`);
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves durable issue enrichment identity when an earlier-sorting case alias is added", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-alias-added-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      const writeConfig = (allowlist: string[]) => writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist,
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 2,
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 2,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            },
+            "Owner/Issue-Repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 2,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
+        }
+      })}\n`);
+      writeConfig(["owner/issue-repo"]);
+
+      const state = new ReviewStateStore(statePath);
+      const posts: Array<{ issueNumber: number; marker: string; body: string }> = [];
+      try {
+        const issue: GitHubRelatedIssueOrPull = {
+          number: 42,
+          title: "Preserve repository identity",
+          state: "open",
+          updated_at: "2026-08-26T10:00:00.000Z",
+          html_url: "https://github.test/owner/issue-repo/issues/42",
+          body: "Acceptance criteria and owner present. Keep one sticky enrichment comment."
+        };
+        const github = {
+          listIssuesForEnrichment: async () => [issue],
+          canPostAsApp: () => true,
+          upsertIssueComment: async (input: { issueNumber: number; marker: string; body: string }) => {
+            posts.push(input);
+            return { action: "created" as const, id: 4200, html_url: `https://github.test/comment/${posts.length}` };
+          }
+        };
+
+        const first = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github,
+          dryRun: false,
+          checkedAt: "2026-08-26T10:05:00.000Z"
+        });
+
+        writeConfig(["Owner/Issue-Repo", "owner/issue-repo"]);
+        const replay = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github,
+          dryRun: false,
+          checkedAt: "2026-08-26T11:06:00.000Z"
+        });
+
+        expect(first.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+        expect(replay.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0, workerSkipped: 0 });
+        expect(posts).toHaveLength(1);
+        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 42)).toMatchObject({
+          status: "posted",
+          commentUrl: "https://github.test/comment/1"
+        });
+        expect(state.getIssueEnrichmentRecord("Owner/Issue-Repo", 42)?.repo).toBe("owner/issue-repo");
       } finally {
         state.close();
       }

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -785,6 +785,56 @@ describe("GitHub App read authentication", () => {
     ).toBe(false);
   });
 
+  it("updates a legacy mixed-case issue enrichment marker without creating a duplicate", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-enrichment-casefold-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const marker = "<!-- evaos-code-review-bot:enrichment repo=owner/repo issue=42 -->";
+    const legacyMarker = "<!-- evaos-code-review-bot:enrichment repo=Owner/Repo issue=42 -->";
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      const method = init?.method ?? "GET";
+      calls.push({
+        url: String(url),
+        method,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined
+      });
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse(canonicalInstallation());
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/42/comments?per_page=100&page=1")) {
+        return jsonResponse([{
+          id: 101,
+          html_url: "https://github.test/comment/101",
+          body: `${legacyMarker}\nold`,
+          user: { login: "evaos-code-review-bot[bot]", type: "Bot" }
+        }]);
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/comments/101") && method === "PATCH") {
+        return jsonResponse({ id: 101, html_url: "https://github.test/comment/101" });
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    const result = await github.upsertIssueComment({
+      repo: "owner/repo",
+      issueNumber: 42,
+      marker,
+      body: `${marker}\nnew`
+    });
+
+    expect(result).toEqual({ action: "updated", html_url: "https://github.test/comment/101", id: 101 });
+    expect(calls.find((call) => call.method === "PATCH")?.body).toEqual({ body: `${marker}\nnew` });
+    expect(calls.some((call) => call.method === "POST" && call.url.endsWith("/repos/owner/repo/issues/42/comments"))).toBe(false);
+  });
+
   it("creates a marked PR walkthrough comment when only user-authored marker comments exist", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-comment-create-"));
     roots.push(root);

--- a/tests/issue-enrichment-repository-policy.test.ts
+++ b/tests/issue-enrichment-repository-policy.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIssueEnrichmentStatus,
+  resolveIssueEnrichmentRepoPolicy,
+  type IssueEnrichmentConfig,
+  type IssueEnrichmentRepoOverride
+} from "../src/issue-enrichment.js";
+import { canonicalIssueEnrichmentRepositories } from "../src/issue-enrichment-repository-policy.js";
+
+const thresholds = (overrides: IssueEnrichmentRepoOverride = {}): IssueEnrichmentRepoOverride => ({
+  maxIssuesPerCycle: 1,
+  maxCommentsPerCycle: 1,
+  cooldownMs: 60_000,
+  burstWindowMs: 60_000,
+  maxIssuesPerBurst: 1,
+  lookbackMs: 60_000,
+  ...overrides
+});
+
+const config = (allowlist: string[], repos: Record<string, IssueEnrichmentRepoOverride>): IssueEnrichmentConfig => ({
+  enabled: true,
+  postIssueComment: true,
+  allowlist,
+  allowedLabels: [],
+  allowedReviewers: [],
+  maxIssuesPerCycle: 1,
+  maxCommentsPerCycle: 1,
+  globalMaxIssuesPerCycle: 1,
+  globalMaxCommentsPerCycle: 1,
+  maxActiveRuns: 1,
+  leaseTtlMs: 60_000,
+  cooldownMs: 60_000,
+  burstWindowMs: 60_000,
+  maxIssuesPerBurst: 1,
+  lookbackMs: 60_000,
+  processExistingOpenIssuesOnActivation: true,
+  repos
+});
+
+describe("issue-enrichment canonical repository policy", () => {
+  it("preserves distinct order and uses a stable casefolded durable identity", () => {
+    const value = config(["z/repo", "Owner/Repo", "a/repo", "owner/repo"], {});
+    expect(canonicalIssueEnrichmentRepositories(value).map(({ key, repo }) => ({ key, repo }))).toEqual([
+      { key: "z/repo", repo: "z/repo" },
+      { key: "owner/repo", repo: "owner/repo" },
+      { key: "a/repo", repo: "a/repo" }
+    ]);
+    expect(canonicalIssueEnrichmentRepositories(config(["owner/repo", "Owner/Repo"], {}))[0]?.repo).toBe("owner/repo");
+    expect(canonicalIssueEnrichmentRepositories(config(["Owner/Repo", "owner/repo"], {}))[0]?.repo).toBe("owner/repo");
+  });
+
+  it("uses the durable-identity override before deterministic casefolded fallback", () => {
+    const durable = thresholds({ maxIssuesPerCycle: 2 });
+    const alias = thresholds({ maxIssuesPerCycle: 7 });
+    expect(canonicalIssueEnrichmentRepositories(config(
+      ["Owner/Repo", "owner/repo"],
+      { "Owner/Repo": alias, "owner/repo": durable }
+    ))[0]?.override).toBe(durable);
+    expect(canonicalIssueEnrichmentRepositories(config(
+      ["Owner/Repo"],
+      { "Owner/Repo": alias }
+    ), ["owner/repo"])[0]).toMatchObject({ repo: "owner/repo", override: alias });
+  });
+
+  it("aligns disabled and missing-threshold policy with live preflight", () => {
+    const disabled = config(["Owner/Repo", "owner/repo"], { "owner/repo": { enabled: false } });
+    expect(buildIssueEnrichmentStatus({
+      config: { issueEnrichment: disabled, codexRuntime: { enabled: true } },
+      canPostAsApp: true,
+      modelAnalysisAvailable: true
+    })).toMatchObject({ ok: true, state: "ready", liveThresholdsMissingRepos: [] });
+    const missing = config(["Owner/Repo", "owner/repo"], { "Owner/Repo": { maxIssuesPerCycle: 1 } });
+    expect(buildIssueEnrichmentStatus({
+      config: { issueEnrichment: missing, codexRuntime: { enabled: true } },
+      canPostAsApp: true,
+      modelAnalysisAvailable: true
+    }).liveThresholdsMissingRepos).toEqual(["owner/repo"]);
+  });
+
+  it("keeps live preflight aligned with runtime policy after alias addition", () => {
+    const value = config(
+      ["Owner/Repo", "owner/repo"],
+      { "Owner/Repo": { maxIssuesPerCycle: 9 }, "owner/repo": thresholds() }
+    );
+    expect(resolveIssueEnrichmentRepoPolicy(value, "Owner/Repo").allowed).toBe(true);
+    expect(buildIssueEnrichmentStatus({
+      config: { issueEnrichment: value, codexRuntime: { enabled: true } },
+      canPostAsApp: true,
+      modelAnalysisAvailable: true
+    })).toMatchObject({ ok: true, state: "ready", liveThresholdsMissingRepos: [] });
+  });
+});

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -232,6 +232,56 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("preserves one legacy mixed-case issue enrichment record and watermark identity", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-casefold-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const store = new ReviewStateStore(dbPath);
+
+    store.recordIssueEnrichment({
+      repo: "Owner/Issue-Repo",
+      issueNumber: 42,
+      issueUpdatedAt: "2026-08-26T10:00:00.000Z",
+      status: "posted",
+      commentUrl: "https://github.test/comment/1",
+      now: new Date("2026-08-26T10:05:00.000Z")
+    });
+    store.recordIssueEnrichmentRepoWatermark({
+      repo: "Owner/Issue-Repo",
+      activatedAt: "2026-08-26T10:00:00.000Z",
+      lastCheckedAt: "2026-08-26T10:05:00.000Z",
+      now: new Date("2026-08-26T10:05:00.000Z")
+    });
+
+    expect(store.getIssueEnrichmentRecord("owner/issue-repo", 42)?.repo).toBe("Owner/Issue-Repo");
+    expect(store.getIssueEnrichmentRepoWatermark("owner/issue-repo")?.repo).toBe("Owner/Issue-Repo");
+    store.recordIssueEnrichment({
+      repo: "owner/issue-repo",
+      issueNumber: 42,
+      issueUpdatedAt: "2026-08-26T10:06:00.000Z",
+      status: "posted",
+      commentUrl: "https://github.test/comment/1",
+      now: new Date("2026-08-26T10:06:00.000Z")
+    });
+    store.recordIssueEnrichmentRepoWatermark({
+      repo: "owner/issue-repo",
+      activatedAt: "2026-08-26T10:06:00.000Z",
+      lastCheckedAt: "2026-08-26T10:06:00.000Z",
+      now: new Date("2026-08-26T10:06:00.000Z")
+    });
+    store.close();
+
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      expect(db.prepare("select repo, count(*) as count from issue_enrichment_records group by repo").all())
+        .toEqual([{ repo: "Owner/Issue-Repo", count: 1 }]);
+      expect(db.prepare("select repo, count(*) as count from issue_enrichment_repo_watermarks group by repo").all())
+        .toEqual([{ repo: "Owner/Issue-Repo", count: 1 }]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("migrates pre-body-hash issue enrichment records before storing hashes", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-migration-"));
     roots.push(root);


### PR DESCRIPTION
## Outcome

Issue enrichment now separates deterministic case-alias policy resolution from durable repository identity. New cycle, selected-run, state, watermark, and sticky-marker paths use one lower-case repository key; existing mixed-case state rows and issue markers remain readable and updateable without a schema or runtime repair.

Closes #1122
Related: #1120, #971, #997

## Classified replacement

This PR consumes the Delivery Governor `SPLIT` receipt from closed-unmerged PR #1121. The discarded mechanism selected the lexically first current alias and could change persisted identity when an earlier-sorting alias was added. This successor instead uses a casefolded durable identity and bounded compatibility at the existing SQLite and issue-comment boundaries.

## Exact candidate

- Base: `8b54c63338ca07ce1240c137ec08a8c54c8cfe3a`
- Head: `05cd750a7a76ad85bcffc450bd1b263d4e97fd94`
- Scope: 366 changed lines across 11 files (347 additions, 19 deletions)
- No new schema, service, datastore, queue, public API, CLI flag, dependency, or runtime migration

## Expected negative

Before source edits, the alias-added replay posted once, then adding `Owner/Issue-Repo` ahead of existing `owner/issue-repo` scanned both spellings and posted one duplicate (`posted: 1`, `alreadyProcessed: 1`). The same fixture now posts zero on replay, classifies the issue once as already processed, and retains one state/comment identity.

## Validation

- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/issue-enrichment-repository-policy.test.ts tests/enrichment.test.ts tests/enrichment-cli.test.ts tests/state.test.ts tests/github-app-read.test.ts` — 221/221 pass
- `/opt/homebrew/bin/node node_modules/typescript/bin/tsc -p tsconfig.build.json --noEmit` — pass
- `git diff --cached --check` before commit — pass
- Exact-lock dependencies restored with Homebrew Node; no security control changed

## Safety and proof boundary

- Preserves dry-before-live, allowlist, disabled-repo, App-authorship, one-worker lease, and duplicate-suppression boundaries.
- The GitHub client uses case-insensitive matching only for markers containing the issue-enrichment ` issue=` token; PR and other markers retain exact matching.
- Existing mixed-case state rows are selected case-insensitively and keep their stored spelling on update; new issue-enrichment cycles use the lower-case durable identity.
- The installed beta, LaunchAgent, config, database, leases, Keychain, customer data, billing, artifacts, feed, website, and public release surfaces were not touched.
- Source and CI prove only this named source path. They do not prove installed runtime, live provider, customer, Desktop, artifact, updater, RC, or GA readiness.

Agent-authored change with human-reviewable expected-negative and focused proof.
