### PR TITLE
feat(github): add strict issue-event pagination receipt

### DIFF
--- a/src/issue-event-pagination.ts
+++ b/src/issue-event-pagination.ts
@@ -1,0 +1,132 @@
+import { parseIssueEventLink } from "./issue-event-pagination-links.js";
+export type IssueEventTerminal = "short_page" | "bounded_tail" | "event_history_unbounded";
+export interface IssueEventPage<T> { page: number; items: T[]; link?: string | null; linkHeader?: string | null; }
+export interface IssueEventPaginationReceipt<T> { items: T[]; rawCount: number; uniqueCount: number; duplicateCount: number; pagesRead: number; lastPage?: number; terminal: IssueEventTerminal; truncated: boolean; overflow: boolean; }
+interface Relations { first?: number; prev?: number; next?: number; last?: number; }
+interface ReadPage<T> { page?: IssueEventPage<T>; relations?: Relations; present: boolean; valid: boolean; }
+const PAGE_SIZE = 100, MAX_ITEMS = 200, RELATIONS = new Set(["first", "prev", "next", "last"]);
+
+export async function readIssueEventHistory<T extends { id?: unknown }>(input: { readPage: (page: number) => Promise<IssueEventPage<T>>; apiOrigin: string; issueEventsPath: string }): Promise<IssueEventPaginationReceipt<T>> {
+  const newest = new Map<string, T>();
+  let anonymous = 0, trustedRawCount = 0, rawCount = 0, pagesRead = 0, lastPage: number | undefined;
+  const add = (items: T[]) => {
+    trustedRawCount += items.length;
+    for (const event of items) {
+      const value = event?.id;
+      const known = Number.isSafeInteger(value) || (typeof value === "string" && value.trim().length > 0);
+      const key = known ? `id:${String(value).trim()}` : `anonymous:${anonymous++}`;
+      newest.delete(key);
+      newest.set(key, event);
+    }
+  };
+  const receipt = (terminal: IssueEventTerminal): IssueEventPaginationReceipt<T> => {
+    const untrusted = terminal === "event_history_unbounded";
+    const allItems = untrusted ? [] : [...newest.values()];
+    const uniqueCount = untrusted ? 0 : allItems.length;
+    return {
+      items: allItems.slice(-MAX_ITEMS), rawCount, uniqueCount,
+      duplicateCount: untrusted ? 0 : trustedRawCount - uniqueCount,
+      pagesRead, ...(lastPage === undefined ? {} : { lastPage }), terminal,
+      truncated: untrusted || terminal === "bounded_tail" || uniqueCount > MAX_ITEMS,
+      overflow: untrusted
+    };
+  };
+  const fail = () => receipt("event_history_unbounded");
+  const read = async (requested: number): Promise<ReadPage<T>> => {
+    // Do not catch this call: provider/network failures are transport failures, not metadata failures.
+    const candidate = await input.readPage(requested) as IssueEventPage<T> | null | undefined;
+    pagesRead += 1;
+    const items = Array.isArray(candidate?.items) ? candidate.items : [];
+    rawCount += items.length;
+    if (!candidate || !Number.isSafeInteger(candidate.page) || candidate.page !== requested || !Array.isArray(candidate.items)) {
+      return { present: false, valid: false };
+    }
+    const hasLink = candidate.link !== undefined && candidate.link !== null;
+    const hasHeader = candidate.linkHeader !== undefined && candidate.linkHeader !== null;
+    if (hasLink && hasHeader && candidate.link !== candidate.linkHeader) return { page: candidate, present: true, valid: false };
+    const value = hasLink ? candidate.link : hasHeader ? candidate.linkHeader : undefined;
+    if (value === undefined) return { page: candidate, present: false, valid: true };
+    const relations = parseRelations(value, input.apiOrigin, input.issueEventsPath);
+    return { page: candidate, relations: relations ?? undefined, present: true, valid: relations !== null };
+  };
+  const chain = (relations: Relations | undefined, page: number, last: number): boolean => Boolean(
+    relations && relations.last === last && (relations.first === undefined || relations.first === 1) &&
+    (page === 1
+      ? relations.prev === undefined && (last === 1 ? relations.next === undefined : relations.next === 2)
+      : relations.prev === page - 1 && (page === last ? relations.next === undefined : relations.next === page + 1))
+  );
+  const terminalLinks = (relations: Relations | undefined, page: number, last: number): boolean => Boolean(
+    relations && relations.last === last && (relations.first === undefined || relations.first === 1) &&
+    relations.prev === (page === 1 ? undefined : page - 1) && relations.next === undefined
+  );
+  const tail = async (existing: number): Promise<IssueEventPaginationReceipt<T>> => {
+    if (!lastPage || lastPage < existing) return fail();
+    const start = Math.max(existing + 1, Math.max(2, lastPage - 4));
+    for (let page = start; page <= lastPage; page += 1) {
+      const result = await read(page);
+      if (!result.valid || !result.present || !chain(result.relations, page, lastPage)) return fail();
+      const items = result.page!.items;
+      if (page < lastPage ? items.length !== PAGE_SIZE : items.length < 1 || items.length > PAGE_SIZE) return fail();
+      add(items);
+    }
+    return receipt("bounded_tail");
+  };
+  const first = await read(1);
+  if (!first.valid) return fail();
+  const firstItems = first.page!.items;
+  if (firstItems.length > PAGE_SIZE) return fail();
+  if (firstItems.length < PAGE_SIZE) {
+    if (first.present && !terminalLinks(first.relations, 1, 1)) return fail();
+    lastPage = 1;
+    add(firstItems);
+    return receipt("short_page");
+  }
+  if (first.present) {
+    if (!first.relations?.last || !chain(first.relations, 1, first.relations.last)) return fail();
+    lastPage = first.relations.last;
+    add(firstItems);
+    return lastPage === 1 ? receipt("short_page") : tail(1);
+  }
+  const second = await read(2);
+  if (!second.valid) return fail();
+  const secondItems = second.page!.items;
+  if (secondItems.length > PAGE_SIZE) return fail();
+  if (secondItems.length < PAGE_SIZE) {
+    if (second.present && (secondItems.length === 0 || !terminalLinks(second.relations, 2, 2))) return fail();
+    lastPage = secondItems.length === 0 ? 1 : 2;
+    add(firstItems);
+    if (secondItems.length > 0) add(secondItems);
+    return receipt("short_page");
+  }
+  if (!second.present || !second.relations?.last || second.relations.last < 2 || !chain(second.relations, 2, second.relations.last)) return fail();
+  lastPage = second.relations.last;
+  add(firstItems);
+  add(secondItems);
+  return tail(2);
+}
+function parseRelations(value: unknown, origin: string, path: string): Relations | null {
+  if (typeof value !== "string") return null;
+  let parsed: ReturnType<typeof parseIssueEventLink>;
+  try { parsed = parseIssueEventLink(value); } catch { return null; }
+  if (parsed.kind === "absent") return null;
+  const result: Relations = {}, seen = new Set<string>();
+  for (const member of parsed.members) {
+    let target: URL;
+    try { target = new URL(member.target); } catch { return null; }
+    const keys = [...target.searchParams.keys()];
+    const pageValues = target.searchParams.getAll("page");
+    const perPageValues = target.searchParams.getAll("per_page");
+    if (target.origin !== origin || target.pathname !== path || target.username || target.password || target.hash
+      || keys.length !== 2 || pageValues.length !== 1 || perPageValues.length !== 1 || perPageValues[0] !== "100"
+      || keys.some((key) => key !== "page" && key !== "per_page") || !/^[1-9]\d*$/.test(pageValues[0]!)) return null;
+    const page = Number(pageValues[0]);
+    if (!Number.isSafeInteger(page)) return null;
+    const relation = member.relation.startsWith('"') ? member.relation.slice(1, -1) : member.relation;
+    for (const name of relation.toLowerCase().split(/\s+/)) {
+      if (!RELATIONS.has(name) || seen.has(name)) return null;
+      seen.add(name);
+      result[name as keyof Relations] = page;
+    }
+  }
+  return seen.size > 0 ? result : null;
+}

--- a/src/issue-event-pagination.ts
+++ b/src/issue-event-pagination.ts
@@ -6,7 +6,7 @@ interface Relations { first?: number; prev?: number; next?: number; last?: numbe
 interface ReadPage<T> { page?: IssueEventPage<T>; relations?: Relations; present: boolean; valid: boolean; }
 const PAGE_SIZE = 100, MAX_ITEMS = 200, RELATIONS = new Set(["first", "prev", "next", "last"]);
 
-export async function readIssueEventHistory<T extends { id?: unknown }>(input: { readPage: (page: number) => Promise<IssueEventPage<T>>; apiOrigin: string; issueEventsPath: string }): Promise<IssueEventPaginationReceipt<T>> {
+export async function readIssueEventHistory<T extends { id?: unknown }>(input: { readPage: (page: number) => Promise<IssueEventPage<T>>; apiOrigin: string; issueEventsPath: string; repositoryId?: number }): Promise<IssueEventPaginationReceipt<T>> {
   const newest = new Map<string, T>();
   let anonymous = 0, trustedRawCount = 0, rawCount = 0, pagesRead = 0, skippedPages = false, lastPage: number | undefined;
   const add = (items: T[]) => {
@@ -46,7 +46,7 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
     if (hasLink && hasHeader && candidate.link !== candidate.linkHeader) return { page: candidate, present: true, valid: false };
     const value = hasLink ? candidate.link : hasHeader ? candidate.linkHeader : undefined;
     if (value === undefined) return { page: candidate, present: false, valid: true };
-    const relations = parseRelations(value, input.apiOrigin, input.issueEventsPath);
+    const relations = parseRelations(value, input.apiOrigin, input.issueEventsPath, input.repositoryId);
     return { page: candidate, relations: relations ?? undefined, present: true, valid: relations !== null };
   };
   const chain = (relations: Relations | undefined, page: number, last: number): boolean => Boolean(
@@ -104,9 +104,9 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
   add(secondItems);
   return tail(2);
 }
-function parseRelations(value: unknown, origin: string, path: string): Relations | null {
+function parseRelations(value: unknown, origin: string, path: string, repositoryId?: number): Relations | null {
   if (typeof value !== "string") return null;
-  let parsed: ReturnType<typeof parseIssueEventLink>;
+  let parsed: ReturnType<typeof parseIssueEventLink>; const canonicalPath = Number.isSafeInteger(repositoryId) && repositoryId! > 0 ? `/repositories/${repositoryId}${path.slice(path.lastIndexOf("/issues/"))}` : "";
   try { parsed = parseIssueEventLink(value); } catch { return null; }
   if (parsed.kind === "absent") return null;
   const result: Relations = {}, seen = new Set<string>();
@@ -116,7 +116,7 @@ function parseRelations(value: unknown, origin: string, path: string): Relations
     const keys = [...target.searchParams.keys()];
     const pageValues = target.searchParams.getAll("page");
     const perPageValues = target.searchParams.getAll("per_page");
-    if (target.origin !== origin || target.pathname !== path || target.username || target.password || target.hash
+    if (target.origin !== origin || (target.pathname !== path && target.pathname !== canonicalPath) || target.username || target.password || target.hash
       || keys.length !== 2 || pageValues.length !== 1 || perPageValues.length !== 1 || perPageValues[0] !== "100"
       || keys.some((key) => key !== "page" && key !== "per_page") || !/^[1-9]\d*$/.test(pageValues[0]!)) return null;
     const page = Number(pageValues[0]);

--- a/src/issue-event-pagination.ts
+++ b/src/issue-event-pagination.ts
@@ -8,7 +8,7 @@ const PAGE_SIZE = 100, MAX_ITEMS = 200, RELATIONS = new Set(["first", "prev", "n
 
 export async function readIssueEventHistory<T extends { id?: unknown }>(input: { readPage: (page: number) => Promise<IssueEventPage<T>>; apiOrigin: string; issueEventsPath: string }): Promise<IssueEventPaginationReceipt<T>> {
   const newest = new Map<string, T>();
-  let anonymous = 0, trustedRawCount = 0, rawCount = 0, pagesRead = 0, lastPage: number | undefined;
+  let anonymous = 0, trustedRawCount = 0, rawCount = 0, pagesRead = 0, skippedPages = false, lastPage: number | undefined;
   const add = (items: T[]) => {
     trustedRawCount += items.length;
     for (const event of items) {
@@ -27,7 +27,7 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
       items: allItems.slice(-MAX_ITEMS), rawCount, uniqueCount,
       duplicateCount: untrusted ? 0 : trustedRawCount - uniqueCount,
       pagesRead, ...(lastPage === undefined ? {} : { lastPage }), terminal,
-      truncated: untrusted || terminal === "bounded_tail" || uniqueCount > MAX_ITEMS,
+      truncated: untrusted || skippedPages || uniqueCount > MAX_ITEMS,
       overflow: untrusted
     };
   };
@@ -50,18 +50,18 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
     return { page: candidate, relations: relations ?? undefined, present: true, valid: relations !== null };
   };
   const chain = (relations: Relations | undefined, page: number, last: number): boolean => Boolean(
-    relations && relations.last === last && (relations.first === undefined || relations.first === 1) &&
+    relations && (relations.last === last || (page === last && relations.last === undefined)) && (relations.first === undefined || relations.first === 1) &&
     (page === 1
       ? relations.prev === undefined && (last === 1 ? relations.next === undefined : relations.next === 2)
       : relations.prev === page - 1 && (page === last ? relations.next === undefined : relations.next === page + 1))
   );
   const terminalLinks = (relations: Relations | undefined, page: number, last: number): boolean => Boolean(
-    relations && relations.last === last && (relations.first === undefined || relations.first === 1) &&
+    relations && (relations.last === last || (page === last && relations.last === undefined)) && (relations.first === undefined || relations.first === 1) &&
     relations.prev === (page === 1 ? undefined : page - 1) && relations.next === undefined
   );
   const tail = async (existing: number): Promise<IssueEventPaginationReceipt<T>> => {
     if (!lastPage || lastPage < existing) return fail();
-    const start = Math.max(existing + 1, Math.max(2, lastPage - 4));
+    const start = Math.max(existing + 1, Math.max(2, lastPage - 4)); skippedPages = start > existing + 1;
     for (let page = start; page <= lastPage; page += 1) {
       const result = await read(page);
       if (!result.valid || !result.present || !chain(result.relations, page, lastPage)) return fail();

--- a/src/issue-event-pagination.ts
+++ b/src/issue-event-pagination.ts
@@ -76,7 +76,7 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
   const firstItems = first.page!.items;
   if (firstItems.length > PAGE_SIZE) return fail();
   if (firstItems.length < PAGE_SIZE) {
-    if (first.present && !terminalLinks(first.relations, 1, 1)) return fail();
+    if (first.present && (firstItems.length === 0 || !terminalLinks(first.relations, 1, 1))) return fail();
     lastPage = 1;
     add(firstItems);
     return receipt("short_page");

--- a/tests/issue-event-pagination.test.ts
+++ b/tests/issue-event-pagination.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { readIssueEventHistory } from "../src/issue-event-pagination.js";
+
+type Event = { id: number; value?: string };
+const origin = "https://api.github.com";
+const path = "/repos/owner/repo/issues/970/events";
+const events = (page: number, count = 100): Event[] => Array.from({ length: count }, (_unused, index) => ({ id: page * 100 + index }));
+const link = (relation: string, page: number) => `<${origin}${path}?per_page=100&page=${page}>; rel="${relation}"`;
+const chain = (page: number, last: number) => [
+  page > 1 ? link("prev", page - 1) : "",
+  page < last ? link("next", page + 1) : "",
+  link("last", last)
+].filter(Boolean).join(", ");
+const run = (pages: Record<number, { page: number; items: Event[]; link?: string }>) => readIssueEventHistory<Event>({ apiOrigin: origin, issueEventsPath: path, readPage: async (page) => pages[page] ?? { page, items: [] } });
+describe("strict issue-event pagination state machine", () => {
+  it("rejects an empty advertised final page without admitting older tail rows", async () => {
+    const pagesRequested: number[] = [];
+    const result = await readIssueEventHistory<Event>({
+      apiOrigin: origin,
+      issueEventsPath: path,
+      readPage: async (page) => {
+        pagesRequested.push(page);
+        return { page, items: page === 8 ? [] : events(page), link: chain(page, 8) };
+      }
+    });
+    expect(pagesRequested).toEqual([1, 4, 5, 6, 7, 8]);
+    expect(result.items).toHaveLength(0);
+    expect(result).toMatchObject({ pagesRead: 6, rawCount: 500, lastPage: 8, terminal: "event_history_unbounded", truncated: true, overflow: true });
+  });
+  it("rejects malformed tail metadata while counting every received row", async () => {
+    const pagesRequested: number[] = [];
+    const result = await readIssueEventHistory<Event>({
+      apiOrigin: origin,
+      issueEventsPath: path,
+      readPage: async (page) => {
+        pagesRequested.push(page);
+        return {
+          page,
+          items: events(page),
+          link: page === 4 ? `<https://evil.invalid${path}?per_page=100&page=4>; rel="next"` : chain(page, 8)
+        };
+      }
+    });
+    expect(pagesRequested).toEqual([1, 4]);
+    expect(result.items).toHaveLength(0);
+    expect(result).toMatchObject({ pagesRead: 2, rawCount: 200, lastPage: 8, terminal: "event_history_unbounded", truncated: true, overflow: true });
+  });
+  it("handles short history and exact full-page probes", async () => {
+    expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page");
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ rawCount: 100, pagesRead: 2, lastPage: 1, terminal: "short_page" });
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3) } })).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "short_page" });
+    expect((await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).terminal).toBe("event_history_unbounded");
+  });
+  it("fails closed on hostile or contradictory pagination metadata", async () => {
+    const invalid: Array<[string | undefined, number]> = [[undefined, 100], [chain(4, 9), 100], [chain(4, 7), 100], [`${link("prev", 2)}, ${link("next", 5)}, ${link("last", 8)}`, 100], [`<${origin}/repos/owner/repo/issues/971/events?per_page=100&page=3>; rel="prev"`, 100], [`<${origin}${path}?per_page=100&page=3&page=4>; rel="prev"`, 100], [`${link("prev", 3)}, ${link("prev", 3)}, ${link("next", 5)}, ${link("last", 8)}`, 100], [chain(4, 8), 50]];
+    for (const [raw, count] of invalid) expect((await run({ 1: { page: 1, items: events(1), link: chain(1, 8) }, 4: { page: 4, items: events(4, count), link: raw } })).terminal).toBe("event_history_unbounded");
+    expect((await run({ 1: { page: 1, items: events(1), link: `${link("next", 2)}, ${link("last", 1)}` } })).terminal).toBe("event_history_unbounded");
+  });
+  it("retains newest duplicates and propagates transport failures", async () => {
+    const pages = Object.fromEntries([1, 2, 3, 4, 5].map((page) => [page, { page, items: page === 5 ? [{ id: 450, value: "new" }, ...events(page, 49)] : events(page), link: chain(page, 5) }]));
+    pages[4].items[50] = { id: 450, value: "old" };
+    const result = await run(pages);
+    expect(result).toMatchObject({ rawCount: 450, uniqueCount: 449, duplicateCount: 1, pagesRead: 5, terminal: "bounded_tail", truncated: true, overflow: false });
+    expect(result.items).toHaveLength(200); expect(result.items.at(-1)?.id).toBe(548);
+    expect(result.items.find((event) => event.id === 450)?.value).toBe("new");
+    await expect(readIssueEventHistory({ apiOrigin: origin, issueEventsPath: path, readPage: async (page) => { if (page === 4) throw new Error("transport"); return { page, items: events(page), link: chain(page, 8) }; } })).rejects.toThrow("transport");
+  });
+});

--- a/tests/issue-event-pagination.test.ts
+++ b/tests/issue-event-pagination.test.ts
@@ -11,7 +11,7 @@ const chain = (page: number, last: number) => [
   page < last ? link("next", page + 1) : "",
   link("last", last)
 ].filter(Boolean).join(", ");
-const run = (pages: Record<number, { page: number; items: Event[]; link?: string }>) => readIssueEventHistory<Event>({ apiOrigin: origin, issueEventsPath: path, readPage: async (page) => pages[page] ?? { page, items: [] } });
+const run = (pages: Record<number, { page: number; items: Event[]; link?: string }>, repositoryId?: number) => readIssueEventHistory<Event>({ apiOrigin: origin, issueEventsPath: path, repositoryId, readPage: async (page) => pages[page] ?? { page, items: [] } });
 describe("strict issue-event pagination state machine", () => {
   it("rejects an empty advertised final page without admitting older tail rows", async () => {
     const pagesRequested: number[] = [];
@@ -48,7 +48,7 @@ describe("strict issue-event pagination state machine", () => {
   it("handles short history and exact full-page probes", async () => {
     expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page"); expect((await run({ 1: { page: 1, items: [], link: link("last", 1) } })).terminal).toBe("event_history_unbounded");
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ rawCount: 100, pagesRead: 2, lastPage: 1, terminal: "short_page" });
-    expect(await run({ 1: { page: 1, items: events(1), link: chain(1, 2) }, 2: { page: 2, items: events(2, 3), link: `${link("prev", 1)}, ${link("first", 1)}` } })).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "bounded_tail", truncated: false });
+    expect(await run({ 1: { page: 1, items: events(1), link: `<${origin}/repositories/1285247004/issues/970/events?per_page=100&page=2>; rel="next", <${origin}/repositories/1285247004/issues/970/events?per_page=100&page=2>; rel="last"` }, 2: { page: 2, items: events(2, 3), link: `<${origin}/repositories/1285247004/issues/970/events?per_page=100&page=1>; rel="prev", <${origin}/repositories/1285247004/issues/970/events?per_page=100&page=1>; rel="first"` } }, 1285247004)).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "bounded_tail", truncated: false });
     expect((await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).terminal).toBe("event_history_unbounded");
   });
   it("fails closed on hostile or contradictory pagination metadata", async () => {

--- a/tests/issue-event-pagination.test.ts
+++ b/tests/issue-event-pagination.test.ts
@@ -46,7 +46,7 @@ describe("strict issue-event pagination state machine", () => {
     expect(result).toMatchObject({ pagesRead: 2, rawCount: 200, lastPage: 8, terminal: "event_history_unbounded", truncated: true, overflow: true });
   });
   it("handles short history and exact full-page probes", async () => {
-    expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page");
+    expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page"); expect((await run({ 1: { page: 1, items: [], link: link("last", 1) } })).terminal).toBe("event_history_unbounded");
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ rawCount: 100, pagesRead: 2, lastPage: 1, terminal: "short_page" });
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3) } })).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "short_page" });
     expect((await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).terminal).toBe("event_history_unbounded");

--- a/tests/issue-event-pagination.test.ts
+++ b/tests/issue-event-pagination.test.ts
@@ -48,7 +48,7 @@ describe("strict issue-event pagination state machine", () => {
   it("handles short history and exact full-page probes", async () => {
     expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page"); expect((await run({ 1: { page: 1, items: [], link: link("last", 1) } })).terminal).toBe("event_history_unbounded");
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ rawCount: 100, pagesRead: 2, lastPage: 1, terminal: "short_page" });
-    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3) } })).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "short_page" });
+    expect(await run({ 1: { page: 1, items: events(1), link: chain(1, 2) }, 2: { page: 2, items: events(2, 3), link: `${link("prev", 1)}, ${link("first", 1)}` } })).toMatchObject({ rawCount: 103, pagesRead: 2, lastPage: 2, terminal: "bounded_tail", truncated: false });
     expect((await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).terminal).toBe("event_history_unbounded");
   });
   it("fails closed on hostile or contradictory pagination metadata", async () => {


### PR DESCRIPTION
Closes #990.

## Outcome

Adds the pure issue-event pagination state machine split from closed-unmerged PR #1127. It validates the exact GitHub issue-events pagination identity, reads only the newest bounded tail, fails closed on partial or contradictory metadata, preserves received-row counts for rejected pages, deduplicates known IDs by newest occurrence, and leaves ordinary transport failures thrown.

## Scope

- `src/issue-event-pagination.ts`
- `tests/issue-event-pagination.test.ts`
- 200 added non-generated lines

No API adapter, enrichment consumer, persistence, runtime, release, or customer change is included. Issue #991 remains blocked until this PR merges.

## Local proof

- focused Vitest: 5/5 passed
- exact-lock TypeScript build: passed
- `git diff --check`: passed
- blind acceptance/adversarial and independent release-risk reviews are running on exact head `5c3a552`

## Proof boundary

This proves deterministic pure pagination and receipt truth only. It does not prove API wiring, enrichment behavior, live GitHub, installed runtime, release artifacts, or customer readiness.
