### PR TITLE
fix(release): fail closed on npm cleanup lag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -819,8 +819,25 @@ jobs:
           const temporaryPath = `${outputPath}.tmp`;
           rmSync(outputPath, { force: true });
           rmSync(temporaryPath, { force: true });
+          const NPM_VERSION_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+          const sanitizeVersion = (value) => (
+            typeof value === "string" && value.length <= 128 && NPM_VERSION_PATTERN.test(value)
+              ? value
+              : "[redacted]"
+          );
+          const sanitizeDistTags = (tags) => Object.fromEntries(
+            Object.entries(tags)
+              .filter(([tag]) => tag === "latest" || tag === "beta" || tag === "release-candidate")
+              .map(([tag, value]) => [tag, sanitizeVersion(value)])
+          );
           const writeResult = (distTags, quarantineCleanup) => {
-            writeFileSync(temporaryPath, `${JSON.stringify({ distTags, quarantineCleanup })}\n`, { encoding: "utf8", mode: 0o600 });
+            const sanitizedCleanup = {
+              ...quarantineCleanup,
+              observedVersion: quarantineCleanup.observedVersion === null
+                ? null
+                : sanitizeVersion(quarantineCleanup.observedVersion)
+            };
+            writeFileSync(temporaryPath, `${JSON.stringify({ distTags: sanitizeDistTags(distTags), quarantineCleanup: sanitizedCleanup })}\n`, { encoding: "utf8", mode: 0o600 });
             renameSync(temporaryPath, outputPath);
           };
           let promotionConfirmed = false;
@@ -872,10 +889,11 @@ jobs:
                 process.exit(0);
               }
               if (quarantineVersion !== expectedVersion) {
-                console.error(`::warning::refusing to remove unexpected release-candidate version ${quarantineVersion}`);
+                const sanitizedQuarantineVersion = sanitizeVersion(quarantineVersion);
+                console.error(`::warning::refusing to remove unexpected release-candidate version ${sanitizedQuarantineVersion}`);
                 writeResult(tags, {
                   state: "unexpected_owner",
-                  observedVersion: quarantineVersion,
+                  observedVersion: sanitizedQuarantineVersion,
                   removalAttempted,
                   removalAccepted
                 });
@@ -907,7 +925,7 @@ jobs:
             removalAttempted,
             removalAccepted
           });
-          process.exit(0);
+          process.exit(1);
           NODE
           # END POST_PROMOTION_CONFIRMATION
           # END V104_PROVENANCE_RECOVERY_MUTATION_GATE

--- a/tests/npm-dist-tag-convergence.test.ts
+++ b/tests/npm-dist-tag-convergence.test.ts
@@ -59,6 +59,10 @@ if (process.env.FAKE_NPM_MODE === "unexpected") {
     if (cleanupCount < Number(process.env.FAKE_NPM_CLEANUP_CONVERGE_AT)) tags["release-candidate"] = "1.0.3";
   }
 }
+if (process.env.FAKE_NPM_EMIT_UNSAFE_OUTPUT === "true") {
+  process.stderr.write("synthetic command stderr token\\n");
+  tags.debug = "synthetic-token";
+}
 process.stdout.write(JSON.stringify(tags));
 `
   );
@@ -71,7 +75,8 @@ function runWorkflowBlock(
   mode: "converge" | "stale" | "hang" | "unexpected",
   attempts: number,
   convergeAt = attempts,
-  cleanupConvergeAt = 2
+  cleanupConvergeAt = 2,
+  emitUnsafeOutput = false
 ) {
   const binDir = writeFakeNpm(root);
   const counterPath = join(root, "view-counter.txt");
@@ -101,7 +106,8 @@ function runWorkflowBlock(
       FAKE_NPM_RM_COUNTER: rmCounterPath,
       FAKE_NPM_RM_MARKER: rmMarkerPath,
       FAKE_NPM_MODE: mode,
-      FAKE_NPM_CONVERGE_AT: String(convergeAt)
+      FAKE_NPM_CONVERGE_AT: String(convergeAt),
+      FAKE_NPM_EMIT_UNSAFE_OUTPUT: String(emitUnsafeOutput)
     }
   });
   return { cleanupCounterPath, counterPath, outputPath, result, rmCounterPath };
@@ -168,7 +174,7 @@ describe("npm dist-tag convergence confirmation", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-cleanup-lag-"));
     const { outputPath, result, rmCounterPath } = runWorkflowBlock(root, "converge", 2, 1, 99);
 
-    expect(result.status).toBe(0);
+    expect(result.status).toBe(1);
     expect(readFileSync(rmCounterPath, "utf8")).toBe("1");
     expect(result.stderr).toContain("::warning::release-candidate cleanup remains unconfirmed after 2 attempts");
     expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
@@ -180,6 +186,19 @@ describe("npm dist-tag convergence confirmation", () => {
         removalAccepted: true
       }
     });
+  });
+
+  it("fails closed with sanitized evidence when cleanup remains unconfirmed", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-cleanup-sanitized-"));
+    const { outputPath, result } = runWorkflowBlock(root, "converge", 2, 1, 99, true);
+
+    expect(result.status).toBe(1);
+    const evidence = readFileSync(outputPath, "utf8");
+    expect(evidence).toContain("pending_registry_convergence");
+    expect(evidence).not.toContain("synthetic-token");
+    expect(evidence).not.toContain("synthetic command stderr token");
+    expect(result.stderr).not.toContain("synthetic command stderr token");
+    expect(JSON.parse(evidence).distTags).toEqual({ latest: "1.0.3", "release-candidate": "1.0.3" });
   });
 
   it("derives the workflow block indentation from its marker", () => {


### PR DESCRIPTION
Related: #559

## Outcome

Make the protected npm continuation fail closed when `release-candidate` cleanup does not converge within its bounded confirmation window. The workflow still preserves foreign quarantine ownership, but an owned cleanup that remains unconfirmed can no longer leave a successful release run.

## Change

- exit nonzero after bounded owned cleanup non-convergence
- emit only allowlisted `latest`, `beta`, and `release-candidate` tags
- accept only bounded semver-shaped versions in the cleanup receipt
- suppress child npm stderr and prove synthetic unsafe output is absent

No package bytes, publication path, rollback path, npm version, public API, runtime, or Desktop artifact changes are included.

## Validation

- `/opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/npm-dist-tag-convergence.test.ts` — 7/7 passed
- adjacent release policy/plumbing checks — 45/45 passed
- `PATH=/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/bin/npm run build` — passed on Node 26.7.0
- `git diff --check` — passed
- the broader provenance orchestration harness is macOS-environment-blocked by its Bash fixture; authoritative GitHub Actions owns that unchanged broad surface

## Safety and proof boundary

Agent-authored. This PR proves source behavior at its exact reviewed head only. It does not prove registry cleanup, npm release completion, Desktop release readiness, runtime behavior, customer readiness, or GA. No credentials, customer data, installed beta state, public release surfaces, or registry state were accessed or changed by this source correction.
