### PR TITLE
fix(enrichment): classify accepted cycle receipts

### DIFF
--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -17,7 +17,7 @@ export type IssueEnrichmentReceiptSnapshot = Readonly<{ kind: "thrown"; reason: 
 }>;
 export interface IssueEnrichmentStatusSnapshot {
   readonly readable: boolean;
-  readonly state: "disabled" | "blocked" | "other" | "unreadable";
+  readonly state: "disabled" | "blocked" | "ready" | "dry_run_only" | "unreadable";
   readonly blockers: IssueEnrichmentBlockersSnapshot;
 }
 export interface IssueEnrichmentBlockersSnapshot {
@@ -99,7 +99,7 @@ function snapshotResult(result: unknown): IssueEnrichmentReceiptSnapshot {
   const state = read(statusValue, "state"), blockers = read(statusValue, "blockers");
   const readable = Boolean(statusValue && state.ok && (state.value === "disabled" || state.value === "blocked" || state.value === "ready" || state.value === "dry_run_only"));
   const statusSnapshot: IssueEnrichmentStatusSnapshot = frozen({
-    readable, state: !state.ok || typeof state.value !== "string" ? "unreadable" : state.value === "disabled" ? "disabled" : state.value === "blocked" ? "blocked" : state.value === "ready" || state.value === "dry_run_only" ? "other" : "unreadable",
+    readable, state: readable ? state.value as IssueEnrichmentStatusSnapshot["state"] : "unreadable",
     blockers: snapshotBlockers(blockers.ok ? blockers.value : undefined)
   });
   const flag = (value: Read): IssueEnrichmentFlagSnapshot => value.ok && value.value === true ? "true" : value.ok && value.value === false ? "false" : "unreadable";

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -44,11 +44,11 @@ function effectiveBlocker(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { ki
 function matrixAccepts(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>, counts: IssueEnrichmentReceiptCounts): boolean {
   const { state, blockers } = snapshot.status;
   if (!snapshot.status.readable || !blockers.readable || !blockers.complete || snapshot.dryRun === "unreadable" || snapshot.ok === "unreadable") return false;
+  if (blockers.reasons.length !== new Set(blockers.reasons).size) return false;
   if (state === "ready" && blockers.reasons.length !== 0) return false;
   if (state === "dry_run_only" && (blockers.reasons.length !== 1 || blockers.reasons[0] !== "issue_enrichment_live_posting_disabled")) return false;
   if (state === "blocked" && !blockers.reasons.some((reason) => BLOCKING_REASONS.has(reason))) return false;
-  if (state === "disabled") return blockers.reasons.includes("issue_enrichment_disabled") &&
-    blockers.reasons.length === new Set(blockers.reasons).size && blockers.reasons.every((reason) => DISABLED_REASONS.has(reason)) &&
+  if (state === "disabled") return blockers.reasons.includes("issue_enrichment_disabled") && blockers.reasons.every((reason) => DISABLED_REASONS.has(reason)) &&
     snapshot.ok === "true" && zeroExcept(counts);
   if (counts.workerSkipped > 0) return snapshot.dryRun === "false" && snapshot.ok === "true" &&
     (state === "ready" || state === "dry_run_only") && zeroExcept(counts, "workerSkipped");
@@ -56,7 +56,7 @@ function matrixAccepts(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind:
   if (snapshot.dryRun === "false" && state === "ready" && counts.dryRunRecorded > 0) return false;
   if (snapshot.dryRun === "false" && state === "dry_run_only" && counts.posted > 0) return false;
   if (counts.posted > 0 && counts.dryRunRecorded > 0) return false;
-  if (any(counts, ITEM_KEYS) && counts.issuesSeen === 0) return false;
+  if (ITEM_KEYS.some((key) => counts[key] > counts.issuesSeen)) return false;
   if (counts.readFailures > 0 && counts.reposScanned === 0) return false;
   if (snapshot.ok === "true" && (counts.readFailures > 0 || counts.failed > 0)) return false;
   const blocker = effectiveBlocker(snapshot);

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -25,6 +25,9 @@ const BLOCKING_REASONS = new Set<IssueEnrichmentBlocker>([
   "issue_enrichment_allowlist_empty", "github_app_credentials_required_for_live_issue_comments", "github_app_issues_permission_required",
   "issue_enrichment_live_repo_thresholds_required", "issue_enrichment_model_runtime_required"
 ]);
+const DISABLED_REASONS = new Set<IssueEnrichmentBlocker>([
+  "issue_enrichment_disabled", "issue_enrichment_allowlist_empty", "issue_enrichment_live_posting_disabled"
+]);
 const emit = (ok: boolean, code: IssueEnrichmentLaneCode, counts: IssueEnrichmentReceiptCounts, reason?: IssueEnrichmentLaneReason): IssueEnrichmentLaneReceipt =>
   Object.freeze({ ok, stage: "issue_enrichment" as const, code, counts, ...(reason ? { reason } : {}) });
 const zeroExcept = (counts: IssueEnrichmentReceiptCounts, exception?: keyof IssueEnrichmentReceiptCounts): boolean =>
@@ -41,7 +44,9 @@ function matrixAccepts(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind:
   if (state === "ready" && blockers.reasons.length !== 0) return false;
   if (state === "dry_run_only" && (blockers.reasons.length !== 1 || blockers.reasons[0] !== "issue_enrichment_live_posting_disabled")) return false;
   if (state === "blocked" && !blockers.reasons.some((reason) => BLOCKING_REASONS.has(reason))) return false;
-  if (state === "disabled") return blockers.reasons.length === 1 && blockers.reasons[0] === "issue_enrichment_disabled" && snapshot.ok === "true" && zeroExcept(counts);
+  if (state === "disabled") return blockers.reasons.includes("issue_enrichment_disabled") &&
+    blockers.reasons.length === new Set(blockers.reasons).size && blockers.reasons.every((reason) => DISABLED_REASONS.has(reason)) &&
+    snapshot.ok === "true" && zeroExcept(counts);
   if (counts.workerSkipped > 0) return snapshot.dryRun === "false" && snapshot.ok === "true" &&
     (state === "ready" || state === "dry_run_only") && zeroExcept(counts, "workerSkipped");
   if (snapshot.dryRun === "true" && any(counts, DRY_RUN_FORBIDDEN)) return false;

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -1,4 +1,4 @@
-import { DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS, type IssueEnrichmentBlocker } from "./issue-enrichment.js";
+import type { IssueEnrichmentBlocker } from "./issue-enrichment.js";
 import {
   ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt,
   type IssueEnrichmentReceiptCounts, type IssueEnrichmentReceiptInput, type IssueEnrichmentReceiptSnapshot
@@ -28,6 +28,9 @@ const BLOCKING_REASONS = new Set<IssueEnrichmentBlocker>([
 const DISABLED_REASONS = new Set<IssueEnrichmentBlocker>([
   "issue_enrichment_disabled", "issue_enrichment_allowlist_empty", "issue_enrichment_live_posting_disabled"
 ]);
+const DRY_RUN_IGNORED_REASONS: readonly IssueEnrichmentBlocker[] = Object.freeze([
+  "github_app_credentials_required_for_live_issue_comments", "issue_enrichment_live_posting_disabled", "issue_enrichment_model_runtime_required"
+]);
 const emit = (ok: boolean, code: IssueEnrichmentLaneCode, counts: IssueEnrichmentReceiptCounts, reason?: IssueEnrichmentLaneReason): IssueEnrichmentLaneReceipt =>
   Object.freeze({ ok, stage: "issue_enrichment" as const, code, counts, ...(reason ? { reason } : {}) });
 const zeroExcept = (counts: IssueEnrichmentReceiptCounts, exception?: keyof IssueEnrichmentReceiptCounts): boolean =>
@@ -36,7 +39,7 @@ const any = (counts: IssueEnrichmentReceiptCounts, keys: readonly (keyof IssueEn
 
 function effectiveBlocker(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>): IssueEnrichmentBlocker | undefined {
   const mayIgnore = snapshot.status.state === "dry_run_only" || (snapshot.dryRun === "true" && snapshot.status.state === "blocked");
-  return snapshot.status.blockers.reasons.find((reason) => !mayIgnore || !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason));
+  return snapshot.status.blockers.reasons.find((reason) => !mayIgnore || !DRY_RUN_IGNORED_REASONS.includes(reason));
 }
 function matrixAccepts(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>, counts: IssueEnrichmentReceiptCounts): boolean {
   const { state, blockers } = snapshot.status;

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -1,0 +1,76 @@
+import { DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS, type IssueEnrichmentBlocker } from "./issue-enrichment.js";
+import {
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt,
+  type IssueEnrichmentReceiptCounts, type IssueEnrichmentReceiptInput, type IssueEnrichmentReceiptSnapshot
+} from "./issue-enrichment-receipt-snapshot.js";
+
+export type IssueEnrichmentLaneCode = "completed" | "no_candidates" | "lease_skipped" | "disabled" | "blocked" | "result_not_ok" | "cycle_failed" | "malformed_summary";
+export type IssueEnrichmentLaneReason = IssueEnrichmentBlocker | "worker_lease_held" | "read_failure" | "item_failure" | "unknown_failure" | "malformed_summary";
+export interface IssueEnrichmentLaneReceipt {
+  readonly ok: boolean; readonly stage: "issue_enrichment"; readonly code: IssueEnrichmentLaneCode;
+  readonly counts: IssueEnrichmentReceiptCounts; readonly reason?: IssueEnrichmentLaneReason;
+}
+
+const ZERO_COUNTS = Object.freeze(Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, 0]))) as IssueEnrichmentReceiptCounts;
+const USEFUL_KEYS: readonly (keyof IssueEnrichmentReceiptCounts)[] = Object.freeze([
+  "eligible", "wouldEnrich", "wouldComment", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed"
+]);
+const ITEM_KEYS: readonly (keyof IssueEnrichmentReceiptCounts)[] = Object.freeze([
+  "eligible", "skipped", "wouldEnrich", "wouldComment", "deferred", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"
+]);
+const DRY_RUN_FORBIDDEN: readonly (keyof IssueEnrichmentReceiptCounts)[] = Object.freeze([
+  "workerSkipped", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded"
+]);
+const BLOCKING_REASONS = new Set<IssueEnrichmentBlocker>([
+  "issue_enrichment_allowlist_empty", "github_app_credentials_required_for_live_issue_comments", "github_app_issues_permission_required",
+  "issue_enrichment_live_repo_thresholds_required", "issue_enrichment_model_runtime_required"
+]);
+const emit = (ok: boolean, code: IssueEnrichmentLaneCode, counts: IssueEnrichmentReceiptCounts, reason?: IssueEnrichmentLaneReason): IssueEnrichmentLaneReceipt =>
+  Object.freeze({ ok, stage: "issue_enrichment" as const, code, counts, ...(reason ? { reason } : {}) });
+const zeroExcept = (counts: IssueEnrichmentReceiptCounts, exception?: keyof IssueEnrichmentReceiptCounts): boolean =>
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.every((key) => key === exception ? counts[key] === 1 : counts[key] === 0);
+const any = (counts: IssueEnrichmentReceiptCounts, keys: readonly (keyof IssueEnrichmentReceiptCounts)[]): boolean => keys.some((key) => counts[key] > 0);
+
+function effectiveBlocker(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>): IssueEnrichmentBlocker | undefined {
+  const mayIgnore = snapshot.status.state === "dry_run_only" || (snapshot.dryRun === "true" && snapshot.status.state === "blocked");
+  return snapshot.status.blockers.reasons.find((reason) => !mayIgnore || !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(reason));
+}
+function matrixAccepts(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>, counts: IssueEnrichmentReceiptCounts): boolean {
+  const { state, blockers } = snapshot.status;
+  if (!snapshot.status.readable || !blockers.readable || !blockers.complete || snapshot.dryRun === "unreadable" || snapshot.ok === "unreadable") return false;
+  if (state === "ready" && blockers.reasons.length !== 0) return false;
+  if (state === "dry_run_only" && (blockers.reasons.length !== 1 || blockers.reasons[0] !== "issue_enrichment_live_posting_disabled")) return false;
+  if (state === "blocked" && !blockers.reasons.some((reason) => BLOCKING_REASONS.has(reason))) return false;
+  if (state === "disabled") return blockers.reasons.length === 1 && blockers.reasons[0] === "issue_enrichment_disabled" && snapshot.ok === "true" && zeroExcept(counts);
+  if (counts.workerSkipped > 0) return snapshot.dryRun === "false" && snapshot.ok === "true" &&
+    (state === "ready" || state === "dry_run_only") && zeroExcept(counts, "workerSkipped");
+  if (snapshot.dryRun === "true" && any(counts, DRY_RUN_FORBIDDEN)) return false;
+  if (snapshot.dryRun === "false" && state === "ready" && counts.dryRunRecorded > 0) return false;
+  if (snapshot.dryRun === "false" && state === "dry_run_only" && counts.posted > 0) return false;
+  if (counts.posted > 0 && counts.dryRunRecorded > 0) return false;
+  if (any(counts, ITEM_KEYS) && counts.issuesSeen === 0) return false;
+  if (counts.readFailures > 0 && counts.reposScanned === 0) return false;
+  if (snapshot.ok === "true" && (counts.readFailures > 0 || counts.failed > 0)) return false;
+  const blocker = effectiveBlocker(snapshot);
+  return state !== "blocked" || blocker === undefined || (snapshot.ok === "false" && zeroExcept(counts));
+}
+
+export function classifyIssueEnrichmentSnapshot(snapshot: IssueEnrichmentReceiptSnapshot): IssueEnrichmentLaneReceipt {
+  if (snapshot.kind === "thrown") return emit(false, "cycle_failed", ZERO_COUNTS, snapshot.reason);
+  if (!snapshot.summary.valid) return emit(false, "malformed_summary", ZERO_COUNTS, "malformed_summary");
+  const counts = snapshot.summary.counts;
+  if (!matrixAccepts(snapshot, counts)) return emit(false, "result_not_ok", counts, "unknown_failure");
+  if (counts.workerSkipped === 1) return emit(true, "lease_skipped", counts, "worker_lease_held");
+  if (snapshot.status.state === "disabled") return emit(true, "disabled", ZERO_COUNTS);
+  if (counts.readFailures > 0) return emit(false, "result_not_ok", counts, "read_failure");
+  if (counts.failed > 0) return emit(false, "result_not_ok", counts, "item_failure");
+  const blocker = effectiveBlocker(snapshot);
+  if (blocker) return emit(false, "blocked", counts, blocker);
+  if (snapshot.ok !== "true") return emit(false, "result_not_ok", counts, "unknown_failure");
+  return emit(true, any(counts, USEFUL_KEYS) ? "completed" : "no_candidates", counts);
+}
+
+export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentLaneReceipt {
+  const snapshot = snapshotIssueEnrichmentReceipt(input);
+  return classifyIssueEnrichmentSnapshot(snapshot);
+}

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -75,6 +75,12 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     expect(capture(left)).toEqual(capture(right)); expect(JSON.stringify(capture(left))).toBe(JSON.stringify(capture(right)));
   });
 
+  it("preserves each accepted status state exactly", () => {
+    for (const state of ["disabled", "blocked", "ready", "dry_run_only"] as const) {
+      expect(snap({ kind: "result", result: plainResult({ status: { state, blockers: [] } }) }).status.state).toBe(state);
+    }
+  });
+
   it("extracts only a bounded leading blocker token from thrown errors", () => {
     const token = "issue_enrichment_model_runtime_required";
     expect(snap({ kind: "thrown", error: new Error(`${token}:${"x".repeat(10_000)}`) })).toMatchObject({ reason: token });

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { classifyIssueEnrichmentReceipt, classifyIssueEnrichmentSnapshot } from "../src/issue-enrichment-receipt.js";
+import { ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt } from "../src/issue-enrichment-receipt-snapshot.js";
+
+const counts = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
+);
+const result = (overrides: Record<string, unknown> = {}) => ({
+  ok: true, dryRun: false, status: { state: "ready", blockers: [] }, summary: counts(), ...overrides
+});
+const classify = (value: unknown) => classifyIssueEnrichmentReceipt(value as never);
+const notOk = { ok: false, code: "result_not_ok", reason: "unknown_failure" };
+
+describe("issue-enrichment receipt classifier", () => {
+  it.each([
+    ["resolved undefined", { kind: "result", result: undefined }, { ok: false, code: "malformed_summary", reason: "malformed_summary" }],
+    ["thrown undefined", { kind: "thrown", error: undefined }, { ok: false, code: "cycle_failed", reason: "unknown_failure" }],
+    ["canonical lease", { kind: "result", result: result({ summary: counts({ workerSkipped: 1 }) }) }, { ok: true, code: "lease_skipped", reason: "worker_lease_held" }],
+    ["dry-run-only lease", { kind: "result", result: result({ status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ workerSkipped: 1 }) }) }, { ok: true, code: "lease_skipped", reason: "worker_lease_held" }],
+    ["canonical disabled", { kind: "result", result: result({ status: { state: "disabled", blockers: ["issue_enrichment_disabled"] } }) }, { ok: true, code: "disabled" }],
+    ["effective blocker", { kind: "result", result: result({ ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] } }) }, { ok: false, code: "blocked", reason: "github_app_issues_permission_required" }],
+    ["ignored dry-run blocker", { kind: "result", result: result({ dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) }, { ok: true, code: "no_candidates" }],
+    ["dry-run-only work", { kind: "result", result: result({ status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ issuesSeen: 1, wouldEnrich: 1 }) }) }, { ok: true, code: "completed" }],
+    ["no candidates", { kind: "result", result: result() }, { ok: true, code: "no_candidates" }]
+  ])("classifies %s", (_name, input, expected) => expect(classify(input)).toMatchObject(expected));
+
+  it.each(["workerSkipped", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded"])(
+    "rejects dry-run %s", (key) => expect(classify({ kind: "result", result: result({ dryRun: true, summary: counts({ [key]: 1 }) }) })).toMatchObject(notOk)
+  );
+
+  it.each(["eligible", "skipped", "wouldEnrich", "wouldComment", "deferred", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed", "failed"])(
+    "requires issuesSeen for %s", (key) => expect(classify({ kind: "result", result: result({ ok: false, summary: counts({ [key]: 1 }) }) })).toMatchObject(notOk)
+  );
+
+  it.each([
+    ["lease count", { summary: counts({ workerSkipped: 2 }) }],
+    ["lease mixed", { summary: counts({ workerSkipped: 1, reposScanned: 1 }) }],
+    ["blocked lease", { ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] }, summary: counts({ workerSkipped: 1 }) }],
+    ["disabled marker", { status: { state: "disabled", blockers: [] } }],
+    ["disabled work", { status: { state: "disabled", blockers: ["issue_enrichment_disabled"] }, summary: counts({ issuesSeen: 1 }) }],
+    ["live ready dry-run record", { summary: counts({ issuesSeen: 1, dryRunRecorded: 1 }) }],
+    ["live dry-run-only post", { status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ issuesSeen: 1, posted: 1 }) }],
+    ["mixed post modes", { summary: counts({ issuesSeen: 1, posted: 1, dryRunRecorded: 1 }) }],
+    ["post without issue", { summary: counts({ posted: 1 }) }],
+    ["read failure without repo", { ok: false, summary: counts({ readFailures: 1 }) }],
+    ["successful read failure", { summary: counts({ reposScanned: 1, readFailures: 1 }) }],
+    ["successful item failure", { summary: counts({ issuesSeen: 1, failed: 1 }) }],
+    ["blocked after work", { ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] }, summary: counts({ issuesSeen: 1 }) }]
+  ])("rejects contradictory %s evidence", (_name, overrides) => {
+    expect(classify({ kind: "result", result: result(overrides) })).toMatchObject(notOk);
+  });
+
+  it.each([
+    [{ ok: false, summary: counts({ reposScanned: 1, readFailures: 1 }) }, "read_failure"],
+    [{ ok: false, summary: counts({ issuesSeen: 1, failed: 1 }) }, "item_failure"]
+  ])("preserves a valid partial failure", (overrides, reason) => {
+    expect(classify({ kind: "result", result: result(overrides) })).toMatchObject({ ok: false, code: "result_not_ok", reason });
+  });
+
+  it("snapshots once and emits only the bounded stable schema", () => {
+    let reads = 0; const source = result();
+    for (const key of ["summary", "status", "dryRun", "ok"] as const) {
+      const value = source[key]; Object.defineProperty(source, key, { get: () => { reads += 1; return value; } });
+    }
+    const receipt = classify({ kind: "result", result: source });
+    expect(reads).toBe(4); expect(Object.keys(receipt).sort()).toEqual(["code", "counts", "ok", "stage"]);
+    const snapshot = snapshotIssueEnrichmentReceipt({ kind: "result", result: result({ summary: counts({ issuesSeen: 1, eligible: 1 }) }) });
+    expect(classifyIssueEnrichmentSnapshot(snapshot)).toEqual(classifyIssueEnrichmentSnapshot(snapshot));
+    expect(JSON.stringify(classify({ kind: "thrown", error: new Error("customer https://example.test ghp_secret") }))).not.toMatch(/customer|example|ghp_/);
+    const hostile = Proxy.revocable({}, {}); hostile.revoke(); expect(classify({ kind: "result", result: hostile.proxy })).toMatchObject({ ok: false, code: "malformed_summary" });
+  });
+});

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { classifyIssueEnrichmentReceipt, classifyIssueEnrichmentSnapshot } from "../src/issue-enrichment-receipt.js";
 import { ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt } from "../src/issue-enrichment-receipt-snapshot.js";
-import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG } from "../src/issue-enrichment.js";
+import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG, DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS } from "../src/issue-enrichment.js";
 
 const counts = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
   ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
@@ -75,5 +75,12 @@ describe("issue-enrichment receipt classifier", () => {
     expect(classifyIssueEnrichmentSnapshot(snapshot)).toEqual(classifyIssueEnrichmentSnapshot(snapshot));
     expect(JSON.stringify(classify({ kind: "thrown", error: new Error("customer https://example.test ghp_secret") }))).not.toMatch(/customer|example|ghp_/);
     const hostile = Proxy.revocable({}, {}); hostile.revoke(); expect(classify({ kind: "result", result: hostile.proxy })).toMatchObject({ ok: false, code: "malformed_summary" });
+  });
+
+  it("classifies one accepted snapshot independently of mutable producer controls", () => {
+    const snapshot = snapshotIssueEnrichmentReceipt({ kind: "result", result: result({ dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) });
+    const before = classifyIssueEnrichmentSnapshot(snapshot), removed = DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.delete("issue_enrichment_model_runtime_required");
+    try { expect(classifyIssueEnrichmentSnapshot(snapshot)).toEqual(before); }
+    finally { if (removed) DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.add("issue_enrichment_model_runtime_required"); }
   });
 });

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { classifyIssueEnrichmentReceipt, classifyIssueEnrichmentSnapshot } from "../src/issue-enrichment-receipt.js";
 import { ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt } from "../src/issue-enrichment-receipt-snapshot.js";
+import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG } from "../src/issue-enrichment.js";
 
 const counts = (overrides: Record<string, unknown> = {}) => Object.fromEntries(
   ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0])
@@ -24,6 +25,11 @@ describe("issue-enrichment receipt classifier", () => {
     ["no candidates", { kind: "result", result: result() }, { ok: true, code: "no_candidates" }]
   ])("classifies %s", (_name, input, expected) => expect(classify(input)).toMatchObject(expected));
 
+  it("accepts the genuine default disabled producer status", () => {
+    const status = buildIssueEnrichmentStatus({ config: { issueEnrichment: DEFAULT_ISSUE_ENRICHMENT_CONFIG }, canPostAsApp: false });
+    expect(classify({ kind: "result", result: result({ status }) })).toMatchObject({ ok: true, code: "disabled" });
+  });
+
   it.each(["workerSkipped", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded"])(
     "rejects dry-run %s", (key) => expect(classify({ kind: "result", result: result({ dryRun: true, summary: counts({ [key]: 1 }) }) })).toMatchObject(notOk)
   );
@@ -37,6 +43,7 @@ describe("issue-enrichment receipt classifier", () => {
     ["lease mixed", { summary: counts({ workerSkipped: 1, reposScanned: 1 }) }],
     ["blocked lease", { ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] }, summary: counts({ workerSkipped: 1 }) }],
     ["disabled marker", { status: { state: "disabled", blockers: [] } }],
+    ["disabled duplicate", { status: { state: "disabled", blockers: ["issue_enrichment_disabled", "issue_enrichment_disabled"] } }],
     ["disabled work", { status: { state: "disabled", blockers: ["issue_enrichment_disabled"] }, summary: counts({ issuesSeen: 1 }) }],
     ["live ready dry-run record", { summary: counts({ issuesSeen: 1, dryRunRecorded: 1 }) }],
     ["live dry-run-only post", { status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ issuesSeen: 1, posted: 1 }) }],

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -52,6 +52,8 @@ describe("issue-enrichment receipt classifier", () => {
     ["read failure without repo", { ok: false, summary: counts({ readFailures: 1 }) }],
     ["successful read failure", { summary: counts({ reposScanned: 1, readFailures: 1 }) }],
     ["successful item failure", { summary: counts({ issuesSeen: 1, failed: 1 }) }],
+    ["item count above issues seen", { summary: counts({ issuesSeen: 1, posted: 2 }) }],
+    ["duplicate blocked reasons", { dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "issue_enrichment_model_runtime_required"] } }],
     ["blocked after work", { ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] }, summary: counts({ issuesSeen: 1 }) }]
   ])("rejects contradictory %s evidence", (_name, overrides) => {
     expect(classify({ kind: "result", result: result(overrides) })).toMatchObject(notOk);


### PR DESCRIPTION
## Summary

- preserve exact accepted issue-enrichment states in the hostile-value snapshot
- classify only the single frozen snapshot through one execution-mode/count consistency matrix
- fail closed for malformed, contradictory, non-OK, and hostile receipt evidence while preserving bounded read/item failure reasons

Closes #1011

## Replacement identity

This is the classified deterministic-receipt-classifier-v3 successor rebuilt from protected main `37d6d34fb5692934e8218ba29e716a7c4c62f77e`. PR #1143 and PR #1144 are terminal closed-unmerged mechanism evidence only and were not reopened, cherry-picked, or used as merge bases.

## Focused proof

- expected-negative: missing classifier import plus collapsed-state fixture failed before implementation
- exact-node focused Vitest: 48/48 PASS
- exact-lock build/typecheck: PASS
- `git diff --check`: PASS
- scope: four owned files, 156 additions / 2 deletions, below the 200-line gate

## Proof boundary

Claim class: `pr_ready` candidate only. This proves deterministic sanitized classification for the exact source fixtures. It does not prove daemon integration, producer capability stability, runtime progress, artifact/release readiness, or customer readiness.

## Review gate

Require exact-head authoritative CI, zero unresolved conversations, release-risk approval, and blind acceptance/adversarial PASS at 95 or above before merge.