### PR TITLE
docs(release): separate staging from promotion acceptance

### DIFF
--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -17,9 +17,11 @@ publication, installed update, runtime adoption, customer readiness, or GA.
 
 **TRANSITION GATE:** executable update, rollback, identical-byte re-update,
 feed/publication, and local-adoption commands remain blocked until #895 reaches
-`source-accepted` with its exact-head CI, review, and acceptance evidence. Until
-then, use only declaration/packet resolution, credential presence checks, and
-non-mutating dry-plan evidence. Manual copy, source reset, rebuild, LaunchAgent
+`source-accepted` with its exact-head CI, review, and acceptance evidence. Private
+development/staging proof and declared artifact construction may proceed in an
+isolated environment without modifying an existing installation or public surface.
+Resolve construction inputs and credentials first; collect artifact verification
+and accepted promotion evidence afterward. Manual copy, source reset, rebuild, LaunchAgent
 restart, database edit, or ad hoc feed mutation is not a supported substitute.
 
 ## Release State Gates
@@ -48,9 +50,12 @@ NeonDiff-Release-Class: desktop-only
 
 The RC product channel is `rc`; its retained Sparkle enclosure and enclosure
 proof remain on the observed `beta` feed ring. Stable uses product channel and
-feed ring `stable`. The exact channel, tag object, peeled source commit,
-artifact, tree, feed, and packet identities must agree before any candidate
-bytes are staged.
+feed ring `stable`. Before construction, bind the accepted declaration, exact
+channel, tag object, peeled source commit, package, intended feed, and logical
+credential profile. Verify actual artifact/tree/signature/notary identities after
+construction. Before promotion, require the complete accepted packet, attestation,
+real-test evidence, and exact artifact/tree/feed agreement. The final packet is
+not a prerequisite for constructing the bytes needed to produce that evidence.
 
 Before any RC or stable declaration, signing, or notarization, #559 must have published
 immutable `neondiff@1.0.5` and a fresh registry readback must prove its exact
@@ -58,6 +63,10 @@ manifest, tarball, CLI, worker, integrity, provenance, and source identity.
 The Desktop-only npm classification is a no-op for the Desktop release only
 after this package identity gate is satisfied; the marker never proves
 unchanged CLI/worker bytes and never bypasses #559.
+
+A redundant `release-candidate` alias resolving to the same verified `1.0.5`
+does not block private staging or construction. Keep cleanup and strict typed
+#559 closure open until proven; both remain required before public GA.
 
 ## Fast Desktop Iteration Before Release
 
@@ -195,7 +204,9 @@ missing or disagrees with the accepted source.
 Required owner/Codex inputs for a real signing run:
 
 - Exact accepted declaration, source SHA, annotated tag and tag-object SHA,
-  version, build, product channel, and accepted packet digest.
+  version, build, product channel, and logical credential profile. The final
+  accepted packet digest is collected after artifact verification and required
+  real tests, before promotion; it is not a signing input.
 - Fresh #559 registry readback for immutable `neondiff@1.0.5`.
 - Unique portable `RUN_ID` for this immutable evidence packet.
 - Developer ID Application identity name, for example
@@ -399,7 +410,9 @@ Create a public-safe packet under:
 $RUN_DIR/
 ```
 
-Minimum files:
+Minimum files collected across the completed release gates, not prerequisites
+for construction. Record missing later-gate evidence as pending; never fabricate
+a packet or treat a construction receipt as promotion approval:
 
 - `source.txt`: repo, branch, source SHA, annotated tag and tag-object SHA,
   version, build, product channel, feed ring, operator, UTC timestamp, and,
@@ -462,7 +475,7 @@ minimal packet:
 
 ```text
 Accepted declaration:
-Accepted packet digest:
+Accepted packet digest (after verification/tests, before promotion):
 Source SHA:
 Annotated tag / tag-object SHA:
 Version / build:
@@ -479,7 +492,8 @@ Rollback target:
 License/update policy:
 ```
 
-The agent should stop before signing if any required input is missing. The agent
+The agent should stop before signing if any construction input above is missing;
+the final accepted packet is later-gate evidence, not a construction input. The agent
 should stop before publishing if appcast hosting, artifact hosting, rollback, or
 license/update policy is undecided.
 

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -203,6 +203,11 @@ missing or disagrees with the accepted source.
 
 Required owner/Codex inputs for a real signing run:
 
+- A passing pre-signing #524 development/staging receipt at the exact candidate
+  source and registry package: clean internal macOS 15 host, supported setup,
+  account/bot/repository/entitlement/configuration/worker agreement, truthful
+  readiness, and one dry review without hidden repair. Missing or failed proof
+  blocks Developer ID signing and notarization; never use the operations app.
 - Exact accepted declaration, source SHA, annotated tag and tag-object SHA,
   version, build, product channel, and logical credential profile. The final
   accepted packet digest is collected after artifact verification and required
@@ -381,6 +386,15 @@ release authority has been recorded. After that gate, use only the exact tested
 repository-owned command supplied by #895; never assemble a transition from
 these snippets or from a mutable live feed.
 
+Distinguish authorized immutable artifact hosting from accepted promotion:
+the packet producer consumes an existing non-draft immutable GitHub release.
+After private signed-byte testing and #895 source acceptance, a separately
+authorized artifact-hosting release may supply those exact bytes while the
+feed/site/download promotion remains held. That hosting action is public and
+must be reported; it is not private staging, an accepted packet, or GA.
+Complete #1093's protected-declaration and feed/packet ordering checks before
+dispatching its workflow; this document does not certify that workflow ready.
+
 Rollback proof:
 
 - Generate or reference the committed rollback fixture/appcast.
@@ -418,6 +432,8 @@ a packet or treat a construction receipt as promotion approval:
   version, build, product channel, feed ring, operator, UTC timestamp, and,
   when CI-built, workflow run URL plus artifact ID/name.
 - `declaration.json`: exact accepted Desktop declaration and index readback.
+- `pre-signing-product-smoke.md`: the passing source/package-bound #524 setup,
+  readiness/alignment and dry-review receipt required before signing.
 - `accepted-packet.json`: content-addressed accepted packet and its digest.
 - `credential-preflight.json`: output from `preflight-credentials.sh --json`.
 - `build.txt`: build commands, bundle metadata, and checksums.

--- a/apps/neondiff-desktop/docs/signing-credentials.md
+++ b/apps/neondiff-desktop/docs/signing-credentials.md
@@ -28,8 +28,10 @@ Exit `0` = all required credentials present; non-zero lists exactly what is miss
 
 ## Release identity and package gate
 
-Before an RC or stable signing action, resolve the fixed Desktop declaration and
-accepted packet. RC and stable require a distinct annotated tag object whose
+Before an RC or stable signing action, resolve the accepted Desktop declaration,
+exact source/package identity, and logical credential profile. Construction does
+not consume the final accepted promotion packet: artifact verification and the
+required real tests supply that packet afterward. RC and stable require a distinct annotated tag object whose
 annotation contains exactly one line:
 
 ```text
@@ -38,8 +40,10 @@ NeonDiff-Release-Class: desktop-only
 
 The RC product channel remains `rc`, even though its retained Sparkle enclosure
 and enclosure proof use the observed `beta` feed ring. Stable uses the `stable`
-feed ring. The tag, peeled source, artifact, tree, feed, and packet identities
-must agree.
+feed ring. Construction must agree with the declaration's tag, peeled source,
+package, channel, and intended feed identity. After construction, verify the
+actual artifact and tree; before promotion, require the complete accepted packet
+and agreement of all artifact, tree, attestation, and feed identities.
 
 Issue #559 must first publish and provenance-bind immutable `neondiff@1.0.5`.
 The release manager must read back its exact manifest, tarball, CLI, worker,
@@ -47,6 +51,10 @@ integrity, provenance, and source identity before declaring, signing, or
 notarizing a Desktop candidate. Credential presence cannot bypass this gate.
 The Desktop-only npm no-op is valid only after that package identity is
 reconciled; the tag marker alone does not prove unchanged CLI/worker bytes.
+
+A redundant `release-candidate` alias resolving to the same verified `1.0.5`
+does not block private staging or construction. It does not satisfy #559's
+strict typed closure, which remains required before public GA.
 
 Executable update, rollback, identical-byte re-update, feed/publication, and
 local-adoption commands remain blocked until #895 reaches `source-accepted`.

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -84,9 +84,38 @@ No layer may be substituted for another. In particular, a source checkout,
 build output, running process, or account-independent health page cannot prove
 the current launch entitlement or installed release identity.
 
+## Construction, verification, and promotion order
+
+The release stages are ordered; later evidence cannot be a prerequisite for
+creating the artifact that produces it. Under #610's product-first staging
+admission, #559 may establish exact immutable `neondiff@1.0.5` package,
+provenance, worker-byte, and install evidence while redundant same-version
+`release-candidate` alias cleanup remains open. This permits private staging
+only. It does not satisfy the strict typed publication validator, close #559,
+or permit public GA; never report an absent alias while it is present.
+
+1. Prove the supported development/staging setup and dry-review path before
+   Developer ID signing or notarization. Do not use the operations installation
+   to debug a candidate.
+2. Construct from the accepted clean source, append-only declaration, exact
+   package identity, and approved credential profile. A final artifact digest,
+   notarization result, or accepted promotion packet does not exist yet.
+3. After signing, notarization, stapling, and packaging, verify the actual
+   artifact and collect its immutable identity and clean-host evidence.
+4. Assemble and accept the promotion packet only from real completed evidence
+   for the selected gate. Source acceptance of #895 precedes RC publication;
+   its live transition acceptance and the stable minimums precede stable
+   promotion. Construction receipts cannot substitute for these approvals.
+
+This ordering adds no alternate transition implementation or evidence schema.
+The accepted-packet validation, cryptographic binding, two-asset retention,
+append-only history, and no-replacement rules below remain mandatory. An
+incomplete construction record must never be passed off as an accepted packet.
+
 ## Immutable accepted evidence packet
 
-Every candidate and promotion decision names one immutable packet containing:
+Every accepted promotion decision names one immutable packet containing the
+completed evidence required by its release gate:
 
 - source SHA, immutable tag object, protected/signed-tag verification, and
   provenance binding exact artifact/tree digests to that source/build;
@@ -271,6 +300,13 @@ startup/update/review session for each on every supported target, a seven-day
 window from last install, 100% candidate-bound startup/update success, zero
 P0/P1 regressions or state-loss/credential-exposure outcomes, and zero
 unresolved P2 threads; unknown denominators or missing outcomes block stable.
+The 24-hour and 72-hour/100-cycle acceptance checkpoints may be collected inside
+the same seven-day window when their candidate, install, account, target, and
+scenario bindings agree; these are not additional consecutive waits. Reinstall
+or an identity/behavior change invalidates the affected observations, not
+unrelated evidence. Five internal unassisted evaluators remain required by
+#524; synthetic sessions cannot substitute.
+
 These are candidate-bound observations, not fleet/customer authority: they may
 not be inferred from process health, ring names, dashboards, or an operator
 install, and the authoritative fleet/customer decision remains separate.

--- a/docs/architecture/mac-ga-release-contract.md
+++ b/docs/architecture/mac-ga-release-contract.md
@@ -107,6 +107,13 @@ or permit public GA; never report an absent alias while it is present.
    its live transition acceptance and the stable minimums precede stable
    promotion. Construction receipts cannot substitute for these approvals.
 
+The immutable GitHub release used as the packet producer's artifact input is
+not itself accepted promotion. Its separately authorized, reported creation
+may follow private signed-byte testing and #895 source acceptance while
+feed/site/download promotion remains held. #1093 must reconcile the producer's
+feed prerequisites and protected stable-declaration selection before execution;
+do not synthesize stable identity from an uploaded asset or imply GA acceptance.
+
 This ordering adds no alternate transition implementation or evidence schema.
 The accepted-packet validation, cryptographic binding, two-asset retention,
 append-only history, and no-replacement rules below remain mandatory. An
@@ -306,6 +313,17 @@ scenario bindings agree; these are not additional consecutive waits. Reinstall
 or an identity/behavior change invalidates the affected observations, not
 unrelated evidence. Five internal unassisted evaluators remain required by
 #524; synthetic sessions cannot substitute.
+
+For #610's observation gate, one cycle is one completed outer worker loop,
+not an item, transport retry, or synthetic test iteration. Record 24-hour and
+72-hour checkpoints with at least 100 completed cycles by the latter: one
+worker pair, no expired held leases or new unclassified failures, a new-failure
+rate below 1% (failed cycles / completed cycles), and zero P0/P1, leaks,
+stale/duplicate posts or state loss. The redacted #524/#610 receipt binds source,
+package/artifact, host/account aliases, install/start/end times, cycle and
+failure counts, classification references, and heartbeat/lease summaries;
+missing counts or bindings fail the gate. Five internal participants require
+at least four unassisted successes and median first review under ten minutes.
 
 These are candidate-bound observations, not fleet/customer authority: they may
 not be inferred from process health, ring names, dashboards, or an operator


### PR DESCRIPTION
## Outcome

Related: #610, #559, #524, #895.

Apply the owner's product-first release decision without changing product/package bytes or publication validators:
- exact-package proof admits private staging while redundant same-version alias cleanup remains open;
- strict #559 closure still gates public GA;
- development/staging product proof precedes signing; construction, artifact verification and promotion acceptance are ordered;
- overlapping 24h/72h/seven-day observation is collected on the same bound candidate, with no weaker thresholds.

## Evidence and scope

Documentation-only: architecture and its two operational runbooks, 107 additions / 15 deletions. Two consolidated targeted corrections align signing inputs, staging order, evidence inventory and handoff with the architecture; they add the required pre-signing product-smoke receipt and existing observation metrics. Public artifact hosting is distinguished from accepted promotion. Verified packet-workflow protected-history/feed ordering gaps are release-blocking follow-ups in existing #1093, not implemented or certified here. No commands changed. Before this edit, the contract required every candidate to have an accepted packet containing evidence generated only after construction. The local control runbooks also incorrectly described npm 1.0.5 as unpublished and required the final packet before credentials/signing. The new section separates stages explicitly.

git diff --check passes. No executable behavior changed, so no local product suite was repeated. Authoritative remote CI and one independent release-risk review remain merge gates. Agent-authored change.

## Boundaries

No npm mutation, signed artifact, release, feed, runtime, customer data, operations-beta mutation, new schema or alternate transition implementation. No #559/#610 closure. Existing cryptographic packet validation, two-asset retention, append-only identity and #895 transition acceptance remain required.