### PR TITLE
fix: admit only ordinary receipt snapshot objects

### DIFF
--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -1,0 +1,118 @@
+import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentBlocker } from "./issue-enrichment.js";
+
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP = 1_000_000;
+export const ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT = 32;
+export const ISSUE_ENRICHMENT_RECEIPT_MESSAGE_LIMIT = 256;
+export const ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS = Object.freeze([
+  "reposScanned", "reposSkipped", "readFailures", "issuesSeen", "eligible", "skipped", "wouldEnrich",
+  "wouldComment", "deferred", "baselinedRepos", "truncatedRepos", "workerSkipped", "posted", "dryRunRecorded",
+  "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
+] as const);
+export type IssueEnrichmentReceiptCounts = { readonly [K in typeof ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS[number]]: number };
+export type IssueEnrichmentReceiptReason = IssueEnrichmentBlocker | "unknown_failure";
+export type IssueEnrichmentReceiptInput = { kind: "result"; result: unknown } | { kind: "thrown"; error: unknown };
+export type IssueEnrichmentReceiptSnapshot = Readonly<{ kind: "thrown"; reason: IssueEnrichmentReceiptReason }> | Readonly<{
+  kind: "result"; summary: Readonly<{ valid: false }> | Readonly<{ valid: true; counts: IssueEnrichmentReceiptCounts }>;
+  status: IssueEnrichmentStatusSnapshot; dryRun: IssueEnrichmentFlagSnapshot; ok: IssueEnrichmentFlagSnapshot;
+}>;
+export interface IssueEnrichmentStatusSnapshot {
+  readonly readable: boolean;
+  readonly state: "disabled" | "blocked" | "other" | "unreadable";
+  readonly blockers: IssueEnrichmentBlockersSnapshot;
+}
+export interface IssueEnrichmentBlockersSnapshot {
+  readonly readable: boolean;
+  readonly complete: boolean;
+  readonly reasons: readonly IssueEnrichmentBlocker[];
+}
+export type IssueEnrichmentFlagSnapshot = "true" | "false" | "unreadable";
+
+const enabledConfig = { ...DEFAULT_ISSUE_ENRICHMENT_CONFIG, enabled: true, postIssueComment: true, allowlist: ["owner/repo"] };
+const BLOCKERS = new Set<IssueEnrichmentBlocker>([
+  ...buildIssueEnrichmentStatus({ config: { issueEnrichment: DEFAULT_ISSUE_ENRICHMENT_CONFIG }, canPostAsApp: false }).blockers,
+  ...buildIssueEnrichmentStatus({ config: { issueEnrichment: enabledConfig }, canPostAsApp: false, modelAnalysisAvailable: false }).blockers,
+  ...buildIssueEnrichmentStatus({ config: { issueEnrichment: enabledConfig }, canPostAsApp: true, modelAnalysisAvailable: true,
+    issueReadChecks: [{ repo: "owner/repo", ok: false }] }).blockers
+]);
+type RecordValue = Record<string, unknown>;
+type Read = { ok: boolean; value?: unknown };
+const isOrdinaryObject = (value: unknown): value is RecordValue => {
+  try {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  } catch { return false; }
+};
+const read = (value: RecordValue | undefined, key: string): Read => {
+  if (!value) return { ok: false };
+  try { return { ok: true, value: value[key] }; } catch { return { ok: false }; }
+};
+const frozen = <T extends object>(value: T): Readonly<T> => Object.freeze(value);
+
+function snapshotSummary(value: unknown): Readonly<{ valid: false }> | Readonly<{ valid: true; counts: IssueEnrichmentReceiptCounts }> {
+  if (!isOrdinaryObject(value)) return frozen({ valid: false });
+  const counts = {} as { -readonly [K in typeof ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS[number]]: number };
+  let valid = true;
+  for (const key of ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS) {
+    const count = read(value, key);
+    if (!count.ok || typeof count.value !== "number" || !Number.isFinite(count.value) || !Number.isInteger(count.value) || count.value < 0) valid = false;
+    else counts[key] = Math.min(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP, count.value);
+  }
+  return valid ? frozen({ valid: true, counts: frozen(counts) }) : frozen({ valid: false });
+}
+function snapshotBlockers(value: unknown): IssueEnrichmentBlockersSnapshot {
+  try {
+    if (!Array.isArray(value)) return frozen({ readable: false, complete: false, reasons: frozen([]) });
+    const length = (value as unknown[]).length;
+    if (!Number.isSafeInteger(length) || length < 0) return frozen({ readable: false, complete: false, reasons: frozen([]) });
+    const reasons: IssueEnrichmentBlocker[] = [];
+    let readable = true; let complete = length <= ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT;
+    for (let index = 0; index < Math.min(length, ISSUE_ENRICHMENT_RECEIPT_BLOCKER_LIMIT); index += 1) {
+      try {
+        const present = Object.prototype.hasOwnProperty.call(value, index);
+        const blocker = (value as unknown[])[index];
+        if (!present || typeof blocker !== "string" || !BLOCKERS.has(blocker as IssueEnrichmentBlocker)) complete = false;
+        else reasons.push(blocker as IssueEnrichmentBlocker);
+      } catch { readable = false; complete = false; }
+    }
+    return frozen({ readable, complete, reasons: frozen(reasons) });
+  } catch { return frozen({ readable: false, complete: false, reasons: frozen([]) }); }
+}
+function snapshotThrown(error: unknown): IssueEnrichmentReceiptSnapshot {
+  let message: unknown;
+  try { message = typeof error === "string" ? error : error && typeof error === "object" ? (error as RecordValue).message : undefined; } catch { /* fail closed */ }
+  if (typeof message === "string") {
+    const prefix = message.slice(0, ISSUE_ENRICHMENT_RECEIPT_MESSAGE_LIMIT).trim();
+    for (const blocker of BLOCKERS) {
+      const next = prefix[blocker.length];
+      if (prefix === blocker || (prefix.startsWith(blocker) && !/[A-Za-z0-9_]/.test(next ?? ""))) return frozen({ kind: "thrown", reason: blocker });
+    }
+  }
+  return frozen({ kind: "thrown", reason: "unknown_failure" });
+}
+function snapshotResult(result: unknown): IssueEnrichmentReceiptSnapshot {
+  const root = isOrdinaryObject(result) ? result : undefined;
+  const summary = read(root, "summary"), status = read(root, "status"), dryRun = read(root, "dryRun"), ok = read(root, "ok");
+  const statusValue = status.ok && isOrdinaryObject(status.value) ? status.value : undefined;
+  const state = read(statusValue, "state"), blockers = read(statusValue, "blockers");
+  const readable = Boolean(statusValue && state.ok && (state.value === "disabled" || state.value === "blocked" || state.value === "ready" || state.value === "dry_run_only"));
+  const statusSnapshot: IssueEnrichmentStatusSnapshot = frozen({
+    readable, state: !state.ok || typeof state.value !== "string" ? "unreadable" : state.value === "disabled" ? "disabled" : state.value === "blocked" ? "blocked" : state.value === "ready" || state.value === "dry_run_only" ? "other" : "unreadable",
+    blockers: snapshotBlockers(blockers.ok ? blockers.value : undefined)
+  });
+  const flag = (value: Read): IssueEnrichmentFlagSnapshot => value.ok && value.value === true ? "true" : value.ok && value.value === false ? "false" : "unreadable";
+  return frozen({ kind: "result", summary: snapshotSummary(summary.ok ? summary.value : undefined), status: statusSnapshot, dryRun: flag(dryRun), ok: flag(ok) });
+}
+export function snapshotIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentReceiptSnapshot {
+  let kind: unknown;
+  try { kind = (input as unknown as RecordValue).kind; } catch { return frozen({ kind: "thrown", reason: "unknown_failure" }); }
+  if (kind === "thrown") {
+    let error: unknown;
+    try { error = (input as { kind: "thrown"; error: unknown }).error; } catch { /* fail closed */ }
+    return snapshotThrown(error);
+  }
+  if (kind !== "result") return frozen({ kind: "thrown", reason: "unknown_failure" });
+  let result: unknown;
+  try { result = (input as { kind: "result"; result: unknown }).result; } catch { /* malformed result */ }
+  return snapshotResult(result);
+}

--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -75,7 +75,7 @@ function snapshotBlockers(value: unknown): IssueEnrichmentBlockersSnapshot {
         else reasons.push(blocker as IssueEnrichmentBlocker);
       } catch { readable = false; complete = false; }
     }
-    return frozen({ readable, complete, reasons: frozen(reasons) });
+    return frozen({ readable, complete: complete && value.length === length, reasons: frozen(reasons) });
   } catch { return frozen({ readable: false, complete: false, reasons: frozen([]) }); }
 }
 function snapshotThrown(error: unknown): IssueEnrichmentReceiptSnapshot {

--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -44,7 +44,7 @@ const isOrdinaryObject = (value: unknown): value is RecordValue => {
   } catch { return false; }
 };
 const read = (value: RecordValue | undefined, key: string): Read => {
-  if (!value) return { ok: false };
+  if (!value || !Object.prototype.hasOwnProperty.call(value, key)) return { ok: false };
   try { return { ok: true, value: value[key] }; } catch { return { ok: false }; }
 };
 const frozen = <T extends object>(value: T): Readonly<T> => Object.freeze(value);

--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -44,8 +44,8 @@ const isOrdinaryObject = (value: unknown): value is RecordValue => {
   } catch { return false; }
 };
 const read = (value: RecordValue | undefined, key: string): Read => {
-  if (!value || !Object.prototype.hasOwnProperty.call(value, key)) return { ok: false };
-  try { return { ok: true, value: value[key] }; } catch { return { ok: false }; }
+  if (!value) return { ok: false };
+  try { if (!Object.prototype.hasOwnProperty.call(value, key)) return { ok: false }; return { ok: true, value: value[key] }; } catch { return { ok: false }; }
 };
 const frozen = <T extends object>(value: T): Readonly<T> => Object.freeze(value);
 

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -39,6 +39,7 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     expect(snap({ kind: "result", result: hostile })).toMatchObject({ summary: { valid: false }, dryRun: "unreadable", ok: "unreadable" });
     const status = new Proxy({ state: "blocked", blockers: [] }, { get() { throw new Error("status"); } });
     expect(snap({ kind: "result", result: plainResult({ status }) }).status).toMatchObject({ readable: false, state: "unreadable" });
+    expect(snap({ kind: "result", result: new Proxy({}, { getOwnPropertyDescriptor() { throw new Error("descriptor"); } }) })).toMatchObject({ summary: { valid: false } });
     const blockers = Proxy.revocable([], {}); blockers.revoke();
     expect(snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers: blockers.proxy } }) }).status.blockers)
       .toMatchObject({ readable: false, complete: false, reasons: [] });

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -26,6 +26,8 @@ describe("issue-enrichment hostile receipt snapshot", () => {
       const nested = new Date(); Object.assign(nested, key === "summary" ? counts() : { state: "ready", blockers: [] });
       expect(snap({ kind: "result", result: plainResult({ [key]: nested }) }).summary.valid).toBe(key !== "summary");
     }
+    Object.assign(Object.prototype, { summary: counts(), status: { state: "ready", blockers: [] }, dryRun: false, ok: true });
+    try { expect(snap({ kind: "result", result: {} })).toMatchObject({ summary: { valid: false }, dryRun: "unreadable", ok: "unreadable" }); } finally { for (const key of ["summary", "status", "dryRun", "ok"]) delete (Object.prototype as Record<string, unknown>)[key]; }
   });
 
   it("fails closed for revoked and throwing/stateful surfaces", () => {

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS,
+  snapshotIssueEnrichmentReceipt,
+  type IssueEnrichmentReceiptSnapshot
+} from "../src/issue-enrichment-receipt-snapshot.js";
+
+const counts = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
+);
+const plainResult = (overrides: Record<string, unknown> = {}) => ({
+  summary: counts(), status: { state: "ready", blockers: [] }, dryRun: false, ok: true, ...overrides
+});
+const snap = (value: unknown): IssueEnrichmentReceiptSnapshot => snapshotIssueEnrichmentReceipt(value as never);
+
+describe("issue-enrichment hostile receipt snapshot", () => {
+  it("accepts only ordinary roots and nested containers", () => {
+    class Result { summary = counts(); status = { state: "ready", blockers: [] }; dryRun = false; ok = true; }
+    for (const value of [new Map(), new Date(), new Result()]) {
+      Object.assign(value, plainResult());
+      expect(snap({ kind: "result", result: value }).summary).toEqual({ valid: false });
+    }
+    const nullResult = Object.assign(Object.create(null), plainResult());
+    expect(snap({ kind: "result", result: nullResult }).summary.valid).toBe(true);
+    for (const key of ["summary", "status"]) {
+      const nested = new Date(); Object.assign(nested, key === "summary" ? counts() : { state: "ready", blockers: [] });
+      expect(snap({ kind: "result", result: plainResult({ [key]: nested }) }).summary.valid).toBe(key !== "summary");
+    }
+  });
+
+  it("fails closed for revoked and throwing/stateful surfaces", () => {
+    const revoked = Proxy.revocable({}, {}); revoked.revoke();
+    const value = snap({ kind: "result", result: revoked.proxy });
+    expect(value).toMatchObject({ kind: "result", summary: { valid: false }, status: { readable: false } });
+    const hostile = plainResult();
+    for (const key of ["summary", "status", "dryRun", "ok"]) Object.defineProperty(hostile, key, { get: () => { throw new Error("hostile"); } });
+    expect(snap({ kind: "result", result: hostile })).toMatchObject({ summary: { valid: false }, dryRun: "unreadable", ok: "unreadable" });
+    const status = new Proxy({ state: "blocked", blockers: [] }, { get() { throw new Error("status"); } });
+    expect(snap({ kind: "result", result: plainResult({ status }) }).status).toMatchObject({ readable: false, state: "unreadable" });
+    const blockers = Proxy.revocable([], {}); blockers.revoke();
+    expect(snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers: blockers.proxy } }) }).status.blockers)
+      .toMatchObject({ readable: false, complete: false, reasons: [] });
+  });
+
+  it("reads each count once, caps counts, and freezes an independent result", () => {
+    const reads = new Map<string, number>();
+    const summary = Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, {
+      get: () => { reads.set(key, (reads.get(key) ?? 0) + 1); return key === "failed" ? 2_000_000 : 1; }
+    }]));
+    for (const [key, descriptor] of Object.entries(summary)) Object.defineProperty(summary, key, descriptor);
+    const source = plainResult({ summary });
+    const value = snap({ kind: "result", result: source });
+    expect(reads.size).toBe(18); expect([...reads.values()].every((count) => count === 1)).toBe(true);
+    expect(value.summary.valid && value.summary.counts.failed).toBe(1_000_000);
+    expect(Object.isFrozen(value)).toBe(true); expect(Object.isFrozen(value.status.blockers.reasons)).toBe(true);
+    Object.defineProperty(source, "summary", { value: counts({ failed: 0 }) });
+    expect(value.summary.valid && value.summary.counts.failed).toBe(1_000_000);
+  });
+
+  it("caps blocker inspection at 32 and rejects sparse or unknown entries", () => {
+    const blockers: unknown[] = []; blockers.length = 2_000_000_000; let reads = 0;
+    for (let i = 0; i < 40; i++) Object.defineProperty(blockers, String(i), { get: () => { reads++; return "github_app_issues_permission_required"; } });
+    const value = snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers } }) });
+    expect(reads).toBe(32); expect(value.status.blockers).toMatchObject({ readable: true, complete: false });
+    expect(snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers: ["future", 1] } }) }).status.blockers.complete).toBe(false);
+  });
+
+  it("extracts only a bounded leading blocker token from thrown errors", () => {
+    const token = "issue_enrichment_model_runtime_required";
+    expect(snap({ kind: "thrown", error: new Error(`${token}:${"x".repeat(10_000)}`) })).toMatchObject({ reason: token });
+    expect(snap({ kind: "thrown", error: `context ${token}` })).toMatchObject({ reason: "unknown_failure" });
+    const error = {}; Object.defineProperty(error, "message", { get: () => { throw new Error("no"); } });
+    expect(snap({ kind: "thrown", error })).toMatchObject({ reason: "unknown_failure" });
+    expect(snap({ kind: "oops", result: plainResult() })).toMatchObject({ kind: "thrown", reason: "unknown_failure" });
+    expect(Object.isFrozen(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS)).toBe(true);
+  });
+});

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -65,6 +65,7 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     for (let i = 0; i < 40; i++) Object.defineProperty(blockers, String(i), { get: () => { reads++; return "github_app_issues_permission_required"; } });
     const value = snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers } }) });
     expect(reads).toBe(32); expect(value.status.blockers).toMatchObject({ readable: true, complete: false });
+    const growing = ["placeholder"]; Object.defineProperty(growing, "0", { get: () => { growing.push("github_app_issues_permission_required"); return "github_app_issues_permission_required"; } }); expect(snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers: growing } }) }).status.blockers.complete).toBe(false);
     expect(snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers: ["future", 1] } }) }).status.blockers.complete).toBe(false);
   });
 


### PR DESCRIPTION
Closes #1036. Rebuilds the strict receipt snapshot seam from protected main. Rejects exotic root and nested containers, fails closed on hostile accessors, bounds reads, and freezes an independent receipt snapshot. Focused Vitest: 5/5. Exact-lock build and diff check pass. Source proof only; no runtime, artifact, customer, or release claim.