### PR TITLE
fix: bound newest issue event history

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -4,6 +4,7 @@ import { isMap, isProxy, isSet } from "node:util/types";
 import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type { IssueEnrichmentIssueList } from "./issue-enrichment.js";
+import { parseIssueEventLink } from "./issue-event-pagination-links.js";
 import { redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, PullReviewComment, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
 import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
@@ -45,6 +46,14 @@ export interface BoundedIssueCommentRead {
   overflow: boolean;
 }
 
+export interface IssueLabelEvent { id?: number; event?: string; created_at?: string; actor?: { login?: string | null } | null; label?: { name?: string | null } | null; }
+
+export type BoundedIssueLabelEventRead = IssueLabelEvent[] & {
+  items: IssueLabelEvent[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number; lastPage?: number;
+  terminal: "short_page" | "bounded_tail" | "event_history_unbounded";
+  truncated: boolean; overflow: boolean;
+};
+
 function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
   const result = items as BoundedGithubList<T>;
   result.items = items.slice();
@@ -65,6 +74,13 @@ function boundedIssueCommentRead(
     truncated: metadata.terminal === "page_cap",
     overflow: metadata.terminal === "page_cap"
   };
+}
+
+function boundedIssueLabelEventRead(items: IssueLabelEvent[], metadata: Omit<BoundedIssueLabelEventRead, keyof IssueLabelEvent[] | "items" | "uniqueCount" | "truncated" | "overflow">): BoundedIssueLabelEventRead {
+  return Object.assign(items, {
+    items: items.slice(), ...metadata, uniqueCount: items.length, truncated: metadata.terminal !== "short_page",
+    overflow: metadata.terminal === "event_history_unbounded"
+  });
 }
 
 export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
@@ -191,6 +207,34 @@ export class GitHubApiTimeoutError extends Error {
     this.path = input.path;
     this.timeoutMs = input.timeoutMs;
   }
+}
+
+function trustedIssueEventLastPage(link: unknown, endpoint: URL, currentPage: number, expectedLastPage?: number): number | undefined {
+  const parsed = parseIssueEventLink(link);
+  if (parsed.kind === "absent") { if (expectedLastPage !== undefined) throw new Error("missing issue-event tail Link"); return undefined; }
+  const relations = new Map<string, number>();
+  for (const member of parsed.members) {
+    const target = new URL(member.target);
+    if (target.origin !== endpoint.origin || target.pathname !== endpoint.pathname || target.username || target.password || target.hash) throw new Error("untrusted issue-event Link target");
+    const pageValues = target.searchParams.getAll("page"), perPageValues = target.searchParams.getAll("per_page");
+    if (pageValues.length !== 1 || perPageValues.length !== 1 || [...target.searchParams.keys()].length !== 2 || perPageValues[0] !== "100" || !/^[1-9]\d*$/.test(pageValues[0]!)) {
+      throw new Error("untrusted issue-event Link query");
+    }
+    const page = Number(pageValues[0]);
+    if (!Number.isSafeInteger(page)) throw new Error("untrusted issue-event Link page");
+    const value = member.relation.startsWith('"') ? member.relation.slice(1, -1) : member.relation;
+    for (const relation of value.split(" ")) {
+      if (!new Set(["first", "prev", "next", "last"]).has(relation) || relations.has(relation)) throw new Error("untrusted issue-event Link relation");
+      relations.set(relation, page);
+    }
+  }
+  const lastPage = expectedLastPage ?? relations.get("last");
+  if (!lastPage || (relations.has("last") && relations.get("last") !== lastPage)) throw new Error("untrusted issue-event last page");
+  if (relations.has("first") && relations.get("first") !== 1) throw new Error("untrusted issue-event first page");
+  if (relations.has("prev") && relations.get("prev") !== currentPage - 1) throw new Error("untrusted issue-event previous page");
+  if (currentPage < lastPage && (relations.get("next") !== currentPage + 1 || relations.get("last") !== lastPage)) throw new Error("untrusted issue-event forward pagination");
+  if (currentPage === lastPage && relations.has("next")) throw new Error("untrusted issue-event terminal pagination");
+  return lastPage;
 }
 
 export class GitHubApi {
@@ -434,26 +478,53 @@ export class GitHubApi {
     });
   }
 
-  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>> {
-    const events: Array<{
-      event?: string;
-      created_at?: string;
-      actor?: { login?: string | null } | null;
-      label?: { name?: string | null } | null;
-    }> = [];
-    for (let page = 1; ; page += 1) {
-      const chunk = await this.request<typeof events>(
-        `/repos/${repo}/issues/${issueNumber}/events?per_page=100&page=${page}`,
-        { token: await this.getReadToken(repo) }
-      );
-      events.push(...chunk);
-      if (chunk.length < 100) return events;
+  async listIssueLabelEvents(repo: string, issueNumber: number): Promise<BoundedIssueLabelEventRead> {
+    const path = `/repos/${repo}/issues/${issueNumber}/events`;
+    const endpoint = new URL(buildApiUrl(this.apiBaseUrl, path, "GitHub issue-event endpoint"));
+    const token = await this.getReadToken(repo);
+    const readPage = async (page: number) => {
+      let link: string | null = null;
+      const items = await this.request<IssueLabelEvent[]>(`${path}?per_page=100&page=${page}`, {
+        token,
+        responseHeaders: (headers) => { link = headers.get("link"); }
+      });
+      return { items, link };
+    };
+    const first = await readPage(1);
+    if (first.items.length < 100) {
+      return boundedIssueLabelEventRead(first.items, { pagesRead: 1, rawCount: first.items.length, duplicateCount: 0, lastPage: 1, terminal: "short_page" });
     }
+    let lastPage: number | undefined;
+    try {
+      lastPage = trustedIssueEventLastPage(first.link, endpoint, 1);
+    } catch {
+      return boundedIssueLabelEventRead([], { pagesRead: 1, rawCount: first.items.length, duplicateCount: 0, terminal: "event_history_unbounded" });
+    }
+    if (!lastPage) {
+      const probe = await readPage(2);
+      if (probe.items.length === 0) return boundedIssueLabelEventRead(first.items, { pagesRead: 2, rawCount: first.items.length, duplicateCount: 0, lastPage: 1, terminal: "short_page" });
+      return boundedIssueLabelEventRead([], { pagesRead: 2, rawCount: first.items.length + probe.items.length, duplicateCount: 0, terminal: "event_history_unbounded" });
+    }
+    const raw = lastPage <= 5 ? first.items.slice() : [];
+    let pagesRead = 1;
+    try {
+      for (let page = Math.max(2, lastPage - 4); page <= lastPage; page += 1) {
+        const result = await readPage(page);
+        pagesRead += 1;
+        trustedIssueEventLastPage(result.link, endpoint, page, lastPage);
+        raw.push(...result.items);
+      }
+    } catch {
+      return boundedIssueLabelEventRead([], { pagesRead, rawCount: raw.length, duplicateCount: 0, lastPage, terminal: "event_history_unbounded" });
+    }
+    const seen = new Set<number>(), items: IssueLabelEvent[] = [];
+    let duplicateCount = 0;
+    for (const event of raw) {
+      if (event.id !== undefined && seen.has(event.id)) { duplicateCount += 1; continue; }
+      if (event.id !== undefined) seen.add(event.id);
+      items.push(event);
+    }
+    return boundedIssueLabelEventRead(items, { pagesRead, rawCount: raw.length, duplicateCount, lastPage, terminal: "bounded_tail" });
   }
 
   async getCollaboratorPermission(
@@ -700,7 +771,7 @@ export class GitHubApi {
 
   private async request<T>(
     path: string,
-    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean } = {}
+    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean; responseHeaders?: (headers: Headers) => void } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
     const controller = new AbortController();
@@ -727,6 +798,7 @@ export class GitHubApi {
           responseText: text
         });
       }
+      options.responseHeaders?.(response.headers);
       return (await response.json()) as T;
     } catch (error) {
       if (error instanceof GitHubApiRequestError) throw error;

--- a/src/github.ts
+++ b/src/github.ts
@@ -47,12 +47,7 @@ export interface BoundedIssueCommentRead {
 }
 
 export interface IssueLabelEvent { id?: number; event?: string; created_at?: string; actor?: { login?: string | null } | null; label?: { name?: string | null } | null; }
-
-export type BoundedIssueLabelEventRead = IssueLabelEvent[] & {
-  items: IssueLabelEvent[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number; lastPage?: number;
-  terminal: "short_page" | "bounded_tail" | "event_history_unbounded"; truncated: boolean; overflow: boolean;
-};
-
+export type BoundedIssueLabelEventRead = IssueLabelEvent[] & { items: IssueLabelEvent[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number; lastPage?: number; terminal: "short_page" | "bounded_tail" | "event_history_unbounded"; truncated: boolean; overflow: boolean; };
 function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
   const result = items as BoundedGithubList<T>;
   result.items = items.slice();
@@ -76,10 +71,7 @@ function boundedIssueCommentRead(
 }
 
 function boundedIssueLabelEventRead(items: IssueLabelEvent[], metadata: Omit<BoundedIssueLabelEventRead, keyof IssueLabelEvent[] | "items" | "uniqueCount" | "truncated" | "overflow">): BoundedIssueLabelEventRead {
-  return Object.assign(items, {
-    items: items.slice(), ...metadata, uniqueCount: items.length, truncated: metadata.terminal !== "short_page",
-    overflow: metadata.terminal === "event_history_unbounded"
-  });
+  return Object.assign(items, { items: items.slice(), ...metadata, uniqueCount: items.length, truncated: metadata.terminal !== "short_page", overflow: metadata.terminal === "event_history_unbounded" });
 }
 
 export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
@@ -209,22 +201,16 @@ export class GitHubApiTimeoutError extends Error {
 }
 
 function trustedIssueEventLastPage(link: unknown, endpoint: URL, currentPage: number, expectedLastPage?: number): number | undefined {
-  const parsed = parseIssueEventLink(link);
-  if (parsed.kind === "absent") { if (expectedLastPage !== undefined) throw new Error("missing issue-event tail Link"); return undefined; }
+  const parsed = parseIssueEventLink(link); if (parsed.kind === "absent") { if (expectedLastPage !== undefined) throw new Error("missing issue-event tail Link"); return undefined; }
   const relations = new Map<string, number>();
   for (const member of parsed.members) {
-    const target = new URL(member.target);
-    if (target.origin !== endpoint.origin || target.pathname !== endpoint.pathname || target.username || target.password || target.hash) throw new Error("untrusted issue-event Link target");
+    const target = new URL(member.target); if (target.origin !== endpoint.origin || target.pathname !== endpoint.pathname || target.username || target.password || target.hash) throw new Error("untrusted issue-event Link target");
     const pageValues = target.searchParams.getAll("page"), perPageValues = target.searchParams.getAll("per_page");
-    if (pageValues.length !== 1 || perPageValues.length !== 1 || [...target.searchParams.keys()].length !== 2 || perPageValues[0] !== "100" || !/^[1-9]\d*$/.test(pageValues[0]!)) {
-      throw new Error("untrusted issue-event Link query");
-    }
-    const page = Number(pageValues[0]);
-    if (!Number.isSafeInteger(page)) throw new Error("untrusted issue-event Link page");
+    if (pageValues.length !== 1 || perPageValues.length !== 1 || [...target.searchParams.keys()].length !== 2 || perPageValues[0] !== "100" || !/^[1-9]\d*$/.test(pageValues[0]!)) throw new Error("untrusted issue-event Link query");
+    const page = Number(pageValues[0]); if (!Number.isSafeInteger(page)) throw new Error("untrusted issue-event Link page");
     const value = member.relation.startsWith('"') ? member.relation.slice(1, -1) : member.relation;
     for (const relation of value.split(" ")) {
-      if (!new Set(["first", "prev", "next", "last"]).has(relation) || relations.has(relation)) throw new Error("untrusted issue-event Link relation");
-      relations.set(relation, page);
+      if (!new Set(["first", "prev", "next", "last"]).has(relation) || relations.has(relation)) throw new Error("untrusted issue-event Link relation"); relations.set(relation, page);
     }
   }
   const lastPage = expectedLastPage ?? relations.get("last");

--- a/src/github.ts
+++ b/src/github.ts
@@ -50,8 +50,7 @@ export interface IssueLabelEvent { id?: number; event?: string; created_at?: str
 
 export type BoundedIssueLabelEventRead = IssueLabelEvent[] & {
   items: IssueLabelEvent[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number; lastPage?: number;
-  terminal: "short_page" | "bounded_tail" | "event_history_unbounded";
-  truncated: boolean; overflow: boolean;
+  terminal: "short_page" | "bounded_tail" | "event_history_unbounded"; truncated: boolean; overflow: boolean;
 };
 
 function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
@@ -491,14 +490,15 @@ export class GitHubApi {
       return { items, link };
     };
     const first = await readPage(1);
-    if (first.items.length < 100) {
-      return boundedIssueLabelEventRead(first.items, { pagesRead: 1, rawCount: first.items.length, duplicateCount: 0, lastPage: 1, terminal: "short_page" });
-    }
     let lastPage: number | undefined;
     try {
       lastPage = trustedIssueEventLastPage(first.link, endpoint, 1);
     } catch {
       return boundedIssueLabelEventRead([], { pagesRead: 1, rawCount: first.items.length, duplicateCount: 0, terminal: "event_history_unbounded" });
+    }
+    if (first.items.length < 100) {
+      if (lastPage !== undefined && lastPage !== 1) return boundedIssueLabelEventRead([], { pagesRead: 1, rawCount: first.items.length, duplicateCount: 0, lastPage, terminal: "event_history_unbounded" });
+      return boundedIssueLabelEventRead(first.items, { pagesRead: 1, rawCount: first.items.length, duplicateCount: 0, lastPage: 1, terminal: "short_page" });
     }
     if (!lastPage) {
       const probe = await readPage(2);

--- a/src/github.ts
+++ b/src/github.ts
@@ -47,7 +47,7 @@ export interface BoundedIssueCommentRead {
 }
 
 export interface IssueLabelEvent { id?: number; event?: string; created_at?: string; actor?: { login?: string | null } | null; label?: { name?: string | null } | null; }
-export type BoundedIssueLabelEventRead = IssueLabelEvent[] & { items: IssueLabelEvent[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number; lastPage?: number; terminal: "short_page" | "bounded_tail" | "event_history_unbounded"; truncated: boolean; overflow: boolean; };
+export type BoundedIssueLabelEventRead = IssueLabelEvent[] & { items: IssueLabelEvent[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number; lastPage?: number; terminal: "short_page" | "complete" | "bounded_tail" | "event_history_unbounded"; truncated: boolean; overflow: boolean; };
 function boundedGithubList<T>(items: T[], truncated: boolean): BoundedGithubList<T> {
   const result = items as BoundedGithubList<T>;
   result.items = items.slice();
@@ -71,7 +71,7 @@ function boundedIssueCommentRead(
 }
 
 function boundedIssueLabelEventRead(items: IssueLabelEvent[], metadata: Omit<BoundedIssueLabelEventRead, keyof IssueLabelEvent[] | "items" | "uniqueCount" | "truncated" | "overflow">): BoundedIssueLabelEventRead {
-  return Object.assign(items, { items: items.slice(), ...metadata, uniqueCount: items.length, truncated: metadata.terminal !== "short_page", overflow: metadata.terminal === "event_history_unbounded" });
+  return Object.assign(items, { items: items.slice(), ...metadata, uniqueCount: items.length, truncated: metadata.terminal === "bounded_tail" || metadata.terminal === "event_history_unbounded", overflow: metadata.terminal === "event_history_unbounded" });
 }
 
 export function unpackBoundedGithubList<T>(result: T[] | BoundedGithubList<T>): {
@@ -510,7 +510,7 @@ export class GitHubApi {
       if (event.id !== undefined) seen.add(event.id);
       items.push(event);
     }
-    return boundedIssueLabelEventRead(items, { pagesRead, rawCount: raw.length, duplicateCount, lastPage, terminal: "bounded_tail" });
+    return boundedIssueLabelEventRead(items, { pagesRead, rawCount: raw.length, duplicateCount, lastPage, terminal: lastPage <= 5 ? "complete" : "bounded_tail" });
   }
 
   async getCollaboratorPermission(

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -990,7 +990,7 @@ export async function runIssueEnrichmentCycle(input: {
               const prepared: GitHubRelatedIssueOrPull[] = [];
               for (const issue of issues) {
                 let events: IssueLabelEvent[] | undefined;
-                try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch {}
+                try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch { events = Object.assign([], { terminal: "event_history_unbounded" }); }
                 if (events) eventHistoryByIssue.set(issueKey(repo, issue.number), events);
                 if ((events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal === "event_history_unbounded") {
                   issuesByKey.set(issueKey(repo, issue.number), issue); eventHistoryOverflow.push({ repo, issue }); continue;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -12,7 +12,7 @@ import {
   type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
-import { unpackBoundedGithubList, type BoundedGithubList } from "./github.js";
+import { unpackBoundedGithubList, type BoundedGithubList, type BoundedIssueLabelEventRead, type IssueLabelEvent } from "./github.js";
 import {
   buildIssueAnalysisInputHash,
   runIssueAnalysis,
@@ -290,12 +290,7 @@ type IssueEnrichmentComment = {
 
 export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub & {
   getRepo?(repo: string): Promise<{ default_branch?: string; clone_url?: string }>;
-  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<Array<{
-    event?: string;
-    created_at?: string;
-    actor?: { login?: string | null } | null;
-    label?: { name?: string | null } | null;
-  }>>;
+  listIssueLabelEvents?(repo: string, issueNumber: number): Promise<IssueLabelEvent[] | BoundedIssueLabelEventRead>;
   getCollaboratorPermission?(repo: string, login: string): Promise<IssuePromotionPermission>;
   listIssueComments?(repo: string, issueNumber: number): Promise<IssueEnrichmentComment[] | BoundedGithubList<IssueEnrichmentComment>>;
   listIssueCommentsForEnrichment?(repo: string, issueNumber: number): Promise<BoundedGithubList<IssueEnrichmentComment>>;
@@ -328,7 +323,7 @@ export type IssueEnrichmentScanReason =
   | "eligible"
   | "stale_issue_closed"
   | "issue_is_pull_request"
-  | "preservation_only_upstream_intake"
+  | "preservation_only_upstream_intake" | "event_history_unbounded"
   | "repo_max_issues_per_cycle"
   | "repo_max_comments_per_cycle"
   | "global_max_issues_per_cycle"
@@ -386,6 +381,7 @@ async function evaluateIssuePromotion(input: {
   issue: GitHubRelatedIssueOrPull;
   override?: IssueEnrichmentRepoOverride;
   github: IssueEnrichmentCycleGithub;
+  events?: IssueLabelEvent[];
 }): Promise<{ issue: GitHubRelatedIssueOrPull; evidence?: IssuePromotionEvidence }> {
   const labels = (input.issue.labels ?? [])
     .map((label) => typeof label === "string" ? label : label.name ?? "")
@@ -399,7 +395,7 @@ async function evaluateIssuePromotion(input: {
     return { issue: input.issue };
   }
   try {
-    const events = await input.github.listIssueLabelEvents(input.repo, input.issue.number);
+    const events = input.events ?? await input.github.listIssueLabelEvents(input.repo, input.issue.number);
     const labelEvent = events
       .filter((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation")
       .filter((event) => Boolean(event.actor?.login && event.created_at))
@@ -444,6 +440,7 @@ export async function buildIssueEvidenceContext(input: {
   github: IssueEnrichmentCycleGithub;
   defaultBranch: string;
   headSha: string;
+  labelEvents?: IssueLabelEvent[];
 }): Promise<IssueAnalysisEvidenceContext> {
   const commentResult = input.github.listIssueCommentsForEnrichment
     ? await input.github.listIssueCommentsForEnrichment(input.repo, input.issue.number)
@@ -454,9 +451,9 @@ export async function buildIssueEvidenceContext(input: {
   const externalComments = rawComments.filter((comment) =>
     !(comment.body ?? "").trimStart().startsWith(ENRICHMENT_MARKER_PREFIX)
   );
-  const rawTimeline = input.github.listIssueLabelEvents
+  const rawTimeline = input.labelEvents ?? (input.github.listIssueLabelEvents
     ? await input.github.listIssueLabelEvents(input.repo, input.issue.number)
-    : [];
+    : []);
   const linkedNumbers = extractIssueReferenceNumbers(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`, input.issue.number);
   const linkedItems: IssueAnalysisEvidenceContext["linkedItems"] = [];
   if (input.github.getIssueOrPull) {
@@ -484,7 +481,7 @@ export async function buildIssueEvidenceContext(input: {
       updatedAt: boundedIssueContext(redactSecrets(comment.updated_at ?? ""), 100),
       body: boundedIssueContext(redactSecrets(comment.body ?? ""), 8_000)
     })),
-    timeline: rawTimeline.slice(0, 200).map((event) => ({
+    timeline: rawTimeline.slice(-200).map((event) => ({
       event: boundedIssueContext(redactSecrets(event.event ?? ""), 100),
       actor: boundedIssueContext(redactSecrets(event.actor?.login ?? ""), 200),
       createdAt: boundedIssueContext(redactSecrets(event.created_at ?? ""), 100),
@@ -931,6 +928,7 @@ export async function runIssueEnrichmentCycle(input: {
     }
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
+    const eventHistoryByIssue = new Map<string, IssueLabelEvent[]>(), eventHistoryOverflow: Array<{ repo: string; issue: GitHubRelatedIssueOrPull }> = [];
     const issueEvidenceContextByIssue = new Map<string, IssueAnalysisEvidenceContext>();
     const promotionEvidenceByIssue = new Map<string, IssuePromotionEvidence>();
     const plannedEnrichmentByIssue = new Map<string, EnrichmentComment>();
@@ -991,11 +989,17 @@ export async function runIssueEnrichmentCycle(input: {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
               const prepared: GitHubRelatedIssueOrPull[] = [];
               for (const issue of issues) {
+                let events: IssueLabelEvent[] | undefined;
+                try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch {}
+                if (events) eventHistoryByIssue.set(issueKey(repo, issue.number), events);
+                if ((events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal === "event_history_unbounded") {
+                  issuesByKey.set(issueKey(repo, issue.number), issue); eventHistoryOverflow.push({ repo, issue }); continue;
+                }
                 const promotion = await evaluateIssuePromotion({
                   repo,
                   issue,
                   override: canonicalIssueEnrichmentRepository(config, repo).override,
-                  github: input.github
+                  github: input.github, events
                 });
                 prepared.push(promotion.issue);
                 issuesByKey.set(issueKey(repo, issue.number), promotion.issue);
@@ -1026,6 +1030,10 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
+    for (const { repo, issue } of eventHistoryOverflow) {
+      const repoScan = scanned.repos.find((candidate) => candidate.repo === repo); if (repoScan) repoScan.issuesSeen += 1;
+      scanned.items.push({ repo, issueNumber: issue.number, state: issue.state ?? "unknown", action: "skipped", reason: "event_history_unbounded", ...(issue.html_url ? { url: issue.html_url } : {}) });
+    }
     const combinedRepos = [...baselineRepos, ...scanned.repos];
     const combinedSummary = summarizeScan(combinedRepos);
     const scan: IssueEnrichmentScanResult = {
@@ -1065,6 +1073,10 @@ export async function runIssueEnrichmentCycle(input: {
 
     for (const item of scan.items.filter((candidate) => candidate.action === "skipped")) {
       const issueUpdatedAt = canonicalIssueUpdatedAt(issuesByKey.get(issueKey(item.repo, item.issueNumber)), checkedAt);
+      const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
+      if (item.reason === "event_history_unbounded" && input.force !== true && existing?.status === "skipped" && existing.reason === item.reason && existing.issueUpdatedAt === issueUpdatedAt) {
+        summary.alreadyProcessed += 1; items.push({ ...item, skippedExisting: true, recordStatus: "skipped" }); continue;
+      }
       if (!input.dryRun) input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "skipped", reason: item.reason, now: new Date(checkedAt) });
       if (!input.dryRun) summary.skippedRecorded += 1;
       items.push({ ...item, ...(!input.dryRun ? { recordStatus: "skipped" as const } : {}) });
@@ -1091,7 +1103,8 @@ export async function runIssueEnrichmentCycle(input: {
             defaultBranches.set(repoKey, defaultBranch);
           }
           issueEvidenceContextByIssue.set(issueKey(item.repo, item.issueNumber), await buildIssueEvidenceContext({
-            repo: item.repo, issue, github: input.github, defaultBranch: defaultBranches.get(repoKey)!, headSha: sourceSnapshots.get(repoKey)!.headSha
+            repo: item.repo, issue, github: input.github, defaultBranch: defaultBranches.get(repoKey)!, headSha: sourceSnapshots.get(repoKey)!.headSha,
+            labelEvents: eventHistoryByIssue.get(issueKey(item.repo, item.issueNumber))
           }));
         } catch (error) {
           const message = redactSecrets(error instanceof Error ? error.message : String(error));

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -989,16 +989,17 @@ export async function runIssueEnrichmentCycle(input: {
               const issues = await input.github.listIssuesForEnrichment(repo, options);
               const prepared: GitHubRelatedIssueOrPull[] = [];
               for (const issue of issues) {
-                let events: IssueLabelEvent[] | undefined;
-                try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch { events = Object.assign([], { terminal: "event_history_unbounded" }); }
-                if (events) eventHistoryByIssue.set(issueKey(repo, issue.number), events);
-                if ((events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal === "event_history_unbounded") {
+                const override = canonicalIssueEnrichmentRepository(config, repo).override, labels = (issue.labels ?? []).map((label) => (typeof label === "string" ? label : label.name ?? "").trim().toLowerCase());
+                const needsPromotion = labels.includes("upstream-intake") && labels.includes("active-continuation") && (override?.promotionMaintainers?.length ?? 0) > 0;
+                let events: IssueLabelEvent[] | undefined; if (needsPromotion) try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch { events = Object.assign([], { terminal: "event_history_unbounded" }); }
+                if (events) eventHistoryByIssue.set(issueKey(repo, issue.number), events); const terminal = (events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal;
+                if (terminal === "event_history_unbounded" || (terminal === "bounded_tail" && !events!.some((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation" && event.actor?.login && event.created_at))) {
                   issuesByKey.set(issueKey(repo, issue.number), issue); eventHistoryOverflow.push({ repo, issue }); continue;
                 }
                 const promotion = await evaluateIssuePromotion({
                   repo,
                   issue,
-                  override: canonicalIssueEnrichmentRepository(config, repo).override,
+                  override,
                   github: input.github, events
                 });
                 prepared.push(promotion.issue);
@@ -1030,10 +1031,8 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
-    for (const { repo, issue } of eventHistoryOverflow) {
-      const repoScan = scanned.repos.find((candidate) => candidate.repo === repo); if (repoScan) repoScan.issuesSeen += 1;
-      scanned.items.push({ repo, issueNumber: issue.number, state: issue.state ?? "unknown", action: "skipped", reason: "event_history_unbounded", ...(issue.html_url ? { url: issue.html_url } : {}) });
-    }
+    for (const { repo, issue } of eventHistoryOverflow) { const repoScan = scanned.repos.find((candidate) => candidate.repo === repo); if (repoScan) repoScan.issuesSeen += 1;
+      scanned.items.push({ repo, issueNumber: issue.number, state: issue.state ?? "unknown", action: "skipped", reason: "event_history_unbounded", ...(issue.html_url ? { url: issue.html_url } : {}) }); }
     const combinedRepos = [...baselineRepos, ...scanned.repos];
     const combinedSummary = summarizeScan(combinedRepos);
     const scan: IssueEnrichmentScanResult = {
@@ -1074,9 +1073,7 @@ export async function runIssueEnrichmentCycle(input: {
     for (const item of scan.items.filter((candidate) => candidate.action === "skipped")) {
       const issueUpdatedAt = canonicalIssueUpdatedAt(issuesByKey.get(issueKey(item.repo, item.issueNumber)), checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      if (item.reason === "event_history_unbounded" && input.force !== true && existing?.status === "skipped" && existing.reason === item.reason && existing.issueUpdatedAt === issueUpdatedAt) {
-        summary.alreadyProcessed += 1; items.push({ ...item, skippedExisting: true, recordStatus: "skipped" }); continue;
-      }
+      if (item.reason === "event_history_unbounded" && input.force !== true && existing?.status === "skipped" && existing.reason === item.reason && existing.issueUpdatedAt === issueUpdatedAt) { summary.alreadyProcessed += 1; items.push({ ...item, skippedExisting: true, recordStatus: "skipped" }); continue; }
       if (!input.dryRun) input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "skipped", reason: item.reason, now: new Date(checkedAt) });
       if (!input.dryRun) summary.skippedRecorded += 1;
       items.push({ ...item, ...(!input.dryRun ? { recordStatus: "skipped" as const } : {}) });
@@ -1092,6 +1089,8 @@ export async function runIssueEnrichmentCycle(input: {
       if (shouldCollectModelEvidence && issue) {
         const repoKey = item.repo.toLowerCase(), wasPrepared = sourceSnapshots.has(repoKey);
         try {
+          let events = eventHistoryByIssue.get(issueKey(item.repo, item.issueNumber)); if (!events && input.github.listIssueLabelEvents) try { events = await input.github.listIssueLabelEvents(item.repo, item.issueNumber); } catch { events = Object.assign([], { terminal: "event_history_unbounded" }); }
+          if ((events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal === "event_history_unbounded") throw new Error("issue_enrichment_event_history_unbounded"); if (events) eventHistoryByIssue.set(issueKey(item.repo, item.issueNumber), events);
           if (!wasPrepared) {
             const metadata = await input.github.getRepo!(item.repo), defaultBranch = metadata.default_branch?.trim();
             if (!defaultBranch) throw new Error(`issue_enrichment_default_branch_missing: ${item.repo}`);
@@ -1108,6 +1107,9 @@ export async function runIssueEnrichmentCycle(input: {
           }));
         } catch (error) {
           const message = redactSecrets(error instanceof Error ? error.message : String(error));
+          if (message === "issue_enrichment_event_history_unbounded") {
+            if (!input.dryRun) { input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "skipped", reason: "event_history_unbounded", now: new Date(checkedAt) }); summary.skippedRecorded += 1; }
+            admissionLedger.release(admitted.candidate); settled.add(admitted.candidate.key); items.push({ ...item, action: "skipped", reason: "event_history_unbounded", ...(!input.dryRun ? { recordStatus: "skipped" as const } : {}) }); continue; }
           if (!wasPrepared && !sourceSnapshots.has(repoKey)) admissionLedger.blockRepo(item.repo);
           else admissionLedger.release(admitted.candidate);
           input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "failed", reason: "source_or_evidence_failed", error: message, now: new Date(checkedAt) });

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -991,8 +991,9 @@ export async function runIssueEnrichmentCycle(input: {
               for (const issue of issues) {
                 const override = canonicalIssueEnrichmentRepository(config, repo).override, labels = (issue.labels ?? []).map((label) => (typeof label === "string" ? label : label.name ?? "").trim().toLowerCase());
                 const needsPromotion = labels.includes("upstream-intake") && labels.includes("active-continuation") && (override?.promotionMaintainers?.length ?? 0) > 0;
-                let events: IssueLabelEvent[] | undefined; if (needsPromotion) try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch { events = Object.assign([], { terminal: "event_history_unbounded" }); }
-                if (events) eventHistoryByIssue.set(issueKey(repo, issue.number), events); const terminal = (events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal;
+                let events: IssueLabelEvent[] | undefined; if (needsPromotion) try { events = input.github.listIssueLabelEvents ? await input.github.listIssueLabelEvents(repo, issue.number) : []; } catch { events = Object.assign([], { terminal: "event_history_read_failed" }); }
+                if (events) eventHistoryByIssue.set(issueKey(repo, issue.number), events); const terminal = (events as { terminal?: string } | undefined)?.terminal;
+                if (terminal === "event_history_read_failed") throw new Error("issue_enrichment_event_history_read_failed");
                 if (terminal === "event_history_unbounded" || (terminal === "bounded_tail" && !events!.some((event) => event.event === "labeled" && event.label?.name?.trim().toLowerCase() === "active-continuation" && event.actor?.login && event.created_at))) {
                   issuesByKey.set(issueKey(repo, issue.number), issue); eventHistoryOverflow.push({ repo, issue }); continue;
                 }
@@ -1031,8 +1032,7 @@ export async function runIssueEnrichmentCycle(input: {
           items: [],
           recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
         };
-    for (const { repo, issue } of eventHistoryOverflow) { const repoScan = scanned.repos.find((candidate) => candidate.repo === repo); if (repoScan) repoScan.issuesSeen += 1;
-      scanned.items.push({ repo, issueNumber: issue.number, state: issue.state ?? "unknown", action: "skipped", reason: "event_history_unbounded", ...(issue.html_url ? { url: issue.html_url } : {}) }); }
+    for (const { repo, issue } of eventHistoryOverflow) { const repoScan = scanned.repos.find((candidate) => candidate.repo === repo); if (repoScan) repoScan.issuesSeen += 1; scanned.items.push({ repo, issueNumber: issue.number, state: issue.state ?? "unknown", action: "skipped", reason: "event_history_unbounded", ...(issue.html_url ? { url: issue.html_url } : {}) }); }
     const combinedRepos = [...baselineRepos, ...scanned.repos];
     const combinedSummary = summarizeScan(combinedRepos);
     const scan: IssueEnrichmentScanResult = {
@@ -1089,8 +1089,8 @@ export async function runIssueEnrichmentCycle(input: {
       if (shouldCollectModelEvidence && issue) {
         const repoKey = item.repo.toLowerCase(), wasPrepared = sourceSnapshots.has(repoKey);
         try {
-          let events = eventHistoryByIssue.get(issueKey(item.repo, item.issueNumber)); if (!events && input.github.listIssueLabelEvents) try { events = await input.github.listIssueLabelEvents(item.repo, item.issueNumber); } catch { events = Object.assign([], { terminal: "event_history_unbounded" }); }
-          if ((events as Partial<BoundedIssueLabelEventRead> | undefined)?.terminal === "event_history_unbounded") throw new Error("issue_enrichment_event_history_unbounded"); if (events) eventHistoryByIssue.set(issueKey(item.repo, item.issueNumber), events);
+          let events = eventHistoryByIssue.get(issueKey(item.repo, item.issueNumber)); if (!events && input.github.listIssueLabelEvents) try { events = await input.github.listIssueLabelEvents(item.repo, item.issueNumber); } catch { events = Object.assign([], { terminal: "event_history_read_failed" }); }
+          const terminal = (events as { terminal?: string } | undefined)?.terminal; if (terminal === "event_history_unbounded" || terminal === "event_history_read_failed") throw new Error(`issue_enrichment_${terminal}`); if (events) eventHistoryByIssue.set(issueKey(item.repo, item.issueNumber), events);
           if (!wasPrepared) {
             const metadata = await input.github.getRepo!(item.repo), defaultBranch = metadata.default_branch?.trim();
             if (!defaultBranch) throw new Error(`issue_enrichment_default_branch_missing: ${item.repo}`);
@@ -1108,8 +1108,7 @@ export async function runIssueEnrichmentCycle(input: {
         } catch (error) {
           const message = redactSecrets(error instanceof Error ? error.message : String(error));
           if (message === "issue_enrichment_event_history_unbounded") {
-            if (!input.dryRun) { input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "skipped", reason: "event_history_unbounded", now: new Date(checkedAt) }); summary.skippedRecorded += 1; }
-            admissionLedger.release(admitted.candidate); settled.add(admitted.candidate.key); items.push({ ...item, action: "skipped", reason: "event_history_unbounded", ...(!input.dryRun ? { recordStatus: "skipped" as const } : {}) }); continue; }
+            if (!input.dryRun) { input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "skipped", reason: "event_history_unbounded", now: new Date(checkedAt) }); summary.skippedRecorded += 1; } admissionLedger.release(admitted.candidate); settled.add(admitted.candidate.key); items.push({ ...item, action: "skipped", reason: "event_history_unbounded", ...(!input.dryRun ? { recordStatus: "skipped" as const } : {}) }); continue; }
           if (!wasPrepared && !sourceSnapshots.has(repoKey)) admissionLedger.blockRepo(item.repo);
           else admissionLedger.release(admitted.candidate);
           input.state.recordIssueEnrichment({ repo: item.repo, issueNumber: item.issueNumber, issueUpdatedAt, status: "failed", reason: "source_or_evidence_failed", error: message, now: new Date(checkedAt) });

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -862,7 +862,7 @@ describe("sticky enrichment comments", () => {
         statePath,
         issueEnrichment: {
           enabled: true,
-          postIssueComment: false,
+          postIssueComment: true,
           allowlist: ["Electricsheephq/lcm-x", "electricsheephq/lcm-x"],
           maxIssuesPerCycle: 1,
           maxCommentsPerCycle: 1,
@@ -874,7 +874,8 @@ describe("sticky enrichment comments", () => {
               cooldownMs: 60_000,
               burstWindowMs: 60_000,
               maxIssuesPerBurst: 2,
-              lookbackMs: 60_000
+              lookbackMs: 60_000,
+              promotionMaintainers: [{ login: "Tosko4", validFrom: "2026-08-01T00:00:00Z", validUntil: "2026-09-01T00:00:00Z" }]
             }
           }
         }
@@ -892,14 +893,15 @@ describe("sticky enrichment comments", () => {
               title: "[Upstream PR #461] retrieval: add exhaustive citable recall mode",
               state: "open",
               updated_at: "2026-08-15T20:24:56Z",
-              labels: [{ name: "upstream-intake" }, { name: "upstream-pr" }],
+              labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
               body: "Attributed preservation record only."
-            }, { number: 128, title: "Eligible sibling", state: "open", updated_at: "2026-08-15T20:25:00Z" }],
-            listIssueLabelEvents: async (_repo, issueNumber) => { if (issueNumber === 127) throw new Error("fixture event-read failure"); return []; },
+            }, { number: 128, title: "Eligible sibling", state: "open", updated_at: "2026-08-15T20:25:00Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }] }, { number: 129, title: "Failed history sibling", state: "open", updated_at: "2026-08-15T20:26:00Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }] }],
+            listIssueLabelEvents: async (_repo, issueNumber) => { if (issueNumber === 127) return Object.assign([], { terminal: "bounded_tail" }); if (issueNumber === 129) throw new Error("fixture event-read failure"); return [{ event: "labeled", created_at: "2026-08-15T20:24:00Z", actor: { login: "Tosko4" }, label: { name: "active-continuation" } }]; },
+            getCollaboratorPermission: async () => "maintain",
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;
-              throw new Error("preservation records must not post");
+              return { action: "created" as const, comment: { html_url: "https://github.test/comment/128" } };
             }
           },
           dryRun: false,
@@ -912,9 +914,9 @@ describe("sticky enrichment comments", () => {
         });
 
         expect(result.summary).toMatchObject({
-          skippedRecorded: 1,
-          dryRunRecorded: 1,
-          posted: 0,
+          skippedRecorded: 2,
+          dryRunRecorded: 0,
+          posted: 1,
           failed: 0
         });
         expect(result.items[0]).toMatchObject({
@@ -923,8 +925,8 @@ describe("sticky enrichment comments", () => {
           reason: "event_history_unbounded",
           recordStatus: "skipped"
         });
-        expect(analysisCalls).toBe(0);
-        expect(postCalls).toBe(0);
+        expect(analysisCalls).toBe(1);
+        expect(postCalls).toBe(1);
         expect(state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")).toMatchObject({ lastCheckedAt: "2026-08-15T21:00:00.000Z" });
       } finally {
         state.close();

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -853,7 +853,7 @@ describe("sticky enrichment comments", () => {
     expect(JSON.stringify(output)).not.toContain("body");
   });
 
-  it("records upstream-intake as skipped without invoking the model or creating a comment", async () => {
+  it("records unbounded event history without consuming sibling admission or blocking the watermark", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-upstream-intake-"));
     try {
       const configPath = join(root, "config.json");
@@ -862,7 +862,7 @@ describe("sticky enrichment comments", () => {
         statePath,
         issueEnrichment: {
           enabled: true,
-          postIssueComment: true,
+          postIssueComment: false,
           allowlist: ["Electricsheephq/lcm-x", "electricsheephq/lcm-x"],
           maxIssuesPerCycle: 1,
           maxCommentsPerCycle: 1,
@@ -894,7 +894,8 @@ describe("sticky enrichment comments", () => {
               updated_at: "2026-08-15T20:24:56Z",
               labels: [{ name: "upstream-intake" }, { name: "upstream-pr" }],
               body: "Attributed preservation record only."
-            }],
+            }, { number: 128, title: "Eligible sibling", state: "open", updated_at: "2026-08-15T20:25:00Z" }],
+            listIssueLabelEvents: async (_repo, issueNumber) => issueNumber === 127 ? Object.assign([], { items: [], pagesRead: 2, rawCount: 200, uniqueCount: 0, duplicateCount: 0, terminal: "event_history_unbounded", truncated: true, overflow: true }) : [],
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;
@@ -912,17 +913,19 @@ describe("sticky enrichment comments", () => {
 
         expect(result.summary).toMatchObject({
           skippedRecorded: 1,
+          dryRunRecorded: 1,
           posted: 0,
           failed: 0
         });
         expect(result.items[0]).toMatchObject({
           issueNumber: 127,
           action: "skipped",
-          reason: "preservation_only_upstream_intake",
+          reason: "event_history_unbounded",
           recordStatus: "skipped"
         });
         expect(analysisCalls).toBe(0);
         expect(postCalls).toBe(0);
+        expect(state.getIssueEnrichmentRepoWatermark("electricsheephq/lcm-x")).toMatchObject({ lastCheckedAt: "2026-08-15T21:00:00.000Z" });
       } finally {
         state.close();
       }

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -895,7 +895,7 @@ describe("sticky enrichment comments", () => {
               labels: [{ name: "upstream-intake" }, { name: "upstream-pr" }],
               body: "Attributed preservation record only."
             }, { number: 128, title: "Eligible sibling", state: "open", updated_at: "2026-08-15T20:25:00Z" }],
-            listIssueLabelEvents: async (_repo, issueNumber) => issueNumber === 127 ? Object.assign([], { items: [], pagesRead: 2, rawCount: 200, uniqueCount: 0, duplicateCount: 0, terminal: "event_history_unbounded", truncated: true, overflow: true }) : [],
+            listIssueLabelEvents: async (_repo, issueNumber) => { if (issueNumber === 127) throw new Error("fixture event-read failure"); return []; },
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
               postCalls += 1;

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -895,8 +895,8 @@ describe("sticky enrichment comments", () => {
               updated_at: "2026-08-15T20:24:56Z",
               labels: [{ name: "upstream-intake" }, { name: "active-continuation" }],
               body: "Attributed preservation record only."
-            }, { number: 128, title: "Eligible sibling", state: "open", updated_at: "2026-08-15T20:25:00Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }] }, { number: 129, title: "Failed history sibling", state: "open", updated_at: "2026-08-15T20:26:00Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }] }],
-            listIssueLabelEvents: async (_repo, issueNumber) => { if (issueNumber === 127) return Object.assign([], { terminal: "bounded_tail" }); if (issueNumber === 129) throw new Error("fixture event-read failure"); return [{ event: "labeled", created_at: "2026-08-15T20:24:00Z", actor: { login: "Tosko4" }, label: { name: "active-continuation" } }]; },
+            }, { number: 128, title: "Eligible sibling", state: "open", updated_at: "2026-08-15T20:25:00Z", labels: [{ name: "upstream-intake" }, { name: "active-continuation" }] }],
+            listIssueLabelEvents: async (_repo, issueNumber) => issueNumber === 127 ? Object.assign([], { terminal: "bounded_tail" }) : [{ event: "labeled", created_at: "2026-08-15T20:24:00Z", actor: { login: "Tosko4" }, label: { name: "active-continuation" } }],
             getCollaboratorPermission: async () => "maintain",
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
@@ -914,7 +914,7 @@ describe("sticky enrichment comments", () => {
         });
 
         expect(result.summary).toMatchObject({
-          skippedRecorded: 2,
+          skippedRecorded: 1,
           dryRunRecorded: 0,
           posted: 1,
           failed: 0

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -952,13 +952,40 @@ describe("GitHub App read authentication", () => {
     expect(result.truncated).toBe(true);
     expect(result.overflow).toBe(true);
   });
+
+  it("listIssueLabelEvents reads only the newest five pages from trusted pagination metadata", async () => {
+    const pagesRequested: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const match = /\/repos\/owner\/repo\/issues\/970\/events\?per_page=100&page=(\d+)$/.exec(String(url));
+      if (!match) return jsonResponse({ message: "unexpected" }, 404);
+      const page = Number(match[1]);
+      pagesRequested.push(page);
+      if (page > 8) return jsonResponse([]);
+      const link = page < 8
+        ? `<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=${page + 1}>; rel="next", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=8>; rel="last"`
+        : `<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=1>; rel="first", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=7>; rel="prev"`;
+      return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: page * 100 + index })), 200, "", { Link: link });
+    }) as typeof fetch;
+
+    const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+
+    expect(pagesRequested).toEqual([1, 4, 5, 6, 7, 8]);
+    expect(result).toHaveLength(500);
+    expect(result).toMatchObject({ pagesRead: 6, lastPage: 8, terminal: "bounded_tail", truncated: true, overflow: false });
+
+    pagesRequested.length = 0;
+    globalThis.fetch = vi.fn(async (url) => { const page = Number(new URL(String(url)).searchParams.get("page")); pagesRequested.push(page); return jsonResponse(page <= 2 ? Array.from({ length: 100 }, (_unused, index) => ({ id: page * 100 + index })) : []); }) as typeof fetch;
+    const overflow = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+    expect(pagesRequested).toEqual([1, 2]);
+    expect(overflow).toMatchObject({ pagesRead: 2, terminal: "event_history_unbounded", truncated: true, overflow: true });
+  });
 });
 
-function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
+function jsonResponse(body: unknown, status = 200, statusText = "", headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,
     statusText,
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json", ...headers }
   });
 }
 

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -970,6 +970,9 @@ describe("GitHub App read authentication", () => {
     expect(pagesRequested).toEqual([1, 4, 5, 6, 7, 8]);
     expect(result).toHaveLength(500);
     expect(result).toMatchObject({ pagesRead: 6, lastPage: 8, terminal: "bounded_tail", truncated: true, overflow: false });
+    pagesRequested.length = 0; globalThis.fetch = vi.fn(async (url) => { const page = Number(new URL(String(url)).searchParams.get("page")); pagesRequested.push(page); const link = page === 1 ? '<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=2>; rel="next", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=2>; rel="last"' : '<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=1>; rel="first", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=1>; rel="prev"'; return jsonResponse(Array.from({ length: 100 }, (_unused, id) => ({ id: page * 100 + id })), 200, "", { Link: link }); }) as typeof fetch;
+    const complete = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+    expect(pagesRequested).toEqual([1, 2]); expect(complete).toMatchObject({ lastPage: 2, terminal: "complete", truncated: false, overflow: false });
     pagesRequested.length = 0;
     globalThis.fetch = vi.fn(async (url) => { const page = Number(new URL(String(url)).searchParams.get("page")); pagesRequested.push(page); return jsonResponse(page <= 2 ? Array.from({ length: 100 }, (_unused, index) => ({ id: page * 100 + index })) : []); }) as typeof fetch;
     const overflow = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -966,19 +966,15 @@ describe("GitHub App read authentication", () => {
         : `<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=1>; rel="first", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=7>; rel="prev"`;
       return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: page * 100 + index })), 200, "", { Link: link });
     }) as typeof fetch;
-
     const result = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
-
     expect(pagesRequested).toEqual([1, 4, 5, 6, 7, 8]);
     expect(result).toHaveLength(500);
     expect(result).toMatchObject({ pagesRead: 6, lastPage: 8, terminal: "bounded_tail", truncated: true, overflow: false });
-
     pagesRequested.length = 0;
     globalThis.fetch = vi.fn(async (url) => { const page = Number(new URL(String(url)).searchParams.get("page")); pagesRequested.push(page); return jsonResponse(page <= 2 ? Array.from({ length: 100 }, (_unused, index) => ({ id: page * 100 + index })) : []); }) as typeof fetch;
     const overflow = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
     expect(pagesRequested).toEqual([1, 2]);
     expect(overflow).toMatchObject({ pagesRead: 2, terminal: "event_history_unbounded", truncated: true, overflow: true });
-
     pagesRequested.length = 0;
     globalThis.fetch = vi.fn(async () => { pagesRequested.push(1); return jsonResponse(Array.from({ length: 50 }, (_unused, id) => ({ id })), 200, "", { Link: '<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=2>; rel="next", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=2>; rel="last"' }); }) as typeof fetch;
     const contradiction = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -978,6 +978,11 @@ describe("GitHub App read authentication", () => {
     const overflow = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
     expect(pagesRequested).toEqual([1, 2]);
     expect(overflow).toMatchObject({ pagesRead: 2, terminal: "event_history_unbounded", truncated: true, overflow: true });
+
+    pagesRequested.length = 0;
+    globalThis.fetch = vi.fn(async () => { pagesRequested.push(1); return jsonResponse(Array.from({ length: 50 }, (_unused, id) => ({ id })), 200, "", { Link: '<https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=2>; rel="next", <https://api.github.com/repos/owner/repo/issues/970/events?per_page=100&page=2>; rel="last"' }); }) as typeof fetch;
+    const contradiction = await new GitHubApi({ token: "fixture" }).listIssueLabelEvents("owner/repo", 970);
+    expect(contradiction).toMatchObject({ pagesRead: 1, lastPage: 2, terminal: "event_history_unbounded", overflow: true });
   });
 });
 


### PR DESCRIPTION
## Summary

- normalize and validate issue-event pagination authority against the exact configured GitHub API endpoint
- read page 1 plus only the newest five trusted pages, with a six-request maximum
- classify missing or contradictory pagination as durable `event_history_unbounded`
- distinguish fully read trusted histories from bounded tails
- keep transient provider read failures retryable without durable skip or watermark advancement
- fetch event history lazily only for supported promotion and model-evidence paths
- preserve sibling admission, repository watermark progress, and idempotent terminal receipts
- pass only the newest 200 trusted events into model evidence

## Failing-first proof

At base `2b43faf645659be6e5f4434a5058a7ede72628f4`, the eight-page fixture expected requests `[1,4,5,6,7,8]` but observed `[1,2,3,4,5,6,7,8,9]`. The fixture was recorded as `EXPECTED_NEGATIVE` before source edits.

## Local validation

- focused Vitest: 5 files, 146 tests passed
- TypeScript build typecheck: passed
- full `npm run build`: passed, including postbuild secret-rule check
- `git diff --check`: passed
- scope: 4 files, 154 additions and 46 deletions (200 changed lines; issue ceiling 200)

The initial review and three targeted delta passes are represented by exact heads `1dea44c`, `1cf5251`, `1323aa8`, and `1db7b2a`. The current head is the only merge candidate.

## Proof boundary

This PR proves source behavior only after exact-head CI and review gates pass. It does not prove live enrichment, installed runtime behavior, RC/GA artifacts, release readiness, or customer readiness. The installed beta was not changed.

Fixes #970
