### PR TITLE
Mac GA: classify sanitized issue-enrichment receipts

### DIFF
--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -17,7 +17,7 @@ export type IssueEnrichmentReceiptSnapshot = Readonly<{ kind: "thrown"; reason: 
 }>;
 export interface IssueEnrichmentStatusSnapshot {
   readonly readable: boolean;
-  readonly state: "disabled" | "blocked" | "other" | "unreadable";
+  readonly state: "disabled" | "blocked" | "dry_run_only" | "other" | "unreadable";
   readonly blockers: IssueEnrichmentBlockersSnapshot;
 }
 export interface IssueEnrichmentBlockersSnapshot {
@@ -99,7 +99,7 @@ function snapshotResult(result: unknown): IssueEnrichmentReceiptSnapshot {
   const state = read(statusValue, "state"), blockers = read(statusValue, "blockers");
   const readable = Boolean(statusValue && state.ok && (state.value === "disabled" || state.value === "blocked" || state.value === "ready" || state.value === "dry_run_only"));
   const statusSnapshot: IssueEnrichmentStatusSnapshot = frozen({
-    readable, state: !state.ok || typeof state.value !== "string" ? "unreadable" : state.value === "disabled" ? "disabled" : state.value === "blocked" ? "blocked" : state.value === "ready" || state.value === "dry_run_only" ? "other" : "unreadable",
+    readable, state: !state.ok || typeof state.value !== "string" ? "unreadable" : state.value === "disabled" ? "disabled" : state.value === "blocked" ? "blocked" : state.value === "dry_run_only" ? "dry_run_only" : state.value === "ready" ? "other" : "unreadable",
     blockers: snapshotBlockers(blockers.ok ? blockers.value : undefined)
   });
   const flag = (value: Read): IssueEnrichmentFlagSnapshot => value.ok && value.value === true ? "true" : value.ok && value.value === false ? "false" : "unreadable";

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -68,6 +68,9 @@ export function classifyIssueEnrichmentSnapshot(snapshot: IssueEnrichmentReceipt
       ? receipt(false, "result_not_ok", counts, "unknown_failure")
       : receipt(false, "blocked", counts, effectiveBlocker);
   }
+  if (snapshot.status.state === "blocked" && snapshot.status.blockers.reasons.length === 0) {
+    return receipt(false, "result_not_ok", counts, "unknown_failure");
+  }
   if (snapshot.ok !== "true") return receipt(false, "result_not_ok", counts, "unknown_failure");
   const completed = USEFUL_COUNT_KEYS.some((key) => counts[key] > 0);
   return receipt(true, completed ? "completed" : "no_candidates", counts);

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -1,0 +1,79 @@
+import {
+  DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS,
+  type IssueEnrichmentBlocker
+} from "./issue-enrichment.js";
+import {
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS,
+  snapshotIssueEnrichmentReceipt,
+  type IssueEnrichmentReceiptCounts,
+  type IssueEnrichmentReceiptInput,
+  type IssueEnrichmentReceiptSnapshot
+} from "./issue-enrichment-receipt-snapshot.js";
+
+export type IssueEnrichmentLaneCode =
+  | "completed" | "no_candidates" | "lease_skipped" | "disabled" | "blocked"
+  | "result_not_ok" | "cycle_failed" | "malformed_summary";
+export type IssueEnrichmentLaneReason = IssueEnrichmentBlocker | "worker_lease_held" | "read_failure"
+  | "item_failure" | "unknown_failure" | "malformed_summary";
+export interface IssueEnrichmentLaneReceipt {
+  readonly ok: boolean;
+  readonly stage: "issue_enrichment";
+  readonly code: IssueEnrichmentLaneCode;
+  readonly counts: IssueEnrichmentReceiptCounts;
+  readonly reason?: IssueEnrichmentLaneReason;
+}
+
+const ZERO_COUNTS = Object.freeze(Object.fromEntries(
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, 0])
+)) as IssueEnrichmentReceiptCounts;
+const USEFUL_COUNT_KEYS: readonly (keyof IssueEnrichmentReceiptCounts)[] = Object.freeze([
+  "eligible", "wouldEnrich", "wouldComment", "posted", "dryRunRecorded", "skippedRecorded",
+  "deferredRecorded", "alreadyProcessed"
+]);
+
+const receipt = (ok: boolean, code: IssueEnrichmentLaneCode, counts: IssueEnrichmentReceiptCounts,
+  reason?: IssueEnrichmentLaneReason): IssueEnrichmentLaneReceipt => Object.freeze({
+  ok, stage: "issue_enrichment" as const, code, counts, ...(reason ? { reason } : {})
+});
+
+const controlsReadable = (snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>): boolean =>
+  snapshot.status.readable && snapshot.status.blockers.readable && snapshot.status.blockers.complete &&
+  snapshot.dryRun !== "unreadable" && snapshot.ok !== "unreadable";
+
+export function classifyIssueEnrichmentSnapshot(snapshot: IssueEnrichmentReceiptSnapshot): IssueEnrichmentLaneReceipt {
+  if (snapshot.kind === "thrown") return receipt(false, "cycle_failed", ZERO_COUNTS, snapshot.reason);
+  if (!snapshot.summary.valid) return receipt(false, "malformed_summary", ZERO_COUNTS, "malformed_summary");
+  const counts = snapshot.summary.counts;
+  const readable = controlsReadable(snapshot);
+  if (counts.workerSkipped > 0) {
+    return readable && snapshot.ok === "true"
+      ? receipt(true, "lease_skipped", counts, "worker_lease_held")
+      : receipt(false, "result_not_ok", counts, "unknown_failure");
+  }
+  if (snapshot.status.state === "disabled") {
+    return readable && snapshot.ok === "true"
+      ? receipt(true, "disabled", ZERO_COUNTS)
+      : receipt(false, "result_not_ok", counts, "unknown_failure");
+  }
+  if (counts.readFailures > 0) return receipt(false, "result_not_ok", counts, "read_failure");
+  if (counts.failed > 0) return receipt(false, "result_not_ok", counts, "item_failure");
+  if (!readable) return receipt(false, "result_not_ok", counts, "unknown_failure");
+
+  const effectiveBlocker = snapshot.status.state === "blocked"
+    ? snapshot.status.blockers.reasons.find((reason) =>
+      snapshot.dryRun !== "true" || !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason))
+    : undefined;
+  if (effectiveBlocker) {
+    const hasScanEvidence = ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.some((key) => counts[key] > 0);
+    return hasScanEvidence
+      ? receipt(false, "result_not_ok", counts, "unknown_failure")
+      : receipt(false, "blocked", counts, effectiveBlocker);
+  }
+  if (snapshot.ok !== "true") return receipt(false, "result_not_ok", counts, "unknown_failure");
+  const completed = USEFUL_COUNT_KEYS.some((key) => counts[key] > 0);
+  return receipt(true, completed ? "completed" : "no_candidates", counts);
+}
+
+export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentLaneReceipt {
+  return classifyIssueEnrichmentSnapshot(snapshotIssueEnrichmentReceipt(input));
+}

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -60,7 +60,8 @@ export function classifyIssueEnrichmentSnapshot(snapshot: IssueEnrichmentReceipt
   if (!readable) return receipt(false, "result_not_ok", counts, "unknown_failure");
 
   const effectiveBlocker = snapshot.status.blockers.reasons.find((reason) =>
-    snapshot.dryRun !== "true" || !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason));
+    (snapshot.dryRun !== "true" && snapshot.status.state !== "dry_run_only") ||
+    !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason));
   if (effectiveBlocker) {
     const hasScanEvidence = ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.some((key) => counts[key] > 0);
     return hasScanEvidence

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -59,10 +59,8 @@ export function classifyIssueEnrichmentSnapshot(snapshot: IssueEnrichmentReceipt
   if (counts.failed > 0) return receipt(false, "result_not_ok", counts, "item_failure");
   if (!readable) return receipt(false, "result_not_ok", counts, "unknown_failure");
 
-  const effectiveBlocker = snapshot.status.state === "blocked"
-    ? snapshot.status.blockers.reasons.find((reason) =>
-      snapshot.dryRun !== "true" || !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason))
-    : undefined;
+  const effectiveBlocker = snapshot.status.blockers.reasons.find((reason) =>
+    snapshot.dryRun !== "true" || !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason));
   if (effectiveBlocker) {
     const hasScanEvidence = ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.some((key) => counts[key] > 0);
     return hasScanEvidence

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -26,6 +26,7 @@ describe("issue-enrichment receipt classifier", () => {
     ["disabled", { kind: "result", result: result({ summary: counts({ issuesSeen: 2 }), status: { state: "disabled", blockers: ["issue_enrichment_disabled"] } }) }, true, "disabled", undefined],
     ["ignored blocker with read failure", { kind: "result", result: result({ ok: false, dryRun: true, summary: counts({ readFailures: 1 }), status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) }, false, "result_not_ok", "read_failure"],
     ["mixed blockers", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "github_app_issues_permission_required"] } }) }, false, "blocked", "github_app_issues_permission_required"],
+    ["effective blocker contradicts ready state", { kind: "result", result: result({ status: { state: "ready", blockers: ["github_app_issues_permission_required"] } }) }, false, "blocked", "github_app_issues_permission_required"],
     ["blocker after scan", { kind: "result", result: result({ ok: false, summary: counts({ issuesSeen: 1 }), status: { state: "blocked", blockers: ["github_app_issues_permission_required"] } }) }, false, "result_not_ok", "unknown_failure"],
     ["completed", { kind: "result", result: result({ summary: counts({ wouldEnrich: 1 }) }) }, true, "completed", undefined],
     ["no candidates", { kind: "result", result: result() }, true, "no_candidates", undefined],

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyIssueEnrichmentReceipt,
+  classifyIssueEnrichmentSnapshot,
+  type IssueEnrichmentLaneReceipt
+} from "../src/issue-enrichment-receipt.js";
+import {
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP,
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS,
+  snapshotIssueEnrichmentReceipt
+} from "../src/issue-enrichment-receipt-snapshot.js";
+
+const counts = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
+);
+const result = (overrides: Record<string, unknown> = {}) => ({
+  ok: true, dryRun: false, status: { state: "ready", blockers: [] }, summary: counts(), ...overrides
+});
+const classify = (input: unknown): IssueEnrichmentLaneReceipt => classifyIssueEnrichmentReceipt(input as never);
+
+describe("issue-enrichment receipt classifier", () => {
+  it.each([
+    ["resolved undefined", { kind: "result", result: undefined }, false, "malformed_summary", "malformed_summary"],
+    ["thrown undefined", { kind: "thrown", error: undefined }, false, "cycle_failed", "unknown_failure"],
+    ["lease before disabled", { kind: "result", result: result({ summary: counts({ workerSkipped: 1 }), status: { state: "disabled", blockers: ["issue_enrichment_disabled"] } }) }, true, "lease_skipped", "worker_lease_held"],
+    ["disabled", { kind: "result", result: result({ summary: counts({ issuesSeen: 2 }), status: { state: "disabled", blockers: ["issue_enrichment_disabled"] } }) }, true, "disabled", undefined],
+    ["ignored blocker with read failure", { kind: "result", result: result({ ok: false, dryRun: true, summary: counts({ readFailures: 1 }), status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) }, false, "result_not_ok", "read_failure"],
+    ["mixed blockers", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "github_app_issues_permission_required"] } }) }, false, "blocked", "github_app_issues_permission_required"],
+    ["blocker after scan", { kind: "result", result: result({ ok: false, summary: counts({ issuesSeen: 1 }), status: { state: "blocked", blockers: ["github_app_issues_permission_required"] } }) }, false, "result_not_ok", "unknown_failure"],
+    ["completed", { kind: "result", result: result({ summary: counts({ wouldEnrich: 1 }) }) }, true, "completed", undefined],
+    ["no candidates", { kind: "result", result: result() }, true, "no_candidates", undefined],
+    ["capped completion", { kind: "result", result: result({ summary: counts({ posted: Number.MAX_SAFE_INTEGER }) }) }, true, "completed", undefined]
+  ])("classifies %s", (_name, input, ok, code, reason) => {
+    const receipt = classify(input);
+    expect(receipt).toMatchObject({ ok, stage: "issue_enrichment", code, ...(reason ? { reason } : {}) });
+    if (code === "disabled") expect(Object.values(receipt.counts).every((count) => count === 0)).toBe(true);
+    if (_name === "capped completion") expect(receipt.counts.posted).toBe(ISSUE_ENRICHMENT_RECEIPT_COUNT_CAP);
+  });
+
+  it.each([
+    ["missing count", (() => { const value = counts(); delete value.failed; return value; })()],
+    ["negative", counts({ failed: -1 })], ["fractional", counts({ failed: 1.5 })],
+    ["NaN", counts({ failed: Number.NaN })], ["string", counts({ failed: "1" })], ["null", null]
+  ])("fails closed for malformed summary: %s", (_name, summary) => {
+    expect(classify({ kind: "result", result: result({ summary }) })).toMatchObject({ ok: false, code: "malformed_summary", reason: "malformed_summary" });
+  });
+
+  it("fails closed when status, blockers, dry-run, or ok are unreadable", () => {
+    const hostile = result();
+    for (const key of ["status", "dryRun", "ok"]) Object.defineProperty(hostile, key, { get: () => { throw new Error("secret"); } });
+    expect(classify({ kind: "result", result: hostile })).toMatchObject({ ok: false, code: "result_not_ok", reason: "unknown_failure" });
+    const blockers = Proxy.revocable([], {}); blockers.revoke();
+    expect(classify({ kind: "result", result: result({ status: { state: "blocked", blockers: blockers.proxy } }) })).toMatchObject({ ok: false, code: "result_not_ok" });
+    expect(classify({ kind: "result", result: result({ summary: counts({ workerSkipped: 1 }), ok: "yes" }) })).toMatchObject({ ok: false, code: "result_not_ok" });
+  });
+
+  it("classifies a frozen snapshot deterministically and emits only the bounded schema", () => {
+    const snapshot = snapshotIssueEnrichmentReceipt({ kind: "result", result: result({ summary: counts({ eligible: 1 }) }) });
+    expect(classifyIssueEnrichmentSnapshot(snapshot)).toEqual(classifyIssueEnrichmentSnapshot(snapshot));
+    const receipt = classify({ kind: "thrown", error: new Error("customer body https://example.test ghp_secret") });
+    expect(Object.keys(receipt).sort()).toEqual(["code", "counts", "ok", "reason", "stage"]);
+    expect(JSON.stringify(receipt)).not.toMatch(/ghp_secret|example\.test|customer body/);
+  });
+});

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -29,6 +29,7 @@ describe("issue-enrichment receipt classifier", () => {
     ["effective blocker contradicts ready state", { kind: "result", result: result({ status: { state: "ready", blockers: ["github_app_issues_permission_required"] } }) }, false, "blocked", "github_app_issues_permission_required"],
     ["live-posting blocker contradicts ready state", { kind: "result", result: result({ status: { state: "ready", blockers: ["issue_enrichment_live_posting_disabled"] } }) }, false, "blocked", "issue_enrichment_live_posting_disabled"],
     ["dry-run-only cycle", { kind: "result", result: result({ status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ wouldEnrich: 1 }) }) }, true, "completed", undefined],
+    ["blocked state without blockers", { kind: "result", result: result({ status: { state: "blocked", blockers: [] } }) }, false, "result_not_ok", "unknown_failure"],
     ["blocker after scan", { kind: "result", result: result({ ok: false, summary: counts({ issuesSeen: 1 }), status: { state: "blocked", blockers: ["github_app_issues_permission_required"] } }) }, false, "result_not_ok", "unknown_failure"],
     ["completed", { kind: "result", result: result({ summary: counts({ wouldEnrich: 1 }) }) }, true, "completed", undefined],
     ["no candidates", { kind: "result", result: result() }, true, "no_candidates", undefined],

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -27,6 +27,8 @@ describe("issue-enrichment receipt classifier", () => {
     ["ignored blocker with read failure", { kind: "result", result: result({ ok: false, dryRun: true, summary: counts({ readFailures: 1 }), status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) }, false, "result_not_ok", "read_failure"],
     ["mixed blockers", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "github_app_issues_permission_required"] } }) }, false, "blocked", "github_app_issues_permission_required"],
     ["effective blocker contradicts ready state", { kind: "result", result: result({ status: { state: "ready", blockers: ["github_app_issues_permission_required"] } }) }, false, "blocked", "github_app_issues_permission_required"],
+    ["live-posting blocker contradicts ready state", { kind: "result", result: result({ status: { state: "ready", blockers: ["issue_enrichment_live_posting_disabled"] } }) }, false, "blocked", "issue_enrichment_live_posting_disabled"],
+    ["dry-run-only cycle", { kind: "result", result: result({ status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ wouldEnrich: 1 }) }) }, true, "completed", undefined],
     ["blocker after scan", { kind: "result", result: result({ ok: false, summary: counts({ issuesSeen: 1 }), status: { state: "blocked", blockers: ["github_app_issues_permission_required"] } }) }, false, "result_not_ok", "unknown_failure"],
     ["completed", { kind: "result", result: result({ summary: counts({ wouldEnrich: 1 }) }) }, true, "completed", undefined],
     ["no candidates", { kind: "result", result: result() }, true, "no_candidates", undefined],


### PR DESCRIPTION
Closes #1011

## Summary
- add the pure deterministic classifier over the accepted hostile-value receipt snapshot
- keep the public facade explicitly discriminated and snapshot producer values exactly once
- preserve the required thrown, malformed, lease, disabled, dry-run-only, failure, blocker, unreadable, completed, and no-candidate precedence
- preserve dry_run_only distinctly so its canonical live-posting-disabled blocker is accepted without accepting that blocker on a contradictory ready result
- reject blocker-free blocked snapshots rather than allowing a false success
- emit only bounded counts and allowlisted sanitized reasons

This PR is agent-authored. Closed PR #999 is historical mechanism evidence only; this candidate was built from current protected main and did not reopen, cherry-pick, or use #999 as a merge base.

## Validation
- EXPECTED_NEGATIVE: focused Vitest failed before source because the classifier module did not exist
- focused snapshot plus classifier Vitest: 28/28 passed on exact head ec0224a
- exact-lock build: passed
- git diff --check: passed
- source correction 1/3 fixed contradictory ready results with effective blockers
- source correction 2/3 fixed valid dry-run-only cycles while preserving fail-closed contradictory ready behavior
- source correction 3/3 fixed blocker-free blocked snapshots; further candidate correction is frozen pending classified fallback

## Safety and scope
- exactly three tightly coupled source/test files and 153 non-generated changed lines
- no daemon, persistence, state, watermark, runtime, release, customer, config, database, Keychain, or public-surface mutation
- installed NeonDiff beta.87/build 11091 remains untouched

## Proof boundary
This proves deterministic sanitized classifier behavior in source fixtures only. It does not prove daemon integration, serialized runtime logs, installed worker progress, release readiness, or customer behavior.