### PR TITLE
GitHub: bound issue-event pagination state

### DIFF
--- a/src/issue-event-pagination-state.ts
+++ b/src/issue-event-pagination-state.ts
@@ -16,14 +16,15 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
   endpointIdentity: Readonly<GitHubIssueEventEndpointIdentity>;
   readPage: (page: number) => Promise<IssueEventPage<T>>;
 }): Promise<IssueEventPaginationReceipt<T>> {
-  const newest = new Map<string, T>();
+  const newest = new Map<string, T>(), tailKeys = new Set<string>();
   let anonymous = 0, pagesRead = 0, rawCount = 0, trustedRawCount = 0, skipped = false, lastPage: number | undefined;
-  const add = (items: T[]) => {
+  const add = (items: T[], tail = false) => {
     trustedRawCount += items.length;
     for (const item of items) {
       const value = item?.id;
       const known = (typeof value === "number" && Number.isSafeInteger(value)) || (typeof value === "string" && value.trim() !== "");
       const key = known ? `id:${String(value).trim()}` : `anonymous:${anonymous++}`;
+      if (tail) tailKeys.add(key);
       newest.delete(key); newest.set(key, item);
     }
   };
@@ -72,8 +73,9 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
       if (!result.valid || !result.present || !chain(result.relations, page, lastPage)) return fail();
       const count = result.page.items.length;
       if (page < lastPage ? count !== SIZE : count < 1 || count > SIZE) return fail();
-      add(result.page.items);
+      add(result.page.items, true);
     }
+    if (skipped && tailKeys.size < MAX) return fail();
     return finish("bounded_tail");
   };
   const first = await read(1);

--- a/src/issue-event-pagination-state.ts
+++ b/src/issue-event-pagination-state.ts
@@ -61,8 +61,9 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
       return { page: candidate, present: true, relations: parsed, valid: parsed !== undefined };
     } catch { return { page: candidate, present: true, valid: false }; }
   };
-  const chain = (r: Relations | undefined, page: number, last: number) => Boolean(r && r.last === last && (r.first === undefined || r.first === 1) && (page === 1 ? r.prev === undefined && (last === 1 ? r.next === undefined : r.next === 2) : r.prev === page - 1 && (page === last ? r.next === undefined : r.next === page + 1)));
-  const terminalLinks = (r: Relations | undefined, page: number, last: number) => Boolean(r && r.last === last && (r.first === undefined || r.first === 1) && r.prev === (page === 1 ? undefined : page - 1) && r.next === undefined);
+  const lastMatches = (r: Relations, page: number, last: number) => r.last === last || (page === last && r.last === undefined);
+  const chain = (r: Relations | undefined, page: number, last: number) => Boolean(r && lastMatches(r, page, last) && (r.first === undefined || r.first === 1) && (page === 1 ? r.prev === undefined && (last === 1 ? r.next === undefined : r.next === 2) : r.prev === page - 1 && (page === last ? r.next === undefined : r.next === page + 1)));
+  const terminalLinks = (r: Relations | undefined, page: number, last: number) => Boolean(r && lastMatches(r, page, last) && (r.first === undefined || r.first === 1) && r.prev === (page === 1 ? undefined : page - 1) && r.next === undefined);
   const tail = async (existing: number): Promise<IssueEventPaginationReceipt<T>> => {
     if (!lastPage || lastPage < existing) return fail();
     const start = Math.max(existing + 1, Math.max(2, lastPage - 4)); skipped = start > existing + 1;

--- a/src/issue-event-pagination-state.ts
+++ b/src/issue-event-pagination-state.ts
@@ -1,0 +1,125 @@
+import { matchesGitHubIssueEventEndpointIdentity, type GitHubIssueEventEndpointIdentity } from "./github-issue-event-endpoint-identity.js";
+import { parseIssueEventLink, type IssueEventLinkMember } from "./issue-event-pagination-links.js";
+
+export type IssueEventTerminal = "short_page" | "bounded_tail" | "event_history_unbounded";
+export interface IssueEventPage<T> { page: number; items: T[]; link?: string | null; linkHeader?: string | null; }
+export interface IssueEventPaginationReceipt<T> {
+  items: T[]; pagesRead: number; rawCount: number; uniqueCount: number; duplicateCount: number;
+  lastPage?: number; terminal: IssueEventTerminal; truncated: boolean; overflow: boolean;
+}
+type Relation = "first" | "prev" | "next" | "last";
+type Relations = Partial<Record<Relation, number>>;
+type CheckedPage<T> = { page: IssueEventPage<T>; relations?: Relations; present: boolean; valid: boolean };
+const SIZE = 100, MAX = 200, RELATIONS = new Set<Relation>(["first", "prev", "next", "last"]);
+
+export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
+  endpointIdentity: Readonly<GitHubIssueEventEndpointIdentity>;
+  readPage: (page: number) => Promise<IssueEventPage<T>>;
+}): Promise<IssueEventPaginationReceipt<T>> {
+  const newest = new Map<string, T>();
+  let anonymous = 0, pagesRead = 0, rawCount = 0, trustedRawCount = 0, skipped = false, lastPage: number | undefined;
+  const add = (items: T[]) => {
+    trustedRawCount += items.length;
+    for (const item of items) {
+      const value = item?.id;
+      const known = (typeof value === "number" && Number.isSafeInteger(value)) || (typeof value === "string" && value.trim() !== "");
+      const key = known ? `id:${String(value).trim()}` : `anonymous:${anonymous++}`;
+      newest.delete(key); newest.set(key, item);
+    }
+  };
+  const finish = (terminal: IssueEventTerminal): IssueEventPaginationReceipt<T> => {
+    const unsafe = terminal === "event_history_unbounded", all = unsafe ? [] : [...newest.values()];
+    const uniqueCount = unsafe ? 0 : all.length;
+    return {
+      items: all.slice(-MAX), pagesRead, rawCount, uniqueCount,
+      duplicateCount: unsafe ? 0 : trustedRawCount - uniqueCount,
+      ...(lastPage === undefined ? {} : { lastPage }), terminal,
+      truncated: unsafe || skipped || uniqueCount > MAX, overflow: unsafe
+    };
+  };
+  const fail = () => finish("event_history_unbounded");
+  const identity = input.endpointIdentity;
+  try {
+    if (!matchesGitHubIssueEventEndpointIdentity(identity, `${identity.origin}${identity.repositoryPath}`)) return fail();
+  } catch { return fail(); }
+  const read = async (requested: number): Promise<CheckedPage<T>> => {
+    const candidate = await input.readPage(requested) as IssueEventPage<T> | null | undefined;
+    pagesRead += 1;
+    const items = Array.isArray(candidate?.items) ? candidate.items : [];
+    rawCount += items.length;
+    if (!candidate || !Number.isSafeInteger(candidate.page) || candidate.page !== requested || !Array.isArray(candidate.items) || items.length > SIZE) {
+      return { page: candidate as IssueEventPage<T>, present: false, valid: false };
+    }
+    if (candidate.link != null && candidate.linkHeader != null && candidate.link !== candidate.linkHeader) return { page: candidate, present: true, valid: false };
+    const link = candidate.link !== undefined && candidate.link !== null ? candidate.link : candidate.linkHeader;
+    const present = link !== undefined && link !== null;
+    if (!present) return { page: candidate, present: false, valid: true };
+    try {
+      const framed = parseIssueEventLink(link);
+      if (framed.kind !== "present") return { page: candidate, present: true, valid: false };
+      const parsed = relations(framed.members, identity);
+      return { page: candidate, present: true, relations: parsed, valid: parsed !== undefined };
+    } catch { return { page: candidate, present: true, valid: false }; }
+  };
+  const chain = (r: Relations | undefined, page: number, last: number) => Boolean(r && r.last === last && (r.first === undefined || r.first === 1) && (page === 1 ? r.prev === undefined && (last === 1 ? r.next === undefined : r.next === 2) : r.prev === page - 1 && (page === last ? r.next === undefined : r.next === page + 1)));
+  const terminalLinks = (r: Relations | undefined, page: number, last: number) => Boolean(r && r.last === last && (r.first === undefined || r.first === 1) && r.prev === (page === 1 ? undefined : page - 1) && r.next === undefined);
+  const tail = async (existing: number): Promise<IssueEventPaginationReceipt<T>> => {
+    if (!lastPage || lastPage < existing) return fail();
+    const start = Math.max(existing + 1, Math.max(2, lastPage - 4)); skipped = start > existing + 1;
+    for (let page = start; page <= lastPage; page += 1) {
+      const result = await read(page);
+      if (!result.valid || !result.present || !chain(result.relations, page, lastPage)) return fail();
+      const count = result.page.items.length;
+      if (page < lastPage ? count !== SIZE : count < 1 || count > SIZE) return fail();
+      add(result.page.items);
+    }
+    return finish("bounded_tail");
+  };
+  const first = await read(1);
+  if (!first.valid) return fail();
+  if (first.page.items.length < SIZE) {
+    if (first.present && (first.page.items.length === 0 || !terminalLinks(first.relations, 1, 1))) return fail();
+    lastPage = 1; add(first.page.items); return finish("short_page");
+  }
+  if (first.present) {
+    if (!first.relations?.last || !chain(first.relations, 1, first.relations.last)) return fail();
+    lastPage = first.relations.last; add(first.page.items);
+    return lastPage === 1 ? finish("short_page") : tail(1);
+  }
+  const second = await read(2);
+  if (!second.valid) return fail();
+  if (second.page.items.length < SIZE) {
+    if (second.present && (second.page.items.length === 0 || !terminalLinks(second.relations, 2, second.page.items.length ? 2 : 1))) return fail();
+    lastPage = second.page.items.length ? 2 : 1; add(first.page.items); if (second.page.items.length) add(second.page.items); return finish("short_page");
+  }
+  if (!second.present || !second.relations?.last || second.relations.last < 2 || !chain(second.relations, 2, second.relations.last)) return fail();
+  lastPage = second.relations.last; add(first.page.items); add(second.page.items); return tail(2);
+}
+
+function relations(members: IssueEventLinkMember[], identity: Readonly<GitHubIssueEventEndpointIdentity>): Relations | undefined {
+  const result: Relations = {}, seen = new Set<Relation>();
+  for (const member of members) {
+    const page = targetPage(member.target, identity);
+    if (page === undefined) return;
+    const relation = member.relation.startsWith('"') ? member.relation.slice(1, -1) : member.relation;
+    for (const name of relation.toLowerCase().split(" ")) {
+      if (!RELATIONS.has(name as Relation) || seen.has(name as Relation)) return;
+      seen.add(name as Relation); result[name as Relation] = page;
+    }
+  }
+  return seen.size ? result : undefined;
+}
+
+function targetPage(raw: string, identity: Readonly<GitHubIssueEventEndpointIdentity>): number | undefined {
+  let parsed: URL;
+  try { parsed = new URL(raw); } catch { return; }
+  const endpoint = `${parsed.origin}${parsed.pathname}`;
+  if (!matchesGitHubIssueEventEndpointIdentity(identity, endpoint) || !raw.startsWith(`${endpoint}?`)) return;
+  const parts = raw.slice(endpoint.length + 1).split("&");
+  if (parts.length !== 2) return;
+  const pagePart = parts.find((part) => part.startsWith("page="));
+  const perPart = parts.find((part) => part.startsWith("per_page="));
+  if (!pagePart || !perPart || perPart !== "per_page=100" || !/^[1-9]\d*$/.test(pagePart.slice(5))) return;
+  const page = Number(pagePart.slice(5));
+  return Number.isSafeInteger(page) ? page : undefined;
+}

--- a/src/issue-event-pagination-state.ts
+++ b/src/issue-event-pagination-state.ts
@@ -92,7 +92,7 @@ export async function readIssueEventHistory<T extends { id?: unknown }>(input: {
   const second = await read(2);
   if (!second.valid) return fail();
   if (second.page.items.length < SIZE) {
-    if (second.present && (second.page.items.length === 0 || !terminalLinks(second.relations, 2, second.page.items.length ? 2 : 1))) return fail();
+    if (second.present && !terminalLinks(second.relations, 2, second.page.items.length ? 2 : 1)) return fail();
     lastPage = second.page.items.length ? 2 : 1; add(first.page.items); if (second.page.items.length) add(second.page.items); return finish("short_page");
   }
   if (!second.present || !second.relations?.last || second.relations.last < 2 || !chain(second.relations, 2, second.relations.last)) return fail();

--- a/tests/issue-event-pagination-state.test.ts
+++ b/tests/issue-event-pagination-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { resolveGitHubIssueEventEndpointIdentity } from "../src/github-issue-event-endpoint-identity.js";
+import { readIssueEventHistory, type IssueEventPage } from "../src/issue-event-pagination-state.js";
+
+type Event = { id: number; value?: string };
+const resolved = resolveGitHubIssueEventEndpointIdentity({ apiBaseUrl: "https://api.github.com", repository: "owner/repo", repositoryId: 42, issueNumber: 990 });
+if (!resolved.ok) throw new Error("test identity setup failed");
+const identity = resolved.identity;
+const events = (page: number, count = 100): Event[] => Array.from({ length: count }, (_unused, index) => ({ id: page * 100 + index }));
+const link = (relation: string, page: number, path = identity.repositoryPath) => `<${identity.origin}${path}?per_page=100&page=${page}>; rel="${relation}"`;
+const chain = (page: number, last: number) => [page > 1 ? link("prev", page - 1) : "", page < last ? link("next", page + 1) : "", link("last", last)].filter(Boolean).join(
+  ", "
+);
+const run = (pages: Record<number, IssueEventPage<Event>>) => readIssueEventHistory({ endpointIdentity: identity, readPage: async (page) => pages[page] ?? { page, items: [] } });
+
+describe("strict issue-event pagination state", () => {
+  it("rejects an empty advertised final page without admitting older tail rows", async () => {
+    const requested: number[] = [];
+    const result = await readIssueEventHistory<Event>({ endpointIdentity: identity, readPage: async (page) => {
+      requested.push(page);
+      return { page, items: page === 8 ? [] : events(page), link: chain(page, 8) };
+    } });
+    expect(requested).toEqual([1, 4, 5, 6, 7, 8]);
+    expect(result).toMatchObject({ items: [], pagesRead: 6, rawCount: 500, uniqueCount: 0, lastPage: 8, terminal: "event_history_unbounded", truncated: true, overflow: true });
+  });
+
+  it("counts rows from a malformed tail response but trusts none of it", async () => {
+    const requested: number[] = [];
+    const result = await readIssueEventHistory<Event>({ endpointIdentity: identity, readPage: async (page) => {
+      requested.push(page);
+      return { page, items: events(page), link: page === 4 ? `<https://evil.invalid${identity.repositoryPath}?per_page=100&page=4>; rel="next"` : chain(page, 8) };
+    } });
+    expect(requested).toEqual([1, 4]);
+    expect(result).toMatchObject({ items: [], pagesRead: 2, rawCount: 200, uniqueCount: 0, lastPage: 8, terminal: "event_history_unbounded", truncated: true, overflow: true });
+  });
+
+  it("handles short pages, exact probes, bounded tails, dedupe, and transport errors", async () => {
+    expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page");
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ pagesRead: 2, rawCount: 100, lastPage: 1, terminal: "short_page" });
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3), link: chain(2, 2) }, 3: { page: 3, items: [] } })).toMatchObject({ rawCount: 103, lastPage: 2, terminal: "short_page" });
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).toMatchObject({ terminal: "event_history_unbounded", truncated: true, overflow: true });
+    const pages: Record<number, IssueEventPage<Event>> = {};
+    for (let page = 1; page <= 5; page += 1) pages[page] = { page, items: page === 5 ? [{ id: 450, value: "new" }, ...events(page, 49)] : events(page), link: chain(page, 5) };
+    pages[4].items[50] = { id: 450, value: "old" };
+    const bounded = await run(pages);
+    expect(bounded).toMatchObject({ rawCount: 450, uniqueCount: 449, duplicateCount: 1, pagesRead: 5, lastPage: 5, terminal: "bounded_tail", truncated: true, overflow: false });
+    expect(bounded.items).toHaveLength(200); expect(bounded.items.find((event) => event.id === 450)?.value).toBe("new");
+    await expect(readIssueEventHistory({ endpointIdentity: identity, readPage: async (page) => { if (page === 4) throw new Error("transport"); return { page, items: events(page), link: chain(page, 8) }; } })).rejects.toThrow("transport");
+  });
+
+  it("rejects hostile, incomplete, and contradictory Link/page metadata", async () => {
+    const badFirst = [`<https://evil.invalid${identity.repositoryPath}?per_page=100&page=2>; rel="next"`, link("next", 2, "/wrong"), link("next", 2).replace("per_page=100", "per_page=99"), link("next", 2).replace("page=2", "page=2&page=2"), `${link("next", 2)}, ${link("next", 2)}`, `${link("next", 2)}, ${link("last", 1)}`];
+    for (const raw of badFirst) expect((await run({ 1: { page: 1, items: events(1), link: raw } })).terminal).toBe("event_history_unbounded");
+    const badTail = [undefined, chain(4, 9), chain(4, 7), chain(4, 8).replace("page=3", "page=2"), chain(4, 8).replace("page=5", "page=6"), chain(4, 8).replace("page=3", "page=3&page=3")];
+    for (const raw of badTail) expect((await run({ 1: { page: 1, items: events(1), link: chain(1, 8) }, 4: { page: 4, items: events(4, raw === chain(4, 8) ? 99 : 100), link: raw } })).terminal).toBe("event_history_unbounded");
+    expect((await run({ 1: { page: 1, items: events(1), link: `${link("next", 2)}, ${link("last", 1)}` } })).terminal).toBe("event_history_unbounded");
+  });
+});

--- a/tests/issue-event-pagination-state.test.ts
+++ b/tests/issue-event-pagination-state.test.ts
@@ -37,7 +37,7 @@ describe("strict issue-event pagination state", () => {
 
   it("handles short pages, exact probes, bounded tails, dedupe, and transport errors", async () => {
     expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page");
-    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ pagesRead: 2, rawCount: 100, lastPage: 1, terminal: "short_page" });
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [], link: [link("prev", 1), link("last", 1), link("first", 1)].join(", ") } })).toMatchObject({ pagesRead: 2, rawCount: 100, lastPage: 1, terminal: "short_page" });
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3), link: terminal(2) }, 3: { page: 3, items: [] } })).toMatchObject({ rawCount: 103, lastPage: 2, terminal: "short_page" });
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).toMatchObject({ terminal: "event_history_unbounded", truncated: true, overflow: true });
     const pages: Record<number, IssueEventPage<Event>> = {};

--- a/tests/issue-event-pagination-state.test.ts
+++ b/tests/issue-event-pagination-state.test.ts
@@ -46,6 +46,9 @@ describe("strict issue-event pagination state", () => {
     const bounded = await run(pages);
     expect(bounded).toMatchObject({ rawCount: 450, uniqueCount: 449, duplicateCount: 1, pagesRead: 5, lastPage: 5, terminal: "bounded_tail", truncated: true, overflow: false });
     expect(bounded.items).toHaveLength(200); expect(bounded.items.find((event) => event.id === 450)?.value).toBe("new");
+    const duplicateTail: Record<number, IssueEventPage<Event>> = {};
+    for (let page = 1; page <= 8; page += 1) duplicateTail[page] = { page, items: page === 1 ? events(1) : events(8), link: page === 8 ? terminal(page) : chain(page, 8) };
+    expect(await run(duplicateTail)).toMatchObject({ items: [], terminal: "event_history_unbounded", overflow: true });
     await expect(readIssueEventHistory({ endpointIdentity: identity, readPage: async (page) => { if (page === 4) throw new Error("transport"); return { page, items: events(page), link: chain(page, 8) }; } })).rejects.toThrow("transport");
   });
 

--- a/tests/issue-event-pagination-state.test.ts
+++ b/tests/issue-event-pagination-state.test.ts
@@ -11,6 +11,7 @@ const link = (relation: string, page: number, path = identity.repositoryPath) =>
 const chain = (page: number, last: number) => [page > 1 ? link("prev", page - 1) : "", page < last ? link("next", page + 1) : "", link("last", last)].filter(Boolean).join(
   ", "
 );
+const terminal = (page: number) => [link("first", 1), link("prev", page - 1)].join(", ");
 const run = (pages: Record<number, IssueEventPage<Event>>) => readIssueEventHistory({ endpointIdentity: identity, readPage: async (page) => pages[page] ?? { page, items: [] } });
 
 describe("strict issue-event pagination state", () => {
@@ -37,10 +38,10 @@ describe("strict issue-event pagination state", () => {
   it("handles short pages, exact probes, bounded tails, dedupe, and transport errors", async () => {
     expect((await run({ 1: { page: 1, items: events(1, 3) } })).terminal).toBe("short_page");
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: [] } })).toMatchObject({ pagesRead: 2, rawCount: 100, lastPage: 1, terminal: "short_page" });
-    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3), link: chain(2, 2) }, 3: { page: 3, items: [] } })).toMatchObject({ rawCount: 103, lastPage: 2, terminal: "short_page" });
+    expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2, 3), link: terminal(2) }, 3: { page: 3, items: [] } })).toMatchObject({ rawCount: 103, lastPage: 2, terminal: "short_page" });
     expect(await run({ 1: { page: 1, items: events(1) }, 2: { page: 2, items: events(2) } })).toMatchObject({ terminal: "event_history_unbounded", truncated: true, overflow: true });
     const pages: Record<number, IssueEventPage<Event>> = {};
-    for (let page = 1; page <= 5; page += 1) pages[page] = { page, items: page === 5 ? [{ id: 450, value: "new" }, ...events(page, 49)] : events(page), link: chain(page, 5) };
+    for (let page = 1; page <= 5; page += 1) pages[page] = { page, items: page === 5 ? [{ id: 450, value: "new" }, ...events(page, 49)] : events(page), link: page === 5 ? terminal(page) : chain(page, 5) };
     pages[4].items[50] = { id: 450, value: "old" };
     const bounded = await run(pages);
     expect(bounded).toMatchObject({ rawCount: 450, uniqueCount: 449, duplicateCount: 1, pagesRead: 5, lastPage: 5, terminal: "bounded_tail", truncated: true, overflow: false });


### PR DESCRIPTION
Closes #990

## Outcome

Add the pure, event-specific pagination state machine that consumes the accepted #1135 endpoint identity and strict Link framing. It bounds issue-event reads to page 1 plus the newest five-page tail and fails closed as `event_history_unbounded` when pagination metadata is malformed, contradictory, partial, hostile, or advertises an empty final page.

## Scope

- `src/issue-event-pagination-state.ts`
- `tests/issue-event-pagination-state.test.ts`

Exactly 183 added non-generated lines across two files. No API adapter, enrichment consumer, state/database, runtime, release, customer, or public-surface change.

## Validation

- The failing fixture file was created before the source module. Its first focused invocation was environment-blocked because dependencies were absent; the exact-lock bootstrap then exposed the known native-addon signature mismatch under the default Node route. This is recorded as `ENVIRONMENT_BLOCKED`, not a behavioral expected negative.
- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/issue-event-pagination-state.test.ts` — 4/4 passed.
- `/opt/homebrew/bin/node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run build` — passed.
- `git diff --check` — passed.
- Candidate head: `638ece6` from exact protected main `845cf55`.

## Safety and proof boundary

Agent-authored under the NeonDiff BYO Mac GA release-manager plan. Transport failures remain thrown. Rejected pages contribute only bounded receipt counts and never trusted items. The change adds no GitHub write, credential path, live worker change, artifact, billing, release, or customer mutation.

Passing source tests and CI will prove only the pure pagination receipt seam. Production adapter/enrichment wiring remains #991 and no runtime, artifact, release, or customer readiness claim is made.
