### PR TITLE
fix: continue immutable npm 1.0.5 promotion

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,6 +15,11 @@ on:
         required: true
         type: boolean
         default: false
+      v105_existing_package_continuation:
+        description: Verify and promote the already-published v1.0.5 release-candidate package without publishing
+        required: true
+        type: boolean
+        default: false
       predecessor_rollback:
         description: Roll back npm latest from immutable 1.0.5 to immutable 1.0.4 after guarded verification
         required: true
@@ -47,6 +52,7 @@ jobs:
       - name: Verify rollback dispatch and policy identity
         env:
           PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+          V105_EXISTING_PACKAGE_CONTINUATION: ${{ inputs.v105_existing_package_continuation || false }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
@@ -56,6 +62,10 @@ jobs:
           }
           test "$PROVENANCE_RECOVERY" != "true" || {
             echo "::error::Predecessor rollback cannot run with provenance recovery"
+            exit 1
+          }
+          test "$V105_EXISTING_PACKAGE_CONTINUATION" != "true" || {
+            echo "::error::Predecessor rollback cannot run with v1.0.5 existing-package continuation"
             exit 1
           }
           test "$WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/publish-npm.yml@refs/heads/main" || {
@@ -188,6 +198,7 @@ jobs:
       RELEASE_EVENT_NAME: ${{ github.event_name }}
       RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
       PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+      V105_EXISTING_PACKAGE_CONTINUATION: ${{ inputs.v105_existing_package_continuation || false }}
       PREDECESSOR_ROLLBACK: ${{ inputs.predecessor_rollback || false }}
       WORKFLOW_REF: ${{ github.workflow_ref }}
       WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -204,11 +215,41 @@ jobs:
           RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
           RELEASE_EVENT_NAME: ${{ github.event_name }}
           PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+          V105_EXISTING_PACKAGE_CONTINUATION: ${{ inputs.v105_existing_package_continuation || false }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+          if [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
+            test "$RELEASE_EVENT_NAME" = "workflow_dispatch" || {
+              echo "::error::v1.0.5 existing-package continuation requires workflow_dispatch"
+              exit 1
+            }
+            test "$GITHUB_REF" = "refs/heads/main" || {
+              echo "::error::v1.0.5 existing-package continuation must run from protected main"
+              exit 1
+            }
+            test "$RELEASE_TAG" = "v1.0.5" || {
+              echo "::error::v1.0.5 existing-package continuation is scoped only to v1.0.5"
+              exit 1
+            }
+            test "$PROVENANCE_RECOVERY" != "true" || {
+              echo "::error::v1.0.5 existing-package continuation cannot run with v1.0.4 provenance recovery"
+              exit 1
+            }
+            test "$WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/publish-npm.yml@refs/heads/main" || {
+              echo "::error::v1.0.5 continuation workflow ref must be publish-npm.yml on protected main"
+              exit 1
+            }
+            test "$WORKFLOW_SHA" = "$GITHUB_SHA" || {
+              echo "::error::v1.0.5 continuation workflow SHA must equal the protected-main dispatch SHA"
+              exit 1
+            }
+            test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA" || {
+              echo "::error::v1.0.5 continuation dispatch SHA is not the current protected-main head"
+              exit 1
+            }
+          elif [ "$PROVENANCE_RECOVERY" = "true" ]; then
             test "$RELEASE_EVENT_NAME" = "workflow_dispatch" || {
               echo "::error::Provenance recovery requires workflow_dispatch"
               exit 1
@@ -240,7 +281,12 @@ jobs:
             exit 1
           }
           TAG_COMMIT="$(git rev-list -n 1 "$RELEASE_TAG")"
-          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+          if [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
+            test "$TAG_COMMIT" = "5e26b79abadaf14b9a6f625ae4e01aad54f313e0" || {
+              echo "::error::v1.0.5 continuation tag must peel to the immutable v1.0.5 release commit"
+              exit 1
+            }
+          elif [ "$PROVENANCE_RECOVERY" = "true" ]; then
             test "$RELEASE_TAG" = "v1.0.4" || {
               echo "::error::Provenance recovery is scoped only to v1.0.4"
               exit 1
@@ -376,8 +422,8 @@ jobs:
             --candidate-ledger "$CANDIDATE_LEDGER" \
             --prepublication "$PREPUBLICATION_MODE"
 
-      - name: Checkout protected-main recovery policy
-        if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+      - name: Checkout protected-main publication policy
+        if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && (inputs.provenance_recovery == true || inputs.v105_existing_package_continuation == true) }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.workflow_sha }}
@@ -385,8 +431,8 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Verify protected-main recovery policy checkout
-        if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+      - name: Verify protected-main publication policy checkout
+        if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && (inputs.provenance_recovery == true || inputs.v105_existing_package_continuation == true) }}
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
@@ -404,6 +450,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
           RELEASE_EVENT_NAME: ${{ github.event_name }}
           PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+          V105_EXISTING_PACKAGE_CONTINUATION: ${{ inputs.v105_existing_package_continuation || false }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
@@ -420,11 +467,11 @@ jobs:
           PACK_TARBALL="$RUNNER_TEMP/neondiff-reviewed-pack/neondiff-$PACKAGE_VERSION.tgz"
           POLICY_SCRIPT="scripts/npm-release-policy.mjs"
           PROVENANCE_VERIFIER="scripts/verify-npm-provenance.mjs"
-          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+          if [ "$PROVENANCE_RECOVERY" = "true" ] || [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
             POLICY_SCRIPT=".recovery-policy/scripts/npm-release-policy.mjs"
             PROVENANCE_VERIFIER=".recovery-policy/scripts/verify-npm-provenance.mjs"
             test -f "$POLICY_SCRIPT" -a -f "$PROVENANCE_VERIFIER" || {
-              echo "::error::Protected-main recovery policy files are missing"
+              echo "::error::Protected-main publication policy files are missing"
               exit 1
             }
           fi
@@ -433,7 +480,7 @@ jobs:
             exit 1
           }
           PACKAGE_ALREADY_EXISTS=false
-          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+          if [ "$PROVENANCE_RECOVERY" = "true" ] || [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
             for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
               OBSERVED_PACKAGE_VERSION="$(npm view "neondiff@$PACKAGE_VERSION" version --prefer-online 2>/dev/null || true)"
               if [ "$OBSERVED_PACKAGE_VERSION" = "$PACKAGE_VERSION" ]; then
@@ -445,7 +492,7 @@ jobs:
           elif npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
             PACKAGE_ALREADY_EXISTS=true
           fi
-          if { [ "$GITHUB_REF" = "refs/heads/main" ] || [ "$WORKFLOW_REF" = "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main" ]; } && [ "$PROVENANCE_RECOVERY" != "true" ]; then
+          if { [ "$GITHUB_REF" = "refs/heads/main" ] || [ "$WORKFLOW_REF" = "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main" ]; } && [ "$PROVENANCE_RECOVERY" != "true" ] && [ "$V105_EXISTING_PACKAGE_CONTINUATION" != "true" ]; then
             echo "::error::Protected-main npm execution must remain in provenance recovery mode"
             exit 1
           fi
@@ -567,6 +614,16 @@ jobs:
               exit 1
             }
             echo "neondiff@$PACKAGE_VERSION already exists; provenance recovery will not publish"
+          elif [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
+            test "$PACKAGE_VERSION" = "1.0.5" || {
+              echo "::error::v1.0.5 existing-package continuation package version is not 1.0.5"
+              exit 1
+            }
+            test "$PACKAGE_ALREADY_EXISTS" = "true" || {
+              echo "::error::v1.0.5 existing-package continuation requires neondiff@$PACKAGE_VERSION to already exist"
+              exit 1
+            }
+            echo "neondiff@$PACKAGE_VERSION already exists; existing-package continuation will not publish"
           elif [ "$PACKAGE_ALREADY_EXISTS" = "true" ]; then
             echo "neondiff@$PACKAGE_VERSION already exists; verifying reviewed tarball identity"
           else
@@ -677,7 +734,7 @@ jobs:
             --target-version "$PACKAGE_VERSION" \
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
-          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+          if [ "$PROVENANCE_RECOVERY" = "true" ] || [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
             git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
             PREPROMOTION_MAIN_SHA="$(git rev-parse refs/remotes/origin/main)"
             test "$PREPROMOTION_MAIN_SHA" = "$GITHUB_SHA" || {
@@ -688,6 +745,27 @@ jobs:
           npm view neondiff dist-tags --json --prefer-online > prepromotion-channel.json
           PREPROMOTION_TAG_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!tags || Array.isArray(tags) || typeof tags !== "object") process.exit(1); process.stdout.write(tags[process.argv[2]] ?? "")' prepromotion-channel.json "$NPM_TAG")"
           PREPROMOTION_QUARANTINE_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!tags || Array.isArray(tags) || typeof tags !== "object") process.exit(1); process.stdout.write(tags["release-candidate"] ?? "")' prepromotion-channel.json)"
+          # BEGIN V105_EXISTING_PACKAGE_CONTINUATION
+          if [ "$V105_EXISTING_PACKAGE_CONTINUATION" = "true" ]; then
+            node "$POLICY_SCRIPT" verify-v105-existing-package-continuation \
+              --event-name "$RELEASE_EVENT_NAME" \
+              --github-ref "$GITHUB_REF" \
+              --workflow-ref "$WORKFLOW_REF" \
+              --workflow-sha "$WORKFLOW_SHA" \
+              --github-sha "$GITHUB_SHA" \
+              --main-sha "$PREPROMOTION_MAIN_SHA" \
+              --release-tag "$RELEASE_TAG" \
+              --tag-commit "$EXPECTED_GIT_HEAD" \
+              --package-version "$PACKAGE_VERSION" \
+              --package-exists "$PACKAGE_ALREADY_EXISTS" \
+              --existing-package-continuation "$V105_EXISTING_PACKAGE_CONTINUATION" \
+              --provenance-recovery "$PROVENANCE_RECOVERY" \
+              --latest-version "$PREPROMOTION_TAG_VERSION" \
+              --quarantine-version "$PREPROMOTION_QUARANTINE_VERSION" \
+              --target-version "$PACKAGE_VERSION" \
+              --expected-predecessor "$EXPECTED_PREDECESSOR"
+          fi
+          # END V105_EXISTING_PACKAGE_CONTINUATION
           # BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD
           if [ "$PROVENANCE_RECOVERY" = "true" ]; then
             node "$POLICY_SCRIPT" verify-recovery-channels \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -422,7 +422,7 @@ jobs:
             --candidate-ledger "$CANDIDATE_LEDGER" \
             --prepublication "$PREPUBLICATION_MODE"
 
-      - name: Checkout protected-main publication policy
+      - name: Checkout protected-main recovery policy
         if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && (inputs.provenance_recovery == true || inputs.v105_existing_package_continuation == true) }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -431,7 +431,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Verify protected-main publication policy checkout
+      - name: Verify protected-main recovery policy checkout
         if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && (inputs.provenance_recovery == true || inputs.v105_existing_package_continuation == true) }}
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -14,6 +14,15 @@ const V104_PROVENANCE_RECOVERY = Object.freeze({
   commit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
   predecessor: "1.0.3"
 });
+const V105_PROVENANCE_RELEASE = Object.freeze({
+  package: "neondiff",
+  version: "1.0.5",
+  repository: "electricsheephq/evaos-code-review-bot-neondiff",
+  workflow: ".github/workflows/publish-npm.yml",
+  tag: "v1.0.5",
+  commit: "5e26b79abadaf14b9a6f625ae4e01aad54f313e0",
+  predecessor: "1.0.4"
+});
 const DESKTOP_ONLY_RC_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-rc\.(?:[1-9]\d*)$/;
 const DESKTOP_ONLY_FINAL_TAG = "v1.1.0";
 const NPM_SHA512_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/;
@@ -231,47 +240,56 @@ function verifyPack(args) {
       const expectedRepository = required(args, "expected-repository");
       const expectedWorkflow = required(args, "expected-workflow");
       const expectedTag = required(args, "expected-tag");
-      if (
-        expectedPackage !== V104_PROVENANCE_RECOVERY.package
-        || expectedVersion !== V104_PROVENANCE_RECOVERY.version
-        || expectedRepository !== V104_PROVENANCE_RECOVERY.repository
-        || expectedWorkflow !== V104_PROVENANCE_RECOVERY.workflow
-        || expectedTag !== V104_PROVENANCE_RECOVERY.tag
-        || expectedGitHead !== V104_PROVENANCE_RECOVERY.commit
-      ) {
-        fail("verified npm provenance fallback is scoped only to the v1.0.4 recovery");
-      }
       const recoveryProofPath = args.get("recovery-proof");
-      if (!recoveryProofPath) {
-        fail("npm gitHead fallback requires a protected-main recovery dispatch proof");
+      const isV104Recovery = expectedPackage === V104_PROVENANCE_RECOVERY.package
+        && expectedVersion === V104_PROVENANCE_RECOVERY.version
+        && expectedRepository === V104_PROVENANCE_RECOVERY.repository
+        && expectedWorkflow === V104_PROVENANCE_RECOVERY.workflow
+        && expectedTag === V104_PROVENANCE_RECOVERY.tag
+        && expectedGitHead === V104_PROVENANCE_RECOVERY.commit;
+      const isV105Release = expectedPackage === V105_PROVENANCE_RELEASE.package
+        && expectedVersion === V105_PROVENANCE_RELEASE.version
+        && expectedRepository === V105_PROVENANCE_RELEASE.repository
+        && expectedWorkflow === V105_PROVENANCE_RELEASE.workflow
+        && expectedTag === V105_PROVENANCE_RELEASE.tag
+        && expectedGitHead === V105_PROVENANCE_RELEASE.commit;
+      if (!isV104Recovery && !isV105Release) {
+        fail("verified npm provenance fallback is scoped only to the exact v1.0.5 release or v1.0.4 recovery");
       }
-      let recoveryProof;
-      try {
-        recoveryProof = JSON.parse(readFileSync(recoveryProofPath, "utf8"));
-      } catch {
-        fail("recovery dispatch proof is not valid JSON");
-      }
-      if (
-        recoveryProof?.schemaVersion !== 1
-        || recoveryProof?.kind !== "neondiff.npm.provenance-recovery-dispatch"
-        || recoveryProof?.eventName !== "workflow_dispatch"
-        || recoveryProof?.githubRef !== "refs/heads/main"
-        || recoveryProof?.workflowRef !== V104_PROVENANCE_RECOVERY.workflowRef
-        || typeof recoveryProof?.githubSha !== "string"
-        || !/^[0-9a-f]{40}$/.test(recoveryProof.githubSha)
-        || recoveryProof?.workflowSha !== recoveryProof.githubSha
-        || recoveryProof?.mainSha !== recoveryProof.githubSha
-        || recoveryProof?.package !== expectedPackage
-        || recoveryProof?.repository !== expectedRepository
-        || recoveryProof?.workflow !== expectedWorkflow
-        || recoveryProof?.tag !== expectedTag
-        || recoveryProof?.tagCommit !== expectedGitHead
-        || recoveryProof?.packageVersion !== expectedVersion
-        || recoveryProof?.provenanceRecovery !== true
-        || recoveryProof?.releaseValid !== true
-        || recoveryProof?.packageExists !== true
-      ) {
-        fail("recovery dispatch proof does not match the exact protected-main v1.0.4 recovery");
+      if (isV104Recovery) {
+        if (!recoveryProofPath) {
+          fail("npm gitHead fallback requires a protected-main recovery dispatch proof");
+        }
+        let recoveryProof;
+        try {
+          recoveryProof = JSON.parse(readFileSync(recoveryProofPath, "utf8"));
+        } catch {
+          fail("recovery dispatch proof is not valid JSON");
+        }
+        if (
+          recoveryProof?.schemaVersion !== 1
+          || recoveryProof?.kind !== "neondiff.npm.provenance-recovery-dispatch"
+          || recoveryProof?.eventName !== "workflow_dispatch"
+          || recoveryProof?.githubRef !== "refs/heads/main"
+          || recoveryProof?.workflowRef !== V104_PROVENANCE_RECOVERY.workflowRef
+          || typeof recoveryProof?.githubSha !== "string"
+          || !/^[0-9a-f]{40}$/.test(recoveryProof.githubSha)
+          || recoveryProof?.workflowSha !== recoveryProof.githubSha
+          || recoveryProof?.mainSha !== recoveryProof.githubSha
+          || recoveryProof?.package !== expectedPackage
+          || recoveryProof?.repository !== expectedRepository
+          || recoveryProof?.workflow !== expectedWorkflow
+          || recoveryProof?.tag !== expectedTag
+          || recoveryProof?.tagCommit !== expectedGitHead
+          || recoveryProof?.packageVersion !== expectedVersion
+          || recoveryProof?.provenanceRecovery !== true
+          || recoveryProof?.releaseValid !== true
+          || recoveryProof?.packageExists !== true
+        ) {
+          fail("recovery dispatch proof does not match the exact protected-main v1.0.4 recovery");
+        }
+      } else if (recoveryProofPath) {
+        fail("v1.0.5 verified npm provenance fallback cannot use a recovery dispatch proof");
       }
       let provenance;
       try {
@@ -397,6 +415,77 @@ function verifyRecoveryChannels(args) {
     targetVersion,
     expectedPredecessor,
     action
+  }));
+}
+
+function verifyV105ExistingPackageContinuation(args) {
+  const eventName = required(args, "event-name");
+  const githubRef = required(args, "github-ref");
+  const workflowRef = required(args, "workflow-ref");
+  const workflowSha = required(args, "workflow-sha");
+  const githubSha = required(args, "github-sha");
+  const mainSha = required(args, "main-sha");
+  const releaseTag = required(args, "release-tag");
+  const tagCommit = required(args, "tag-commit");
+  const packageVersion = required(args, "package-version");
+  const packageExists = parseBoolean(required(args, "package-exists"), "package-exists");
+  const existingPackageContinuation = parseBoolean(required(args, "existing-package-continuation"), "existing-package-continuation");
+  const provenanceRecovery = parseBoolean(required(args, "provenance-recovery"), "provenance-recovery");
+  const latestVersion = required(args, "latest-version");
+  const quarantineVersion = args.get("quarantine-version") ?? "";
+  const targetVersion = required(args, "target-version");
+  const expectedPredecessor = required(args, "expected-predecessor");
+
+  if (
+    !existingPackageContinuation
+    || provenanceRecovery
+    || eventName !== "workflow_dispatch"
+    || githubRef !== "refs/heads/main"
+    || workflowRef !== "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main"
+  ) {
+    fail("v1.0.5 existing-package continuation requires an explicit protected-main workflow dispatch");
+  }
+  if (
+    !/^[0-9a-f]{40}$/.test(githubSha)
+    || workflowSha !== githubSha
+    || mainSha !== githubSha
+  ) {
+    fail("v1.0.5 continuation workflow and protected-main SHAs must match exactly");
+  }
+  if (
+    releaseTag !== V105_PROVENANCE_RELEASE.tag
+    || tagCommit !== V105_PROVENANCE_RELEASE.commit
+    || packageVersion !== V105_PROVENANCE_RELEASE.version
+    || targetVersion !== V105_PROVENANCE_RELEASE.version
+    || expectedPredecessor !== V105_PROVENANCE_RELEASE.predecessor
+  ) {
+    fail("v1.0.5 existing-package continuation is scoped only to the immutable v1.0.5 release");
+  }
+  if (!packageExists) fail("v1.0.5 existing-package continuation requires the immutable npm package to already exist");
+
+  let action;
+  if (latestVersion === expectedPredecessor) {
+    if (quarantineVersion !== targetVersion) {
+      fail("v1.0.5 continuation requires the exact package to own release-candidate before promotion");
+    }
+    action = "promote_existing_package";
+  } else if (latestVersion === targetVersion) {
+    if (quarantineVersion !== "" && quarantineVersion !== targetVersion) {
+      fail("v1.0.5 continuation refuses unexpected release-candidate ownership");
+    }
+    action = quarantineVersion === targetVersion ? "confirm_and_cleanup" : "confirmed";
+  } else {
+    fail("v1.0.5 continuation refuses unexpected latest ownership");
+  }
+  console.log(JSON.stringify({
+    bounded: true,
+    action,
+    latestVersion,
+    quarantineVersion,
+    targetVersion,
+    expectedPredecessor,
+    packageExists,
+    existingPackageContinuation
   }));
 }
 
@@ -540,5 +629,6 @@ else if (command === "verify-pack") verifyPack(args);
 else if (command === "verify-channel") verifyChannel(args);
 else if (command === "verify-recovery-dispatch") verifyRecoveryDispatch(args);
 else if (command === "verify-recovery-channels") verifyRecoveryChannels(args);
+else if (command === "verify-v105-existing-package-continuation") verifyV105ExistingPackageContinuation(args);
 else if (command === "verify-predecessor-rollback") verifyPredecessorRollback(args);
-else fail("command must be classify, verify-git, verify-pack, verify-channel, verify-recovery-dispatch, verify-recovery-channels, or verify-predecessor-rollback");
+else fail("command must be classify, verify-git, verify-pack, verify-channel, verify-recovery-dispatch, verify-recovery-channels, verify-v105-existing-package-continuation, or verify-predecessor-rollback");

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -239,6 +239,7 @@ fi
         GIT_STATE_FILE: gitState,
         FAIL_STAGE: "",
         PROVENANCE_RECOVERY: "true",
+        V105_EXISTING_PACKAGE_CONTINUATION: "false",
         RUNNER_TEMP: root,
         RELEASE_EVENT_NAME: "workflow_dispatch",
         GITHUB_REF: "refs/heads/main",
@@ -308,6 +309,56 @@ fi
       const commands = readFileSync(log, "utf8");
       expect(commands).not.toMatch(/^publish\b/m);
       expect(result.status).toBe(packageAlreadyExists === "true" ? 0 : 1);
+    }
+  });
+
+  it("only continues v1.0.5 from its existing release-candidate package", () => {
+    const block = extractBlock("V105_EXISTING_PACKAGE_CONTINUATION");
+    const policyScript = resolve("scripts/npm-release-policy.mjs");
+    const { root, bin, log } = harness();
+    const exactEnvironment = {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      NPM_MUTATION_LOG: log,
+      POLICY_SCRIPT: policyScript,
+      V105_EXISTING_PACKAGE_CONTINUATION: "true",
+      PROVENANCE_RECOVERY: "false",
+      RELEASE_EVENT_NAME: "workflow_dispatch",
+      GITHUB_REF: "refs/heads/main",
+      WORKFLOW_REF: "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+      WORKFLOW_SHA: "a".repeat(40),
+      GITHUB_SHA: "a".repeat(40),
+      PREPROMOTION_MAIN_SHA: "a".repeat(40),
+      RELEASE_TAG: "v1.0.5",
+      EXPECTED_GIT_HEAD: "5e26b79abadaf14b9a6f625ae4e01aad54f313e0",
+      PACKAGE_VERSION: "1.0.5",
+      PACKAGE_ALREADY_EXISTS: "true",
+      PREPROMOTION_TAG_VERSION: "1.0.4",
+      PREPROMOTION_QUARANTINE_VERSION: "1.0.5",
+      EXPECTED_PREDECESSOR: "1.0.4",
+      NPM_TAG: "latest"
+    };
+    const accepted = spawnSync("bash", ["-euo", "pipefail", "-c", block], {
+      cwd: root,
+      encoding: "utf8",
+      env: exactEnvironment
+    });
+    expect(accepted.status, `${accepted.stdout}\n${accepted.stderr}`).toBe(0);
+    expect(readFileSync(log, "utf8")).toBe("");
+
+    for (const [name, overrides] of [
+      ["foreign latest", { PREPROMOTION_TAG_VERSION: "9.9.9" }],
+      ["foreign quarantine", { PREPROMOTION_QUARANTINE_VERSION: "9.9.9" }],
+      ["missing package", { PACKAGE_ALREADY_EXISTS: "false" }],
+      ["recovery mode", { PROVENANCE_RECOVERY: "true" }]
+    ] as const) {
+      const rejected = spawnSync("bash", ["-euo", "pipefail", "-c", block], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...exactEnvironment, ...overrides }
+      });
+      expect(rejected.status, name).not.toBe(0);
+      expect(readFileSync(log, "utf8"), name).toBe("");
     }
   });
 

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -462,6 +462,55 @@ describe("npm release policy", () => {
     expect(malformedProof.stderr).toContain("recovery dispatch proof is not valid JSON");
   });
 
+  it("accepts an absent npm gitHead with exact verified v1.0.5 provenance", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-v105-provenance-fallback-"));
+    roots.push(root);
+    const localPath = join(root, "pack.json");
+    const remotePath = join(root, "remote.json");
+    const provenancePath = join(root, "verified-provenance.json");
+    const integrity = `sha512-${Buffer.from("reviewed-v1.0.5-tarball").toString("base64")}`;
+    const releaseCommit = "5e26b79abadaf14b9a6f625ae4e01aad54f313e0";
+    writeFileSync(localPath, JSON.stringify([{
+      version: "1.0.5",
+      integrity,
+      shasum: "2".repeat(40)
+    }]));
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.5",
+      "dist.integrity": integrity,
+      "dist.shasum": "2".repeat(40)
+    }));
+    writeFileSync(provenancePath, JSON.stringify({
+      package: "neondiff",
+      version: "1.0.5",
+      integrity,
+      sha512: Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex"),
+      repository: "electricsheephq/evaos-code-review-bot-neondiff",
+      workflow: ".github/workflows/publish-npm.yml",
+      tag: "v1.0.5",
+      commit: releaseCommit
+    }));
+
+    const result = spawnSync(process.execPath, [
+      policyScript, "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.5",
+      "--expected-git-head", releaseCommit,
+      "--verified-provenance", provenancePath,
+      "--expected-package", "neondiff",
+      "--expected-repository", "electricsheephq/evaos-code-review-bot-neondiff",
+      "--expected-workflow", ".github/workflows/publish-npm.yml",
+      "--expected-tag", "v1.0.5"
+    ], { encoding: "utf8" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      version: "1.0.5",
+      sourceIdentity: "verified_provenance_fallback"
+    });
+  });
+
   it("rejects malformed, mismatched, or under-bound provenance for an absent gitHead", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-npm-provenance-rejections-"));
     roots.push(root);
@@ -660,6 +709,56 @@ describe("npm release policy", () => {
       ["9.9.9", "1.0.4"]
     ]) {
       expect(run(latest, quarantine).status, `${latest}/${quarantine}`).not.toBe(0);
+    }
+  });
+
+  it("scopes v1.0.5 existing-package continuation to protected main and its release-candidate", () => {
+    const exactArgs = [
+      policyScript, "verify-v105-existing-package-continuation",
+      "--event-name", "workflow_dispatch",
+      "--github-ref", "refs/heads/main",
+      "--workflow-ref", "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+      "--workflow-sha", "a".repeat(40),
+      "--github-sha", "a".repeat(40),
+      "--main-sha", "a".repeat(40),
+      "--release-tag", "v1.0.5",
+      "--tag-commit", "5e26b79abadaf14b9a6f625ae4e01aad54f313e0",
+      "--package-version", "1.0.5",
+      "--package-exists", "true",
+      "--existing-package-continuation", "true",
+      "--provenance-recovery", "false",
+      "--latest-version", "1.0.4",
+      "--quarantine-version", "1.0.5",
+      "--target-version", "1.0.5",
+      "--expected-predecessor", "1.0.4"
+    ];
+    const accepted = spawnSync(process.execPath, exactArgs, { encoding: "utf8" });
+    expect(accepted.status, accepted.stderr).toBe(0);
+    expect(JSON.parse(accepted.stdout)).toMatchObject({
+      action: "promote_existing_package",
+      targetVersion: "1.0.5",
+      expectedPredecessor: "1.0.4"
+    });
+
+    for (const [flag, value] of [
+      ["--event-name", "release"],
+      ["--github-ref", "refs/tags/v1.0.5"],
+      ["--workflow-ref", "other"],
+      ["--workflow-sha", "b".repeat(40)],
+      ["--github-sha", "b".repeat(40)],
+      ["--main-sha", "b".repeat(40)],
+      ["--release-tag", "v1.0.4"],
+      ["--tag-commit", "f".repeat(40)],
+      ["--package-version", "1.0.4"],
+      ["--package-exists", "false"],
+      ["--provenance-recovery", "true"],
+      ["--latest-version", "9.9.9"],
+      ["--quarantine-version", "9.9.9"]
+    ] as const) {
+      const args = [...exactArgs];
+      args[args.indexOf(flag) + 1] = value;
+      const rejected = spawnSync(process.execPath, args, { encoding: "utf8" });
+      expect(rejected.status, flag).not.toBe(0);
     }
   });
 

--- a/tests/npm-v105-release-plumbing.test.ts
+++ b/tests/npm-v105-release-plumbing.test.ts
@@ -79,4 +79,24 @@ describe("neondiff@1.0.5 release plumbing", () => {
     const installStep = rollback?.steps?.find((step) => (step as { name?: string }).name === "Install exact script-free rollback dependencies");
     expect(installStep?.run?.trim()).toBe("npm ci --ignore-scripts");
   });
+
+  it("routes immutable v1.0.5 existing-package continuation through protected main", () => {
+    const workflow = read(".github/workflows/publish-npm.yml");
+    const parsed = parse(workflow) as {
+      on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+      jobs?: Record<string, { if?: string }>;
+    };
+
+    expect(parsed.on?.workflow_dispatch?.inputs).toHaveProperty("v105_existing_package_continuation");
+    expect(workflow).toContain("V105_EXISTING_PACKAGE_CONTINUATION");
+    expect(workflow).toContain("verify-v105-existing-package-continuation");
+    expect(workflow).toContain("Checkout protected-main publication policy");
+    expect(workflow).toContain('test "$RELEASE_TAG" = "v1.0.5"');
+    expect(workflow).toContain('$V105_EXISTING_PACKAGE_CONTINUATION" != "true"');
+    expect(workflow).toContain('neondiff@$PACKAGE_VERSION already exists; existing-package continuation will not publish');
+    expect(workflow).not.toContain('npm publish "$PACK_TARBALL" --provenance --access public --tag "latest"');
+    expect(parsed.jobs?.publish?.if).toContain("predecessor_rollback");
+    expect(parsed.jobs?.rollback_predecessor?.if).toContain("predecessor_rollback");
+    expect(workflow).toContain("Predecessor rollback cannot run with v1.0.5 existing-package continuation");
+  });
 });

--- a/tests/npm-v105-release-plumbing.test.ts
+++ b/tests/npm-v105-release-plumbing.test.ts
@@ -90,7 +90,7 @@ describe("neondiff@1.0.5 release plumbing", () => {
     expect(parsed.on?.workflow_dispatch?.inputs).toHaveProperty("v105_existing_package_continuation");
     expect(workflow).toContain("V105_EXISTING_PACKAGE_CONTINUATION");
     expect(workflow).toContain("verify-v105-existing-package-continuation");
-    expect(workflow).toContain("Checkout protected-main publication policy");
+    expect(workflow).toContain("Checkout protected-main recovery policy");
     expect(workflow).toContain('test "$RELEASE_TAG" = "v1.0.5"');
     expect(workflow).toContain('$V105_EXISTING_PACKAGE_CONTINUATION" != "true"');
     expect(workflow).toContain('neondiff@$PACKAGE_VERSION already exists; existing-package continuation will not publish');


### PR DESCRIPTION
Related: #559

## Outcome

Adds one protected-main, existing-package-only continuation for the already-published immutable `neondiff@1.0.5` package. The continuation verifies the exact tag, release commit, package bytes, registry provenance, lifecycle evidence, and current `latest=1.0.4` / `release-candidate=1.0.5` ownership before it may promote `latest`.

This is the smallest recovery for failed run 33349501065. That run published the exact reviewed package under `release-candidate`, then stopped before `latest` because the tagged policy only allowed missing-`gitHead` provenance fallback for historical `v1.0.4` recovery.

## Safety boundaries

- The continuation never runs `npm publish`; the immutable `1.0.5` package must already exist.
- It runs only as `workflow_dispatch` from current protected `main`, for exact annotated tag `v1.0.5` peeling to `5e26b79abadaf14b9a6f625ae4e01aad54f313e0`.
- It loads the corrected publication policy from the exact protected-main workflow SHA while rebuilding the reviewed package from the immutable tag.
- Missing or foreign package, tag, source, workflow, provenance, `latest`, or quarantine identity fails before mutation.
- Predecessor rollback, historical `v1.0.4` provenance recovery, and `v1.0.5` continuation are mutually exclusive.
- Historical `v1.0.4` recovery retains its exact dispatch-proof requirement.
- No package bytes, runtime, installed beta, customer data, secret values, public Desktop surface, or website state changed.

## Validation

- `PATH=/opt/homebrew/bin:/tmp:$PATH npm test -- tests/npm-release-policy.test.ts tests/npm-v105-release-plumbing.test.ts` — 45/45
- `PATH=/opt/homebrew/bin:/tmp:$PATH npm test -- tests/npm-provenance-recovery.test.ts -t 'never publishes|only continues'` — 2/2 targeted, 42 skipped
- `PATH=/tmp:$PATH npm run build` — pass
- YAML parse — pass (`rollback_predecessor,publish`)
- `git diff --check HEAD^ HEAD` — pass
- local `npm pack --ignore-scripts` matches immutable public `neondiff@1.0.5`: shasum `b6e95cc85e12b51aa40b57d42fe2e42f282ba937` and the reviewed SHA-512 integrity
- blind adversarial review — PASS 97
- blind acceptance review — PASS 93; no blocker found, but its local Vitest optional Rollup module was unavailable and local actionlint timed out. Authoritative Linux CI and an exact-head follow-up are required before merge.

The complete legacy provenance harness and local actionlint are environment-blocked on this Mac; authoritative GitHub Actions is the merge gate.

## Proof boundary

This PR proves source and workflow policy only. It does not promote an npm dist-tag, complete the typed publication receipt, prove Desktop signing/updater/runtime behavior, or establish RC/GA readiness.
