### PR TITLE
chore(release): bind v1.0.5 lifecycle evidence

### DIFF
--- a/docs/evidence/v1.0.5/dashboard-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/dashboard-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,15 @@
+{
+  "evidenceKind": "dashboard",
+  "releaseVersion": "v1.0.5",
+  "candidateHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+  "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+  "harnessRunId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8",
+  "records": [
+    {
+      "setupBlockedBeforeActivation": true,
+      "providerBlockedBeforeActivation": true,
+      "activatedStatusVisible": true
+    }
+  ]
+}

--- a/docs/evidence/v1.0.5/desktop-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/desktop-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,14 @@
+{
+  "evidenceKind": "desktop",
+  "releaseVersion": "v1.0.5",
+  "candidateHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+  "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+  "harnessRunId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8",
+  "records": [
+    {
+      "brokerUnavailable": true,
+      "usefulWorkBlocked": true
+    }
+  ]
+}

--- a/docs/evidence/v1.0.5/install-upgrade-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/install-upgrade-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,15 @@
+{
+  "evidenceKind": "install-upgrade",
+  "releaseVersion": "v1.0.5",
+  "candidateHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+  "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+  "harnessRunId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8",
+  "records": [
+    {
+      "freshInstallPassed": true,
+      "upgradedFromVersion": "1.0.3",
+      "upgradePassed": true
+    }
+  ]
+}

--- a/docs/evidence/v1.0.5/mandatory-activation-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/mandatory-activation-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,319 @@
+{
+  "evidenceKind": "mandatory_activation_no_bypass",
+  "releaseVersion": "v1.0.5",
+  "observedAt": "2026-08-31T01:46:12.148Z",
+  "harness": {
+    "name": "neondiff-license-lifecycle-smoke",
+    "version": 1,
+    "sourceHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+    "runId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8"
+  },
+  "installedCandidate": {
+    "packageVersion": "1.0.5",
+    "binaryVersion": "1.0.5",
+    "sourceHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+    "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+    "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+    "installSource": "npm_pack_tarball"
+  },
+  "productionLifecycle": {
+    "apiBaseUrl": "https://neondiff-license.fly.dev",
+    "licenseFingerprint": "sha256:27409f1367eb5fb5ceef4c9c1c2a1f2994ce315e5962061d386b0fd3f40e7701",
+    "steps": [
+      {
+        "id": "issue",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "issued"
+        },
+        "responseSha256": "db39729fbf39606818951fdd7f204be24a9e978e5d8eae13210b81d1ada858b8"
+      },
+      {
+        "id": "activate",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "active",
+          "source": "api"
+        },
+        "responseSha256": "e5b310ba6a63039dcfddf7b3790efcec023fd50c478b6a80efb7cb2821f61ff3"
+      },
+      {
+        "id": "validate_active",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "active",
+          "source": "api"
+        },
+        "responseSha256": "e5b310ba6a63039dcfddf7b3790efcec023fd50c478b6a80efb7cb2821f61ff3"
+      },
+      {
+        "id": "deactivate",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "deactivated"
+        },
+        "responseSha256": "61e8e39cc6ca2e8ad1e9d9c55fb64e7cbd2aec7ee2aa7195202679de79052f11"
+      },
+      {
+        "id": "validate_denied",
+        "outcome": "denied",
+        "statusCode": 409,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "scope_mismatch"
+        },
+        "responseSha256": "1f5bbf0030b90422c0722d0105bb6944f7fe9d1b058d68e5392b9a319853f693"
+      }
+    ]
+  },
+  "matrix": {
+    "bypassAllowedCases": 0,
+    "scenarios": [
+      {
+        "id": "public_active",
+        "visibility": "public",
+        "expected": "allowed",
+        "actual": "allowed",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "e86241864d32daef1b7b37ec2584bf11578298357d4705270dc2bf18f37547cf"
+      },
+      {
+        "id": "private_active",
+        "visibility": "private",
+        "expected": "allowed",
+        "actual": "allowed",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "d4135f25438afd68f799279856720570b79bc7a3007dd5c884c668b545a5c9c7"
+      },
+      {
+        "id": "unknown_repo",
+        "visibility": "unknown",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "2283019bf11f1bd809497bd4d994ce3b9e5524a5f1e98a1ac95e218073fe21b8"
+      },
+      {
+        "id": "public_denied",
+        "visibility": "public",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "a7c894e15f2301a64ddf1014076a555d1766a454538aa437ff62495afe046076"
+      },
+      {
+        "id": "private_denied",
+        "visibility": "private",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "7ec3ccccae0ef0bb775262b4882c623fbe0e678d1e78fb8a450efdf73ec03dc7"
+      },
+      {
+        "id": "missing_key",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "97af2d992c8a29ace5bfe83944e6f1b7d2311740ecd497d40983dc433b0129d2"
+      },
+      {
+        "id": "missing_api_url",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "2fbe1182402aad54a12535d8906c0b6a2b4eaa20383f24a0db4a1bfbdbe83857"
+      },
+      {
+        "id": "offline",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "b98f9f8a54acbb037898968bb627956a437bedd15729b1c3c2587f1cfaac8bc1"
+      },
+      {
+        "id": "timeout",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "d885c417ccb53275530d7911ff2de893dc40250d46ae872d906c266fc52e59ad"
+      },
+      {
+        "id": "forged_cache",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "944509eaf2da99710b138e291f5ab507d349487352050401e234c20022352484"
+      },
+      {
+        "id": "mismatched_cache",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "3d145e07aee6cd380a63dd1282e26f638aa8264010a1cf32e5ae945b6aef7e7f"
+      },
+      {
+        "id": "disabled_policy_attempt",
+        "visibility": "public",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "639c6b77e5e83d7e6cf6b8872eb4fe7cf74024091925c646a312f66887fa3141"
+      },
+      {
+        "id": "fake_api",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "cfb7c014262fb941b22a3c1cde4e436fb48359a39c661598594f514e38a567b1"
+      },
+      {
+        "id": "rate_limited",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "98a5da4b8aa6a37e425ca80bdf639c7c7ec6cde7a94ab2a1079c7972652f4a57"
+      },
+      {
+        "id": "server_error",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "635e5daa00ef20106540b508210fde30ce3bab56daa5d28f010154f04e322f22"
+      },
+      {
+        "id": "malformed_response",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "f04f1e9b4a181a7fc8fc8a9ff44ec323001ed394b0d195a3f9f787ea66c76e5f"
+      },
+      {
+        "id": "revoked",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "738c4d042db7a3a9b69bf6baef657fd6323d47757c8c4acd74480f33a8975b03"
+      },
+      {
+        "id": "expired",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "ecd373de277dcffc9c72d31f022a90d42c737f1a940b3153e21f3b35edd7c6ea"
+      },
+      {
+        "id": "dashboard_provider_pre_activation",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "b66b4c0fc91860bb4d0460d605f698d1cb4278b6ab0ce5e8d0d0953cfef3678d"
+      }
+    ]
+  },
+  "usefulWorkBoundaries": {
+    "reportPassed": true,
+    "totalTests": 256,
+    "requiredPassingTests": [
+      "providers verify license admission denies before provider-key stdin or provider network",
+      "public NeonDiff CLI surface blocks provider-key stdin and provider network before activation",
+      "public NeonDiff CLI surface blocks run-once before the first GitHub request without activation",
+      "public NeonDiff CLI surface applies default-deny admission to useful commands without scoped help metadata",
+      "local HTML dashboard serves HTML status but blocks provider verification before activation"
+    ],
+    "resultSha256": "6d9b901a23398ca9b16c415158dd78b776707db4982cac8f6e16e52c589108a5"
+  },
+  "installUpgrade": {
+    "freshInstallPassed": true,
+    "upgradedFromVersion": "1.0.3",
+    "upgradePassed": true,
+    "resultSha256": "f12ab8b63fe0eaf412422d0837c78a3b6cf39ca17c10bd7f1b0d1123a7325108"
+  },
+  "dashboard": {
+    "setupBlockedBeforeActivation": true,
+    "providerBlockedBeforeActivation": true,
+    "activatedStatusVisible": true,
+    "resultSha256": "88db5f8b5e3797b3a1080bf3107f9517ff7677b0888ab6a3f3c641bb5f5b9e83"
+  },
+  "desktop": {
+    "brokerUnavailable": true,
+    "usefulWorkBlocked": true,
+    "resultSha256": "d3804db15e08bbf0e19920a86c6ded27fc105b56cc8a8308d7e906d33dae1fd2"
+  },
+  "redaction": {
+    "rawLicenseKeyAbsent": true,
+    "bearerTokenAbsent": true,
+    "privatePathsAbsent": true
+  },
+  "artifacts": [
+    {
+      "kind": "production-lifecycle",
+      "ref": "docs/evidence/v1.0.5/production-lifecycle-348b99da43fd7282f6b88a0ce5b407528433cd1d.json",
+      "sha256": "285a968a884adf3b351a5ad6173addfa855938757bb801e739b39a47a904231c"
+    },
+    {
+      "kind": "no-bypass-matrix",
+      "ref": "docs/evidence/v1.0.5/no-bypass-matrix-348b99da43fd7282f6b88a0ce5b407528433cd1d.json",
+      "sha256": "bbc5856ea34306b2b0c47580fadecbbf5dfdfe2e90efb4a5331bd795d345b6f6"
+    },
+    {
+      "kind": "useful-work-boundaries",
+      "ref": "docs/evidence/v1.0.5/useful-work-boundaries-348b99da43fd7282f6b88a0ce5b407528433cd1d.json",
+      "sha256": "9463dcbe2a3b630c65edd6fab334a29470fdd4782932fde7167c0754c4bf0636"
+    },
+    {
+      "kind": "dashboard",
+      "ref": "docs/evidence/v1.0.5/dashboard-348b99da43fd7282f6b88a0ce5b407528433cd1d.json",
+      "sha256": "279cff40e4dcdaa54c379a298c13c309c3f2531c378093016284a5a0d6d8e582"
+    },
+    {
+      "kind": "desktop",
+      "ref": "docs/evidence/v1.0.5/desktop-348b99da43fd7282f6b88a0ce5b407528433cd1d.json",
+      "sha256": "8731a52674833f1f3bcbcbcf8693159a3f8bb3dc0595f1a1575707fce4d196e7"
+    },
+    {
+      "kind": "install-upgrade",
+      "ref": "docs/evidence/v1.0.5/install-upgrade-348b99da43fd7282f6b88a0ce5b407528433cd1d.json",
+      "sha256": "abdd6872f878c03501a242733fa71310487afd4da0aeefbe47684ce7261e77c7"
+    }
+  ]
+}

--- a/docs/evidence/v1.0.5/no-bypass-matrix-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/no-bypass-matrix-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,162 @@
+{
+  "evidenceKind": "no-bypass-matrix",
+  "releaseVersion": "v1.0.5",
+  "candidateHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+  "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+  "harnessRunId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8",
+  "records": [
+    {
+      "id": "public_active",
+      "visibility": "public",
+      "expected": "allowed",
+      "actual": "allowed",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "private_active",
+      "visibility": "private",
+      "expected": "allowed",
+      "actual": "allowed",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "unknown_repo",
+      "visibility": "unknown",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "public_denied",
+      "visibility": "public",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "private_denied",
+      "visibility": "private",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "missing_key",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    },
+    {
+      "id": "missing_api_url",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "offline",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "timeout",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "forged_cache",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    },
+    {
+      "id": "mismatched_cache",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "disabled_policy_attempt",
+      "visibility": "public",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    },
+    {
+      "id": "fake_api",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "rate_limited",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "server_error",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "malformed_response",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "revoked",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "expired",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "dashboard_provider_pre_activation",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    }
+  ]
+}

--- a/docs/evidence/v1.0.5/production-lifecycle-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/production-lifecycle-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,57 @@
+{
+  "evidenceKind": "production-lifecycle",
+  "releaseVersion": "v1.0.5",
+  "candidateHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+  "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+  "harnessRunId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8",
+  "records": [
+    {
+      "id": "issue",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "issued"
+      }
+    },
+    {
+      "id": "activate",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "active",
+        "source": "api"
+      }
+    },
+    {
+      "id": "validate_active",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "active",
+        "source": "api"
+      }
+    },
+    {
+      "id": "deactivate",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "deactivated"
+      }
+    },
+    {
+      "id": "validate_denied",
+      "outcome": "denied",
+      "statusCode": 409,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "scope_mismatch"
+      }
+    }
+  ]
+}

--- a/docs/evidence/v1.0.5/useful-work-boundaries-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
+++ b/docs/evidence/v1.0.5/useful-work-boundaries-348b99da43fd7282f6b88a0ce5b407528433cd1d.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "useful-work-boundaries",
+  "releaseVersion": "v1.0.5",
+  "candidateHead": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "packShasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+  "packIntegrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==",
+  "harnessRunId": "3ae5bd0f5dbd08e73610da9a57ddd8b2c5d6c5c96848cd5546bf31f6acce98a8",
+  "records": [
+    {
+      "reportPassed": true,
+      "totalTests": 256,
+      "requiredPassingTests": [
+        "providers verify license admission denies before provider-key stdin or provider network",
+        "public NeonDiff CLI surface blocks provider-key stdin and provider network before activation",
+        "public NeonDiff CLI surface blocks run-once before the first GitHub request without activation",
+        "public NeonDiff CLI surface applies default-deny admission to useful commands without scoped help metadata",
+        "local HTML dashboard serves HTML status but blocks provider verification before activation"
+      ]
+    }
+  ]
+}

--- a/docs/release-candidates/v1.0.5.json
+++ b/docs/release-candidates/v1.0.5.json
@@ -4,10 +4,13 @@
   "publishedVersionAtCandidateCut": "v1.0.4",
   "state": "candidate_pending_publication",
   "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559",
+  "candidateSourceSha": "348b99da43fd7282f6b88a0ce5b407528433cd1d",
+  "proofRunUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/33348308615",
   "publicationProofPath": "docs/evidence/v1.0.5-publication-proof.json",
   "releaseLevel": "source-beta",
   "source": {
-    "shaState": "pending_source_merge"
+    "shaState": "merged_protected_main",
+    "candidateHeadBeforeReleaseMetadata": "348b99da43fd7282f6b88a0ce5b407528433cd1d"
   },
   "docs": {
     "version": "v1.0.5",
@@ -19,7 +22,8 @@
     "state": "pending",
     "checkoutIssuanceRequiredForThisRelease": false,
     "checkoutIssuanceState": "deferred",
-    "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559"
+    "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559",
+    "activationProofPath": "docs/evidence/v1.0.5/mandatory-activation-348b99da43fd7282f6b88a0ce5b407528433cd1d.json"
   },
   "updateChannels": {
     "cli": {
@@ -42,7 +46,9 @@
     "version": "1.0.5",
     "requiredForThisRelease": true,
     "state": "candidate",
-    "previousReleasedPackageVersion": "1.0.4"
+    "previousReleasedPackageVersion": "1.0.4",
+    "shasum": "b6e95cc85e12b51aa40b57d42fe2e42f282ba937",
+    "integrity": "sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg=="
   },
   "registry": {
     "state": "pending_publication",

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -310,9 +310,15 @@ describe("beta release status", () => {
     expect(candidate.docs.ok).toBe(true);
     expect(candidate.licenseApi.ok).toBe(true);
     expect(candidate.updateChannels.ok).toBe(true);
-    expect(candidate.licenseApi.activationProofPath).toBeUndefined();
-    expect(candidate.npmPublication.requiredForThisRelease).toBe(true);
-    expect(["candidate_pending_publication", "published"]).toContain(candidate.npmPublication.state);
+    expect(candidate.licenseApi.activationProofPath).toBe(
+      "docs/evidence/v1.0.5/mandatory-activation-348b99da43fd7282f6b88a0ce5b407528433cd1d.json"
+    );
+    expect(candidate.npmPublication).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "candidate_pending_publication",
+      candidateReadyForPublication: true
+    });
   });
 
   it("fails closed when the live checkout is dirty or not at the expected head", () => {


### PR DESCRIPTION
## Outcome

Bind the exact merged-head `v1.0.5` lifecycle proof to the release-candidate ledger without changing any publishable package byte.

## Exact identity

- Base: `348b99da43fd7282f6b88a0ce5b407528433cd1d`
- Lifecycle run: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/33348308615
- Release: `v1.0.5`
- State after this PR: `candidate_pending_publication`

## Evidence

- The protected merged-head lifecycle workflow completed successfully and produced the root proof plus six referenced, GitHub-attested evidence files.
- Production `gh attestation verify --deny-self-hosted-runners` succeeded with the exact repository, workflow, source ref, and source SHA.
- Focused release-status, public-readiness, and npm-release-plumbing tests: `136/136`.
- Exact-lock build: pass.
- Secret scan: pass.
- Prepublication readiness check: pass with `candidateReadyForPublication=true` and `publicReady=false`.
- A post-metadata `npm pack` exactly matched the lifecycle package: shasum `b6e95cc85e12b51aa40b57d42fe2e42f282ba937` and integrity `sha512-5RcDO46fAWuVSyS9TUJc5YtObisRO0nLLPBdXLWD3JWooVIWlwywAoP0CeUMFNdy+6PhgpuPWhmSgbA2jz0RQg==`.

## Scope

Nine evidence/metadata/test files only. No product source, package, workflow, runtime, Desktop artifact, customer, npm, or public-surface mutation.

## Proof boundary

This PR proves the repository's exact prepublication evidence binding and unchanged package bytes. It does not publish `neondiff@1.0.5`, create a tag or GitHub Release, prove registry installation, or establish Desktop/RC/GA readiness. Issue #559 remains open until its publication and post-publication acceptance gates pass.

Refs #559
