### PR TITLE
fix: sanitize daemon issue enrichment receipts

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,6 +4,7 @@ import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { GitHubApi } from "./github.js";
 import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
+import { classifyIssueEnrichmentReceipt } from "./issue-enrichment-receipt.js";
 import { runScheduledCycle } from "./scheduler.js";
 import {
   isAuthenticProductionLicenseAdmission,
@@ -353,17 +354,16 @@ async function runIssueEnrichmentLane(input: {
       phase: "complete",
       cycle: input.input.cycle,
       dryRun: input.input.dryRun,
-      result: issueEnrichment
+      receipt: classifyIssueEnrichmentReceipt({ kind: "result", result: issueEnrichment })
     }));
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
     input.recordHeartbeat("daemon_cycle_progress", "issue_enrichment_failed", input.heartbeatRunId);
     input.stderr(formatDaemonLog({
       event: "daemon_issue_enrichment_failed",
       level: "error",
       cycle: input.input.cycle,
       dryRun: input.input.dryRun,
-      error: message
+      receipt: classifyIssueEnrichmentReceipt({ kind: "thrown", error })
     }));
   }
 }

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -520,14 +520,25 @@ describe("daemon cycle resilience", () => {
         event: "daemon_issue_enrichment",
         phase: "complete",
         cycle: 9,
-        result: expect.objectContaining({
-          summary: expect.objectContaining({
-            reposScanned: 1,
-            dryRunRecorded: 1
-          })
+        receipt: expect.objectContaining({
+          ok: true,
+          code: "completed",
+          counts: expect.objectContaining({ reposScanned: 1, dryRunRecorded: 1 })
         })
       })
     ]));
+  });
+
+  it("logs only the sanitized receipt for a resolved issue-lane failure", async () => {
+    const stdout: string[] = [], sentinel = "raw-result-ghp_fake_token-https://customer.example";
+    const failed = successfulIssueEnrichmentCycleResult() as IssueEnrichmentCycleResult & { rawSentinel: string };
+    Object.assign(failed, { ok: false, dryRun: true, rawSentinel: sentinel, status: { ...failed.status, state: "blocked", blockers: ["issue_enrichment_model_runtime_required"] }, summary: { ...failed.summary, readFailures: 1, dryRunRecorded: 0 } });
+    const result = await runDaemonCycle({ cycle: 14, dryRun: true, pilotRepos: [], monitoredRepos: [], canaryPulls: [], commandsEnabled: false, reviewSchedulerEnabled: true, issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(), issueEnrichmentCycleImpl: async () => failed, recordHeartbeatImpl: () => undefined,
+      stdout: (line) => stdout.push(line), stderr: () => undefined });
+    expect(result.ok).toBe(true);
+    expect(stdout.map((line) => JSON.parse(line))).toEqual(expect.arrayContaining([expect.objectContaining({ event: "daemon_issue_enrichment", phase: "complete", receipt: expect.objectContaining({ ok: false, code: "result_not_ok", reason: "read_failure" }) })]));
+    expect(stdout.join("\n")).not.toContain(sentinel);
   });
 
   it("holds PR review work while preserving live issue enrichment", async () => {
@@ -730,10 +741,11 @@ describe("daemon cycle resilience", () => {
     expect(failure).toMatchObject({
       event: "daemon_issue_enrichment_failed",
       level: "error",
-      cycle: 10
+      cycle: 10,
+      receipt: { ok: false, stage: "issue_enrichment", code: "cycle_failed", reason: "unknown_failure" }
     });
-    expect(failure.error).toContain("issue enrichment failed");
-    expect(failure.error).not.toContain("ghp_fake_token");
+    expect(failure).not.toHaveProperty("error");
+    expect(stderr.join("\n")).not.toContain("ghp_fake_token");
   });
 });
 


### PR DESCRIPTION
## Summary

- classify resolved issue-enrichment cycle results before daemon logging
- classify thrown issue-enrichment failures without retaining the raw message
- log only the bounded sanitized receipt while preserving event phase, heartbeat codes, review-lane independence, and daemon liveness

Closes #995

## Identity

- exact base: `cfc2ae222bb5782ea97f3e8aba67fcbee1aa6eb1`
- exact head: `e883b1d40e9270880a448318709de7fc1f18f60e`
- accepted classifier source: PR #1146 / #1011
- candidate: `daemon-sanitized-receipt-v1`

## Failing-first proof

Before source edits, the focused daemon fixture passed 16/19 and failed the three new exact receipt assertions. The resolved path exposed the full cycle result under `result`; the thrown path exposed an `error` field and no bounded receipt. This was recorded as `EXPECTED_NEGATIVE`.

## Validation

- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/daemon-loop.test.ts` — 19/19 PASS
- `/opt/homebrew/bin/node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run build` — PASS
- `git diff --check` — PASS
- scope — two issue-owned files, 23 insertions and 11 deletions, 34 changed lines

## Safety and proof boundary

- no classifier redesign, producer, config, persistence, database, watermark, worker, runtime, installed app, release, customer, or public-surface mutation
- no raw issue-enrichment result, thrown message, repository, item, URL, secret, or customer identifier reaches the issue-lane log envelope
- local source proof does not establish authoritative remote CI, merge readiness, durable state/operator projection, installed runtime, release, artifact, or customer readiness

Agent-authored change. Exact-head CI, zero unresolved conversations, independent release-risk approval, and blind acceptance/adversarial PASS at 95 or above remain required before merge.
