### PR TITLE
fix: canonicalize receipt blocker order

### DIFF
--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -34,6 +34,7 @@ const BLOCKERS = new Set<IssueEnrichmentBlocker>([
   ...buildIssueEnrichmentStatus({ config: { issueEnrichment: enabledConfig }, canPostAsApp: true, modelAnalysisAvailable: true,
     issueReadChecks: [{ repo: "owner/repo", ok: false }] }).blockers
 ]);
+const BLOCKER_RANK = new Map([...BLOCKERS].map((blocker, index) => [blocker, index]));
 type RecordValue = Record<string, unknown>;
 type Read = { ok: boolean; value?: unknown };
 const isOrdinaryObject = (value: unknown): value is RecordValue => {
@@ -75,6 +76,7 @@ function snapshotBlockers(value: unknown): IssueEnrichmentBlockersSnapshot {
         else reasons.push(blocker as IssueEnrichmentBlocker);
       } catch { readable = false; complete = false; }
     }
+    reasons.sort((left, right) => (BLOCKER_RANK.get(left) ?? 0) - (BLOCKER_RANK.get(right) ?? 0));
     return frozen({ readable, complete: complete && value.length === length, reasons: frozen(reasons) });
   } catch { return frozen({ readable: false, complete: false, reasons: frozen([]) }); }
 }

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -69,6 +69,12 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     expect(snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers: ["future", 1] } }) }).status.blockers.complete).toBe(false);
   });
 
+  it("canonicalizes recognized blocker order without dropping duplicates", () => {
+    const left = ["issue_enrichment_model_runtime_required", "github_app_issues_permission_required", "github_app_issues_permission_required"], right = [...left].reverse();
+    const capture = (blockers: string[]) => snap({ kind: "result", result: plainResult({ status: { state: "blocked", blockers } }) }).status.blockers;
+    expect(capture(left)).toEqual(capture(right)); expect(JSON.stringify(capture(left))).toBe(JSON.stringify(capture(right)));
+  });
+
   it("extracts only a bounded leading blocker token from thrown errors", () => {
     const token = "issue_enrichment_model_runtime_required";
     expect(snap({ kind: "thrown", error: new Error(`${token}:${"x".repeat(10_000)}`) })).toMatchObject({ reason: token });


### PR DESCRIPTION
Closes #1037. Derives canonical blocker rank from the existing recognized blocker source, sorts only captured recognized reasons before freezing, and preserves duplicates as a bounded multiset. Failing-first order/byte-equality fixture captured. Focused Vitest 6/6, exact-lock build, and diff check pass. Source proof only; no classifier, daemon, runtime, artifact, release, or customer claim.