### PR TITLE
fix: classify issue enrichment receipts deterministically

### DIFF
--- a/src/issue-enrichment-receipt-snapshot.ts
+++ b/src/issue-enrichment-receipt-snapshot.ts
@@ -17,7 +17,7 @@ export type IssueEnrichmentReceiptSnapshot = Readonly<{ kind: "thrown"; reason: 
 }>;
 export interface IssueEnrichmentStatusSnapshot {
   readonly readable: boolean;
-  readonly state: "disabled" | "blocked" | "other" | "unreadable";
+  readonly state: "disabled" | "blocked" | "ready" | "dry_run_only" | "unreadable";
   readonly blockers: IssueEnrichmentBlockersSnapshot;
 }
 export interface IssueEnrichmentBlockersSnapshot {
@@ -99,7 +99,7 @@ function snapshotResult(result: unknown): IssueEnrichmentReceiptSnapshot {
   const state = read(statusValue, "state"), blockers = read(statusValue, "blockers");
   const readable = Boolean(statusValue && state.ok && (state.value === "disabled" || state.value === "blocked" || state.value === "ready" || state.value === "dry_run_only"));
   const statusSnapshot: IssueEnrichmentStatusSnapshot = frozen({
-    readable, state: !state.ok || typeof state.value !== "string" ? "unreadable" : state.value === "disabled" ? "disabled" : state.value === "blocked" ? "blocked" : state.value === "ready" || state.value === "dry_run_only" ? "other" : "unreadable",
+    readable, state: readable ? state.value as IssueEnrichmentStatusSnapshot["state"] : "unreadable",
     blockers: snapshotBlockers(blockers.ok ? blockers.value : undefined)
   });
   const flag = (value: Read): IssueEnrichmentFlagSnapshot => value.ok && value.value === true ? "true" : value.ok && value.value === false ? "false" : "unreadable";

--- a/src/issue-enrichment-receipt.ts
+++ b/src/issue-enrichment-receipt.ts
@@ -1,0 +1,79 @@
+import type { IssueEnrichmentBlocker } from "./issue-enrichment.js";
+import {
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt,
+  type IssueEnrichmentReceiptCounts, type IssueEnrichmentReceiptInput, type IssueEnrichmentReceiptSnapshot
+} from "./issue-enrichment-receipt-snapshot.js";
+
+export type IssueEnrichmentLaneCode = "completed" | "no_candidates" | "lease_skipped" | "disabled" | "blocked" | "result_not_ok" | "cycle_failed" | "malformed_summary";
+export type IssueEnrichmentLaneReason = IssueEnrichmentBlocker | "worker_lease_held" | "read_failure" | "item_failure" | "unknown_failure" | "malformed_summary";
+export interface IssueEnrichmentLaneReceipt {
+  readonly ok: boolean; readonly stage: "issue_enrichment"; readonly code: IssueEnrichmentLaneCode;
+  readonly counts: IssueEnrichmentReceiptCounts; readonly reason?: IssueEnrichmentLaneReason;
+}
+
+type CountKey = keyof IssueEnrichmentReceiptCounts;
+const ZERO_COUNTS = Object.freeze(Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, 0]))) as IssueEnrichmentReceiptCounts;
+const USEFUL_KEYS: readonly CountKey[] = Object.freeze(["eligible", "wouldEnrich", "wouldComment", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded", "alreadyProcessed"]);
+const DRY_RUN_FORBIDDEN: readonly CountKey[] = Object.freeze(["workerSkipped", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded"]);
+const RELATIONS: readonly (readonly [CountKey, CountKey])[] = Object.freeze([
+  ["readFailures", "reposScanned"], ["truncatedRepos", "reposScanned"], ["wouldEnrich", "eligible"],
+  ["wouldComment", "wouldEnrich"], ["deferred", "eligible"], ["posted", "wouldComment"],
+  ["dryRunRecorded", "wouldEnrich"], ["skippedRecorded", "skipped"], ["deferredRecorded", "deferred"],
+  ["alreadyProcessed", "issuesSeen"], ["failed", "issuesSeen"]
+]);
+const BLOCKING_REASONS = new Set<IssueEnrichmentBlocker>([
+  "issue_enrichment_allowlist_empty", "github_app_credentials_required_for_live_issue_comments", "github_app_issues_permission_required",
+  "issue_enrichment_live_repo_thresholds_required", "issue_enrichment_model_runtime_required"
+]);
+const DISABLED_REASONS = new Set<IssueEnrichmentBlocker>(["issue_enrichment_disabled", "issue_enrichment_allowlist_empty", "issue_enrichment_live_posting_disabled"]);
+const DRY_RUN_IGNORED_REASONS: readonly IssueEnrichmentBlocker[] = Object.freeze([
+  "github_app_credentials_required_for_live_issue_comments", "issue_enrichment_live_posting_disabled", "issue_enrichment_model_runtime_required"
+]);
+const emit = (ok: boolean, code: IssueEnrichmentLaneCode, counts: IssueEnrichmentReceiptCounts, reason?: IssueEnrichmentLaneReason): IssueEnrichmentLaneReceipt =>
+  Object.freeze({ ok, stage: "issue_enrichment" as const, code, counts, ...(reason ? { reason } : {}) });
+const zeroExcept = (counts: IssueEnrichmentReceiptCounts, exception?: CountKey): boolean =>
+  ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.every((key) => key === exception ? counts[key] === 1 : counts[key] === 0);
+const any = (counts: IssueEnrichmentReceiptCounts, keys: readonly CountKey[]): boolean => keys.some((key) => counts[key] > 0);
+
+function effectiveBlocker(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>): IssueEnrichmentBlocker | undefined {
+  const mayIgnore = snapshot.status.state === "dry_run_only" || (snapshot.dryRun === "true" && snapshot.status.state === "blocked");
+  return snapshot.status.blockers.reasons.find((reason) => !mayIgnore || !DRY_RUN_IGNORED_REASONS.includes(reason));
+}
+
+function matrixAccepts(snapshot: Extract<IssueEnrichmentReceiptSnapshot, { kind: "result" }>, counts: IssueEnrichmentReceiptCounts): boolean {
+  const { state, blockers } = snapshot.status;
+  if (!snapshot.status.readable || !blockers.readable || !blockers.complete || snapshot.dryRun === "unreadable" || snapshot.ok === "unreadable") return false;
+  if (blockers.reasons.length !== new Set(blockers.reasons).size) return false;
+  if (state === "ready" && blockers.reasons.length !== 0) return false;
+  if (state === "dry_run_only" && (blockers.reasons.length !== 1 || blockers.reasons[0] !== "issue_enrichment_live_posting_disabled")) return false;
+  if (state === "blocked" && !blockers.reasons.some((reason) => BLOCKING_REASONS.has(reason))) return false;
+  if (state === "disabled") return blockers.reasons.includes("issue_enrichment_disabled") && blockers.reasons.every((reason) => DISABLED_REASONS.has(reason)) && snapshot.ok === "true" && zeroExcept(counts);
+  if (RELATIONS.some(([part, whole]) => counts[part] > counts[whole]) || counts.skipped + counts.eligible > counts.issuesSeen) return false;
+  if (snapshot.ok === "true" && (counts.readFailures > 0 || counts.failed > 0)) return false;
+  if (counts.workerSkipped > 0) return snapshot.dryRun === "false" && snapshot.ok === "true" && (state === "ready" || state === "dry_run_only") && zeroExcept(counts, "workerSkipped");
+  if (snapshot.dryRun === "true" && any(counts, DRY_RUN_FORBIDDEN)) return false;
+  if (snapshot.dryRun === "false" && state === "ready" && counts.dryRunRecorded > 0) return false;
+  if (snapshot.dryRun === "false" && state === "dry_run_only" && counts.posted > 0) return false;
+  if (counts.posted > 0 && counts.dryRunRecorded > 0) return false;
+  const blocker = effectiveBlocker(snapshot);
+  return state !== "blocked" || blocker === undefined || (snapshot.ok === "false" && zeroExcept(counts));
+}
+
+export function classifyIssueEnrichmentSnapshot(snapshot: IssueEnrichmentReceiptSnapshot): IssueEnrichmentLaneReceipt {
+  if (snapshot.kind === "thrown") return emit(false, "cycle_failed", ZERO_COUNTS, snapshot.reason);
+  if (!snapshot.summary.valid) return emit(false, "malformed_summary", ZERO_COUNTS, "malformed_summary");
+  const counts = snapshot.summary.counts;
+  if (!matrixAccepts(snapshot, counts)) return emit(false, "result_not_ok", counts, "unknown_failure");
+  if (counts.workerSkipped === 1) return emit(true, "lease_skipped", counts, "worker_lease_held");
+  if (snapshot.status.state === "disabled") return emit(true, "disabled", ZERO_COUNTS);
+  if (counts.readFailures > 0) return emit(false, "result_not_ok", counts, "read_failure");
+  if (counts.failed > 0) return emit(false, "result_not_ok", counts, "item_failure");
+  const blocker = effectiveBlocker(snapshot);
+  if (blocker) return emit(false, "blocked", counts, blocker);
+  if (snapshot.ok !== "true") return emit(false, "result_not_ok", counts, "unknown_failure");
+  return emit(true, any(counts, USEFUL_KEYS) ? "completed" : "no_candidates", counts);
+}
+
+export function classifyIssueEnrichmentReceipt(input: IssueEnrichmentReceiptInput): IssueEnrichmentLaneReceipt {
+  return classifyIssueEnrichmentSnapshot(snapshotIssueEnrichmentReceipt(input));
+}

--- a/tests/issue-enrichment-receipt-snapshot.test.ts
+++ b/tests/issue-enrichment-receipt-snapshot.test.ts
@@ -75,6 +75,12 @@ describe("issue-enrichment hostile receipt snapshot", () => {
     expect(capture(left)).toEqual(capture(right)); expect(JSON.stringify(capture(left))).toBe(JSON.stringify(capture(right)));
   });
 
+  it("preserves each accepted status state exactly", () => {
+    for (const state of ["disabled", "blocked", "ready", "dry_run_only"] as const) {
+      expect(snap({ kind: "result", result: plainResult({ status: { state, blockers: [] } }) }).status.state).toBe(state);
+    }
+  });
+
   it("extracts only a bounded leading blocker token from thrown errors", () => {
     const token = "issue_enrichment_model_runtime_required";
     expect(snap({ kind: "thrown", error: new Error(`${token}:${"x".repeat(10_000)}`) })).toMatchObject({ reason: token });

--- a/tests/issue-enrichment-receipt.test.ts
+++ b/tests/issue-enrichment-receipt.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { classifyIssueEnrichmentReceipt, classifyIssueEnrichmentSnapshot } from "../src/issue-enrichment-receipt.js";
+import { ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS, snapshotIssueEnrichmentReceipt } from "../src/issue-enrichment-receipt-snapshot.js";
+import { buildIssueEnrichmentStatus, DEFAULT_ISSUE_ENRICHMENT_CONFIG, DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS } from "../src/issue-enrichment.js";
+
+const counts = (overrides: Record<string, unknown> = {}) => Object.fromEntries(ISSUE_ENRICHMENT_RECEIPT_COUNT_KEYS.map((key) => [key, overrides[key] ?? 0]));
+const result = (overrides: Record<string, unknown> = {}) => ({ ok: true, dryRun: false, status: { state: "ready", blockers: [] }, summary: counts(), ...overrides });
+const classify = (value: unknown) => classifyIssueEnrichmentReceipt(value as never);
+const unknown = { ok: false, code: "result_not_ok", reason: "unknown_failure" };
+
+const relationCases = [
+  ["read failures", { reposScanned: 1, readFailures: 1 }, { reposScanned: 1, readFailures: 2 }, { ok: false }, "read_failure"],
+  ["truncated repos", { reposScanned: 1, truncatedRepos: 1 }, { reposScanned: 1, truncatedRepos: 2 }, {}, undefined],
+  ["skipped plus eligible", { issuesSeen: 2, skipped: 1, eligible: 1 }, { issuesSeen: 1, skipped: 1, eligible: 1 }, {}, undefined],
+  ["would enrich", { issuesSeen: 1, eligible: 1, wouldEnrich: 1 }, { issuesSeen: 1, eligible: 0, wouldEnrich: 1 }, {}, undefined],
+  ["would comment", { issuesSeen: 1, eligible: 1, wouldEnrich: 1, wouldComment: 1 }, { issuesSeen: 1, eligible: 1, wouldEnrich: 0, wouldComment: 1 }, {}, undefined],
+  ["deferred", { issuesSeen: 1, eligible: 1, deferred: 1 }, { issuesSeen: 1, eligible: 0, deferred: 1 }, {}, undefined],
+  ["posted", { issuesSeen: 1, eligible: 1, wouldEnrich: 1, wouldComment: 1, posted: 1 }, { issuesSeen: 1, eligible: 1, wouldEnrich: 1, wouldComment: 0, posted: 1 }, {}, undefined],
+  ["dry-run recorded", { issuesSeen: 1, eligible: 1, wouldEnrich: 1, dryRunRecorded: 1 }, { issuesSeen: 1, eligible: 1, wouldEnrich: 0, dryRunRecorded: 1 }, { status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] } }, undefined],
+  ["skipped recorded", { issuesSeen: 1, skipped: 1, skippedRecorded: 1 }, { issuesSeen: 1, skipped: 0, skippedRecorded: 1 }, {}, undefined],
+  ["deferred recorded", { issuesSeen: 1, eligible: 1, deferred: 1, deferredRecorded: 1 }, { issuesSeen: 1, eligible: 1, deferred: 0, deferredRecorded: 1 }, {}, undefined],
+  ["already processed", { issuesSeen: 1, alreadyProcessed: 1 }, { issuesSeen: 0, alreadyProcessed: 1 }, {}, undefined],
+  ["item failures", { issuesSeen: 1, failed: 1 }, { issuesSeen: 0, failed: 1 }, { ok: false }, "item_failure"]
+] as const;
+
+describe("issue-enrichment receipt classifier", () => {
+  it.each([
+    ["resolved undefined", { kind: "result", result: undefined }, { ok: false, code: "malformed_summary", reason: "malformed_summary" }],
+    ["thrown undefined", { kind: "thrown", error: undefined }, { ok: false, code: "cycle_failed", reason: "unknown_failure" }],
+    ["lease", { kind: "result", result: result({ summary: counts({ workerSkipped: 1 }) }) }, { ok: true, code: "lease_skipped" }],
+    ["disabled", { kind: "result", result: result({ status: buildIssueEnrichmentStatus({ config: { issueEnrichment: DEFAULT_ISSUE_ENRICHMENT_CONFIG }, canPostAsApp: false }) }) }, { ok: true, code: "disabled" }],
+    ["blocked", { kind: "result", result: result({ ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] } }) }, { ok: false, code: "blocked" }],
+    ["ignored dry-run blocker", { kind: "result", result: result({ dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) }, { ok: true, code: "no_candidates" }],
+    ["read failure before ignored blocker", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] }, summary: counts({ reposScanned: 1, readFailures: 1 }) }) }, { ok: false, reason: "read_failure" }],
+    ["item failure before ignored blocker", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] }, summary: counts({ issuesSeen: 1, failed: 1 }) }) }, { ok: false, reason: "item_failure" }],
+    ["mixed effective blocker", { kind: "result", result: result({ ok: false, dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "github_app_issues_permission_required"] } }) }, { ok: false, code: "blocked", reason: "github_app_issues_permission_required" }],
+    ["completed", { kind: "result", result: result({ summary: counts({ issuesSeen: 1, eligible: 1 }) }) }, { ok: true, code: "completed" }],
+    ["no candidates", { kind: "result", result: result() }, { ok: true, code: "no_candidates" }]
+  ])("classifies %s", (_name, input, expected) => expect(classify(input)).toMatchObject(expected));
+
+  it.each(relationCases)("accepts exact %s relation boundaries", (_name, valid, _invalid, controls, reason) => {
+    const receipt = classify({ kind: "result", result: result({ ...controls, summary: counts(valid) }) });
+    expect(receipt).not.toMatchObject(unknown); if (reason) expect(receipt.reason).toBe(reason);
+  });
+  it.each(relationCases)("rejects %s contradictions", (_name, _valid, invalid, controls) => {
+    expect(classify({ kind: "result", result: result({ ...controls, summary: counts(invalid) }) })).toMatchObject(unknown);
+  });
+
+  it.each(["workerSkipped", "posted", "dryRunRecorded", "skippedRecorded", "deferredRecorded"])("rejects dry-run %s", (key) => {
+    expect(classify({ kind: "result", result: result({ dryRun: true, summary: counts({ issuesSeen: 1, eligible: 1, wouldEnrich: 1, [key]: 1 }) }) })).toMatchObject(unknown);
+  });
+  it.each([
+    ["duplicate blockers", { dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required", "issue_enrichment_model_runtime_required"] } }],
+    ["lease mixed", { summary: counts({ workerSkipped: 1, reposScanned: 1 }) }],
+    ["disabled work", { status: { state: "disabled", blockers: ["issue_enrichment_disabled"] }, summary: counts({ issuesSeen: 1 }) }],
+    ["live ready dry-run record", { summary: counts({ issuesSeen: 1, eligible: 1, wouldEnrich: 1, dryRunRecorded: 1 }) }],
+    ["live dry-run-only post", { status: { state: "dry_run_only", blockers: ["issue_enrichment_live_posting_disabled"] }, summary: counts({ issuesSeen: 1, eligible: 1, wouldEnrich: 1, wouldComment: 1, posted: 1 }) }],
+    ["blocked after work", { ok: false, status: { state: "blocked", blockers: ["github_app_issues_permission_required"] }, summary: counts({ reposScanned: 1 }) }]
+  ])("rejects contradictory %s", (_name, overrides) => expect(classify({ kind: "result", result: result(overrides) })).toMatchObject(unknown));
+
+  it("snapshots once, stays deterministic, and emits only bounded fields", () => {
+    let reads = 0; const source = result(); for (const key of ["summary", "status", "dryRun", "ok"] as const) { const value = source[key]; Object.defineProperty(source, key, { get: () => { reads += 1; return value; } }); }
+    const receipt = classify({ kind: "result", result: source }); expect(reads).toBe(4); expect(Object.keys(receipt).sort()).toEqual(["code", "counts", "ok", "stage"]);
+    const reordered = { status: source.status, ok: source.ok, summary: source.summary, dryRun: source.dryRun };
+    expect(classify({ kind: "result", result: reordered })).toEqual(receipt);
+    const snapshot = snapshotIssueEnrichmentReceipt({ kind: "result", result: result({ dryRun: true, status: { state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] } }) });
+    const before = classifyIssueEnrichmentSnapshot(snapshot), removed = DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.delete("issue_enrichment_model_runtime_required");
+    try { expect(classifyIssueEnrichmentSnapshot(snapshot)).toEqual(before); } finally { if (removed) DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.add("issue_enrichment_model_runtime_required"); }
+    expect(JSON.stringify(classify({ kind: "thrown", error: new Error("customer https://example.test ghp_secret") }))).not.toMatch(/customer|example|ghp_/);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve the exact accepted issue-enrichment status state in the hostile-value snapshot
- add a pure classifier facade that snapshots once and classifies only the frozen accepted snapshot
- validate one producer-derived matrix for state shape, execution mode, repository-source counts, and item-source counts before terminal precedence
- keep the output bounded to sanitized counts, codes, and allowlisted reasons

Closes #1011

## Replacement identity

This is the classified `deterministic-receipt-classifier-v4` successor rebuilt from protected main `37d6d34fb5692934e8218ba29e716a7c4c62f77e`.

PR #1143, PR #1144, and PR #1145 are terminal closed-unmerged mechanism evidence. This branch did not reopen, cherry-pick, or use any of them as a merge base.

## Failing-first proof

Before source edits, the focused fixture failed because the public classifier module did not exist and the accepted snapshot collapsed `ready` to `other`. That result was recorded as `EXPECTED_NEGATIVE`.

## Validation

- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/issue-enrichment-receipt-snapshot.test.ts tests/issue-enrichment-receipt.test.ts` — 54/54 PASS
- `/opt/homebrew/bin/node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run build` — PASS
- `git diff --check` — PASS
- scope — four issue-owned files, 158 insertions and 2 deletions, 160 changed lines

## Safety and proof boundary

- no producer, daemon, persistence, database, watermark, runtime, installed app, release, customer, or public-surface mutation
- no raw result, error message, repository, item, body, URL, secret, or customer identifier is emitted
- local source proof does not establish remote CI, merge readiness, daemon serialization, runtime progress, release, artifact, or customer readiness

Agent-authored change. Exact-head CI, review-thread disposition, independent release-risk review, and blind acceptance/adversarial gates remain required before merge.
