### PR TITLE
GitHub: require exact raw endpoint identity

### DIFF
--- a/src/github-issue-event-endpoint-identity.ts
+++ b/src/github-issue-event-endpoint-identity.ts
@@ -44,7 +44,7 @@ export function matchesGitHubIssueEventEndpointIdentity(
   identity: Readonly<GitHubIssueEventEndpointIdentity>,
   targetUrl: string
 ): boolean {
-  if (!Object.isFrozen(identity) || typeof targetUrl !== "string" || hasForbiddenRawSyntax(targetUrl)) return false;
+  if (!isEndpointIdentity(identity) || typeof targetUrl !== "string" || hasForbiddenRawSyntax(targetUrl)) return false;
   try {
     const target = new URL(targetUrl);
     const exact = `${target.origin}${target.pathname}`;
@@ -68,6 +68,18 @@ function hasForbiddenRawSyntax(value: string): boolean {
   return value.trim() !== value || /[%\\\u0000-\u0020\u007f-\uffff]/.test(value)
     || value.includes("?") || value.includes("#") || value.includes("@")
     || /(?:^|\/)\.{1,2}(?:\/|$)/.test(value);
+}
+
+function isEndpointIdentity(value: unknown): value is Readonly<GitHubIssueEventEndpointIdentity> {
+  try {
+    if (!value || typeof value !== "object" || Array.isArray(value) || !Object.isFrozen(value)) return false;
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    const record = value as Record<string, unknown>;
+    return Object.keys(record).length === 4 && typeof record.origin === "string"
+      && typeof record.basePath === "string" && typeof record.repositoryPath === "string"
+      && typeof record.canonicalRepositoryPath === "string";
+  } catch { return false; }
 }
 
 function positiveSafeInteger(value: unknown): value is number {

--- a/src/github-issue-event-endpoint-identity.ts
+++ b/src/github-issue-event-endpoint-identity.ts
@@ -1,0 +1,75 @@
+import { isLoopbackHost } from "./url-safety.js";
+
+export interface GitHubIssueEventEndpointIdentityInput {
+  apiBaseUrl: string;
+  repository: string;
+  repositoryId: number;
+  issueNumber: number;
+}
+
+export interface GitHubIssueEventEndpointIdentity {
+  origin: string;
+  basePath: string;
+  repositoryPath: string;
+  canonicalRepositoryPath: string;
+}
+
+export type GitHubIssueEventEndpointIdentityResult =
+  | Readonly<{ ok: true; identity: Readonly<GitHubIssueEventEndpointIdentity> }>
+  | Readonly<{ ok: false; reason: "invalid_endpoint_identity" }>;
+
+const INVALID = Object.freeze({ ok: false, reason: "invalid_endpoint_identity" } as const);
+const REPOSITORY = /^([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)\/([A-Za-z0-9._-]{1,100})$/;
+
+export function resolveGitHubIssueEventEndpointIdentity(input: GitHubIssueEventEndpointIdentityInput): GitHubIssueEventEndpointIdentityResult {
+  try {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return INVALID;
+    const { apiBaseUrl, repository, repositoryId, issueNumber } = input;
+    if (typeof apiBaseUrl !== "string" || typeof repository !== "string" || !positiveSafeInteger(repositoryId)
+      || !positiveSafeInteger(issueNumber)) return INVALID;
+    const base = parseExactBase(apiBaseUrl);
+    const match = REPOSITORY.exec(repository);
+    if (!base || !match || match[2] === "." || match[2] === "..") return INVALID;
+    const identity = Object.freeze({
+      origin: base.origin,
+      basePath: base.basePath,
+      repositoryPath: `${base.basePath}/repos/${match[1]}/${match[2]}/issues/${issueNumber}/events`,
+      canonicalRepositoryPath: `${base.basePath}/repositories/${repositoryId}/issues/${issueNumber}/events`
+    });
+    return Object.freeze({ ok: true as const, identity });
+  } catch { return INVALID; }
+}
+
+export function matchesGitHubIssueEventEndpointIdentity(
+  identity: Readonly<GitHubIssueEventEndpointIdentity>,
+  targetUrl: string
+): boolean {
+  if (!Object.isFrozen(identity) || typeof targetUrl !== "string" || hasForbiddenRawSyntax(targetUrl)) return false;
+  try {
+    const target = new URL(targetUrl);
+    const exact = `${target.origin}${target.pathname}`;
+    return targetUrl === exact && !target.username && !target.password && !target.search && !target.hash
+      && target.origin === identity.origin
+      && (target.pathname === identity.repositoryPath || target.pathname === identity.canonicalRepositoryPath);
+  } catch { return false; }
+}
+
+function parseExactBase(raw: string): Readonly<{ origin: string; basePath: string }> | null {
+  if (hasForbiddenRawSyntax(raw) || raw.endsWith("//")) return null;
+  const parsed = new URL(raw);
+  if ((parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopbackHost(parsed.hostname)))
+    || parsed.username || parsed.password || parsed.search || parsed.hash || parsed.pathname.includes("//")) return null;
+  const normalizedRaw = raw.endsWith("/") ? raw.slice(0, -1) : raw;
+  const basePath = parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/$/, "");
+  return normalizedRaw === `${parsed.origin}${basePath}` ? Object.freeze({ origin: parsed.origin, basePath }) : null;
+}
+
+function hasForbiddenRawSyntax(value: string): boolean {
+  return value.trim() !== value || /[%\\\u0000-\u0020\u007f-\uffff]/.test(value)
+    || value.includes("?") || value.includes("#") || value.includes("@")
+    || /(?:^|\/)\.{1,2}(?:\/|$)/.test(value);
+}
+
+function positiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/src/github-issue-event-endpoint-identity.ts
+++ b/src/github-issue-event-endpoint-identity.ts
@@ -19,6 +19,7 @@ export type GitHubIssueEventEndpointIdentityResult =
   | Readonly<{ ok: false; reason: "invalid_endpoint_identity" }>;
 
 const INVALID = Object.freeze({ ok: false, reason: "invalid_endpoint_identity" } as const);
+const ENDPOINT_IDENTITIES = new WeakSet<object>();
 const REPOSITORY = /^([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)\/([A-Za-z0-9._-]{1,100})$/;
 
 export function resolveGitHubIssueEventEndpointIdentity(input: GitHubIssueEventEndpointIdentityInput): GitHubIssueEventEndpointIdentityResult {
@@ -36,6 +37,7 @@ export function resolveGitHubIssueEventEndpointIdentity(input: GitHubIssueEventE
       repositoryPath: `${base.basePath}/repos/${match[1]}/${match[2]}/issues/${issueNumber}/events`,
       canonicalRepositoryPath: `${base.basePath}/repositories/${repositoryId}/issues/${issueNumber}/events`
     });
+    ENDPOINT_IDENTITIES.add(identity);
     return Object.freeze({ ok: true as const, identity });
   } catch { return INVALID; }
 }
@@ -72,7 +74,8 @@ function hasForbiddenRawSyntax(value: string): boolean {
 
 function isEndpointIdentity(value: unknown): value is Readonly<GitHubIssueEventEndpointIdentity> {
   try {
-    if (!value || typeof value !== "object" || Array.isArray(value) || !Object.isFrozen(value)) return false;
+    if (!value || typeof value !== "object" || Array.isArray(value) || !Object.isFrozen(value)
+      || !ENDPOINT_IDENTITIES.has(value)) return false;
     const prototype = Object.getPrototypeOf(value);
     if (prototype !== Object.prototype) return false;
     const record = value as Record<string, unknown>;

--- a/src/github-issue-event-endpoint-identity.ts
+++ b/src/github-issue-event-endpoint-identity.ts
@@ -74,7 +74,7 @@ function isEndpointIdentity(value: unknown): value is Readonly<GitHubIssueEventE
   try {
     if (!value || typeof value !== "object" || Array.isArray(value) || !Object.isFrozen(value)) return false;
     const prototype = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) return false;
+    if (prototype !== Object.prototype) return false;
     const record = value as Record<string, unknown>;
     return Object.keys(record).length === 4 && typeof record.origin === "string"
       && typeof record.basePath === "string" && typeof record.repositoryPath === "string"

--- a/tests/github-issue-event-endpoint-identity.test.ts
+++ b/tests/github-issue-event-endpoint-identity.test.ts
@@ -60,6 +60,12 @@ describe("exact raw GitHub issue-event endpoint identity", () => {
       "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/évents"
     ];
     for (const target of rejected) expect(matchesGitHubIssueEventEndpointIdentity(result.identity, target)).toBe(false);
+
+    const forgedArray = Object.freeze(Object.assign([], result.identity));
+    expect(matchesGitHubIssueEventEndpointIdentity(
+      forgedArray as unknown as typeof result.identity,
+      accepted[0]
+    )).toBe(false);
   });
 
   it("rejects noncanonical base and malformed identity input", () => {

--- a/tests/github-issue-event-endpoint-identity.test.ts
+++ b/tests/github-issue-event-endpoint-identity.test.ts
@@ -66,6 +66,11 @@ describe("exact raw GitHub issue-event endpoint identity", () => {
       forgedArray as unknown as typeof result.identity,
       accepted[0]
     )).toBe(false);
+    const nullPrototype = Object.freeze(Object.assign(Object.create(null), result.identity));
+    expect(matchesGitHubIssueEventEndpointIdentity(
+      nullPrototype as typeof result.identity,
+      accepted[0]
+    )).toBe(false);
   });
 
   it("rejects noncanonical base and malformed identity input", () => {

--- a/tests/github-issue-event-endpoint-identity.test.ts
+++ b/tests/github-issue-event-endpoint-identity.test.ts
@@ -71,6 +71,16 @@ describe("exact raw GitHub issue-event endpoint identity", () => {
       nullPrototype as typeof result.identity,
       accepted[0]
     )).toBe(false);
+    const forgedFrozenIdentity = Object.freeze({
+      origin: "https://attacker.example",
+      basePath: "",
+      repositoryPath: "/accepted",
+      canonicalRepositoryPath: "/other"
+    });
+    expect(matchesGitHubIssueEventEndpointIdentity(
+      forgedFrozenIdentity,
+      "https://attacker.example/accepted"
+    )).toBe(false);
   });
 
   it("rejects noncanonical base and malformed identity input", () => {

--- a/tests/github-issue-event-endpoint-identity.test.ts
+++ b/tests/github-issue-event-endpoint-identity.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { matchesGitHubIssueEventEndpointIdentity, resolveGitHubIssueEventEndpointIdentity } from "../src/github-issue-event-endpoint-identity.js";
+
+const valid = {
+  apiBaseUrl: "https://api.github.com",
+  repository: "electric-sheep/neondiff.js",
+  repositoryId: 1_285_247_004,
+  issueNumber: 990
+};
+
+describe("exact raw GitHub issue-event endpoint identity", () => {
+  it("derives immutable GitHub.com and Enterprise identities", () => {
+    expect(resolveGitHubIssueEventEndpointIdentity(valid)).toEqual({
+      ok: true,
+      identity: {
+        origin: "https://api.github.com",
+        basePath: "",
+        repositoryPath: "/repos/electric-sheep/neondiff.js/issues/990/events",
+        canonicalRepositoryPath: "/repositories/1285247004/issues/990/events"
+      }
+    });
+    const enterprise = resolveGitHubIssueEventEndpointIdentity({ ...valid, apiBaseUrl: "https://ghe.example.com/api/v3/" });
+    expect(enterprise).toEqual({
+      ok: true,
+      identity: {
+        origin: "https://ghe.example.com",
+        basePath: "/api/v3",
+        repositoryPath: "/api/v3/repos/electric-sheep/neondiff.js/issues/990/events",
+        canonicalRepositoryPath: "/api/v3/repositories/1285247004/issues/990/events"
+      }
+    });
+    expect(enterprise.ok && Object.isFrozen(enterprise.identity)).toBe(true);
+    expect(Object.isFrozen(enterprise)).toBe(true);
+  });
+
+  it("matches only exact raw target serializations", () => {
+    const result = resolveGitHubIssueEventEndpointIdentity({ ...valid, apiBaseUrl: "https://ghe.example.com/api/v3" });
+    if (!result.ok) throw new Error("expected valid identity");
+    const accepted = [
+      "https://ghe.example.com/api/v3/repos/electric-sheep/neondiff.js/issues/990/events",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/events"
+    ];
+    for (const target of accepted) expect(matchesGitHubIssueEventEndpointIdentity(result.identity, target)).toBe(true);
+    const rejected = [
+      "https://other.example.com/api/v3/repositories/1285247004/issues/990/events",
+      "https://ghe.example.com/repositories/1285247004/issues/990/events",
+      "https://ghe.example.com/api/v3/repositories/9/issues/990/events",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/991/events",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/events/extra",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/events?",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/events#",
+      "https://@ghe.example.com/api/v3/repositories/1285247004/issues/990/events",
+      "https://ghe.example.com\\api\\v3\\repositories\\1285247004\\issues\\990\\events",
+      "https://ghe.example.com/api/v3/repositories/%31%32%38%35%32%34%37%30%30%34/issues/990/events",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/x/../events",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/{events}",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/e^ents",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/e`ents",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/e\"ents",
+      "https://ghe.example.com/api/v3/repositories/1285247004/issues/990/évents"
+    ];
+    for (const target of rejected) expect(matchesGitHubIssueEventEndpointIdentity(result.identity, target)).toBe(false);
+  });
+
+  it("rejects noncanonical base and malformed identity input", () => {
+    const rejected = [
+      { apiBaseUrl: "http://ghe.example.com/api/v3" },
+      { apiBaseUrl: "https://@ghe.example.com/api/v3" },
+      { apiBaseUrl: "https://ghe.example.com/api/v3?" },
+      { apiBaseUrl: "https://ghe.example.com/api/v3#" },
+      { apiBaseUrl: "https://ghe.example.com/api/%76%33" },
+      { apiBaseUrl: "https://ghe.example.com/api/../v3" },
+      { apiBaseUrl: "https://ghe.example.com/api/{v3}" },
+      { apiBaseUrl: "https://ghe.example.com/api/v^3" },
+      { apiBaseUrl: "https://ghe.example.com/api/v`3" },
+      { apiBaseUrl: "https://ghe.example.com/api/v\"3" },
+      { apiBaseUrl: "https://ghe.example.com/api/é" },
+      { repository: "electric-sheep" },
+      { repository: 42 },
+      { repositoryId: 0 },
+      { repositoryId: Number.MAX_SAFE_INTEGER + 1 },
+      { issueNumber: 0 }
+    ];
+    for (const change of rejected) {
+      const result = resolveGitHubIssueEventEndpointIdentity({ ...valid, ...change });
+      expect(result).toEqual({ ok: false, reason: "invalid_endpoint_identity" });
+      expect(Object.isFrozen(result)).toBe(true);
+    }
+    expect(resolveGitHubIssueEventEndpointIdentity({ ...valid, apiBaseUrl: "http://127.0.0.1:3000/api/v3" }).ok).toBe(true);
+  });
+});

--- a/tests/github-issue-event-endpoint-identity.test.ts
+++ b/tests/github-issue-event-endpoint-identity.test.ts
@@ -72,10 +72,8 @@ describe("exact raw GitHub issue-event endpoint identity", () => {
       accepted[0]
     )).toBe(false);
     const forgedFrozenIdentity = Object.freeze({
-      origin: "https://attacker.example",
-      basePath: "",
-      repositoryPath: "/accepted",
-      canonicalRepositoryPath: "/other"
+      origin: "https://attacker.example", basePath: "",
+      repositoryPath: "/accepted", canonicalRepositoryPath: "/other"
     });
     expect(matchesGitHubIssueEventEndpointIdentity(
       forgedFrozenIdentity,


### PR DESCRIPTION
Closes #1135

## Outcome

Adds one pure immutable GitHub issue-event endpoint identity that rejects any raw API base or Link target whose parsed canonical serialization differs from the supplied bytes. This preserves supported GitHub Enterprise prefixes without trusting WHATWG URL normalization.

## Replacement receipt

PR #1134 / issue #1133 terminalized after its blacklist mechanism exhausted 3/3 source corrections. This successor starts from protected main and uses the materially different `exact-raw-url-roundtrip-v2` mechanism; no commit or source was imported from PR #1134.

## Contract

- HTTPS plus the existing loopback-development HTTP allowance
- exact raw-to-canonical equality, with one controlled API-base trailing slash normalization
- no percent input, credentials/userinfo, query or fragment delimiter, backslash, non-ASCII/control/space, dot segment, or silent default-port/host/path rewrite
- exact configured origin plus only the derived owner/repository or numeric-repository issue-event path
- positive safe repository and issue IDs
- frozen normalized identity or deterministic invalid result

## Validation

- failing-first fixture: `EXPECTED_NEGATIVE` after exact-lock bootstrap
- focused Vitest: 3/3 passed
- exact-lock build/typecheck: passed
- `git diff --cached --check`: passed
- cumulative non-generated scope: 166 additions across two owned files

## Scope

- `src/github-issue-event-endpoint-identity.ts`
- `tests/github-issue-event-endpoint-identity.test.ts`

No pagination state machine, GitHub adapter, enrichment consumer, state/database, runtime, release, customer, or live-provider mutation.

## Proof boundary

This PR can prove pure exact-raw GitHub issue-event endpoint identity at its exact head. It does not prove pagination, adapter wiring, enrichment, live GitHub, runtime, release, or customer readiness. #990 restarts only from merged protected main after this gate closes.
